### PR TITLE
feat(session-ingest): route fenced browser providers

### DIFF
--- a/services/session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.test.ts
@@ -35,6 +35,21 @@ import {
   MAX_DURABLE_RESULT_BYTES,
   UserConnectionDO,
 } from './UserConnectionDO';
+import {
+  BROWSER_APPROVAL_TIMEOUT_MS,
+  BROWSER_EXECUTION_TIMEOUT_MS,
+  BROWSER_LEASE_MS,
+  BROWSER_QUEUE_TIMEOUT_MS,
+  BROWSER_RETENTION_MS,
+} from './browser-job-store';
+import {
+  browserCLIInboundMessageSchema,
+  browserProviderInboundMessageSchema,
+  browserJobSnapshotSchema,
+  type BrowserRequest,
+  type BrowserProviderOutboundMessage,
+  type BrowserJobSnapshot,
+} from '../types/user-connection-protocol';
 
 // ---------------------------------------------------------------------------
 // Mock WebSocket
@@ -53,15 +68,17 @@ type MockWS = {
 function createMockWs(tags: string[] = [], attachment?: unknown): MockWS {
   const ws: MockWS = {
     send: vi.fn(),
-    close: vi.fn(),
+    close: vi.fn(() => {
+      ws.readyState = 3;
+    }),
     readyState: 1,
-    _attachment: attachment ?? null,
+    _attachment: structuredClone(attachment ?? null),
     _tags: tags,
     serializeAttachment(att: unknown) {
-      ws._attachment = att;
+      ws._attachment = structuredClone(att);
     },
     deserializeAttachment() {
-      return ws._attachment;
+      return structuredClone(ws._attachment);
     },
   };
   return ws;
@@ -71,10 +88,57 @@ function createMockWs(tags: string[] = [], attachment?: unknown): MockWS {
 // Mock DurableObjectState (this.ctx)
 // ---------------------------------------------------------------------------
 
-/** In-memory Map-backed KV fake for ctx.storage (put/get/delete/list). */
+/** KV fake with serial, atomic transactions and observable alarm state. */
 function makeStorageFake() {
   const store = new Map<string, unknown>();
+  let alarmAt: number | null = null;
+  let serial: Promise<unknown> = Promise.resolve();
+  const transaction = vi.fn(<T>(run: (tx: DurableObjectTransaction) => Promise<T>): Promise<T> => {
+    const next = serial.then(async () => {
+      const working = new Map(store);
+      const writes = new Set<string>();
+      const deletes = new Set<string>();
+      const tx = {
+        async get<V>(key: string): Promise<V | undefined> {
+          return structuredClone(working.get(key)) as V | undefined;
+        },
+        async put(key: string, value: unknown) {
+          working.set(key, structuredClone(value));
+          writes.add(key);
+          deletes.delete(key);
+        },
+        async delete(key: string) {
+          writes.delete(key);
+          deletes.add(key);
+          return working.delete(key);
+        },
+        async list<V>(options: { prefix?: string; limit?: number } = {}): Promise<Map<string, V>> {
+          return new Map(
+            [...working]
+              .filter(([key]) => key.startsWith(options.prefix ?? ''))
+              .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+              .slice(0, options.limit)
+              .map(([key, value]) => [key, structuredClone(value) as V])
+          );
+        },
+      };
+      const result = await run(tx as DurableObjectTransaction);
+      for (const key of writes) store.set(key, working.get(key));
+      for (const key of deletes) store.delete(key);
+      return result;
+    });
+    serial = next.catch(() => undefined);
+    return next;
+  });
   return {
+    transaction,
+    get alarmAt() {
+      return alarmAt;
+    },
+    getAlarm: vi.fn(async () => alarmAt),
+    deleteAlarm: vi.fn(async () => {
+      alarmAt = null;
+    }),
     store,
     put: vi.fn(async (key: string, value: unknown) => {
       store.set(key, value);
@@ -95,7 +159,9 @@ function makeStorageFake() {
       }
       return result;
     }),
-    setAlarm: vi.fn(),
+    setAlarm: vi.fn(async (at: number) => {
+      alarmAt = at;
+    }),
   };
 }
 
@@ -223,7 +289,11 @@ function connectWebSocket(doInstance: UserConnectionDO, connectionId: string): M
   return server;
 }
 
-function connectCliSocket(doInstance: UserConnectionDO, connectionId: string): MockWS {
+function connectCliSocket(
+  doInstance: UserConnectionDO,
+  connectionId: string,
+  kiloUserId = ''
+): MockWS {
   const client = createMockWs();
   const server = createMockWs();
   vi.stubGlobal(
@@ -241,7 +311,7 @@ function connectCliSocket(doInstance: UserConnectionDO, connectionId: string): M
   );
 
   doInstance.fetch(
-    new Request(`http://local/cli?connectionId=${connectionId}`, {
+    new Request(`http://local/cli?connectionId=${connectionId}&kiloUserId=${kiloUserId}`, {
       headers: { Upgrade: 'websocket' },
     })
   );
@@ -426,6 +496,1294 @@ describe('UserConnectionDO', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  describe('browser relay', () => {
+    const now = Date.UTC(2026, 7, 28);
+    const owner = { parentSessionId: 'ses_parent', parentProof: 'a'.repeat(64) };
+    const otherOwner = { parentSessionId: 'ses_other', parentProof: 'b'.repeat(64) };
+    const tab = {
+      tabId: 42,
+      title: 'Approved page',
+      url: 'https://example.com/',
+      effectiveMode: 'safe' as const,
+    };
+    const registration = {
+      type: 'provider_register',
+      requestId: '00000000-0000-4000-8000-000000000001',
+      providerId: 'bp_00000000-0000-4000-8000-000000000001',
+      providerProof: 'c'.repeat(64),
+      label: 'Work profile',
+      generation: 0,
+      enabled: true,
+    } satisfies BrowserProviderOutboundMessage;
+    type Invoke = Extract<BrowserRequest, { operation: 'invoke' }>;
+
+    function invokeRequest(n = 1, changes: Partial<Invoke> = {}): Invoke {
+      return {
+        type: 'browser_request',
+        operation: 'invoke',
+        requestId: crypto.randomUUID(),
+        owner,
+        providerId: registration.providerId,
+        invocationId: `b1.${now}.${n.toString(16).padStart(64, '0')}`,
+        goal: `Observe page ${n}`,
+        ...changes,
+      };
+    }
+
+    async function frame(doInstance: UserConnectionDO, ws: MockWS, message: unknown) {
+      await doInstance.webSocketMessage(ws as never, JSON.stringify(message));
+      await flushAsync();
+    }
+
+    async function negotiate(doInstance: UserConnectionDO, ws: MockWS, role: 'cli' | 'web') {
+      await frame(
+        doInstance,
+        ws,
+        role === 'cli'
+          ? { type: 'heartbeat', sessions: [], capabilities: { browserJobsV1: true } }
+          : { type: 'ping', nonce: 'browser', capabilities: { browserJobsV1: true } }
+      );
+    }
+
+    async function browserSetup() {
+      vi.spyOn(Date, 'now').mockReturnValue(now);
+      const f = setup();
+      const cli = addCliSocket(f.mockCtx, 'cli-browser', [], undefined, 'usr_1');
+      const panel = addWebSocket(f.mockCtx, 'panel');
+      const viewer = addWebSocket(f.mockCtx, 'viewer');
+      await negotiate(f.doInstance, cli, 'cli');
+      await negotiate(f.doInstance, panel, 'web');
+      await frame(f.doInstance, panel, registration);
+      cli.send.mockClear();
+      panel.send.mockClear();
+      viewer.send.mockClear();
+      return { ...f, cli, panel, viewer };
+    }
+    type Fixture = Awaited<ReturnType<typeof browserSetup>>;
+
+    function response(ws: MockWS, requestId: string) {
+      const sent = allSent(ws).findLast(
+        m => m.type === 'browser_response' && m.requestId === requestId
+      );
+      const parsed = browserCLIInboundMessageSchema.parse(sent);
+      if (parsed.type !== 'browser_response') throw new Error('Missing browser response');
+      return parsed.response;
+    }
+
+    function job(f: Fixture, jobId: string): BrowserJobSnapshot {
+      const stored = f.ctx.storage.store.get(`browser/job/${jobId}`);
+      if (!isRecord(stored)) throw new Error('Missing stored browser job');
+      return browserJobSnapshotSchema.parse(stored.snapshot);
+    }
+
+    async function invoke(f: Fixture, n = 1, changes: Partial<Invoke> = {}, cli = f.cli) {
+      const request = invokeRequest(n, changes);
+      await frame(f.doInstance, cli, request);
+      const accepted = response(cli, request.requestId);
+      if (accepted.kind !== 'ack') throw new Error(`Admission failed: ${JSON.stringify(accepted)}`);
+      return job(f, accepted.jobId);
+    }
+
+    function binding(snapshot: BrowserJobSnapshot) {
+      return {
+        providerId: snapshot.providerId,
+        browserTaskId: snapshot.browserTaskId,
+        jobId: snapshot.jobId,
+        invocationId: snapshot.invocationId,
+        generation: snapshot.generation,
+      };
+    }
+
+    function providerJobs(ws: MockWS): BrowserJobSnapshot[] {
+      return allSent(ws).flatMap(message => {
+        const parsed = browserProviderInboundMessageSchema.safeParse(message);
+        return parsed.success && parsed.data.type === 'provider_job' ? [parsed.data.job] : [];
+      });
+    }
+
+    async function approve(f: Fixture, snapshot: BrowserJobSnapshot) {
+      await frame(f.doInstance, f.panel, {
+        type: 'provider_approval',
+        ...binding(snapshot),
+        approval: { decision: 'approved', tab },
+      });
+      return job(f, snapshot.jobId);
+    }
+
+    function resultMessage(snapshot: BrowserJobSnapshot) {
+      const { generation: _generation, ...handle } = binding(snapshot);
+      return {
+        type: 'provider_result',
+        ...binding(snapshot),
+        tab,
+        result: {
+          ...handle,
+          status: 'succeeded',
+          reason: 'completed',
+          effectsUncertain: false,
+          summary: 'Observed the requested page.',
+          evidence: [{ text: 'The page contains the requested value.', url: tab.url }],
+        },
+      };
+    }
+
+    function lookup(
+      snapshot: BrowserJobSnapshot,
+      operation: 'status' | 'cancel' = 'status',
+      proof = owner
+    ) {
+      return {
+        type: 'browser_request',
+        requestId: crypto.randomUUID(),
+        operation,
+        owner: proof,
+        browserTaskId: snapshot.browserTaskId,
+        jobId: snapshot.jobId,
+      } satisfies BrowserRequest;
+    }
+
+    async function quiesce(f: Fixture, snapshot: BrowserJobSnapshot, panel = f.panel) {
+      await frame(f.doInstance, panel, {
+        type: 'provider_quiesced',
+        ...binding(snapshot),
+        tabId: tab.tabId,
+      });
+    }
+
+    async function heartbeat(f: Fixture, generation = 1, panel = f.panel) {
+      await frame(f.doInstance, panel, {
+        type: 'provider_heartbeat',
+        requestId: crypto.randomUUID(),
+        providerId: registration.providerId,
+        generation,
+      });
+    }
+
+    it('negotiates through legacy acknowledgements and sends no browser frames before opt-in', async () => {
+      const { doInstance, mockCtx } = setup();
+      const cli = addCliSocket(mockCtx, 'cli', [], undefined, 'usr_1');
+      const panel = addWebSocket(mockCtx, 'panel');
+      await frame(doInstance, cli, { type: 'heartbeat', sessions: [] });
+      await frame(doInstance, panel, { type: 'ping', nonce: 'legacy' });
+      await frame(doInstance, cli, invokeRequest());
+      await frame(doInstance, panel, registration);
+      expect(allSent(cli)).toEqual([{ type: 'heartbeat_ack' }]);
+      expect(allSent(panel).filter(m => m.type !== 'system')).toEqual([
+        { type: 'pong', nonce: 'legacy' },
+      ]);
+      expect(mockCtx.storage.store.size).toBe(0);
+      expect(cli.deserializeAttachment()).toMatchObject({
+        browserCapabilities: { browserJobsV1: false },
+      });
+      await negotiate(doInstance, cli, 'cli');
+      await negotiate(doInstance, panel, 'web');
+      expect(allSent(cli).at(-1)).toEqual({
+        type: 'heartbeat_ack',
+        capabilities: { browserJobsV1: true },
+      });
+      expect(allSent(panel).at(-1)).toEqual({
+        type: 'pong',
+        nonce: 'browser',
+        capabilities: { browserJobsV1: true },
+      });
+    });
+
+    it('preserves negotiation and registration during delayed subscription access', async () => {
+      const f = await browserSetup();
+      f.panel = addWebSocket(f.mockCtx, 'late-panel');
+      const accessible = {
+        kiloSessionId: 'ses_delayed',
+        organizationId: null,
+        cloudAgentSessionScopeId: null,
+      };
+      const access = Promise.withResolvers<typeof accessible>();
+      sessionAccessMocks.resolveAccessibleKiloSession.mockReturnValueOnce(access.promise);
+      const pending = sendSubscribe(f.doInstance, f.panel, accessible.kiloSessionId);
+
+      await negotiate(f.doInstance, f.panel, 'web');
+      await frame(f.doInstance, f.panel, registration);
+      const registered = f.panel.deserializeAttachment() as Record<string, unknown>;
+      expect(registered).toMatchObject({
+        browserCapabilities: { browserJobsV1: true },
+        browserSocketId: expect.any(String),
+        browserProvider: { providerId: registration.providerId, generation: 2 },
+      });
+      access.resolve(accessible);
+      await pending;
+
+      expect(f.panel.deserializeAttachment()).toEqual({
+        ...registered,
+        subscribedSessions: [accessible.kiloSessionId],
+      });
+      const active = await approve(f, await invoke(f));
+      await frame(f.doInstance, f.panel, resultMessage(active));
+      expect(providerJobs(f.panel).map(snapshot => snapshot.jobId)).toEqual([active.jobId]);
+      expect(
+        allSent(f.cli).filter(
+          message => message.type === 'browser_event' && message.event === 'result'
+        )
+      ).toMatchObject([{ result: { jobId: active.jobId, status: 'succeeded' } }]);
+    });
+
+    it('preserves approval during delayed subscription access across hibernation', async () => {
+      const f = await browserSetup();
+      const active = await invoke(f);
+      const accessible = {
+        kiloSessionId: 'ses_delayed',
+        organizationId: null,
+        cloudAgentSessionScopeId: null,
+      };
+      const access = Promise.withResolvers<typeof accessible>();
+      sessionAccessMocks.resolveAccessibleKiloSession.mockReturnValueOnce(access.promise);
+      const pending = sendSubscribe(f.doInstance, f.panel, accessible.kiloSessionId);
+
+      await approve(f, active);
+      expect(job(f, active.jobId).status).toBe('running');
+      access.resolve(accessible);
+      await pending;
+      f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+      await f.doInstance.alarm();
+      await flushAsync();
+
+      expect(job(f, active.jobId)).toMatchObject({ status: 'running', approvedTab: tab });
+      await frame(f.doInstance, f.panel, resultMessage(active));
+      expect(providerJobs(f.panel).map(snapshot => snapshot.jobId)).toEqual([active.jobId]);
+      expect(
+        allSent(f.cli).filter(
+          message => message.type === 'browser_event' && message.event === 'result'
+        )
+      ).toMatchObject([{ result: { jobId: active.jobId, status: 'succeeded' } }]);
+    });
+
+    it.each(['replacement', 'close'] as const)(
+      'preserves the %s fence when delayed subscription access completes',
+      async cause => {
+        const f = await browserSetup();
+        const accessible = {
+          kiloSessionId: 'ses_delayed',
+          organizationId: null,
+          cloudAgentSessionScopeId: null,
+        };
+        const access = Promise.withResolvers<typeof accessible>();
+        sessionAccessMocks.resolveAccessibleKiloSession.mockReturnValueOnce(access.promise);
+        const pending = sendSubscribe(f.doInstance, f.panel, accessible.kiloSessionId);
+
+        if (cause === 'replacement') connectWebSocket(f.doInstance, 'panel');
+        else await f.doInstance.webSocketClose(f.panel as never, 1000, 'closed', true);
+        await flushAsync();
+        const closed = f.panel.deserializeAttachment();
+        f.cli.send.mockClear();
+        f.panel.send.mockClear();
+        access.resolve(accessible);
+        await pending;
+
+        expect(f.panel.deserializeAttachment()).toEqual(closed);
+        expect(allSent(f.panel)).toEqual([]);
+        expect(allSent(f.cli).filter(message => message.type === 'subscribe')).toEqual([]);
+      }
+    );
+
+    it('keeps discovery private and separate from the unchanged CLI instance list', async () => {
+      const f = await browserSetup();
+      const spawner = addCliSocket(f.mockCtx, 'spawner', [], {
+        name: 'Laptop',
+        projectName: 'Repo',
+      });
+      await frame(f.doInstance, spawner, {
+        type: 'heartbeat',
+        sessions: [],
+        instance: { name: 'Laptop', projectName: 'Repo' },
+      });
+      const before = f.doInstance.getConnectedInstances();
+      const request: BrowserRequest = {
+        type: 'browser_request',
+        operation: 'list',
+        requestId: crypto.randomUUID(),
+      };
+      await frame(f.doInstance, f.cli, request);
+      expect(response(f.cli, request.requestId)).toEqual({
+        kind: 'providers',
+        providers: [
+          {
+            providerId: registration.providerId,
+            label: 'Work profile',
+            availability: 'available',
+            queueDepth: 0,
+          },
+        ],
+      });
+      expect(f.doInstance.getConnectedInstances()).toEqual(before);
+      expect(before).toEqual({
+        instances: [{ connectionId: 'spawner', name: 'Laptop', projectName: 'Repo' }],
+      });
+      expect(allSent(f.viewer).every(m => m.type === 'system')).toBe(true);
+      expect(JSON.stringify(response(f.cli, request.requestId))).not.toMatch(
+        /Proof|socketId|generation|goal|parent/
+      );
+    });
+
+    it('returns empty discovery and authoritative not-found recovery without allocating work', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(now);
+      const { doInstance, mockCtx } = setup();
+      const cli = addCliSocket(mockCtx, 'cli', [], undefined, 'usr_1');
+      await negotiate(doInstance, cli, 'cli');
+      const list: BrowserRequest = {
+        type: 'browser_request',
+        operation: 'list',
+        requestId: crypto.randomUUID(),
+      };
+      const recover: BrowserRequest = {
+        type: 'browser_request',
+        operation: 'recover',
+        owner,
+        invocationId: invokeRequest().invocationId,
+        requestId: crypto.randomUUID(),
+      };
+      await frame(doInstance, cli, list);
+      await frame(doInstance, cli, recover);
+      expect(response(cli, list.requestId)).toEqual({ kind: 'providers', providers: [] });
+      expect(response(cli, recover.requestId)).toEqual({
+        kind: 'not_found',
+        invocationId: recover.invocationId,
+      });
+      expect([...mockCtx.storage.store.keys()].filter(key => key.startsWith('browser/'))).toEqual(
+        []
+      );
+    });
+
+    it('commits admission and acknowledges it before one persisted provider dispatch', async () => {
+      const f = await browserSetup();
+      const order: string[] = [];
+      f.cli.send.mockImplementation((raw: string) => {
+        const message = browserCLIInboundMessageSchema.parse(JSON.parse(raw));
+        if (message.type === 'browser_response' && message.response.kind === 'ack') {
+          expect(job(f, message.response.jobId).status).toBe(
+            order.length === 0 ? 'queued' : 'awaiting_approval'
+          );
+          order.push('ack');
+        }
+      });
+      f.panel.send.mockImplementation((raw: string) => {
+        const message = browserProviderInboundMessageSchema.parse(JSON.parse(raw));
+        if (message.type === 'provider_job') {
+          expect(f.ctx.storage.store.get(`browser/job/${message.job.jobId}`)).toMatchObject({
+            dispatch: { at: now },
+            snapshot: { status: 'awaiting_approval' },
+          });
+          order.push('dispatch');
+        }
+      });
+      const accepted = await invoke(f);
+      await invoke(f);
+      expect(order).toEqual(['ack', 'dispatch', 'ack']);
+      expect(providerJobs(f.panel).map(j => j.jobId)).toEqual([accepted.jobId]);
+      expect(allSent(f.viewer)).toEqual([]);
+      expect(JSON.stringify(allSent(f.panel))).not.toContain(owner.parentProof);
+      expect(JSON.stringify([...f.ctx.storage.store])).not.toContain(registration.providerProof);
+    });
+
+    it('requires explicit provider selection, enabled registration, and the correct socket roles', async () => {
+      const f = await browserSetup();
+      const active = await invoke(f);
+      const before = structuredClone([...f.ctx.storage.store]);
+      const { providerId: _providerId, ...implicit } = invokeRequest(2);
+      await frame(f.doInstance, f.cli, implicit);
+      await frame(f.doInstance, f.panel, invokeRequest(2));
+      await frame(f.doInstance, f.viewer, invokeRequest(2));
+      await frame(f.doInstance, f.cli, {
+        type: 'provider_approval',
+        ...binding(active),
+        approval: { decision: 'approved', tab },
+      });
+      await frame(f.doInstance, f.panel, { ...registration, enabled: false });
+      expect([...f.ctx.storage.store]).toEqual(before);
+      expect(providerJobs(f.panel)).toHaveLength(1);
+      expect(job(f, active.jobId).status).toBe('awaiting_approval');
+    });
+
+    it('keeps retryable capacity or availability failures distinct from non-retryable proof failures', async () => {
+      const f = await browserSetup();
+      const active = await invoke(f);
+      const unavailable = invokeRequest(2, {
+        providerId: 'bp_00000000-0000-4000-8000-000000000002',
+      });
+      await frame(f.doInstance, f.cli, unavailable);
+      expect(response(f.cli, unavailable.requestId)).toMatchObject({
+        kind: 'error',
+        code: 'provider_unavailable',
+        retryable: true,
+      });
+      const forged = lookup(active, 'status', { ...owner, parentProof: 'f'.repeat(64) });
+      await frame(f.doInstance, f.cli, forged);
+      expect(response(f.cli, forged.requestId)).toMatchObject({
+        kind: 'error',
+        code: 'owner_mismatch',
+        retryable: false,
+      });
+      expect(job(f, active.jobId).status).toBe('awaiting_approval');
+    });
+
+    it('isolates multiple parents across two CLI sockets despite a forged heartbeat', async () => {
+      const f = await browserSetup();
+      const second = addCliSocket(f.mockCtx, 'second', [], undefined, 'usr_1');
+      await negotiate(f.doInstance, second, 'cli');
+      const a = await invoke(f);
+      const b = await invoke(f, 2, { owner: otherOwner });
+      await frame(f.doInstance, second, {
+        type: 'heartbeat',
+        capabilities: { browserJobsV1: true },
+        sessions: [makeSession(owner.parentSessionId), makeSession(otherOwner.parentSessionId)],
+      });
+      for (const target of [a, b]) {
+        for (const operation of ['status', 'cancel'] as const) {
+          const request = lookup(target, operation, { ...owner, parentProof: 'd'.repeat(64) });
+          await frame(f.doInstance, second, request);
+          expect(response(second, request.requestId)).toMatchObject({
+            kind: 'error',
+            code: 'owner_mismatch',
+          });
+        }
+      }
+      await approve(f, a);
+      await frame(f.doInstance, f.panel, resultMessage(a));
+      expect(allSent(second).filter(m => m.type === 'browser_event')).toEqual([]);
+      expect(
+        allSent(f.cli).filter(m => m.type === 'browser_event' && m.event === 'result')
+      ).toMatchObject([{ result: { jobId: a.jobId, summary: 'Observed the requested page.' } }]);
+      expect(job(f, b.jobId).status).toBe('queued');
+    });
+
+    it('requires fresh approval and the exact approved tab before accepting a result', async () => {
+      const f = await browserSetup();
+      const active = await invoke(f);
+      await frame(f.doInstance, f.panel, resultMessage(active));
+      expect(job(f, active.jobId).status).toBe('awaiting_approval');
+      await approve(f, active);
+      for (const changed of [
+        { tabId: 99 },
+        { title: 'Other' },
+        { url: 'https://other.example/' },
+        { effectiveMode: 'dangerous' },
+      ]) {
+        await frame(f.doInstance, f.panel, {
+          ...resultMessage(active),
+          tab: { ...tab, ...changed },
+        });
+        expect(job(f, active.jobId).status).toBe('running');
+      }
+      await frame(f.doInstance, f.panel, resultMessage(active));
+      await quiesce(f, active);
+      const continued = await invoke(f, 2, { browserTaskId: active.browserTaskId });
+      expect(continued.browserTaskId).toBe(active.browserTaskId);
+      expect(continued.status).toBe('awaiting_approval');
+      expect(continued.approvedTab).toBeUndefined();
+      await frame(f.doInstance, f.panel, resultMessage(continued));
+      expect(job(f, continued.jobId).status).toBe('awaiting_approval');
+    });
+
+    it('advances FIFO only after exact quiescence, not terminal success or an empty CLI heartbeat', async () => {
+      const f = await browserSetup();
+      const first = await approve(f, await invoke(f));
+      const second = await invoke(f, 2);
+      const third = await invoke(f, 3);
+      await frame(f.doInstance, f.panel, resultMessage(first));
+      await negotiate(f.doInstance, f.cli, 'cli');
+      await heartbeat(f);
+      expect(providerJobs(f.panel).map(j => j.jobId)).toEqual([first.jobId]);
+      await quiesce(f, first);
+      expect(providerJobs(f.panel).map(j => j.jobId)).toEqual([first.jobId, second.jobId]);
+      await quiesce(f, first);
+      expect(job(f, third.jobId).status).toBe('queued');
+      expect(providerJobs(f.panel)).toHaveLength(2);
+    });
+
+    it('settles denied approval without running and holds FIFO until quiescence', async () => {
+      const f = await browserSetup();
+      const first = await invoke(f);
+      const next = await invoke(f, 2);
+      await frame(f.doInstance, f.panel, {
+        type: 'provider_approval',
+        ...binding(first),
+        approval: { decision: 'denied', reason: 'approval_denied' },
+      });
+      expect(job(f, first.jobId)).toMatchObject({
+        status: 'failed',
+        result: { reason: 'approval_denied', effectsUncertain: false },
+      });
+      expect(job(f, first.jobId).approvedTab).toBeUndefined();
+      expect(providerJobs(f.panel)).toHaveLength(1);
+      await quiesce(f, first);
+      expect(providerJobs(f.panel).map(j => j.jobId)).toEqual([first.jobId, next.jobId]);
+    });
+
+    it('authorizes provider_cancel by the registered socket and generation, including queued jobs', async () => {
+      const f = await browserSetup();
+      const active = await approve(f, await invoke(f));
+      const queued = await invoke(f, 2, { owner: otherOwner });
+      const stranger = addWebSocket(f.mockCtx, 'stranger');
+      await negotiate(f.doInstance, stranger, 'web');
+      const cancel = { type: 'provider_cancel', ...binding(queued) };
+      await frame(f.doInstance, stranger, cancel);
+      await frame(f.doInstance, f.cli, cancel);
+      await frame(f.doInstance, f.panel, { ...cancel, generation: queued.generation + 1 });
+      expect(job(f, queued.jobId).status).toBe('queued');
+      await frame(f.doInstance, f.panel, cancel);
+      expect(job(f, queued.jobId)).toMatchObject({
+        status: 'cancelled',
+        result: { effectsUncertain: false },
+      });
+      expect(job(f, active.jobId).status).toBe('running');
+      expect(allSent(stranger).filter(m => m.type === 'provider_snapshot')).toEqual([]);
+    });
+
+    it.each(['awaiting_approval', 'running'] as const)(
+      'forwards cancellation after settlement and fences %s work against late success',
+      async state => {
+        const f = await browserSetup();
+        let active = await invoke(f);
+        if (state === 'running') active = await approve(f, active);
+        const queued = await invoke(f, 2);
+        const cancelledBeforeDelivery: string[] = [];
+        f.panel.send.mockImplementation((raw: string) => {
+          const message = JSON.parse(raw) as { type: string };
+          if (message.type === 'provider_job_cancel')
+            cancelledBeforeDelivery.push(job(f, active.jobId).status);
+        });
+        const cancel = lookup(active, 'cancel');
+        await frame(f.doInstance, f.cli, cancel);
+        expect(response(f.cli, cancel.requestId)).toMatchObject({
+          kind: 'ack',
+          operation: 'cancel',
+          jobId: active.jobId,
+        });
+        expect(cancelledBeforeDelivery).toEqual(['cancelled']);
+        expect(job(f, active.jobId).result).toMatchObject({
+          status: 'cancelled',
+          reason: 'cancelled',
+        });
+        await frame(f.doInstance, f.panel, resultMessage(active));
+        expect(job(f, active.jobId).status).toBe('cancelled');
+        expect(providerJobs(f.panel)).toHaveLength(1);
+        expect(job(f, queued.jobId).status).toBe(state === 'running' ? 'interrupted' : 'queued');
+        await quiesce(f, active);
+        expect(providerJobs(f.panel)).toHaveLength(state === 'running' ? 1 : 2);
+      }
+    );
+
+    it.each(['panel close', 'socket error', 'disablement', 'shutdown'] as const)(
+      'settles active and queued jobs on %s without releasing uncertain execution',
+      async cause => {
+        const f = await browserSetup();
+        const active = await approve(f, await invoke(f));
+        const queued = await invoke(f, 2);
+        if (cause === 'panel close')
+          await f.doInstance.webSocketClose(f.panel as never, 1000, 'closed', true);
+        else if (cause === 'socket error') await f.doInstance.webSocketError(f.panel as never);
+        else
+          await frame(f.doInstance, f.panel, {
+            type: 'provider_unavailable',
+            providerId: active.providerId,
+            generation: active.generation,
+            reason: 'provider_unavailable',
+            effectsUncertain: true,
+          });
+        await flushAsync();
+        expect(job(f, active.jobId)).toMatchObject({
+          status: 'interrupted',
+          result: { effectsUncertain: true },
+        });
+        expect(job(f, queued.jobId)).toMatchObject({
+          status: 'interrupted',
+          result: { reason: 'provider_unavailable', effectsUncertain: false },
+        });
+        expect(f.ctx.storage.store.get(`browser/provider/${active.providerId}`)).toMatchObject({
+          fence: { jobId: active.jobId, requiresRecovery: true },
+          queue: [],
+        });
+        const replacement = addWebSocket(f.mockCtx, `replacement-${cause}`);
+        await negotiate(f.doInstance, replacement, 'web');
+        await frame(f.doInstance, replacement, { ...registration, generation: active.generation });
+        expect(allSent(replacement).at(-1)).toMatchObject({
+          type: 'response',
+          error: { code: 'provider_unavailable' },
+        });
+        expect(providerJobs(replacement)).toEqual([]);
+        expect(
+          allSent(f.cli).filter(m => m.type === 'browser_event' && m.event === 'result')
+        ).toHaveLength(2);
+      }
+    );
+
+    it('settles a failed provider send as interruption and never retries executable work', async () => {
+      const f = await browserSetup();
+      let attempted = 0;
+      f.panel.send.mockImplementation((raw: string) => {
+        if ((JSON.parse(raw) as { type: string }).type === 'provider_job') {
+          attempted++;
+          throw new Error('Socket closed during dispatch');
+        }
+      });
+      const first = await invoke(f);
+      expect(first).toMatchObject({
+        status: 'interrupted',
+        result: { reason: 'provider_lost', effectsUncertain: true },
+      });
+      const duplicate = await invoke(f);
+      expect(duplicate.jobId).toBe(first.jobId);
+      expect(duplicate.result).toEqual(first.result);
+      f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+      await invoke(f);
+      expect(attempted).toBe(1);
+      expect(f.ctx.storage.store.get(`browser/provider/${first.providerId}`)).toMatchObject({
+        fence: { jobId: first.jobId },
+        queue: [],
+      });
+    });
+
+    it('does not opt in a socket when its capability acknowledgement cannot be sent', async () => {
+      const f = await browserSetup();
+      const cli = addCliSocket(f.mockCtx, 'lost-ack', [], undefined, 'usr_1');
+      cli.send.mockImplementationOnce(() => {
+        throw new Error('Ack lost');
+      });
+      await negotiate(f.doInstance, cli, 'cli');
+      await frame(f.doInstance, cli, invokeRequest());
+      expect(cli.deserializeAttachment()).toMatchObject({
+        browserCapabilities: { browserJobsV1: false },
+      });
+      expect(providerJobs(f.panel)).toEqual([]);
+      expect([...f.ctx.storage.store.keys()].filter(key => key.startsWith('browser/job/'))).toEqual(
+        []
+      );
+      await negotiate(f.doInstance, cli, 'cli');
+      const accepted = await invoke(f, 1, {}, cli);
+      expect(accepted.status).toBe('awaiting_approval');
+    });
+
+    it('sends neither acceptance nor work when the admission transaction fails', async () => {
+      const f = await browserSetup();
+      f.ctx.storage.transaction.mockRejectedValueOnce(new Error('Commit failed'));
+      await expect(frame(f.doInstance, f.cli, invokeRequest())).rejects.toThrow('Commit failed');
+      await flushAsync();
+      expect(allSent(f.cli).filter(m => m.type === 'browser_response')).toEqual([]);
+      expect(providerJobs(f.panel)).toEqual([]);
+      expect([...f.ctx.storage.store.keys()].filter(key => key.startsWith('browser/job/'))).toEqual(
+        []
+      );
+    });
+
+    it('rejects changed duplicate payloads without replacing the accepted job', async () => {
+      const f = await browserSetup();
+      const accepted = await invoke(f);
+      const conflict = invokeRequest(1, { goal: 'Different work' });
+      await frame(f.doInstance, f.cli, conflict);
+      expect(response(f.cli, conflict.requestId)).toMatchObject({
+        kind: 'error',
+        code: 'invocation_conflict',
+        retryable: false,
+      });
+      expect(job(f, accepted.jobId)).toEqual(accepted);
+      expect(providerJobs(f.panel)).toHaveLength(1);
+    });
+
+    it('preserves jobs after CLI loss and recovers a stored result only after parent proof', async () => {
+      const f = await browserSetup();
+      const active = await approve(f, await invoke(f));
+      await disconnectCli(f.doInstance, f.cli);
+      f.mockCtx.removeSocket(f.cli);
+      expect(job(f, active.jobId).status).toBe('running');
+      f.cli.send.mockClear();
+      await frame(f.doInstance, f.panel, resultMessage(active));
+      expect(allSent(f.cli)).toEqual([]);
+      const replacement = addCliSocket(f.mockCtx, 'recovered-cli', [], undefined, 'usr_1');
+      await negotiate(f.doInstance, replacement, 'cli');
+      const recover: BrowserRequest = {
+        type: 'browser_request',
+        operation: 'recover',
+        requestId: crypto.randomUUID(),
+        owner,
+        invocationId: active.invocationId,
+      };
+      await frame(f.doInstance, replacement, recover);
+      expect(response(replacement, recover.requestId)).toMatchObject({
+        kind: 'recovered',
+        job: {
+          jobId: active.jobId,
+          status: 'succeeded',
+          result: { summary: 'Observed the requested page.' },
+        },
+      });
+      expect(providerJobs(f.panel)).toHaveLength(1);
+    });
+
+    it('does not transfer parent subscriptions on same-ID CLI replacement or accept the replaced heartbeat', async () => {
+      const f = await browserSetup();
+      const first = await approve(f, await invoke(f));
+      const other = await invoke(f, 2, { owner: otherOwner });
+      const replacement = connectCliSocket(f.doInstance, 'cli-browser', 'usr_1');
+      await negotiate(f.doInstance, replacement, 'cli');
+      f.cli.send.mockClear();
+      await frame(f.doInstance, f.cli, {
+        type: 'heartbeat',
+        sessions: [makeSession('ses_forged')],
+        capabilities: { browserJobsV1: true },
+      });
+      expect(f.doInstance.hasActiveCliSession('ses_forged')).toBe(false);
+      expect(allSent(f.cli)).toEqual([]);
+      const forged = lookup(first, 'cancel', { ...owner, parentProof: 'f'.repeat(64) });
+      await frame(f.doInstance, replacement, forged);
+      expect(response(replacement, forged.requestId)).toMatchObject({
+        kind: 'error',
+        code: 'owner_mismatch',
+      });
+      const recovered = lookup(first);
+      await frame(f.doInstance, replacement, recovered);
+      expect(response(replacement, recovered.requestId)).toMatchObject({
+        kind: 'status',
+        job: { jobId: first.jobId },
+      });
+      await frame(f.doInstance, f.panel, resultMessage(first));
+      await quiesce(f, first);
+      await approve(f, other);
+      await frame(f.doInstance, f.panel, resultMessage(other));
+      const results = allSent(replacement).filter(
+        m => m.type === 'browser_event' && m.event === 'result'
+      );
+      expect(results).toMatchObject([
+        { requestId: recovered.requestId, result: { jobId: first.jobId } },
+      ]);
+      expect(results).toHaveLength(1);
+    });
+
+    it('restores running bindings after hibernation and preserves the nonce through CLI heartbeats', async () => {
+      const f = await browserSetup();
+      const active = await approve(f, await invoke(f));
+      const before = f.cli.deserializeAttachment() as { browserSocketId: string };
+      f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+      await negotiate(f.doInstance, f.cli, 'cli');
+      expect(f.cli.deserializeAttachment()).toMatchObject({
+        browserSocketId: before.browserSocketId,
+      });
+      await frame(f.doInstance, f.panel, resultMessage(active));
+      expect(job(f, active.jobId).status).toBe('succeeded');
+      expect(
+        allSent(f.cli).filter(m => m.type === 'browser_event' && m.event === 'result')
+      ).toMatchObject([{ result: { jobId: active.jobId } }]);
+      expect(providerJobs(f.panel)).toHaveLength(1);
+    });
+
+    it('interrupts unacknowledged dispatch after hibernation without sending another executable job', async () => {
+      const f = await browserSetup();
+      const active = await invoke(f);
+      const queued = await invoke(f, 2);
+      f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+      await f.doInstance.alarm();
+      await flushAsync();
+      expect(job(f, active.jobId)).toMatchObject({
+        status: 'interrupted',
+        result: { reason: 'provider_lost', effectsUncertain: true },
+      });
+      expect(job(f, queued.jobId).status).toBe('interrupted');
+      await invoke(f);
+      await approve(f, active);
+      expect(job(f, active.jobId).status).toBe('interrupted');
+      expect(providerJobs(f.panel)).toHaveLength(1);
+      expect(f.ctx.storage.store.get(`browser/provider/${active.providerId}`)).toMatchObject({
+        fence: { jobId: active.jobId, requiresRecovery: true },
+      });
+    });
+
+    it('requires the provider proof and explicit affected-tab recovery before granting a fresh generation', async () => {
+      const f = await browserSetup();
+      const active = await approve(f, await invoke(f));
+      const queued = await invoke(f, 2);
+      await f.doInstance.webSocketClose(f.panel as never, 1000, 'closed', true);
+      const replacement = connectWebSocket(f.doInstance, 'panel');
+      await negotiate(f.doInstance, replacement, 'web');
+      await frame(f.doInstance, replacement, {
+        ...registration,
+        providerProof: 'd'.repeat(64),
+        generation: active.generation,
+      });
+      expect(allSent(replacement).at(-1)).toMatchObject({
+        type: 'response',
+        error: { code: 'owner_mismatch' },
+      });
+      const recover = {
+        ...registration,
+        generation: active.generation,
+        recovery: {
+          invocationId: active.invocationId,
+          tabId: tab.tabId,
+          tabClosed: true,
+          locksDrained: true,
+        },
+      };
+      for (const fields of [{ tabId: 99 }, { tabClosed: false }, { locksDrained: false }]) {
+        await frame(f.doInstance, replacement, {
+          ...recover,
+          recovery: { ...recover.recovery, ...fields },
+        });
+        expect(f.ctx.storage.store.get(`browser/provider/${active.providerId}`)).toMatchObject({
+          fence: { jobId: active.jobId },
+        });
+      }
+      await frame(f.doInstance, replacement, recover);
+      expect(allSent(replacement)).toContainEqual(
+        expect.objectContaining({ type: 'provider_lease_ack', generation: active.generation + 1 })
+      );
+      expect(job(f, queued.jobId).status).toBe('interrupted');
+      expect(providerJobs(replacement)).toEqual([]);
+      await frame(f.doInstance, f.panel, {
+        type: 'provider_quiesced',
+        ...binding(active),
+        tabId: tab.tabId,
+      });
+      const continuation = await invoke(f, 3, { browserTaskId: active.browserTaskId });
+      expect(continuation.status).toBe('awaiting_approval');
+      expect(providerJobs(replacement).map(j => j.jobId)).toEqual([continuation.jobId]);
+      expect(providerJobs(f.panel)).toHaveLength(1);
+    });
+
+    it('does not deliver a terminal result before its transaction commits', async () => {
+      const f = await browserSetup();
+      const active = await approve(f, await invoke(f));
+      const transaction = f.ctx.storage.transaction.getMockImplementation();
+      if (!transaction) throw new Error('Missing transaction fake');
+      const arrived = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      f.ctx.storage.transaction.mockImplementationOnce(run =>
+        transaction(async tx => {
+          const value = await run(tx);
+          arrived.resolve();
+          await release.promise;
+          return value;
+        })
+      );
+      const pending = f.doInstance.webSocketMessage(
+        f.panel as never,
+        JSON.stringify(resultMessage(active))
+      );
+      await arrived.promise;
+      expect(job(f, active.jobId).status).toBe('running');
+      expect(
+        allSent(f.cli).filter(m => m.type === 'browser_event' && m.event === 'result')
+      ).toEqual([]);
+      release.resolve();
+      await pending;
+      expect(job(f, active.jobId).status).toBe('succeeded');
+      expect(
+        allSent(f.cli).filter(m => m.type === 'browser_event' && m.event === 'result')
+      ).toMatchObject([{ result: { jobId: active.jobId, status: 'succeeded' } }]);
+    });
+
+    it('settles a cancellation/result race once and never replaces its terminal result', async () => {
+      const f = await browserSetup();
+      const active = await approve(f, await invoke(f));
+      await Promise.all([
+        frame(f.doInstance, f.cli, lookup(active, 'cancel')),
+        frame(f.doInstance, f.panel, resultMessage(active)),
+      ]);
+      expect(job(f, active.jobId).status).toBe('cancelled');
+      f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+      await frame(f.doInstance, f.panel, resultMessage(active));
+      expect(job(f, active.jobId).status).toBe('cancelled');
+      expect(
+        allSent(f.cli).filter(m => m.type === 'browser_event' && m.event === 'result')
+      ).toHaveLength(1);
+    });
+
+    it.each(['queue', 'approval', 'execution', 'lease'] as const)(
+      'settles the %s deadline with a finite, distinct result and no replay',
+      async phase => {
+        const f = await browserSetup();
+        let active = await invoke(f);
+        if (phase !== 'approval') active = await approve(f, active);
+        let timed = active;
+        if (phase === 'queue') {
+          await frame(f.doInstance, f.panel, resultMessage(active));
+          timed = await invoke(f, 2);
+        }
+        const duration =
+          phase === 'queue'
+            ? BROWSER_QUEUE_TIMEOUT_MS
+            : phase === 'approval'
+              ? BROWSER_APPROVAL_TIMEOUT_MS
+              : phase === 'execution'
+                ? BROWSER_EXECUTION_TIMEOUT_MS
+                : BROWSER_LEASE_MS;
+        if (phase !== 'lease') {
+          for (let elapsed = 10_000; elapsed < duration; elapsed += 10_000) {
+            vi.mocked(Date.now).mockReturnValue(now + elapsed);
+            await heartbeat(f);
+            await negotiate(f.doInstance, f.cli, 'cli');
+          }
+        }
+        vi.mocked(Date.now).mockReturnValue(now + duration);
+        await f.doInstance.alarm();
+        await flushAsync();
+        expect(job(f, timed.jobId)).toMatchObject({
+          status: phase === 'lease' ? 'interrupted' : 'timed_out',
+          result: { reason: phase === 'lease' ? 'lease_expired' : `${phase}_timeout` },
+        });
+        expect(
+          allSent(f.cli).filter(m => m.type === 'browser_event' && m.event === 'result')
+        ).toContainEqual(
+          expect.objectContaining({
+            result: expect.objectContaining({
+              jobId: timed.jobId,
+              reason: phase === 'lease' ? 'lease_expired' : `${phase}_timeout`,
+            }),
+          })
+        );
+        await frame(f.doInstance, f.panel, resultMessage(timed));
+        expect(job(f, timed.jobId).status).not.toBe('succeeded');
+        expect(providerJobs(f.panel)).toHaveLength(1);
+      }
+    );
+
+    it('settles encoded retention before cleanup and retains the unresolved execution fence', async () => {
+      const f = await browserSetup();
+      const active = await approve(
+        f,
+        await invoke(f, 1, {
+          invocationId: `b1.${now - BROWSER_RETENTION_MS + 1_000}.${'1'.padStart(64, '0')}`,
+        })
+      );
+      expect(f.ctx.storage.alarmAt).toBe(now + 1_000);
+      vi.mocked(Date.now).mockReturnValue(now + 1_000);
+      await f.doInstance.alarm();
+      await flushAsync();
+      expect(f.ctx.storage.store.has(`browser/job/${active.jobId}`)).toBe(false);
+      expect(
+        allSent(f.cli).filter(m => m.type === 'browser_event' && m.event === 'result')
+      ).toMatchObject([
+        { result: { jobId: active.jobId, status: 'timed_out', reason: 'invocation_expired' } },
+      ]);
+      expect(f.ctx.storage.store.get(`browser/provider/${active.providerId}`)).toMatchObject({
+        fence: { jobId: active.jobId, requiresRecovery: true },
+      });
+      const expired: BrowserRequest = {
+        type: 'browser_request',
+        operation: 'recover',
+        requestId: crypto.randomUUID(),
+        owner,
+        invocationId: active.invocationId,
+      };
+      await frame(f.doInstance, f.cli, expired);
+      expect(response(f.cli, expired.requestId)).toMatchObject({
+        kind: 'error',
+        code: 'invocation_expired',
+        retryable: false,
+      });
+      f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+      await f.doInstance.alarm();
+      expect(providerJobs(f.panel)).toHaveLength(1);
+      expect(allSent(f.panel).filter(m => m.type === 'provider_job_cancel').length).toBeGreaterThan(
+        0
+      );
+    });
+
+    it.each([
+      ['missing expiry', {}],
+      ['not-a-number expiry', { expiresAt: NaN }],
+      ['infinite expiry', { expiresAt: Infinity }],
+      ['null record', null],
+    ])('arms a browser deadline despite a legacy command with %s', async (_name, legacy) => {
+      const f = await browserSetup();
+      await f.ctx.storage.put('pendingCommand/old-format', legacy);
+      await invoke(f, 1, {
+        invocationId: `b1.${now - BROWSER_RETENTION_MS + 1_000}.${'1'.padStart(64, '0')}`,
+      });
+      expect(f.ctx.storage.alarmAt).toBe(now + 1_000);
+    });
+
+    it('composes ready pushes, durable commands, leases, CLI eviction, and retention after hibernation', async () => {
+      const f = await browserSetup();
+      const active = await approve(f, await invoke(f));
+      await f.ctx.storage.put('readyPush:ses_ready', {
+        kiloUserId: 'usr_1',
+        title: 'Ready',
+        fireAt: now + 5_000,
+        attempts: 0,
+      });
+      await f.ctx.storage.put('pendingCommand/legacy', {
+        originalId: 'legacy',
+        command: 'send_message',
+        targetConnectionId: 'cli-browser',
+        webConnectionId: 'viewer',
+        expiresAt: now + 7_000,
+        state: 'pending',
+      });
+      f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+      await f.doInstance.alarm();
+      expect(f.ctx.storage.alarmAt).toBe(now + 5_000);
+      vi.mocked(Date.now).mockReturnValue(now + 5_000);
+      await f.doInstance.alarm();
+      expect(f.ctx.storage.store.has('readyPush:ses_ready')).toBe(false);
+      expect(f.ctx.storage.alarmAt).toBe(now + 7_000);
+      vi.mocked(Date.now).mockReturnValue(now + 7_000);
+      await f.doInstance.alarm();
+      await flushAsync();
+      expect(allSent(f.viewer)).toContainEqual({
+        type: 'response',
+        id: 'legacy',
+        error: { source: 'relay', code: 'COMMAND_EXPIRED', message: 'Command expired' },
+      });
+      await f.doInstance.alarm();
+      expect(f.ctx.storage.store.has('pendingCommand/legacy')).toBe(false);
+      expect(f.ctx.storage.alarmAt).toBe(now + BROWSER_LEASE_MS);
+      vi.mocked(Date.now).mockReturnValue(now + BROWSER_LEASE_MS);
+      await f.doInstance.alarm();
+      expect(job(f, active.jobId).result?.reason).toBe('lease_expired');
+      expect(f.ctx.storage.alarmAt).toBe(now + 30_000);
+      vi.mocked(Date.now).mockReturnValue(now + 30_000);
+      await f.doInstance.alarm();
+      expect(f.cli.close.mock.calls).toContainEqual([4408, 'heartbeat timeout']);
+      expect(f.ctx.storage.alarmAt).toBe(now + BROWSER_RETENTION_MS);
+      vi.mocked(Date.now).mockReturnValue(now + BROWSER_RETENTION_MS);
+      await f.doInstance.alarm();
+      expect(f.ctx.storage.store.has(`browser/job/${active.jobId}`)).toBe(false);
+      expect(f.ctx.storage.alarmAt).toBeNull();
+    });
+
+    it('does not extend a provider lease through CLI traffic or queue snapshots', async () => {
+      const f = await browserSetup();
+      const active = await approve(f, await invoke(f));
+      vi.mocked(Date.now).mockReturnValue(now + 10_000);
+      await negotiate(f.doInstance, f.cli, 'cli');
+      const queued = await invoke(f, 2);
+      expect(f.ctx.storage.alarmAt).toBe(now + BROWSER_LEASE_MS);
+      vi.mocked(Date.now).mockReturnValue(now + BROWSER_LEASE_MS);
+      await f.doInstance.alarm();
+      expect(job(f, active.jobId).result?.reason).toBe('lease_expired');
+      expect(job(f, queued.jobId).result?.reason).toBe('provider_unavailable');
+    });
+
+    it('keeps independent provider snapshots and parent results on their proven sockets', async () => {
+      const f = await browserSetup();
+      const panel = addWebSocket(f.mockCtx, 'second-profile');
+      const cli = addCliSocket(f.mockCtx, 'second-process', [], undefined, 'usr_1');
+      await negotiate(f.doInstance, panel, 'web');
+      await negotiate(f.doInstance, cli, 'cli');
+      const providerId = 'bp_00000000-0000-4000-8000-000000000002';
+      await frame(f.doInstance, panel, {
+        ...registration,
+        providerId,
+        providerProof: 'e'.repeat(64),
+        label: 'Personal profile',
+      });
+      const first = await approve(f, await invoke(f));
+      const second = await invoke(f, 2, { owner: otherOwner, providerId }, cli);
+      expect(providerJobs(panel).map(j => j.jobId)).toEqual([second.jobId]);
+      expect(providerJobs(f.panel).map(j => j.jobId)).toEqual([first.jobId]);
+      await frame(f.doInstance, panel, {
+        type: 'provider_approval',
+        ...binding(second),
+        approval: { decision: 'approved', tab },
+      });
+      await frame(f.doInstance, panel, resultMessage(second));
+      await frame(f.doInstance, f.panel, resultMessage(first));
+      expect(
+        allSent(cli).filter(m => m.type === 'browser_event' && m.event === 'result')
+      ).toMatchObject([{ result: { jobId: second.jobId } }]);
+      expect(
+        allSent(f.cli).filter(m => m.type === 'browser_event' && m.event === 'result')
+      ).toMatchObject([{ result: { jobId: first.jobId } }]);
+      expect(
+        allSent(panel)
+          .filter(m => m.type === 'provider_snapshot')
+          .every(m => m.providerId === providerId)
+      ).toBe(true);
+      expect(allSent(f.viewer).filter(m => m.type !== 'system')).toEqual([]);
+    });
+
+    it('does not publish uncommitted admission or give a racing same-ID replacement its authority', async () => {
+      const f = await browserSetup();
+      const transaction = f.ctx.storage.transaction.getMockImplementation();
+      if (!transaction) throw new Error('Missing transaction fake');
+      const arrived = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      f.ctx.storage.transaction.mockImplementationOnce(run =>
+        transaction(async tx => {
+          const value = await run(tx);
+          arrived.resolve();
+          await release.promise;
+          return value;
+        })
+      );
+      const pending = f.doInstance.webSocketMessage(
+        f.cli as never,
+        JSON.stringify(invokeRequest())
+      );
+      await arrived.promise;
+      expect(allSent(f.cli).filter(m => m.type === 'browser_response')).toEqual([]);
+      expect(providerJobs(f.panel)).toEqual([]);
+      expect([...f.ctx.storage.store.keys()].filter(key => key.startsWith('browser/job/'))).toEqual(
+        []
+      );
+      const replacement = connectCliSocket(f.doInstance, 'cli-browser', 'usr_1');
+      await negotiate(f.doInstance, replacement, 'cli');
+      release.resolve();
+      await pending;
+      await flushAsync();
+      const active = providerJobs(f.panel)[0];
+      if (!active) throw new Error('Missing committed dispatch');
+      expect(allSent(replacement).filter(m => m.type === 'browser_event')).toEqual([]);
+      const forged = lookup(active, 'status', otherOwner);
+      await frame(f.doInstance, replacement, forged);
+      expect(response(replacement, forged.requestId)).toMatchObject({
+        kind: 'error',
+        code: 'owner_mismatch',
+      });
+      const proven = lookup(active);
+      await frame(f.doInstance, replacement, proven);
+      await approve(f, active);
+      await frame(f.doInstance, f.panel, resultMessage(active));
+      expect(
+        allSent(replacement).filter(m => m.type === 'browser_event' && m.event === 'result')
+      ).toMatchObject([{ requestId: proven.requestId, result: { jobId: active.jobId } }]);
+      expect(f.cli.deserializeAttachment()).toMatchObject({ replaced: true });
+    });
+
+    it('settles live provider replacement without waiting for a close callback or trusting the new connection ID', async () => {
+      const f = await browserSetup();
+      const active = await approve(f, await invoke(f));
+      const queued = await invoke(f, 2);
+      const replacement = connectWebSocket(f.doInstance, 'panel');
+      await negotiate(f.doInstance, replacement, 'web');
+      expect(job(f, active.jobId).status).toBe('interrupted');
+      expect(job(f, queued.jobId).status).toBe('interrupted');
+      expect(f.panel.deserializeAttachment()).toMatchObject({ replaced: true });
+      await frame(f.doInstance, replacement, { ...registration, generation: active.generation });
+      expect(allSent(replacement).at(-1)).toMatchObject({
+        type: 'response',
+        error: { code: 'provider_unavailable' },
+      });
+      await heartbeat(f, active.generation);
+      expect(f.ctx.storage.store.get(`browser/provider/${active.providerId}`)).toMatchObject({
+        fence: { jobId: active.jobId, requiresRecovery: true },
+      });
+      expect(providerJobs(replacement)).toEqual([]);
+    });
+
+    it('revokes browser capability without sending new frame types to the downgraded panel', async () => {
+      const f = await browserSetup();
+      const active = await approve(f, await invoke(f));
+      const queued = await invoke(f, 2);
+      f.panel.send.mockClear();
+      await frame(f.doInstance, f.panel, {
+        type: 'ping',
+        nonce: 'disabled',
+        capabilities: { browserJobsV1: false },
+      });
+      expect(job(f, active.jobId).status).toBe('interrupted');
+      expect(job(f, queued.jobId).status).toBe('interrupted');
+      expect(allSent(f.panel)).toEqual([{ type: 'pong', nonce: 'disabled' }]);
+      await heartbeat(f);
+      expect(allSent(f.panel)).toEqual([{ type: 'pong', nonce: 'disabled' }]);
+    });
+
+    it('settles revoked provider sockets before a delayed close callback', async () => {
+      const f = await browserSetup();
+      const active = await approve(f, await invoke(f));
+      const queued = await invoke(f, 2);
+      f.doInstance.closeViewerSockets();
+      await flushAsync();
+      expect(job(f, active.jobId).status).toBe('interrupted');
+      expect(job(f, queued.jobId).status).toBe('interrupted');
+      expect(f.panel.readyState).toBe(3);
+      expect(f.ctx.storage.store.get(`browser/provider/${active.providerId}`)).toMatchObject({
+        fence: { jobId: active.jobId, requiresRecovery: true },
+      });
+    });
+
+    it('rejects a prior provider socket even when it guesses the replacement generation', async () => {
+      const f = await browserSetup();
+      const replacement = addWebSocket(f.mockCtx, 'new-panel');
+      await negotiate(f.doInstance, replacement, 'web');
+      await frame(f.doInstance, replacement, registration);
+      const active = await invoke(f);
+      expect(active.generation).toBe(2);
+      const prior = {
+        type: 'provider_approval',
+        ...binding(active),
+        approval: { decision: 'approved', tab },
+      };
+      await frame(f.doInstance, f.panel, prior);
+      expect(job(f, active.jobId).status).toBe('awaiting_approval');
+      vi.mocked(Date.now).mockReturnValue(now + 10_000);
+      await heartbeat(f, active.generation);
+      expect(f.ctx.storage.alarmAt).toBe(now + BROWSER_LEASE_MS);
+      await frame(f.doInstance, replacement, prior);
+      expect(job(f, active.jobId).status).toBe('running');
+      expect(providerJobs(replacement)).toHaveLength(1);
+      expect(providerJobs(f.panel)).toEqual([]);
+    });
+
+    it('rejects cross-parent access with a valid foreign proof and rejects another authenticated user', async () => {
+      const f = await browserSetup();
+      const first = await invoke(f);
+      const second = await invoke(f, 2, { owner: otherOwner });
+      for (const [target, proof] of [
+        [first, otherOwner],
+        [second, owner],
+      ] as const) {
+        for (const operation of ['status', 'cancel'] as const) {
+          const request = lookup(target, operation, proof);
+          await frame(f.doInstance, f.cli, request);
+          expect(response(f.cli, request.requestId)).toMatchObject({
+            kind: 'error',
+            code: 'owner_mismatch',
+          });
+        }
+      }
+      const foreignUser = addCliSocket(f.mockCtx, 'foreign-user', [], undefined, 'usr_2');
+      await negotiate(f.doInstance, foreignUser, 'cli');
+      const request = lookup(first);
+      await frame(f.doInstance, foreignUser, request);
+      expect(response(foreignUser, request.requestId)).toMatchObject({
+        kind: 'error',
+        code: 'owner_mismatch',
+      });
+      expect(job(f, first.jobId).status).toBe('awaiting_approval');
+      expect(job(f, second.jobId).status).toBe('queued');
+    });
+
+    it('does not treat queued cancellation as acknowledgement of another dispatched invocation', async () => {
+      const f = await browserSetup();
+      const active = await invoke(f);
+      const queued = await invoke(f, 2);
+      await frame(f.doInstance, f.panel, { type: 'provider_cancel', ...binding(queued) });
+      f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+      await f.doInstance.alarm();
+      expect(job(f, active.jobId)).toMatchObject({
+        status: 'interrupted',
+        result: { reason: 'provider_lost' },
+      });
+      expect(job(f, queued.jobId).status).toBe('cancelled');
+      expect(providerJobs(f.panel)).toHaveLength(1);
+    });
+
+    it('returns a retryable queue-cap error without evicting accepted work', async () => {
+      const f = await browserSetup();
+      const active = await approve(f, await invoke(f));
+      for (let n = 2; n <= 101; n++) await invoke(f, n);
+      const overflow = invokeRequest(102);
+      await frame(f.doInstance, f.cli, overflow);
+      expect(response(f.cli, overflow.requestId)).toMatchObject({
+        kind: 'error',
+        code: 'capacity_exceeded',
+        retryable: true,
+      });
+      expect(
+        [...f.ctx.storage.store.keys()].filter(key => key.startsWith('browser/job/'))
+      ).toHaveLength(101);
+      expect(job(f, active.jobId).status).toBe('running');
+      expect(providerJobs(f.panel)).toHaveLength(1);
+    });
   });
 
   describe('notifySessionEvent', () => {
@@ -771,7 +2129,8 @@ describe('UserConnectionDO', () => {
       const cliWs = addCliSocket(mockCtx, 'cli-1');
 
       sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
-      expect(ctx.storage.setAlarm).toHaveBeenCalled();
+      await flushAsync();
+      expect(ctx.storage.alarmAt).toBeGreaterThan(Date.now());
     });
 
     it('sends heartbeat_ack to CLI socket', async () => {
@@ -1234,6 +2593,7 @@ describe('UserConnectionDO', () => {
         connectionId: 'viewer-1',
         subscribedSessions: [],
         kiloUserId: 'usr_1',
+        browserCapabilities: { browserJobsV1: false },
       });
     });
   });
@@ -2119,8 +3479,49 @@ describe('UserConnectionDO', () => {
       ctx.storage.setAlarm.mockClear();
       vi.mocked(Date.now).mockReturnValue(now + 20_000);
       sendHeartbeat(doInstance, cliWs, [makeSession('s1')]);
+      await flushAsync();
 
-      expect(ctx.storage.setAlarm).toHaveBeenCalledWith(now + 35_000);
+      expect(ctx.storage.alarmAt).toBe(now + 35_000);
+    });
+
+    it('does not delay a committed legacy command behind an unrelated alarm read', async () => {
+      const { doInstance, mockCtx, ctx } = setup();
+      const cli = addCliSocket(mockCtx, 'cli-1');
+      const nextOwner = addCliSocket(mockCtx, 'cli-2');
+      const web = addWebSocket(mockCtx);
+      sendHeartbeat(doInstance, cli, [makeSession('s1')]);
+      sendHeartbeat(doInstance, nextOwner, []);
+      await flushAsync();
+      const list = ctx.storage.list.getMockImplementation();
+      if (!list) throw new Error('Missing list fake');
+      const arrived = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      ctx.storage.list.mockImplementationOnce(async options => {
+        arrived.resolve();
+        await release.promise;
+        return list(options);
+      });
+      sendHeartbeat(doInstance, cli, [makeSession('s1')]);
+      await arrived.promise;
+      await sendCommand(doInstance, web, {
+        id: 'committed',
+        command: 'send_message',
+        sessionId: 's1',
+      });
+      const beforeOwnerChange = allSent(cli).filter(message => message.type === 'command');
+      sendHeartbeat(doInstance, nextOwner, [makeSession('s1')]);
+      await flushAsync();
+      release.resolve();
+      await flushAsync();
+      expect(beforeOwnerChange).toMatchObject([
+        { type: 'command', command: 'send_message', sessionId: 's1' },
+      ]);
+      expect(allSent(cli).filter(message => message.type === 'command')).toHaveLength(1);
+      expect(allSent(web)).toContainEqual({
+        type: 'response',
+        id: 'committed',
+        error: { source: 'relay', code: 'SESSION_OWNER_CHANGED', message: 'Session owner changed' },
+      });
     });
 
     it('expires pending commands during alarm processing', async () => {

--- a/services/session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.test.ts
@@ -661,6 +661,222 @@ describe('UserConnectionDO', () => {
       });
     }
 
+    describe('provider status', () => {
+      function historyRequest(): Extract<
+        BrowserProviderOutboundMessage,
+        { type: 'provider_status' }
+      > {
+        return {
+          type: 'provider_status',
+          requestId: crypto.randomUUID(),
+          providerId: registration.providerId,
+          providerProof: registration.providerProof,
+        };
+      }
+
+      it.each(['registered', 'unregistered'] as const)(
+        'returns prior-generation history privately to the %s requester without restoring execution',
+        async requester => {
+          const f = await browserSetup();
+          const first = await approve(f, await invoke(f));
+          await frame(f.doInstance, f.panel, resultMessage(first));
+          await quiesce(f, first);
+          const completed = job(f, first.jobId);
+          await frame(f.doInstance, f.panel, { ...registration, generation: first.generation });
+          const current = await invoke(f, 2);
+          expect(current.generation).toBeGreaterThan(completed.generation);
+          const reader =
+            requester === 'registered' ? f.panel : addWebSocket(f.mockCtx, 'history-reader');
+          if (requester === 'unregistered') await negotiate(f.doInstance, reader, 'web');
+          const request = historyRequest();
+          const before = structuredClone([...f.ctx.storage.store]);
+          const attachments = f.mockCtx.sockets.map(ws => ws.deserializeAttachment());
+          const alarmAt = f.ctx.storage.alarmAt;
+          for (const ws of f.mockCtx.sockets) ws.send.mockClear();
+          vi.mocked(Date.now).mockReturnValue(now + 1_000);
+          f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+
+          await frame(f.doInstance, reader, request);
+
+          expect(allSent(reader)).toEqual([
+            {
+              type: 'provider_status_result',
+              requestId: request.requestId,
+              providerId: registration.providerId,
+              jobs: expect.arrayContaining([completed, current]),
+            },
+          ]);
+          expect(allSent(reader)[0]?.jobs).toHaveLength(2);
+          for (const ws of f.mockCtx.sockets) {
+            if (ws !== reader) expect(allSent(ws)).toEqual([]);
+          }
+          expect([...f.ctx.storage.store]).toEqual(before);
+          expect(f.mockCtx.sockets.map(ws => ws.deserializeAttachment())).toEqual(attachments);
+          expect(f.ctx.storage.alarmAt).toBe(alarmAt);
+        }
+      );
+
+      it('returns fenced interruption history when reconnect registration fails', async () => {
+        const f = await browserSetup();
+        const active = await approve(f, await invoke(f));
+        await f.doInstance.webSocketClose(f.panel as never, 1000, 'closed', true);
+        const reader = addWebSocket(f.mockCtx, 'reconnected-reader');
+        await negotiate(f.doInstance, reader, 'web');
+        const attempt = { ...registration, generation: active.generation };
+        await frame(f.doInstance, reader, attempt);
+        expect(allSent(reader).at(-1)).toMatchObject({
+          type: 'response',
+          id: attempt.requestId,
+          error: { code: 'provider_unavailable', retryable: true },
+        });
+        const interrupted = job(f, active.jobId);
+        expect(interrupted).toMatchObject({
+          status: 'interrupted',
+          result: { reason: 'provider_lost', effectsUncertain: true },
+        });
+        const before = structuredClone([...f.ctx.storage.store]);
+        const attachments = f.mockCtx.sockets.map(ws => ws.deserializeAttachment());
+        for (const ws of f.mockCtx.sockets) ws.send.mockClear();
+        f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+        const request = historyRequest();
+
+        await frame(f.doInstance, reader, request);
+
+        expect(allSent(reader)).toEqual([
+          {
+            type: 'provider_status_result',
+            requestId: request.requestId,
+            providerId: active.providerId,
+            jobs: [interrupted],
+          },
+        ]);
+        for (const ws of f.mockCtx.sockets) {
+          if (ws !== reader) expect(allSent(ws)).toEqual([]);
+        }
+        expect([...f.ctx.storage.store]).toEqual(before);
+        expect(f.mockCtx.sockets.map(ws => ws.deserializeAttachment())).toEqual(attachments);
+        await frame(f.doInstance, reader, attempt);
+        expect(allSent(reader).at(-1)).toMatchObject({
+          type: 'response',
+          id: attempt.requestId,
+          error: { code: 'provider_unavailable', retryable: true },
+        });
+        expect(providerJobs(reader)).toEqual([]);
+      });
+
+      it.each([
+        { name: 'wrong proof', kiloUserId: 'usr_1', providerProof: 'd'.repeat(64) },
+        { name: 'wrong user', kiloUserId: 'usr_2', providerProof: registration.providerProof },
+      ])(
+        'correlates a $name failure without exposing history or changing authority',
+        async fields => {
+          const f = await browserSetup();
+          await invoke(f);
+          const reader = addWebSocket(f.mockCtx, 'denied-reader', [], fields.kiloUserId);
+          await negotiate(f.doInstance, reader, 'web');
+          const request = { ...historyRequest(), providerProof: fields.providerProof };
+          const before = structuredClone([...f.ctx.storage.store]);
+          const attachments = f.mockCtx.sockets.map(ws => ws.deserializeAttachment());
+          for (const ws of f.mockCtx.sockets) ws.send.mockClear();
+          f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+
+          await frame(f.doInstance, reader, request);
+
+          expect(allSent(reader)).toEqual([
+            {
+              type: 'response',
+              id: request.requestId,
+              error: {
+                source: 'relay',
+                code: 'owner_mismatch',
+                message: 'Browser job request rejected: owner_mismatch',
+                retryable: false,
+              },
+            },
+          ]);
+          for (const ws of f.mockCtx.sockets) {
+            if (ws !== reader) expect(allSent(ws)).toEqual([]);
+          }
+          expect([...f.ctx.storage.store]).toEqual(before);
+          expect(f.mockCtx.sockets.map(ws => ws.deserializeAttachment())).toEqual(attachments);
+        }
+      );
+
+      it.each(['CLI', 'unnegotiated web'] as const)(
+        'exposes no history to a %s requester with a valid provider proof',
+        async requester => {
+          const f = await browserSetup();
+          await invoke(f);
+          const reader = requester === 'CLI' ? f.cli : f.viewer;
+          const before = structuredClone([...f.ctx.storage.store]);
+          const attachments = f.mockCtx.sockets.map(ws => ws.deserializeAttachment());
+          for (const ws of f.mockCtx.sockets) ws.send.mockClear();
+
+          await frame(f.doInstance, reader, historyRequest());
+
+          for (const ws of f.mockCtx.sockets) expect(allSent(ws)).toEqual([]);
+          expect([...f.ctx.storage.store]).toEqual(before);
+          expect(f.mockCtx.sockets.map(ws => ws.deserializeAttachment())).toEqual(attachments);
+        }
+      );
+
+      it('returns an empty history without renewing an expired lease or changing its alarm', async () => {
+        const f = await browserSetup();
+        const reader = addWebSocket(f.mockCtx, 'empty-history-reader');
+        await negotiate(f.doInstance, reader, 'web');
+        const request = historyRequest();
+        const before = structuredClone([...f.ctx.storage.store]);
+        const attachment = reader.deserializeAttachment();
+        const alarmAt = f.ctx.storage.alarmAt;
+        for (const ws of f.mockCtx.sockets) ws.send.mockClear();
+        vi.mocked(Date.now).mockReturnValue(now + BROWSER_LEASE_MS + 1);
+
+        await frame(f.doInstance, reader, request);
+
+        expect(allSent(reader)).toEqual([
+          {
+            type: 'provider_status_result',
+            requestId: request.requestId,
+            providerId: registration.providerId,
+            jobs: [],
+          },
+        ]);
+        for (const ws of f.mockCtx.sockets) {
+          if (ws !== reader) expect(allSent(ws)).toEqual([]);
+        }
+        expect([...f.ctx.storage.store]).toEqual(before);
+        expect(reader.deserializeAttachment()).toEqual(attachment);
+        expect(f.ctx.storage.alarmAt).toBe(alarmAt);
+      });
+
+      it('rejects unknown history without creating provider or socket authority', async () => {
+        const f = setup();
+        const reader = addWebSocket(f.mockCtx, 'unknown-history-reader');
+        await negotiate(f.doInstance, reader, 'web');
+        reader.send.mockClear();
+        const attachment = reader.deserializeAttachment();
+        const request = historyRequest();
+
+        await frame(f.doInstance, reader, request);
+
+        expect(allSent(reader)).toEqual([
+          {
+            type: 'response',
+            id: request.requestId,
+            error: {
+              source: 'relay',
+              code: 'not_found',
+              message: 'Browser job request rejected: not_found',
+              retryable: false,
+            },
+          },
+        ]);
+        expect([...f.ctx.storage.store]).toEqual([]);
+        expect(reader.deserializeAttachment()).toEqual(attachment);
+        expect(f.ctx.storage.alarmAt).toBeNull();
+      });
+    });
+
     it('negotiates through legacy acknowledgements and sends no browser frames before opt-in', async () => {
       const { doInstance, mockCtx } = setup();
       const cli = addCliSocket(mockCtx, 'cli', [], undefined, 'usr_1');

--- a/services/session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.test.ts
@@ -662,6 +662,14 @@ describe('UserConnectionDO', () => {
     }
 
     describe('provider status', () => {
+      const otherRegistration = {
+        ...registration,
+        requestId: '00000000-0000-4000-8000-000000000002',
+        providerId: 'bp_00000000-0000-4000-8000-000000000002',
+        providerProof: 'd'.repeat(64),
+        label: 'Other profile',
+      } satisfies BrowserProviderOutboundMessage;
+
       function historyRequest(): Extract<
         BrowserProviderOutboundMessage,
         { type: 'provider_status' }
@@ -704,6 +712,7 @@ describe('UserConnectionDO', () => {
               requestId: request.requestId,
               providerId: registration.providerId,
               jobs: expect.arrayContaining([completed, current]),
+              unresolvedFence: { invocationId: current.invocationId },
             },
           ]);
           expect(allSent(reader)[0]?.jobs).toHaveLength(2);
@@ -716,67 +725,134 @@ describe('UserConnectionDO', () => {
         }
       );
 
-      it('returns fenced interruption history when reconnect registration fails', async () => {
-        const f = await browserSetup();
-        const active = await approve(f, await invoke(f));
-        await f.doInstance.webSocketClose(f.panel as never, 1000, 'closed', true);
-        const reader = addWebSocket(f.mockCtx, 'reconnected-reader');
-        await negotiate(f.doInstance, reader, 'web');
-        const attempt = { ...registration, generation: active.generation };
-        await frame(f.doInstance, reader, attempt);
-        expect(allSent(reader).at(-1)).toMatchObject({
-          type: 'response',
-          id: attempt.requestId,
-          error: { code: 'provider_unavailable', retryable: true },
-        });
-        const interrupted = job(f, active.jobId);
-        expect(interrupted).toMatchObject({
-          status: 'interrupted',
-          result: { reason: 'provider_lost', effectsUncertain: true },
-        });
-        const before = structuredClone([...f.ctx.storage.store]);
-        const attachments = f.mockCtx.sockets.map(ws => ws.deserializeAttachment());
-        for (const ws of f.mockCtx.sockets) ws.send.mockClear();
-        f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
-        const request = historyRequest();
+      it.each(['awaiting_approval', 'running'] as const)(
+        'returns the %s fence privately after registration refusal and history expiry',
+        async phase => {
+          const f = await browserSetup();
+          let active = await invoke(f, 1, {
+            invocationId: `b1.${now - BROWSER_RETENTION_MS + 1_000}.${'1'.padStart(64, '0')}`,
+          });
+          if (phase === 'running') active = await approve(f, active);
+          expect(active.status).toBe(phase);
+          await f.doInstance.webSocketClose(f.panel as never, 1000, 'closed', true);
+          const interrupted = job(f, active.jobId);
+          expect(interrupted).toMatchObject({
+            status: 'interrupted',
+            result: { reason: 'provider_lost', effectsUncertain: true },
+          });
+          const otherPanel = addWebSocket(f.mockCtx, 'other-provider');
+          await negotiate(f.doInstance, otherPanel, 'web');
+          await frame(f.doInstance, otherPanel, otherRegistration);
+          expect(otherPanel.deserializeAttachment()).toMatchObject({
+            browserProvider: { providerId: otherRegistration.providerId },
+          });
+          addWebSocket(f.mockCtx, 'history-subscriber', [owner.parentSessionId]);
+          const reader = addWebSocket(f.mockCtx, 'reconnected-reader');
+          await negotiate(f.doInstance, reader, 'web');
 
-        await frame(f.doInstance, reader, request);
+          for (const expired of [false, true]) {
+            if (expired) {
+              vi.mocked(Date.now).mockReturnValue(now + 1_000);
+              await f.doInstance.alarm();
+              await flushAsync();
+              expect(f.ctx.storage.store.has(`browser/job/${active.jobId}`)).toBe(false);
+            }
+            const attempt = {
+              ...registration,
+              requestId: crypto.randomUUID(),
+              generation: active.generation,
+            };
+            await frame(f.doInstance, reader, attempt);
+            expect(allSent(reader).at(-1)).toMatchObject({
+              type: 'response',
+              id: attempt.requestId,
+              error: { code: 'provider_unavailable', retryable: true },
+            });
+            expect(reader.deserializeAttachment()).not.toHaveProperty('browserProvider');
+            const before = structuredClone([...f.ctx.storage.store]);
+            const attachments = f.mockCtx.sockets.map(ws => ws.deserializeAttachment());
+            const alarmAt = f.ctx.storage.alarmAt;
+            for (const ws of f.mockCtx.sockets) ws.send.mockClear();
+            f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+            const request = historyRequest();
 
-        expect(allSent(reader)).toEqual([
-          {
-            type: 'provider_status_result',
-            requestId: request.requestId,
-            providerId: active.providerId,
-            jobs: [interrupted],
-          },
-        ]);
-        for (const ws of f.mockCtx.sockets) {
-          if (ws !== reader) expect(allSent(ws)).toEqual([]);
+            await frame(f.doInstance, reader, request);
+
+            expect(allSent(reader)).toEqual([
+              {
+                type: 'provider_status_result',
+                requestId: request.requestId,
+                providerId: active.providerId,
+                jobs: expired ? [] : [interrupted],
+                unresolvedFence:
+                  phase === 'running'
+                    ? { invocationId: active.invocationId, tabId: tab.tabId }
+                    : { invocationId: active.invocationId },
+              },
+            ]);
+            for (const ws of f.mockCtx.sockets) {
+              if (ws !== reader) expect(allSent(ws)).toEqual([]);
+            }
+            expect([...f.ctx.storage.store]).toEqual(before);
+            expect(f.mockCtx.sockets.map(ws => ws.deserializeAttachment())).toEqual(attachments);
+            expect(f.ctx.storage.alarmAt).toBe(alarmAt);
+            await frame(f.doInstance, reader, attempt);
+            expect(allSent(reader).at(-1)).toMatchObject({
+              type: 'response',
+              id: attempt.requestId,
+              error: { code: 'provider_unavailable', retryable: true },
+            });
+            expect(providerJobs(reader)).toEqual([]);
+          }
         }
-        expect([...f.ctx.storage.store]).toEqual(before);
-        expect(f.mockCtx.sockets.map(ws => ws.deserializeAttachment())).toEqual(attachments);
-        await frame(f.doInstance, reader, attempt);
-        expect(allSent(reader).at(-1)).toMatchObject({
-          type: 'response',
-          id: attempt.requestId,
-          error: { code: 'provider_unavailable', retryable: true },
-        });
-        expect(providerJobs(reader)).toEqual([]);
-      });
+      );
 
       it.each([
-        { name: 'wrong proof', kiloUserId: 'usr_1', providerProof: 'd'.repeat(64) },
-        { name: 'wrong user', kiloUserId: 'usr_2', providerProof: registration.providerProof },
+        {
+          name: 'wrong proof',
+          kiloUserId: 'usr_1',
+          providerId: registration.providerId,
+          providerProof: 'e'.repeat(64),
+        },
+        {
+          name: 'wrong user',
+          kiloUserId: 'usr_2',
+          providerId: registration.providerId,
+          providerProof: registration.providerProof,
+        },
+        {
+          name: 'wrong provider',
+          kiloUserId: 'usr_1',
+          providerId: otherRegistration.providerId,
+          providerProof: registration.providerProof,
+        },
       ])(
-        'correlates a $name failure without exposing history or changing authority',
+        'correlates a $name failure without exposing an expired fence or changing authority',
         async fields => {
           const f = await browserSetup();
-          await invoke(f);
+          const active = await approve(
+            f,
+            await invoke(f, 1, {
+              invocationId: `b1.${now - BROWSER_RETENTION_MS + 1_000}.${'1'.padStart(64, '0')}`,
+            })
+          );
+          const otherPanel = addWebSocket(f.mockCtx, 'other-provider');
+          await negotiate(f.doInstance, otherPanel, 'web');
+          await frame(f.doInstance, otherPanel, otherRegistration);
+          vi.mocked(Date.now).mockReturnValue(now + 1_000);
+          await f.doInstance.alarm();
+          await flushAsync();
+          expect(f.ctx.storage.store.has(`browser/job/${active.jobId}`)).toBe(false);
           const reader = addWebSocket(f.mockCtx, 'denied-reader', [], fields.kiloUserId);
           await negotiate(f.doInstance, reader, 'web');
-          const request = { ...historyRequest(), providerProof: fields.providerProof };
+          const request = {
+            ...historyRequest(),
+            providerId: fields.providerId,
+            providerProof: fields.providerProof,
+          };
           const before = structuredClone([...f.ctx.storage.store]);
           const attachments = f.mockCtx.sockets.map(ws => ws.deserializeAttachment());
+          const alarmAt = f.ctx.storage.alarmAt;
           for (const ws of f.mockCtx.sockets) ws.send.mockClear();
           f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
 
@@ -799,15 +875,22 @@ describe('UserConnectionDO', () => {
           }
           expect([...f.ctx.storage.store]).toEqual(before);
           expect(f.mockCtx.sockets.map(ws => ws.deserializeAttachment())).toEqual(attachments);
+          expect(f.ctx.storage.alarmAt).toBe(alarmAt);
         }
       );
 
-      it.each(['CLI', 'unnegotiated web'] as const)(
-        'exposes no history to a %s requester with a valid provider proof',
+      it.each(['CLI', 'unnegotiated web', 'unauthenticated web'] as const)(
+        'exposes no history or fence to a %s requester with a valid provider proof',
         async requester => {
           const f = await browserSetup();
           await invoke(f);
-          const reader = requester === 'CLI' ? f.cli : f.viewer;
+          const reader =
+            requester === 'CLI'
+              ? f.cli
+              : requester === 'unnegotiated web'
+                ? f.viewer
+                : addWebSocket(f.mockCtx, 'unauthenticated-reader', [], '');
+          if (requester === 'unauthenticated web') await negotiate(f.doInstance, reader, 'web');
           const before = structuredClone([...f.ctx.storage.store]);
           const attachments = f.mockCtx.sockets.map(ws => ws.deserializeAttachment());
           for (const ws of f.mockCtx.sockets) ws.send.mockClear();

--- a/services/session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.test.ts
@@ -43,6 +43,7 @@ import {
   BROWSER_RETENTION_MS,
 } from './browser-job-store';
 import {
+  BROWSER_PAGE_SIZE,
   browserCLIInboundMessageSchema,
   browserProviderInboundMessageSchema,
   browserJobSnapshotSchema,
@@ -682,6 +683,163 @@ describe('UserConnectionDO', () => {
         };
       }
 
+      it.each(['provider_snapshot', 'provider_status_result'] as const)(
+        'preserves trusted owners and global queue positions in %s pages',
+        async responseType => {
+          const f = await browserSetup();
+          // Reverse job IDs so page order differs from equal-time FIFO admission.
+          let uuid = 1_000;
+          vi.spyOn(crypto, 'randomUUID').mockImplementation(
+            () => `00000000-0000-4000-8000-${(uuid--).toString(16).padStart(12, '0')}`
+          );
+          const active = await approve(f, await invoke(f));
+          const expected: BrowserJobSnapshot[] = [{ ...active, ownerLabel: owner.parentSessionId }];
+          for (let position = 1; position <= BROWSER_PAGE_SIZE + 1; position++) {
+            const queuedOwner = position % 2 === 0 ? otherOwner : owner;
+            const queued = await invoke(f, position + 1, {
+              owner: queuedOwner,
+              goal: `Owner: untrusted-${position}`,
+            });
+            expected.push({
+              ...queued,
+              ownerLabel: queuedOwner.parentSessionId,
+              queuePosition: position,
+            });
+          }
+          const reader =
+            responseType === 'provider_snapshot'
+              ? f.panel
+              : addWebSocket(f.mockCtx, 'queue-history-reader');
+          if (reader !== f.panel) await negotiate(f.doInstance, reader, 'web');
+          const before = structuredClone([...f.ctx.storage.store]);
+          const attachments = f.mockCtx.sockets.map(ws => ws.deserializeAttachment());
+          const alarmAt = f.ctx.storage.alarmAt;
+          for (const ws of f.mockCtx.sockets) ws.send.mockClear();
+          f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
+          const pageOrder = expected.toReversed();
+          let cursor: BrowserJobSnapshot['jobId'] | undefined;
+
+          for (const pageNumber of [0, 1]) {
+            const requestId = crypto.randomUUID();
+            await frame(
+              f.doInstance,
+              reader,
+              responseType === 'provider_snapshot'
+                ? {
+                    type: 'provider_heartbeat',
+                    providerId: registration.providerId,
+                    generation: active.generation,
+                    requestId,
+                    cursor,
+                  }
+                : { ...historyRequest(), requestId, cursor }
+            );
+            const page = browserProviderInboundMessageSchema.parse(
+              allSent(reader).findLast(message => message.type === responseType)
+            );
+            if (page.type !== 'provider_snapshot' && page.type !== 'provider_status_result') {
+              throw new Error('Missing provider page');
+            }
+            const expectedJobs = pageOrder.slice(
+              pageNumber * BROWSER_PAGE_SIZE,
+              (pageNumber + 1) * BROWSER_PAGE_SIZE
+            );
+            expect(page).toEqual({
+              type: responseType,
+              requestId,
+              providerId: registration.providerId,
+              ...(responseType === 'provider_snapshot'
+                ? { generation: active.generation }
+                : { unresolvedFence: { invocationId: active.invocationId, tabId: tab.tabId } }),
+              jobs: expectedJobs,
+              ...(pageNumber === 0 ? { nextCursor: expectedJobs.at(-1)?.jobId } : {}),
+            });
+            cursor = page.nextCursor;
+          }
+
+          expect(allSent(reader).map(message => message.type)).toEqual(
+            responseType === 'provider_snapshot'
+              ? [
+                  'provider_lease_ack',
+                  'provider_snapshot',
+                  'provider_lease_ack',
+                  'provider_snapshot',
+                ]
+              : ['provider_status_result', 'provider_status_result']
+          );
+          for (const ws of f.mockCtx.sockets) {
+            if (ws !== reader) expect(allSent(ws)).toEqual([]);
+          }
+          expect([...f.ctx.storage.store]).toEqual(before);
+          expect(f.mockCtx.sockets.map(ws => ws.deserializeAttachment())).toEqual(attachments);
+          expect(f.ctx.storage.alarmAt).toBe(alarmAt);
+        }
+      );
+
+      it.each(['foreign socket', 'prior socket', 'stale generation', 'future generation'] as const)(
+        'rejects snapshot metadata for a %s',
+        async caller => {
+          const f = await browserSetup();
+          const prior = f.panel;
+          f.panel = addWebSocket(f.mockCtx, 'current-panel');
+          await negotiate(f.doInstance, f.panel, 'web');
+          await frame(f.doInstance, f.panel, registration);
+          const active = await approve(f, await invoke(f));
+          const queued = await invoke(f, 2, { owner: otherOwner });
+          await invoke(f, 3);
+          const reader =
+            caller === 'foreign socket'
+              ? addWebSocket(f.mockCtx, 'foreign-reader')
+              : caller === 'prior socket'
+                ? prior
+                : f.panel;
+          if (caller === 'foreign socket') {
+            await negotiate(f.doInstance, reader, 'web');
+            await frame(f.doInstance, reader, historyRequest());
+            expect(allSent(reader).at(-1)).toMatchObject({
+              type: 'provider_status_result',
+              jobs: expect.arrayContaining([
+                { ...queued, ownerLabel: otherOwner.parentSessionId, queuePosition: 1 },
+              ]),
+            });
+          }
+          const request = {
+            type: 'provider_heartbeat',
+            requestId: crypto.randomUUID(),
+            providerId: registration.providerId,
+            generation:
+              caller === 'stale generation'
+                ? active.generation - 1
+                : caller === 'future generation'
+                  ? active.generation + 1
+                  : active.generation,
+          } satisfies BrowserProviderOutboundMessage;
+          const before = structuredClone([...f.ctx.storage.store]);
+          const alarmAt = f.ctx.storage.alarmAt;
+          for (const ws of f.mockCtx.sockets) ws.send.mockClear();
+
+          await frame(f.doInstance, reader, request);
+
+          expect(allSent(reader)).toEqual([
+            {
+              type: 'response',
+              id: request.requestId,
+              error: {
+                source: 'relay',
+                code: 'owner_mismatch',
+                message: 'Browser job request rejected: owner_mismatch',
+                retryable: false,
+              },
+            },
+          ]);
+          for (const ws of f.mockCtx.sockets) {
+            if (ws !== reader) expect(allSent(ws)).toEqual([]);
+          }
+          expect([...f.ctx.storage.store]).toEqual(before);
+          expect(f.ctx.storage.alarmAt).toBe(alarmAt);
+        }
+      );
+
       it.each(['registered', 'unregistered'] as const)(
         'returns prior-generation history privately to the %s requester without restoring execution',
         async requester => {
@@ -692,6 +850,8 @@ describe('UserConnectionDO', () => {
           const completed = job(f, first.jobId);
           await frame(f.doInstance, f.panel, { ...registration, generation: first.generation });
           const current = await invoke(f, 2);
+          const queued = await invoke(f, 3, { owner: otherOwner });
+          const nextQueued = await invoke(f, 4);
           expect(current.generation).toBeGreaterThan(completed.generation);
           const reader =
             requester === 'registered' ? f.panel : addWebSocket(f.mockCtx, 'history-reader');
@@ -711,11 +871,16 @@ describe('UserConnectionDO', () => {
               type: 'provider_status_result',
               requestId: request.requestId,
               providerId: registration.providerId,
-              jobs: expect.arrayContaining([completed, current]),
+              jobs: expect.arrayContaining([
+                { ...completed, ownerLabel: owner.parentSessionId },
+                { ...current, ownerLabel: owner.parentSessionId },
+                { ...queued, ownerLabel: otherOwner.parentSessionId, queuePosition: 1 },
+                { ...nextQueued, ownerLabel: owner.parentSessionId, queuePosition: 2 },
+              ]),
               unresolvedFence: { invocationId: current.invocationId },
             },
           ]);
-          expect(allSent(reader)[0]?.jobs).toHaveLength(2);
+          expect(allSent(reader)[0]?.jobs).toHaveLength(4);
           for (const ws of f.mockCtx.sockets) {
             if (ws !== reader) expect(allSent(ws)).toEqual([]);
           }
@@ -783,7 +948,7 @@ describe('UserConnectionDO', () => {
                 type: 'provider_status_result',
                 requestId: request.requestId,
                 providerId: active.providerId,
-                jobs: expired ? [] : [interrupted],
+                jobs: expired ? [] : [{ ...interrupted, ownerLabel: owner.parentSessionId }],
                 unresolvedFence:
                   phase === 'running'
                     ? { invocationId: active.invocationId, tabId: tab.tabId }
@@ -827,7 +992,7 @@ describe('UserConnectionDO', () => {
           providerProof: registration.providerProof,
         },
       ])(
-        'correlates a $name failure without exposing an expired fence or changing authority',
+        'correlates a $name failure without exposing queue metadata or an expired fence',
         async fields => {
           const f = await browserSetup();
           const active = await approve(
@@ -836,13 +1001,11 @@ describe('UserConnectionDO', () => {
               invocationId: `b1.${now - BROWSER_RETENTION_MS + 1_000}.${'1'.padStart(64, '0')}`,
             })
           );
+          await invoke(f, 2, { owner: otherOwner });
+          await invoke(f, 3);
           const otherPanel = addWebSocket(f.mockCtx, 'other-provider');
           await negotiate(f.doInstance, otherPanel, 'web');
           await frame(f.doInstance, otherPanel, otherRegistration);
-          vi.mocked(Date.now).mockReturnValue(now + 1_000);
-          await f.doInstance.alarm();
-          await flushAsync();
-          expect(f.ctx.storage.store.has(`browser/job/${active.jobId}`)).toBe(false);
           const reader = addWebSocket(f.mockCtx, 'denied-reader', [], fields.kiloUserId);
           await negotiate(f.doInstance, reader, 'web');
           const request = {
@@ -850,40 +1013,51 @@ describe('UserConnectionDO', () => {
             providerId: fields.providerId,
             providerProof: fields.providerProof,
           };
-          const before = structuredClone([...f.ctx.storage.store]);
-          const attachments = f.mockCtx.sockets.map(ws => ws.deserializeAttachment());
-          const alarmAt = f.ctx.storage.alarmAt;
-          for (const ws of f.mockCtx.sockets) ws.send.mockClear();
-          f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
 
-          await frame(f.doInstance, reader, request);
+          for (const expired of [false, true]) {
+            if (expired) {
+              vi.mocked(Date.now).mockReturnValue(now + 1_000);
+              await f.doInstance.alarm();
+              await flushAsync();
+              expect(f.ctx.storage.store.has(`browser/job/${active.jobId}`)).toBe(false);
+            }
+            const before = structuredClone([...f.ctx.storage.store]);
+            const attachments = f.mockCtx.sockets.map(ws => ws.deserializeAttachment());
+            const alarmAt = f.ctx.storage.alarmAt;
+            for (const ws of f.mockCtx.sockets) ws.send.mockClear();
+            f.doInstance = new UserConnectionDO(f.ctx as never, {} as never);
 
-          expect(allSent(reader)).toEqual([
-            {
-              type: 'response',
-              id: request.requestId,
-              error: {
-                source: 'relay',
-                code: 'owner_mismatch',
-                message: 'Browser job request rejected: owner_mismatch',
-                retryable: false,
+            await frame(f.doInstance, reader, request);
+
+            expect(allSent(reader)).toEqual([
+              {
+                type: 'response',
+                id: request.requestId,
+                error: {
+                  source: 'relay',
+                  code: 'owner_mismatch',
+                  message: 'Browser job request rejected: owner_mismatch',
+                  retryable: false,
+                },
               },
-            },
-          ]);
-          for (const ws of f.mockCtx.sockets) {
-            if (ws !== reader) expect(allSent(ws)).toEqual([]);
+            ]);
+            for (const ws of f.mockCtx.sockets) {
+              if (ws !== reader) expect(allSent(ws)).toEqual([]);
+            }
+            expect([...f.ctx.storage.store]).toEqual(before);
+            expect(f.mockCtx.sockets.map(ws => ws.deserializeAttachment())).toEqual(attachments);
+            expect(f.ctx.storage.alarmAt).toBe(alarmAt);
           }
-          expect([...f.ctx.storage.store]).toEqual(before);
-          expect(f.mockCtx.sockets.map(ws => ws.deserializeAttachment())).toEqual(attachments);
-          expect(f.ctx.storage.alarmAt).toBe(alarmAt);
         }
       );
 
       it.each(['CLI', 'unnegotiated web', 'unauthenticated web'] as const)(
-        'exposes no history or fence to a %s requester with a valid provider proof',
+        'exposes no queue metadata, history, or fence to a %s requester with a valid provider proof',
         async requester => {
           const f = await browserSetup();
           await invoke(f);
+          await invoke(f, 2, { owner: otherOwner });
+          await invoke(f, 3);
           const reader =
             requester === 'CLI'
               ? f.cli

--- a/services/session-ingest/src/dos/UserConnectionDO.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.ts
@@ -4,7 +4,22 @@ import type { Env } from '../env';
 import { getSessionIngestDO } from './SessionIngestDO';
 import { resolveAccessibleKiloSession } from '../services/session-access';
 import {
+  BrowserJobStoreError,
+  createBrowserJobStore,
+  type BrowserStoreEffects,
+} from './browser-job-store';
+import {
   CLIOutboundMessageSchema,
+  cliOutboundWithBrowserMessageSchema,
+  webOutboundWithBrowserMessageSchema,
+  normalizedBrowserCapabilitiesSchema,
+  type BrowserCapabilities,
+  type BrowserRequest,
+  type BrowserResponse,
+  type BrowserEvent,
+  type BrowserJobSnapshot,
+  type BrowserProviderInboundMessage,
+  type BrowserProviderOutboundMessage,
   type CLIInboundMessage,
   type Instance,
   type SessionEventPayload,
@@ -42,7 +57,19 @@ type ConnectionCapabilities = {
   sessionClone?: boolean;
 };
 
-type WSAttachment =
+type BrowserProviderBinding = {
+  providerId: BrowserJobSnapshot['providerId'];
+  generation: number;
+  unacknowledgedDispatch?: BrowserJobSnapshot['jobId'];
+};
+
+type WSAttachment = {
+  browserSocketId?: string;
+  // Old attachments omit this field; normalize them to unsupported until they retire.
+  browserCapabilities?: BrowserCapabilities;
+  browserProvider?: BrowserProviderBinding;
+  replaced?: true;
+} & (
   | {
       role: 'cli';
       connectionId: string;
@@ -76,7 +103,8 @@ type WSAttachment =
       // accepted before this field existed. Needed for command/subscribe
       // access rechecks against current session membership.
       kiloUserId?: string;
-    };
+    }
+);
 
 // Type re-export so test files and other internal callers can reference the
 // connection-row shape from a single place.
@@ -301,6 +329,358 @@ export class UserConnectionDO extends DurableObject<Env> {
   private completedCorrelationIds = new Set<string>();
 
   private stateReconstructed = false;
+  private browserJobs = createBrowserJobStore(this.ctx.storage);
+  private browserWork: Promise<unknown> = Promise.resolve();
+  private browserRestored = false;
+  private alarmWork: Promise<void> = Promise.resolve();
+
+  // Serialize browser effects as well as ledger commits, without blocking legacy traffic.
+  private runBrowserOperation<T>(run: () => Promise<T>): Promise<T> {
+    const next = this.browserWork.then(async () => {
+      await this.restoreBrowserState();
+      return run();
+    });
+    this.browserWork = next.catch(() => undefined);
+    return next;
+  }
+
+  private async restoreBrowserState(): Promise<void> {
+    if (this.browserRestored) return;
+    for (const ws of this.ctx.getWebSockets('web')) {
+      const attachment = ws.deserializeAttachment() as WSAttachment | null;
+      if (!attachment?.browserProvider?.unacknowledgedDispatch) continue;
+      // Approval acknowledges the dispatched invocation. Never resend work on wake
+      // when that acknowledgement is missing; the ledger retains the execution fence.
+      const change = await this.browserJobs.disconnectProvider(ws);
+      this.deliverBrowserEffects(change.effects);
+      const current = ws.deserializeAttachment() as WSAttachment | null;
+      if (current?.browserProvider) {
+        delete current.browserProvider.unacknowledgedDispatch;
+        ws.serializeAttachment(current);
+      }
+    }
+    this.deliverBrowserEffects({
+      updates: [],
+      cancellations: await this.browserJobs.pendingCancellations(),
+    });
+    this.browserRestored = true;
+  }
+
+  private isBrowserSocket(ws: WebSocket): boolean {
+    const attachment = ws.deserializeAttachment() as WSAttachment | null;
+    return Boolean(
+      attachment &&
+      !attachment.replaced &&
+      attachment.kiloUserId &&
+      ws.readyState === WebSocket.OPEN &&
+      this.ctx.getWebSockets(attachment.role).includes(ws) &&
+      normalizedBrowserCapabilitiesSchema.parse(attachment.browserCapabilities).browserJobsV1
+    );
+  }
+
+  private findBrowserSocket(
+    routing: { socketId: string; connectionId: string },
+    role: 'cli' | 'web'
+  ): WebSocket | undefined {
+    return this.ctx.getWebSockets(role).find(ws => {
+      const attachment = ws.deserializeAttachment() as WSAttachment | null;
+      return (
+        attachment?.role === role &&
+        attachment.browserSocketId === routing.socketId &&
+        attachment.connectionId === routing.connectionId &&
+        this.isBrowserSocket(ws)
+      );
+    });
+  }
+
+  private findBrowserProvider(providerId: string, generation?: number): WebSocket | undefined {
+    return this.ctx.getWebSockets('web').find(ws => {
+      const attachment = ws.deserializeAttachment() as WSAttachment | null;
+      return (
+        attachment?.browserProvider?.providerId === providerId &&
+        (generation === undefined || attachment.browserProvider.generation === generation) &&
+        this.isBrowserSocket(ws)
+      );
+    });
+  }
+
+  private sendBrowserMessage(
+    ws: WebSocket,
+    message: BrowserResponse | BrowserEvent | BrowserProviderInboundMessage
+  ): boolean {
+    if (!this.isBrowserSocket(ws)) return false;
+    try {
+      ws.send(JSON.stringify(message));
+      return true;
+    } catch {
+      // Do not log proof-bearing input or socket errors containing frame data.
+      console.warn('Browser socket send failed');
+      return false;
+    }
+  }
+
+  private negotiateBrowser(
+    ws: WebSocket,
+    capabilities: unknown,
+    acknowledgement:
+      | Extract<CLIInboundMessage, { type: 'heartbeat_ack' }>
+      | Extract<WebInboundMessage, { type: 'pong' }>
+  ): void {
+    const normalized = normalizedBrowserCapabilitiesSchema.parse(capabilities);
+    const attachment = ws.deserializeAttachment() as WSAttachment | null;
+    if (!attachment) return;
+    try {
+      // Old peers receive the original ack/pong shape until they advertise support.
+      // Remove this fallback only when all legacy clients retire.
+      ws.send(
+        JSON.stringify({
+          ...acknowledgement,
+          ...(normalized.browserJobsV1 ? { capabilities: normalized } : {}),
+        })
+      );
+      attachment.browserCapabilities = normalized;
+    } catch {
+      attachment.browserCapabilities = { browserJobsV1: false };
+    }
+    ws.serializeAttachment(attachment);
+  }
+
+  private sendBrowserJob(ws: WebSocket, requestId: string, job: BrowserJobSnapshot): void {
+    this.sendBrowserMessage(
+      ws,
+      job.result
+        ? { type: 'browser_event', requestId, event: 'result', result: job.result }
+        : { type: 'browser_event', requestId, event: 'progress', job }
+    );
+  }
+
+  private sendBrowserSnapshot(job: BrowserJobSnapshot): void {
+    const ws = this.findBrowserProvider(job.providerId, job.generation);
+    if (!ws) return;
+    // Incremental reconciliation; provider heartbeats also return bounded full pages.
+    this.sendBrowserMessage(ws, {
+      type: 'provider_snapshot',
+      providerId: job.providerId,
+      generation: job.generation,
+      jobs: [job],
+    });
+  }
+
+  private deliverBrowserEffects(effects: BrowserStoreEffects): void {
+    for (const cancellation of effects.cancellations) {
+      const ws = this.findBrowserSocket(cancellation.routing, 'web');
+      if (ws) this.sendBrowserMessage(ws, cancellation.message);
+    }
+    for (const { job, delivery } of effects.updates) {
+      const ws = this.findBrowserSocket(delivery, 'cli');
+      if (ws) this.sendBrowserJob(ws, delivery.requestId, job);
+      this.sendBrowserSnapshot(job);
+    }
+  }
+
+  private async disconnectBrowserProvider(ws: WebSocket): Promise<void> {
+    const attachment = ws.deserializeAttachment() as WSAttachment | null;
+    if (!attachment?.browserProvider) return;
+    const change = await this.browserJobs.disconnectProvider(ws);
+    this.deliverBrowserEffects(change.effects);
+    const current = ws.deserializeAttachment() as WSAttachment | null;
+    if (current?.browserProvider) {
+      delete current.browserProvider.unacknowledgedDispatch;
+      ws.serializeAttachment(current);
+    }
+    this.scheduleNextAlarm(Date.now());
+  }
+
+  private async dispatchBrowserJob(providerId: string): Promise<void> {
+    const provider = this.findBrowserProvider(providerId);
+    if (!provider) return;
+    const change = await this.browserJobs.dispatch(providerId);
+    if (!change.value) {
+      this.deliverBrowserEffects(change.effects);
+      return;
+    }
+    const attachment = provider.deserializeAttachment() as WSAttachment | null;
+    if (attachment?.browserProvider) {
+      attachment.browserProvider.unacknowledgedDispatch = change.value.message.job.jobId;
+      provider.serializeAttachment(attachment);
+    }
+    this.deliverBrowserEffects(change.effects);
+    const target = this.findBrowserSocket(change.value.routing, 'web');
+    if (!target || !this.sendBrowserMessage(target, change.value.message)) {
+      // The dispatch intent already committed. A send failure cannot put it back in FIFO.
+      await this.disconnectBrowserProvider(provider);
+    }
+  }
+
+  private sendBrowserAcknowledgement(
+    ws: WebSocket,
+    request: BrowserRequest & { operation: 'invoke' | 'cancel' },
+    job: BrowserJobSnapshot
+  ): void {
+    this.sendBrowserMessage(ws, {
+      type: 'browser_response',
+      requestId: request.requestId,
+      response: {
+        kind: 'ack',
+        operation: request.operation,
+        providerId: job.providerId,
+        browserTaskId: job.browserTaskId,
+        jobId: job.jobId,
+        invocationId: job.invocationId,
+      },
+    });
+  }
+
+  private async handleBrowserRequest(ws: WebSocket, request: BrowserRequest): Promise<void> {
+    if (!this.isBrowserSocket(ws)) return;
+    try {
+      if (request.operation === 'list') {
+        const providers = await this.browserJobs.listProviders(ws, request);
+        this.sendBrowserMessage(ws, {
+          type: 'browser_response',
+          requestId: request.requestId,
+          response: { kind: 'providers', ...providers },
+        });
+      } else if (request.operation === 'invoke') {
+        const change = await this.browserJobs.invoke(ws, request);
+        const { job } = change.value;
+        this.sendBrowserAcknowledgement(ws, request, job);
+        this.deliverBrowserEffects(change.effects);
+        this.sendBrowserJob(ws, request.requestId, job);
+        this.sendBrowserSnapshot(job);
+        await this.dispatchBrowserJob(job.providerId);
+      } else {
+        const change = await this.browserJobs.lookup(ws, request);
+        const job = change.value;
+        if (!job && request.operation === 'recover') {
+          this.sendBrowserMessage(ws, {
+            type: 'browser_response',
+            requestId: request.requestId,
+            response: { kind: 'not_found', invocationId: request.invocationId },
+          });
+        } else if (job) {
+          if (request.operation === 'cancel') {
+            this.sendBrowserAcknowledgement(ws, request, job);
+          } else {
+            this.sendBrowserMessage(ws, {
+              type: 'browser_response',
+              requestId: request.requestId,
+              response: { kind: request.operation === 'recover' ? 'recovered' : 'status', job },
+            });
+          }
+          this.deliverBrowserEffects(change.effects);
+          if (request.operation === 'cancel' && change.effects.updates.length === 0) {
+            this.sendBrowserJob(ws, request.requestId, job);
+          }
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof BrowserJobStoreError)) throw error;
+      this.sendBrowserMessage(ws, {
+        type: 'browser_response',
+        requestId: request.requestId,
+        response: {
+          kind: 'error',
+          code: error.code,
+          message: error.message,
+          retryable: error.retryable,
+        },
+      });
+    } finally {
+      this.scheduleNextAlarm(Date.now());
+    }
+  }
+
+  private async handleBrowserProvider(
+    ws: WebSocket,
+    message: BrowserProviderOutboundMessage
+  ): Promise<void> {
+    if (!this.isBrowserSocket(ws)) return;
+    try {
+      if (message.type === 'provider_register') {
+        const previous = (ws.deserializeAttachment() as WSAttachment | null)?.browserProvider;
+        if (previous && previous.providerId !== message.providerId) {
+          throw new BrowserJobStoreError('owner_mismatch');
+        }
+        const change = await this.browserJobs.registerProvider(ws, message);
+        const { providerId, generation, leaseExpiresAt } = change.value;
+        this.deliverBrowserEffects(change.effects);
+        // A grant replaces only this profile's delivery binding, not its durable fence.
+        for (const other of this.ctx.getWebSockets('web')) {
+          const attachment = other.deserializeAttachment() as WSAttachment | null;
+          if (other !== ws && attachment?.browserProvider?.providerId === providerId) {
+            delete attachment.browserProvider;
+            other.serializeAttachment(attachment);
+          }
+        }
+        const attachment = ws.deserializeAttachment() as WSAttachment;
+        attachment.browserProvider = { providerId, generation };
+        ws.serializeAttachment(attachment);
+        if (!this.isBrowserSocket(ws)) {
+          await this.disconnectBrowserProvider(ws);
+          return;
+        }
+        this.sendBrowserMessage(ws, {
+          type: 'provider_lease_ack',
+          requestId: message.requestId,
+          providerId,
+          generation,
+          leaseExpiresAt: new Date(leaseExpiresAt).toISOString(),
+        });
+        this.sendBrowserMessage(ws, {
+          type: 'provider_snapshot',
+          providerId,
+          generation,
+          jobs: [],
+        });
+      } else {
+        const change = await this.browserJobs.updateProvider(ws, message);
+        this.deliverBrowserEffects(change.effects);
+        const value = change.value;
+        if (value.job && value.job.status !== 'awaiting_approval') {
+          const attachment = ws.deserializeAttachment() as WSAttachment | null;
+          if (attachment?.browserProvider?.unacknowledgedDispatch === value.job.jobId) {
+            delete attachment.browserProvider.unacknowledgedDispatch;
+            ws.serializeAttachment(attachment);
+          }
+          if (change.effects.updates.length === 0) this.sendBrowserSnapshot(value.job);
+        }
+        if (message.type === 'provider_heartbeat' && value.leaseExpiresAt !== undefined) {
+          this.sendBrowserMessage(ws, {
+            type: 'provider_lease_ack',
+            requestId: message.requestId,
+            providerId: message.providerId,
+            generation: message.generation,
+            leaseExpiresAt: new Date(value.leaseExpiresAt).toISOString(),
+          });
+          if (value.snapshot) {
+            this.sendBrowserMessage(ws, { ...value.snapshot, requestId: message.requestId });
+          }
+        }
+        if (message.type === 'provider_quiesced' || message.type === 'provider_heartbeat') {
+          await this.dispatchBrowserJob(message.providerId);
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof BrowserJobStoreError)) throw error;
+      // Registration/heartbeat errors use the legacy response envelope, not an
+      // unnegotiated provider frame. Never expose validation issues or raw proofs.
+      if ('requestId' in message && this.isBrowserSocket(ws)) {
+        this.sendToWeb(ws, {
+          type: 'response',
+          id: message.requestId,
+          error: {
+            source: 'relay',
+            code: error.code,
+            message: error.message,
+            retryable: error.retryable,
+          },
+        });
+      }
+    } finally {
+      this.scheduleNextAlarm(Date.now());
+    }
+  }
 
   private ensureState(): void {
     if (this.stateReconstructed) return;
@@ -311,7 +691,7 @@ export class UserConnectionDO extends DurableObject<Env> {
 
     for (const ws of this.ctx.getWebSockets()) {
       const attachment = ws.deserializeAttachment() as WSAttachment | null;
-      if (!attachment) continue;
+      if (!attachment || attachment.replaced) continue;
 
       if (attachment.role === 'cli') {
         cliCount++;
@@ -329,7 +709,6 @@ export class UserConnectionDO extends DurableObject<Env> {
           ws.serializeAttachment({ ...attachment, heartbeatAt });
         }
       } else {
-        if (attachment.replaced) continue;
         webCount++;
         for (const sessionId of attachment.subscribedSessions) {
           let subs = this.webSubscriptions.get(sessionId);
@@ -454,9 +833,26 @@ export class UserConnectionDO extends DurableObject<Env> {
       return;
     }
 
+    if (attachment.replaced) return;
     if (attachment.role === 'cli') {
+      if (this.isBrowserSocket(ws)) {
+        const browser = cliOutboundWithBrowserMessageSchema.safeParse(parsed);
+        if (browser.success && browser.data.type === 'browser_request') {
+          const request = browser.data;
+          await this.runBrowserOperation(() => this.handleBrowserRequest(ws, request));
+          return;
+        }
+      }
       this.handleCliMessage(ws, attachment, parsed, raw, binaryByteCount);
-    } else if (!attachment.replaced) {
+    } else {
+      if (this.isBrowserSocket(ws)) {
+        const browser = webOutboundWithBrowserMessageSchema.safeParse(parsed);
+        if (browser.success && 'providerId' in browser.data) {
+          const provider = browser.data;
+          await this.runBrowserOperation(() => this.handleBrowserProvider(ws, provider));
+          return;
+        }
+      }
       await this.handleWebMessage(ws, attachment, parsed);
     }
   }
@@ -472,12 +868,17 @@ export class UserConnectionDO extends DurableObject<Env> {
     const attachment = ws.deserializeAttachment() as WSAttachment | null;
     if (!attachment) return;
 
+    // Fence late frames immediately, including a close racing a browser transaction.
+    ws.serializeAttachment({ ...attachment, replaced: true });
     if (attachment.role === 'cli') {
-      // Await attention resets so cli.disconnected is not broadcast until the
-      // stored status write has committed (mobile history refetch races otherwise).
+      // Browser jobs survive CLI loss. Only proven recovery can rebind delivery.
+      // Await attention resets before the legacy cli.disconnected broadcast.
       return this.handleCliDisconnect(ws, attachment);
     }
     this.handleWebDisconnect(ws);
+    if (attachment.browserProvider) {
+      return this.runBrowserOperation(() => this.disconnectBrowserProvider(ws));
+    }
   }
 
   webSocketError(ws: WebSocket): void | Promise<void> {
@@ -493,6 +894,11 @@ export class UserConnectionDO extends DurableObject<Env> {
     this.ensureState();
 
     const now = Date.now();
+    await this.runBrowserOperation(async () => {
+      const expired = await this.browserJobs.expire(now);
+      this.deliverBrowserEffects(expired.effects);
+      await this.browserJobs.cleanup(now);
+    });
     this.expirePendingCommands(now);
     await this.fireReadyPushes(now);
     const staleConnectionIds: string[] = [];
@@ -507,10 +913,11 @@ export class UserConnectionDO extends DurableObject<Env> {
       // Find and close the stale CLI WebSocket
       for (const ws of this.ctx.getWebSockets('cli')) {
         const att = ws.deserializeAttachment() as WSAttachment | null;
-        if (att?.role === 'cli' && att.connectionId === connectionId) {
+        if (att?.role === 'cli' && !att.replaced && att.connectionId === connectionId) {
           console.log('Closing stale CLI connection (heartbeat timeout)', {
             connectionId,
           });
+          ws.serializeAttachment({ ...att, replaced: true });
           ws.close(4408, 'heartbeat timeout');
           break;
         }
@@ -520,7 +927,7 @@ export class UserConnectionDO extends DurableObject<Env> {
     }
 
     this.scheduleNextAlarm(now);
-    this.scheduleDurablePendingAlarm();
+    await this.alarmWork;
   }
 
   // ---------------------------------------------------------------------------
@@ -658,8 +1065,9 @@ export class UserConnectionDO extends DurableObject<Env> {
       }
     }
 
-    // Persist to attachment for hibernation recovery
+    // Preserve the actual browser socket nonce across legacy heartbeats.
     const updatedAttachment: WSAttachment = {
+      ...attachment,
       role: 'cli',
       connectionId,
       sessions,
@@ -667,7 +1075,7 @@ export class UserConnectionDO extends DurableObject<Env> {
       protocolVersion,
       capabilities,
       kiloUserId: attachment.kiloUserId,
-      ...(instance ? { instance } : {}),
+      instance,
     };
     ws.serializeAttachment(updatedAttachment);
 
@@ -688,7 +1096,7 @@ export class UserConnectionDO extends DurableObject<Env> {
       },
     });
 
-    this.sendToCli(ws, { type: 'heartbeat_ack' });
+    this.negotiateBrowser(ws, capabilities, { type: 'heartbeat_ack' });
   }
 
   /**
@@ -1250,7 +1658,10 @@ export class UserConnectionDO extends DurableObject<Env> {
         await this.handleWebCommand(ws, attachment, msg);
         break;
       case 'ping':
-        this.sendToWeb(ws, { type: 'pong', nonce: msg.nonce });
+        this.negotiateBrowser(ws, msg.capabilities, { type: 'pong', nonce: msg.nonce });
+        if (attachment.browserProvider && !this.isBrowserSocket(ws)) {
+          await this.runBrowserOperation(() => this.disconnectBrowserProvider(ws));
+        }
         break;
     }
   }
@@ -1274,6 +1685,10 @@ export class UserConnectionDO extends DurableObject<Env> {
       return;
     }
 
+    // Access resolution can race provider updates or replacement on this socket.
+    const current = ws.deserializeAttachment() as WSAttachment | null;
+    if (current?.role !== 'web' || current.replaced) return;
+
     let subs = this.webSubscriptions.get(sessionId);
     if (!subs) {
       subs = new Set();
@@ -1282,9 +1697,9 @@ export class UserConnectionDO extends DurableObject<Env> {
     subs.add(ws);
 
     // Persist subscription in attachment for hibernation recovery
-    if (!attachment.subscribedSessions.includes(sessionId)) {
-      attachment.subscribedSessions.push(sessionId);
-      ws.serializeAttachment(attachment);
+    if (!current.subscribedSessions.includes(sessionId)) {
+      current.subscribedSessions.push(sessionId);
+      ws.serializeAttachment(current);
     }
 
     this.sendToWeb(ws, {
@@ -1634,7 +2049,6 @@ export class UserConnectionDO extends DurableObject<Env> {
       state: 'pending' as const,
     } satisfies PendingCommandEntry);
     this.scheduleNextAlarm(now);
-    this.scheduleDurablePendingAlarm();
 
     this.sendToCli(targetCli, {
       type: 'command',
@@ -1696,7 +2110,6 @@ export class UserConnectionDO extends DurableObject<Env> {
             return;
           }
           this.scheduleNextAlarm(now);
-          this.scheduleDurablePendingAlarm();
           this.sendToCli(targetCli, {
             type: 'command',
             id: correlationId,
@@ -1750,7 +2163,7 @@ export class UserConnectionDO extends DurableObject<Env> {
     const replaced = this.ctx.getWebSockets('cli').some(ws => {
       if (ws === disconnectedWs) return false;
       const att = ws.deserializeAttachment() as WSAttachment | null;
-      return att?.role === 'cli' && att.connectionId === connectionId;
+      return att?.role === 'cli' && !att.replaced && att.connectionId === connectionId;
     });
 
     // Fail pending commands that targeted this specific socket.
@@ -1931,6 +2344,15 @@ export class UserConnectionDO extends DurableObject<Env> {
   closeViewerSockets(): number {
     const sockets = this.ctx.getWebSockets('web');
     for (const ws of sockets) {
+      const attachment = ws.deserializeAttachment() as WSAttachment | null;
+      if (attachment?.browserProvider) {
+        ws.serializeAttachment({ ...attachment, replaced: true });
+        this.ctx.waitUntil(
+          this.runBrowserOperation(() => this.disconnectBrowserProvider(ws)).catch(() => {
+            console.error('Failed to settle revoked browser provider');
+          })
+        );
+      }
       ws.close(1000, 'session access revoked');
     }
     return sockets.length;
@@ -2028,7 +2450,7 @@ export class UserConnectionDO extends DurableObject<Env> {
   private closeStaleSocket(connectionId: string): boolean {
     for (const ws of this.ctx.getWebSockets('cli')) {
       const att = ws.deserializeAttachment() as WSAttachment | null;
-      if (att?.role === 'cli' && att.connectionId === connectionId) {
+      if (att?.role === 'cli' && !att.replaced && att.connectionId === connectionId) {
         console.log('Closing stale CLI socket for reconnect', { connectionId });
         this.ctx.waitUntil(
           this.failPendingCommandsForSocket(ws, false).catch((error: unknown) => {
@@ -2038,7 +2460,8 @@ export class UserConnectionDO extends DurableObject<Env> {
             });
           })
         );
-        // Preserve session ownership — the reconnecting CLI still owns these sessions
+        // Preserve legacy session ownership, but never migrate browser delivery authority.
+        ws.serializeAttachment({ ...att, replaced: true });
         ws.close(1000, 'replaced by reconnect');
         return true;
       }
@@ -2059,6 +2482,13 @@ export class UserConnectionDO extends DurableObject<Env> {
 
       ws.serializeAttachment({ ...attachment, replaced: true });
       this.handleWebDisconnect(ws);
+      if (attachment.browserProvider) {
+        this.ctx.waitUntil(
+          this.runBrowserOperation(() => this.disconnectBrowserProvider(ws)).catch(() => {
+            console.error('Failed to settle replaced browser provider');
+          })
+        );
+      }
       ws.close(1000, 'replaced by reconnect');
     }
   }
@@ -2079,7 +2509,12 @@ export class UserConnectionDO extends DurableObject<Env> {
   private findCliByConnectionId(connectionId: string): WebSocket | undefined {
     for (const ws of this.ctx.getWebSockets('cli')) {
       const attachment = ws.deserializeAttachment() as WSAttachment | null;
-      if (attachment?.role === 'cli' && attachment.connectionId === connectionId) {
+      if (
+        attachment?.role === 'cli' &&
+        !attachment.replaced &&
+        attachment.connectionId === connectionId &&
+        ws.readyState === WebSocket.OPEN
+      ) {
         return ws;
       }
     }
@@ -2478,29 +2913,6 @@ export class UserConnectionDO extends DurableObject<Env> {
     );
   }
 
-  private scheduleDurablePendingAlarm(): void {
-    this.ctx.waitUntil(
-      (async () => {
-        const entries = await this.ctx.storage.list<PendingCommandEntry>({
-          prefix: PENDING_COMMAND_KEY_PREFIX,
-        });
-        const now = Date.now();
-        let expiresAt: number | undefined;
-        for (const entry of entries.values()) {
-          if (entry.expiresAt <= now) continue;
-          if (expiresAt === undefined || entry.expiresAt < expiresAt) {
-            expiresAt = entry.expiresAt;
-          }
-        }
-        if (expiresAt === undefined) return;
-        const currentAlarm = await this.ctx.storage.getAlarm();
-        if (currentAlarm === null || expiresAt < currentAlarm) {
-          await this.ctx.storage.setAlarm(expiresAt);
-        }
-      })()
-    );
-  }
-
   private expirePendingCommands(now: number): void {
     // Track correlationIds already delivered in-memory so the durable
     // sweep does not double-deliver to the same web socket.
@@ -2600,64 +3012,56 @@ export class UserConnectionDO extends DurableObject<Env> {
   }
 
   private scheduleNextAlarm(now: number): void {
-    // Post-eviction one-shot: rebuild readyPushFireAt from KV when the mirror
-    // is empty and we have not yet successfully refreshed this wake.
-    if (this.readyPushFireAt.size === 0 && !this.readyPushRebuilt) {
-      this.ctx.waitUntil(
-        (async () => {
-          try {
-            const pending = await this.ctx.storage.list<ReadyPushEntry>({
-              prefix: READY_PUSH_KEY_PREFIX,
-            });
-            for (const [key, entry] of pending) {
-              if (!entry || typeof entry.fireAt !== 'number') continue;
-              const sessionId = key.slice(READY_PUSH_KEY_PREFIX.length);
-              if (sessionId) this.readyPushFireAt.set(sessionId, entry.fireAt);
-            }
-            this.readyPushRebuilt = true;
-            this.scheduleNextAlarm(Date.now());
-          } catch (error: unknown) {
-            // Leave readyPushRebuilt false so the next schedule retries.
-            console.error('Failed to rebuild readyPush mirror', {
-              error: error instanceof Error ? error.message : String(error),
-            });
+    // Serialize reads and the single alarm write. A late legacy scheduling task
+    // must not overwrite an earlier browser deadline with a stale decision.
+    const scheduled = this.alarmWork
+      .catch(() => undefined)
+      .then(async () => {
+        if (this.readyPushFireAt.size === 0 && !this.readyPushRebuilt) {
+          const pending = await this.ctx.storage.list<ReadyPushEntry>({
+            prefix: READY_PUSH_KEY_PREFIX,
+          });
+          for (const [key, entry] of pending) {
+            if (!entry || typeof entry.fireAt !== 'number') continue;
+            const sessionId = key.slice(READY_PUSH_KEY_PREFIX.length);
+            if (sessionId) this.readyPushFireAt.set(sessionId, entry.fireAt);
           }
-        })()
-      );
-    }
-
-    let nextAlarmAt: number | undefined;
-
-    for (const lastSeen of this.lastHeartbeatAt.values()) {
-      const staleAt = lastSeen + UserConnectionDO.HEARTBEAT_TIMEOUT_MS;
-      if (staleAt > now && (nextAlarmAt === undefined || staleAt < nextAlarmAt)) {
-        nextAlarmAt = staleAt;
-      }
-    }
-
-    for (const entry of this.pendingCommands.values()) {
-      if (entry.expiresAt > now && (nextAlarmAt === undefined || entry.expiresAt < nextAlarmAt)) {
-        nextAlarmAt = entry.expiresAt;
-      }
-    }
-
-    // readyPush entries are NEVER filtered by fireAt > now: if any exists and
-    // min(fireAt) <= now, arm at now (immediate fire). Arm whenever any
-    // readyPush exists, even with zero heartbeat/pending candidates.
-    if (this.readyPushFireAt.size > 0) {
-      let minFireAt = Infinity;
-      for (const fireAt of this.readyPushFireAt.values()) {
-        if (fireAt < minFireAt) minFireAt = fireAt;
-      }
-      const readyAt = minFireAt <= now ? now : minFireAt;
-      if (nextAlarmAt === undefined || readyAt < nextAlarmAt) {
-        nextAlarmAt = readyAt;
-      }
-    }
-
-    if (nextAlarmAt !== undefined) {
-      void this.ctx.storage.setAlarm(nextAlarmAt);
-    }
+          this.readyPushRebuilt = true;
+        }
+        const durable = await this.ctx.storage.list<PendingCommandEntry>({
+          prefix: PENDING_COMMAND_KEY_PREFIX,
+        });
+        const browser = await this.browserJobs.deadlines();
+        const currentNow = Math.max(now, Date.now());
+        let next = Infinity;
+        const include = (at: number) => {
+          if (Number.isFinite(at)) next = Math.min(next, Math.max(currentNow, at));
+        };
+        for (const [connectionId, lastSeen] of this.lastHeartbeatAt) {
+          if (this.findCliByConnectionId(connectionId)) {
+            include(lastSeen + UserConnectionDO.HEARTBEAT_TIMEOUT_MS);
+          }
+        }
+        for (const entry of this.pendingCommands.values()) include(entry.expiresAt);
+        // Include done entries too, but keep malformed legacy deadlines out of the shared decision.
+        for (const entry of durable.values()) {
+          if (entry) include(entry.expiresAt);
+        }
+        for (const fireAt of this.readyPushFireAt.values()) include(fireAt);
+        if (browser.next !== null) include(browser.next);
+        if (Number.isFinite(next)) {
+          await this.ctx.storage.setAlarm(next);
+        } else {
+          await this.ctx.storage.deleteAlarm();
+        }
+      });
+    this.alarmWork = scheduled;
+    this.ctx.waitUntil(
+      scheduled.catch(() => {
+        // A later scheduling site retries the full decision, never a partial deadline.
+        console.error('Failed to compose user connection alarm');
+      })
+    );
   }
 
   private aggregateSessions(): Array<

--- a/services/session-ingest/src/dos/UserConnectionDO.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.ts
@@ -591,9 +591,33 @@ export class UserConnectionDO extends DurableObject<Env> {
     }
   }
 
+  private async handleBrowserProviderStatus(
+    ws: WebSocket,
+    message: Extract<BrowserProviderOutboundMessage, { type: 'provider_status' }>
+  ): Promise<void> {
+    if (!this.isBrowserSocket(ws)) return;
+    try {
+      this.sendBrowserMessage(ws, await this.browserJobs.providerStatus(ws, message));
+    } catch (error) {
+      if (!(error instanceof BrowserJobStoreError)) throw error;
+      if (this.isBrowserSocket(ws)) {
+        this.sendToWeb(ws, {
+          type: 'response',
+          id: message.requestId,
+          error: {
+            source: 'relay',
+            code: error.code,
+            message: error.message,
+            retryable: error.retryable,
+          },
+        });
+      }
+    }
+  }
+
   private async handleBrowserProvider(
     ws: WebSocket,
-    message: BrowserProviderOutboundMessage
+    message: Exclude<BrowserProviderOutboundMessage, { type: 'provider_status' }>
   ): Promise<void> {
     if (!this.isBrowserSocket(ws)) return;
     try {
@@ -849,7 +873,12 @@ export class UserConnectionDO extends DurableObject<Env> {
         const browser = webOutboundWithBrowserMessageSchema.safeParse(parsed);
         if (browser.success && 'providerId' in browser.data) {
           const provider = browser.data;
-          await this.runBrowserOperation(() => this.handleBrowserProvider(ws, provider));
+          if (provider.type === 'provider_status') {
+            // History must not restore execution state or deliver mutation effects.
+            await this.handleBrowserProviderStatus(ws, provider);
+          } else {
+            await this.runBrowserOperation(() => this.handleBrowserProvider(ws, provider));
+          }
           return;
         }
       }

--- a/services/session-ingest/src/dos/browser-alarm-inventory.test.ts
+++ b/services/session-ingest/src/dos/browser-alarm-inventory.test.ts
@@ -1,0 +1,187 @@
+import { readFileSync } from 'node:fs';
+import { URL } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+type AlarmSite = { member: string; operation: string; kind: 'write' | 'alias'; line: number };
+
+/** Conservatively track writer aliases inside this class, including aliases stored on this. */
+function alarmInventory(text: string): AlarmSite[] {
+  const source = ts.createSourceFile('UserConnectionDO.ts', text, ts.ScriptTarget.Latest, true);
+  const target = source.statements.find(
+    node => ts.isClassDeclaration(node) && node.name?.text === 'UserConnectionDO'
+  );
+  if (!target || !ts.isClassDeclaration(target)) throw new Error('UserConnectionDO is missing');
+  const aliases = new Map<string, string>();
+  const names = new Map<string, string>();
+  const nodes: { node: ts.Node; member: string }[] = [];
+  for (const member of target.members) {
+    const name = member.name?.getText(source) ?? 'constructor';
+    const visit = (node: ts.Node) => {
+      // Other Durable Object classes do not belong to this inventory.
+      if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) return;
+      nodes.push({ node, member: name });
+      ts.forEachChild(node, visit);
+    };
+    visit(member);
+  }
+
+  function property(node: ts.Node | undefined): string | undefined {
+    if (!node) return undefined;
+    if (ts.isIdentifier(node)) return names.get(node.text) ?? node.text;
+    if (ts.isStringLiteralLike(node)) return node.text;
+    return undefined;
+  }
+
+  function writer(node: ts.Expression): string | undefined {
+    if (
+      ts.isParenthesizedExpression(node) ||
+      ts.isAsExpression(node) ||
+      ts.isNonNullExpression(node)
+    ) {
+      return writer(node.expression);
+    }
+    const alias = aliases.get(node.getText(source));
+    if (alias) return alias;
+    if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
+      const name = property(
+        ts.isPropertyAccessExpression(node) ? node.name : node.argumentExpression
+      );
+      if (name === 'setAlarm' || name === 'deleteAlarm') return name;
+      if (name === 'bind' || name === 'call' || name === 'apply') return writer(node.expression);
+    }
+    if (ts.isCallExpression(node)) return writer(node.expression);
+    return undefined;
+  }
+
+  // A fixed point also catches assignment chains and references before declarations.
+  let changed = true;
+  while (changed) {
+    const size = aliases.size + names.size;
+    for (const { node } of nodes) {
+      if (ts.isVariableDeclaration(node) && node.initializer) {
+        if (ts.isIdentifier(node.name)) {
+          if (ts.isStringLiteralLike(node.initializer))
+            names.set(node.name.text, node.initializer.text);
+          const operation = writer(node.initializer);
+          if (operation) aliases.set(node.name.text, operation);
+        } else if (ts.isObjectBindingPattern(node.name)) {
+          for (const element of node.name.elements) {
+            const operation = property(element.propertyName ?? element.name);
+            if (operation === 'setAlarm' || operation === 'deleteAlarm') {
+              aliases.set(element.name.getText(source), operation);
+            }
+          }
+        }
+      }
+      if (ts.isPropertyDeclaration(node) && node.initializer) {
+        const operation = writer(node.initializer);
+        if (operation) aliases.set(`this.${node.name.getText(source)}`, operation);
+      }
+      if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+        const operation = writer(node.right);
+        if (operation) aliases.set(node.left.getText(source), operation);
+      }
+    }
+    changed = aliases.size + names.size !== size;
+  }
+
+  const sites: AlarmSite[] = [];
+  for (const { node, member } of nodes) {
+    let operation: string | undefined;
+    let kind: AlarmSite['kind'] = 'alias';
+    if (ts.isCallExpression(node)) {
+      operation = writer(node.expression);
+      const name = ts.isPropertyAccessExpression(node.expression)
+        ? node.expression.name.text
+        : ts.isElementAccessExpression(node.expression)
+          ? property(node.expression.argumentExpression)
+          : undefined;
+      if (name !== 'bind') kind = 'write';
+    } else if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
+      operation = writer(node);
+    } else if (ts.isBindingElement(node)) {
+      operation = aliases.get(node.name.getText(source));
+    }
+    if (operation) {
+      sites.push({
+        member,
+        operation,
+        kind,
+        line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+      });
+    }
+  }
+  return sites;
+}
+
+function checkAlarmOwnership(source: string): void {
+  const sites = alarmInventory(source);
+  const competing = sites.filter(site => site.member !== 'scheduleNextAlarm');
+  if (competing.length || !sites.some(site => site.kind === 'write')) {
+    throw new Error(
+      `Competing or missing UserConnectionDO alarm writer: ${JSON.stringify(competing)}`
+    );
+  }
+}
+
+const composed =
+  'scheduleNextAlarm() { this.ctx.storage.setAlarm(100); this.ctx.storage.deleteAlarm(); }';
+
+describe('UserConnectionDO alarm ownership', () => {
+  it('allows only the composed scheduler in the actual relay source', () => {
+    checkAlarmOwnership(readFileSync(new URL('./UserConnectionDO.ts', import.meta.url), 'utf8'));
+  });
+
+  it.each([
+    ['direct write', 'competing() { this.ctx.storage.setAlarm(1); }'],
+    ['direct deletion', 'competing() { this.ctx.storage.deleteAlarm(); }'],
+    ['receiver alias', 'competing() { const storage = this.ctx.storage; storage.setAlarm(1); }'],
+    ['method alias', 'competing() { const write = this.ctx.storage.setAlarm; write(1); }'],
+    [
+      'destructured alias',
+      'competing() { const { setAlarm: write } = this.ctx.storage; write(1); }',
+    ],
+    [
+      'bound alias',
+      'competing() { const write = this.ctx.storage.setAlarm.bind(this.ctx.storage); write(1); }',
+    ],
+    ['computed write', 'competing() { this.ctx.storage["setAlarm"](1); }'],
+    ['computed key alias', 'competing() { const key = "setAlarm"; this.ctx.storage[key](1); }'],
+    [
+      'call alias',
+      'competing() { const write = this.ctx.storage.setAlarm; write.call(this.ctx.storage, 1); }',
+    ],
+  ])('rejects a synthetic %s outside the scheduler', (_name, competing) => {
+    expect(() =>
+      checkAlarmOwnership(`class UserConnectionDO { ${composed} ${competing} }`)
+    ).toThrow(/competing/);
+  });
+
+  it('rejects a writer stored inside the scheduler and invoked elsewhere', () => {
+    expect(() =>
+      checkAlarmOwnership(`class UserConnectionDO {
+      scheduleNextAlarm() { this.write = this.ctx.storage.setAlarm.bind(this.ctx.storage); this.write(1); }
+      competing() { const again = this.write; again(2); }
+    }`)
+    ).toThrow(/competing/);
+  });
+
+  it('rejects a missing target class instead of silently inspecting another Durable Object', () => {
+    expect(() => checkAlarmOwnership(`class SessionIngestDO { ${composed} }`)).toThrow(/missing/);
+  });
+
+  it('rejects an empty scheduler inventory', () => {
+    expect(() => checkAlarmOwnership('class UserConnectionDO { scheduleNextAlarm() {} }')).toThrow(
+      /missing/
+    );
+  });
+
+  it('excludes other Durable Object classes and unrelated similarly named text', () => {
+    checkAlarmOwnership(`
+      class SessionIngestDO { alarm() { this.ctx.storage.setAlarm(1); } }
+      class UserConnectionDO { ${composed} note() { return 'storage.setAlarm(1)'; } }
+      class SessionAccessCacheDO { alarm() { const { setAlarm: write } = this.ctx.storage; write(1); } }
+    `);
+  });
+});


### PR DESCRIPTION
No new behavior — this change prepares browser tasks but does not add controls that people can use.

---

## Summary

`browserJobsV1` now negotiates authenticated `BrowserRequest` and `BrowserProviderOutboundMessage` routing through `heartbeat_ack` and `pong`; legacy clients retain unchanged responses.
`WSAttachment` and `BrowserProviderBinding` preserve parent-authorized delivery, provider generations, and dispatch acknowledgement through hibernation and subscription races; reconnects alone cannot transfer authority.
The ledger enforces approval, cancellation, and recovery without dispatch replay; one composed alarm preserves browser deadlines, retention, and legacy alarms.

<details>
<summary>Files</summary>

- `services/session-ingest/src/dos/UserConnectionDO.ts` — Source; modified (M); 608 changed lines (+506/−102). Routes `list`, `invoke`, `status`, `cancel`, and `recover`. Missing capabilities and failed acknowledgements disable browser traffic. Roles separate requests from provider updates; parent proofs, not heartbeats or connection identifiers, authorize access. Discovery lists labels, identifiers, availability, and queue counts separately from command-line interface (CLI) instances. Registration binds one provider and generation per socket; replies, progress, results, lease acknowledgements, and bounded snapshots remain private. Serialized commits precede sends; acceptance precedes dispatch. Each invocation needs tab approval; only quiescence advances the queue. Cancellation settles before forwarding and rejects late success; uncertain cancellation interrupts queued jobs. Provider loss, replacement, revocation, disablement, or shutdown settles jobs without clearing uncertain execution fences. Provider recovery requires proof plus confirmation of tab closure and drained locks. CLI loss preserves jobs; proven lookup or recovery rebinds delivery. Hibernation preserves acknowledged work, resends pending cancellations, and interrupts unacknowledged dispatch without replay. Heartbeats preserve socket identity; reconstruction ignores replaced sockets, and CLI lookups select open, unreplaced sockets. Delayed subscriptions reload attachments to preserve negotiation, registration, dispatch acknowledgement, and close or replacement markers. The scheduler replaces competing writers and combines queue, approval, execution, lease, and retention deadlines with heartbeats, commands, and ready pushes. It restores ready pushes, includes completed commands, ignores malformed deadlines, schedules overdue work now, and deletes empty alarms. Legacy dispatch does not wait for alarm reads. Browser errors preserve retryability and omit proofs; provider errors retain the legacy response envelope.
- `services/session-ingest/src/dos/UserConnectionDO.test.ts` — Test; modified (M); 1,421 changed lines (+1,411/−10). Adds coverage for negotiation, private discovery, parent isolation, provider generations, approval, cancellation, recovery, deadlines, hibernation, reconnects, and delayed subscriptions. The mocks clone attachments, track closed sockets, serialize atomic transactions, and expose alarm state. The helpers accept authenticated CLI identities; legacy assertions await scheduling, and a regression case checks command dispatch during delayed alarm reads.

</details>

The default suite restricts `UserConnectionDO` alarm writes to `scheduleNextAlarm` through a TypeScript abstract syntax tree (AST) inventory.
`setAlarm` and `deleteAlarm` aliases count as writers; unrelated text and other Durable Objects do not.
Independent writers, a missing target class, and an empty inventory fail the check, so new scheduling code must use the composed scheduler.

<details>
<summary>Files</summary>

- `services/session-ingest/src/dos/browser-alarm-inventory.test.ts` — Test; added (A); 187 changed lines (+187/−0). Adds the inventory and synthetic checks for direct, computed, destructured, bound, chained, and class-field aliases. Checks reject missing or empty inventories and exclude other Durable Object classes.

</details>

Tests: 2 files changed — `UserConnectionDO.test.ts` modified and `browser-alarm-inventory.test.ts` added; 1,598 insertions and 10 deletions.
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual verification: pending on the stack tips. Client integration follows in later levels, and the handoff attaches no end-to-end (E2E) report.

## Reviewer Notes

### Human steps

- **before merge — After all section pull requests receive human-ready, merge each repository's levels from bottom to top.**
- This level requires no additional environment value, secret, or migration.

### Automated evidence

- The initial round passed 321 tests; the repair added four regression cases that failed before the fix.
- The supplied repair evidence records 5/5 checks passed: formatting, format verification, lint, the focused tests, and whitespace verification.
- Both focused suites passed with `pnpm --filter cloudflare-session-ingest exec vitest run --no-cache --configLoader runner src/dos/UserConnectionDO.test.ts src/dos/browser-alarm-inventory.test.ts`.
- The supplied evidence does not establish continuous integration (CI) or live verification.

### Scope and dependencies

- Cloud worktree: `/Users/igor/Projects/.worktrees/browser-task-0787`, branch `browser-task-0787-s3`, base `browser-task-0787-s2`. This description covers level 3 only.
- Kilocode worktree: `/Users/igor/Projects/.worktrees/browser-task-0787-kilocode`, branch `browser-task-0787`. Its matching contracts have landed; this worktree provides contract context only.
- Base pull request: https://github.com/Kilo-Org/cloud/pull/5644 — the preceding level supplies the durable browser ledger.
- Cloud contracts: https://github.com/Kilo-Org/cloud/pull/5638 — the shared browser message contracts.
- Command-line interface (CLI) contracts: https://github.com/Kilo-Org/kilocode/pull/13535 — the matching contracts for CLI integration.

### Notes

Runtime verification remains pending on the stack tips. Browser traffic requires explicit capability negotiation; client integration follows in later levels.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `browser-task-0787` — #5638
2. `browser-task-0787-s2` — #5644
3. `browser-task-0787-s3` — #5648 ← this PR
4. `browser-task-0787-s4` — #5653
7. `browser-task-0787-s7` — #5681
8. `browser-task-0787-s8` — #5694
9. `browser-task-0787-s9` — #5698
10. `browser-task-0787-s10` — #5702
11. `browser-task-0787-s11` — #5716
12. `browser-task-0787-s12` — #5734
13. `browser-task-0787-s13` — #5742 (tip)

