### PR TITLE
fix(mobile): track accepted live query outcomes

### DIFF
--- a/apps/mobile/src/components/agents/agents-tab-badge.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/agents-tab-badge.mounted.test.tsx
@@ -4,17 +4,18 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { act, type ReactTestInstance } from 'react-test-renderer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { organization } from './agents-tab-badge.test-helpers';
 import TabsLayout from '@/app/(app)/(tabs)/_layout';
 import { buildActiveSessionsTrayInput } from '@/lib/active-sessions-live';
+import { makeTestQueryClient } from '@/lib/active-sessions-live-sync.test-helpers';
 import { type ActiveSession } from '@/lib/hooks/use-agent-sessions';
-import { createTestQueryClient, renderWithProviders, waitFor } from '@/test/render-with-providers';
+import { renderWithProviders, waitFor } from '@/test/render-with-providers';
 import { AgentSessionListScreen } from './session-list-screen';
 
-const organization = vi.hoisted(() => ({ organizationId: null as string | null, isLoaded: true }));
 const fetchSessions = vi.hoisted(() => vi.fn<() => Promise<{ sessions: ActiveSession[] }>>());
 
-vi.mock('@/lib/trpc', () => ({
-  useTRPC: () => ({
+vi.mock('@/lib/trpc', () => {
+  const trpc = {
     activeSessions: {
       list: {
         queryKey: (input: unknown) => [['activeSessions', 'list'], { input, type: 'query' }],
@@ -25,12 +26,9 @@ vi.mock('@/lib/trpc', () => ({
         }),
       },
     },
-  }),
-}));
-vi.mock('@/lib/organization-context', () => ({ useOrganization: () => organization }));
-vi.mock('@/lib/hooks/use-user-web-connection-state', () => ({
-  useUserWebConnectionState: () => false,
-}));
+  };
+  return { useTRPC: () => trpc };
+});
 vi.mock('@/lib/active-sessions-live-sync', () => ({
   refreshActiveSessionsNow: vi.fn().mockResolvedValue(false),
 }));
@@ -125,7 +123,7 @@ function CountSurfaces() {
   );
 }
 
-async function mount(queryClient = createTestQueryClient()) {
+async function mount(queryClient = makeTestQueryClient()) {
   const result = await renderWithProviders(createElement(CountSurfaces), { queryClient });
   mounts.push(result);
   return result;
@@ -191,7 +189,7 @@ describe('Agents live count surfaces', () => {
   ])(
     'shares the active cache and updates to $count while Home has focus',
     async ({ count, label }) => {
-      const queryClient = createTestQueryClient();
+      const queryClient = makeTestQueryClient();
       queryClient.setQueryData(key(), { sessions: [] });
       const { renderer } = await mount(queryClient);
       expectCounts(renderer);
@@ -226,7 +224,7 @@ describe('Agents live count surfaces', () => {
 
   it('hides cached counts and disables fetching until the organization loads', async () => {
     organization.isLoaded = false;
-    const queryClient = createTestQueryClient();
+    const queryClient = makeTestQueryClient();
     queryClient.setQueryData(key(), { sessions: sessions(3) }, { updatedAt: 0 });
     const result = await mount(queryClient);
     expectCounts(result.renderer);
@@ -253,7 +251,7 @@ describe('Agents live count surfaces', () => {
   });
 
   it('hides counts but retains cached rows after refetch failure, then recovers through refresh', async () => {
-    const queryClient = createTestQueryClient();
+    const queryClient = makeTestQueryClient();
     const cachedRows = sessions(3);
     queryClient.setQueryData(key(), { sessions: cachedRows });
     const { renderer } = await mount(queryClient);
@@ -279,7 +277,7 @@ describe('Agents live count surfaces', () => {
 
   it('never carries the previous organization count through loading or authorization failure', async () => {
     organization.organizationId = 'org-a';
-    const queryClient = createTestQueryClient();
+    const queryClient = makeTestQueryClient();
     queryClient.setQueryData(key('org-a'), { sessions: sessions(4, 'org-a') });
     const result = await mount(queryClient);
     expectCounts(result.renderer, 4, '4 LIVE');

--- a/apps/mobile/src/components/agents/agents-tab-badge.test-helpers.ts
+++ b/apps/mobile/src/components/agents/agents-tab-badge.test-helpers.ts
@@ -1,0 +1,45 @@
+import { vi } from 'vitest';
+
+import { currentAuthEpoch } from '@/lib/auth/auth-epoch';
+
+const organization = vi.hoisted(() => ({
+  organizationId: null as string | null,
+  isLoaded: true,
+}));
+
+export { organization };
+
+vi.mock('@/lib/auth/auth-context', () => ({
+  useAuth: () => ({
+    token: 'account',
+    isLoading: false,
+    isSigningOut: false,
+    authEpoch: currentAuthEpoch(),
+  }),
+}));
+vi.mock('@/lib/organization-context', () => ({ useOrganization: () => organization }));
+vi.mock('@/lib/hooks/use-organization-queries', () => {
+  const orgs = ['org-a', 'org-b'].map(organizationId => ({
+    organizationId,
+    organizationName: organizationId,
+  }));
+  return {
+    useOrgBoundary: () => ({
+      orgs,
+      org: orgs.find(org => org.organizationId === organization.organizationId),
+      isResolving: false,
+      isError: false,
+      refetch: vi.fn(),
+    }),
+  };
+});
+vi.mock('@/lib/hooks/use-offline-banner-state', () => ({
+  useCommittedConnectivityStatus: () => 'online',
+}));
+vi.mock('@/lib/hooks/use-user-web-connection-state', () => ({
+  useUserWebConnectionState: () => false,
+  useUserWebConnectionHealth: () => ({ isConnected: true, reconnectExhausted: false }),
+}));
+vi.mock('@/components/agents/user-web-connection-provider', () => ({
+  useUserWebConnection: () => ({ retryConnection: vi.fn() }),
+}));

--- a/apps/mobile/src/components/agents/remote-session-row.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/remote-session-row.mounted.test.tsx
@@ -12,6 +12,7 @@ import {
 import { ActiveSessionsLiveSync } from '@/lib/active-sessions-live-sync';
 import {
   deferred,
+  flushQueryUpdates as flush,
   makeCached,
   makeConnection,
   QUERY_KEY,
@@ -96,14 +97,6 @@ const otherKey = [
 ];
 const session: ActiveSession = makeCached({ createdOnPlatform: 'cli' });
 
-async function flush() {
-  await new Promise<void>(resolve => {
-    setTimeout(resolve, 0);
-  });
-  await new Promise<void>(resolve => {
-    setTimeout(resolve, 0);
-  });
-}
 async function render() {
   await act(async () => {
     const tree = createElement(

--- a/apps/mobile/src/components/agents/remote-session-row.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/remote-session-row.mounted.test.tsx
@@ -1,0 +1,273 @@
+/* eslint-disable typescript-eslint/no-deprecated -- DOM-free React Native row integration */
+import { createElement } from 'react';
+import { type QueryClient, QueryClientProvider, QueryObserver } from '@tanstack/react-query';
+import TestRenderer, { act } from 'react-test-renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RemoteSessionRow } from './remote-session-row';
+import {
+  buildActiveSessionsTrayInput,
+  type CachedActiveSessionsData,
+} from '@/lib/active-sessions-live';
+import { ActiveSessionsLiveSync } from '@/lib/active-sessions-live-sync';
+import {
+  deferred,
+  makeCached,
+  makeConnection,
+  QUERY_KEY,
+} from '@/lib/active-sessions-live-sync.test-helpers';
+import { bumpAuthEpoch } from '@/lib/auth/auth-epoch';
+import { setSignOutActive } from '@/lib/auth/sign-out-state';
+import { type ActiveSession } from '@/lib/hooks/use-agent-sessions';
+import { createKiloAppQueryClient, getActiveSessionsQueryMetadata } from '@/lib/query-client';
+
+const state = vi.hoisted(() => ({
+  organizationId: null as string | null,
+  exit: undefined as (() => void) | undefined,
+  request: vi.fn<() => Promise<CachedActiveSessionsData>>(),
+  send: vi.fn(),
+}));
+vi.mock('@/lib/organization-context', () => ({
+  useOrganization: () => ({ organizationId: state.organizationId, isLoaded: true }),
+}));
+vi.mock('@/lib/trpc', () => {
+  const trpc = {
+    activeSessions: {
+      list: {
+        queryKey: (input: unknown) => [['activeSessions', 'list'], { input, type: 'query' }],
+      },
+    },
+  };
+  return { useTRPC: () => trpc };
+});
+vi.mock('@/components/agents/user-web-connection-provider', () => ({
+  useUserWebConnection: () => ({ sendCommand: state.send }),
+}));
+vi.mock('@/lib/hooks/use-session-mutations', () => ({
+  useSessionMutations: () => ({ renameSession: vi.fn() }),
+}));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({ useThemeColors: () => ({ mutedSoft: '#777' }) }));
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' }, Pressable: 'Pressable', View: 'View' }));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ bottom: 0 }) }));
+vi.mock('@expo/react-native-action-sheet', () => ({
+  useActionSheet: () => ({ showActionSheetWithOptions: vi.fn() }),
+}));
+vi.mock('expo-haptics', () => ({
+  impactAsync: vi.fn(),
+  ImpactFeedbackStyle: { Medium: 'medium' },
+}));
+vi.mock('@/components/rename-modal', () => ({ RenameModal: () => null }));
+vi.mock('@/components/ui/session-row', () => ({ SessionRow: 'SessionRow' }));
+vi.mock('@/components/agents/session-platform-icon', () => ({
+  selectRowPlatformPresentation: () => ({ iconKind: null, spokenPlatform: null }),
+  SessionPlatformIcon: () => null,
+}));
+vi.mock('@/components/agents/session-row-actions', () => ({
+  showSessionActionMenu: (options: { onExit?: () => void }) => {
+    state.exit = options.onExit;
+  },
+  copySessionId: vi.fn(),
+  showRenamePrompt: vi.fn(),
+}));
+vi.mock('@/components/agents/remote-session-exit-alert', () => ({
+  showRemoteSessionExitConfirmation: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('@/lib/a11y/announcing-toast', () => ({
+  announcingToast: { error: vi.fn(), success: vi.fn() },
+}));
+vi.mock('@/lib/session-attention', () => ({
+  isAttentionAcked: () => false,
+  reconcileSessionAttention: vi.fn(),
+  shouldShowNeedsInput: () => false,
+  useSessionAttentionRevision: () => 0,
+}));
+
+let client: QueryClient = createKiloAppQueryClient();
+let renderer: TestRenderer.ReactTestRenderer | undefined = undefined;
+let owner: ActiveSessionsLiveSync | undefined = undefined;
+let unsubscribe: (() => void) | undefined = undefined;
+const cached = { sessions: [makeCached({ createdOnPlatform: 'cli' })] };
+const otherKey = [
+  ['activeSessions', 'list'],
+  {
+    input: { ...buildActiveSessionsTrayInput(null), includeCloudAgentSessions: false },
+    type: 'query',
+  },
+];
+const session: ActiveSession = makeCached({ createdOnPlatform: 'cli' });
+
+async function flush() {
+  await new Promise<void>(resolve => {
+    setTimeout(resolve, 0);
+  });
+  await new Promise<void>(resolve => {
+    setTimeout(resolve, 0);
+  });
+}
+async function render() {
+  await act(async () => {
+    const tree = createElement(
+      QueryClientProvider,
+      { client },
+      createElement(RemoteSessionRow, { session, onPress: vi.fn<() => void>() })
+    );
+    if (renderer) {
+      renderer.update(tree);
+    } else {
+      renderer = TestRenderer.create(tree);
+    }
+    await flush();
+  });
+}
+function attach(queryKey: readonly unknown[] = QUERY_KEY) {
+  owner = new ActiveSessionsLiveSync({
+    connection: makeConnection(),
+    queryClient: client,
+    queryKey,
+    queryFn: state.request,
+  });
+  owner.attach();
+}
+async function exit() {
+  await act(async () => {
+    if (!renderer) {
+      throw new Error('Missing row');
+    }
+    const props = renderer.root.findByType('Pressable').props as { onLongPress: () => void };
+    props.onLongPress();
+    if (!state.exit) {
+      throw new Error('Missing exit action');
+    }
+    state.exit();
+    await flush();
+  });
+}
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  setSignOutActive(false);
+  state.organizationId = null;
+  state.exit = undefined;
+  state.request.mockReset().mockResolvedValue({ sessions: [] });
+  state.send.mockReset().mockResolvedValue(undefined);
+  client = createKiloAppQueryClient();
+  client.setDefaultOptions({ queries: { retry: false, gcTime: Infinity } });
+  client.setQueryData(QUERY_KEY, cached);
+  client.setQueryData(otherKey, cached);
+  const observer = new QueryObserver(client, {
+    queryKey: QUERY_KEY,
+    queryFn: state.request,
+    staleTime: Infinity,
+  });
+  unsubscribe = observer.subscribe(() => undefined);
+});
+afterEach(async () => {
+  await act(async () => {
+    renderer?.unmount();
+    owner?.detach();
+    unsubscribe?.();
+    client.clear();
+    await flush();
+  });
+  renderer = undefined;
+  owner = undefined;
+  unsubscribe = undefined;
+  setSignOutActive(false);
+});
+
+describe('row exit refresh caller', () => {
+  it.each(['matching', 'mismatched', 'absent'] as const)(
+    'reconciles its exact query with a %s owner',
+    async scope => {
+      if (scope !== 'absent') {
+        attach(scope === 'matching' ? QUERY_KEY : otherKey);
+      }
+      await render();
+      await exit();
+      expect(client.getQueryData(QUERY_KEY)).toEqual({ sessions: [] });
+      expect(client.getQueryData(otherKey)).toEqual(cached);
+      expect(
+        getActiveSessionsQueryMetadata(
+          client.getQueryCache().find({ queryKey: QUERY_KEY, exact: true })
+        ).acceptedRevision
+      ).toBe(1);
+      expect(state.send.mock.calls).toEqual([['a1', 'exit_cli', { protocolVersion: 1 }, 'c1']]);
+    }
+  );
+
+  it('does not launch another refresh after a handled owner failure', async () => {
+    attach();
+    state.request.mockRejectedValue(new Error('offline'));
+    await render();
+    await exit();
+    expect(client.getQueryData(QUERY_KEY)).toEqual(cached);
+    expect(owner?.getPendingReasons()).toContain('manual');
+    expect(state.request.mock.calls).toHaveLength(1);
+  });
+
+  it.each(['context', 'account', 'sign-out', 'reattach', 'unmount'] as const)(
+    'does not reconcile a replacement scope after late %s completion',
+    async change => {
+      attach();
+      const network = deferred<CachedActiveSessionsData>();
+      state.request.mockReturnValue(network.promise);
+      await render();
+      await exit();
+      if (change === 'context' || change === 'unmount') {
+        state.organizationId = 'org-b';
+      }
+      if (change === 'account') {
+        bumpAuthEpoch();
+        client.clear();
+      }
+      if (change === 'sign-out') {
+        setSignOutActive(true);
+      }
+      if (change === 'reattach') {
+        owner?.detach();
+        owner?.attach();
+      }
+      const key = [
+        ['activeSessions', 'list'],
+        { input: buildActiveSessionsTrayInput(state.organizationId), type: 'query' },
+      ];
+      const current = { sessions: [makeCached({ id: 'b', organizationId: state.organizationId })] };
+      await act(async () => {
+        client.setQueryData(key, current);
+        await flush();
+      });
+      if (change === 'unmount') {
+        await act(() => {
+          renderer?.unmount();
+        });
+        renderer = undefined;
+      } else {
+        await render();
+      }
+      await act(async () => {
+        network.resolve({ sessions: [] });
+        await flush();
+      });
+      expect(client.getQueryData(key)).toEqual(current);
+      expect(state.request.mock.calls).toHaveLength(1);
+    }
+  );
+
+  it('skips reconciliation when the account changes before the exit acknowledgement', async () => {
+    attach();
+    const acknowledgement = deferred<undefined>();
+    state.send.mockReturnValue(acknowledgement.promise);
+    await render();
+    await exit();
+    bumpAuthEpoch();
+    client.clear();
+    const current = { sessions: [makeCached({ id: 'b' })] };
+    client.setQueryData(QUERY_KEY, current);
+    await render();
+    await act(async () => {
+      acknowledgement.resolve(undefined);
+      await flush();
+    });
+    expect(client.getQueryData(QUERY_KEY)).toEqual(current);
+    expect(state.request.mock.calls).toHaveLength(0);
+  });
+});

--- a/apps/mobile/src/components/agents/remote-session-row.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/remote-session-row.mounted.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable typescript-eslint/no-deprecated -- DOM-free React Native row integration */
 import { createElement } from 'react';
+import { Pressable } from 'react-native';
 import { type QueryClient, QueryClientProvider, QueryObserver } from '@tanstack/react-query';
 import TestRenderer, { act } from 'react-test-renderer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -126,7 +127,7 @@ async function exit() {
     if (!renderer) {
       throw new Error('Missing row');
     }
-    const props = renderer.root.findByType('Pressable').props as { onLongPress: () => void };
+    const props = renderer.root.findByType(Pressable).props as { onLongPress: () => void };
     props.onLongPress();
     if (!state.exit) {
       throw new Error('Missing exit action');

--- a/apps/mobile/src/components/agents/remote-session-row.tsx
+++ b/apps/mobile/src/components/agents/remote-session-row.tsx
@@ -1,7 +1,12 @@
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import { useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { buildActiveSessionsTrayInput } from '@/lib/active-sessions-live';
+import { currentAuthEpoch, isCurrentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { isSignOutActive } from '@/lib/auth/sign-out-state';
+import { useOrganization } from '@/lib/organization-context';
 import { Platform, Pressable, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -64,6 +69,24 @@ export function RemoteSessionRow({
   const queryClient = useQueryClient();
   const trpc = useTRPC();
   const connection = useUserWebConnection();
+  const { organizationId, isLoaded } = useOrganization();
+  const authEpoch = currentAuthEpoch();
+  const refreshScope = useMemo(
+    () => ({
+      queryKey: trpc.activeSessions.list.queryKey(buildActiveSessionsTrayInput(organizationId)),
+      authEpoch,
+      isLoaded,
+    }),
+    [trpc, organizationId, authEpoch, isLoaded]
+  );
+  const currentRefreshScope = useRef<typeof refreshScope | null>(refreshScope);
+  currentRefreshScope.current = refreshScope;
+  useEffect(() => {
+    currentRefreshScope.current = refreshScope;
+    return () => {
+      currentRefreshScope.current = null;
+    };
+  }, [refreshScope]);
   const exitingRef = useRef(false);
   const title = session.title.length > 0 ? session.title : t('agents.sessionRow.untitled');
   const [renameVisible, setRenameVisible] = useState(false);
@@ -125,10 +148,23 @@ export function RemoteSessionRow({
     ) : undefined;
 
   const refreshActiveList = async () => {
-    if (await refreshActiveSessionsNow()) {
+    const { queryKey } = refreshScope;
+    const query = queryClient.getQueryCache().find({ queryKey, exact: true });
+    const isCurrent = () =>
+      refreshScope.isLoaded &&
+      currentRefreshScope.current === refreshScope &&
+      isCurrentAuthEpoch(refreshScope.authEpoch) &&
+      !isSignOutActive() &&
+      query === queryClient.getQueryCache().find({ queryKey, exact: true });
+    if (!isCurrent()) {
       return;
     }
-    await queryClient.invalidateQueries(trpc.activeSessions.list.pathFilter());
+    if (await refreshActiveSessionsNow(queryKey)) {
+      return;
+    }
+    if (isCurrent()) {
+      await queryClient.invalidateQueries({ queryKey, exact: true });
+    }
   };
 
   const handleExit = () => {

--- a/apps/mobile/src/lib/active-sessions-live-sync-mount.tsx
+++ b/apps/mobile/src/lib/active-sessions-live-sync-mount.tsx
@@ -1,33 +1,103 @@
-import { useEffect, useMemo } from 'react';
-import { type QueryFunction, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef } from 'react';
+import { type QueryFunction, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useUserWebConnection } from '@/components/agents/user-web-connection-provider';
-import { ActiveSessionsLiveSync } from '@/lib/active-sessions-live-sync';
+import { ActiveSessionsLiveSync, refreshActiveSessionsNow } from '@/lib/active-sessions-live-sync';
 import {
   buildActiveSessionsTrayInput,
   type CachedActiveSessionsData,
 } from '@/lib/active-sessions-live';
+import { useAuth } from '@/lib/auth/auth-context';
+import { isCurrentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { isSignOutActive } from '@/lib/auth/sign-out-state';
+import { type UseAgentSessionsOptions } from '@/lib/hooks/use-agent-sessions';
+import { useUserWebConnectionState } from '@/lib/hooks/use-user-web-connection-state';
 import { useOrganization } from '@/lib/organization-context';
+import { captureActiveSessionsQueryRefresh, fenceActiveSessionsQuery } from '@/lib/query-client';
 import { useTRPC } from '@/lib/trpc';
 
-/**
- * React entry point for the active-sessions live-sync owner. Holds a standing
- * socket lease for the mount lifetime and recreates the per-context owner when
- * the selected personal/org context changes.
- */
+/** Shared active query for the live-only and combined hooks. */
+export function useActiveSessions(options?: UseAgentSessionsOptions) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const { token, isLoading, isSigningOut, authEpoch } = useAuth();
+  const { isLoaded } = useOrganization();
+  const canRead =
+    Boolean(token) &&
+    !isLoading &&
+    !isSigningOut &&
+    isLoaded &&
+    options?.enabled !== false &&
+    !isSignOutActive();
+  const wsConnected = useUserWebConnectionState();
+  const input = useMemo(
+    () => buildActiveSessionsTrayInput(options?.organizationId),
+    [options?.organizationId]
+  );
+  const queryKey = useMemo(() => trpc.activeSessions.list.queryKey(input), [trpc, input]);
+  const queryOptions = trpc.activeSessions.list.queryOptions(input, {
+    // Cloud rows need a floor poll; socket writes remain the instant CLI path.
+    refetchInterval: wsConnected ? 30_000 : 10_000,
+    staleTime: 5000,
+    enabled: canRead,
+  });
+  const queryFn = queryOptions.queryFn;
+  const active = useQuery({
+    ...queryOptions,
+    queryFn:
+      queryFn &&
+      fenceActiveSessionsQuery(queryFn, () => isCurrentAuthEpoch(authEpoch) && !isSignOutActive()),
+  });
+  const scope = useMemo(() => ({ queryKey, canRead, authEpoch }), [queryKey, canRead, authEpoch]);
+  const currentScope = useRef<typeof scope | null>(scope);
+  currentScope.current = scope;
+  useEffect(() => {
+    currentScope.current = scope;
+    return () => {
+      currentScope.current = null;
+    };
+  }, [scope]);
+
+  const refetch = async (): Promise<boolean> => {
+    const isCurrentScope = () =>
+      canRead &&
+      currentScope.current === scope &&
+      isCurrentAuthEpoch(authEpoch) &&
+      !isSignOutActive();
+    if (!isCurrentScope()) {
+      return false;
+    }
+    const refresh = captureActiveSessionsQueryRefresh(queryClient, queryKey);
+    const handled = await refreshActiveSessionsNow(queryKey);
+    if (!isCurrentScope() || !refresh.isCurrent()) {
+      return false;
+    }
+    if (handled === false) {
+      await active.refetch();
+    }
+    return (
+      isCurrentScope() && (handled === false || handled.accepted) && refresh.hasAcceptedResult()
+    );
+  };
+  return { ...active, queryKey, canRead, refetch };
+}
+
+/** Holds the socket lease across personal/organization context changes. */
 function useActiveSessionsLiveSync(): void {
   const connection = useUserWebConnection();
   const queryClient = useQueryClient();
   const trpc = useTRPC();
   const { organizationId, isLoaded } = useOrganization();
+  const { token, isLoading, isSigningOut, authEpoch } = useAuth();
+  const enabled = Boolean(token) && !isLoading && !isSigningOut && isLoaded;
 
-  // The per-context owner below is recreated on every context switch, and its
-  // detach()/attach() pair would drop the retain count to zero in between —
-  // which stops the shared user-web socket. This lease spans the mount's whole
-  // lifetime, so a context switch swaps owners without ever closing the socket,
-  // and the socket still comes up before the organization context has loaded,
-  // exactly as it does today. `retain()` returns its own release function.
-  useEffect(() => connection.retain(), [connection]);
+  // Each per-context owner also owns and releases its own lease.
+  useEffect(() => {
+    if (enabled && !isSignOutActive()) {
+      return connection.retain();
+    }
+    return undefined;
+  }, [connection, enabled, authEpoch]);
 
   const input = useMemo(() => buildActiveSessionsTrayInput(organizationId), [organizationId]);
   const queryKey = useMemo(() => trpc.activeSessions.list.queryKey(input), [trpc, input]);
@@ -37,25 +107,16 @@ function useActiveSessionsLiveSync(): void {
         .queryFn as QueryFunction<CachedActiveSessionsData>,
     [trpc, input]
   );
-
-  // One owner per context: the tray cache key varies with the selected
-  // personal/org context, so switching context has to retarget the WS writes. A
-  // fresh instance per key is simpler than mutating a live owner's key, and
-  // `attach()`'s cleanup releases the previous retain and listeners. Gated on
-  // `isLoaded` so the pre-load default (personal) never claims the socket for a
-  // context the user has not actually selected.
+  // An unresolved selection must never attach the default personal context.
   useEffect(() => {
-    if (!isLoaded) {
+    if (!enabled || isSignOutActive()) {
       return undefined;
     }
     const sync = new ActiveSessionsLiveSync({ connection, queryClient, queryKey, queryFn });
     return sync.attach();
-  }, [connection, isLoaded, queryClient, queryFn, queryKey]);
+  }, [connection, enabled, authEpoch, queryClient, queryFn, queryKey]);
 }
 
-/**
- * Component form for the layout wiring. Renders `null`.
- */
 export function ActiveSessionsLiveSyncMount(): null {
   useActiveSessionsLiveSync();
   return null;

--- a/apps/mobile/src/lib/active-sessions-live-sync.attention.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.attention.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, type Mock } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   ActiveSessionsLiveSync,
@@ -88,7 +88,7 @@ describe('ActiveSessionsLiveSync — session.status.updated', () => {
     qc.__setCached({
       sessions: [makeCached({ id: 'ses-1', status: 'question' })],
     });
-    const setQueryDataCalls = qc.setQueryData as Mock;
+    const setQueryDataCalls = vi.spyOn(qc, 'setQueryData');
     setQueryDataCalls.mockClear();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,

--- a/apps/mobile/src/lib/active-sessions-live-sync.manual-refresh.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.manual-refresh.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getActiveSessionsQueryMetadata } from '@/lib/query-client';
 
 import {
   ActiveSessionsLiveSync,
@@ -37,14 +39,14 @@ describe('ActiveSessionsLiveSync — manual refresh', () => {
     });
     sync.attach();
 
-    const pending = refreshActiveSessionsNow();
+    const pending = refreshActiveSessionsNow(QUERY_KEY);
     await sync.getFetchQueue();
     expect(qc.__hasPendingFetch()).toBe(true);
     expect(qc.fetchQueryCalls).toBe(1);
 
     qc.__triggerFetchResolve({ sessions: [makeCached({ createdOnPlatform: 'cli' })] });
     const result = await pending;
-    expect(result).toBe(true);
+    expect(result).toEqual({ accepted: true });
     expect(qc.__getCached()?.sessions[0]?.id).toBe('a1');
   });
 
@@ -61,7 +63,7 @@ describe('ActiveSessionsLiveSync — manual refresh', () => {
     sync.attach();
 
     let settled = false;
-    const pending = refreshActiveSessionsNow();
+    const pending = refreshActiveSessionsNow(QUERY_KEY);
     // eslint-disable-next-line promise/prefer-await-to-then, promise/always-return
     void pending.then(() => {
       settled = true;
@@ -76,43 +78,48 @@ describe('ActiveSessionsLiveSync — manual refresh', () => {
     expect(settled).toBe(true);
   });
 
-  it('stays pending across a write that cancels the manual fetch', async () => {
+  it('waits for an accepted replacement when cancellation fulfills with cached data', async () => {
     const conn = makeConnection();
-    const qc = makeFakeQueryClient();
-    const queryFn = makeQueryFn();
+    const cached = { sessions: [makeCached({ createdOnPlatform: 'cli' })] };
+    const qc = makeFakeQueryClient(cached);
+    const query = qc.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
+    const before = getActiveSessionsQueryMetadata(query);
     sync = new ActiveSessionsLiveSync({
       connection: conn,
       queryClient: qc,
       queryKey: QUERY_KEY,
-      queryFn,
+      queryFn: makeQueryFn(),
     });
     sync.attach();
 
-    const settledFlag = { value: false };
-    const pending = refreshActiveSessionsNow();
-    // eslint-disable-next-line promise/prefer-await-to-then, promise/always-return
-    void pending.then(() => {
-      settledFlag.value = true;
-    });
+    let settled = false;
+    const fetchSpy = vi.spyOn(qc, 'fetchQuery');
+    const pending = (async () => {
+      const result = await refreshActiveSessionsNow(QUERY_KEY);
+      settled = true;
+      return result;
+    })();
     await sync.getFetchQueue();
-    expect(qc.fetchQueryCalls).toBe(1);
-
-    const disconnected: SystemEvent = {
-      event: 'cli.disconnected',
-      data: { connectionId: 'c1' },
-    };
-    conn.__fireSystem(disconnected);
+    const canceledFetch = fetchSpy.mock.results[0]?.value;
+    conn.__fireSystem({ event: 'cli.disconnected', data: { connectionId: 'c1' } });
     await sync.getWriteQueue();
     await sync.getFetchQueue();
 
-    expect(qc.fetchQueryCalls).toBe(2);
+    expect(await canceledFetch).toEqual(cached);
+    expect(getActiveSessionsQueryMetadata(query)).toBe(before);
+    expect(qc.__getCached()?.sessions).toEqual([]);
+    expect(sync.getPendingReasons()).toContain('manual');
     expect(qc.__hasPendingFetch()).toBe(true);
-    expect(settledFlag.value).toBe(false);
+    expect(settled).toBe(false);
 
-    qc.__triggerFetchResolve({ sessions: [makeCached({ createdOnPlatform: 'cli' })] });
-    await pending;
-    expect(settledFlag.value).toBe(true);
-    expect(qc.__getCached()?.sessions[0]?.id).toBe('a1');
+    qc.__triggerFetchResolve(cached);
+    expect(await pending).toEqual({ accepted: true });
+    expect(getActiveSessionsQueryMetadata(query).acceptedRevision).toBe(
+      before.acceptedRevision + 1
+    );
+    expect(sync.getPendingReasons()).toEqual(new Set());
+    expect(settled).toBe(true);
+    expect(qc.__getCached()).toEqual(cached);
   });
 
   it('refetches after a failed refresh left a reason pending', async () => {
@@ -144,14 +151,14 @@ describe('ActiveSessionsLiveSync — manual refresh', () => {
 
     // Manual refresh kicks a new fetch that clears the stuck reason.
     const previousCalls = qc.fetchQueryCalls;
-    const pending = refreshActiveSessionsNow();
+    const pending = refreshActiveSessionsNow(QUERY_KEY);
     await sync.getFetchQueue();
     expect(qc.fetchQueryCalls).toBe(previousCalls + 1);
     expect(qc.__hasPendingFetch()).toBe(true);
 
     qc.__triggerFetchResolve({ sessions: [makeCached({ createdOnPlatform: 'cli' })] });
     const result = await pending;
-    expect(result).toBe(true);
+    expect(result).toEqual({ accepted: true });
     expect(qc.__getCached()?.sessions[0]?.id).toBe('a1');
   });
 
@@ -169,7 +176,7 @@ describe('ActiveSessionsLiveSync — manual refresh', () => {
     sync.detach();
 
     const prevCalls = qc.fetchQueryCalls;
-    const result = await refreshActiveSessionsNow();
+    const result = await refreshActiveSessionsNow(QUERY_KEY);
     expect(result).toBe(false);
     expect(qc.fetchQueryCalls).toBe(prevCalls);
   });

--- a/apps/mobile/src/lib/active-sessions-live-sync.pending.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.pending.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { getActiveSessionsQueryMetadata } from '@/lib/query-client';
+
 import {
   ActiveSessionsLiveSync,
   makeCached,
@@ -70,10 +72,14 @@ describe('ActiveSessionsLiveSync — pending-reason semantics', () => {
     expect(sync.getPendingReasons().has('cli-disconnected')).toBe(true);
     expect(qc.__hasPendingFetch()).toBe(true);
     expect(queryFn).toHaveBeenCalledTimes(2);
-    // Resolve it; the reason clears.
+    const query = qc.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
+    expect(getActiveSessionsQueryMetadata(query).acceptedRevision).toBe(0);
+    // Only the accepted replacement clears the reason.
     qc.__triggerFetchResolve({ sessions: [] });
     await sync.getFetchCompletion();
     expect(sync.getPendingReasons().has('cli-disconnected')).toBe(false);
+    expect(getActiveSessionsQueryMetadata(query).acceptedRevision).toBe(1);
+    expect(qc.__getCached()).toEqual({ sessions: [] });
   });
 
   it('a fetch that errors does not clear its reason (transient failure)', async () => {

--- a/apps/mobile/src/lib/active-sessions-live-sync.race.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.race.test.ts
@@ -13,7 +13,103 @@ import {
   type SystemEvent,
 } from '@/lib/active-sessions-live-sync.test-helpers';
 
+import { bumpAuthEpoch } from '@/lib/auth/auth-epoch';
+import { setSignOutActive } from '@/lib/auth/sign-out-state';
+import { createKiloAppQueryClient, getActiveSessionsQueryMetadata } from '@/lib/query-client';
+
 setupTimers();
+
+describe('ActiveSessionsLiveSync — publication fences', () => {
+  it.each([
+    { operation: 'write', accountChange: true },
+    { operation: 'fetch', accountChange: true },
+    { operation: 'write', accountChange: false },
+    { operation: 'fetch', accountChange: false },
+  ])(
+    'fences queued $operation work after cancellation, accountChange=$accountChange',
+    async ({ operation, accountChange }) => {
+      const conn = makeConnection();
+      const qc = makeFakeQueryClient();
+      const sync = new ActiveSessionsLiveSync({
+        connection: conn,
+        queryClient: qc,
+        queryKey: QUERY_KEY,
+        queryFn: makeQueryFn(),
+      });
+      sync.attach();
+      const gate = deferred<undefined>();
+      const cancel = qc.cancelQueries.bind(qc);
+      let waiting = false;
+      vi.spyOn(qc, 'cancelQueries').mockImplementationOnce(async filters => {
+        await cancel(filters);
+        waiting = true;
+        await gate.promise;
+      });
+      if (operation === 'write') {
+        conn.__fireSystem({
+          event: 'sessions.list',
+          data: { sessions: [makeCached({ title: 'stale' })] },
+        });
+        conn.__fireSystem({ event: 'sessions.list', data: { sessions: [] } });
+      } else {
+        sync.scheduleRefresh('manual');
+      }
+      await vi.waitFor(() => {
+        expect(waiting).toBe(true);
+      });
+      if (accountChange) {
+        bumpAuthEpoch();
+        qc.clear();
+      } else {
+        setSignOutActive(true);
+      }
+      const current = { sessions: [makeCached({ title: 'Current account' })] };
+      qc.setQueryData(QUERY_KEY, current);
+      try {
+        gate.resolve(undefined);
+        await sync.getWriteQueue();
+        await sync.getFetchCompletion();
+        expect(qc.__getCached()).toEqual(current);
+        expect(qc.getQueryState(QUERY_KEY)?.fetchStatus).toBe('idle');
+        expect(qc.__hasPendingFetch()).toBe(false);
+      } finally {
+        sync.detach();
+        setSignOutActive(false);
+      }
+    }
+  );
+
+  it('rejects a server result after synchronous sign-out closes publication', async () => {
+    const conn = makeConnection();
+    const cached = { sessions: [makeCached({ title: 'Before sign-out' })] };
+    const qc = createKiloAppQueryClient();
+    qc.setQueryData(QUERY_KEY, cached);
+    const query = qc.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
+    const network = deferred<CachedActiveSessionsData>();
+    const sync = new ActiveSessionsLiveSync({
+      connection: conn,
+      queryClient: qc,
+      queryKey: QUERY_KEY,
+      queryFn: async () => {
+        const result = await network.promise;
+        return result;
+      },
+    });
+    sync.attach();
+    const pending = sync.refreshNow(QUERY_KEY);
+    await sync.getFetchQueue();
+    setSignOutActive(true);
+    try {
+      network.resolve({ sessions: [makeCached({ title: 'Late result' })] });
+      expect(await pending).toEqual({ accepted: false });
+      expect(qc.getQueryData(QUERY_KEY)).toEqual(cached);
+      expect(getActiveSessionsQueryMetadata(query).acceptedRevision).toBe(0);
+    } finally {
+      sync.detach();
+      setSignOutActive(false);
+    }
+  });
+});
 
 describe('ActiveSessionsLiveSync — race tests', () => {
   it('heartbeat wins over an in-flight fetch (cache reflects heartbeat)', async () => {

--- a/apps/mobile/src/lib/active-sessions-live-sync.reconnect.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.reconnect.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { getActiveSessionsQueryMetadata } from '@/lib/query-client';
+
 import {
   ActiveSessionsLiveSync,
   makeConnection,
@@ -37,6 +39,12 @@ describe('ActiveSessionsLiveSync — reconnect (onConnectionChange rising edge)'
     conn.__fireConnection(true);
     await sync.getFetchQueue();
     expect(queryFn).toHaveBeenCalledTimes(2);
+    const query = qc.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
+    expect(getActiveSessionsQueryMetadata(query).acceptedRevision).toBe(0);
+    qc.__triggerFetchResolve({ sessions: [] });
+    await sync.getFetchCompletion();
+    expect(sync.getPendingReasons()).toEqual(new Set());
+    expect(getActiveSessionsQueryMetadata(query).acceptedRevision).toBe(1);
   });
 
   it('release-then-retain still produces exactly one refresh per rising edge', async () => {

--- a/apps/mobile/src/lib/active-sessions-live-sync.test-helpers.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.test-helpers.ts
@@ -1,5 +1,11 @@
+/* eslint-disable typescript-eslint/no-deprecated -- DOM-free mounted query fixtures */
+import { createElement, type ReactNode } from 'react';
+import { type QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import TestRenderer, { act } from 'react-test-renderer';
 import { afterEach, beforeEach, vi } from 'vitest';
-import { type QueryFunction, type QueryKey } from '@tanstack/react-query';
+import { createKiloAppQueryClient } from '@/lib/query-client';
+import { bumpAuthEpoch } from '@/lib/auth/auth-epoch';
+import { setSignOutActive } from '@/lib/auth/sign-out-state';
 
 import {
   ActiveSessionsLiveSync,
@@ -7,6 +13,7 @@ import {
   type LiveSyncQueryClient,
 } from '@/lib/active-sessions-live-sync';
 import {
+  buildActiveSessionsTrayInput,
   type CachedActiveSession,
   type CachedActiveSessionsData,
 } from '@/lib/active-sessions-live';
@@ -106,96 +113,75 @@ type FakeQueryClient = LiveSyncQueryClient & {
 
 const emptySessionsData = (): CachedActiveSessionsData => ({ sessions: [] });
 
+/** Real QueryClient cancellation/provenance with a controlled network result. */
 export function makeFakeQueryClient(
   initial: CachedActiveSessionsData = emptySessionsData()
 ): FakeQueryClient {
-  let cache: CachedActiveSessionsData | undefined = initial;
+  const qc = makeTestQueryClient();
+  const seed = qc.setQueryData.bind(qc);
+  seed(QUERY_KEY, initial);
   let pendingFetch: Deferred<CachedActiveSessionsData> | null = null;
-  let fetchQueryCalls = 0;
-  let cancelQueriesCalls = 0;
-  const qc = {
-    cancelQueries: vi.fn(async () => {
-      cancelQueriesCalls += 1;
-      if (pendingFetch) {
-        const d = pendingFetch;
-        pendingFetch = null;
-        d.reject(new Error('canceled'));
-      }
-      await Promise.resolve();
-    }),
-    setQueryData: vi.fn((_key: QueryKey, updater: unknown): unknown => {
-      const next =
-        typeof updater === 'function'
-          ? (updater as (old: CachedActiveSessionsData | undefined) => unknown)(cache)
-          : updater;
-      cache = next as CachedActiveSessionsData;
-      return next;
-    }),
-    getQueryData: vi.fn((_key: QueryKey) => cache as unknown),
-    fetchQuery: vi.fn(
-      async (opts: {
-        queryKey: QueryKey;
-        queryFn: QueryFunction<CachedActiveSessionsData>;
-        staleTime?: number;
-      }): Promise<CachedActiveSessionsData> => {
-        fetchQueryCalls += 1;
-        // Drive the supplied queryFn so tests can assert it was invoked,
-        // but let the test control the resolved value via __triggerFetchResolve.
-        // QueryFunction requires a context arg; the fake only needs to observe the call.
-        await (opts.queryFn as unknown as () => Promise<unknown>)();
-        const d = deferred<CachedActiveSessionsData>();
-        pendingFetch = d;
+  const fetch = qc.fetchQuery.bind(qc);
+  const cancel = qc.cancelQueries.bind(qc);
+  const fetchSpy = vi.spyOn(qc, 'fetchQuery').mockImplementation(async options => {
+    const queryFn = options.queryFn;
+    if (typeof queryFn !== 'function') {
+      throw new TypeError('Expected a query function');
+    }
+    const result = await fetch({
+      ...options,
+      queryFn: async context => {
+        const pending = deferred<CachedActiveSessionsData>();
+        pendingFetch = pending;
         try {
-          const result = await d.promise;
-          return result;
+          await queryFn(context);
+          return await pending.promise;
         } finally {
-          if (pendingFetch === d) {
+          if (pendingFetch === pending) {
             pendingFetch = null;
           }
         }
-      }
-    ),
-    fetchQueryCalls: 0,
-    cancelQueriesCalls: 0,
+      },
+    });
+    return result;
+  });
+  const cancelSpy = vi.spyOn(qc, 'cancelQueries').mockImplementation(async (...args) => {
+    pendingFetch = null;
+    await cancel(...args);
+  });
+  vi.spyOn(qc, 'setQueryData');
+  Object.assign(qc, {
     __setCached(data: CachedActiveSessionsData | undefined) {
-      cache = data;
+      if (data === undefined) {
+        qc.removeQueries({ queryKey: QUERY_KEY, exact: true });
+      } else {
+        seed(QUERY_KEY, data);
+      }
     },
     __triggerFetchResolve(data: CachedActiveSessionsData) {
-      if (pendingFetch) {
-        const d = pendingFetch;
-        pendingFetch = null;
-        cache = data;
-        d.resolve(data);
-      }
+      pendingFetch?.resolve(data);
     },
     __triggerFetchReject(error: Error) {
-      if (pendingFetch) {
-        const d = pendingFetch;
-        pendingFetch = null;
-        d.reject(error);
-      }
+      pendingFetch?.reject(error);
     },
     __hasPendingFetch() {
       return pendingFetch !== null;
     },
     __getCached() {
-      return cache;
-    },
-  };
-  Object.defineProperty(qc, 'fetchQueryCalls', {
-    get() {
-      return fetchQueryCalls;
+      return qc.getQueryData<CachedActiveSessionsData>(QUERY_KEY);
     },
   });
-  Object.defineProperty(qc, 'cancelQueriesCalls', {
-    get() {
-      return cancelQueriesCalls;
-    },
+  Object.defineProperties(qc, {
+    fetchQueryCalls: { get: () => fetchSpy.mock.calls.length },
+    cancelQueriesCalls: { get: () => cancelSpy.mock.calls.length },
   });
-  return qc as unknown as FakeQueryClient;
+  return qc as FakeQueryClient;
 }
 
-export const QUERY_KEY = ['activeSessions', 'list'] as const;
+export const QUERY_KEY = [
+  ['activeSessions', 'list'],
+  { input: buildActiveSessionsTrayInput(null), type: 'query' },
+] as const;
 
 export function makeQueryFn(response: CachedActiveSessionsData = emptySessionsData()) {
   return vi.fn(async () => {
@@ -231,6 +217,88 @@ export function setupTimers(): void {
   afterEach(() => {
     vi.useRealTimers();
   });
+}
+
+export function makeActiveSessionsQueryKey(organizationId: string | null = null) {
+  return [
+    ['activeSessions', 'list'],
+    { input: buildActiveSessionsTrayInput(organizationId), type: 'query' },
+  ] as const;
+}
+
+export async function flushQueryUpdates(): Promise<void> {
+  await new Promise<void>(resolve => {
+    setTimeout(resolve, 0);
+  });
+  await new Promise<void>(resolve => {
+    setTimeout(resolve, 0);
+  });
+}
+
+/** Reuse the DOM-free query-provider lifecycle without sharing query clients. */
+export function createQueryProbe(Probe: () => ReactNode, getClient: () => QueryClient) {
+  let renderer: TestRenderer.ReactTestRenderer | undefined = undefined;
+  return {
+    render: async () => {
+      await act(async () => {
+        const tree = createElement(
+          QueryClientProvider,
+          { client: getClient() },
+          createElement(Probe)
+        );
+        if (renderer) {
+          renderer.update(tree);
+        } else {
+          renderer = TestRenderer.create(tree);
+        }
+        await flushQueryUpdates();
+      });
+    },
+    unmount: () => {
+      renderer?.unmount();
+      renderer = undefined;
+    },
+  };
+}
+
+export function makeTestQueryClient(): QueryClient {
+  const client = createKiloAppQueryClient();
+  client.setDefaultOptions({
+    queries: { retry: false, gcTime: Infinity },
+    mutations: { retry: false, gcTime: Infinity },
+  });
+  return client;
+}
+
+export function seedMutationSessions(
+  client: QueryClient,
+  listKey: readonly unknown[],
+  title = 'Old'
+) {
+  const cliSessions = [
+    { session_id: 's1', title },
+    { session_id: 's2', title: 'Other' },
+  ];
+  client.setQueryData(listKey, { pages: [{ cliSessions }], pageParams: [null] });
+  client.setQueryData(QUERY_KEY, { sessions: [makeCached({ id: 's1', title })] });
+}
+
+export function mutationStoredTitles(client: QueryClient, listKey: readonly unknown[]) {
+  return client
+    .getQueryData<{ pages: { cliSessions: { title: string }[] }[] }>(listKey)
+    ?.pages.flatMap(page => page.cliSessions.map(session => session.title));
+}
+
+export function mutationActiveTitle(client: QueryClient) {
+  return client.getQueryData<CachedActiveSessionsData>(QUERY_KEY)?.sessions[0]?.title;
+}
+
+export function replaceMutationAccount(client: QueryClient, listKey: readonly unknown[]) {
+  setSignOutActive(true);
+  bumpAuthEpoch();
+  client.clear();
+  setSignOutActive(false);
+  seedMutationSessions(client, listKey, 'Account B');
 }
 
 export { ActiveSessionsLiveSync };

--- a/apps/mobile/src/lib/active-sessions-live-sync.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.test.ts
@@ -15,7 +15,7 @@ import {
 setupTimers();
 
 describe('ActiveSessionsLiveSync — attach / detach', () => {
-  it('retains the connection on attach and releases on detach', () => {
+  it('retains the connection on attach and ignores socket writes after detach', async () => {
     const release = vi.fn();
     const conn = makeConnection({ retain: vi.fn(() => release) });
     const qc = makeFakeQueryClient();
@@ -31,6 +31,9 @@ describe('ActiveSessionsLiveSync — attach / detach', () => {
     expect(conn.onConnectionChange).toHaveBeenCalledTimes(1);
     detach();
     expect(release).toHaveBeenCalledTimes(1);
+    conn.__fireSystem({ event: 'sessions.list', data: { sessions: [makeCached()] } });
+    await sync.getWriteQueue();
+    expect(qc.__getCached()).toEqual({ sessions: [] });
   });
 
   it('does not publish a queued write after detach', async () => {
@@ -44,7 +47,7 @@ describe('ActiveSessionsLiveSync — attach / detach', () => {
     });
     sync.attach();
     const blockedWrite = deferred<undefined>();
-    vi.mocked(qc.cancelQueries).mockImplementationOnce(async () => {
+    vi.spyOn(qc, 'cancelQueries').mockImplementationOnce(async () => {
       await blockedWrite.promise;
     });
     conn.__fireSystem({
@@ -58,21 +61,14 @@ describe('ActiveSessionsLiveSync — attach / detach', () => {
     sync.detach();
     blockedWrite.resolve(undefined);
     await sync.getWriteQueue();
-    expect(qc.setQueryData).not.toHaveBeenCalled();
+    expect(qc.__getCached()).toEqual({ sessions: [] });
   });
 
   it('keeps queued work fenced after detach and re-attach', async () => {
     const conn = makeConnection();
-    const qc = makeFakeQueryClient();
-    qc.__setCached({
-      sessions: [
-        makeCached({
-          id: 'current',
-          connectionId: 'c2',
-          createdAt: '2026-07-20T00:00:00.000Z',
-        }),
-      ],
-    });
+    const createdAt = '2026-07-20T00:00:00.000Z';
+    const current = makeCached({ id: 'current', connectionId: 'c2', createdAt });
+    const qc = makeFakeQueryClient({ sessions: [current] });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
       queryClient: qc,
@@ -80,8 +76,14 @@ describe('ActiveSessionsLiveSync — attach / detach', () => {
       queryFn: makeQueryFn(),
     });
     const detach = sync.attach();
+    const published: string[][] = [];
+    qc.getQueryCache().subscribe(event => {
+      if (event.type === 'updated' && event.action.type === 'success') {
+        published.push(qc.__getCached()?.sessions.map(session => session.id) ?? []);
+      }
+    });
     const blockedWrite = deferred<undefined>();
-    vi.mocked(qc.cancelQueries).mockImplementationOnce(async () => {
+    vi.spyOn(qc, 'cancelQueries').mockImplementationOnce(async () => {
       await blockedWrite.promise;
     });
     conn.__fireSystem({
@@ -101,7 +103,7 @@ describe('ActiveSessionsLiveSync — attach / detach', () => {
     await new Promise<void>(resolve => {
       setTimeout(resolve, 0);
     });
-    expect(qc.cancelQueries).toHaveBeenCalledTimes(1);
+    expect(qc.cancelQueriesCalls).toBe(1);
 
     detach();
     sync.attach();
@@ -121,7 +123,7 @@ describe('ActiveSessionsLiveSync — attach / detach', () => {
     blockedWrite.resolve(undefined);
     await sync.getWriteQueue();
 
-    expect(qc.setQueryData).toHaveBeenCalledTimes(1);
+    expect(published).toEqual([['current']]);
     expect(qc.__getCached()?.sessions.map(session => session.id)).toEqual(['current']);
     expect(sync.getPendingReasons()).toEqual(new Set());
   });
@@ -144,7 +146,7 @@ describe('ActiveSessionsLiveSync — attach / detach', () => {
     await Promise.resolve();
     expect(sync.getPendingReasons()).toEqual(new Set());
     expect(qc.fetchQueryCalls).toBe(1);
-    expect(qc.setQueryData).not.toHaveBeenCalled();
+    expect(qc.__getCached()).toEqual({ sessions: [] });
   });
 });
 
@@ -270,7 +272,7 @@ describe('ActiveSessionsLiveSync — cli.connected', () => {
     const conn = makeConnection();
     const qc = makeFakeQueryClient();
     qc.__setCached({ sessions: [makeCached({ id: 'a' })] });
-    const setQueryDataCalls = qc.setQueryData as ReturnType<typeof vi.fn>;
+    const setQueryDataCalls = vi.spyOn(qc, 'setQueryData');
     setQueryDataCalls.mockClear();
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({

--- a/apps/mobile/src/lib/active-sessions-live-sync.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.ts
@@ -1,12 +1,11 @@
-/**
- * App-level owner for active-sessions live-sync: retains UserWebConnection,
- * applies onSystemEvent payloads to trpc.activeSessions.list via a serialized
- * cancelQueries+setQueryData pipeline, and coalesces refreshes (cli.connected /
- * disconnected, reconnect, enrichment) with fetchQuery staleTime:0.
- * Framework-agnostic; React glue is active-sessions-live-sync-mount.tsx.
- */
-
-import { type QueryClient, type QueryFunction, type QueryKey } from '@tanstack/react-query';
+/** Serialized socket writes and accepted server refreshes for one tray scope. */
+import {
+  hashKey,
+  type QueryClient,
+  type QueryFunction,
+  type QueryKey,
+} from '@tanstack/react-query';
+import { type UserWebConnection, type UserWebSystemEvent } from '@kilocode/cloud-agent-sdk';
 
 import {
   type CachedActiveSession,
@@ -14,28 +13,18 @@ import {
   hasUnenrichedLiveId,
   planLiveSystemEventActions,
 } from './active-sessions-live';
-
-import { type UserWebConnection, type UserWebSystemEvent } from '@kilocode/cloud-agent-sdk';
+import { currentAuthEpoch, isCurrentAuthEpoch } from './auth/auth-epoch';
+import { isSignOutActive } from './auth/sign-out-state';
+import { captureActiveSessionsQueryRefresh, fenceActiveSessionsQuery } from './query-client';
 
 const ENRICHMENT_RETRY_MIN_INTERVAL_MS = 10_000;
-
 type RefreshReason = 'enrichment' | 'cli-connected' | 'cli-disconnected' | 'reconnect' | 'manual';
-
-type SystemEvent = UserWebSystemEvent;
-
 type WriteUpdater = (current: CachedActiveSession[]) => CachedActiveSession[];
-
-/** Minimal UserWebConnection surface used by this owner. */
 export type LiveSyncConnection = Pick<
   UserWebConnection,
   'retain' | 'isConnected' | 'onConnectionChange' | 'onSystemEvent'
 >;
-
-export type LiveSyncQueryClient = Pick<
-  QueryClient,
-  'cancelQueries' | 'setQueryData' | 'getQueryData' | 'fetchQuery'
->;
-
+export type LiveSyncQueryClient = QueryClient;
 type CreateLiveSyncOptions = {
   connection: LiveSyncConnection;
   queryClient: LiveSyncQueryClient;
@@ -44,24 +33,16 @@ type CreateLiveSyncOptions = {
   now?: () => number;
 };
 
-/** Testable owner: serialized pipeline, pending reasons, reconnect edge. */
 export class ActiveSessionsLiveSync {
-  private readonly connection: LiveSyncConnection;
-  private readonly queryClient: LiveSyncQueryClient;
-  private readonly queryKey: QueryKey;
-  private readonly queryFn: QueryFunction<CachedActiveSessionsData>;
   private readonly now: () => number;
-
   // eslint-disable-next-line promise/prefer-await-to-then
   private writeQueue: Promise<void> = Promise.resolve();
   // eslint-disable-next-line promise/prefer-await-to-then
   private fetchQueue: Promise<void> = Promise.resolve();
-
   private fetchStartCount = 0;
-  private fetchStartWaiters: (() => void)[] = [];
+  private readonly fetchStartWaiters: (() => void)[] = [];
   private lastGetFetchQueueCount = 0;
-  private fetchCompletionWaiters: (() => void)[] = [];
-
+  private readonly fetchCompletionWaiters: (() => void)[] = [];
   private readonly pendingReasons = new Set<RefreshReason>();
   private inFlightReasons: Set<RefreshReason> | null = null;
   private isFetchInFlight = false;
@@ -69,35 +50,36 @@ export class ActiveSessionsLiveSync {
   private lastEnrichmentAttemptAt: number | null = null;
   private lastConnectedState: boolean;
   private attachmentEpoch = 0;
-
+  private authEpoch = currentAuthEpoch();
   private releaseRetain: (() => void) | null = null;
   private systemListenerUnsubscribe: (() => void) | null = null;
   private connectionListenerUnsubscribe: (() => void) | null = null;
 
+  private readonly options: CreateLiveSyncOptions;
+
   constructor(options: CreateLiveSyncOptions) {
-    this.connection = options.connection;
-    this.queryClient = options.queryClient;
-    this.queryKey = options.queryKey;
-    this.queryFn = options.queryFn;
+    // Copy the inputs so a caller cannot retarget this owner by changing them.
+    this.options = { ...options };
     this.now = options.now ?? (() => Date.now());
-    this.lastConnectedState = this.connection.isConnected();
+    this.lastConnectedState = options.connection.isConnected();
   }
 
-  /** Subscribe, retain; detach releases listeners + retain. */
   attach(): () => void {
     if (this.releaseRetain) {
       throw new Error('ActiveSessionsLiveSync already attached');
     }
-    // Re-attach while connected must not look like a rising edge.
     this.attachmentEpoch += 1;
-    this.lastConnectedState = this.connection.isConnected();
-    this.releaseRetain = this.connection.retain();
+    this.authEpoch = currentAuthEpoch();
+    const { connection } = this.options;
+    // Re-attachment while connected must not look like a rising edge.
+    this.lastConnectedState = connection.isConnected();
+    this.releaseRetain = connection.retain();
     // eslint-disable-next-line typescript-eslint/no-this-alias, unicorn/no-this-assignment
     attachedSync = this;
-    this.systemListenerUnsubscribe = this.connection.onSystemEvent(event => {
+    this.systemListenerUnsubscribe = connection.onSystemEvent(event => {
       this.handleSystemEvent(event);
     });
-    this.connectionListenerUnsubscribe = this.connection.onConnectionChange(connected => {
+    this.connectionListenerUnsubscribe = connection.onConnectionChange(connected => {
       this.handleConnectionChange(connected);
     });
     return () => {
@@ -117,37 +99,33 @@ export class ActiveSessionsLiveSync {
     if (attachedSync === this) {
       attachedSync = null;
     }
-    void this.queryClient.cancelQueries({ queryKey: this.queryKey });
+    void this.options.queryClient.cancelQueries({ queryKey: this.options.queryKey, exact: true });
+  }
+
+  private isCurrentAttachment(epoch: number): boolean {
+    const isAttached = this.releaseRetain !== null && epoch === this.attachmentEpoch;
+    return isAttached && isCurrentAuthEpoch(this.authEpoch) && !isSignOutActive();
   }
 
   scheduleRefresh(reason: RefreshReason): void {
-    if (this.releaseRetain === null) {
+    if (!this.isCurrentAttachment(this.attachmentEpoch)) {
       return;
     }
     this.pendingReasons.add(reason);
     this.kickFetch();
   }
 
-  /**
-   * Manual (pull-to-refresh) resync. Runs through the same serialized fetch
-   * queue as WS-driven refreshes, so it can neither be cancelled by nor race
-   * with this owner's own writes, and it retries a refresh that an earlier
-   * failure left pending. Resolves when the forced fetch settles — it never
-   * rejects (`processFetchQueue` swallows fetch failures), so a caller's
-   * pull-to-refresh spinner always stops. Returns false when detached, so the
-   * caller can fall back to a plain query refetch.
-   */
-  async refreshNow(): Promise<boolean> {
-    if (this.releaseRetain === null) {
+  /** False selects a caller fallback; handled failures must not start another fetch. */
+  async refreshNow(queryKey: QueryKey): Promise<false | { accepted: boolean }> {
+    const epoch = this.attachmentEpoch;
+    if (!this.isCurrentAttachment(epoch) || hashKey(queryKey) !== hashKey(this.options.queryKey)) {
       return false;
     }
+    const refresh = captureActiveSessionsQueryRefresh(this.options.queryClient, queryKey);
     this.scheduleRefresh('manual');
-    // A write landing mid-fetch cancels that fetch and re-kicks the queue, so
-    // awaiting a single hop can return while the replacement fetch is still in
-    // flight. Follow the chain until the manual refresh is done (a successful
-    // fetch clears the reason) or nothing new was scheduled.
+    // Cached-data cancellation can fulfill. Follow the replacement fetches.
     /* eslint-disable no-await-in-loop */
-    while (this.pendingReasons.has('manual')) {
+    while (this.pendingReasons.has('manual') && this.isCurrentAttachment(epoch)) {
       const queue = this.fetchQueue;
       await queue;
       if (this.fetchQueue === queue) {
@@ -155,7 +133,12 @@ export class ActiveSessionsLiveSync {
       }
     }
     /* eslint-enable no-await-in-loop */
-    return true;
+    return {
+      accepted:
+        this.isCurrentAttachment(epoch) &&
+        !this.pendingReasons.has('manual') &&
+        refresh.hasAcceptedResult(),
+    };
   }
 
   async getWriteQueue(): Promise<void> {
@@ -166,33 +149,30 @@ export class ActiveSessionsLiveSync {
     if (this.pendingReasons.size === 0) {
       return;
     }
-    if (this.fetchStartCount > this.lastGetFetchQueueCount) {
-      this.lastGetFetchQueueCount = this.fetchStartCount;
-      return;
+    if (this.fetchStartCount <= this.lastGetFetchQueueCount) {
+      await new Promise<void>(resolve => {
+        this.fetchStartWaiters.push(resolve);
+      });
     }
-    await new Promise<void>(resolve => {
-      this.fetchStartWaiters.push(resolve);
-    });
     this.lastGetFetchQueueCount = this.fetchStartCount;
   }
 
   async getFetchCompletion(): Promise<void> {
-    if (!this.isFetchInFlight) {
-      return;
+    if (this.isFetchInFlight) {
+      await new Promise<void>(resolve => {
+        this.fetchCompletionWaiters.push(resolve);
+      });
     }
-    await new Promise<void>(resolve => {
-      this.fetchCompletionWaiters.push(resolve);
-    });
   }
 
   getPendingReasons(): Set<RefreshReason> {
     return new Set(this.pendingReasons);
   }
 
-  private handleSystemEvent(event: SystemEvent): void {
+  private handleSystemEvent(event: UserWebSystemEvent): void {
     for (const action of planLiveSystemEventActions(event)) {
       if (action.type === 'write') {
-        this.enqueueWrite(current => action.updater(current));
+        this.enqueueWrite(action.updater);
       } else {
         this.scheduleRefresh(action.reason);
       }
@@ -208,28 +188,27 @@ export class ActiveSessionsLiveSync {
   }
 
   private enqueueWrite(updater: WriteUpdater): void {
-    if (this.releaseRetain === null) {
+    if (!this.isCurrentAttachment(this.attachmentEpoch)) {
       return;
     }
     const attachmentEpoch = this.attachmentEpoch;
+    const { queryClient, queryKey } = this.options;
     // Serialized cancel+setQueryData; never awaits network.
     this.writeQueue = (async () => {
       await this.writeQueue;
-      if (attachmentEpoch !== this.attachmentEpoch) {
+      if (!this.isCurrentAttachment(attachmentEpoch)) {
         return;
       }
-      // Cancel in-flight fetch so stale results cannot overwrite.
       if (this.isFetchInFlight) {
         this.inFlightFetchCanceled = true;
       }
-      await this.queryClient.cancelQueries({ queryKey: this.queryKey });
-      if (attachmentEpoch !== this.attachmentEpoch) {
+      await queryClient.cancelQueries({ queryKey, exact: true });
+      if (!this.isCurrentAttachment(attachmentEpoch)) {
         return;
       }
-      this.queryClient.setQueryData<CachedActiveSessionsData>(this.queryKey, current => {
-        const existing = current?.sessions ?? [];
-        return { sessions: updater(existing) };
-      });
+      queryClient.setQueryData<CachedActiveSessionsData>(queryKey, current => ({
+        sessions: updater(current?.sessions ?? []),
+      }));
       this.maybeScheduleEnrichmentRefresh();
     })();
   }
@@ -242,8 +221,9 @@ export class ActiveSessionsLiveSync {
   }
 
   private updateEnrichmentReason(): void {
+    const { queryClient, queryKey } = this.options;
     const cachedSessions =
-      this.queryClient.getQueryData<CachedActiveSessionsData>(this.queryKey)?.sessions ?? [];
+      queryClient.getQueryData<CachedActiveSessionsData>(queryKey)?.sessions ?? [];
     if (!hasUnenrichedLiveId(cachedSessions)) {
       this.pendingReasons.delete('enrichment');
       return;
@@ -263,30 +243,25 @@ export class ActiveSessionsLiveSync {
 
   private notifyFetchStart(): void {
     this.fetchStartCount += 1;
-    const waiters = this.fetchStartWaiters;
-    this.fetchStartWaiters = [];
-    for (const resolve of waiters) {
+    for (const resolve of this.fetchStartWaiters.splice(0)) {
       resolve();
     }
   }
 
   private notifyFetchCompletion(): void {
-    const waiters = this.fetchCompletionWaiters;
-    this.fetchCompletionWaiters = [];
-    for (const resolve of waiters) {
+    for (const resolve of this.fetchCompletionWaiters.splice(0)) {
       resolve();
     }
   }
 
   private kickFetch(): void {
-    if (this.releaseRetain === null) {
+    if (!this.isCurrentAttachment(this.attachmentEpoch)) {
       return;
     }
     const attachmentEpoch = this.attachmentEpoch;
-    // Cancel in-flight fetch so a new refresh starts immediately.
     if (this.isFetchInFlight) {
       this.inFlightFetchCanceled = true;
-      void this.queryClient.cancelQueries({ queryKey: this.queryKey });
+      void this.options.queryClient.cancelQueries({ queryKey: this.options.queryKey, exact: true });
     }
     this.fetchQueue = (async () => {
       await this.fetchQueue;
@@ -295,36 +270,39 @@ export class ActiveSessionsLiveSync {
   }
 
   private async processFetchQueue(attachmentEpoch: number): Promise<void> {
-    if (attachmentEpoch !== this.attachmentEpoch || this.pendingReasons.size === 0) {
-      return;
-    }
-    if (this.isFetchInFlight) {
+    // Start a replacement after the write that canceled its predecessor.
+    await this.writeQueue;
+    const canFetch = this.pendingReasons.size > 0 && !this.isFetchInFlight;
+    if (!canFetch || !this.isCurrentAttachment(attachmentEpoch)) {
       return;
     }
     this.isFetchInFlight = true;
     this.inFlightFetchCanceled = false;
     const inFlightReasons = new Set(this.pendingReasons);
     this.inFlightReasons = inFlightReasons;
+    const { queryClient, queryKey, queryFn } = this.options;
+    const refresh = captureActiveSessionsQueryRefresh(queryClient, queryKey);
     let success = false;
     try {
-      await this.queryClient.cancelQueries({ queryKey: this.queryKey });
-      if (attachmentEpoch === this.attachmentEpoch) {
-        // staleTime:0 forces a network call after setQueryData.
-        const fetchPromise = this.queryClient.fetchQuery({
-          queryKey: this.queryKey,
-          queryFn: this.queryFn,
+      await queryClient.cancelQueries({ queryKey, exact: true });
+      if (this.isCurrentAttachment(attachmentEpoch) && refresh.isCurrent()) {
+        const fetchPromise = queryClient.fetchQuery({
+          queryKey,
+          queryFn: fenceActiveSessionsQuery(queryFn, () =>
+            this.isCurrentAttachment(attachmentEpoch)
+          ),
           staleTime: 0,
         });
         this.notifyFetchStart();
         await fetchPromise;
-        success = true;
+        success = !this.readInFlightFetchCanceled() && refresh.hasAcceptedResult();
       }
     } catch {
-      // Canceled or network failure: keep reasons pending for retry.
+      // Cancellation and network failure keep reasons pending for Retry.
     } finally {
       this.isFetchInFlight = false;
     }
-    if (attachmentEpoch !== this.attachmentEpoch) {
+    if (!this.isCurrentAttachment(attachmentEpoch)) {
       this.inFlightReasons = null;
       this.notifyFetchCompletion();
       return;
@@ -333,17 +311,15 @@ export class ActiveSessionsLiveSync {
       this.lastEnrichmentAttemptAt = this.now();
     }
     if (success) {
-      for (const r of inFlightReasons) {
-        this.pendingReasons.delete(r);
+      for (const reason of inFlightReasons) {
+        this.pendingReasons.delete(reason);
       }
       this.updateEnrichmentReason();
     }
     const hasNewReasons = [...this.pendingReasons].some(reason => !inFlightReasons.has(reason));
-    // Helper so CFA does not treat the field as stuck at false after await.
     const wasCanceled = this.readInFlightFetchCanceled();
     this.inFlightReasons = null;
     this.notifyFetchCompletion();
-    // Re-kick only after intentional cancel or new reasons mid-flight.
     if (this.pendingReasons.size > 0 && (wasCanceled || hasNewReasons)) {
       this.kickFetch();
     }
@@ -354,17 +330,12 @@ export class ActiveSessionsLiveSync {
   }
 }
 
-/**
- * The currently attached owner. One `<ActiveSessionsLiveSyncMount />` in
- * `app/(app)/_layout.tsx` owns the live tray app-wide, so a module-scoped
- * reference is the whole registry this needs.
- */
+/** One app-level mount owns the registry and socket lease. */
 let attachedSync: ActiveSessionsLiveSync | null = null;
 
-/**
- * Pull-to-refresh entry point for the live tray. Returns false when no owner
- * is attached, so the caller falls back to a plain query refetch.
- */
-export async function refreshActiveSessionsNow(): Promise<boolean> {
-  return (await attachedSync?.refreshNow()) ?? false;
+/** Returns false if no current owner handles this exact key. */
+export async function refreshActiveSessionsNow(
+  queryKey: QueryKey
+): Promise<false | { accepted: boolean }> {
+  return (await attachedSync?.refreshNow(queryKey)) ?? false;
 }

--- a/apps/mobile/src/lib/hooks/use-agent-sessions.combined.mounted.test.tsx
+++ b/apps/mobile/src/lib/hooks/use-agent-sessions.combined.mounted.test.tsx
@@ -1,0 +1,307 @@
+/* eslint-disable typescript-eslint/no-deprecated -- DOM-free React Native hook integration */
+import { act } from 'react-test-renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildActiveSessionsTrayInput } from '@/lib/active-sessions-live';
+import { ActiveSessionsLiveSync } from '@/lib/active-sessions-live-sync';
+import {
+  createQueryProbe,
+  deferred,
+  flushQueryUpdates as flush,
+  makeActiveSessionsQueryKey,
+  makeCached,
+  makeConnection,
+  makeTestQueryClient,
+  QUERY_KEY,
+} from '@/lib/active-sessions-live-sync.test-helpers';
+import { bumpAuthEpoch, currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { isSignOutActive, setSignOutActive } from '@/lib/auth/sign-out-state';
+import { useAgentSessions, useLiveAgentSessions } from '@/lib/hooks/use-agent-sessions';
+
+const state = vi.hoisted(() => ({
+  organizationId: null as string | null,
+  active: vi.fn(),
+  stored: vi.fn(),
+  maintenance: [] as (() => void)[],
+}));
+const STORED_KEY = [['cliSessionsV2', 'list'], { type: 'infinite' }] as const;
+vi.mock('@/lib/auth/auth-context', () => ({
+  useAuth: () => ({
+    token: 'account',
+    isLoading: false,
+    isSigningOut: isSignOutActive(),
+    authEpoch: currentAuthEpoch(),
+  }),
+}));
+vi.mock('@/lib/organization-context', () => ({
+  useOrganization: () => ({ organizationId: state.organizationId, isLoaded: true }),
+}));
+vi.mock('@/lib/trpc', () => {
+  const trpc = {
+    activeSessions: {
+      list: {
+        queryKey: (input: unknown) => [['activeSessions', 'list'], { input, type: 'query' }],
+        queryOptions: (input: unknown, options: object) => ({
+          queryKey: [['activeSessions', 'list'], { input, type: 'query' }],
+          queryFn: state.active,
+          ...options,
+        }),
+      },
+    },
+    cliSessionsV2: {
+      list: {
+        infiniteQueryKey: () => STORED_KEY,
+        pathFilter: () => ({ queryKey: [['cliSessionsV2', 'list']] }),
+        infiniteQueryOptions: (_input: unknown, options: object) => ({
+          queryKey: STORED_KEY,
+          queryFn: state.stored,
+          initialPageParam: null,
+          ...options,
+        }),
+      },
+    },
+  };
+  return { useTRPC: () => trpc };
+});
+vi.mock('@/lib/hooks/use-user-web-connection-state', () => ({
+  useUserWebConnectionState: () => false,
+}));
+vi.mock('react-native', () => ({
+  InteractionManager: {
+    runAfterInteractions: (run: () => void) => {
+      state.maintenance.push(run);
+    },
+  },
+}));
+vi.mock('@/components/agents/user-web-connection-provider', () => ({
+  useUserWebConnection: vi.fn(),
+}));
+
+let client = makeTestQueryClient();
+let latest: ReturnType<typeof useAgentSessions> | undefined = undefined;
+let live: ReturnType<typeof useLiveAgentSessions> | undefined = undefined;
+let owner: ActiveSessionsLiveSync | undefined = undefined;
+function stored(title: string, sessionId = 'stored') {
+  return {
+    session_id: sessionId,
+    title,
+    created_at: '2026-08-28T00:00:00Z',
+    updated_at: '2026-08-28T00:00:00Z',
+  };
+}
+function history(title: string) {
+  return { cliSessions: [stored(title)], nextCursor: null };
+}
+function Probe() {
+  latest = useAgentSessions({ organizationId: state.organizationId });
+  live = useLiveAgentSessions({ organizationId: state.organizationId });
+  return null;
+}
+const { render, unmount } = createQueryProbe(Probe, () => client);
+function combined() {
+  if (!latest) {
+    throw new Error('Missing combined hook');
+  }
+  return latest;
+}
+function attach(queryKey: readonly unknown[]) {
+  owner = new ActiveSessionsLiveSync({
+    connection: makeConnection(),
+    queryClient: client,
+    queryKey,
+    queryFn: state.active,
+  });
+  owner.attach();
+}
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  setSignOutActive(false);
+  state.organizationId = null;
+  state.maintenance.length = 0;
+  state.active.mockReset().mockResolvedValue({
+    sessions: [makeCached({ id: 'fresh', createdOnPlatform: 'cli', organizationId: null })],
+  });
+  state.stored.mockReset().mockResolvedValue(history('New history'));
+  client = makeTestQueryClient();
+  client.setQueryData(QUERY_KEY, { sessions: [makeCached({ organizationId: null })] });
+  client.setQueryData(STORED_KEY, { pages: [history('Old history')], pageParams: [null] });
+});
+afterEach(async () => {
+  await act(async () => {
+    unmount();
+    owner?.detach();
+    client.clear();
+    await flush();
+  });
+  owner = undefined;
+  latest = undefined;
+  live = undefined;
+  setSignOutActive(false);
+});
+async function refreshLive() {
+  let accepted = false;
+  await act(async () => {
+    if (!live) {
+      throw new Error('Missing live hook');
+    }
+    accepted = await live.refetch();
+    await flush();
+  });
+  return accepted;
+}
+
+describe('combined and live refresh callers', () => {
+  it('uses the live query fallback when an owner has another complete key', async () => {
+    const otherKey = [
+      ['activeSessions', 'list'],
+      {
+        input: { ...buildActiveSessionsTrayInput(null), includeCloudAgentSessions: false },
+        type: 'query',
+      },
+    ];
+    const other = { sessions: [makeCached({ id: 'other' })] };
+    client.setQueryData(otherKey, other);
+    attach(otherKey);
+    state.active.mockResolvedValue({ sessions: [] });
+    await render();
+    expect(await refreshLive()).toBe(true);
+    expect(live?.activeSessions).toEqual([]);
+    expect(client.getQueryData(otherKey)).toEqual(other);
+  });
+
+  it('does not start a live fallback loop after a handled owner failure', async () => {
+    attach(QUERY_KEY);
+    await render();
+    state.active.mockRejectedValue(new Error('offline'));
+    expect(await refreshLive()).toBe(false);
+    expect(state.active.mock.calls).toHaveLength(1);
+    expect(owner?.getPendingReasons()).toContain('manual');
+    expect(live?.terminalError?.kind).toBe('retryable');
+    expect(live?.activeSessions.map(row => row.id)).toEqual(['a1']);
+  });
+
+  it.each(['matching', 'mismatched'] as const)(
+    'waits for storedRefetch with a %s live owner',
+    async scope => {
+      const otherKey = makeActiveSessionsQueryKey('other-org');
+      client.setQueryData(otherKey, { sessions: [makeCached({ id: 'other' })] });
+      attach(scope === 'matching' ? QUERY_KEY : otherKey);
+      await render();
+      const storedRequest = deferred<ReturnType<typeof history>>();
+      state.stored.mockReturnValueOnce(storedRequest.promise);
+      let done = false;
+      let pending: Promise<void> | undefined = undefined;
+      await act(async () => {
+        pending = (async () => {
+          await combined().refetch();
+          done = true;
+        })();
+        await flush();
+      });
+      expect(combined().activeSessions.map(row => row.id)).toEqual(['fresh']);
+      expect(combined().storedSessions.map(row => row.title)).toEqual(['Old history']);
+      expect(done).toBe(false);
+      await act(async () => {
+        storedRequest.resolve(history('New history'));
+        await pending;
+        await flush();
+      });
+      expect(done).toBe(true);
+      expect(combined().storedSessions.map(row => row.title)).toEqual(['New history']);
+      expect(client.getQueryData(otherKey)).toEqual({ sessions: [makeCached({ id: 'other' })] });
+    }
+  );
+
+  it('keeps stored refetch behind an in-flight next page', async () => {
+    client.setQueryData(STORED_KEY, {
+      pages: [{ ...history('Old history'), nextCursor: 'next' }],
+      pageParams: [null],
+    });
+    await render();
+    const nextPage = deferred<ReturnType<typeof history>>();
+    const firstPage = deferred<ReturnType<typeof history>>();
+    state.stored.mockReturnValueOnce(nextPage.promise).mockReturnValueOnce(firstPage.promise);
+    let page: Promise<void> | undefined = undefined;
+    let refresh: Promise<void> | undefined = undefined;
+    let finished = false;
+    await act(async () => {
+      page = combined().fetchNextPage();
+      refresh = (async () => {
+        await combined().refetch();
+        finished = true;
+      })();
+      await flush();
+    });
+    expect(state.stored.mock.calls).toHaveLength(1);
+    expect(finished).toBe(false);
+    await act(async () => {
+      nextPage.resolve({ cliSessions: [stored('Next page', 'next')], nextCursor: null });
+      await page;
+      await flush();
+    });
+    expect(state.stored.mock.calls).toHaveLength(2);
+    expect(combined().storedSessions.map(row => row.title)).toEqual(['Old history', 'Next page']);
+    await act(async () => {
+      firstPage.resolve(history('New history'));
+      await refresh;
+      await flush();
+    });
+    expect(combined().storedSessions.map(row => row.title)).toEqual(['New history']);
+    expect(finished).toBe(true);
+  });
+
+  it.each(['context', 'account', 'sign-out', 'reattach'] as const)(
+    'does not publish old refresh or departure work after %s changes',
+    async change => {
+      attach(QUERY_KEY);
+      await render();
+      const network = deferred<{ sessions: ReturnType<typeof makeCached>[] }>();
+      state.active.mockReturnValue(network.promise);
+      let pending: Promise<void> | undefined = undefined;
+      await act(async () => {
+        pending = combined().refetch();
+        await flush();
+      });
+      if (change === 'account') {
+        await act(async () => {
+          client.setQueryData(QUERY_KEY, { sessions: [] });
+          await flush();
+        });
+        expect(state.maintenance.length).toBeGreaterThan(0);
+        bumpAuthEpoch();
+        client.clear();
+      }
+      if (change === 'context') {
+        state.organizationId = 'org-b';
+      }
+      if (change === 'sign-out') {
+        setSignOutActive(true);
+      }
+      if (change === 'reattach') {
+        owner?.detach();
+        owner?.attach();
+      }
+      const key = makeActiveSessionsQueryKey(state.organizationId);
+      client.setQueryData(key, {
+        sessions: [makeCached({ id: 'b', organizationId: state.organizationId })],
+      });
+      const historyB = { pages: [history('Account B')], pageParams: [null] };
+      client.setQueryData(STORED_KEY, historyB);
+      await render();
+      await act(async () => {
+        network.resolve({ sessions: [] });
+        await pending;
+        for (const run of state.maintenance.splice(0)) {
+          run();
+        }
+        await flush();
+      });
+      expect(combined().activeSessions.map(row => row.id)).toEqual(
+        change === 'sign-out' ? [] : ['b']
+      );
+      if (change === 'account') {
+        expect(client.getQueryData(STORED_KEY)).toEqual(historyB);
+      }
+    }
+  );
+});

--- a/apps/mobile/src/lib/hooks/use-agent-sessions.live.mounted.test.tsx
+++ b/apps/mobile/src/lib/hooks/use-agent-sessions.live.mounted.test.tsx
@@ -1,173 +1,310 @@
-/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/lib/hooks/use-route-foreground-refresh.mounted.test.tsx) */
+/* eslint-disable typescript-eslint/no-deprecated -- DOM-free React Native hook integration */
 import { createElement } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import TestRenderer, { act } from 'react-test-renderer';
+import { onlineManager } from '@tanstack/react-query';
+import { act } from 'react-test-renderer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { buildActiveSessionsTrayInput } from '@/lib/active-sessions-live';
+import { type CachedActiveSessionsData } from '@/lib/active-sessions-live';
+import { ActiveSessionsLiveSync } from '@/lib/active-sessions-live-sync';
+import { ActiveSessionsLiveSyncMount } from '@/lib/active-sessions-live-sync-mount';
+import {
+  createQueryProbe,
+  deferred,
+  flushQueryUpdates as flush,
+  makeActiveSessionsQueryKey,
+  makeCached,
+  makeConnection,
+  makeTestQueryClient,
+  QUERY_KEY,
+} from '@/lib/active-sessions-live-sync.test-helpers';
+import { bumpAuthEpoch, currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { setSignOutActive } from '@/lib/auth/sign-out-state';
 import { useLiveAgentSessions } from '@/lib/hooks/use-agent-sessions';
 
-const refreshActiveSessionsNow = vi.hoisted(() => vi.fn());
-
-// When true, the mocked tRPC queryFn rejects, so a plain active refetch settles
-// in error (the fallback path's failure case).
-const queryFnImpl = vi.hoisted(() => ({ reject: false }));
-
-vi.mock('@/lib/trpc', () => ({
-  useTRPC: vi.fn(() => ({
+const state = vi.hoisted(() => ({
+  auth: {
+    token: 'account' as string | undefined,
+    isLoading: false,
+    isSigningOut: false,
+    authEpoch: 0,
+  },
+  organization: { organizationId: null as string | null, isLoaded: true },
+  request: vi.fn<() => Promise<CachedActiveSessionsData>>(),
+  mountSync: false,
+}));
+vi.mock('@/lib/auth/auth-context', () => ({ useAuth: () => state.auth }));
+vi.mock('@/lib/organization-context', () => ({ useOrganization: () => state.organization }));
+function key(input: unknown) {
+  return [['activeSessions', 'list'], { input, type: 'query' }];
+}
+vi.mock('@/lib/trpc', () => {
+  const trpc = {
     activeSessions: {
       list: {
-        queryKey: (input: unknown) => [['activeSessions', 'list'], { input, type: 'query' }],
-        queryOptions: (input: unknown) => ({
-          queryKey: [['activeSessions', 'list'], { input, type: 'query' }],
-          retry: false,
-          queryFn: async () => {
-            await Promise.resolve();
-            if (queryFnImpl.reject) {
-              throw new Error('seeded active-list failure');
-            }
-            return { sessions: [] };
-          },
+        queryKey: key,
+        queryOptions: (input: unknown, options: object) => ({
+          queryKey: key(input),
+          queryFn: state.request,
+          ...options,
         }),
       },
     },
-  })),
-}));
-
+  };
+  return { useTRPC: () => trpc };
+});
 vi.mock('@/lib/hooks/use-user-web-connection-state', () => ({
   useUserWebConnectionState: () => false,
 }));
-
-vi.mock('@/lib/active-sessions-live-sync', () => ({
-  refreshActiveSessionsNow,
+vi.mock('@/components/agents/user-web-connection-provider', () => ({
+  useUserWebConnection: () => connection,
 }));
+vi.mock('react-native', () => ({ InteractionManager: { runAfterInteractions: vi.fn() } }));
 
-vi.mock('react-native', () => ({
-  InteractionManager: { runAfterInteractions: vi.fn() },
-}));
-
-// The exact owner query key for `organizationId: null`: the live-sync mount and
-// the hook both derive it from `buildActiveSessionsTrayInput`, and the mocked
-// `queryKey` embeds the same `input`.
-const KEY: readonly unknown[] = [
-  ['activeSessions', 'list'],
-  { input: buildActiveSessionsTrayInput(null), type: 'query' },
-];
-
-const latestRef: { refetch?: () => Promise<boolean> } = {};
-
+let client = makeTestQueryClient();
+let connection = makeConnection();
+let leases = 0;
+let latest: ReturnType<typeof useLiveAgentSessions> | undefined = undefined;
+const owners: ActiveSessionsLiveSync[] = [];
+const cached = { sessions: [makeCached({ organizationId: null })] };
 function Probe() {
-  const { refetch } = useLiveAgentSessions({ organizationId: null });
-  latestRef.refetch = refetch;
-  return createElement('ProbeText', null, 'probe');
+  latest = useLiveAgentSessions({ organizationId: state.organization.organizationId });
+  return state.mountSync ? createElement(ActiveSessionsLiveSyncMount) : null;
 }
-
-const mountedRenderers: TestRenderer.ReactTestRenderer[] = [];
-
-async function delay(ms: number): Promise<void> {
-  await new Promise<void>(resolve => {
-    setTimeout(resolve, ms);
-  });
-}
-
-// React Query's default notifyManager schedules via setTimeout(fn, 0); a few
-// sequential macrotask turns let a settled fetch apply its state inside `act`.
-async function flushTimers(): Promise<void> {
-  await delay(0);
-  await delay(0);
-  await delay(0);
-  await delay(0);
-}
-
-async function renderProbe(queryClient: QueryClient): Promise<TestRenderer.ReactTestRenderer> {
-  const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
-    current: undefined,
-  };
-  await act(async () => {
-    rendererRef.current = TestRenderer.create(
-      createElement(QueryClientProvider, { client: queryClient }, createElement(Probe))
-    );
-    await flushTimers();
-  });
-  const renderer = rendererRef.current;
-  if (!renderer) {
-    throw new Error('renderer was not created');
+const { render, unmount } = createQueryProbe(Probe, () => client);
+function live() {
+  if (!latest) {
+    throw new Error('Missing live hook');
   }
-  mountedRenderers.push(renderer);
-  return renderer;
+  return latest;
 }
-
-async function seedError(queryClient: QueryClient): Promise<void> {
+async function startRefresh(): Promise<{ pending: Promise<boolean> | undefined }> {
+  let pending: Promise<boolean> | undefined = undefined;
   await act(async () => {
-    queryClient
-      .getQueryCache()
-      .find({ queryKey: KEY })
-      ?.setState({
-        status: 'error',
-        fetchStatus: 'idle',
-        data: undefined,
-        error: new Error('seeded active-list failure'),
-      });
-    await flushTimers();
+    pending = live().refetch();
+    await flush();
+  });
+  return { pending };
+}
+async function refresh() {
+  const { pending } = await startRefresh();
+  const result = await pending;
+  return result;
+}
+async function finishRefresh(
+  network: ReturnType<typeof deferred<CachedActiveSessionsData>>,
+  pending: Promise<boolean> | undefined
+) {
+  await act(async () => {
+    network.resolve({ sessions: [] });
+    await pending;
+    await flush();
   });
 }
-
-async function refetchAndSettle(): Promise<boolean> {
-  let outcome = false;
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  setSignOutActive(false);
+  onlineManager.setOnline(true);
+  Object.assign(state.auth, {
+    token: 'account',
+    isLoading: false,
+    isSigningOut: false,
+    authEpoch: currentAuthEpoch(),
+  });
+  Object.assign(state.organization, { organizationId: null, isLoaded: true });
+  state.request.mockReset().mockResolvedValue({ sessions: [] });
+  state.mountSync = false;
+  leases = 0;
+  connection = makeConnection({
+    retain: () => {
+      leases += 1;
+      return () => {
+        leases -= 1;
+      };
+    },
+  });
+  client = makeTestQueryClient();
+});
+afterEach(async () => {
   await act(async () => {
-    const refetch = latestRef.refetch;
-    if (!refetch) {
-      throw new Error('probe did not expose a refetch');
+    unmount();
+    for (const owner of owners) {
+      owner.detach();
     }
-    outcome = await refetch();
-    await flushTimers();
+    client.clear();
+    await flush();
   });
-  return outcome;
-}
+  latest = undefined;
+  owners.length = 0;
+  setSignOutActive(false);
+  onlineManager.setOnline(true);
+});
 
-describe('useLiveAgentSessions live owner-path refetch (mounted)', () => {
-  beforeEach(() => {
-    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    latestRef.refetch = undefined;
-    queryFnImpl.reject = false;
-    refreshActiveSessionsNow.mockReset();
+describe('live query presentation and refresh contracts', () => {
+  it('keeps manual-only empty data unconfirmed until the fallback accepts a server result', async () => {
+    client.setQueryData(QUERY_KEY, { sessions: [] });
+    await render();
+    expect(live().isLoading).toBe(false);
+    expect(live().hasAcceptedSuccess).toBe(false);
+    expect(await refresh()).toBe(true);
+    expect(live().hasAcceptedSuccess).toBe(true);
+    expect(live().activeSessions).toEqual([]);
   });
 
-  afterEach(() => {
-    act(() => {
-      for (const renderer of mountedRenderers) {
-        renderer.unmount();
+  it('exposes paused first load without treating isLoading false as empty success', async () => {
+    onlineManager.setOnline(false);
+    await render();
+    expect(live().isLoading).toBe(false);
+    expect(live().isPaused).toBe(true);
+    expect(live().isFetching).toBe(false);
+    expect(live().hasAcceptedSuccess).toBe(false);
+  });
+
+  it.each([
+    ['retryable', new Error('offline')],
+    ['non-retryable', Object.assign(new Error('denied'), { data: { code: 'FORBIDDEN' } })],
+  ] as const)(
+    'retains an initial %s failure across socket writes, remount, and retry',
+    async (kind, error) => {
+      state.request.mockRejectedValue(error);
+      await render();
+      expect(live().terminalError).toEqual({ error, kind });
+      await act(async () => {
+        client.setQueryData(QUERY_KEY, cached);
+        await flush();
+        unmount();
+      });
+      await render();
+      expect(live().terminalError?.error).toBe(error);
+      expect(live().hasAcceptedSuccess).toBe(false);
+      expect(live().activeSessions.map(row => row.id)).toEqual(['a1']);
+      const network = deferred<CachedActiveSessionsData>();
+      state.request.mockReturnValue(network.promise);
+      const { pending } = await startRefresh();
+      expect(live().terminalError?.error).toBe(error);
+      expect(live().isFetching).toBe(true);
+      await finishRefresh(network, pending);
+      expect(await pending).toBe(true);
+      expect(live().terminalError).toBeNull();
+      expect(live().hasAcceptedSuccess).toBe(true);
+    }
+  );
+
+  it.each([null, 'org-a', 'org-b'])(
+    'shows only rows attributed to the current context %s',
+    async organizationId => {
+      state.organization.organizationId = organizationId;
+      client.setQueryData(makeActiveSessionsQueryKey(organizationId), {
+        sessions: [
+          makeCached({ id: 'personal', organizationId: null }),
+          makeCached({ id: 'org-a', organizationId: 'org-a' }),
+          makeCached({ id: 'org-b', organizationId: 'org-b' }),
+          makeCached({ id: 'unattributed' }),
+        ],
+      });
+      await render();
+      expect(live().activeSessions.map(row => row.id)).toEqual([organizationId ?? 'personal']);
+    }
+  );
+
+  it.each(['cancel', 'sign-out'])(
+    'rejects a fallback result after %s without publishing late data',
+    async boundary => {
+      await client.fetchQuery({ queryKey: QUERY_KEY, queryFn: () => cached });
+      await render();
+      const network = deferred<CachedActiveSessionsData>();
+      state.request.mockReturnValue(network.promise);
+      const { pending } = await startRefresh();
+      if (boundary === 'cancel') {
+        await act(async () => {
+          await client.cancelQueries({ queryKey: QUERY_KEY, exact: true });
+        });
+      } else {
+        setSignOutActive(true);
       }
-    });
-    mountedRenderers.length = 0;
-    latestRef.refetch = undefined;
-  });
+      await finishRefresh(network, pending);
+      expect(await pending).toBe(false);
+      expect(client.getQueryData(QUERY_KEY)).toEqual(cached);
+    }
+  );
 
-  it('reports false on the owner path after the live-list query settled in error', async () => {
-    const queryClient = new QueryClient();
-    await renderProbe(queryClient);
-    await seedError(queryClient);
-    refreshActiveSessionsNow.mockResolvedValue(true);
+  it.each(['context', 'clear', 'sign-out', 'unmount', 'reattach'] as const)(
+    'rejects a late owner result after %s',
+    async change => {
+      client.setQueryData(QUERY_KEY, cached);
+      const owner = new ActiveSessionsLiveSync({
+        connection,
+        queryClient: client,
+        queryKey: QUERY_KEY,
+        queryFn: state.request,
+      });
+      owner.attach();
+      owners.push(owner);
+      await render();
+      const network = deferred<CachedActiveSessionsData>();
+      state.request.mockReturnValue(network.promise);
+      const { pending } = await startRefresh();
+      if (change === 'context') {
+        state.organization.organizationId = 'org-b';
+        client.setQueryData(makeActiveSessionsQueryKey('org-b'), {
+          sessions: [makeCached({ id: 'b', organizationId: 'org-b' })],
+        });
+        await render();
+        expect(live().activeSessions.map(row => row.id)).toEqual(['b']);
+      } else if (change === 'clear') {
+        await act(async () => {
+          client.clear();
+          bumpAuthEpoch();
+          state.auth.authEpoch = currentAuthEpoch();
+          client.setQueryData(QUERY_KEY, cached);
+          await flush();
+        });
+        await render();
+      } else if (change === 'sign-out') {
+        setSignOutActive(true);
+        state.auth.isSigningOut = true;
+        await render();
+        expect(live().activeSessions).toEqual([]);
+      } else if (change === 'unmount') {
+        await act(unmount);
+      } else {
+        owner.detach();
+        owner.attach();
+      }
+      await finishRefresh(network, pending);
+      expect(await pending).toBe(false);
+    }
+  );
 
-    expect(await refetchAndSettle()).toBe(false);
-  });
-
-  it('reports true on the owner path after the live-list query settled in success', async () => {
-    const queryClient = new QueryClient();
-    await renderProbe(queryClient);
-    expect(queryClient.getQueryState(KEY)?.status).toBe('success');
-    refreshActiveSessionsNow.mockResolvedValue(true);
-
-    expect(await refetchAndSettle()).toBe(true);
-  });
-
-  it('reports false on the fallback path when the plain refetch settles in error', async () => {
-    const queryClient = new QueryClient();
-    await renderProbe(queryClient);
-    queryFnImpl.reject = true;
-    await seedError(queryClient);
-    refreshActiveSessionsNow.mockResolvedValue(false);
-
-    expect(await refetchAndSettle()).toBe(false);
-  });
+  it.each(['token', 'bootstrap', 'sign-out', 'organization'] as const)(
+    'gates cached reads and socket ownership on %s readiness',
+    async gate => {
+      client.setQueryData(QUERY_KEY, cached);
+      state.mountSync = true;
+      if (gate === 'token') {
+        state.auth.token = undefined;
+      }
+      if (gate === 'bootstrap') {
+        state.auth.isLoading = true;
+      }
+      if (gate === 'sign-out') {
+        state.auth.isSigningOut = true;
+        setSignOutActive(true);
+      }
+      if (gate === 'organization') {
+        state.organization.isLoaded = false;
+      }
+      await render();
+      expect(live().activeSessions).toEqual([]);
+      expect(await refresh()).toBe(false);
+      expect(leases).toBe(0);
+      connection.__fireSystem({ event: 'sessions.list', data: { sessions: [] } });
+      expect(client.getQueryData(QUERY_KEY)).toEqual(cached);
+      Object.assign(state.auth, { token: 'account', isLoading: false, isSigningOut: false });
+      state.organization.isLoaded = true;
+      setSignOutActive(false);
+      await render();
+      expect(leases).toBe(2);
+      expect(live().activeSessions.map(row => row.id)).toEqual(['a1']);
+    }
+  );
 });

--- a/apps/mobile/src/lib/hooks/use-agent-sessions.test.ts
+++ b/apps/mobile/src/lib/hooks/use-agent-sessions.test.ts
@@ -17,6 +17,11 @@ import {
 vi.mock('@/lib/trpc', () => ({
   useTRPC: vi.fn(),
 }));
+vi.mock('@/lib/auth/auth-context', () => ({ useAuth: vi.fn() }));
+vi.mock('@/lib/organization-context', () => ({ useOrganization: vi.fn() }));
+vi.mock('@/components/agents/user-web-connection-provider', () => ({
+  useUserWebConnection: vi.fn(),
+}));
 
 vi.mock('@/lib/hooks/use-user-web-connection-state', () => ({
   useUserWebConnectionState: () => false,

--- a/apps/mobile/src/lib/hooks/use-agent-sessions.ts
+++ b/apps/mobile/src/lib/hooks/use-agent-sessions.ts
@@ -5,16 +5,22 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+
+import { useActiveSessions } from '@/lib/active-sessions-live-sync-mount';
+import { currentAuthEpoch, isCurrentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { isSignOutActive } from '@/lib/auth/sign-out-state';
+import {
+  getActiveSessionsQueryMetadata,
+  subscribeActiveSessionsQueryMetadata,
+} from '@/lib/query-client';
 
 import { createOperationCoordinator } from '@/components/agents/use-history-backfill';
 import { sortActiveSessionsByCreatedAt } from '@/lib/active-session-order';
 import {
-  buildActiveSessionsTrayInput,
   filterActiveSessionsByOrganization,
   selectActiveExclusionIds,
 } from '@/lib/active-sessions-live';
-import { refreshActiveSessionsNow } from '@/lib/active-sessions-live-sync';
 import {
   buildAgentSessionListInput,
   buildAgentSessionSearchInput,
@@ -33,7 +39,6 @@ import {
 import { reconcileFirstPage, withInfiniteRetention } from '@/lib/query/infinite-retention';
 import { scheduleCacheMaintenance } from '@/lib/query/schedule-cache-maintenance';
 import { useTRPC } from '@/lib/trpc';
-import { useUserWebConnectionState } from '@/lib/hooks/use-user-web-connection-state';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -43,7 +48,7 @@ export type StoredSession = RouterOutputs['cliSessionsV2']['list']['cliSessions'
 
 export type ActiveSession = RouterOutputs['activeSessions']['list']['sessions'][number];
 
-type UseAgentSessionsOptions = {
+export type UseAgentSessionsOptions = {
   createdOnPlatform?: string | string[];
   gitUrl?: string | string[];
   organizationId?: string | null;
@@ -130,27 +135,6 @@ function useStoredSessions(options?: UseAgentSessionsOptions) {
   const trpc = useTRPC();
 
   return useInfiniteQuery(buildStoredSessionsQueryOptions(trpc, options));
-}
-
-function useActiveSessions(options?: UseAgentSessionsOptions) {
-  const trpc = useTRPC();
-  // Cloud rows have no WS channel — discovery from other devices and departure
-  // on session stop need a floor poll even while connected. WS writes remain
-  // the instant path for CLI rows; the poll uses the same wholesale-replace
-  // semantics as the existing enrichment refresh. When the socket is down,
-  // poll every 10s so a transient outage still updates the tray.
-  const wsConnected = useUserWebConnectionState();
-  const input = useMemo(
-    () => buildActiveSessionsTrayInput(options?.organizationId),
-    [options?.organizationId]
-  );
-  return useQuery(
-    trpc.activeSessions.list.queryOptions(input, {
-      refetchInterval: wsConnected ? 30_000 : 10_000,
-      staleTime: 5000,
-      enabled: options?.enabled,
-    })
-  );
 }
 
 export function useRecentAgentRepositories(options?: UseRecentAgentRepositoriesOptions) {
@@ -282,11 +266,11 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
     () =>
       sortActiveSessionsByCreatedAt(
         filterActiveSessionsByOrganization(
-          active.data?.sessions ?? [],
+          active.canRead ? (active.data?.sessions ?? []) : [],
           options?.organizationId ?? null
         )
       ),
-    [active.data, options?.organizationId]
+    [active.canRead, active.data, options?.organizationId]
   );
 
   const activeSessionIds = useMemo(() => new Set(activeSessions.map(s => s.id)), [activeSessions]);
@@ -301,8 +285,8 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
   // Compatibility: the old Agents combined list used it for exclusion; remove
   // when no caller remains.
   const activeExclusionIds = useMemo(
-    () => selectActiveExclusionIds(active.data?.sessions ?? []),
-    [active.data]
+    () => selectActiveExclusionIds(active.canRead ? (active.data?.sessions ?? []) : []),
+    [active.canRead, active.data]
   );
 
   const dateGroups = useMemo(
@@ -323,15 +307,16 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
   // transition (first poll) is ignored, and the initial mount with a non-empty
   // set is ignored (no "before" to compare against). The render hold above
   // keeps the last rows visible while this reset refetches page one.
-  const previousActiveIdsRef = useRef<Set<string> | null>(null);
+  const previousActiveIdsRef = useRef<{ ids: Set<string>; epoch: number } | null>(null);
   useEffect(() => {
+    const epoch = currentAuthEpoch();
     const previous = previousActiveIdsRef.current;
-    previousActiveIdsRef.current = activeSessionIds;
-    if (!previous) {
+    previousActiveIdsRef.current = { ids: activeSessionIds, epoch };
+    if (!active.canRead || !previous || previous.epoch !== epoch) {
       return;
     }
     let departedId: string | undefined = undefined;
-    for (const id of previous) {
+    for (const id of previous.ids) {
       if (!activeSessionIds.has(id)) {
         departedId = id;
         break;
@@ -339,10 +324,12 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
     }
     if (departedId) {
       scheduleCacheMaintenance(() => {
-        reconcileFirstPage(queryClient, trpc.cliSessionsV2.list.pathFilter().queryKey);
+        if (isCurrentAuthEpoch(epoch) && !isSignOutActive()) {
+          reconcileFirstPage(queryClient, trpc.cliSessionsV2.list.pathFilter().queryKey);
+        }
       });
     }
-  }, [activeSessionIds, queryClient, trpc]);
+  }, [active.canRead, activeSessionIds, queryClient, trpc]);
 
   return {
     storedSessions: renderedStoredSessions,
@@ -375,19 +362,7 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
     isFetchingNextPage: stored.isFetchingNextPage,
     fetchNextPage,
     refetch: async () => {
-      await Promise.all([
-        storedRefetch(),
-        (async () => {
-          // The live-sync owner writes and cancels this same query key, so a
-          // plain refetch alone can be swallowed by it. Drive the owner when
-          // one is attached — it is keyed to the same organization context
-          // this hook is given — and fall back to the plain refetch otherwise.
-          if (await refreshActiveSessionsNow()) {
-            return;
-          }
-          await active.refetch();
-        })(),
-      ]);
+      await Promise.all([storedRefetch(), active.refetch()]);
     },
   };
 }
@@ -395,52 +370,41 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
 /**
  * Live-only Agents tab variant. Reads the same `activeSessions.list` query as
  * `useAgentSessions` but never mounts the stored/history infinite query, so the
- * tab does not wait on stored pages. Reuses the private `useActiveSessions`.
+ * tab does not wait on stored pages. Reuses the shared active query.
  */
 export function useLiveAgentSessions(options?: UseAgentSessionsOptions) {
-  const trpc = useTRPC();
   const active = useActiveSessions(options);
   const queryClient = useQueryClient();
-
-  const input = useMemo(
-    () => buildActiveSessionsTrayInput(options?.organizationId),
-    [options?.organizationId]
+  const query = active.canRead
+    ? queryClient.getQueryCache().find({ queryKey: active.queryKey, exact: true })
+    : undefined;
+  const subscribe = useCallback(
+    (listener: () => void) => subscribeActiveSessionsQueryMetadata(query, listener),
+    [query]
   );
-  const queryKey = useMemo(() => trpc.activeSessions.list.queryKey(input), [trpc, input]);
-
+  const getSnapshot = useCallback(() => getActiveSessionsQueryMetadata(query), [query]);
+  const metadata = useSyncExternalStore(subscribe, getSnapshot);
   const activeSessions = useMemo(
     () =>
       sortActiveSessionsByCreatedAt(
         filterActiveSessionsByOrganization(
-          active.data?.sessions ?? [],
+          active.canRead ? (active.data?.sessions ?? []) : [],
           options?.organizationId ?? null
         )
       ),
-    [active.data, options?.organizationId]
+    [active.canRead, active.data, options?.organizationId]
   );
 
   return {
     activeSessions,
-    // Compatibility: the old combined `stored.isLoading || active.isLoading`
-    // remains on `useAgentSessions` for Home and Share; the live tab must not
-    // use it — it reads only the active poll. Remove the split only when no
-    // caller needs stored and active loading apart.
+    // Preserve the old flags; presentation must use provenance, not isLoading,
+    // to distinguish unconfirmed empty data from accepted empty success.
     isLoading: active.isLoading,
     isError: active.isError,
-    refetch: async (): Promise<boolean> => {
-      // The live-sync owner writes and cancels this same query key, so a plain
-      // refetch alone can be swallowed by it. Drive the owner when one is
-      // attached — it is keyed to the same organization context this hook is
-      // given — and fall back to the plain refetch otherwise.
-      if (await refreshActiveSessionsNow()) {
-        // The owner drove the refresh and swallows its own failures; read the
-        // settled query state to report success to the caller. Match by the
-        // exact owner query key (`getQueryState` is exact by default), not by
-        // a loose prefix.
-        return queryClient.getQueryState(queryKey)?.status !== 'error';
-      }
-      const result = await active.refetch();
-      return !result.isError;
-    },
+    hasAcceptedSuccess: metadata.acceptedRevision > 0,
+    terminalError: metadata.terminalError,
+    isFetching: active.canRead && active.isFetching,
+    isPaused: active.canRead && active.isPaused,
+    refetch: active.refetch,
   };
 }

--- a/apps/mobile/src/lib/hooks/use-session-mutations.test.ts
+++ b/apps/mobile/src/lib/hooks/use-session-mutations.test.ts
@@ -1,391 +1,302 @@
-/* eslint-disable max-lines -- one file for the rename/delete optimistic mutation wiring and rollback suites */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as ReactQuery from '@tanstack/react-query';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  mutationActiveTitle as activeTitle,
+  deferred,
+  flushQueryUpdates as flush,
+  makeCached,
+  makeTestQueryClient,
+  QUERY_KEY,
+  replaceMutationAccount,
+  seedMutationSessions,
+  mutationStoredTitles as titles,
+} from '@/lib/active-sessions-live-sync.test-helpers';
+import { isSignOutActive, setSignOutActive } from '@/lib/auth/sign-out-state';
+import { setTrpcUnauthorizedHandler } from '@/lib/auth/trpc-unauthorized';
+import { getActiveSessionsQueryMetadata } from '@/lib/query-client';
 import { useSessionMutations } from './use-session-mutations';
 
-type MutationOptions = {
-  onMutate?: (input: { session_id: string; title?: string }) => Promise<unknown> | unknown;
-  onError?: (error: Error, input: unknown, context: unknown) => void;
-  onSettled?: () => unknown;
-  scope?: { id: string };
-  [key: string]: unknown;
-};
-type TrpcMock = {
-  cliSessionsV2: {
-    list: { infiniteQueryKey: () => readonly unknown[] };
-    recentRepositories: unknown;
-    rename: { mutationOptions: (opts: MutationOptions) => MutationOptions };
-    delete: { mutationOptions: (opts: MutationOptions) => MutationOptions };
+type Input = { session_id: string; title?: string };
+type MutationOptions = ReactQuery.MutationOptions<unknown, Error, Input>;
+let client = makeTestQueryClient();
+const rpc = { rename: vi.fn(), delete: vi.fn() };
+const messages: string[] = [];
+const settled: (() => void)[] = [];
+const listKey = [['cliSessionsV2', 'list'], { type: 'infinite' }] as const;
+const activeFilter = { queryKey: [['activeSessions', 'list']] };
+
+// Execute real mutations, including cancellation, context, and late rejection.
+vi.mock('@tanstack/react-query', async importOriginal => {
+  const actual = await importOriginal<typeof ReactQuery>();
+  return {
+    ...actual,
+    useQueryClient: () => client,
+    useMutation: (options: MutationOptions) => {
+      const owner = client;
+      return {
+        mutateAsync: async (input: Input) => {
+          const result = await owner.getMutationCache().build(owner, options).execute(input);
+          return result;
+        },
+      };
+    },
   };
-  activeSessions: {
-    list: { pathFilter: () => { queryKey: readonly unknown[] } };
-  };
-};
-
-const mutationOptionsSpy = vi.fn<(opts: MutationOptions) => MutationOptions>();
-const capturedOptions: { rename: MutationOptions | null; delete: MutationOptions | null } = {
-  rename: null,
-  delete: null,
-};
-const mutateAsyncMock = vi.fn();
-const cancelQueriesMock = vi.fn();
-const getQueriesDataMock = vi.fn();
-const setQueriesDataMock = vi.fn();
-const setQueryDataMock = vi.fn();
-const invalidateQueriesMock = vi.fn();
-const invalidateAgentSessionsMock = vi.fn();
-const scheduleCacheMaintenanceMock = vi.fn<(run: () => void) => void>();
-const toastErrorMock = vi.fn();
-const toastSuccessMock = vi.fn();
-// eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
-const chainSaveMock = vi.fn((_id: string, op: () => Promise<unknown>) => op());
-
-const listKey = ['cliSessionsV2', 'list'] as const;
-const activeFilter = { queryKey: ['activeSessions', 'list'] as const };
-
-const makeMutationOptions = (opts: MutationOptions) => {
-  mutationOptionsSpy(opts);
-  return opts;
-};
-
-vi.mock('@tanstack/react-query', () => ({
-  useMutation: (opts: MutationOptions) => {
-    // rename is registered second in useSessionMutations; capture both.
-    if (capturedOptions.delete === null) {
-      capturedOptions.delete = opts;
-    } else {
-      capturedOptions.rename = opts;
-    }
-    return { mutateAsync: mutateAsyncMock };
-  },
-  useQueryClient: () => ({
-    cancelQueries: cancelQueriesMock,
-    getQueriesData: getQueriesDataMock,
-    setQueriesData: setQueriesDataMock,
-    setQueryData: setQueryDataMock,
-    invalidateQueries: invalidateQueriesMock,
-  }),
-  hashKey: (key: unknown) => JSON.stringify(key),
-}));
-
+});
 vi.mock('@/lib/trpc', () => ({
-  useTRPC: () =>
-    ({
-      cliSessionsV2: {
-        list: { infiniteQueryKey: () => listKey },
-        recentRepositories: {},
-        rename: { mutationOptions: makeMutationOptions },
-        delete: { mutationOptions: makeMutationOptions },
+  useTRPC: () => ({
+    cliSessionsV2: {
+      list: { infiniteQueryKey: () => listKey },
+      rename: {
+        mutationOptions: (options: MutationOptions) => ({ ...options, mutationFn: rpc.rename }),
       },
-      activeSessions: {
-        list: { pathFilter: () => activeFilter },
+      delete: {
+        mutationOptions: (options: MutationOptions) => ({ ...options, mutationFn: rpc.delete }),
       },
-    }) satisfies TrpcMock,
+    },
+    activeSessions: { list: { pathFilter: () => activeFilter } },
+  }),
 }));
-
 vi.mock('@/lib/agent-session-cache', () => ({
-  // eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
-  invalidateAgentSessionQueries: (...args: unknown[]) => {
-    invalidateAgentSessionsMock(...args);
-    return Promise.resolve();
+  invalidateAgentSessionQueries: async (owner: ReactQuery.QueryClient) => {
+    await owner.invalidateQueries();
   },
 }));
-
 vi.mock('@/lib/query/schedule-cache-maintenance', () => ({
   scheduleCacheMaintenance: (run: () => void) => {
-    scheduleCacheMaintenanceMock(run);
+    settled.push(run);
   },
 }));
+vi.mock('@/lib/a11y/announcing-toast', () => {
+  const record = (message: string) => {
+    messages.push(message);
+  };
+  return { announcingToast: { error: record, success: record } };
+});
 
-vi.mock('sonner-native', () => ({
-  toast: { error: (msg: string) => toastErrorMock(msg) },
-}));
+function expectAccountBUnchanged() {
+  expect(titles(client, listKey)).toEqual(['Account B', 'Other']);
+  expect(activeTitle(client)).toBe('Account B');
+  expect(messages).toEqual([]);
+  expect(client.getQueryState(listKey)?.isInvalidated).toBe(false);
+  expect(isSignOutActive()).toBe(false);
+}
+afterAll(
+  setTrpcUnauthorizedHandler(() => {
+    setSignOutActive(true);
+  })
+);
+beforeEach(() => {
+  setSignOutActive(false);
+  client = makeTestQueryClient();
+  rpc.rename.mockReset().mockResolvedValue(undefined);
+  rpc.delete.mockReset().mockResolvedValue(undefined);
+  messages.length = 0;
+  settled.length = 0;
+  seedMutationSessions(client, listKey);
+});
+afterEach(() => {
+  client.clear();
+  setSignOutActive(false);
+});
 
-vi.mock('@/lib/a11y/announcing-toast', () => ({
-  announcingToast: {
-    error: (msg: string) => toastErrorMock(msg),
-    success: (msg: string) => toastSuccessMock(msg),
-  },
-}));
-
-vi.mock('@/lib/hooks/save-chain', () => ({
-  // eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
-  chainSave: (id: string, op: () => Promise<unknown>) => chainSaveMock(id, op),
-}));
-
-describe('useSessionMutations', () => {
-  beforeEach(() => {
-    mutationOptionsSpy.mockClear();
-    capturedOptions.rename = null;
-    capturedOptions.delete = null;
-    mutateAsyncMock.mockReset();
-    cancelQueriesMock.mockReset();
-    getQueriesDataMock.mockReset();
-    setQueriesDataMock.mockReset();
-    setQueryDataMock.mockReset();
-    invalidateQueriesMock.mockReset();
-    invalidateAgentSessionsMock.mockReset();
-    scheduleCacheMaintenanceMock.mockReset();
-    toastErrorMock.mockReset();
-    toastSuccessMock.mockReset();
-    chainSaveMock.mockClear();
-    // eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
-    chainSaveMock.mockImplementation((_id, op) => op());
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  describe('renameSessionAsync', () => {
-    it('rejects after the mutation onError has toasted and rolled back list cache', async () => {
-      const error = new Error('rename failed');
-      mutateAsyncMock.mockRejectedValueOnce(error);
-      getQueriesDataMock.mockReturnValue([]);
-
-      const { renameSessionAsync } = useSessionMutations();
-      await expect(renameSessionAsync('s1', 'New title')).rejects.toBe(error);
-
-      expect(chainSaveMock).toHaveBeenCalledWith('s1', expect.any(Function));
-      // The mutation's onError must run before the rejection propagates so the
-      // existing list-cache rollback and user-visible toast still fire.
-      const options = capturedOptions.rename;
-      expect(options?.onError).toBeDefined();
-      options?.onError?.(error, { session_id: 's1', title: 'New title' }, undefined);
-      expect(toastErrorMock).toHaveBeenCalledWith('rename failed');
+describe('useSessionMutations account publication', () => {
+  it('retitles and rolls back both caches without accepting manual writes or clearing a fetch failure', async () => {
+    const query = client.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
+    await client.fetchQuery({
+      queryKey: QUERY_KEY,
+      queryFn: () => ({ sessions: [makeCached({ id: 's1', title: 'Old' })] }),
     });
-
-    it('reuses the same rename mutation options as renameSession', () => {
-      // The detail hook relies on the async variant being backed by the exact
-      // same mutation (and therefore the same onError/onSettled wiring) as
-      // the list's fire-and-forget variant.
-      const { renameSessionAsync } = useSessionMutations();
-      void renameSessionAsync;
-      expect(mutationOptionsSpy).toHaveBeenCalled();
+    await expect(
+      client.fetchQuery({
+        queryKey: QUERY_KEY,
+        queryFn: () => {
+          throw new Error('offline');
+        },
+      })
+    ).rejects.toThrow('offline');
+    const metadata = getActiveSessionsQueryMetadata(query);
+    const request = deferred<undefined>();
+    rpc.rename.mockReturnValue(request.promise);
+    const error = new Error('rename failed');
+    const rejection = expect(useSessionMutations().renameSessionAsync('s1', 'New')).rejects.toBe(
+      error
+    );
+    await vi.waitFor(() => {
+      expect(activeTitle(client)).toBe('New');
     });
+    expect(titles(client, listKey)).toEqual(['New', 'Other']);
+    expect(getActiveSessionsQueryMetadata(query)).toBe(metadata);
+    request.reject(error);
+    await rejection;
+    expect(activeTitle(client)).toBe('Old');
+    expect(titles(client, listKey)).toEqual(['Old', 'Other']);
+    expect(getActiveSessionsQueryMetadata(query)).toBe(metadata);
+    expect(messages).toEqual(['rename failed']);
+    expect(rpc.rename.mock.calls[0]?.[0]).toEqual({ session_id: 's1', title: 'New' });
   });
 
-  describe('rename optimistic tray patch', () => {
-    it('onMutate cancels and patches both the stored-list and active-list caches', async () => {
-      const storedSnapshot: [unknown, unknown][] = [[listKey, { pages: [], pageParams: [] }]];
-      const activeSnapshot: [unknown, unknown][] = [
-        [
-          activeFilter.queryKey,
-          {
-            sessions: [
-              { id: 's1', title: 'Old' },
-              { id: 's2', title: 'Other' },
-            ],
-          },
-        ],
-      ];
-      // First getQueriesData = stored list; second = active list.
-      getQueriesDataMock.mockReturnValueOnce(storedSnapshot).mockReturnValueOnce(activeSnapshot);
+  it('deletes only stored rows and moves focus after server confirmation', async () => {
+    const request = deferred<undefined>();
+    rpc.delete.mockReturnValue(request.promise);
+    let focused = 'row';
+    useSessionMutations().deleteSession('s1', () => {
+      focused = 'list';
+    });
+    await vi.waitFor(() => {
+      expect(titles(client, listKey)).toEqual(['Other']);
+    });
+    expect(activeTitle(client)).toBe('Old');
+    expect(focused).toBe('row');
+    request.resolve(undefined);
+    await vi.waitFor(() => {
+      expect(focused).toBe('list');
+    });
+    expect(messages).toEqual(['Session deleted']);
+    expect(rpc.delete.mock.calls[0]?.[0]).toEqual({ session_id: 's1' });
+  });
 
-      useSessionMutations();
-      const onMutate = capturedOptions.rename?.onMutate;
-      expect(onMutate).toBeDefined();
-      if (!onMutate) {
-        throw new Error('expected rename onMutate');
+  it.each([
+    { operation: 'rename', fails: true },
+    { operation: 'delete', fails: true },
+    { operation: 'rename', fails: false },
+    { operation: 'delete', fails: false },
+  ] as const)(
+    'fences late $operation settlement, fails=$fails, after real clear and replacement',
+    async ({ operation, fails }) => {
+      const mutations = useSessionMutations();
+      await mutations.renameSessionAsync('s1', 'Prepared');
+      const request = deferred<undefined>();
+      rpc[operation].mockReturnValue(request.promise);
+      const outcomes: Promise<unknown>[] = [];
+      let focused = 'account-b';
+      if (operation === 'rename') {
+        outcomes.push(
+          expect(mutations.renameSessionAsync('s1', 'New')).rejects.toBeInstanceOf(Error)
+        );
+      } else {
+        mutations.deleteSession('s1', () => {
+          focused = 'stale-row';
+        });
       }
-
-      const context = await onMutate({ session_id: 's1', title: 'New title' });
-
-      expect(cancelQueriesMock).toHaveBeenCalledWith({ queryKey: listKey });
-      expect(cancelQueriesMock).toHaveBeenCalledWith(activeFilter);
-      expect(setQueriesDataMock).toHaveBeenCalledTimes(2);
-
-      // Stored-list updater (first setQueriesData call).
-      const storedUpdater = setQueriesDataMock.mock.calls[0]?.[1] as
-        | ((old: unknown) => unknown)
-        | undefined;
-      expect(storedUpdater).toBeTypeOf('function');
-
-      // Active-list updater retitles only the target row.
-      const activeUpdater = setQueriesDataMock.mock.calls[1]?.[1] as
-        | ((old: { sessions: { id: string; title: string }[] } | undefined) => unknown)
-        | undefined;
-      expect(setQueriesDataMock.mock.calls[1]?.[0]).toBe(activeFilter);
-      expect(activeUpdater).toBeTypeOf('function');
-      expect(
-        activeUpdater?.({
-          sessions: [
-            { id: 's1', title: 'Old' },
-            { id: 's2', title: 'Other' },
-          ],
-        })
-      ).toEqual({
-        sessions: [
-          { id: 's1', title: 'New title' },
-          { id: 's2', title: 'Other' },
-        ],
-      });
-      expect(activeUpdater?.(undefined)).toBeUndefined();
-
-      expect(context).toEqual({
-        previous: storedSnapshot,
-        previousActive: activeSnapshot,
-        generation: expect.any(Number),
-      });
-    });
-
-    it('onError restores both snapshots and toasts the error', async () => {
-      const storedSnapshot: [unknown, unknown][] = [[['stored-key'], { pages: ['stored'] }]];
-      const activeSnapshot: [unknown, unknown][] = [
-        [['active-key'], { sessions: [{ id: 's1', title: 'Old' }] }],
-      ];
-      getQueriesDataMock.mockReturnValueOnce(storedSnapshot).mockReturnValueOnce(activeSnapshot);
-
-      useSessionMutations();
-      const options = capturedOptions.rename;
-      const onMutate = options?.onMutate;
-      if (!onMutate) {
-        throw new Error('expected rename onMutate');
-      }
-      const context = await onMutate({ session_id: 's1', title: 'New' });
-
-      setQueryDataMock.mockClear();
-      options.onError?.(new Error('rename failed'), { session_id: 's1', title: 'New' }, context);
-
-      expect(setQueryDataMock).toHaveBeenCalledWith(['stored-key'], { pages: ['stored'] });
-      expect(setQueryDataMock).toHaveBeenCalledWith(['active-key'], {
-        sessions: [{ id: 's1', title: 'Old' }],
-      });
-      expect(toastErrorMock).toHaveBeenCalledWith('rename failed');
-    });
-
-    it('onSettled still invalidates agent session queries', () => {
-      useSessionMutations();
-      const options = capturedOptions.rename;
-      options?.onSettled?.();
-
-      // The invalidation is deferred behind the interaction scheduler; drive
-      // the injected callback to run it in this turn.
-      const scheduled = scheduleCacheMaintenanceMock.mock.calls[0]?.[0];
-      expect(scheduled).toBeTypeOf('function');
-      scheduled?.();
-
-      expect(invalidateAgentSessionsMock).toHaveBeenCalled();
-    });
-  });
-
-  describe('delete does not touch the active cache', () => {
-    it('onMutate only patches the stored-list cache', async () => {
-      getQueriesDataMock.mockReturnValue([]);
-
-      useSessionMutations();
-      const onMutate = capturedOptions.delete?.onMutate;
-      expect(onMutate).toBeDefined();
-      if (!onMutate) {
-        throw new Error('expected delete onMutate');
-      }
-
-      await onMutate({ session_id: 's1' });
-
-      expect(cancelQueriesMock).toHaveBeenCalledWith({ queryKey: listKey });
-      expect(cancelQueriesMock).not.toHaveBeenCalledWith(activeFilter);
-      expect(setQueriesDataMock).toHaveBeenCalledTimes(1);
-      expect(setQueriesDataMock.mock.calls[0]?.[0]).toEqual({ queryKey: listKey });
-    });
-  });
-
-  describe('generation guard (shared cliSessionsV2.list cache)', () => {
-    it('adds no scope.id (callers already serialize per session via chainSave)', () => {
-      useSessionMutations();
-      expect(capturedOptions.delete?.scope).toBeUndefined();
-      expect(capturedOptions.rename?.scope).toBeUndefined();
-    });
-
-    it('a failing older delete does not roll back while a newer rename owns the shared list cache', async () => {
-      const deleteSnapshot: [unknown, unknown][] = [[['delete-key'], { pages: ['delete'] }]];
-      const renameStoredSnapshot: [unknown, unknown][] = [[['stored-key'], { pages: ['stored'] }]];
-      const renameActiveSnapshot: [unknown, unknown][] = [
-        [['active-key'], { sessions: [{ id: 's2', title: 'Old' }] }],
-      ];
-      getQueriesDataMock
-        .mockReturnValueOnce(deleteSnapshot)
-        .mockReturnValueOnce(renameStoredSnapshot)
-        .mockReturnValueOnce(renameActiveSnapshot);
-
-      useSessionMutations();
-      const deleteOnMutate = capturedOptions.delete?.onMutate;
-      const renameOnMutate = capturedOptions.rename?.onMutate;
-      if (!deleteOnMutate || !renameOnMutate) {
-        throw new Error('expected onMutate');
-      }
-
-      const olderDelete = await deleteOnMutate({ session_id: 's1' });
-      const newerRename = await renameOnMutate({ session_id: 's2', title: 'New' });
-
-      setQueryDataMock.mockClear();
-      capturedOptions.delete?.onError?.(
-        new Error('delete failed'),
-        { session_id: 's1' },
-        olderDelete
-      );
-      // The older delete's rollback must not restore its snapshot over the
-      // newer rename's optimistic write.
-      expect(setQueryDataMock).not.toHaveBeenCalled();
-      expect(toastErrorMock).toHaveBeenCalledWith('delete failed');
-
-      capturedOptions.rename?.onError?.(
-        new Error('rename failed'),
-        { session_id: 's2', title: 'New' },
-        newerRename
-      );
-      expect(setQueryDataMock).toHaveBeenCalledWith(['stored-key'], { pages: ['stored'] });
-      expect(setQueryDataMock).toHaveBeenCalledWith(['active-key'], {
-        sessions: [{ id: 's2', title: 'Old' }],
-      });
-      expect(toastErrorMock).toHaveBeenCalledWith('rename failed');
-    });
-
-    it('a failing latest delete rolls back its snapshot and toasts', async () => {
-      const deleteSnapshot: [unknown, unknown][] = [[['delete-key'], { pages: ['delete'] }]];
-      getQueriesDataMock.mockReturnValue(deleteSnapshot);
-
-      useSessionMutations();
-      const onMutate = capturedOptions.delete?.onMutate;
-      if (!onMutate) {
-        throw new Error('expected delete onMutate');
-      }
-      const context = await onMutate({ session_id: 's1' });
-
-      setQueryDataMock.mockClear();
-      capturedOptions.delete?.onError?.(new Error('delete failed'), { session_id: 's1' }, context);
-      expect(setQueryDataMock).toHaveBeenCalledWith(['delete-key'], { pages: ['delete'] });
-      expect(toastErrorMock).toHaveBeenCalledWith('delete failed');
-    });
-  });
-
-  describe('deleteSession completion callback', () => {
-    it('toasts success and invokes onDeleted after a successful delete', async () => {
-      mutateAsyncMock.mockResolvedValue(undefined);
-      const onDeleted = vi.fn(() => undefined);
-
-      const { deleteSession } = useSessionMutations();
-      deleteSession('s1', onDeleted);
-
       await vi.waitFor(() => {
-        expect(onDeleted).toHaveBeenCalledTimes(1);
+        expect(titles(client, listKey)).not.toContain('Prepared');
       });
-      expect(chainSaveMock).toHaveBeenCalledWith('s1', expect.any(Function));
-      expect(toastSuccessMock).toHaveBeenCalledWith('Session deleted');
-    });
+      replaceMutationAccount(client, listKey);
+      for (const run of settled) {
+        run();
+      }
+      if (fails) {
+        request.reject(
+          Object.assign(new Error('late unauthorized'), { data: { authRequired: true } })
+        );
+      } else {
+        request.resolve(undefined);
+      }
+      await Promise.all(outcomes);
+      await flush();
+      expectAccountBUnchanged();
+      expect(focused).toBe('account-b');
+    }
+  );
 
-    it('does not invoke onDeleted or the success toast when the delete fails', async () => {
-      mutateAsyncMock.mockRejectedValueOnce(new Error('delete failed'));
-      const onDeleted = vi.fn(() => undefined);
-
-      const { deleteSession } = useSessionMutations();
-      deleteSession('s1', onDeleted);
-
-      // Flush the async IIFE so the internal catch has definitely run.
-      await new Promise<void>(resolve => {
-        setTimeout(resolve, 0);
+  it.each(['stored-rename', 'active-rename', 'stored-delete'] as const)(
+    'rechecks the account after delayed %s cancellation',
+    async stage => {
+      const gate = deferred<undefined>();
+      const cancel = client.cancelQueries.bind(client);
+      const target = stage === 'active-rename' ? activeFilter.queryKey : listKey;
+      let waiting = false;
+      vi.spyOn(client, 'cancelQueries').mockImplementation(async filters => {
+        if (JSON.stringify(filters?.queryKey) === JSON.stringify(target)) {
+          waiting = true;
+          await gate.promise;
+        }
+        await cancel(filters);
       });
-      expect(onDeleted).not.toHaveBeenCalled();
-      expect(toastSuccessMock).not.toHaveBeenCalled();
+      const mutations = useSessionMutations();
+      if (stage === 'stored-delete') {
+        mutations.deleteSession('s1');
+      } else {
+        mutations.renameSession('s1', 'New');
+      }
+      await vi.waitFor(() => {
+        expect(waiting).toBe(true);
+      });
+      replaceMutationAccount(client, listKey);
+      gate.resolve(undefined);
+      await flush();
+      expectAccountBUnchanged();
+      expect(rpc.rename.mock.calls).toEqual([]);
+      expect(rpc.delete.mock.calls).toEqual([]);
+    }
+  );
+
+  it.each(['rename', 'delete'] as const)(
+    'rejects queued %s work from the previous account',
+    async queued => {
+      const request = deferred<undefined>();
+      rpc.rename.mockReturnValueOnce(request.promise);
+      const mutations = useSessionMutations();
+      mutations.renameSession('s1', 'New');
+      if (queued === 'rename') {
+        mutations.renameSession('s1', 'Later');
+      } else {
+        mutations.deleteSession('s1');
+      }
+      await vi.waitFor(() => {
+        expect(activeTitle(client)).toBe('New');
+      });
+      replaceMutationAccount(client, listKey);
+      request.resolve(undefined);
+      await flush();
+      expectAccountBUnchanged();
+      expect(rpc.rename.mock.calls.map(call => call[0])).toEqual([
+        { session_id: 's1', title: 'New' },
+      ]);
+      expect(rpc.delete.mock.calls).toEqual([]);
+    }
+  );
+
+  it('does not send a mutation after replacement between onMutate and mutationFn', async () => {
+    const unsubscribe = client.getMutationCache().subscribe(event => {
+      if (
+        event.type === 'updated' &&
+        event.action.type === 'pending' &&
+        event.mutation.state.context
+      ) {
+        replaceMutationAccount(client, listKey);
+      }
     });
+    await expect(useSessionMutations().renameSessionAsync('s1', 'New')).rejects.toThrow(
+      'inactive account'
+    );
+    unsubscribe();
+    expectAccountBUnchanged();
+    expect(rpc.rename.mock.calls).toEqual([]);
+  });
+
+  it('keeps the latest same-account mutation generation in control of rollback', async () => {
+    const deletion = deferred<undefined>();
+    const rename = deferred<undefined>();
+    rpc.delete.mockReturnValue(deletion.promise);
+    rpc.rename.mockReturnValue(rename.promise);
+    const mutations = useSessionMutations();
+    mutations.deleteSession('s1');
+    await vi.waitFor(() => {
+      expect(titles(client, listKey)).toEqual(['Other']);
+    });
+    const error = new Error('rename failed');
+    const rejection = expect(mutations.renameSessionAsync('s2', 'Newer')).rejects.toBe(error);
+    await vi.waitFor(() => {
+      expect(titles(client, listKey)).toEqual(['Newer']);
+    });
+    deletion.reject(new Error('delete failed'));
+    await flush();
+    expect(titles(client, listKey)).toEqual(['Newer']);
+    rename.reject(error);
+    await rejection;
+    expect(titles(client, listKey)).toEqual(['Other']);
+    expect(messages).toEqual(['delete failed', 'rename failed']);
   });
 });

--- a/apps/mobile/src/lib/hooks/use-session-mutations.test.ts
+++ b/apps/mobile/src/lib/hooks/use-session-mutations.test.ts
@@ -21,6 +21,7 @@ type Input = { session_id: string; title?: string };
 type MutationOptions = ReactQuery.MutationOptions<unknown, Error, Input>;
 let client = makeTestQueryClient();
 const rpc = { rename: vi.fn(), delete: vi.fn() };
+let renameMutationFn: MutationOptions['mutationFn'] = rpc.rename;
 const messages: string[] = [];
 const settled: (() => void)[] = [];
 const listKey = [['cliSessionsV2', 'list'], { type: 'infinite' }] as const;
@@ -48,7 +49,10 @@ vi.mock('@/lib/trpc', () => ({
     cliSessionsV2: {
       list: { infiniteQueryKey: () => listKey },
       rename: {
-        mutationOptions: (options: MutationOptions) => ({ ...options, mutationFn: rpc.rename }),
+        mutationOptions: (options: MutationOptions) => ({
+          ...options,
+          mutationFn: renameMutationFn,
+        }),
       },
       delete: {
         mutationOptions: (options: MutationOptions) => ({ ...options, mutationFn: rpc.delete }),
@@ -89,7 +93,7 @@ afterAll(
 beforeEach(() => {
   setSignOutActive(false);
   client = makeTestQueryClient();
-  rpc.rename.mockReset().mockResolvedValue(undefined);
+  renameMutationFn = rpc.rename.mockReset().mockResolvedValue(undefined);
   rpc.delete.mockReset().mockResolvedValue(undefined);
   messages.length = 0;
   settled.length = 0;
@@ -101,6 +105,13 @@ afterEach(() => {
 });
 
 describe('useSessionMutations account publication', () => {
+  it('rejects a missing rename mutation function and restores both caches', async () => {
+    renameMutationFn = undefined;
+    await expect(useSessionMutations().renameSessionAsync('s1', 'New')).rejects.toThrow();
+    expect(titles(client, listKey)).toEqual(['Old', 'Other']);
+    expect(activeTitle(client)).toBe('Old');
+  });
+
   it('retitles and rolls back both caches without accepting manual writes or clearing a fetch failure', async () => {
     const query = client.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
     await client.fetchQuery({

--- a/apps/mobile/src/lib/hooks/use-session-mutations.ts
+++ b/apps/mobile/src/lib/hooks/use-session-mutations.ts
@@ -4,6 +4,8 @@ import { i18n } from '@/i18n';
 import { invalidateAgentSessionQueries } from '@/lib/agent-session-cache';
 import { applyActiveSessionTitle, type CachedActiveSessionsData } from '@/lib/active-sessions-live';
 import { announcingToast } from '@/lib/a11y/announcing-toast';
+import { currentAuthEpoch, isCurrentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { isSignOutActive } from '@/lib/auth/sign-out-state';
 import {
   isLatestMutationGeneration,
   nextMutationGeneration,
@@ -19,6 +21,32 @@ import { useTRPC } from '@/lib/trpc';
 
 type SessionsListSnapshot = [QueryKey, SessionsListData | undefined][];
 
+// Keep the epoch beside the original variables, never in the mutation input.
+// Weak keys survive a hook render without retaining completed operations.
+const operationEpochs = new WeakMap<object, number>();
+
+function isCurrentOperation(epoch: number | undefined): epoch is number {
+  return epoch !== undefined && isCurrentAuthEpoch(epoch) && !isSignOutActive();
+}
+
+function assertCurrentOperation(epoch: number | undefined): asserts epoch is number {
+  if (!isCurrentOperation(epoch)) {
+    throw new Error('Session operation belongs to an inactive account');
+  }
+}
+
+// Fence both outcomes before MutationCache can run global auth callbacks.
+async function settleCurrentOperation<T>(epoch: number, operation: Promise<T>): Promise<T> {
+  try {
+    const result = await operation;
+    assertCurrentOperation(epoch);
+    return result;
+  } catch (error) {
+    assertCurrentOperation(epoch);
+    throw error;
+  }
+}
+
 const onError = (error: { message: string }) => {
   announcingToast.error(error.message || i18n.t('common.somethingWentWrong'));
 };
@@ -29,140 +57,167 @@ export function useSessionMutations() {
   const listKey = trpc.cliSessionsV2.list.infiniteQueryKey();
   const activeListFilter = trpc.activeSessions.list.pathFilter();
 
-  const invalidateSessions = () => {
+  const invalidateSessions = (epoch: number | undefined) => {
+    if (!isCurrentOperation(epoch)) {
+      return;
+    }
     scheduleCacheMaintenance(() => {
-      void invalidateAgentSessionQueries(queryClient, trpc);
+      if (isCurrentOperation(epoch)) {
+        void invalidateAgentSessionQueries(queryClient, trpc);
+      }
     });
   };
 
   const snapshotAndUpdate = async (
-    update: (data: SessionsListData) => SessionsListData
-  ): Promise<{ previous: SessionsListSnapshot; generation: number }> => {
+    update: (data: SessionsListData) => SessionsListData,
+    epoch: number | undefined
+  ): Promise<{ previous: SessionsListSnapshot; generation: number; epoch: number }> => {
+    assertCurrentOperation(epoch);
     await queryClient.cancelQueries({ queryKey: listKey });
+    assertCurrentOperation(epoch);
     const generation = nextMutationGeneration(hashKey(listKey));
     const previous = queryClient.getQueriesData<SessionsListData>({ queryKey: listKey });
     queryClient.setQueriesData<SessionsListData>({ queryKey: listKey }, old =>
-      old ? update(old) : old
+      old && isCurrentOperation(epoch) ? update(old) : old
     );
-    return { previous, generation };
+    return { previous, generation, epoch };
   };
 
-  /**
-   * Optimistically retitle the row in every cached "Active now" tray. The tray
-   * cache is keyed per personal/org context, so patch them all by path filter —
-   * the mutation hook has no context of its own, and a rename is rare.
-   */
-  const snapshotAndUpdateActive = async (sessionId: string, title: string) => {
+  /** Retitle every cached tray without changing its context or cache envelope. */
+  const snapshotAndUpdateActive = async (sessionId: string, title: string, epoch: number) => {
+    assertCurrentOperation(epoch);
     await queryClient.cancelQueries(activeListFilter);
+    assertCurrentOperation(epoch);
     const previousActive = queryClient.getQueriesData<CachedActiveSessionsData>(activeListFilter);
     queryClient.setQueriesData<CachedActiveSessionsData>(activeListFilter, old =>
-      old ? { sessions: applyActiveSessionTitle(old.sessions, sessionId, title) } : old
+      old && isCurrentOperation(epoch)
+        ? { sessions: applyActiveSessionTitle(old.sessions, sessionId, title) }
+        : old
     );
     return previousActive;
   };
 
-  const rollback = (previous?: [QueryKey, unknown][]) => {
+  const rollback = (previous: [QueryKey, unknown][] | undefined, epoch: number) => {
     for (const [key, data] of previous ?? []) {
+      if (!isCurrentOperation(epoch)) {
+        return;
+      }
       queryClient.setQueryData(key, data);
     }
   };
 
-  // onError policy: roll back the onMutate snapshot (latest generation only)
-  // and toast error.message.
-  const deleteSessionMutation = useMutation(
-    trpc.cliSessionsV2.delete.mutationOptions({
-      onMutate: async ({ session_id }) => {
-        const { previous, generation } = await snapshotAndUpdate(data =>
-          removeStoredSession(data, session_id)
-        );
-        return { previous, generation };
-      },
-      onError: (error, _input, context) => {
-        if (context && isLatestMutationGeneration(hashKey(listKey), context.generation)) {
-          rollback(context.previous);
-        }
-        onError(error);
-      },
-      onSettled: invalidateSessions,
-    })
-  );
+  const deleteOptions = trpc.cliSessionsV2.delete.mutationOptions({
+    onMutate: async input => {
+      const snapshot = await snapshotAndUpdate(
+        data => removeStoredSession(data, input.session_id),
+        operationEpochs.get(input)
+      );
+      return snapshot;
+    },
+    onError: (error, input, context) => {
+      if (!isCurrentOperation(operationEpochs.get(input))) {
+        return;
+      }
+      if (context && isLatestMutationGeneration(hashKey(listKey), context.generation)) {
+        rollback(context.previous, context.epoch);
+      }
+      onError(error);
+    },
+    onSettled: (_data, _error, input) => {
+      invalidateSessions(operationEpochs.get(input));
+    },
+  });
+  const deleteSessionMutation = useMutation({
+    ...deleteOptions,
+    mutationFn: async (input, context) => {
+      const epoch = operationEpochs.get(input);
+      assertCurrentOperation(epoch);
+      const result = await settleCurrentOperation(epoch, deleteOptions.mutationFn(input, context));
+      return result;
+    },
+  });
 
-  // onError policy: roll back the onMutate snapshot (latest generation only)
-  // and toast error.message.
-  const renameSessionMutation = useMutation(
-    trpc.cliSessionsV2.rename.mutationOptions({
-      onMutate: async ({ session_id, title }) => {
-        const { previous, generation } = await snapshotAndUpdate(data =>
-          mapStoredSessions(data, session_id, session => ({ ...session, title }))
-        );
-        const previousActive = await snapshotAndUpdateActive(session_id, title);
-        return { previous, previousActive, generation };
-      },
-      onError: (error, _input, context) => {
-        if (context && isLatestMutationGeneration(hashKey(listKey), context.generation)) {
-          rollback(context.previous);
-          rollback(context.previousActive);
-        }
-        onError(error);
-      },
-      onSettled: invalidateSessions,
-    })
-  );
+  const renameOptions = trpc.cliSessionsV2.rename.mutationOptions({
+    onMutate: async input => {
+      const snapshot = await snapshotAndUpdate(
+        data =>
+          mapStoredSessions(data, input.session_id, session => ({
+            ...session,
+            title: input.title,
+          })),
+        operationEpochs.get(input)
+      );
+      const previousActive = await snapshotAndUpdateActive(
+        input.session_id,
+        input.title,
+        snapshot.epoch
+      );
+      return { ...snapshot, previousActive };
+    },
+    onError: (error, input, context) => {
+      if (!isCurrentOperation(operationEpochs.get(input))) {
+        return;
+      }
+      if (context && isLatestMutationGeneration(hashKey(listKey), context.generation)) {
+        rollback(context.previous, context.epoch);
+        rollback(context.previousActive, context.epoch);
+      }
+      onError(error);
+    },
+    onSettled: (_data, _error, input) => {
+      invalidateSessions(operationEpochs.get(input));
+    },
+  });
+  const renameSessionMutation = useMutation({
+    ...renameOptions,
+    mutationFn: async (input, context) => {
+      const epoch = operationEpochs.get(input);
+      assertCurrentOperation(epoch);
+      const result = await settleCurrentOperation(epoch, renameOptions.mutationFn(input, context));
+      return result;
+    },
+  });
 
-  // Per session row: DISTINCT operations (a delete during a settling rename,
-  // a re-rename to a different title) run serialized through a per-session
-  // chain (chainSave, see save-chain.ts) so their optimistic
-  // snapshots/rollbacks can't interleave and an older request can never
-  // overwrite a newer one's result. Rename goes through a modal confirm and
-  // delete through Alert.alert, so an adjacent double-fire of the same op
-  // is already impossible — no dedupe needed here.
-  //
-  // `renameSession` is the list's fire-and-forget caller. Detail callers
-  // (e.g. the session detail header) use `renameSessionAsync`, which awaits
-  // the same mutation + chain so a rejection surfaces the existing toast,
-  // rolls back the list cache, and lets the caller keep its modal open for
-  // retry.
+  // Preserve per-session sequencing and the detail caller's rejection contract.
+  const renameSessionAsync = async (sessionId: string, title: string) => {
+    const epoch = currentAuthEpoch();
+    const input = { session_id: sessionId, title };
+    operationEpochs.set(input, epoch);
+    await chainSave(sessionId, async () => {
+      assertCurrentOperation(epoch);
+      await renameSessionMutation.mutateAsync(input);
+      assertCurrentOperation(epoch);
+    });
+  };
+
   return {
-    // `onDeleted` runs only after the server confirms the delete (the
-    // optimistic removal already happened in onMutate). It lets the list
-    // move assistive-technology focus to a stable anchor; it is NOT invoked
-    // on failure, so a failed delete never moves focus. The success toast
-    // lives here (the hook owns outcome toasts) and announces the deletion
-    // through the shared announcingToast owner.
     deleteSession: (sessionId: string, onDeleted?: () => void) => {
+      const epoch = currentAuthEpoch();
+      const input = { session_id: sessionId };
+      operationEpochs.set(input, epoch);
       void (async () => {
         try {
-          // eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
-          await chainSave(sessionId, () =>
-            deleteSessionMutation.mutateAsync({ session_id: sessionId })
-          );
+          await chainSave(sessionId, async () => {
+            assertCurrentOperation(epoch);
+            await deleteSessionMutation.mutateAsync(input);
+          });
+          assertCurrentOperation(epoch);
           announcingToast.success(i18n.t('agents.sessionRow.sessionDeleted'));
           onDeleted?.();
         } catch {
-          // Already surfaced via the mutation's own onError (toast + rollback).
+          // Current-account failures use onError; stale outcomes stay silent.
         }
       })();
     },
     renameSession: (sessionId: string, title: string) => {
       void (async () => {
         try {
-          // eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
-          await chainSave(sessionId, () =>
-            renameSessionMutation.mutateAsync({ session_id: sessionId, title })
-          );
+          await renameSessionAsync(sessionId, title);
         } catch {
-          // Already surfaced via the mutation's own onError (toast + rollback).
+          // Current-account failures use onError; stale outcomes stay silent.
         }
       })();
     },
-    renameSessionAsync: async (sessionId: string, title: string) => {
-      // The mutation's onError toasts and rolls back the list cache before
-      // this rejection propagates, so callers can rethrow to keep their
-      // modal open without duplicating user-visible error handling.
-      // eslint-disable-next-line typescript-eslint/promise-function-async -- conflicting require-await rule
-      await chainSave(sessionId, () =>
-        renameSessionMutation.mutateAsync({ session_id: sessionId, title })
-      );
-    },
+    renameSessionAsync,
   };
 }

--- a/apps/mobile/src/lib/hooks/use-session-mutations.ts
+++ b/apps/mobile/src/lib/hooks/use-session-mutations.ts
@@ -132,6 +132,9 @@ export function useSessionMutations() {
     mutationFn: async (input, context) => {
       const epoch = operationEpochs.get(input);
       assertCurrentOperation(epoch);
+      if (!deleteOptions.mutationFn) {
+        throw new Error('No mutationFn found');
+      }
       const result = await settleCurrentOperation(epoch, deleteOptions.mutationFn(input, context));
       return result;
     },
@@ -173,6 +176,9 @@ export function useSessionMutations() {
     mutationFn: async (input, context) => {
       const epoch = operationEpochs.get(input);
       assertCurrentOperation(epoch);
+      if (!renameOptions.mutationFn) {
+        throw new Error('No mutationFn found');
+      }
       const result = await settleCurrentOperation(epoch, renameOptions.mutationFn(input, context));
       return result;
     },

--- a/apps/mobile/src/lib/query-client.test.ts
+++ b/apps/mobile/src/lib/query-client.test.ts
@@ -1,48 +1,38 @@
-import { QueryObserver } from '@tanstack/react-query';
+import { CancelledError, QueryObserver } from '@tanstack/react-query';
+
+import {
+  deferred,
+  makeTestQueryClient as makeClient,
+  QUERY_KEY,
+} from './active-sessions-live-sync.test-helpers';
+import {
+  createKiloAppQueryClient,
+  getActiveSessionsQueryMetadata,
+  subscribeActiveSessionsQueryMetadata,
+} from './query-client';
 import { describe, expect, it, vi } from 'vitest';
 
 import { setTrpcUnauthorizedHandler } from '@/lib/auth/trpc-unauthorized';
 
-import { createKiloAppQueryClient } from './query-client';
-
 describe('createKiloAppQueryClient', () => {
-  it('runs the registered unauthorized handler for mutation 401 errors', async () => {
-    const signOut = vi.fn();
-    const clear = setTrpcUnauthorizedHandler(signOut);
-    const queryClient = createKiloAppQueryClient();
-    const error = Object.assign(new Error('unauthorized'), {
-      data: { authRequired: true, httpStatus: 401 },
+  it.each([
+    { data: { authRequired: true, httpStatus: 401 } },
+    { shape: { data: { authRequired: true, httpStatus: 401 } } },
+  ])('runs the unauthorized handler for mutation errors shaped as %j', async metadata => {
+    let signedIn = true;
+    const clear = setTrpcUnauthorizedHandler(() => {
+      signedIn = false;
     });
-
-    const mutation = queryClient.getMutationCache().build(queryClient, {
+    const client = createKiloAppQueryClient();
+    const error = Object.assign(new Error('unauthorized'), metadata);
+    const mutation = client.getMutationCache().build(client, {
       mutationFn: async () => {
         await Promise.resolve();
         throw error;
       },
     });
-
     await expect(mutation.execute(undefined)).rejects.toBe(error);
-    expect(signOut).toHaveBeenCalledTimes(1);
-    clear();
-  });
-
-  it('runs the registered unauthorized handler for shaped mutation 401 errors', async () => {
-    const signOut = vi.fn();
-    const clear = setTrpcUnauthorizedHandler(signOut);
-    const queryClient = createKiloAppQueryClient();
-    const error = Object.assign(new Error('unauthorized'), {
-      shape: { data: { authRequired: true, httpStatus: 401 } },
-    });
-
-    const mutation = queryClient.getMutationCache().build(queryClient, {
-      mutationFn: async () => {
-        await Promise.resolve();
-        throw error;
-      },
-    });
-
-    await expect(mutation.execute(undefined)).rejects.toBe(error);
-    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(signedIn).toBe(false);
     clear();
   });
 });
@@ -177,5 +167,170 @@ describe('permission-denied query removal', () => {
     expect(queryClient.getQueryData(key)).toEqual({ members: ['a'] });
     expect(signOut).not.toHaveBeenCalled();
     clear();
+  });
+});
+
+const emptyResult = { sessions: [] };
+
+describe('accepted active-session outcomes', () => {
+  it('does not accept manual empty data, timestamps, or generic success as a server result', async () => {
+    const client = makeClient();
+    const absent = getActiveSessionsQueryMetadata(undefined);
+    client.setQueryData(QUERY_KEY, emptyResult);
+    const query = client.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
+    query?.setState({ status: 'success', dataUpdatedAt: Date.now() - 1 });
+    expect(getActiveSessionsQueryMetadata(query)).toBe(absent);
+    await client.fetchQuery({ queryKey: QUERY_KEY, queryFn: () => emptyResult, staleTime: 0 });
+    const accepted = getActiveSessionsQueryMetadata(query);
+    expect(accepted.acceptedRevision).toBe(1);
+    client.setQueryData(QUERY_KEY, emptyResult);
+    expect(getActiveSessionsQueryMetadata(query)).toBe(accepted);
+  });
+
+  it.each([
+    ['retryable', new Error('offline')],
+    [
+      'non-retryable',
+      Object.assign(new Error('denied'), { shape: { data: { code: 'FORBIDDEN' } } }),
+    ],
+  ] as const)(
+    'retains the original %s failure through manual writes, retry, and cancellation',
+    async (kind, error) => {
+      const client = makeClient();
+      const observer = new QueryObserver(client, {
+        queryKey: QUERY_KEY,
+        enabled: false,
+        retry: false,
+        queryFn: () => {
+          throw error;
+        },
+      });
+      const unsubscribe = observer.subscribe(() => undefined);
+      // An enabled observer keeps permission failures in the cache.
+      observer.setOptions({ ...observer.options, enabled: true });
+      await observer.refetch();
+      const query = client.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
+      const failed = getActiveSessionsQueryMetadata(query);
+      expect(failed.terminalError).toEqual({ error, kind });
+      expect(failed.terminalError?.error).toBe(error);
+      expect(failed.acceptedRevision).toBe(0);
+      client.setQueryData(QUERY_KEY, { sessions: [{ id: 'live', title: 'socket' }] });
+      const recovery = deferred<typeof emptyResult>();
+      const retry = client.fetchQuery({
+        queryKey: QUERY_KEY,
+        queryFn: async () => {
+          const result = await recovery.promise;
+          return result;
+        },
+      });
+      expect(getActiveSessionsQueryMetadata(query)).toBe(failed);
+      await client.cancelQueries({ queryKey: QUERY_KEY, exact: true });
+      await retry;
+      expect(getActiveSessionsQueryMetadata(query)).toBe(failed);
+      recovery.resolve(emptyResult);
+      await client.fetchQuery({ queryKey: QUERY_KEY, queryFn: () => emptyResult });
+      expect(getActiveSessionsQueryMetadata(query)).toEqual({
+        acceptedRevision: 1,
+        terminalError: null,
+      });
+      unsubscribe();
+    }
+  );
+
+  it('ignores retry attempts and a terminal cancellation error', async () => {
+    const client = makeClient();
+    const result = deferred<typeof emptyResult>();
+    let attempts = 0;
+    const pending = client.fetchQuery({
+      queryKey: QUERY_KEY,
+      retry: 1,
+      retryDelay: 0,
+      queryFn: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error('retry attempt');
+        }
+        const accepted = await result.promise;
+        return accepted;
+      },
+    });
+    const query = client.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
+    await vi.waitFor(() => {
+      expect(attempts).toBe(2);
+    });
+    expect(getActiveSessionsQueryMetadata(query)).toBe(getActiveSessionsQueryMetadata(undefined));
+    result.reject(new CancelledError());
+    await expect(pending).rejects.toBeInstanceOf(CancelledError);
+    expect(getActiveSessionsQueryMetadata(query).terminalError).toBeNull();
+  });
+
+  it.each(['remove', 'clear'] as const)(
+    'preserves provenance across remounts but resets it after %s',
+    async removal => {
+      const client = makeClient();
+      await client.fetchQuery({ queryKey: QUERY_KEY, queryFn: () => emptyResult });
+      const query = client.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
+      const accepted = getActiveSessionsQueryMetadata(query);
+      const observer = new QueryObserver(client, { queryKey: QUERY_KEY, staleTime: Infinity });
+      observer.subscribe(() => undefined)();
+      const unsubscribe = observer.subscribe(() => undefined);
+      expect(getActiveSessionsQueryMetadata(query)).toBe(accepted);
+      unsubscribe();
+      const published: number[] = [];
+      subscribeActiveSessionsQueryMetadata(query, () => {
+        published.push(getActiveSessionsQueryMetadata(query).acceptedRevision);
+      });
+      if (removal === 'clear') {
+        client.clear();
+      } else {
+        client.removeQueries({ queryKey: QUERY_KEY, exact: true });
+      }
+      expect(published).toEqual([0]);
+      expect(getActiveSessionsQueryMetadata(query)).toBe(getActiveSessionsQueryMetadata(undefined));
+      client.setQueryData(QUERY_KEY, emptyResult);
+      const recreated = client.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
+      expect(recreated).not.toBe(query);
+      expect(getActiveSessionsQueryMetadata(recreated).acceptedRevision).toBe(0);
+      await client.fetchQuery({ queryKey: QUERY_KEY, queryFn: () => emptyResult });
+      expect(getActiveSessionsQueryMetadata(recreated).acceptedRevision).toBe(1);
+      expect(published).toEqual([0]);
+    }
+  );
+
+  it.each([
+    { otherKey: [['activeSessions', 'list', 'detail'], { type: 'query' }] },
+    { otherKey: [['activeSessions', 'list'], { type: 'infinite' }] },
+    { otherKey: [['cliSessionsV2', 'list'], { type: 'query' }] },
+    { otherKey: [['activeSessions', 'list'], { type: 'query' }, 'extra'] },
+    { otherKey: ['activeSessions', 'list'] },
+  ])('isolates clients and subscriptions and excludes $otherKey', async ({ otherKey }) => {
+    const client = makeClient();
+    const otherClient = makeClient();
+    client.setQueryData(QUERY_KEY, emptyResult);
+    otherClient.setQueryData(QUERY_KEY, emptyResult);
+    const query = client.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
+    const otherQuery = otherClient.getQueryCache().find({ queryKey: QUERY_KEY, exact: true });
+    const published: number[] = [];
+    const otherPublished: number[] = [];
+    subscribeActiveSessionsQueryMetadata(query, () => {
+      published.push(getActiveSessionsQueryMetadata(query).acceptedRevision);
+    });
+    subscribeActiveSessionsQueryMetadata(otherQuery, () => {
+      otherPublished.push(getActiveSessionsQueryMetadata(otherQuery).acceptedRevision);
+    });
+    await client.fetchQuery({ queryKey: otherKey, queryFn: () => emptyResult });
+    expect(
+      getActiveSessionsQueryMetadata(client.getQueryCache().find({ queryKey: otherKey }))
+        .acceptedRevision
+    ).toBe(0);
+    expect(published).toEqual([]);
+    await client.fetchQuery({ queryKey: QUERY_KEY, queryFn: () => emptyResult });
+    expect(published).toEqual([1]);
+    client.setQueryData(QUERY_KEY, emptyResult);
+    expect(published).toEqual([1]);
+    await client.fetchQuery({ queryKey: QUERY_KEY, queryFn: () => emptyResult });
+    expect(published).toEqual([1, 2]);
+    expect(otherPublished).toEqual([]);
+    expect(getActiveSessionsQueryMetadata(otherQuery).acceptedRevision).toBe(0);
   });
 });

--- a/apps/mobile/src/lib/query-client.ts
+++ b/apps/mobile/src/lib/query-client.ts
@@ -1,8 +1,132 @@
-import { MutationCache, type Query, QueryCache, QueryClient } from '@tanstack/react-query';
+import {
+  CancelledError,
+  MutationCache,
+  type Query,
+  QueryCache,
+  QueryClient,
+  type QueryFunction,
+  type QueryKey,
+} from '@tanstack/react-query';
 import { z } from 'zod';
 
 import { handleTrpcQueryError } from '@/lib/auth/trpc-unauthorized';
 import { reportTrpcError } from '@/lib/force-update-signal';
+import { isTerminalTrpcCode, readTrpcErrorField } from '@/lib/trpc-error';
+
+export type ActiveSessionsQueryMetadata = Readonly<{
+  acceptedRevision: number;
+  terminalError: Readonly<{
+    error: unknown;
+    kind: 'retryable' | 'non-retryable';
+  }> | null;
+}>;
+
+// Old/manual-only cache entries have no server provenance. They cannot establish
+// empty success; keep this fallback while those entries can occur.
+const EMPTY_ACTIVE_SESSIONS_METADATA: ActiveSessionsQueryMetadata = {
+  acceptedRevision: 0,
+  terminalError: null,
+};
+const activeSessionsMetadata = new WeakMap<Query, ActiveSessionsQueryMetadata>();
+const activeSessionsListeners = new WeakMap<Query, Set<() => void>>();
+const activeSessionsQueryKeySchema = z.tuple([
+  z.tuple([z.literal('activeSessions'), z.literal('list')]),
+  z.object({ type: z.literal('query'), input: z.unknown().optional() }),
+]);
+
+export function getActiveSessionsQueryMetadata(
+  query: Query | undefined
+): ActiveSessionsQueryMetadata {
+  return (query && activeSessionsMetadata.get(query)) ?? EMPTY_ACTIVE_SESSIONS_METADATA;
+}
+
+export function subscribeActiveSessionsQueryMetadata(
+  query: Query | undefined,
+  listener: () => void
+): () => void {
+  if (!query) {
+    return () => undefined;
+  }
+  const listeners = activeSessionsListeners.get(query) ?? new Set<() => void>();
+  activeSessionsListeners.set(query, listeners);
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function captureActiveSessionsQueryRefresh(client: QueryClient, queryKey: QueryKey) {
+  const query = client.getQueryCache().build(client, { queryKey });
+  const revision = getActiveSessionsQueryMetadata(query).acceptedRevision;
+  const isCurrent = () => client.getQueryCache().get(query.queryHash) === query;
+  return {
+    isCurrent,
+    hasAcceptedResult: () =>
+      isCurrent() && getActiveSessionsQueryMetadata(query).acceptedRevision > revision,
+  };
+}
+
+/** Keep canceled account/attachment work out of Query's success reducer. */
+export function fenceActiveSessionsQuery<TData, TKey extends QueryKey>(
+  queryFn: QueryFunction<TData, TKey>,
+  isCurrent: () => boolean
+): QueryFunction<TData, TKey> {
+  return async context => {
+    if (!isCurrent()) {
+      throw new CancelledError({ revert: true });
+    }
+    const result = await queryFn(context);
+    if (!isCurrent()) {
+      throw new CancelledError({ revert: true });
+    }
+    return result;
+  };
+}
+
+function observeActiveSessionsQueryOutcomes(queryCache: QueryCache): void {
+  // This client-lifetime subscription survives QueryClient.clear().
+  queryCache.subscribe(event => {
+    const query: Query = event.query;
+    if (!activeSessionsQueryKeySchema.safeParse(query.queryKey).success) {
+      return;
+    }
+    const previous = getActiveSessionsQueryMetadata(query);
+    if (event.type === 'removed') {
+      activeSessionsMetadata.delete(query);
+    } else if (
+      event.type === 'updated' &&
+      event.action.type === 'success' &&
+      !event.action.manual
+    ) {
+      activeSessionsMetadata.set(query, {
+        acceptedRevision: previous.acceptedRevision + 1,
+        terminalError: null,
+      });
+    } else if (
+      event.type === 'updated' &&
+      event.action.type === 'error' &&
+      !(event.action.error instanceof CancelledError)
+    ) {
+      if (previous.terminalError?.error === event.action.error) {
+        return;
+      }
+      activeSessionsMetadata.set(query, {
+        ...previous,
+        terminalError: {
+          error: event.action.error,
+          kind: isTerminalTrpcCode(readTrpcErrorField(event.action.error, 'code'))
+            ? 'non-retryable'
+            : 'retryable',
+        },
+      });
+    } else {
+      return;
+    }
+    for (const listener of activeSessionsListeners.get(query) ?? []) {
+      listener();
+    }
+  });
+}
 
 // tRPC error codes that retrying can never fix — surface these immediately
 // instead of sitting on a skeleton through the default retry backoff.
@@ -129,6 +253,7 @@ export function createKiloAppQueryClient(): QueryClient {
       },
     }),
   });
+  observeActiveSessionsQueryOutcomes(queryClient.getQueryCache());
   return queryClient;
 }
 


### PR DESCRIPTION
## Summary

- Live sessions appear only after sign-in and organization selection finish, and no longer remain visible during sign-out.
- Refreshing live sessions only reports success after fresh results arrive for the selected organization.
- After you switch accounts, earlier rename or delete actions no longer change the new account's lists, show old notices, or sign it out.
- Exiting a live session refreshes only the current personal or organization list. That refresh cannot carry over when you switch organizations or accounts.

---

### Maintainer changelog

`ActiveSessionsQueryMetadata` records `acceptedRevision` and retryable/non-retryable `terminalError` for `activeSessions.list`; old or manually written data does not establish accepted success.
`captureActiveSessionsQueryRefresh` checks query identity and a newer revision; `fenceActiveSessionsQuery` rejects results when their account or attachment expires.
`createKiloAppQueryClient` installs the observer; `getActiveSessionsQueryMetadata` and `subscribeActiveSessionsQueryMetadata` expose metadata, with `activeSessionsQueryKeySchema` limiting which keys qualify.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/query-client.ts` — Source; modified; 127 changed lines. Keys metadata and listeners by Query without changing session payloads. Accepted responses increment the revision and clear errors; manual writes and cancellation preserve metadata. Query removal resets metadata, while the client-lifetime observer survives cache clearing. Adds terminal error classification, identity/revision capture, and cancellation fences before and after responses.
- `apps/mobile/src/lib/query-client.test.ts` — Test; modified; 221 changed lines. Updates the query-client suite.

</details>

`refreshActiveSessionsNow` and `ActiveSessionsLiveSync.refreshNow` now require a `QueryKey`; `false` means no matching owner, while `{ accepted: boolean }` reports handled completion.
Acceptance requires a newer server result for the exact query, current account, and current attachment; cancelled replacements remain pending.
`LiveSyncQueryClient` now requires a full `QueryClient`; callers must supply their scope and must not start a fallback fetch after a handled failure.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/active-sessions-live-sync.ts` — Source; modified; 219 changed lines. Copies owner options, guards writes and refreshes by account and attachment, and cancels only the exact query. Fetches wait for queued writes; manual refresh follows replacement fetches. Only accepted results clear pending reasons; failures retain them for retry.
- `apps/mobile/src/lib/active-sessions-live-sync.attention.test.ts` — Test; modified; 4 changed lines. Updates the attention suite.
- `apps/mobile/src/lib/active-sessions-live-sync.manual-refresh.test.ts` — Test; modified; 67 changed lines. Updates the manual refresh suite.
- `apps/mobile/src/lib/active-sessions-live-sync.pending.test.ts` — Test; modified; 8 changed lines. Updates the pending-reasons suite.
- `apps/mobile/src/lib/active-sessions-live-sync.race.test.ts` — Test; modified; 96 changed lines. Updates the race suite.
- `apps/mobile/src/lib/active-sessions-live-sync.reconnect.test.ts` — Test; modified; 8 changed lines. Updates the reconnect suite.
- `apps/mobile/src/lib/active-sessions-live-sync.test-helpers.ts` — Test; modified; 202 changed lines. Updates the shared live-sync test helper.
- `apps/mobile/src/lib/active-sessions-live-sync.test.ts` — Test; modified; 38 changed lines. Updates the live-sync suite.

</details>

`useActiveSessions` shares exported `UseAgentSessionsOptions` with `useAgentSessions`, exposes `queryKey`/`canRead`, and gates reads and socket leases on authentication and organization readiness.
`useLiveAgentSessions` adds `hasAcceptedSuccess`, `terminalError`, `isFetching`, and `isPaused`; its boolean `refetch` confirms a new accepted response rather than a successful cache state.
Legacy flags remain available; account changes block cached active rows and departure reconciliation, while obsolete organization scopes and unmounted callers cannot confirm refresh success.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/active-sessions-live-sync-mount.tsx` — Source; modified; 115 changed lines. Centralizes guarded reads and exact-scope refreshes, preserving 30-second connected polling, 10-second disconnected polling, and five-second freshness. Authentication and organization readiness control socket leases; epoch, scope, query identity, and unmount checks fence completion. A handled failure does not trigger the plain-query fallback.
- `apps/mobile/src/lib/hooks/use-agent-sessions.ts` — Source; modified; 120 changed lines. Exports shared options, subscribes to query metadata, and hides unreadable active rows and history exclusion IDs. Tracks departure IDs by account epoch and guards deferred history resets; both consumers delegate active refresh to the shared hook.
- `apps/mobile/src/lib/hooks/use-agent-sessions.combined.mounted.test.tsx` — Test; added; 307 changed lines. Adds a mounted combined-session suite.
- `apps/mobile/src/lib/hooks/use-agent-sessions.live.mounted.test.tsx` — Test; modified; 427 changed lines. Updates the mounted live-session suite.
- `apps/mobile/src/lib/hooks/use-agent-sessions.test.ts` — Test; modified; 5 changed lines. Updates the session-hook suite.

</details>

`useSessionMutations` binds rename and delete work to its starting authentication epoch without changing `cliSessionsV2.rename` or `cliSessionsV2.delete` inputs.
After account changes, queued requests, late outcomes, optimistic writes, rollbacks, toasts, deletion callbacks, and deferred invalidation stop affecting the new account.
`renameSessionAsync` keeps its rejecting promise contract, while current-account edits retain per-session sequencing, optimistic updates, and latest-generation rollback.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/hooks/use-session-mutations.ts` — Source; modified; 245 changed lines. Stores operation epochs beside mutation inputs in a WeakMap and checks them across asynchronous boundaries. Fences both mutation outcomes before global authentication callbacks, suppresses stale side effects, and retains current-account error handling and deletion announcements.
- `apps/mobile/src/lib/hooks/use-session-mutations.test.ts` — Test; modified; 640 changed lines. Updates the session-mutation suite.

</details>

`RemoteSessionRow` limits exit-triggered refreshes to the selected organization and the current query instance, rather than refreshing every cached context.
`refreshActiveSessionsNow` receives that exact `QueryKey`; only an unhandled request permits the fallback invalidation.
Account changes, unresolved organization selection, unmounting, and replaced queries suppress obsolete completion work.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/remote-session-row.tsx` — Source; modified; 42 changed lines. Replaces prefix invalidation with exact invalidation after an unhandled owner refresh. Checks organization readiness, row lifetime, query identity, and account epoch before refreshing or falling back.
- `apps/mobile/src/components/agents/remote-session-row.mounted.test.tsx` — Test; added; 267 changed lines. Adds a mounted remote-row suite.

</details>

Tests: 13 changed files (12 suites, 1 helper), with 2 additions, 11 modifications, and 2,290 changed lines.
Generated: none (0 changed files).

---

## Verification

Local end-to-end verification on an iOS simulator, 2026-09-01. Four of six checks passed. Two have no verdict.

This section covers the stack's three PRs together: #5641, #5649, and #5652.

No product bug was found. No product source changed. The worktree stayed clean.

| Check | Result | Evidence |
|---|---|---|
| Existing live content stays visible during loading, reconnect, and recoverable errors | PASS | `56-live-recoverable-error.png` |
| Task creation and account tools stay usable during live loading and errors | PASS | `50-create-ready-during-live-load.png` |
| PR Review opens while membership queries wait on a lock | PASS | `32-pr-review-org-pending.png` |
| Refresh stays pending until fresh results arrive | PASS | `48-refresh-fresh-result.png` |
| History loads independently of live sessions | NO VERDICT | see below |
| Unresolved organization selection gates the live query | NO VERDICT | see below |

### Why two checks have no verdict

Both gaps are test-harness limits, not defects.

- **History isolation.** The history query and the live query both read `cli_sessions_v2` and `github_branch_pull_requests`. No table belongs to history alone, so a table lock delays live loading too and cannot isolate the history request. A request-specific delay on `cliSessionsV2.list` would close this.
- **Organization selection.** The stored selection loads through local `SecureStore.getItemAsync` at `apps/mobile/src/lib/organization-context.tsx:45`. A backend lock cannot delay or fail a local keychain read, so no fault seam exists for this timing.

### Setup

- Real worktree stack and Metro, with the app built and installed on the simulator.
- Signed in through the normal email-code screen. Delays came from bounded PostgreSQL transactions on named tables.
- Screenshots captured with `xcrun simctl io <udid> screenshot`. Full report and images: `/Users/igor/Projects/.scratch/local-e2e-live-loading/`.
