### PR TITLE
fix(mobile): bind restored context and drafts to account scope

### DIFF
--- a/apps/mobile/src/lib/auth/account-metadata-write.ts
+++ b/apps/mobile/src/lib/auth/account-metadata-write.ts
@@ -2,6 +2,7 @@ import * as SecureStore from 'expo-secure-store';
 
 import { currentAuthEpoch, isCurrentAuthEpoch } from '@/lib/auth/auth-epoch';
 import { chainSave } from '@/lib/hooks/save-chain';
+import { getAuthenticatedOwner } from '@/lib/context-scope';
 
 /**
  * Epoch-fenced, per-key serialized SecureStore write for account-scoped
@@ -9,10 +10,19 @@ import { chainSave } from '@/lib/hooks/save-chain';
  * queued behind an in-flight save for the same key skips entirely when a
  * sign-out (or sign-in) bumps the epoch before it runs.
  */
-export async function writeAccountMetadata(key: string, write: () => Promise<void>): Promise<void> {
+export async function writeAccountMetadata(
+  key: string,
+  write: () => Promise<void>,
+  isCurrent?: () => boolean
+): Promise<void> {
   const epoch = currentAuthEpoch();
+  const owner = getAuthenticatedOwner();
   await chainSave(key, async () => {
-    if (!isCurrentAuthEpoch(epoch)) {
+    if (
+      !isCurrentAuthEpoch(epoch) ||
+      owner.generation !== getAuthenticatedOwner().generation ||
+      (isCurrent && !isCurrent())
+    ) {
       return;
     }
     await write();

--- a/apps/mobile/src/lib/auth/auth-context.test.tsx
+++ b/apps/mobile/src/lib/auth/auth-context.test.tsx
@@ -5,6 +5,8 @@ import { createElement } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as AuthContextModule from './auth-context';
+import type * as LogoutCleanupModule from './logout-cleanup';
+import type * as StorageKeysModule from '@/lib/storage-keys';
 
 // ---- hoisted mocks ----
 
@@ -66,6 +68,7 @@ const hoisted = vi.hoisted(() => {
   // Hoisted so the foreground tests can capture AppState listeners from the
   // same mock instance every module registry resolves to.
   const appState = {
+    currentState: 'active',
     addEventListener: vi.fn(() => ({ remove: vi.fn() })),
   };
 
@@ -147,13 +150,43 @@ vi.mock('@/lib/telemetry/posthog-storage', () => ({
   purgePostHogPersistence: hoisted.posthogStorage.purgePostHogPersistence,
 }));
 
-vi.mock('@/lib/query-client', () => ({
-  queryClient: { clear: vi.fn() },
-}));
+vi.mock('@/lib/query-client', async () => {
+  const { QueryClient } = await import('@tanstack/react-query');
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  vi.spyOn(queryClient, 'clear');
+  vi.spyOn(queryClient, 'cancelQueries');
+  return { queryClient };
+});
 
 vi.mock('@/lib/persist/read-cache', () => readCacheMock);
 
-vi.mock('@/lib/auth/logout-cleanup', () => logoutCleanupMock);
+vi.mock('@/lib/auth/logout-cleanup', async importOriginal => ({
+  ...(await importOriginal<typeof LogoutCleanupModule>()),
+  ...logoutCleanupMock,
+}));
+
+const cleanupRemote = vi.hoisted(() => ({
+  revoke: vi.fn().mockResolvedValue({ outcome: 'revoked' }),
+  unregister: vi.fn(),
+  pushToken: vi.fn(),
+}));
+vi.mock('@/lib/trpc', () => ({
+  trpcClient: {
+    user: {
+      revokeCurrentDeviceSession: { mutate: cleanupRemote.revoke },
+      unregisterPushToken: { mutate: cleanupRemote.unregister },
+    },
+  },
+}));
+vi.mock('@/lib/notifications', () => ({
+  getDevicePushTokenOutcome: cleanupRemote.pushToken,
+  emitNotificationTokenUpdated: vi.fn(),
+}));
+
+const legacyExchangeMock = vi.hoisted(() => ({
+  exchangeLegacyToken: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/lib/auth/exchange-legacy-token', () => legacyExchangeMock);
 
 vi.mock('@/lib/consent', () => ({
   clearPendingConsentOutcome: consentMock.clearPendingConsentOutcome,
@@ -229,7 +262,8 @@ vi.mock('@/lib/pr-review/viewed-files', () => ({
   clearViewedFiles: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('@/lib/storage-keys', () => ({
+vi.mock('@/lib/storage-keys', async importOriginal => ({
+  ...(await importOriginal<typeof StorageKeysModule>()),
   ACTIVE_USER_ID_KEY: 'active-user-id',
   AUTH_TOKEN_KEY: 'auth-token',
   KEEP_SCREEN_ON_KEY: 'keep-session-screen-on',
@@ -331,6 +365,69 @@ describe('sign-out teardown ordering', () => {
     vi.clearAllMocks();
     hoisted.callOrder.length = 0;
     hoisted.secureStore.getItemAsync.mockResolvedValue(null);
+  });
+
+  it('retains A in a real failed cleanup tombstone and cannot unregister under B after content revocation', async () => {
+    const { ctx, unmount } = await mountAndGetContext();
+    const scope = await import('../context-scope');
+    const cleanup = await vi.importActual<typeof LogoutCleanupModule>('./logout-cleanup');
+    const { LOGOUT_CLEANUP_TOMBSTONE_KEY } = await import('../storage-keys');
+    const persisted = new Map<string, string>();
+    const registrations = new Map([['account-b', 'push-a']]);
+    cleanupRemote.pushToken.mockResolvedValueOnce({ kind: 'token', token: 'push-a' });
+    cleanupRemote.unregister
+      .mockImplementation(({ token }: { token: string }) => {
+        const userId = scope.getAuthenticatedOwner().userId;
+        if (userId && registrations.get(userId) === token) {
+          registrations.delete(userId);
+        }
+        return { success: true };
+      })
+      .mockRejectedValueOnce(new Error('offline'));
+    await act(async () => {
+      await ctx.signIn('token-a');
+      scope.confirmAuthenticatedOwner(scope.getAuthenticatedOwner(), 'account-a');
+    });
+    const logoutOwner = scope.getAuthenticatedOwner();
+    const reproof: boolean[] = [];
+    const unsubscribe = scope.subscribeAuthenticatedOwner(() => {
+      const current = scope.getAuthenticatedOwner();
+      if (current.userId === null) {
+        reproof.push(scope.confirmAuthenticatedOwner(current, 'account-a'));
+      }
+    });
+    hoisted.secureStore.setItemAsync.mockImplementationOnce((storageKey: string, value: string) => {
+      persisted.set(storageKey, value);
+    });
+    logoutCleanupMock.runLogoutCleanup.mockImplementationOnce(cleanup.runLogoutCleanup);
+    await act(async () => {
+      await ctx.signOut();
+    });
+    unsubscribe();
+    expect(scope.isAuthenticatedOwner(logoutOwner)).toBe(false);
+    expect(scope.getAuthenticatedOwner().userId).toBeNull();
+    expect(reproof).not.toContain(true);
+    hoisted.secureStore.getItemAsync.mockResolvedValueOnce(
+      persisted.get(LOGOUT_CLEANUP_TOMBSTONE_KEY) ?? null
+    );
+    expect(await cleanup.readLogoutCleanupTombstone()).toMatchObject({
+      userId: 'account-a',
+      pushToken: 'push-a',
+      needsPushUnregister: true,
+    });
+    await act(async () => {
+      await ctx.signIn('token-b');
+      scope.confirmAuthenticatedOwner(scope.getAuthenticatedOwner(), 'account-b');
+    });
+    hoisted.secureStore.getItemAsync.mockResolvedValueOnce(
+      persisted.get(LOGOUT_CLEANUP_TOMBSTONE_KEY) ?? null
+    );
+    const { attemptLogoutReconciliation } = await import('./logout-reconciliation');
+    expect(await attemptLogoutReconciliation('account-b')).toEqual({
+      kind: 'different-user-discarded',
+    });
+    expect(registrations.get('account-b')).toBe('push-a');
+    unmount();
   });
 
   it('orders capture, cleanup, flush, clearTelemetryDecision, then Sentry.setUser', async () => {
@@ -452,7 +549,7 @@ describe('sign-out teardown ordering', () => {
       'auth-token',
       expect.anything()
     );
-    expect(hoisted.secureStore.deleteItemAsync).toHaveBeenCalledWith('organization');
+    expect(hoisted.secureStore.deleteItemAsync).not.toHaveBeenCalledWith('organization');
     expect(hoisted.secureStore.deleteItemAsync).toHaveBeenCalledWith('session-filters');
     expect(hoisted.secureStore.deleteItemAsync).toHaveBeenCalledWith('notification-prompt-seen');
     expect(hoisted.secureStore.deleteItemAsync).toHaveBeenCalledWith('pending-deep-link');
@@ -572,7 +669,7 @@ describe('sign-out teardown ordering', () => {
     // Let signOut reach the per-key metadata deletes while the filters write
     // is still in flight, so the filters delete must serialize behind it.
     await vi.waitFor(() => {
-      expect(secureStore.deleteItemAsync).toHaveBeenCalledWith('organization');
+      expect(secureStore.deleteItemAsync).toHaveBeenCalledWith('active-user-id');
     });
     releaseInFlight?.();
     await act(async () => {
@@ -675,6 +772,136 @@ describe('stale sign-in continuation', () => {
     };
   }
 
+  it('clears A content and revokes A authority before replacement credentials can publish', async () => {
+    const { getCtx, unmount } = await mountStaleTest();
+    const scope = await import('@/lib/context-scope');
+    const { queryClient: client } = await import('@/lib/query-client');
+    await act(async () => {
+      await getCtx().signIn('token-a');
+    });
+    scope.confirmAuthenticatedOwner(scope.getAuthenticatedOwner(), 'account-a');
+    const previous = scope.getAuthenticatedOwner();
+    const unsubscribe = scope.subscribeAuthenticatedOwner(() => {
+      const current = scope.getAuthenticatedOwner();
+      if (current.userId === null) {
+        // Simulate a synchronous observer attempting to prove A before B credentials publish.
+        scope.confirmAuthenticatedOwner(current, 'account-a');
+      }
+    });
+    client.setQueryData(['private-content'], 'private a');
+    const gate = Promise.withResolvers<undefined>();
+    hoisted.secureStore.setItemAsync.mockImplementationOnce(async () => {
+      await gate.promise;
+    });
+    const replacing = getCtx().signIn('token-b');
+    await act(async () => {
+      await new Promise(resolve => {
+        setTimeout(resolve, 0);
+      });
+    });
+    expect(scope.isAuthenticatedOwner(previous)).toBe(false);
+    expect(scope.getAuthenticatedOwner().userId).toBeNull();
+    expect(client.getQueryData(['private-content'])).toBeUndefined();
+    expect(getCtx().token).toBeUndefined();
+    gate.resolve(undefined);
+    await act(async () => {
+      await replacing;
+    });
+    expect(getCtx().token).toBe('token-b');
+    expect(client.getQueryData(['private-content'])).toBeUndefined();
+    unsubscribe();
+    unmount();
+  });
+
+  it('initializes local access from a background AppState without granting foreground readiness', async () => {
+    hoisted.appState.currentState = 'background';
+    const { getCtx, unmount } = await mountStaleTest();
+    try {
+      const scope = await import('@/lib/context-scope');
+      const access = await import('@/lib/local-access');
+      await act(async () => {
+        await getCtx().signIn('token-a');
+      });
+      await act(async () => {
+        scope.confirmAuthenticatedOwner(scope.getAuthenticatedOwner(), 'account-a');
+        await new Promise(resolve => {
+          setTimeout(resolve, 0);
+        });
+      });
+      expect(access.getLocalAccessSnapshot()).toMatchObject({
+        userId: 'account-a',
+        enabled: false,
+        foregroundReady: false,
+        unlocked: false,
+      });
+    } finally {
+      unmount();
+      hoisted.appState.currentState = 'active';
+    }
+  });
+
+  it('loads disabled-account security readiness without a presentation component', async () => {
+    const { getCtx, unmount } = await mountStaleTest();
+    const scope = await import('@/lib/context-scope');
+    const access = await import('@/lib/local-access');
+    await act(async () => {
+      await getCtx().signIn('token-a');
+    });
+    await act(async () => {
+      scope.confirmAuthenticatedOwner(scope.getAuthenticatedOwner(), 'account-a');
+      await new Promise(resolve => {
+        setTimeout(resolve, 0);
+      });
+    });
+    expect(access.getLocalAccessSnapshot()).toMatchObject({
+      userId: 'account-a',
+      preference: 'absent',
+      enabled: false,
+      foregroundReady: true,
+      unlocked: true,
+    });
+    access.setLocalAccessContextReady(true);
+    expect(
+      access.captureLocalAccessLease({ userId: 'account-a', organizationId: null }).userId
+    ).toBe('account-a');
+    unmount();
+  });
+
+  it('does not publish A security preference after direct sign-in replaces its owner', async () => {
+    const { getCtx, unmount } = await mountStaleTest();
+    const scope = await import('@/lib/context-scope');
+    const access = await import('@/lib/local-access');
+    const { localAccessStorageKey } = await import('@/lib/local-access-storage');
+    await act(async () => {
+      await getCtx().signIn('token-a');
+    });
+    const gate = Promise.withResolvers<string | null>();
+    hoisted.secureStore.getItemAsync.mockImplementation(async (key: string) => {
+      if (key === localAccessStorageKey('account-a')) {
+        const value = await gate.promise;
+        return value;
+      }
+      return null;
+    });
+    scope.confirmAuthenticatedOwner(scope.getAuthenticatedOwner(), 'account-a');
+    await act(async () => {
+      await getCtx().signIn('token-b');
+    });
+    await act(async () => {
+      scope.confirmAuthenticatedOwner(scope.getAuthenticatedOwner(), 'account-b');
+      gate.resolve('{"version":1,"enabled":true}');
+      await new Promise(resolve => {
+        setTimeout(resolve, 0);
+      });
+    });
+    expect(access.getLocalAccessSnapshot()).toMatchObject({
+      userId: 'account-b',
+      enabled: false,
+      unlocked: true,
+    });
+    unmount();
+  });
+
   it('signs the new session out when a sign-out is queued behind a sign-in (FIFO)', async () => {
     const { getCtx, unmount } = await mountStaleTest();
 
@@ -697,7 +924,7 @@ describe('stale sign-in continuation', () => {
     expect(getCtx().sessionEnded).toBe(true);
     expect(getCtx().isSigningOut).toBe(true);
     const { queryClient: queryClientMock } = await import('@/lib/query-client');
-    expect(vi.mocked(queryClientMock.clear)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(queryClientMock.clear)).toHaveBeenCalledTimes(2);
 
     unmount();
   });
@@ -848,6 +1075,30 @@ describe('bootstrap and foreground race fencing', () => {
       mod,
     };
   }
+
+  it('does not publish a legacy exchange result after direct sign-in changes its epoch', async () => {
+    const gate = Promise.withResolvers<{
+      token: string;
+      refreshToken: string;
+      expiresIn: number;
+    }>();
+    hoisted.secureStore.getItemAsync.mockResolvedValueOnce('legacy-a').mockResolvedValueOnce(null);
+    legacyExchangeMock.exchangeLegacyToken.mockReturnValueOnce(gate.promise);
+    const { getCtx, unmount } = await mountProvider();
+    await act(async () => {
+      await getCtx().signIn('replacement-b');
+    });
+    await act(async () => {
+      gate.resolve({ token: 'exchanged-a', refreshToken: 'refresh-a', expiresIn: 3600 });
+      await new Promise(resolve => {
+        setTimeout(resolve, 0);
+      });
+    });
+    const tokens = await import('@/lib/auth/token-owner');
+    expect(getCtx().token).toBe('replacement-b');
+    expect(tokens.getActiveToken()?.token).toBe('replacement-b');
+    unmount();
+  });
 
   it('regression: sign-out during bootstrap does not restore the preloaded token into React state or the owner', async () => {
     let releaseRead: (() => void) | undefined = undefined;
@@ -1235,9 +1486,8 @@ describe('auth-transition queue and sign-out failure matrix', () => {
       await Promise.all([signOutPromise, signInPromise]);
     });
 
-    // Whole-body FIFO: the sign-out's teardown (including the query-client
-    // clear) settled before the sign-in's credential write ran.
-    expect(clearMock).toHaveBeenCalledTimes(1);
+    // Sign-out and replacement sign-in each clear content before the credential write.
+    expect(clearMock).toHaveBeenCalledTimes(2);
     const clearOrder = clearMock.mock.invocationCallOrder[0];
     const setOrder = hoisted.secureStore.setItemAsync.mock.invocationCallOrder[0];
     expect(clearOrder).toBeLessThan(setOrder);
@@ -1287,7 +1537,7 @@ describe('auth-transition queue and sign-out failure matrix', () => {
       'auth-token',
       expect.anything()
     );
-    expect(hoisted.secureStore.deleteItemAsync).toHaveBeenCalledWith('organization');
+    expect(hoisted.secureStore.deleteItemAsync).not.toHaveBeenCalledWith('organization');
     const { queryClient: queryClientMock } = await import('@/lib/query-client');
     expect(vi.mocked(queryClientMock.clear)).toHaveBeenCalledTimes(1);
     expect(getCtx().token).toBeUndefined();
@@ -1342,7 +1592,7 @@ describe('auth-transition queue and sign-out failure matrix', () => {
       'auth-token',
       expect.anything()
     );
-    expect(hoisted.secureStore.deleteItemAsync).toHaveBeenCalledWith('organization');
+    expect(hoisted.secureStore.deleteItemAsync).not.toHaveBeenCalledWith('organization');
     expect(hoisted.secureStore.deleteItemAsync).toHaveBeenCalledWith('session-filters');
     expect(hoisted.secureStore.deleteItemAsync).toHaveBeenCalledWith('active-user-id');
     const { clearAgentModelPreference } = await import('@/lib/hooks/use-persisted-agent-model');
@@ -1356,11 +1606,10 @@ describe('auth-transition queue and sign-out failure matrix', () => {
 
   it('resets auth state even when the deletion batch phase throws synchronously', async () => {
     const { getCtx, unmount } = await mountQueueTest();
-    // A synchronous throw while the allSettled batch is being built: the
-    // batch never runs, the preference clears are skipped, and the inner
-    // finally still resets query and auth state.
-    readCacheMock.readCachedUserId.mockImplementationOnce(() => {
-      throw new Error('cache read exploded');
+    // A synchronous throw during batch construction skips the preference
+    // clears, but the inner finally still resets query and auth state.
+    readCacheMock.clearCacheScopeForSignOut.mockImplementationOnce(() => {
+      throw new Error('cache cleanup exploded');
     });
 
     const signOutPromise = getCtx().signOut();

--- a/apps/mobile/src/lib/auth/auth-context.tsx
+++ b/apps/mobile/src/lib/auth/auth-context.tsx
@@ -64,7 +64,6 @@ import {
   AUTH_TOKEN_KEY,
   LEGACY_EXCHANGE_DONE_KEY,
   NOTIFICATION_PROMPT_SEEN_KEY,
-  ORGANIZATION_STORAGE_KEY,
   PENDING_DEEP_LINK_KEY,
   PICKER_LAUNCH_CONTEXT_KEY,
   REFRESH_TOKEN_KEY,
@@ -75,6 +74,15 @@ import { clearTelemetryDecision } from '@/lib/telemetry/controller';
 import { clearSentryUser } from '@/lib/sentry-context';
 import { purgePostHogPersistence } from '@/lib/telemetry/posthog-storage';
 import { AppState } from 'react-native';
+import {
+  beginAuthenticatedOwner,
+  getAuthenticatedOwner,
+  isAuthenticatedOwner,
+  subscribeAuthenticatedOwner,
+} from '@/lib/context-scope';
+import { initializeLocalAccess, setLocalAccessOwner } from '@/lib/local-access';
+import { createLocalAccessStorage } from '@/lib/local-access-storage';
+import { authenticateLocalAccess } from '@/lib/local-authentication';
 
 // Pre-load tokens at module level so they're available before React mounts
 export const preloadedAuthToken = SecureStore.getItemAsync(AUTH_TOKEN_KEY);
@@ -143,6 +151,35 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
   const isSignedOutReference = useRef(false);
 
   useEffect(() => {
+    const dispose = initializeLocalAccess({
+      storage: createLocalAccessStorage(),
+      authenticate: async () => {
+        const { i18n } = await import('@/i18n');
+        return authenticateLocalAccess(i18n.t('common.continue'));
+      },
+      lifecycle: {
+        getCurrentState: () => AppState.currentState,
+        subscribe: listener => {
+          const subscription = AppState.addEventListener('change', listener);
+          return () => {
+            subscription.remove();
+          };
+        },
+      },
+    });
+    const bindOwner = () => {
+      const owner = getAuthenticatedOwner();
+      void setLocalAccessOwner(owner.userId, owner.authEpoch);
+    };
+    const unsubscribe = subscribeAuthenticatedOwner(bindOwner);
+    bindOwner();
+    return () => {
+      unsubscribe();
+      dispose();
+    };
+  }, []);
+
+  useEffect(() => {
     const load = async () => {
       try {
         // Capture the epoch before any asynchronous read: every later check
@@ -157,7 +194,7 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
           // Legacy exchange: if we have a token but no refresh token, upgrade once.
           if (!storedRefresh) {
             const pair = await exchangeLegacyToken();
-            if (pair) {
+            if (pair && isCurrentAuthEpoch(epoch)) {
               setToken(pair.token);
               setCurrentDeepLinkUserId(readUserIdFromToken(pair.token));
               setIsLoading(false);
@@ -210,13 +247,47 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
       // full teardown, and a sign-out queued behind a sign-in signs that new
       // session out (documented, correct FIFO semantics).
       await chainSave('auth-transition', async () => {
+        const previousUserId = readCachedUserId(queryClient);
+        const hadSession = getActiveToken() !== null;
+        // Close admission before owner subscribers can request identity with the old credentials.
+        setSignOutActive(true);
+        setSignOutTeardownActive(true);
         bumpAuthEpoch();
+        beginAuthenticatedOwner();
         setAuthEpoch(currentAuthEpoch());
-        // Bind the pending deep-link slot to the new user id at the same
-        // place the auth epoch advances, so a destination captured while this
-        // account is signed in restores only for this account.
-        setCurrentDeepLinkUserId(readUserIdFromToken(tokenValue));
+        setToken(undefined);
+        clearActiveToken();
+        const cancelled = queryClient.cancelQueries();
+        queryClient.clear();
+        // Reset before the credential write can expose replacement content. The transition queue
+        // also keeps old per-key deletes ahead of every replacement account's metadata write.
+        gateKiloClawOwned();
+        clearSessionScopedState();
+        clearAgentModelPreference();
+        clearReasoningPreference();
+        clearKeepScreenOnPreference();
+        clearPrReviewFooterPreference();
+        clearPendingConsentOutcome();
+        clearSentryUser();
         const epoch = currentAuthEpoch();
+        await Promise.all([
+          cancelled,
+          deleteAccountMetadata(ACTIVE_USER_ID_KEY),
+          deleteAccountMetadata(SESSION_FILTERS_KEY),
+          deleteAccountMetadata(NOTIFICATION_PROMPT_SEEN_KEY),
+          deleteAccountMetadata(PICKER_LAUNCH_CONTEXT_KEY),
+          clearLastActiveInstance(),
+          clearKiloClawOwned(),
+          clearRecentPrs(),
+          clearViewedFiles(),
+          clearSessionAttentionForSignOut(),
+          ...(hadSession ? [clearCacheScopeForSignOut(previousUserId)] : []),
+        ]);
+        if (!isCurrentAuthEpoch(epoch)) {
+          return;
+        }
+        // Preserve the development destination contract; the token id is only a deep-link hint.
+        setCurrentDeepLinkUserId(readUserIdFromToken(tokenValue));
         const published = await persistSignInCredentialsAtEpoch(tokenValue, refreshTokenValue, {
           expiresIn,
         });
@@ -240,9 +311,6 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
         trackEvent('login');
         resetPurchaseErrorToastDedup();
         setToken(tokenValue);
-        // A direct account switch must not keep the prior account's session
-        // state: trusted hosts, image confirms, media caches, temp copies.
-        clearSessionScopedState();
       });
     },
     []
@@ -257,6 +325,8 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
       if (isSignedOutReference.current) {
         return;
       }
+      const logoutOwner = getAuthenticatedOwner();
+      const logoutUserId = isAuthenticatedOwner(logoutOwner) ? logoutOwner.userId : null;
       isSignedOutReference.current = true;
       // Close the teardown guard synchronously, before the first await: a
       // refresh or request-token cold read must not touch the old credentials
@@ -271,6 +341,7 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
       // the read-cache mount unsubscribes and cannot resubscribe while the old
       // user id is still cached.
       setSignOutActive(true);
+      beginAuthenticatedOwner();
       // Drop an account-bound pending deep-link destination synchronously,
       // before the first await, so a different account signed in later in this
       // process cannot navigate to the previous account's destination. A
@@ -291,7 +362,7 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
         // headers, and while optional telemetry is still allowed so the
         // unregister emit in logout-cleanup can capture. Never throws by
         // contract.
-        await runLogoutCleanup();
+        await runLogoutCleanup(logoutUserId);
         // Flush the logout and any cleanup-captured events, then tear the SDK
         // down — drop queues, do not flush them. Must happen before any
         // SecureStore or cache awaits so optional analytics cannot transmit
@@ -319,16 +390,15 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
         // fence) and before any local deletion (no deferred save can land
         // after it).
         bumpAuthEpoch();
+        beginAuthenticatedOwner();
         setAuthEpoch(currentAuthEpoch());
         // The signed-out session owns no user id: a destination captured
         // during teardown is recorded as "captured while signed out".
         setCurrentDeepLinkUserId(null);
         clearActiveToken();
         try {
-          // Independent local cleanup, concurrent via allSettled: a
-          // rejection in any member must never stop the others or the
-          // preference clears. The credential deletion and the identity-hint
-          // deletion are members of the same always-attempted batch.
+          // Independent local cleanup must continue after any individual failure.
+          // The ownerless legacy organization key stays available for deliberate recovery.
           await Promise.allSettled([
             writeCredentials(async () => {
               await SecureStore.deleteItemAsync(AUTH_TOKEN_KEY, IOS_BEARER_SECURE_STORE_OPTIONS);
@@ -340,18 +410,13 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
               await SecureStore.deleteItemAsync(LEGACY_EXCHANGE_DONE_KEY);
             }),
             deleteAccountMetadata(ACTIVE_USER_ID_KEY),
-            deleteAccountMetadata(ORGANIZATION_STORAGE_KEY),
             deleteAccountMetadata(SESSION_FILTERS_KEY),
             deleteAccountMetadata(NOTIFICATION_PROMPT_SEEN_KEY),
             deleteAccountMetadata(PENDING_DEEP_LINK_KEY),
             deleteAccountMetadata(PICKER_LAUNCH_CONTEXT_KEY),
-            // Phase 4b read-cache cleanup: capture the authoritative user
-            // id from the getMe cache while it is still present (the batch
-            // expression runs before queryClient.clear()), then remove that
-            // user's cache scope (or every `cache:` scope when the id is
-            // unknown — privacy wins). Best effort: a failed cleanup can
-            // never abort sign-out.
-            clearCacheScopeForSignOut(readCachedUserId(queryClient)),
+            // Cleanup retains the captured identity, never authority to publish content.
+            // An unresolved owner still clears every cache scope for privacy.
+            clearCacheScopeForSignOut(logoutUserId),
             clearLastActiveInstance(),
             clearKiloClawOwned(),
             clearRecentPrs(),

--- a/apps/mobile/src/lib/auth/logout-cleanup.test.ts
+++ b/apps/mobile/src/lib/auth/logout-cleanup.test.ts
@@ -30,47 +30,10 @@ vi.mock('@/lib/notifications', () => ({
   getDevicePushTokenOutcome: vi.fn(),
 }));
 
-vi.mock('@/lib/auth/token-owner', () => ({
-  getActiveToken: vi.fn(),
-}));
-
-// The cleanup reads the cached user id from the read cache, which calls the
-// encrypted-kv module; the mock keeps the native SQLCipher chain out of this
-// node suite.
-vi.mock('@/lib/persist/encrypted-kv', () => ({
-  getItem: vi.fn(),
-  setItem: vi.fn(),
-  removeItem: vi.fn(),
-  clearScope: vi.fn(),
-  clearScopePrefix: vi.fn(),
-}));
-
 import { readLogoutCleanupTombstone, runLogoutCleanup } from '@/lib/auth/logout-cleanup';
 import { getDevicePushTokenOutcome } from '@/lib/notifications';
-import { getActiveToken } from '@/lib/auth/token-owner';
-import { queryClient } from '@/lib/query-client';
 import { LOGOUT_CLEANUP_TOMBSTONE_KEY } from '@/lib/storage-keys';
 /* eslint-enable import/first */
-
-const GET_ME_QUERY_KEY: readonly unknown[] = [['user', 'getMe'], { type: 'query' }];
-
-function base64url(input: string): string {
-  return btoa(input).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
-}
-
-function makeToken(payload: unknown): string {
-  return `${base64url('{"alg":"none"}')}.${base64url(JSON.stringify(payload))}.signature`;
-}
-
-const TOKEN_WITH_SESSION = makeToken({ sub: 'u1' });
-
-function seedUser(userId: string | null): void {
-  if (userId === null) {
-    queryClient.removeQueries({ queryKey: GET_ME_QUERY_KEY });
-  } else {
-    queryClient.setQueryData(GET_ME_QUERY_KEY, { id: userId });
-  }
-}
 
 function pushOutcome(kind: 'token' | 'none' | 'lookup-failed', token?: string): void {
   vi.mocked(getDevicePushTokenOutcome).mockResolvedValue(
@@ -82,11 +45,6 @@ describe('runLogoutCleanup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     store.clear();
-    vi.mocked(getActiveToken).mockReturnValue({
-      token: TOKEN_WITH_SESSION,
-      expiresAtMs: null,
-    });
-    seedUser('u1');
   });
 
   it('revokes the session and unregisters the token, then deletes any existing tombstone on full success', async () => {
@@ -95,7 +53,7 @@ describe('runLogoutCleanup', () => {
     trpcMock.revokeCurrentDeviceSession.mutate.mockResolvedValue({ outcome: 'revoked' });
     trpcMock.unregisterPushToken.mutate.mockResolvedValue({ success: true });
 
-    await expect(runLogoutCleanup()).resolves.toBeUndefined();
+    await expect(runLogoutCleanup('u1')).resolves.toBeUndefined();
 
     expect(trpcMock.revokeCurrentDeviceSession.mutate).toHaveBeenCalledTimes(1);
     expect(trpcMock.unregisterPushToken.mutate).toHaveBeenCalledWith({ token: 'push-1' });
@@ -108,7 +66,7 @@ describe('runLogoutCleanup', () => {
       outcome: 'no_identifiable_session',
     });
 
-    await runLogoutCleanup();
+    await runLogoutCleanup('u1');
 
     // No unregister call for a permission-denied device; the fulfilled revoke
     // means nothing is outstanding.
@@ -121,7 +79,7 @@ describe('runLogoutCleanup', () => {
     trpcMock.revokeCurrentDeviceSession.mutate.mockRejectedValue(new Error('network down'));
     trpcMock.unregisterPushToken.mutate.mockRejectedValue(new Error('server 500'));
 
-    await runLogoutCleanup();
+    await runLogoutCleanup('u1');
 
     const tombstone = await readLogoutCleanupTombstone();
     expect(tombstone).toEqual({
@@ -137,7 +95,7 @@ describe('runLogoutCleanup', () => {
     trpcMock.revokeCurrentDeviceSession.mutate.mockResolvedValue({ outcome: 'revoked' });
     trpcMock.unregisterPushToken.mutate.mockRejectedValue(new Error('server 500'));
 
-    await runLogoutCleanup();
+    await runLogoutCleanup('u1');
 
     const tombstone = await readLogoutCleanupTombstone();
     expect(tombstone).toMatchObject({
@@ -152,7 +110,7 @@ describe('runLogoutCleanup', () => {
     trpcMock.revokeCurrentDeviceSession.mutate.mockRejectedValue({ data: { code: 'NOT_FOUND' } });
     trpcMock.unregisterPushToken.mutate.mockResolvedValue({ success: true });
 
-    await runLogoutCleanup();
+    await runLogoutCleanup('u1');
 
     // Nothing outstanding: the tombstone is deleted, not written.
     expect(store.has(LOGOUT_CLEANUP_TOMBSTONE_KEY)).toBe(false);
@@ -162,7 +120,7 @@ describe('runLogoutCleanup', () => {
     pushOutcome('lookup-failed');
     trpcMock.revokeCurrentDeviceSession.mutate.mockResolvedValue({ outcome: 'revoked' });
 
-    await runLogoutCleanup();
+    await runLogoutCleanup('u1');
 
     expect(trpcMock.unregisterPushToken.mutate).not.toHaveBeenCalled();
     const tombstone = await readLogoutCleanupTombstone();
@@ -176,7 +134,7 @@ describe('runLogoutCleanup', () => {
     pushOutcome('none');
     trpcMock.revokeCurrentDeviceSession.mutate.mockResolvedValue({ outcome: 'revoked' });
 
-    await runLogoutCleanup();
+    await runLogoutCleanup('u1');
 
     expect(trpcMock.unregisterPushToken.mutate).not.toHaveBeenCalled();
     expect(store.has(LOGOUT_CLEANUP_TOMBSTONE_KEY)).toBe(false);
@@ -192,7 +150,7 @@ describe('runLogoutCleanup', () => {
     const { setItemAsync } = await import('expo-secure-store');
     vi.mocked(setItemAsync).mockRejectedValueOnce(new Error('secure store down'));
 
-    await expect(runLogoutCleanup()).resolves.toBeUndefined();
+    await expect(runLogoutCleanup('u1')).resolves.toBeUndefined();
     expect(captureException).toHaveBeenCalledWith(expect.any(Error), {
       tags: { 'error.subsystem': 'auth', 'error.operation': 'write_logout_tombstone' },
     });
@@ -202,7 +160,7 @@ describe('runLogoutCleanup', () => {
     vi.mocked(getDevicePushTokenOutcome).mockRejectedValue(new Error('native error'));
     trpcMock.revokeCurrentDeviceSession.mutate.mockResolvedValue({ outcome: 'revoked' });
 
-    await expect(runLogoutCleanup()).resolves.toBeUndefined();
+    await expect(runLogoutCleanup('u1')).resolves.toBeUndefined();
 
     // The failed lookup is treated as outstanding so reconciliation re-reads.
     const tombstone = await readLogoutCleanupTombstone();

--- a/apps/mobile/src/lib/auth/logout-cleanup.ts
+++ b/apps/mobile/src/lib/auth/logout-cleanup.ts
@@ -3,8 +3,6 @@ import * as Sentry from '@sentry/react-native';
 import * as z from 'zod';
 
 import { emitNotificationTokenUpdated, getDevicePushTokenOutcome } from '@/lib/notifications';
-import { readCachedUserId } from '@/lib/persist/read-cache';
-import { queryClient } from '@/lib/query-client';
 import { LOGOUT_CLEANUP_TOMBSTONE_KEY } from '@/lib/storage-keys';
 import { trpcClient } from '@/lib/trpc';
 
@@ -30,7 +28,7 @@ import { trpcClient } from '@/lib/trpc';
  * `z.number()` rejects NaN and Infinity, so `failedAt` is always finite.
  */
 const logoutCleanupTombstoneSchema = z.object({
-  /** getMe cache identity at logout, or null when the query had not resolved. */
+  /** Proved identity captured before logout revokes content access, or null when unresolved. */
   userId: z.string().nullable(),
   /** Device push token at logout; null when lookup failed or permission missing. */
   pushToken: z.string().nullable(),
@@ -73,7 +71,8 @@ async function writeLogoutCleanupTombstone(tombstone: LogoutCleanupTombstone): P
 /**
  * Runs remote logout cleanup while the token owner still serves auth headers
  * (called by sign-out BEFORE the epoch bump and BEFORE any credential
- * deletion). It NEVER throws: every step is internally caught, so a remote
+ * deletion). The caller captures the proved user ID before revoking content access.
+ * It NEVER throws: every step is internally caught, so a remote
  * or storage failure can never block local sign-out.
  *
  * - Revokes the current device session and unregisters the device push token
@@ -82,10 +81,8 @@ async function writeLogoutCleanupTombstone(tombstone: LogoutCleanupTombstone): P
  *   push unregister writes a tombstone; a successful one deletes any existing
  *   tombstone, and is never retried later.
  */
-export async function runLogoutCleanup(): Promise<void> {
+export async function runLogoutCleanup(userId: string | null): Promise<void> {
   try {
-    const userId = readCachedUserId(queryClient);
-
     // Push token outcome: 'none' → nothing to unregister; 'lookup-failed' →
     // a server row may exist, so reconciliation re-reads the stable device
     // token and the tombstone stores pushToken: null.

--- a/apps/mobile/src/lib/context-scope.test.ts
+++ b/apps/mobile/src/lib/context-scope.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { bumpAuthEpoch } from '@/lib/auth/auth-epoch';
+import { setSignOutActive } from '@/lib/auth/sign-out-state';
+import {
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+  contextScope,
+  getAuthenticatedOwner,
+  isAuthenticatedOwner,
+  parseSelectedContext,
+  selectedContextStorageKey,
+  serializeSelectedContext,
+} from './context-scope';
+
+beforeEach(() => {
+  setSignOutActive(false);
+  beginAuthenticatedOwner();
+});
+
+describe('authenticated ownership', () => {
+  it('rejects late identity proof after a direct account replacement', () => {
+    const first = getAuthenticatedOwner();
+    bumpAuthEpoch();
+    const replacement = beginAuthenticatedOwner();
+    expect(confirmAuthenticatedOwner(first, 'account-a')).toBe(false);
+    expect(confirmAuthenticatedOwner(replacement, 'account-b')).toBe(true);
+    expect(getAuthenticatedOwner().userId).toBe('account-b');
+    expect(first.userId).toBeNull();
+  });
+
+  it('revokes old authority before credentials change, even before the epoch bump', () => {
+    confirmAuthenticatedOwner(getAuthenticatedOwner(), 'account-a');
+    const old = getAuthenticatedOwner();
+    beginAuthenticatedOwner();
+    expect(isAuthenticatedOwner(old)).toBe(false);
+    expect(getAuthenticatedOwner().userId).toBeNull();
+  });
+
+  it('does not replace a proved identity with another user in the same generation', () => {
+    const credential = getAuthenticatedOwner();
+    confirmAuthenticatedOwner(credential, 'account-a');
+    expect(confirmAuthenticatedOwner(credential, 'account-b')).toBe(false);
+    expect(getAuthenticatedOwner().userId).toBe('account-a');
+  });
+});
+
+describe('selected context records', () => {
+  it.each(['oauth/a:b', 'a/b', 'a_b', 'a.b', 'a\u0000b', '用户', 'personal'])(
+    'round-trips arbitrary owner %s without mixing storage keys',
+    userId => {
+      const key = selectedContextStorageKey(userId);
+      expect(key).toMatch(/^[a-zA-Z0-9._-]+$/);
+      expect(key).not.toBe(selectedContextStorageKey(`${userId}:other`));
+      const bytes = serializeSelectedContext(userId, contextScope('personal'));
+      expect(parseSelectedContext(bytes, userId)).toEqual({
+        status: 'present',
+        context: { kind: 'organization', organizationId: 'personal' },
+      });
+      expect(parseSelectedContext(bytes, `${userId}:other`)).toEqual({ status: 'owner-mismatch' });
+    }
+  );
+
+  it('distinguishes saved Personal from an absent record', () => {
+    expect(parseSelectedContext(serializeSelectedContext('u', contextScope(null)), 'u')).toEqual({
+      status: 'present',
+      context: { kind: 'personal' },
+    });
+    expect(parseSelectedContext(null, 'u')).toEqual({ status: 'absent' });
+  });
+
+  it.each([
+    'org-id',
+    '{',
+    'null',
+    '{}',
+    '{"version":2,"userId":"u","context":{"kind":"personal"}}',
+    '{"version":1,"userId":"u","context":{"kind":"organization","organizationId":""}}',
+    '{"version":1,"userId":"u","context":{"kind":"personal","organizationId":"org"}}',
+  ])('preserves malformed/legacy input instead of admitting Personal: %s', bytes => {
+    expect(parseSelectedContext(bytes, 'u')).toEqual({ status: 'malformed' });
+  });
+});

--- a/apps/mobile/src/lib/context-scope.ts
+++ b/apps/mobile/src/lib/context-scope.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod';
+
+import { currentAuthEpoch, isCurrentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { isSignOutActive } from '@/lib/auth/sign-out-state';
+import { encodeStorageKey, SELECTED_CONTEXT_KEY_PREFIX } from '@/lib/storage-keys';
+
+export const contextScopeSchema = z.discriminatedUnion('kind', [
+  z.strictObject({ kind: z.literal('personal') }),
+  z.strictObject({ kind: z.literal('organization'), organizationId: z.string().min(1) }),
+]);
+export type ContextScope = Readonly<z.infer<typeof contextScopeSchema>>;
+export type AuthenticatedOwner = Readonly<{
+  authEpoch: number;
+  generation: number;
+  userId: string | null;
+}>;
+
+let owner: AuthenticatedOwner = Object.freeze({
+  authEpoch: currentAuthEpoch(),
+  generation: 0,
+  userId: null,
+});
+const listeners = new Set<() => void>();
+
+export function getAuthenticatedOwner(): AuthenticatedOwner {
+  return owner;
+}
+
+/** Capture a persistence generation, including cleanup while sign-out has closed admission. */
+export function captureAccountGeneration(): () => boolean {
+  const epoch = currentAuthEpoch();
+  const generation = owner.generation;
+  return () => isCurrentAuthEpoch(epoch) && owner.generation === generation;
+}
+
+export function subscribeAuthenticatedOwner(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function publish(next: AuthenticatedOwner): AuthenticatedOwner {
+  owner = Object.freeze(next);
+  for (const listener of listeners) {
+    listener();
+  }
+  return owner;
+}
+
+/** Revoke authority before changing credentials or any account-bound memory. Refresh does not call this. */
+export function beginAuthenticatedOwner(): AuthenticatedOwner {
+  return publish({ authEpoch: currentAuthEpoch(), generation: owner.generation + 1, userId: null });
+}
+
+export function isCurrentOwner(captured: AuthenticatedOwner): boolean {
+  return (
+    !isSignOutActive() &&
+    isCurrentAuthEpoch(captured.authEpoch) &&
+    captured.authEpoch === owner.authEpoch &&
+    captured.generation === owner.generation &&
+    (captured.userId === null || captured.userId === owner.userId)
+  );
+}
+
+/** Only a getMe response requested in this credential generation can supply durable identity. */
+export function confirmAuthenticatedOwner(captured: AuthenticatedOwner, userId: string): boolean {
+  if (!userId || !isCurrentOwner(captured) || (owner.userId !== null && owner.userId !== userId)) {
+    return false;
+  }
+  if (owner.userId === null) {
+    publish({ ...owner, userId });
+  }
+  return true;
+}
+
+export function isAuthenticatedOwner(captured: AuthenticatedOwner): boolean {
+  return captured.userId !== null && isCurrentOwner(captured);
+}
+
+export function contextScope(organizationId: string | null): ContextScope {
+  return organizationId === null ? { kind: 'personal' } : { kind: 'organization', organizationId };
+}
+
+export function sameContext(left: ContextScope, right: ContextScope): boolean {
+  return left.kind === 'personal'
+    ? right.kind === 'personal'
+    : right.kind === 'organization' && left.organizationId === right.organizationId;
+}
+
+const permissionFailureSchema = z.object({
+  data: z.object({ code: z.enum(['FORBIDDEN', 'NOT_FOUND', 'UNAUTHORIZED']) }),
+});
+export function isContextUnavailableError(error: unknown): boolean {
+  return permissionFailureSchema.safeParse(error).success;
+}
+
+const selectedContextSchema = z.strictObject({
+  version: z.literal(1),
+  userId: z.string().min(1),
+  context: contextScopeSchema,
+});
+export type SelectedContextResult =
+  | Readonly<{ status: 'present'; context: ContextScope }>
+  | Readonly<{ status: 'absent' | 'malformed' | 'owner-mismatch' }>;
+
+export function selectedContextStorageKey(userId: string): string {
+  return encodeStorageKey(SELECTED_CONTEXT_KEY_PREFIX, userId);
+}
+
+export function serializeSelectedContext(userId: string, context: ContextScope): string {
+  return JSON.stringify(selectedContextSchema.parse({ version: 1, userId, context }));
+}
+
+export function parseSelectedContext(bytes: string | null, userId: string): SelectedContextResult {
+  if (bytes === null) {
+    return { status: 'absent' };
+  }
+  try {
+    const record = selectedContextSchema.safeParse(JSON.parse(bytes));
+    if (!record.success) {
+      return { status: 'malformed' };
+    }
+    return record.data.userId === userId
+      ? { status: 'present', context: record.data.context }
+      : { status: 'owner-mismatch' };
+  } catch {
+    return { status: 'malformed' };
+  }
+}

--- a/apps/mobile/src/lib/hooks/use-current-user-id.ts
+++ b/apps/mobile/src/lib/hooks/use-current-user-id.ts
@@ -1,6 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
+import { useEffect, useSyncExternalStore } from 'react';
 
-import { useTRPC } from '@/lib/trpc';
+import { useAuth } from '@/lib/auth/auth-context';
+import {
+  confirmAuthenticatedOwner,
+  getAuthenticatedOwner,
+  isCurrentOwner,
+  subscribeAuthenticatedOwner,
+} from '@/lib/context-scope';
+import { trpcClient, useTRPC } from '@/lib/trpc';
 
 type UseCurrentUserIdOptions = {
   readonly enabled?: boolean;
@@ -8,15 +16,41 @@ type UseCurrentUserIdOptions = {
 
 export function useCurrentUserId(options: UseCurrentUserIdOptions = {}) {
   const trpc = useTRPC();
-  const { data, isLoading, isError, refetch } = useQuery({
+  const { token, isSigningOut } = useAuth();
+  const owner = useSyncExternalStore(subscribeAuthenticatedOwner, getAuthenticatedOwner);
+  const enabled = (options.enabled ?? true) && Boolean(token) && !isSigningOut;
+  const { data, isError, refetch } = useQuery({
     ...trpc.user.getMe.queryOptions(),
-    enabled: options.enabled ?? true,
+    // Keep the stock key. A restored or manually seeded getMe result is not owner proof.
+    queryFn: async ({ signal }) => {
+      const captured = getAuthenticatedOwner();
+      if (!isCurrentOwner(captured)) {
+        throw new Error('Authenticated identity is unavailable during account transition');
+      }
+      const user = await trpcClient.user.getMe.query(undefined, { signal });
+      if (signal.aborted || !confirmAuthenticatedOwner(captured, user.id)) {
+        throw new Error('Stale authenticated identity');
+      }
+      return user;
+    },
+    enabled,
+    refetchOnMount: owner.userId === null ? 'always' : true,
   });
+  // Another observer can populate the shared stock key without running this query function.
+  // Request proof through this observer rather than promoting that cached identity.
+  useEffect(() => {
+    if (enabled && data && !isError && getAuthenticatedOwner().userId === null) {
+      void refetch();
+    }
+  }, [enabled, data, isError, refetch, owner.generation]);
+  const ready =
+    enabled && isCurrentOwner(owner) && owner.userId !== null && data?.id === owner.userId;
 
   return {
-    userId: data?.id,
-    email: data?.email,
-    isLoading,
+    userId: ready ? data.id : undefined,
+    email: ready ? data.email : undefined,
+    owner,
+    isLoading: enabled && !ready && !isError,
     isError,
     refetch: () => {
       void refetch();

--- a/apps/mobile/src/lib/organization-context.mounted.test.tsx
+++ b/apps/mobile/src/lib/organization-context.mounted.test.tsx
@@ -1,0 +1,393 @@
+/* eslint-disable typescript-eslint/no-deprecated -- React Native provider tests use the installed DOM-free renderer */
+/* eslint-disable require-await, typescript-eslint/require-await -- async act callbacks flush React updates; native fixture methods resolve synchronously */
+/* eslint-disable max-lines -- mounted account, context, and membership races share one real QueryClient harness */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { bumpAuthEpoch, currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { setSignOutActive } from '@/lib/auth/sign-out-state';
+import {
+  beginAuthenticatedOwner,
+  contextScope,
+  getAuthenticatedOwner,
+  parseSelectedContext,
+  selectedContextStorageKey,
+  serializeSelectedContext,
+} from './context-scope';
+import { OrganizationProvider, useOrganization } from './organization-context';
+import { ORGANIZATION_STORAGE_KEY } from './storage-keys';
+
+const mocks = vi.hoisted(() => ({
+  user: 'account-a',
+  token: 'token-a' as string | undefined,
+  getMe: vi.fn(),
+  memberships: vi.fn(),
+  read: vi.fn(),
+  write: vi.fn(),
+}));
+vi.mock('expo-secure-store', () => ({ getItemAsync: mocks.read, setItemAsync: mocks.write }));
+vi.mock('@/lib/auth/auth-context', () => ({
+  useAuth: () => ({ token: mocks.token, authEpoch: currentAuthEpoch(), isSigningOut: false }),
+}));
+vi.mock('@/lib/trpc', () => ({
+  useTRPC: () => ({
+    user: { getMe: { queryOptions: () => ({ queryKey: [['user', 'getMe'], { type: 'query' }] }) } },
+  }),
+  trpcClient: {
+    user: { getMe: { query: mocks.getMe } },
+    organizations: { list: { query: mocks.memberships } },
+  },
+}));
+
+const bytes = new Map<string, string>();
+let client = new QueryClient();
+let renderer: TestRenderer.ReactTestRenderer | undefined = undefined;
+const observed: { current: ReturnType<typeof useOrganization> | null } = { current: null };
+function Probe() {
+  const value = useOrganization();
+  observed.current = value;
+  return createElement('output', null, `${value.status}:${value.organizationId ?? 'none'}`);
+}
+function tree() {
+  return createElement(
+    QueryClientProvider,
+    { client },
+    createElement(OrganizationProvider, null, createElement(Probe))
+  );
+}
+async function mount() {
+  await act(async () => {
+    renderer = TestRenderer.create(tree());
+  });
+}
+function state() {
+  if (!observed.current) {
+    throw new Error('Context did not mount');
+  }
+  return observed.current;
+}
+function deferred<T>() {
+  return Promise.withResolvers<T>();
+}
+async function replaceAccount(user: string) {
+  await act(async () => {
+    mocks.user = user;
+    mocks.token = `token-${user}`;
+    bumpAuthEpoch();
+    beginAuthenticatedOwner();
+    client.clear();
+    renderer?.update(tree());
+  });
+}
+beforeEach(() => {
+  vi.resetAllMocks();
+  setSignOutActive(false);
+  beginAuthenticatedOwner();
+  bytes.clear();
+  observed.current = null;
+  mocks.user = 'account-a';
+  mocks.token = 'token-a';
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  mocks.getMe.mockImplementation(async () => ({
+    id: mocks.user,
+    email: `${mocks.user}@example.test`,
+  }));
+  mocks.memberships.mockResolvedValue([
+    { organizationId: 'org-a' },
+    { organizationId: 'personal' },
+  ]);
+  mocks.read.mockImplementation(async (key: string) => bytes.get(key) ?? null);
+  mocks.write.mockImplementation(async (key: string, value: string) => {
+    bytes.set(key, value);
+  });
+});
+afterEach(async () => {
+  await act(async () => {
+    renderer?.unmount();
+  });
+  client.clear();
+});
+
+describe('OrganizationProvider owner-bound restoration', () => {
+  it.each(['FORBIDDEN', 'NOT_FOUND', 'UNAUTHORIZED'])(
+    'marks membership %s as unavailable rather than retryable',
+    async code => {
+      bytes.set(
+        selectedContextStorageKey('account-a'),
+        serializeSelectedContext('account-a', contextScope('org-a'))
+      );
+      mocks.memberships.mockRejectedValueOnce({ data: { code } });
+      await mount();
+      expect(state()).toMatchObject({
+        status: 'unavailable',
+        reason: 'membership-revoked',
+        isReady: false,
+      });
+    }
+  );
+  it('does not let a late membership restore replace a deliberate choice', async () => {
+    bytes.set(
+      selectedContextStorageKey('account-a'),
+      serializeSelectedContext('account-a', contextScope('org-a'))
+    );
+    const gate = deferred<{ organizationId: string }[]>();
+    mocks.memberships.mockReturnValueOnce(gate.promise);
+    await mount();
+    await act(async () => {
+      state().setOrganizationId(null);
+    });
+    await act(async () => {
+      gate.resolve([{ organizationId: 'org-a' }]);
+    });
+    expect(state()).toMatchObject({ status: 'ready', organizationId: null });
+  });
+  it('keeps an already-started old-account write bound to its original owner', async () => {
+    await mount();
+    const gate = deferred<undefined>();
+    mocks.write.mockImplementationOnce(async (storageKey: string, value: string) => {
+      await gate.promise;
+      bytes.set(storageKey, value);
+    });
+    await act(async () => {
+      state().setOrganizationId('org-a');
+    });
+    await replaceAccount('account-b');
+    await act(async () => {
+      gate.resolve(undefined);
+    });
+    expect(state()).toMatchObject({
+      status: 'ready',
+      organizationId: null,
+      owner: { userId: 'account-b' },
+    });
+    expect(bytes.has(selectedContextStorageKey('account-b'))).toBe(false);
+    expect(
+      parseSelectedContext(bytes.get(selectedContextStorageKey('account-a')) ?? null, 'account-a')
+    ).toEqual({ status: 'present', context: contextScope('org-a') });
+  });
+  it('restores saved Personal without importing the legacy organization', async () => {
+    bytes.set(
+      selectedContextStorageKey('account-a'),
+      serializeSelectedContext('account-a', contextScope(null))
+    );
+    bytes.set(ORGANIZATION_STORAGE_KEY, 'org-a');
+    await mount();
+    expect(state()).toMatchObject({
+      status: 'ready',
+      isLoaded: true,
+      organizationId: null,
+      context: { kind: 'personal' },
+    });
+    expect(bytes.get(ORGANIZATION_STORAGE_KEY)).toBe('org-a');
+  });
+  it('admits Personal after successful absence with an empty organization list', async () => {
+    mocks.memberships.mockResolvedValue([]);
+    await mount();
+    await act(async () => {
+      state().setOrganizationId(null);
+    });
+    expect(state()).toMatchObject({ status: 'ready', context: { kind: 'personal' } });
+  });
+  it('does not label unresolved identity as Personal', async () => {
+    mocks.token = undefined;
+    await mount();
+    expect(state()).toMatchObject({ status: 'unresolved', isReady: false, context: null });
+    expect(renderer?.toJSON()).toMatchObject({ children: ['unresolved:none'] });
+  });
+  it('does not promote a cached getMe from a previous account into owner proof', async () => {
+    const gate = deferred<{ id: string; email: string }>();
+    mocks.getMe.mockReturnValue(gate.promise);
+    client.setQueryData([['user', 'getMe'], { type: 'query' }], {
+      id: 'previous',
+      email: 'old@example.test',
+    });
+    await mount();
+    expect(state()).toMatchObject({ status: 'unresolved', isReady: false });
+    expect(getAuthenticatedOwner().userId).toBeNull();
+    await act(async () => {
+      gate.resolve({ id: 'account-a', email: 'a@example.test' });
+      await new Promise(resolve => {
+        setTimeout(resolve, 0);
+      });
+    });
+    expect(getAuthenticatedOwner().userId).toBe('account-a');
+    expect(state().status).toBe('ready');
+  });
+  it('waits for authoritative membership before admitting a saved organization', async () => {
+    bytes.set(
+      selectedContextStorageKey('account-a'),
+      serializeSelectedContext('account-a', contextScope('org-a'))
+    );
+    const gate = deferred<{ organizationId: string }[]>();
+    mocks.memberships.mockReturnValue(gate.promise);
+    await mount();
+    expect(state()).toMatchObject({
+      status: 'unresolved',
+      reason: 'membership',
+      isReady: false,
+      context: null,
+    });
+    await act(async () => {
+      gate.resolve([{ organizationId: 'org-a' }]);
+    });
+    expect(state()).toMatchObject({ status: 'ready', organizationId: 'org-a' });
+  });
+  it('keeps revoked membership unavailable instead of falling back to Personal', async () => {
+    bytes.set(
+      selectedContextStorageKey('account-a'),
+      serializeSelectedContext('account-a', contextScope('org-a'))
+    );
+    mocks.memberships.mockResolvedValue([]);
+    await mount();
+    expect(state()).toMatchObject({
+      status: 'unavailable',
+      reason: 'membership-revoked',
+      isReady: false,
+      context: null,
+    });
+  });
+  it('retains a rejected storage read and recovers only on Retry', async () => {
+    const saved = serializeSelectedContext('account-a', contextScope('org-a'));
+    bytes.set(selectedContextStorageKey('account-a'), saved);
+    mocks.read.mockRejectedValueOnce(new Error('temporary keychain failure'));
+    await mount();
+    expect(state()).toMatchObject({ status: 'failed', reason: 'storage', isLoaded: false });
+    expect(bytes.get(selectedContextStorageKey('account-a'))).toBe(saved);
+    await act(async () => {
+      state().retry();
+    });
+    expect(state()).toMatchObject({ status: 'ready', organizationId: 'org-a' });
+  });
+  it('keeps retryable membership failure distinct from revoked membership', async () => {
+    bytes.set(
+      selectedContextStorageKey('account-a'),
+      serializeSelectedContext('account-a', contextScope('org-a'))
+    );
+    mocks.memberships.mockRejectedValueOnce(new Error('offline'));
+    await mount();
+    expect(state()).toMatchObject({ status: 'failed', reason: 'membership', isReady: false });
+    await act(async () => {
+      state().retry();
+    });
+    expect(state().organizationId).toBe('org-a');
+  });
+  it.each(['{', '{"version":1,"userId":"account-b","context":{"kind":"personal"}}'])(
+    'protects invalid owner records: %s',
+    async value => {
+      bytes.set(selectedContextStorageKey('account-a'), value);
+      await mount();
+      expect(state()).toMatchObject({ status: 'unavailable', isReady: false });
+      expect(bytes.get(selectedContextStorageKey('account-a'))).toBe(value);
+    }
+  );
+  it('does not let a late restore replace a deliberate Personal selection', async () => {
+    const gate = deferred<string | null>();
+    mocks.read.mockReturnValueOnce(gate.promise);
+    await mount();
+    await act(async () => {
+      state().setOrganizationId(null);
+    });
+    await act(async () => {
+      gate.resolve(serializeSelectedContext('account-a', contextScope('org-a')));
+    });
+    expect(state()).toMatchObject({ status: 'ready', organizationId: null });
+    expect(
+      parseSelectedContext(bytes.get(selectedContextStorageKey('account-a')) ?? null, 'account-a')
+    ).toEqual({ status: 'present', context: { kind: 'personal' } });
+  });
+  it('abandons an old account context read during direct sign-in', async () => {
+    const gate = deferred<string | null>();
+    mocks.read.mockReturnValueOnce(gate.promise);
+    await mount();
+    await replaceAccount('account-b');
+    await act(async () => {
+      gate.resolve(serializeSelectedContext('account-a', contextScope('org-a')));
+    });
+    expect(state()).toMatchObject({
+      status: 'ready',
+      organizationId: null,
+      owner: { userId: 'account-b' },
+    });
+  });
+  it('abandons an old membership result during direct sign-in', async () => {
+    bytes.set(
+      selectedContextStorageKey('account-a'),
+      serializeSelectedContext('account-a', contextScope('org-a'))
+    );
+    const gate = deferred<{ organizationId: string }[]>();
+    mocks.memberships.mockReturnValueOnce(gate.promise);
+    await mount();
+    await replaceAccount('account-b');
+    await act(async () => {
+      gate.resolve([{ organizationId: 'org-a' }]);
+    });
+    expect(state()).toMatchObject({
+      status: 'ready',
+      organizationId: null,
+      owner: { userId: 'account-b' },
+    });
+  });
+  it('requires an explicit validated legacy selection and preserves its original bytes', async () => {
+    bytes.set(ORGANIZATION_STORAGE_KEY, 'org-a');
+    await mount();
+    expect(state()).toMatchObject({
+      status: 'unresolved',
+      reason: 'selection-required',
+      legacyOrganizationId: 'org-a',
+    });
+    expect(bytes.has(selectedContextStorageKey('account-a'))).toBe(false);
+    await act(async () => {
+      state().selectLegacyOrganization();
+    });
+    expect(state()).toMatchObject({ status: 'ready', organizationId: 'org-a' });
+    expect(
+      parseSelectedContext(bytes.get(selectedContextStorageKey('account-a')) ?? null, 'account-a')
+    ).toEqual({ status: 'present', context: contextScope('org-a') });
+    expect(bytes.get(ORGANIZATION_STORAGE_KEY)).toBe('org-a');
+  });
+  it('rejects an explicit legacy organization that no longer has membership', async () => {
+    bytes.set(ORGANIZATION_STORAGE_KEY, 'revoked');
+    await mount();
+    await act(async () => {
+      state().selectLegacyOrganization();
+    });
+    expect(state()).toMatchObject({ status: 'unavailable', reason: 'membership-revoked' });
+    expect(bytes.has(selectedContextStorageKey('account-a'))).toBe(false);
+    expect(bytes.get(ORGANIZATION_STORAGE_KEY)).toBe('revoked');
+  });
+  it('does not publish a failed context write as ready and Retry retains the deliberate selection', async () => {
+    await mount();
+    mocks.write.mockRejectedValueOnce(new Error('keychain unavailable'));
+    await act(async () => {
+      state().setOrganizationId('org-a');
+    });
+    expect(state()).toMatchObject({ status: 'failed', reason: 'write', isReady: false });
+    await act(async () => {
+      state().retry();
+    });
+    expect(state()).toMatchObject({ status: 'ready', organizationId: 'org-a' });
+  });
+  it('serializes selections so a held write cannot replace the later choice', async () => {
+    await mount();
+    const gate = deferred<undefined>();
+    mocks.write.mockImplementationOnce(async (key: string, value: string) => {
+      await gate.promise;
+      bytes.set(key, value);
+    });
+    await act(async () => {
+      state().setOrganizationId('org-a');
+    });
+    await act(async () => {
+      state().setOrganizationId(null);
+    });
+    await act(async () => {
+      gate.resolve(undefined);
+    });
+    expect(state()).toMatchObject({ status: 'ready', organizationId: null });
+    expect(
+      parseSelectedContext(bytes.get(selectedContextStorageKey('account-a')) ?? null, 'account-a')
+    ).toEqual({ status: 'present', context: { kind: 'personal' } });
+  });
+});

--- a/apps/mobile/src/lib/organization-context.tsx
+++ b/apps/mobile/src/lib/organization-context.tsx
@@ -6,70 +6,229 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
 import { useAuth } from '@/lib/auth/auth-context';
-import { deleteAccountMetadata, setAccountMetadata } from '@/lib/auth/account-metadata-write';
+import { writeAccountMetadata } from '@/lib/auth/account-metadata-write';
+import {
+  type AuthenticatedOwner,
+  type ContextScope,
+  contextScope,
+  isAuthenticatedOwner,
+  isContextUnavailableError,
+  parseSelectedContext,
+  selectedContextStorageKey,
+  serializeSelectedContext,
+} from '@/lib/context-scope';
+import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
+import { chainSave } from '@/lib/hooks/save-chain';
+import { setLocalAccessContextReady } from '@/lib/local-access';
 import { ORGANIZATION_STORAGE_KEY } from '@/lib/storage-keys';
+import { trpcClient } from '@/lib/trpc';
+
+type ContextState =
+  | Readonly<{
+      status: 'unresolved';
+      reason: 'identity' | 'storage' | 'membership' | 'selection-required';
+    }>
+  | Readonly<{ status: 'ready'; context: ContextScope }>
+  | Readonly<{ status: 'failed'; reason: 'identity' | 'storage' | 'membership' | 'write' }>
+  | Readonly<{
+      status: 'unavailable';
+      reason: 'malformed' | 'owner-mismatch' | 'membership-revoked';
+    }>;
 
 type OrganizationContextValue = {
-  /** null = personal, string = org UUID */
+  /** null means Personal only when isReady is true. */
   organizationId: string | null;
   isLoaded: boolean;
+  isReady: boolean;
+  status: ContextState['status'];
+  reason: Exclude<ContextState, { status: 'ready' }>['reason'] | null;
+  context: ContextScope | null;
+  owner: AuthenticatedOwner;
+  selectionGeneration: number;
+  legacyOrganizationId: string | null;
   setOrganizationId: (id: string | null) => void;
+  selectLegacyOrganization: () => void;
+  retry: () => void;
 };
-
 const OrganizationContext = createContext<OrganizationContextValue | undefined>(undefined);
+const unresolved: ContextState = { status: 'unresolved', reason: 'identity' };
+
+type SelectionRequest = { kind: 'restore' } | { kind: 'select'; organizationId: string | null };
 
 export function OrganizationProvider({ children }: { readonly children: ReactNode }) {
-  const { token } = useAuth();
-  const [organizationId, setOrgState] = useState<string | null>(null);
-  const [isLoaded, setIsLoaded] = useState(false);
+  const { token, isSigningOut } = useAuth();
+  const identity = useCurrentUserId();
+  const { userId, owner } = identity;
+  const ownerKey = JSON.stringify([owner.authEpoch, owner.generation, userId]);
+  const generation = useRef(0);
+  const activeOwnerKey = useRef(ownerKey);
+  if (activeOwnerKey.current !== ownerKey) {
+    activeOwnerKey.current = ownerKey;
+    generation.current += 1;
+  }
+  const [storedState, setStoredState] = useState<{
+    ownerKey: string;
+    state: ContextState;
+    legacy: string | null;
+  }>({
+    ownerKey,
+    state: unresolved,
+    legacy: null,
+  });
+  const lastRequest = useRef<SelectionRequest>({ kind: 'restore' });
+  const state = storedState.ownerKey === ownerKey ? storedState.state : unresolved;
+  const legacyOrganizationId = storedState.ownerKey === ownerKey ? storedState.legacy : null;
 
-  // The provider mounts above the auth gate and never remounts, so the
-  // in-memory selection must be reset when the session ends — otherwise the
-  // previous user's org id keeps being sent after a different account signs in.
-  // Loading from storage is gated on the same token so a sign-out cancels any
-  // in-flight read that would otherwise reinstate the previous user's org id.
-  useEffect(() => {
-    if (!token) {
-      setOrgState(null);
-      setIsLoaded(true);
-      return undefined;
-    }
-    setIsLoaded(false);
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const stored = await SecureStore.getItemAsync(ORGANIZATION_STORAGE_KEY);
-        if (!cancelled) {
-          setOrgState(stored ?? null);
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoaded(true);
-        }
+  const resolve = useCallback(
+    async (request: SelectionRequest) => {
+      if (!token || isSigningOut || !userId || !isAuthenticatedOwner(owner)) {
+        return;
       }
-    };
-    void load();
+      lastRequest.current = request;
+      generation.current += 1;
+      const selection = generation.current;
+      const isCurrent = () =>
+        isAuthenticatedOwner(owner) &&
+        generation.current === selection &&
+        activeOwnerKey.current === ownerKey;
+      const publish = (next: ContextState, legacy: string | null = null) => {
+        if (isCurrent()) {
+          setStoredState({ ownerKey, state: next, legacy });
+          setLocalAccessContextReady(next.status === 'ready');
+        }
+      };
+      publish({ status: 'unresolved', reason: 'storage' });
+      const key = selectedContextStorageKey(userId);
+      let phase: 'storage' | 'membership' | 'write' = 'storage';
+      try {
+        let selected: ContextScope = contextScope(null);
+        if (request.kind === 'restore') {
+          const bytes = await chainSave(key, async () => {
+            const stored = await SecureStore.getItemAsync(key);
+            return stored;
+          });
+          if (!isCurrent()) {
+            return;
+          }
+          const saved = parseSelectedContext(bytes, userId);
+          if (saved.status === 'malformed' || saved.status === 'owner-mismatch') {
+            publish({ status: 'unavailable', reason: saved.status });
+            return;
+          }
+          if (saved.status === 'absent') {
+            // Legacy fallback is a candidate only. Remove this read after all legacy selections migrate.
+            const legacy = await SecureStore.getItemAsync(ORGANIZATION_STORAGE_KEY);
+            if (!isCurrent()) {
+              return;
+            }
+            if (legacy) {
+              publish({ status: 'unresolved', reason: 'selection-required' }, legacy);
+              return;
+            }
+            selected = contextScope(null);
+          } else {
+            selected = saved.context;
+          }
+        } else {
+          selected = contextScope(request.organizationId);
+        }
+        if (selected.kind === 'organization') {
+          phase = 'membership';
+          publish({ status: 'unresolved', reason: 'membership' });
+          // Do not use a cached membership as proof, even when it belongs to this user.
+          const organizationId = selected.organizationId;
+          const organizations = await trpcClient.organizations.list.query();
+          if (!isCurrent()) {
+            return;
+          }
+          if (!organizations.some(org => org.organizationId === organizationId)) {
+            publish({ status: 'unavailable', reason: 'membership-revoked' });
+            return;
+          }
+        }
+        if (request.kind === 'select') {
+          phase = 'write';
+          await writeAccountMetadata(
+            key,
+            async () => {
+              await SecureStore.setItemAsync(key, serializeSelectedContext(userId, selected));
+            },
+            isCurrent
+          );
+        }
+        publish({ status: 'ready', context: selected });
+      } catch (error) {
+        publish(
+          phase === 'membership' && isContextUnavailableError(error)
+            ? { status: 'unavailable', reason: 'membership-revoked' }
+            : { status: 'failed', reason: phase }
+        );
+      }
+    },
+    [token, isSigningOut, userId, owner, ownerKey]
+  );
+
+  useEffect(() => {
+    void resolve({ kind: 'restore' });
     return () => {
-      cancelled = true;
+      generation.current += 1;
     };
-  }, [token]);
+  }, [resolve]);
 
-  const setOrganizationId = useCallback((id: string | null) => {
-    setOrgState(id);
-    if (id) {
-      void setAccountMetadata(ORGANIZATION_STORAGE_KEY, id);
-    } else {
-      void deleteAccountMetadata(ORGANIZATION_STORAGE_KEY);
+  const setOrganizationId = useCallback(
+    (id: string | null) => {
+      void resolve({ kind: 'select', organizationId: id });
+    },
+    [resolve]
+  );
+  const retry = useCallback(() => {
+    if (identity.isError) {
+      identity.refetch();
+    } else if (state.status === 'failed') {
+      void resolve(lastRequest.current);
     }
-  }, []);
-
+  }, [identity, state.status, resolve]);
+  const selectLegacyOrganization = useCallback(() => {
+    if (legacyOrganizationId !== null) {
+      setOrganizationId(legacyOrganizationId);
+    }
+  }, [legacyOrganizationId, setOrganizationId]);
+  const visibleState = useMemo<ContextState>(() => {
+    if (!token || isSigningOut || !userId || !isAuthenticatedOwner(owner)) {
+      return identity.isError ? { status: 'failed', reason: 'identity' } : unresolved;
+    }
+    return state;
+  }, [token, isSigningOut, userId, owner, identity.isError, state]);
+  const context = visibleState.status === 'ready' ? visibleState.context : null;
   const value = useMemo<OrganizationContextValue>(
-    () => ({ organizationId, isLoaded, setOrganizationId }),
-    [organizationId, isLoaded, setOrganizationId]
+    () => ({
+      organizationId: context?.kind === 'organization' ? context.organizationId : null,
+      isLoaded: visibleState.status === 'ready',
+      isReady: visibleState.status === 'ready',
+      status: visibleState.status,
+      reason: visibleState.status === 'ready' ? null : visibleState.reason,
+      context,
+      owner,
+      selectionGeneration: generation.current,
+      legacyOrganizationId,
+      setOrganizationId,
+      selectLegacyOrganization,
+      retry,
+    }),
+    [
+      context,
+      visibleState,
+      owner,
+      legacyOrganizationId,
+      setOrganizationId,
+      selectLegacyOrganization,
+      retry,
+    ]
   );
 
   return <OrganizationContext value={value}>{children}</OrganizationContext>;

--- a/apps/mobile/src/lib/persist/cache-persistence-mount.test.ts
+++ b/apps/mobile/src/lib/persist/cache-persistence-mount.test.ts
@@ -1,481 +1,207 @@
-/* eslint-disable max-lines -- cohesive mount suite for identity resolution, mismatch recovery, and persister lifecycle */
-/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (node env, no jsdom); its React 19 deprecation notice points to the DOM-based Testing Library, which cannot render this app's non-DOM tree. See src/app/(app)/(tabs)/(2_agents)/index.mounted.test.tsx. */
-/* eslint-disable require-await, @typescript-eslint/require-await -- the fake KV and SecureStore factories settle without await because they resolve immediately */
-import { createElement, useSyncExternalStore } from 'react';
+/* eslint-disable typescript-eslint/no-deprecated -- mounted cache tests use the installed DOM-free renderer */
+/* eslint-disable require-await, typescript-eslint/require-await -- native fixtures and async act callbacks settle synchronously */
+/* eslint-disable max-params -- the KV fixture mirrors the four-argument guarded write API */
+import { createElement } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
-import { type Mutation } from '@tanstack/react-query';
-import { type PersistedQueryClientSaveOptions } from '@tanstack/react-query-persist-client';
+import { hashKey } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { bumpAuthEpoch, currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { isSignOutActive, setSignOutActive } from '@/lib/auth/sign-out-state';
 import {
-  isSignOutActive,
-  setSignOutActive,
-  subscribeSignOutActive,
-} from '@/lib/auth/sign-out-state';
-import { CachePersistenceMount } from './cache-persistence-mount';
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+  getAuthenticatedOwner,
+} from '@/lib/context-scope';
 import { queryClient } from '@/lib/query-client';
-import {
-  clearCacheScopeForSignOut,
-  createReadCachePersister,
-  resetReadCacheForTests,
-  restorePersistedCacheOnColdStart,
-  shouldPersistReadCacheQuery,
-  takeOverColdStartRestore,
-} from './read-cache';
-import { GET_ME_QUERY_KEY, makePersistedClient } from './test-fixtures';
 import { ACTIVE_USER_ID_KEY } from '@/lib/storage-keys';
+import { CachePersistenceMount } from './cache-persistence-mount';
+import { resetReadCacheForTests, restorePersistedCacheOnColdStart } from './read-cache';
+import { GET_ME_QUERY_KEY, makePersistedClient } from './test-fixtures';
 
-type Identity = {
-  userId: string | undefined;
-  isLoading: boolean;
-  isError: boolean;
-};
-
-const identityMock = vi.hoisted<{ value: Identity }>(() => ({
-  value: { userId: undefined, isLoading: true, isError: false },
+const mocks = vi.hoisted(() => ({
+  userId: undefined as string | undefined,
+  store: new Map<string, string>(),
+  hint: new Map<string, string>(),
+  get: vi.fn(),
+  set: vi.fn(),
+  setHint: vi.fn(),
 }));
-
-const authMock = vi.hoisted<{ value: { authEpoch: number; isSigningOut: boolean } }>(() => ({
-  value: { authEpoch: 0, isSigningOut: false },
-}));
-
-const persistQueryClientSubscribeMock = vi.hoisted(() =>
-  vi.fn<(options: PersistedQueryClientSaveOptions) => () => void>()
-);
-const persistQueryClientRestoreMock = vi.hoisted(() => vi.fn(async () => undefined));
-const unsubscribeMock = vi.hoisted(() => vi.fn<() => void>());
-
-const kvMock = vi.hoisted(() => ({
-  getItem: vi.fn(async (): Promise<string | null> => null),
-  setItem: vi.fn(async (): Promise<void> => undefined),
-  removeItem: vi.fn(async (): Promise<void> => undefined),
-  clearScope: vi.fn(async (): Promise<void> => undefined),
-  clearScopePrefix: vi.fn(async (): Promise<void> => undefined),
-}));
-
-const secureStoreMock = vi.hoisted(() => ({
-  getItemAsync: vi.fn(async (): Promise<string | null> => null),
-  setItemAsync: vi.fn(async (): Promise<void> => undefined),
-  deleteItemAsync: vi.fn(async (): Promise<void> => undefined),
-}));
-
 vi.mock('@/lib/hooks/use-current-user-id', () => ({
-  useCurrentUserId: vi.fn(() => identityMock.value),
+  useCurrentUserId: () => ({
+    userId: mocks.userId,
+    owner: getAuthenticatedOwner(),
+    isLoading: false,
+    isError: false,
+  }),
 }));
-
 vi.mock('@/lib/auth/auth-context', () => ({
-  useAuth: vi.fn(() => authMock.value),
+  useAuth: () => ({ authEpoch: currentAuthEpoch(), isSigningOut: isSignOutActive() }),
 }));
-
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: async (key: string) => mocks.hint.get(key) ?? null,
+  setItemAsync: mocks.setHint,
+}));
 vi.mock('@/lib/persist/encrypted-kv', () => ({
-  getItem: kvMock.getItem,
-  setItem: kvMock.setItem,
-  removeItem: kvMock.removeItem,
-  clearScope: kvMock.clearScope,
-  clearScopePrefix: kvMock.clearScopePrefix,
+  getItem: mocks.get,
+  setItem: mocks.set,
+  removeItem: async (scope: string, _key: string, guard?: () => boolean) => {
+    if (!guard || guard()) {
+      mocks.store.delete(scope);
+    }
+  },
+  clearScopePrefix: async (prefix: string, guard?: () => boolean) => {
+    if (guard && !guard()) {
+      return;
+    }
+    for (const scope of mocks.store.keys()) {
+      if (scope.startsWith(prefix)) {
+        mocks.store.delete(scope);
+      }
+    }
+  },
 }));
 
-vi.mock('@tanstack/react-query-persist-client', () => ({
-  persistQueryClientSubscribe: persistQueryClientSubscribeMock,
-  persistQueryClientRestore: persistQueryClientRestoreMock,
-}));
-
-vi.mock('expo-secure-store', () => secureStoreMock);
-
+const RECENT_KEY = [['cliSessionsV2', 'recentRepositories'], { type: 'query' }];
+let renderer: TestRenderer.ReactTestRenderer | undefined = undefined;
+function prove(userId: string) {
+  bumpAuthEpoch();
+  beginAuthenticatedOwner();
+  mocks.userId = userId;
+  queryClient.clear();
+  queryClient.setQueryData(GET_ME_QUERY_KEY, { id: userId });
+  confirmAuthenticatedOwner(getAuthenticatedOwner(), userId);
+}
+function seed(userId: string, text: string) {
+  const blob = makePersistedClient({ id: userId });
+  const fixture = blob.clientState.queries[0];
+  if (!fixture) {
+    throw new Error('Missing query fixture');
+  }
+  blob.clientState.queries.push({
+    ...fixture,
+    queryHash: hashKey(RECENT_KEY),
+    queryKey: RECENT_KEY,
+    state: { ...fixture.state, data: { text } },
+  });
+  mocks.store.set(`cache:${userId}:1`, JSON.stringify(blob));
+}
+async function mount() {
+  await act(async () => {
+    renderer = TestRenderer.create(createElement(CachePersistenceMount));
+  });
+}
+async function update() {
+  await act(async () => {
+    renderer?.update(createElement(CachePersistenceMount));
+  });
+}
 beforeEach(() => {
   vi.clearAllMocks();
   resetReadCacheForTests();
-  identityMock.value = { userId: undefined, isLoading: true, isError: false };
-  authMock.value = { authEpoch: 0, isSigningOut: false };
-  kvMock.getItem.mockResolvedValue(null);
-  kvMock.setItem.mockResolvedValue(undefined);
-  kvMock.removeItem.mockResolvedValue(undefined);
-  kvMock.clearScope.mockResolvedValue(undefined);
-  kvMock.clearScopePrefix.mockResolvedValue(undefined);
-  secureStoreMock.getItemAsync.mockResolvedValue(null);
-  secureStoreMock.setItemAsync.mockResolvedValue(undefined);
-  secureStoreMock.deleteItemAsync.mockResolvedValue(undefined);
-  persistQueryClientSubscribeMock.mockReturnValue(unsubscribeMock);
-  persistQueryClientRestoreMock.mockResolvedValue(undefined);
-});
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
-
-function mount(): TestRenderer.ReactTestRenderer {
-  const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
-    current: undefined,
-  };
-  act(() => {
-    rendererRef.current = TestRenderer.create(createElement(CachePersistenceMount));
+  beginAuthenticatedOwner();
+  queryClient.clear();
+  mocks.userId = undefined;
+  mocks.store.clear();
+  mocks.hint.clear();
+  mocks.get.mockImplementation(async (scope: string) => mocks.store.get(scope) ?? null);
+  // eslint-disable-next-line max-params -- mirror the guarded KV write API
+  mocks.set.mockImplementation(
+    async (scope: string, _key: string, value: string, guard?: () => boolean) => {
+      if (!guard || guard()) {
+        mocks.store.set(scope, value);
+      }
+    }
+  );
+  mocks.setHint.mockImplementation(async (key: string, value: string) => {
+    mocks.hint.set(key, value);
   });
-  if (!rendererRef.current) {
-    throw new Error('CachePersistenceMount did not render');
-  }
-  return rendererRef.current;
-}
-
-async function flushMicrotasks(): Promise<void> {
+});
+afterEach(async () => {
   await act(async () => {
-    await new Promise(resolve => {
-      setTimeout(resolve, 0);
-    });
+    renderer?.unmount();
   });
-}
+  queryClient.clear();
+});
 
-function latestPersistOptions(): PersistedQueryClientSaveOptions | undefined {
-  return persistQueryClientSubscribeMock.mock.calls.at(-1)?.[0];
-}
-
-function mutationLike(state: Partial<Mutation['state']>): Mutation {
-  return { state } as unknown as Mutation;
-}
-
-describe('CachePersistenceMount', () => {
-  it('resolves identity, writes the hint, and subscribes one scoped persister', async () => {
-    identityMock.value = { userId: 'u1', isLoading: false, isError: false };
-    const renderer = mount();
-    await flushMicrotasks();
-
-    // The identity hint for the next cold start was written via the fenced helper.
-    expect(secureStoreMock.setItemAsync).toHaveBeenCalledWith(ACTIVE_USER_ID_KEY, 'u1');
-
-    // One mounted subscription with the allowlist-only dehydrate filters. The
-    // root layout already performed the only cold-start restore, so the mount
-    // subscribes without restoring — no `maxAge` and no restore promise. The
-    // schema version lives in the scope, so no `buster` is passed.
-    expect(persistQueryClientSubscribeMock).toHaveBeenCalledTimes(1);
-    expect(latestPersistOptions()).toMatchObject({
-      queryClient,
-      dehydrateOptions: {
-        shouldDehydrateQuery: shouldPersistReadCacheQuery,
-        shouldDehydrateMutation: expect.any(Function),
-      },
-    });
-    expect(latestPersistOptions()?.buster).toBeUndefined();
-
-    // The persister is bound to exactly the user's scope for the schema.
-    await latestPersistOptions()?.persister.restoreClient();
-    expect(kvMock.getItem).toHaveBeenCalledWith('cache:u1:1', 'read-cache');
-
-    // No cold-start restore claimed a scope, so nothing is cleared.
-    expect(kvMock.clearScope).not.toHaveBeenCalled();
-
-    act(() => {
-      renderer.unmount();
-    });
-  });
-
-  it('regression: a failed identity-hint write never escapes as an unhandled rejection', async () => {
-    const unhandled: unknown[] = [];
-    const onUnhandledRejection = (reason: unknown) => {
-      unhandled.push(reason);
-    };
-    process.on('unhandledRejection', onUnhandledRejection);
-
-    try {
-      identityMock.value = { userId: 'u1', isLoading: false, isError: false };
-      secureStoreMock.setItemAsync.mockRejectedValueOnce(new Error('keychain unavailable'));
-      const renderer = mount();
-      await flushMicrotasks();
-
-      // The hint write was still attempted even though SecureStore rejects.
-      expect(secureStoreMock.setItemAsync).toHaveBeenCalledWith(ACTIVE_USER_ID_KEY, 'u1');
-      // Give the runtime a turn to flag an unhandled rejection if the mount
-      // ever fires the write without containing it.
-      await new Promise(resolve => {
-        setImmediate(resolve);
-      });
-      expect(unhandled).toEqual([]);
-
-      act(() => {
-        renderer.unmount();
-      });
-    } finally {
-      process.off('unhandledRejection', onUnhandledRejection);
-    }
-  });
-
-  it('does nothing while identity is loading', () => {
-    identityMock.value = { userId: undefined, isLoading: true, isError: false };
-    const renderer = mount();
-
-    expect(persistQueryClientSubscribeMock).not.toHaveBeenCalled();
-    expect(secureStoreMock.setItemAsync).not.toHaveBeenCalled();
-    act(() => {
-      renderer.unmount();
-    });
-  });
-
-  it('does nothing when identity resolution errored', () => {
-    identityMock.value = { userId: undefined, isLoading: false, isError: true };
-    const renderer = mount();
-
-    expect(persistQueryClientSubscribeMock).not.toHaveBeenCalled();
-    expect(secureStoreMock.setItemAsync).not.toHaveBeenCalled();
-    act(() => {
-      renderer.unmount();
-    });
-  });
-
-  it('does nothing before a userId resolves', () => {
-    identityMock.value = { userId: undefined, isLoading: false, isError: false };
-    const renderer = mount();
-
-    expect(persistQueryClientSubscribeMock).not.toHaveBeenCalled();
-    act(() => {
-      renderer.unmount();
-    });
-  });
-
-  it('keeps a restored scope that matches the authoritative user', async () => {
-    secureStoreMock.getItemAsync.mockResolvedValue('u1');
+describe('CachePersistenceMount owner proof', () => {
+  it('does not restore or publish content from an active-user-id hint alone', async () => {
+    seed('a', 'private a');
+    mocks.hint.set(ACTIVE_USER_ID_KEY, 'a');
     await restorePersistedCacheOnColdStart(queryClient);
-
-    const clearSpy = vi.spyOn(queryClient, 'clear');
-    identityMock.value = { userId: 'u1', isLoading: false, isError: false };
-    const renderer = mount();
-    await flushMicrotasks();
-
-    // The mount consumed the cold-start takeover and did not clear anything.
-    expect(takeOverColdStartRestore()).toBeNull();
-    expect(clearSpy).not.toHaveBeenCalled();
-    expect(kvMock.clearScope).not.toHaveBeenCalled();
-    expect(persistQueryClientSubscribeMock).toHaveBeenCalledTimes(1);
-
-    clearSpy.mockRestore();
-    act(() => {
-      renderer.unmount();
-    });
+    await mount();
+    expect(queryClient.getQueryData(RECENT_KEY)).toBeUndefined();
+    expect(queryClient.getQueryData(GET_ME_QUERY_KEY)).toBeUndefined();
+    expect(mocks.get).not.toHaveBeenCalled();
   });
-
-  it('clears a mismatched restored scope and the query client before rescoping', async () => {
-    secureStoreMock.getItemAsync.mockResolvedValue('user-a');
+  it('restores matching owner content without replacing authoritative getMe', async () => {
+    seed('a', 'private a');
+    prove('a');
+    await mount();
+    expect(queryClient.getQueryData(RECENT_KEY)).toEqual({ text: 'private a' });
+    expect(queryClient.getQueryData(GET_ME_QUERY_KEY)).toEqual({ id: 'a' });
+    expect(mocks.hint.get(ACTIVE_USER_ID_KEY)).toBe('a');
+  });
+  it('ignores a mismatched cold hint and restores only the proved account', async () => {
+    seed('a', 'private a');
+    seed('b', 'private b');
+    mocks.hint.set(ACTIVE_USER_ID_KEY, 'a');
     await restorePersistedCacheOnColdStart(queryClient);
-
-    const clearSpy = vi.spyOn(queryClient, 'clear');
-    identityMock.value = { userId: 'user-b', isLoading: false, isError: false };
-    const renderer = mount();
-    await flushMicrotasks();
-
-    // Authoritative identity wins: the other account's restored data and the
-    // query client are cleared before the new scope subscribes.
-    expect(takeOverColdStartRestore()).toBeNull();
-    expect(clearSpy).toHaveBeenCalledTimes(1);
-    expect(kvMock.clearScope).toHaveBeenCalledWith('cache:user-a:1');
-    await latestPersistOptions()?.persister.restoreClient();
-    expect(kvMock.getItem).toHaveBeenCalledWith('cache:user-b:1', 'read-cache');
-
-    clearSpy.mockRestore();
-    act(() => {
-      renderer.unmount();
-    });
+    prove('b');
+    await mount();
+    expect(queryClient.getQueryData(RECENT_KEY)).toEqual({ text: 'private b' });
+    expect(queryClient.getQueryData(GET_ME_QUERY_KEY)).toEqual({ id: 'b' });
   });
-
-  it('unsubscribes the previous persister when the user changes', async () => {
-    identityMock.value = { userId: 'u1', isLoading: false, isError: false };
-    const renderer = mount();
-    await flushMicrotasks();
-    expect(persistQueryClientSubscribeMock).toHaveBeenCalledTimes(1);
-
-    identityMock.value = { userId: 'u2', isLoading: false, isError: false };
-    act(() => {
-      renderer.update(createElement(CachePersistenceMount));
+  it('drops an old account restore when B signs in during its cache read', async () => {
+    seed('a', 'private a');
+    seed('b', 'private b');
+    const a = mocks.store.get('cache:a:1') ?? null;
+    const gate = Promise.withResolvers<string | null>();
+    mocks.get.mockReturnValueOnce(gate.promise);
+    prove('a');
+    await mount();
+    await act(async () => {
+      prove('b');
     });
-    await flushMicrotasks();
-
-    expect(persistQueryClientSubscribeMock).toHaveBeenCalledTimes(2);
-    expect(unsubscribeMock).toHaveBeenCalled();
-    act(() => {
-      renderer.unmount();
+    await update();
+    await act(async () => {
+      gate.resolve(a);
     });
+    expect(queryClient.getQueryData(RECENT_KEY)).toEqual({ text: 'private b' });
+    expect(queryClient.getQueryData(GET_ME_QUERY_KEY)).toEqual({ id: 'b' });
   });
-
-  it('clears the previous account cache scope when the user changes', async () => {
-    identityMock.value = { userId: 'u1', isLoading: false, isError: false };
-    const renderer = mount();
-    await flushMicrotasks();
-    expect(kvMock.clearScopePrefix).not.toHaveBeenCalled();
-
-    // A direct account switch (no sign-out): the mount must drop the old
-    // account's read-cache scope before subscribing for the new account.
-    identityMock.value = { userId: 'u2', isLoading: false, isError: false };
-    act(() => {
-      renderer.update(createElement(CachePersistenceMount));
-    });
-    await flushMicrotasks();
-
-    expect(kvMock.clearScopePrefix).toHaveBeenCalledWith('cache:u1:');
-    act(() => {
-      renderer.unmount();
-    });
+  it('keeps restoration available after a failed hint write', async () => {
+    seed('a', 'private a');
+    prove('a');
+    mocks.setHint.mockRejectedValueOnce(new Error('temporary keychain error'));
+    await mount();
+    expect(queryClient.getQueryData(RECENT_KEY)).toEqual({ text: 'private a' });
   });
-
-  it('unsubscribes the persister on unmount', async () => {
-    identityMock.value = { userId: 'u1', isLoading: false, isError: false };
-    const renderer = mount();
-    await flushMicrotasks();
-
-    act(() => {
-      renderer.unmount();
-    });
-
-    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('denies every mutation from the persisted client, including paused ones', async () => {
-    identityMock.value = { userId: 'u1', isLoading: false, isError: false };
-    const renderer = mount();
-    await flushMicrotasks();
-
-    const shouldDehydrateMutation =
-      latestPersistOptions()?.dehydrateOptions?.shouldDehydrateMutation;
-    expect(shouldDehydrateMutation).toBeTypeOf('function');
-    // The library default dehydrates paused mutations; the mount denies them
-    // so a restored read cache can never replay one (never-replay).
-    expect(shouldDehydrateMutation?.(mutationLike({ isPaused: true }))).toBe(false);
-    expect(shouldDehydrateMutation?.(mutationLike({ isPaused: false }))).toBe(false);
-    act(() => {
-      renderer.unmount();
-    });
-  });
-
-  it('unsubscribes and resubscribes when the auth epoch changes and the user stays equal', async () => {
-    identityMock.value = { userId: 'u1', isLoading: false, isError: false };
-    authMock.value = { authEpoch: 1, isSigningOut: false };
-    const renderer = mount();
-    await flushMicrotasks();
-    expect(persistQueryClientSubscribeMock).toHaveBeenCalledTimes(1);
-
-    // The epoch bumps (sign-out or newer sign-in) while the authoritative user
-    // id stays equal: the mount must tear down the old persister and
-    // resubscribe so the new subscription is fenced on the current epoch.
-    authMock.value = { authEpoch: 2, isSigningOut: false };
-    act(() => {
-      renderer.update(createElement(CachePersistenceMount));
-    });
-    await flushMicrotasks();
-
-    expect(persistQueryClientSubscribeMock).toHaveBeenCalledTimes(2);
-    expect(unsubscribeMock).toHaveBeenCalled();
-    act(() => {
-      renderer.unmount();
-    });
-  });
-
-  it('regression: sign-out unsubscribes the mount and a query update during delayed cleanup never rewrites the old user blob', async () => {
-    // The old user id stays cached for the whole sign-out teardown (the query
-    // client is only cleared at the end of sign-out).
-    queryClient.setQueryData(GET_ME_QUERY_KEY, { id: 'u1' });
-    identityMock.value = { userId: 'u1', isLoading: false, isError: false };
-    authMock.value = { authEpoch: 0, isSigningOut: false };
-    const renderer = mount();
-    await flushMicrotasks();
-    expect(persistQueryClientSubscribeMock).toHaveBeenCalledTimes(1);
-    const stalePersister = latestPersistOptions()?.persister;
-    expect(stalePersister).toBeDefined();
-
-    // Delay the sign-out scope clear so a query update can land mid-teardown.
-    const cleanupGate: { release: (() => void) | null } = { release: null };
-    const cleanupHeld = new Promise<void>(resolve => {
-      cleanupGate.release = resolve;
-    });
-    kvMock.clearScopePrefix.mockImplementationOnce(async () => {
-      await cleanupHeld;
-    });
-
-    // Sign-out starts: the module epoch bumps and the reactive sign-out state
-    // flips in the same render while the old user id is still cached.
-    bumpAuthEpoch();
+  it('unsubscribes on sign-out and never rewrites the cleared old scope', async () => {
+    prove('a');
+    await mount();
     setSignOutActive(true);
-    authMock.value = { authEpoch: 1, isSigningOut: true };
-    act(() => {
-      renderer.update(createElement(CachePersistenceMount));
+    await update();
+    mocks.store.clear();
+    queryClient.setQueryData(RECENT_KEY, { text: 'late a' });
+    await act(async () => {
+      await new Promise(resolve => {
+        setTimeout(resolve, 0);
+      });
     });
-    await flushMicrotasks();
-
-    // The mount tore down the old subscription and refused to resubscribe.
-    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
-    expect(persistQueryClientSubscribeMock).toHaveBeenCalledTimes(1);
-
-    // The sign-out cleanup starts and is held open.
-    const cleanupPromise = clearCacheScopeForSignOut('u1');
-    await vi.waitFor(() => {
-      expect(kvMock.clearScopePrefix).toHaveBeenCalled();
-    });
-
-    // A query update fires a throttled save from the torn-down subscription
-    // while cleanup is still in flight: no cache blob may be written.
-    await stalePersister?.persistClient(makePersistedClient({ id: 'u1' }));
-    expect(kvMock.setItem).not.toHaveBeenCalled();
-
-    cleanupGate.release?.();
-    await cleanupPromise;
-
-    // Even a persister created at the CURRENT epoch with a matching cached
-    // user id (the resubscription the race used to create) refuses to publish
-    // while sign-out is active, so cleanup is final: a save after the clear
-    // also writes nothing.
-    const freshPersister = createReadCachePersister({
-      queryClient,
-      userId: 'u1',
-      epoch: currentAuthEpoch(),
-    });
-    await freshPersister.persistClient(makePersistedClient({ id: 'u1' }));
-    expect(kvMock.setItem).not.toHaveBeenCalled();
-
-    act(() => {
-      renderer.unmount();
-    });
-    queryClient.removeQueries({ queryKey: GET_ME_QUERY_KEY });
+    expect(mocks.store.size).toBe(0);
   });
-
-  it('feeds one flag to both consumers: the React subscriber and the cache write fence', async () => {
-    queryClient.setQueryData(GET_ME_QUERY_KEY, { id: 'u1' });
-    const persister = createReadCachePersister({
-      queryClient,
-      userId: 'u1',
-      epoch: currentAuthEpoch(),
+  it('does not hydrate after unmount while the cache read is pending', async () => {
+    seed('a', 'private a');
+    const a = mocks.store.get('cache:a:1') ?? null;
+    const gate = Promise.withResolvers<string | null>();
+    mocks.get.mockReturnValueOnce(gate.promise);
+    prove('a');
+    await mount();
+    await act(async () => {
+      renderer?.unmount();
+      gate.resolve(a);
     });
-
-    // The exact subscription the auth context uses for `isSigningOut`.
-    const observed: boolean[] = [];
-    function SignOutConsumer(): null {
-      observed.push(useSyncExternalStore(subscribeSignOutActive, isSignOutActive));
-      return null;
-    }
-    const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
-      current: undefined,
-    };
-    act(() => {
-      rendererRef.current = TestRenderer.create(createElement(SignOutConsumer));
-    });
-    expect(observed.at(-1)).toBe(false);
-
-    // ONE setter: there is no second flag to keep in sync by hand.
-    act(() => {
-      setSignOutActive(true);
-    });
-    // The React consumer re-rendered with the in-progress state.
-    expect(observed.at(-1)).toBe(true);
-
-    // The write path reads the same flag and refuses the KV write.
-    await persister.persistClient(makePersistedClient({ id: 'u1' }));
-    expect(kvMock.setItem).not.toHaveBeenCalled();
-
-    // Clearing the one flag opens both consumers again.
-    act(() => {
-      setSignOutActive(false);
-    });
-    expect(observed.at(-1)).toBe(false);
-    await persister.persistClient(makePersistedClient({ id: 'u1' }));
-    expect(kvMock.setItem).toHaveBeenCalledTimes(1);
-
-    act(() => {
-      rendererRef.current?.unmount();
-    });
-    queryClient.removeQueries({ queryKey: GET_ME_QUERY_KEY });
+    expect(queryClient.getQueryData(RECENT_KEY)).toBeUndefined();
   });
 });

--- a/apps/mobile/src/lib/persist/cache-persistence-mount.tsx
+++ b/apps/mobile/src/lib/persist/cache-persistence-mount.tsx
@@ -4,116 +4,68 @@ import { useEffect, useRef } from 'react';
 
 import { writeAccountMetadata } from '@/lib/auth/account-metadata-write';
 import { useAuth } from '@/lib/auth/auth-context';
+import { isAuthenticatedOwner } from '@/lib/context-scope';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
-import { clearScope } from '@/lib/persist/encrypted-kv';
 import {
   clearCacheScopeForSignOut,
   createReadCachePersister,
-  readCacheScope,
+  restorePersistedCacheForOwner,
   shouldPersistReadCacheQuery,
   takeOverColdStartRestore,
 } from '@/lib/persist/read-cache';
 import { queryClient } from '@/lib/query-client';
 import { ACTIVE_USER_ID_KEY } from '@/lib/storage-keys';
 
-/**
- * Owner of the encrypted read cache for the authenticated identity. Renders
- * null. On identity resolution it takes over from the cold-start restore,
- * writes the identity hint, and subscribes one scoped persister for
- * `cache:<userId>:<SCHEMA_VERSION>`. Cleanup unsubscribes on epoch change,
- * user change, or unmount.
- */
+/** Restore only after network identity proof, then subscribe within that immutable owner generation. */
 export function CachePersistenceMount() {
-  const { userId, isLoading, isError } = useCurrentUserId();
+  const { userId, owner, isLoading, isError } = useCurrentUserId();
   const { authEpoch, isSigningOut } = useAuth();
-  // The last authenticated user id this mount subscribed for. A direct
-  // account switch (sign-in over an existing session, without a sign-out) does
-  // not run the sign-out cleanup, so the mount is the only owner that can drop
-  // the previous account's cache scope when the authoritative user id changes.
-  const previousUserIdRef = useRef<string | null>(null);
-
+  const previousUserId = useRef<string | null>(null);
   useEffect(() => {
-    // While sign-out is active the old user id is still cached (the query
-    // client is only cleared at the end of sign-out): refuse to subscribe so
-    // a resubscription fenced on the new epoch cannot publish the old user's
-    // blob before the sign-out cleanup finishes.
-    if (!userId || isLoading || isError || isSigningOut) {
+    if (!userId || isLoading || isError || isSigningOut || !isAuthenticatedOwner(owner)) {
       return undefined;
     }
-
-    // Account change: drop the previous account's read-cache scope. The
-    // sign-out path already clears the scope, so this only fires on a direct
-    // switch where the sign-out cleanup never ran. Best effort: the helper
-    // swallows a storage failure, and a redundant clear only costs a future
-    // warm start.
-    const previousUserId = previousUserIdRef.current;
-    if (previousUserId !== null && previousUserId !== userId) {
-      void clearCacheScopeForSignOut(previousUserId);
+    let active = true;
+    const isCurrent = () => active && isAuthenticatedOwner(owner);
+    if (previousUserId.current !== null && previousUserId.current !== userId) {
+      void clearCacheScopeForSignOut(previousUserId.current);
     }
-    previousUserIdRef.current = userId;
-
-    // The epoch that owns this identity resolution. Every later sign-in or
-    // sign-out bumps it, fencing the persister against stale writes. The
-    // reactive `authEpoch` re-runs this effect on the bump, so the persister
-    // is recreated even when the user id stays equal. `isSigningOut` re-runs
-    // the effect too: sign-out flips it in the same render as the bump, so
-    // the teardown below runs and the body returns early instead of
-    // resubscribing while the old user id is still cached.
-    const epoch = authEpoch;
-
-    // Authoritative identity takes over from the cold-start hint: a still-
-    // pending restore is abandoned, and a completed restore reports the scope
-    // it hydrated. A scope from another account is cleared together with the
-    // query client, so restored data can never render under the wrong user.
-    // The hint only survives an interrupted teardown, and authoritative
-    // identity wins.
-    const restoredScope = takeOverColdStartRestore();
-    if (restoredScope !== null && restoredScope !== readCacheScope(userId)) {
-      queryClient.clear();
-      void (async () => {
-        try {
-          await clearScope(restoredScope);
-        } catch {
-          // Best effort: a failed scope clear only costs a future warm start.
-        }
-      })();
-    }
-
-    // Record the identity hint for the next cold start. `writeAccountMetadata`
-    // fences the write on the auth epoch; sign-out deletes it. The write is
-    // best effort and its rejection is swallowed so a SecureStore failure can
-    // never escape as an unhandled rejection (a failed hint only costs a
-    // future warm start).
+    previousUserId.current = userId;
+    // The cold-start entry holds a hint only. A mismatch never clears the newly proved identity.
+    takeOverColdStartRestore();
+    let unsubscribe: (() => void) | undefined = undefined;
     void (async () => {
       try {
-        await writeAccountMetadata(ACTIVE_USER_ID_KEY, async () => {
-          await SecureStore.setItemAsync(ACTIVE_USER_ID_KEY, userId);
-        });
+        await writeAccountMetadata(
+          ACTIVE_USER_ID_KEY,
+          async () => {
+            await SecureStore.setItemAsync(ACTIVE_USER_ID_KEY, userId);
+          },
+          isCurrent
+        );
       } catch {
-        // Best effort: a failed identity hint only costs a future warm start.
+        // A failed hint costs a warm start, never owner proof.
       }
+      if (!isCurrent()) {
+        return;
+      }
+      await restorePersistedCacheForOwner(queryClient, owner, isCurrent);
+      if (!isCurrent()) {
+        return;
+      }
+      unsubscribe = persistQueryClientSubscribe({
+        queryClient,
+        persister: createReadCachePersister({ queryClient, userId, epoch: authEpoch }),
+        dehydrateOptions: {
+          shouldDehydrateQuery: shouldPersistReadCacheQuery,
+          shouldDehydrateMutation: () => false,
+        },
+      });
     })();
-
-    const persister = createReadCachePersister({ queryClient, userId, epoch });
-    // Subscribe-only persistence: the root layout already performed the single
-    // cold-start restore via `restorePersistedCacheOnColdStart`, so the mount
-    // must not restore again (a second restore would re-hydrate and rescope).
-    // No `buster`: the scope segment carries the schema version, so a blob from
-    // an older schema lives in another scope and is never read.
-    const unsubscribe = persistQueryClientSubscribe({
-      queryClient,
-      persister,
-      dehydrateOptions: {
-        shouldDehydrateQuery: shouldPersistReadCacheQuery,
-        // No mutation ever enters the read cache: the library default would
-        // dehydrate paused mutations, and a restored read cache must never
-        // replay one (never-replay).
-        shouldDehydrateMutation: () => false,
-      },
-    });
-
-    return unsubscribe;
-  }, [userId, isLoading, isError, authEpoch, isSigningOut]);
-
+    return () => {
+      active = false;
+      unsubscribe?.();
+    };
+  }, [userId, owner, isLoading, isError, authEpoch, isSigningOut]);
   return null;
 }

--- a/apps/mobile/src/lib/persist/drafts.test.ts
+++ b/apps/mobile/src/lib/persist/drafts.test.ts
@@ -16,7 +16,21 @@ const kvMock = vi.hoisted(() => ({
   listEntries: vi.fn(async (_scope: string): Promise<{ k: string; updatedAt: number }[]> => []),
 }));
 
-vi.mock('@/lib/persist/encrypted-kv', () => kvMock);
+vi.mock('@/lib/persist/encrypted-kv', () => ({
+  getItem: kvMock.getItem,
+  listEntries: kvMock.listEntries,
+  // eslint-disable-next-line max-params -- mirror the guarded native KV write API
+  setItem: async (scope: string, key: string, value: string, guard?: () => boolean) => {
+    if (!guard || guard()) {
+      await kvMock.setItem(scope, key, value);
+    }
+  },
+  removeItem: async (scope: string, key: string, guard?: () => boolean) => {
+    if (!guard || guard()) {
+      await kvMock.removeItem(scope, key);
+    }
+  },
+}));
 
 vi.mock('@sentry/react-native', () => ({
   captureException: vi.fn(),
@@ -80,7 +94,7 @@ function isReviewDraft(value: unknown): value is ReviewDraftItem[] {
 }
 
 function storageKey(scope: string, k: string): string {
-  return `${scope}\u0000${k}`;
+  return JSON.stringify([scope, k]);
 }
 
 function seedStoredValue(scope: string, k: string, v: string): void {
@@ -577,5 +591,90 @@ describe('eviction at the entry cap', () => {
     const entries = await kvMock.listEntries('draft:u1');
     expect(entries).toHaveLength(DRAFT_MAX_ENTRIES);
     expect(kvMock.removeItem).not.toHaveBeenCalled();
+  });
+});
+
+// a6 activates production-caller enforcement for each row as it converts the surface.
+const scopedDraftInventory = [
+  { caller: 'new-session', target: { kind: 'new-session' } },
+  { caller: 'session-detail/composer-autosave', target: { kind: 'session', sessionId: 'new' } },
+  { caller: 'history/search', target: { kind: 'search' } },
+  { caller: 'Quick Chat', target: { kind: 'quick-chat' } },
+] as const;
+
+describe('strict draft boundaries and scoped-key inventory', () => {
+  it.each(scopedDraftInventory)(
+    'isolates $caller by tagged context and durable arbitrary user ID',
+    async ({ caller, target }) => {
+      const context = await import('@/lib/context-scope');
+      const { scopedDraftKey } = await import('./scoped-draft-keys');
+      const { loadDraftResult, saveDraftConfirmed } = await import('./drafts');
+      context.beginAuthenticatedOwner();
+      const userId = 'oauth/user:a/b_用户';
+      context.confirmAuthenticatedOwner(context.getAuthenticatedOwner(), userId);
+      const owner = context.getAuthenticatedOwner();
+      const isCurrent = () => context.isAuthenticatedOwner(owner);
+      await Promise.all(
+        [null, 'personal', 'org:a/b'].map(async (org, index) => {
+          const key = scopedDraftKey(context.contextScope(org), target);
+          const text = `${caller} draft ${index}`;
+          expect(await saveDraftConfirmed(userId, key, text, { isCurrent })).toBe('committed');
+          expect(await loadDraftResult(userId, key, isStringDraft, isCurrent)).toMatchObject({
+            status: 'present',
+            value: text,
+          });
+          expect(
+            await loadDraftResult('another-user', key, isStringDraft, isCurrent)
+          ).toMatchObject({ status: 'failed' });
+        })
+      );
+    }
+  );
+  it('does not interpret rejected I/O as an absent draft', async () => {
+    const { loadDraftResult } = await import('./drafts');
+    seedStoredValue('draft:u1', 'k', '"preserved"');
+    kvMock.getItem.mockRejectedValueOnce(new Error('I/O unavailable'));
+    expect(await loadDraftResult('u1', 'k', isStringDraft)).toMatchObject({ status: 'failed' });
+    expect(kvStore.get(storageKey('draft:u1', 'k'))?.v).toBe('"preserved"');
+  });
+  it.each([
+    ['{broken', 'json'],
+    ['42', 'shape'],
+  ])('keeps malformed %s distinct from absence', async (raw, reason) => {
+    const { loadDraftResult } = await import('./drafts');
+    seedStoredValue('draft:u1', 'k', raw);
+    expect(await loadDraftResult('u1', 'k', isStringDraft)).toEqual({
+      status: 'malformed',
+      reason,
+    });
+    expect(kvStore.get(storageKey('draft:u1', 'k'))?.v).toBe(raw);
+  });
+  it('does not publish a draft read after a direct account replacement', async () => {
+    const context = await import('@/lib/context-scope');
+    const { loadDraftResult } = await import('./drafts');
+    const gate = Promise.withResolvers<string | null>();
+    kvMock.getItem.mockReturnValueOnce(gate.promise);
+    const read = loadDraftResult('u1', 'k', isStringDraft);
+    context.beginAuthenticatedOwner();
+    context.confirmAuthenticatedOwner(context.getAuthenticatedOwner(), 'u2');
+    gate.resolve('"private u1"');
+    expect(await read).toMatchObject({ status: 'failed' });
+  });
+  it('cannot write a tagged key from an unproved prefilled/raw save', async () => {
+    const context = await import('@/lib/context-scope');
+    const { scopedDraftKey } = await import('./scoped-draft-keys');
+    const key = scopedDraftKey(context.contextScope(null), { kind: 'new-session' });
+    seedStoredValue('draft:u1', key, '"saved"');
+    saveDraft('u1', key, 'prefill');
+    await flushDraft('u1', key);
+    expect(await clearDraft('u1', key)).toBe(false);
+    expect(kvStore.get(storageKey('draft:u1', key))?.v).toBe('"saved"');
+  });
+  it('does not alias pending keys through NUL delimiters in arbitrary user IDs', async () => {
+    saveDraft('a', 'b\u0000c', 'first');
+    saveDraft('a\u0000b', 'c', 'second');
+    await Promise.all([flushDraft('a', 'b\u0000c'), flushDraft('a\u0000b', 'c')]);
+    expect(kvStore.get(storageKey('draft:a', 'b\u0000c'))?.v).toBe('"first"');
+    expect(kvStore.get(storageKey('draft:a\u0000b', 'c'))?.v).toBe('"second"');
   });
 });

--- a/apps/mobile/src/lib/persist/drafts.ts
+++ b/apps/mobile/src/lib/persist/drafts.ts
@@ -1,205 +1,68 @@
 import * as Sentry from '@sentry/react-native';
-import * as z from 'zod';
-import { currentAuthEpoch, isCurrentAuthEpoch } from '@/lib/auth/auth-epoch';
+import {
+  captureAccountGeneration,
+  getAuthenticatedOwner,
+  isAuthenticatedOwner,
+} from '@/lib/context-scope';
 import { chainSave } from '@/lib/hooks/save-chain';
-import { utf8ByteLength } from '@/lib/utf8-utils';
+import { parseStoredDraft, serializeStoredDraft } from '@/lib/storage-keys';
 import * as encryptedKv from '@/lib/persist/encrypted-kv';
 
-/**
- * Durable high-intent drafts over the encrypted SQLCipher KV store (DEC-01).
- *
- * One entry per `entityKey` under scope `draft:<userId>`, so a draft is
- * account-scoped and survives sign-out by design (user work is not
- * refetchable; cache rows are deleted on sign-out, drafts are not).
- *
- * Writes are debounced 500 ms per full storage key (`draft:<userId>` +
- * entityKey): every pending timer closes over its own userId, entityKey, and
- * value, so switching entity keys or accounts in the same epoch never
- * retargets an older timer — the old key receives only its own write. Each
- * write is epoch-fenced and serialized per full key via `chainSave`; values
- * over 64 KB are skipped (never written partially); a scope holds at most
- * 100 entries, evicting the oldest `updated_at` above the cap.
- *
- * A corrupt or unreadable stored value loads as null (start empty) and is
- * reported to Sentry with no toast: there is no user action that re-reads a
- * draft, so the failure is structurally non-retryable and the composer is
- * already usable empty. Callers pass a shape validator, so a valid-JSON value
- * that does not match its contract (e.g. a number where composer text is
- * expected) is treated as corrupt and discarded the same way.
- *
- * Every asynchronous write (debounced timer, flush, clear) is caught at this
- * boundary: a storage failure is reported to Sentry and swallowed, so the
- * fire-and-forget `void` call sites can never leak an unhandled rejection.
- *
- * Serialization is contained before any timer exists: a value that cannot be
- * JSON-serialized (a circular reference, or a top-level undefined) is
- * reported to Sentry and skipped without scheduling a write.
- */
-
+/** Durable drafts retain their JSON values and draft:<userId> scopes across sign-out. */
 export const DRAFT_DEBOUNCE_MS = 500;
 export const DRAFT_MAX_BYTES = 64 * 1024;
 export const DRAFT_MAX_ENTRIES = 100;
-
-const DRAFT_SCOPE_PREFIX = 'draft:';
-
-/** One user's draft scope. Entity keys live as KV items under this scope. */
+export const SCOPED_DRAFT_KEY_PREFIX = 'context-draft:v1:';
 export function draftScope(userId: string): string {
-  return `${DRAFT_SCOPE_PREFIX}${userId}`;
+  return `draft:${userId}`;
 }
 
-const stringDraftSchema = z.string();
-
-/** Runtime shape guard for a composer text draft (a JSON string). */
-export function isStringDraft(value: unknown): value is string {
-  return stringDraftSchema.safeParse(value).success;
-}
-
-/** Shape validator for one loaded draft value, supplied by the caller. */
+// Compatibility path: unchanged callers retain these exports and nullable reads. New consumers use
+// scoped-draft-keys/useScopedDraftLoad. Remove legacy forms only after a6 and explicit recovery finish.
+export {
+  agentComposerDraftKey,
+  isStringDraft,
+  isMergeDraft,
+  isSharePayloadsDraft,
+  isShareNavigationDraft,
+  NEW_SESSION_DRAFT_KEY,
+  SHARE_PAYLOADS_DRAFT_KEY,
+  SHARE_NAV_DRAFT_KEY,
+  PENDING_SHARE_ID_DRAFT_KEY,
+  SESSION_SEARCH_DRAFT_KEY,
+  prReviewDraftKey,
+  prMergeDraftKey,
+  prReplyDraftKey,
+  prCommentDraftKey,
+  securityDismissDraftKey,
+  resolvePrefillOverDraft,
+  type SharePayloadsDraft,
+  type ShareNavigationDraft,
+} from '@/lib/storage-keys';
 export type DraftShapeValidator<T> = (value: unknown) => value is T;
-
-/** Session composer draft entity key. */
-export function agentComposerDraftKey(sessionId: string): string {
-  return `agent-composer:${sessionId}`;
-}
-
-/** New-session prompt draft entity key. */
-export const NEW_SESSION_DRAFT_KEY = 'agent-composer:new';
-
-/** Durable pending share-intent payloads (map + insertion order) entity key. */
-export const SHARE_PAYLOADS_DRAFT_KEY = 'share-payloads';
-
-/** Durable pending share-navigation queue entity key. */
-export const SHARE_NAV_DRAFT_KEY = 'share-navigation';
-
-/** Durable pending (not-yet-delivered) share id entity key. */
-export const PENDING_SHARE_ID_DRAFT_KEY = 'pending-share-id';
-
-/** Agents session-list search query draft entity key. */
-export const SESSION_SEARCH_DRAFT_KEY = 'session-search-query';
-
-/** Pending-review draft entity key, unique per pull request. */
-export function prReviewDraftKey(owner: string, repo: string, number: number): string {
-  return `pr-review:${owner}/${repo}#${number}`;
-}
-
-/** Merge-sheet draft entity key, unique per pull request. */
-export function prMergeDraftKey(owner: string, repo: string, number: number): string {
-  return `pr-merge:${owner}/${repo}#${number}`;
-}
-
-/** Reply draft entity key, unique per review comment thread. */
-// eslint-disable-next-line eslint/max-params -- the key encodes owner, repo, number, and comment id
-export function prReplyDraftKey(
-  owner: string,
-  repo: string,
-  number: number,
-  commentId: number
-): string {
-  return `pr-reply:${owner}/${repo}#${number}:${commentId}`;
-}
-
-/** Inline review-comment draft entity key, unique per diff position. */
-// eslint-disable-next-line eslint/max-params -- the key encodes the full diff position
-export function prCommentDraftKey(
-  owner: string,
-  repo: string,
-  number: number,
-  path: string,
-  side: string,
-  line: number,
-  startLine?: number
-): string {
-  return `pr-comment:${owner}/${repo}#${number}:${path}:${side}:${startLine ?? line}-${line}`;
-}
-
-const mergeDraftSchema = z.object({
-  title: z.string(),
-  message: z.string(),
-});
-
-/** Runtime shape guard for a merge-sheet draft ({ title, message }). */
-export function isMergeDraft(value: unknown): value is { title: string; message: string } {
-  return mergeDraftSchema.safeParse(value).success;
-}
-
-const sharePayloadsDraftSchema = z.object({
-  order: z.array(z.string()),
-  entries: z.record(
-    z.string(),
-    z.object({
-      text: z.string(),
-      files: z.array(z.object({ name: z.string(), uri: z.string() })),
-      failedFiles: z.array(z.string()),
-    })
-  ),
-});
-
-/** Shape of the persisted share payloads map (order + per-id entries). */
-export type SharePayloadsDraft = z.infer<typeof sharePayloadsDraftSchema>;
-
-/** Runtime shape guard for a persisted share payloads map. */
-export function isSharePayloadsDraft(value: unknown): value is SharePayloadsDraft {
-  return sharePayloadsDraftSchema.safeParse(value).success;
-}
-
-const shareNavigationDraftSchema = z.array(
-  z.object({ href: z.string(), shareId: z.string().nullable() })
-);
-
-/** Shape of the persisted share navigation queue. */
-export type ShareNavigationDraft = z.infer<typeof shareNavigationDraftSchema>;
-
-/** Runtime shape guard for a persisted share navigation queue. */
-export function isShareNavigationDraft(value: unknown): value is ShareNavigationDraft {
-  return shareNavigationDraftSchema.safeParse(value).success;
-}
-
-/** Security dismiss draft entity key, unique per scope and finding. */
-export function securityDismissDraftKey(scope: string, findingId: string): string {
-  return `security-dismiss:${scope}:${findingId}`;
-}
-
-/**
- * New-session initial-prompt precedence: a non-empty share prefill always
- * beats a stored draft (the share payload is the user's explicit current
- * intent); an empty or absent prefill falls back to the stored draft. The
- * caller resolves both before mounting the input, so a draft never renders
- * first and gets replaced by a late prefill.
- */
-export function resolvePrefillOverDraft(
-  prefillText: string | null | undefined,
-  draftText: string | null | undefined
-): string | undefined {
-  if (prefillText !== undefined && prefillText !== null && prefillText.trim().length > 0) {
-    return prefillText;
-  }
-  return draftText ?? undefined;
-}
-
-/** The epoch-fenced write payload for one draft write. */
-type DraftWritePayload = {
-  epoch: number;
+export type DraftLoadResult<T> =
+  | ReturnType<typeof parseStoredDraft<T>>
+  | Readonly<{ status: 'absent' }>
+  | Readonly<{ status: 'failed'; error: unknown }>;
+export type DraftWriteResult = 'committed' | 'failed' | 'stale' | 'conflict';
+export type DraftWriteOptions = { isCurrent?: () => boolean; expectedSerialized?: string | null };
+type DraftWritePayload = DraftWriteOptions & {
+  generationFence: () => boolean;
   userId: string;
   entityKey: string;
   serialized: string;
 };
-
-type PendingSave = {
-  timer: ReturnType<typeof setTimeout>;
-  epoch: number;
-  serialized: string;
-};
-
-// One pending debounced write per full storage key. The timer, epoch, and
-// value are captured together under the full key, so a later save for a
-// different key (or a different account with the same entity key) can never
-// retarget it.
+type PendingSave = DraftWritePayload & { timer: ReturnType<typeof setTimeout> };
 const pendingSaves = new Map<string, PendingSave>();
-
 function fullKey(userId: string, entityKey: string): string {
-  return `${draftScope(userId)}\u0000${entityKey}`;
+  return JSON.stringify([draftScope(userId), entityKey]);
 }
-
+function takePending(key: string): PendingSave | undefined {
+  const pending = pendingSaves.get(key);
+  clearTimeout(pending?.timer);
+  pendingSaves.delete(key);
+  return pending;
+}
 function reportDraftFailure(
   error: unknown,
   operation: 'read' | 'write' | 'clear',
@@ -211,232 +74,240 @@ function reportDraftFailure(
     ...(fingerprint ? { fingerprint: [fingerprint] } : {}),
   });
 }
+function canWrite(userId: string, entityKey: string, isCurrent?: () => boolean): boolean {
+  const owner = getAuthenticatedOwner();
+  return (
+    Boolean(userId) &&
+    (!isCurrent || isCurrent()) &&
+    (!entityKey.startsWith(SCOPED_DRAFT_KEY_PREFIX) ||
+      (Boolean(isCurrent) && isAuthenticatedOwner(owner) && owner.userId === userId))
+  );
+}
 
-/**
- * Loads one draft. Returns the parsed JSON value, or null when the key is
- * absent, the value is corrupt/unreadable, the value exceeds the 64 KB cap,
- * or the parsed value fails the caller's shape validator — all but the absent
- * case load as empty and report corruption to Sentry. The value shape is the
- * caller's contract: composer text stores a JSON string, and pending-review
- * stores a JSON `PendingReviewItem[]`.
- */
+/** A rejected read never proves absence. New tagged reads also require authoritative owner proof. */
+// eslint-disable-next-line max-params -- the optional fence preserves the legacy read API
+export async function loadDraftResult<T>(
+  userId: string,
+  entityKey: string,
+  isValid: DraftShapeValidator<T>,
+  isCurrent?: () => boolean
+): Promise<DraftLoadResult<T>> {
+  const generationFence = captureAccountGeneration();
+  const owner = getAuthenticatedOwner();
+  const allowed = () =>
+    Boolean(userId) &&
+    generationFence() &&
+    (!isCurrent || isCurrent()) &&
+    (!entityKey.startsWith(SCOPED_DRAFT_KEY_PREFIX) ||
+      (isAuthenticatedOwner(owner) && owner.userId === userId));
+  if (!allowed()) {
+    return { status: 'failed', error: new Error('Draft owner is unresolved') };
+  }
+  let raw: string | null = null;
+  try {
+    raw = await encryptedKv.getItem(draftScope(userId), entityKey);
+  } catch (error) {
+    reportDraftFailure(error, 'read');
+    return { status: 'failed', error };
+  }
+  if (!allowed()) {
+    return { status: 'failed', error: new Error('Draft owner changed') };
+  }
+  if (raw === null) {
+    return { status: 'absent' };
+  }
+  const parsed = parseStoredDraft(raw, isValid, DRAFT_MAX_BYTES);
+  if (parsed.status === 'malformed') {
+    const fingerprints = {
+      size: 'draft-read-size-limit',
+      shape: 'draft-read-shape-mismatch',
+      json: undefined,
+    };
+    reportDraftFailure(new Error('Malformed draft'), 'read', fingerprints[parsed.reason]);
+  }
+  return parsed;
+}
 export async function loadDraft<T>(
   userId: string,
   entityKey: string,
   isValid: DraftShapeValidator<T>
 ): Promise<T | null> {
-  if (!userId) {
-    return null;
-  }
-  try {
-    const raw = await encryptedKv.getItem(draftScope(userId), entityKey);
-    if (raw === null) {
-      return null;
-    }
-    if (utf8ByteLength(raw) > DRAFT_MAX_BYTES) {
-      reportDraftFailure(
-        new Error('stored draft exceeds the 64 KB cap'),
-        'read',
-        'draft-read-size-limit'
-      );
-      return null;
-    }
-    const parsed: unknown = JSON.parse(raw);
-    if (!isValid(parsed)) {
-      reportDraftFailure(
-        new Error('stored draft does not match its expected shape'),
-        'read',
-        'draft-read-shape-mismatch'
-      );
-      return null;
-    }
-    return parsed;
-  } catch (error) {
-    reportDraftFailure(error, 'read');
-    return null;
-  }
+  const result = await loadDraftResult(userId, entityKey, isValid);
+  return result.status === 'present' ? result.value : null;
 }
-
-async function writeDraft({
-  epoch,
-  userId,
-  entityKey,
-  serialized,
-}: DraftWritePayload): Promise<void> {
-  const key = fullKey(userId, entityKey);
-  await chainSave(key, async () => {
-    // The authoritative fence lives inside the chained run: a write queued
-    // before a sign-out/sign-in must never land after the epoch moved.
-    if (!isCurrentAuthEpoch(epoch)) {
-      return;
-    }
-    await encryptedKv.setItem(draftScope(userId), entityKey, serialized);
-    await evictOldestBeyondCap(draftScope(userId));
+function serializeDraft(value: unknown): string | null {
+  return serializeStoredDraft(value, DRAFT_MAX_BYTES, (failure, fingerprint) => {
+    reportDraftFailure(failure, 'write', fingerprint);
   });
 }
-
-/**
- * Runs a draft write and contains every failure at this boundary: the error
- * is reported to Sentry and swallowed, so the debounced timer and the
- * fire-and-forget flush/clear call sites can never leak an unhandled
- * rejection, and the composer stays usable (the previous stored value, if
- * any, is left untouched).
- */
-async function writeDraftSafely(payload: DraftWritePayload): Promise<void> {
-  try {
-    await writeDraft(payload);
-  } catch (error) {
-    reportDraftFailure(error, 'write');
-  }
-}
-
-async function evictOldestBeyondCap(scope: string): Promise<void> {
-  const entries = await encryptedKv.listEntries(scope);
-  if (entries.length <= DRAFT_MAX_ENTRIES) {
-    return;
-  }
-  // `listEntries` is oldest-first; remove the oldest entries down to the cap.
-  const overflow = entries.length - DRAFT_MAX_ENTRIES;
-  const oldest = entries.slice(0, overflow);
+async function evictOldestBeyondCap(
+  payload: DraftWritePayload,
+  isCurrent: () => boolean
+): Promise<void> {
+  const scope = draftScope(payload.userId);
+  const all = await encryptedKv.listEntries(scope);
+  // New writes preserve ambiguous legacy candidates. Only explicit migration can remove them.
+  const entries = payload.entityKey.startsWith(SCOPED_DRAFT_KEY_PREFIX)
+    ? all.filter(entry => entry.k.startsWith(SCOPED_DRAFT_KEY_PREFIX))
+    : all;
   await Promise.all(
-    oldest.map(async entry => {
-      await encryptedKv.removeItem(scope, entry.k);
+    entries.slice(0, Math.max(0, entries.length - DRAFT_MAX_ENTRIES)).map(async entry => {
+      await encryptedKv.removeItem(scope, entry.k, isCurrent);
     })
   );
 }
-
-/**
- * Schedules a debounced save of one JSON-serializable draft value, keyed on
- * the full storage key. Values over 64 KB are skipped (never written
- * partially; a previously stored draft stays untouched). Unserializable
- * values (circular references, top-level undefined) are reported to Sentry
- * and skipped. Returns nothing — the write is fire-and-forget; use
- * {@link flushDraft} to force it.
- */
-export function saveDraft(userId: string, entityKey: string, value: unknown): void {
-  if (!userId) {
-    return;
-  }
+async function writeDraftSafely(payload: DraftWritePayload): Promise<DraftWriteResult> {
+  const { userId, entityKey, serialized, expectedSerialized } = payload;
+  const isCurrent = () =>
+    payload.generationFence() && canWrite(userId, entityKey, payload.isCurrent);
   try {
-    // JSON.stringify produces no string for a top-level undefined, function,
-    // or symbol; reject those before the byte-cap check, which needs a string.
-    const serialized = JSON.stringify(value) as string | undefined;
-    if (serialized === undefined) {
-      reportDraftFailure(
-        new Error('draft value cannot be serialized to JSON'),
-        'write',
-        'draft-write-unsupported-value'
-      );
-      return;
-    }
-    if (utf8ByteLength(serialized) > DRAFT_MAX_BYTES) {
-      return;
-    }
-    const key = fullKey(userId, entityKey);
-    const previous = pendingSaves.get(key);
-    if (previous) {
-      clearTimeout(previous.timer);
-    }
-    const epoch = currentAuthEpoch();
-    const timer = setTimeout(() => {
-      pendingSaves.delete(key);
-      void writeDraftSafely({ epoch, userId, entityKey, serialized });
-    }, DRAFT_DEBOUNCE_MS);
-    pendingSaves.set(key, { timer, epoch, serialized });
-  } catch (error) {
-    // Serialization and byte sizing run before any timer exists; contain
-    // every failure here so saveDraft never throws synchronously.
-    reportDraftFailure(error, 'write');
-  }
-}
-
-/**
- * Forces the pending debounced write for the full key to run now (AppState
- * background, unmount, and tests). A no-op when no write is pending. Write
- * failures are reported to Sentry and swallowed, so callers can invoke it
- * fire-and-forget.
- */
-export async function flushDraft(userId: string, entityKey: string): Promise<void> {
-  if (!userId) {
-    return;
-  }
-  const key = fullKey(userId, entityKey);
-  const pending = pendingSaves.get(key);
-  if (!pending) {
-    return;
-  }
-  clearTimeout(pending.timer);
-  pendingSaves.delete(key);
-  await writeDraftSafely({ ...pending, userId, entityKey });
-}
-
-/**
- * Cancels the key's pending debounced write and removes the stored entry.
- * Serialized behind any in-flight write for the same key, so a clear can
- * never race a queued save back into existence. Not epoch-fenced: clearing
- * is explicit user intent and must work regardless of auth transitions.
- * Remove failures are reported to Sentry and swallowed, but the returned
- * boolean tells the caller whether the entry was actually removed, so a
- * discard flow can stay on the screen when the clear fails.
- */
-export async function clearDraft(userId: string, entityKey: string): Promise<boolean> {
-  if (!userId) {
-    return true;
-  }
-  const key = fullKey(userId, entityKey);
-  const pending = pendingSaves.get(key);
-  if (pending) {
-    clearTimeout(pending.timer);
-    pendingSaves.delete(key);
-  }
-  try {
-    await chainSave(key, async () => {
-      await encryptedKv.removeItem(draftScope(userId), entityKey);
+    return await chainSave<DraftWriteResult>(fullKey(userId, entityKey), async () => {
+      if (!isCurrent()) {
+        return 'stale';
+      }
+      if (expectedSerialized !== undefined) {
+        const current = await encryptedKv.getItem(draftScope(userId), entityKey);
+        if (!isCurrent()) {
+          return 'stale';
+        }
+        if (current !== expectedSerialized || pendingSaves.has(fullKey(userId, entityKey))) {
+          return 'conflict';
+        }
+      }
+      await encryptedKv.setItem(draftScope(userId), entityKey, serialized, isCurrent);
+      if (!isCurrent()) {
+        return 'stale';
+      }
+      await evictOldestBeyondCap(payload, isCurrent);
+      return isCurrent() ? 'committed' : 'stale';
     });
+  } catch (error) {
+    reportDraftFailure(error, 'write');
+    return 'failed';
+  }
+}
+/** Immediate confirmed persistence. Migration cannot infer a commit from saveDraft or flushDraft. */
+// eslint-disable-next-line max-params -- retain user/key/value positions from saveDraft
+export async function saveDraftConfirmed(
+  userId: string,
+  entityKey: string,
+  value: unknown,
+  options: DraftWriteOptions = {}
+): Promise<DraftWriteResult> {
+  if (!canWrite(userId, entityKey, options.isCurrent)) {
+    return 'stale';
+  }
+  const serialized = serializeDraft(value);
+  if (serialized === null) {
+    return 'failed';
+  }
+  const result = await writeDraftSafely({
+    ...options,
+    generationFence: captureAccountGeneration(),
+    userId,
+    entityKey,
+    serialized,
+  });
+  return result;
+}
+// eslint-disable-next-line max-params -- scoped callers add their restored hook's fence without changing legacy producers
+export function saveDraft(
+  userId: string,
+  entityKey: string,
+  value: unknown,
+  isCurrent?: () => boolean
+): void {
+  if (!canWrite(userId, entityKey, isCurrent)) {
+    return;
+  }
+  const serialized = serializeDraft(value);
+  if (serialized === null) {
+    return;
+  }
+  const key = fullKey(userId, entityKey);
+  takePending(key);
+  const payload = {
+    generationFence: captureAccountGeneration(),
+    userId,
+    entityKey,
+    serialized,
+    isCurrent,
+  };
+  const timer = setTimeout(() => {
+    pendingSaves.delete(key);
+    void writeDraftSafely(payload);
+  }, DRAFT_DEBOUNCE_MS);
+  pendingSaves.set(key, { ...payload, timer });
+}
+export async function flushDraft(
+  userId: string,
+  entityKey: string,
+  isCurrent?: () => boolean
+): Promise<void> {
+  if (!canWrite(userId, entityKey, isCurrent)) {
+    return;
+  }
+  const key = fullKey(userId, entityKey);
+  const pending = takePending(key);
+  if (pending) {
+    await writeDraftSafely(pending);
+  }
+}
+export async function clearDraft(
+  userId: string,
+  entityKey: string,
+  isCurrent?: () => boolean
+): Promise<boolean> {
+  if (!userId) {
     return true;
+  }
+  if (!canWrite(userId, entityKey, isCurrent)) {
+    return false;
+  }
+  const key = fullKey(userId, entityKey);
+  takePending(key);
+  const generationFence = captureAccountGeneration();
+  const allowed = () => generationFence() && canWrite(userId, entityKey, isCurrent);
+  try {
+    return await chainSave(key, async () => {
+      if (!allowed()) {
+        return false;
+      }
+      await encryptedKv.removeItem(draftScope(userId), entityKey, allowed);
+      return allowed();
+    });
   } catch (error) {
     reportDraftFailure(error, 'clear');
     return false;
   }
 }
-
-/**
- * Conditionally removes a draft entry only when its settled persisted value
- * still equals `expectedSerialized` (the exact stored raw string). Unlike
- * `clearDraft`, this never cancels a pending debounced write, and the compare
- * runs inside the serialized chain, so it sees the final value after any
- * in-flight write settles. A newer value therefore always wins: a clear that
- * is registered after a newer write sees the newer value and skips, and a
- * clear registered before leaves the newer write intact. Remove failures are
- * reported to Sentry and swallowed. Used by the pending share id, where
- * clearing an older id must never delete a just-written id.
- */
+/** Compare settled source bytes before cleanup. A newer edit, owner, or generation wins. */
+// eslint-disable-next-line max-params -- the optional migration fence preserves pending-share callers
 export async function clearDraftIfStill(
   userId: string,
   entityKey: string,
-  expectedSerialized: string
+  expectedSerialized: string,
+  isCurrent?: () => boolean
 ): Promise<void> {
-  if (!userId) {
-    return;
-  }
+  const generationFence = captureAccountGeneration();
+  const allowed = () => generationFence() && canWrite(userId, entityKey, isCurrent);
   const key = fullKey(userId, entityKey);
   try {
     await chainSave(key, async () => {
+      if (!allowed()) {
+        return;
+      }
       const current = await encryptedKv.getItem(draftScope(userId), entityKey);
-      if (current === expectedSerialized) {
-        await encryptedKv.removeItem(draftScope(userId), entityKey);
+      if (allowed() && current === expectedSerialized && !pendingSaves.has(key)) {
+        await encryptedKv.removeItem(draftScope(userId), entityKey, allowed);
       }
     });
   } catch (error) {
     reportDraftFailure(error, 'clear');
   }
 }
-
-// Test-only: cancels every pending debounced timer so a test never leaks a
-// fire into a later case (the same pattern as `resetEncryptedKvOpenForTests`).
 export function resetDraftTimersForTests(): void {
-  for (const pending of pendingSaves.values()) {
-    clearTimeout(pending.timer);
+  for (const key of pendingSaves.keys()) {
+    takePending(key);
   }
-  pendingSaves.clear();
 }

--- a/apps/mobile/src/lib/persist/encrypted-kv.test.ts
+++ b/apps/mobile/src/lib/persist/encrypted-kv.test.ts
@@ -348,93 +348,137 @@ describe('single-flight open contract', () => {
   });
 });
 
-describe('open failure recovery', () => {
+describe('nondestructive open recovery', () => {
+  it.each(['SQLITE_IOERR', 'disk I/O error', 'database is locked', 'unable to open database file'])(
+    'classifies temporary native failure %s as retryable',
+    async message => {
+      const { encryptedStoreRecovery } = await import('./encrypted-kv');
+      expect(encryptedStoreRecovery(new Error(message))).toEqual({
+        status: 'retryable',
+        reason: 'io',
+        guidance: 'retry',
+      });
+    }
+  );
   it.each([
     {
       seam: 'probe',
-      failOnce: () => {
+      fail: () => {
         failNextProbe = true;
       },
+      reason: 'corrupt-database',
     },
     {
       seam: 'PRAGMA key',
-      failOnce: () => {
+      fail: () => {
         failNextPragma = true;
       },
+      reason: 'unknown',
     },
-  ])(
-    'a failing $seam deletes, regenerates the key, reopens, and reports the reset to Sentry',
-    async ({ failOnce }) => {
-      failOnce();
-      await setItem('s', 'a', 'x');
+  ])('protects a failing $seam until explicit Retry', async ({ fail, reason }) => {
+    store.set(PERSIST_DB_KEY, 'a'.repeat(64));
+    fail();
+    await expect(setItem('s', 'a', 'x')).rejects.toThrow(reason);
+    await expect(getItem('s', 'a')).rejects.toThrow(reason);
+    expect(store.get(PERSIST_DB_KEY)).toBe('a'.repeat(64));
+    expect(SQLite.deleteDatabaseAsync).not.toHaveBeenCalled();
+    expect(Crypto.getRandomBytesAsync).not.toHaveBeenCalled();
+    expect(SQLite.openDatabaseSync).toHaveBeenCalledTimes(1);
+    const { retryEncryptedKvOpen } = await import('./encrypted-kv');
+    await Promise.all([retryEncryptedKvOpen(), retryEncryptedKvOpen(), retryEncryptedKvOpen()]);
+    await setItem('s', 'a', 'x');
+    await expect(getItem('s', 'a')).resolves.toBe('x');
+    expect(SQLite.openDatabaseSync).toHaveBeenCalledTimes(2);
+    expect(closeCallCount).toBe(1);
+    expect(store.get(PERSIST_DB_KEY)).toBe('a'.repeat(64));
+  });
 
-      // Only the first handle was closed; the recovery-opened one stays open.
-      expect(closeCallCount).toBe(1);
-      expect(SQLite.deleteDatabaseAsync).toHaveBeenCalledWith('kilo-persist.db');
-      // A fresh key was generated and stored over the old one.
-      expect(Crypto.getRandomBytesAsync).toHaveBeenCalledTimes(2);
-      expect(store.get(PERSIST_DB_KEY)).toMatch(/^02[0-9a-f]{62}$/);
-      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
-      expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error), {
-        level: 'warning',
-        tags: { 'error.subsystem': 'encrypted-kv', 'error.operation': 'reset' },
+  it('does not replace a pending memo when concurrent Retry arrives', async () => {
+    const secureStore = await import('expo-secure-store');
+    const gate = Promise.withResolvers<string | null>();
+    vi.mocked(secureStore.getItemAsync).mockReturnValueOnce(gate.promise);
+    const { retryEncryptedKvOpen } = await import('./encrypted-kv');
+    const first = getItem('s', 'k');
+    const retry = retryEncryptedKvOpen();
+    gate.resolve('b'.repeat(64));
+    await Promise.all([first, retry]);
+    await retryEncryptedKvOpen();
+    await setItem('s', 'k', 'retained');
+    await expect(getItem('s', 'k')).resolves.toBe('retained');
+    expect(SQLite.openDatabaseSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries temporary SecureStore failures without regenerating the stored key', async () => {
+    const secureStore = await import('expo-secure-store');
+    const { retryEncryptedKvOpen, encryptedStoreRecovery } = await import('./encrypted-kv');
+    store.set(PERSIST_DB_KEY, 'c'.repeat(64));
+    vi.mocked(secureStore.getItemAsync).mockRejectedValueOnce(new Error('temporarily locked'));
+    try {
+      await getItem('s', 'k');
+      throw new Error('The read must reject');
+    } catch (error) {
+      expect(encryptedStoreRecovery(error)).toEqual({
+        status: 'retryable',
+        reason: 'secure-store',
+        guidance: 'retry',
       });
-
-      // The store works on the recovered database.
-      await expect(getItem('s', 'a')).resolves.toBe('x');
     }
-  );
+    await expect(getItem('s', 'k')).rejects.toThrow('secure-store');
+    expect(SQLite.openDatabaseSync).not.toHaveBeenCalled();
+    await Promise.all([retryEncryptedKvOpen(), retryEncryptedKvOpen()]);
+    await setItem('s', 'k', 'restored');
+    await expect(getItem('s', 'k')).resolves.toBe('restored');
+    expect(store.get(PERSIST_DB_KEY)).toBe('c'.repeat(64));
+    expect(Crypto.getRandomBytesAsync).not.toHaveBeenCalled();
+    expect(SQLite.deleteDatabaseAsync).not.toHaveBeenCalled();
+  });
 
-  // Every recovery failure reports once, whichever seam fails: the open memo
-  // makes one failure reject every later caller, so silence would hide a
-  // persistence outage that lasts the rest of the install.
-  it.each([
-    {
-      seam: 'probe',
-      failAlways: () => {
-        failNextProbe = true;
-        failEveryProbe = true;
-      },
-      recover: () => {
-        failEveryProbe = false;
-      },
-      sentryReports: 1,
-    },
-    {
-      seam: 'PRAGMA key',
-      failAlways: () => {
-        failEveryPragma = true;
-      },
-      recover: () => {
-        failEveryPragma = false;
-      },
-      sentryReports: 1,
-    },
-  ])(
-    'a $seam that fails on recovery too closes both handles and rejects every later caller',
-    async ({ failAlways, recover, sentryReports }) => {
-      failAlways();
-      await expect(setItem('s', 'a', 'x')).rejects.toThrow();
+  it('retains the first generated key when its SecureStore write temporarily fails', async () => {
+    const secureStore = await import('expo-secure-store');
+    const { retryEncryptedKvOpen } = await import('./encrypted-kv');
+    vi.mocked(secureStore.setItemAsync).mockRejectedValueOnce(new Error('temporary write failure'));
+    await expect(getItem('s', 'k')).rejects.toThrow('secure-store');
+    await retryEncryptedKvOpen();
+    await setItem('s', 'k', 'value');
+    await expect(getItem('s', 'k')).resolves.toBe('value');
+    expect(Crypto.getRandomBytesAsync).toHaveBeenCalledTimes(1);
+    expect(store.get(PERSIST_DB_KEY)).toMatch(/^01[0-9a-f]{62}$/);
+  });
 
-      // Both the first handle and the recovery-opened handle were closed.
-      expect(closeCallCount).toBe(2);
-      expect(SQLite.deleteDatabaseAsync).toHaveBeenCalledTimes(1);
-      expect(Sentry.captureException).toHaveBeenCalledTimes(sentryReports);
-
-      // The failed open stays memoized: no second open, no second delete, no
-      // second Sentry report, however many callers arrive.
-      recover();
-      await expect(setItem('s', 'a', 'x')).rejects.toThrow();
-      await expect(getItem('s', 'a')).rejects.toThrow();
+  it.each(['corrupt', 'missing-sqlcipher'])(
+    'keeps terminal %s failures protected across explicit Retry',
+    async kind => {
+      store.set(PERSIST_DB_KEY, 'd'.repeat(64));
+      failEveryProbe = kind === 'corrupt';
+      hasSQLCipher = kind !== 'missing-sqlcipher';
+      const { retryEncryptedKvOpen } = await import('./encrypted-kv');
+      await expect(getItem('s', 'k')).rejects.toThrow();
+      await expect(retryEncryptedKvOpen()).rejects.toThrow();
+      await expect(getItem('s', 'k')).rejects.toThrow();
+      expect(store.get(PERSIST_DB_KEY)).toBe('d'.repeat(64));
       expect(SQLite.openDatabaseSync).toHaveBeenCalledTimes(2);
-      expect(SQLite.deleteDatabaseAsync).toHaveBeenCalledTimes(1);
-      expect(Sentry.captureException).toHaveBeenCalledTimes(sentryReports);
-
-      // A relaunch (a fresh module) opens cleanly again.
-      resetEncryptedKvOpenForTests();
-      await expect(setItem('s', 'a', 'x')).resolves.toBeUndefined();
+      expect(SQLite.deleteDatabaseAsync).not.toHaveBeenCalled();
+      expect(Crypto.getRandomBytesAsync).not.toHaveBeenCalled();
     }
   );
+
+  it('fences a deferred SQL write and cleanup after the owner changes during open', async () => {
+    const secureStore = await import('expo-secure-store');
+    const gate = Promise.withResolvers<string | null>();
+    vi.mocked(secureStore.getItemAsync).mockReturnValueOnce(gate.promise);
+    let current = true;
+    const write = setItem('draft:a', 'k', 'stale', () => current);
+    const cleanup = clearScope('draft:a', () => current);
+    current = false;
+    gate.resolve('e'.repeat(64));
+    await Promise.all([write, cleanup]);
+    await expect(getItem('draft:a', 'k')).resolves.toBeNull();
+    expect(
+      sqlLog.some(
+        source => source.startsWith('insert into "kv"') || source.startsWith('delete from "kv"')
+      )
+    ).toBe(false);
+  });
 });
 
 describe('database key validation', () => {
@@ -453,33 +497,35 @@ describe('database key validation', () => {
   });
 
   it.each([
+    { kind: 'empty', tamperedKey: '', forbidden: 'PRAGMA key' },
     { kind: 'non-hex', tamperedKey: 'tampered-key-not-hex', forbidden: "x'tampered-key-not-hex'" },
     { kind: 'non-lowercase hex', tamperedKey: 'A'.repeat(64), forbidden: 'AAAAAAAA' },
     { kind: 'wrong-length hex', tamperedKey: 'a'.repeat(32), forbidden: "x'a".repeat(32) },
-  ])(
-    'never interpolates a $kind key and recovers with a fresh key',
-    async ({ tamperedKey, forbidden }) => {
-      store.set(PERSIST_DB_KEY, tamperedKey);
-      await setItem('s', 'a', 'x');
-
-      // The tampered key never reached PRAGMA interpolation.
-      expect(sqlLog.some(sql => sql.includes(forbidden))).toBe(false);
-      // Recovery deleted the database, generated a fresh key, and reopened.
-      expect(SQLite.deleteDatabaseAsync).toHaveBeenCalledWith('kilo-persist.db');
-      expect(Crypto.getRandomBytesAsync).toHaveBeenCalledTimes(1);
-      const stored = store.get(PERSIST_DB_KEY);
-      expect(stored).toMatch(/^[0-9a-f]{64}$/);
-      expect(sqlLog).toContain(`PRAGMA key = "x'${stored}'"`);
-      // No handle was opened for the tampered key, so only the fresh one is open.
-      expect(closeCallCount).toBe(0);
-
-      // The store works on the recovered database.
-      await expect(getItem('s', 'a')).resolves.toBe('x');
-    }
-  );
+  ])('never interpolates or replaces a $kind key', async ({ tamperedKey, forbidden }) => {
+    store.set(PERSIST_DB_KEY, tamperedKey);
+    await expect(setItem('s', 'a', 'x')).rejects.toThrow('malformed-key');
+    const { retryEncryptedKvOpen } = await import('./encrypted-kv');
+    await expect(retryEncryptedKvOpen()).rejects.toThrow('malformed-key');
+    expect(sqlLog.some(sql => sql.includes(forbidden))).toBe(false);
+    expect(SQLite.deleteDatabaseAsync).not.toHaveBeenCalled();
+    expect(Crypto.getRandomBytesAsync).not.toHaveBeenCalled();
+    expect(store.get(PERSIST_DB_KEY)).toBe(tamperedKey);
+    expect(closeCallCount).toBe(0);
+  });
 });
 
 describe('kv behavior', () => {
+  it('cleans only literal user prefixes and numeric cache versions', async () => {
+    await setItem('cache:a_%:1', 'k', 'a');
+    await setItem('cache:a_%:2', 'k', 'a2');
+    await setItem('cache:aXX:1', 'k', 'wildcard collision');
+    await setItem('cache:a_%:nested:1', 'k', 'nested user');
+    await clearScopePrefix('cache:a_%:', undefined, true);
+    await expect(getItem('cache:a_%:1', 'k')).resolves.toBeNull();
+    await expect(getItem('cache:a_%:2', 'k')).resolves.toBeNull();
+    await expect(getItem('cache:aXX:1', 'k')).resolves.toBe('wildcard collision');
+    await expect(getItem('cache:a_%:nested:1', 'k')).resolves.toBe('nested user');
+  });
   it('stores and reads a value', async () => {
     await setItem('draft:u1', 'agent-composer:new', 'hello');
     await expect(getItem('draft:u1', 'agent-composer:new')).resolves.toBe('hello');

--- a/apps/mobile/src/lib/persist/encrypted-kv.ts
+++ b/apps/mobile/src/lib/persist/encrypted-kv.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/react-native';
-import { and, asc, eq, like, sql } from 'drizzle-orm';
+import { and, asc, eq, sql } from 'drizzle-orm';
 // The `drizzle-orm/expo-sqlite` barrel also pulls in `useLiveQuery`, which
 // imports expo-sqlite for change listeners this store never uses; the driver
 // subpath is the same `drizzle()` without that.
@@ -26,19 +26,16 @@ import { kv } from './schema';
  * wraps the *synchronous* handle, so the statements themselves block the JS
  * thread; the exported API stays async because opening and keying do not.
  *
- * Opening is single-flight: one module-level open promise, awaited by every
- * caller. A wrong key or a corrupt file fails the `sqlite_master` probe and
- * is recovered by closing, deleting the database, generating a fresh key,
- * and reopening — the loss is accepted (cache and drafts are recoverable
- * losses), startup is never blocked, and the reset is reported to Sentry.
+ * Opening is single-flight. A failed open stays memoized until explicit nondestructive Retry.
+ * Every failure preserves the database and stored key. Drafts are not recoverable cache data.
+ * Malformed keys, corrupt files, and missing SQLCipher require specific recovery guidance.
  */
 
 const DATABASE_NAME = 'kilo-persist.db';
 const KEY_BYTE_COUNT = 32;
 
 // SQLCipher key format: exactly 64 lowercase hex chars (32 bytes). A stored
-// key that does not match is treated as tampered: it must never reach PRAGMA
-// interpolation, and the open is routed into delete-and-recreate recovery.
+// key that does not match stays protected for explicit repair and never reaches PRAGMA interpolation.
 const DB_KEY_PATTERN = /^[0-9a-f]{64}$/;
 
 /** True when `key` is exactly 64 lowercase hex characters (32 bytes). */
@@ -85,19 +82,35 @@ async function generateHexKey(): Promise<string> {
   return hex;
 }
 
+let pendingNewKey: string | null = null;
+
 async function readOrCreateKey(): Promise<string> {
-  const existing = await SecureStore.getItemAsync(PERSIST_DB_KEY);
-  if (existing) {
+  let existing: string | null = null;
+  try {
+    existing = await SecureStore.getItemAsync(PERSIST_DB_KEY);
+  } catch {
+    throw openFailure({
+      status: 'retryable',
+      reason: 'secure-store',
+      guidance: 'retry',
+    });
+  }
+  // Even an empty stored key is malformed, not evidence that the store is new.
+  if (existing !== null) {
     return existing;
   }
-  const key = await generateHexKey();
-  await SecureStore.setItemAsync(PERSIST_DB_KEY, key);
-  return key;
-}
-
-async function generateAndStoreKey(): Promise<string> {
-  const key = await generateHexKey();
-  await SecureStore.setItemAsync(PERSIST_DB_KEY, key);
+  pendingNewKey ??= await generateHexKey();
+  try {
+    await SecureStore.setItemAsync(PERSIST_DB_KEY, pendingNewKey);
+  } catch {
+    throw openFailure({
+      status: 'retryable',
+      reason: 'secure-store',
+      guidance: 'retry',
+    });
+  }
+  const key = pendingNewKey;
+  pendingNewKey = null;
   return key;
 }
 
@@ -133,15 +146,18 @@ async function closeQuietly(client: SQLite.SQLiteDatabase): Promise<void> {
   try {
     await client.closeAsync();
   } catch {
-    // Close is best-effort; the delete in the recovery path removes the file.
+    // Preserve the original failure and the durable file even when closing the handle fails.
   }
 }
 
 async function openWithKey(key: string): Promise<KVDatabase> {
   if (!isValidDbKey(key)) {
-    // A malformed or tampered key never reaches PRAGMA interpolation; the
-    // thrown error routes the open into delete-and-recreate recovery.
-    throw new TypeError('encrypted-kv: database key must be 64 lowercase hex characters');
+    // Preserve the file and key for explicit recovery. Never interpolate malformed key bytes.
+    throw openFailure({
+      status: 'protected',
+      reason: 'malformed-key',
+      guidance: 'restore-key',
+    });
   }
   // Connection setup, not a query, so it stays on the raw handle: SQLCipher
   // needs the key before the database header and the schema can be read, and
@@ -155,8 +171,7 @@ async function openWithKey(key: string): Promise<KVDatabase> {
     client.execSync(`PRAGMA key = "x'${key}'"`);
     return drizzle(client);
   } catch (error) {
-    // The PRAGMA failed after the handle opened. Close it before rethrowing
-    // so the delete-and-recreate recovery never runs with an open handle.
+    // Close the failed native handle without deleting the file or replacing its key.
     await closeQuietly(client);
     throw error;
   }
@@ -165,83 +180,112 @@ async function openWithKey(key: string): Promise<KVDatabase> {
 async function probeAndMigrate(db: KVDatabase): Promise<void> {
   // A wrong key or a corrupt file makes this throw (DEC-01 step 3).
   db.get(sql`SELECT count(*) FROM sqlite_master`);
-  // Drizzle owns the schema; a recreated (deleted) file has no
-  // `__drizzle_migrations` table, so the migrations run again on it.
+  // Drizzle applies missing migrations without resetting existing records.
   await migrate(db, migrations);
 }
 
+export type EncryptedStoreRecovery = Readonly<{
+  status: 'retryable' | 'protected';
+  reason:
+    | 'secure-store'
+    | 'io'
+    | 'malformed-key'
+    | 'corrupt-database'
+    | 'missing-sqlcipher'
+    | 'unknown';
+  guidance: 'retry' | 'restore-key' | 'repair-database' | 'rebuild' | 'retry-without-reset';
+}>;
+
+const openRecoveries = new WeakMap<Error, EncryptedStoreRecovery>();
+function openFailure(recovery: EncryptedStoreRecovery): Error {
+  const error = new Error(`Encrypted store open failed: ${recovery.reason}`);
+  openRecoveries.set(error, Object.freeze(recovery));
+  return error;
+}
+
+export function encryptedStoreRecovery(error: unknown): EncryptedStoreRecovery {
+  const known = error instanceof Error ? openRecoveries.get(error) : undefined;
+  if (known) {
+    return known;
+  }
+  if (error instanceof MissingSQLCipherError) {
+    return { status: 'protected', reason: 'missing-sqlcipher', guidance: 'rebuild' };
+  }
+  // Drizzle wraps native SQLite errors. Classify the native cause without logging its SQL text.
+  const native = error instanceof Error && error.cause instanceof Error ? error.cause : error;
+  const message = native instanceof Error ? native.message : '';
+  if (
+    /file is not a database|database disk image is malformed|SQLITE_(NOTADB|CORRUPT)/i.test(message)
+  ) {
+    return { status: 'protected', reason: 'corrupt-database', guidance: 'repair-database' };
+  }
+  if (
+    /SQLITE_(BUSY|LOCKED|IOERR|CANTOPEN)|disk I\/O error|database is (locked|busy)|unable to open database file/i.test(
+      message
+    )
+  ) {
+    return { status: 'retryable', reason: 'io', guidance: 'retry' };
+  }
+  return { status: 'protected', reason: 'unknown', guidance: 'retry-without-reset' };
+}
+
 async function openEncryptedDatabase(): Promise<KVDatabase> {
-  const key = await readOrCreateKey();
   let db: KVDatabase | undefined = undefined;
   try {
+    const key = await readOrCreateKey();
     db = await openWithKey(key);
     await probeAndMigrate(db);
     return db;
-  } catch (openError) {
-    if (openError instanceof MissingSQLCipherError) {
-      // Deleting and recreating cannot add SQLCipher to the build, and the
-      // existing file may hold the user's drafts. Fail loud, touch nothing.
-      Sentry.captureException(openError, {
-        level: 'error',
-        tags: { 'error.subsystem': 'encrypted-kv', 'error.operation': 'open' },
-        fingerprint: ['encrypted-kv-missing-sqlcipher'],
-      });
-      throw openError;
-    }
-    // Wrong key, corrupt file, or a tampered key: cache and drafts are
-    // recoverable losses. Close, delete the file, regenerate the key, and
-    // reopen (DEC-01 step 4).
+  } catch (error) {
     if (db) {
       await closeQuietly(db.$client);
     }
-    let reopened: KVDatabase | undefined = undefined;
-    try {
-      await SQLite.deleteDatabaseAsync(DATABASE_NAME);
-      const freshKey = await generateAndStoreKey();
-      reopened = await openWithKey(freshKey);
-      await probeAndMigrate(reopened);
-      Sentry.captureException(openError, {
-        level: 'warning',
-        tags: { 'error.subsystem': 'encrypted-kv', 'error.operation': 'reset' },
-      });
-      return reopened;
-    } catch (resetError) {
-      // The whole recovery is inside this try: a failed delete, key
-      // regeneration, or reopen must report too, because the open memo makes
-      // one failure reject every caller for the rest of the install.
-      // Close the reopened handle before rethrowing so a failed recovery
-      // cannot leak it; the delete above already removed the file.
-      if (reopened) {
-        await closeQuietly(reopened.$client);
-      }
-      Sentry.captureException(resetError, {
-        level: 'error',
-        tags: { 'error.subsystem': 'encrypted-kv', 'error.operation': 'reset' },
-      });
-      throw resetError;
-    }
+    const failure =
+      error instanceof MissingSQLCipherError ? error : openFailure(encryptedStoreRecovery(error));
+    // Never report native SQL text: a failing key pragma can contain the encryption key.
+    Sentry.captureException(failure, {
+      level: 'error',
+      tags: { 'error.subsystem': 'encrypted-kv', 'error.operation': 'open' },
+      ...(error instanceof MissingSQLCipherError
+        ? { fingerprint: ['encrypted-kv-missing-sqlcipher'] }
+        : {}),
+    });
+    throw failure;
   }
 }
 
-let openPromise: Promise<KVDatabase> | null = null;
+type OpenAttempt = { promise: Promise<KVDatabase>; failed: boolean };
+let openAttempt: OpenAttempt | null = null;
 
-// eslint-disable-next-line require-await, @typescript-eslint/require-await -- single-flight must memoize the open synchronously before any await; the awaits live inside the memoized open chain (same pattern as chainSave in save-chain.ts)
-async function openDatabase(): Promise<KVDatabase> {
-  // Single-flight: one module-level open promise, awaited by every caller.
-  // The memo is kept on failure too, so every later caller rejects with the
-  // same error instead of re-running the open. Retrying would delete the
-  // database, regenerate the key, and report to Sentry once per call — and
-  // the read cache calls on every query settle. Nothing an open failure hits
-  // is transient: a wrong key, a corrupt file, and a build without SQLCipher
-  // all need a relaunch or a rebuild.
-  openPromise ??= openEncryptedDatabase();
-  return openPromise;
+async function recordOpenFailure(attempt: OpenAttempt): Promise<void> {
+  try {
+    await attempt.promise;
+  } catch {
+    // Mutate only this settled attempt, never the memo for a newer attempt.
+    attempt.failed = true;
+  }
 }
 
-// Test-only: drops the memoized open so a test can force a fresh open
-// (the same pattern as `inFlightSaveCount` in save-chain.ts).
+// eslint-disable-next-line require-await, @typescript-eslint/require-await -- memoize before any caller can start a second open
+async function openDatabase(): Promise<KVDatabase> {
+  if (!openAttempt) {
+    openAttempt = { promise: openEncryptedDatabase(), failed: false };
+    void recordOpenFailure(openAttempt);
+  }
+  return openAttempt.promise;
+}
+
+/** Explicit, nondestructive Retry. Pending attempts coalesce; successful handles remain open. */
+export async function retryEncryptedKvOpen(): Promise<void> {
+  if (openAttempt?.failed) {
+    openAttempt = null;
+  }
+  await openDatabase();
+}
+
 export function resetEncryptedKvOpenForTests(): void {
-  openPromise = null;
+  openAttempt = null;
+  pendingNewKey = null;
 }
 
 /** Reads one value; returns null when the key is absent. */
@@ -256,11 +300,23 @@ export async function getItem(scope: string, k: string): Promise<string | null> 
   return row?.v ?? null;
 }
 
-/** Writes or overwrites one value, recording `Date.now()`. */
-export async function setItem(scope: string, k: string, v: string): Promise<void> {
+/** Check the captured owner again after the asynchronous open, immediately before the SQL write. */
+// eslint-disable-next-line max-params -- the optional owner fence preserves the KV API
+export async function setItem(
+  scope: string,
+  k: string,
+  v: string,
+  isCurrent?: () => boolean
+): Promise<void> {
   validateItemKey(scope, k);
   validateValue(v);
+  if (isCurrent && !isCurrent()) {
+    return;
+  }
   const db = await openDatabase();
+  if (isCurrent && !isCurrent()) {
+    return;
+  }
   const updatedAt = Date.now();
   db.insert(kv)
     .values({ scope, k, v, updatedAt })
@@ -268,28 +324,59 @@ export async function setItem(scope: string, k: string, v: string): Promise<void
     .run();
 }
 
-/** Removes one value; a missing key is not an error. */
-export async function removeItem(scope: string, k: string): Promise<void> {
+export async function removeItem(
+  scope: string,
+  k: string,
+  isCurrent?: () => boolean
+): Promise<void> {
   validateItemKey(scope, k);
+  if (isCurrent && !isCurrent()) {
+    return;
+  }
   const db = await openDatabase();
+  if (isCurrent && !isCurrent()) {
+    return;
+  }
   db.delete(kv)
     .where(and(eq(kv.scope, scope), eq(kv.k, k)))
     .run();
 }
 
-/** Removes every entry in exactly one scope. */
-export async function clearScope(scope: string): Promise<void> {
+export async function clearScope(scope: string, isCurrent?: () => boolean): Promise<void> {
   validateScope(scope);
+  if (isCurrent && !isCurrent()) {
+    return;
+  }
   const db = await openDatabase();
+  if (isCurrent && !isCurrent()) {
+    return;
+  }
   db.delete(kv).where(eq(kv.scope, scope)).run();
 }
 
-/** Removes every entry whose scope starts with `prefix` (SQL `LIKE prefix || '%'`). */
-export async function clearScopePrefix(prefix: string): Promise<void> {
+/** Match a literal prefix: arbitrary user IDs can contain SQL LIKE wildcards. */
+export async function clearScopePrefix(
+  prefix: string,
+  isCurrent?: () => boolean,
+  numericSuffixOnly = false
+): Promise<void> {
   validateScope(prefix);
+  if (isCurrent && !isCurrent()) {
+    return;
+  }
   const db = await openDatabase();
+  if (isCurrent && !isCurrent()) {
+    return;
+  }
+  // Version-only suffixes prevent user a's cleanup from matching user a:b's cache scopes.
+  const suffix = sql`substr(${kv.scope}, length(${prefix}) + 1)`;
   db.delete(kv)
-    .where(like(kv.scope, sql`${prefix} || '%'`))
+    .where(
+      and(
+        sql`substr(${kv.scope}, 1, length(${prefix})) = ${prefix}`,
+        numericSuffixOnly ? sql`length(${suffix}) > 0 AND ${suffix} NOT GLOB '*[^0-9]*'` : undefined
+      )
+    )
     .run();
 }
 

--- a/apps/mobile/src/lib/persist/read-cache.test.ts
+++ b/apps/mobile/src/lib/persist/read-cache.test.ts
@@ -6,6 +6,12 @@ import * as SecureStore from 'expo-secure-store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { bumpAuthEpoch, currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import {
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+  getAuthenticatedOwner,
+  isAuthenticatedOwner,
+} from '@/lib/context-scope';
 import { setSignOutActive } from '@/lib/auth/sign-out-state';
 import { ACTIVE_USER_ID_KEY } from '@/lib/storage-keys';
 
@@ -45,10 +51,23 @@ const kvMock = vi.hoisted(() => {
 
 vi.mock('@/lib/persist/encrypted-kv', () => ({
   getItem: kvMock.getItem,
-  setItem: kvMock.setItem,
-  removeItem: kvMock.removeItem,
+  // eslint-disable-next-line max-params -- mirror the guarded KV write API
+  setItem: async (scope: string, key: string, value: string, guard?: () => boolean) => {
+    if (!guard || guard()) {
+      await kvMock.setItem(scope, key, value);
+    }
+  },
+  removeItem: async (scope: string, key: string, guard?: () => boolean) => {
+    if (!guard || guard()) {
+      await kvMock.removeItem(scope, key);
+    }
+  },
   clearScope: kvMock.clearScope,
-  clearScopePrefix: kvMock.clearScopePrefix,
+  clearScopePrefix: async (prefix: string, guard?: () => boolean) => {
+    if (!guard || guard()) {
+      await kvMock.clearScopePrefix(prefix);
+    }
+  },
 }));
 
 const store = new Map<string, string>();
@@ -96,6 +115,8 @@ function queryLike(state: Partial<Query['state']>, queryKey: unknown): Query {
 
 function makeAuthoritativeQueryClient(userId: string): QueryClient {
   const queryClient = new QueryClient();
+  beginAuthenticatedOwner();
+  confirmAuthenticatedOwner(getAuthenticatedOwner(), userId);
   queryClient.setQueryData(GET_ME_QUERY_KEY, { id: userId });
   return queryClient;
 }
@@ -426,7 +447,7 @@ describe('publication budget', () => {
     expect(scopes.get('cache:u1:1')?.has('read-cache')).toBe(false);
   });
 
-  it('restores from the scope even when the publication fence would block a write', async () => {
+  it('denies stale-owner reads as well as writes without deleting the stored bytes', async () => {
     const { scopes } = createFakeKv();
     const queryClient = new QueryClient();
     scopes.set(
@@ -441,7 +462,8 @@ describe('publication budget', () => {
     bumpAuthEpoch();
 
     const restored = await persister.restoreClient();
-    expect(restored?.clientState.queries[0]?.state.data).toEqual({ id: 'u1' });
+    expect(restored).toBeUndefined();
+    expect(scopes.get('cache:u1:1')?.has('read-cache')).toBe(true);
   });
 });
 
@@ -492,180 +514,172 @@ describe('publication fence', () => {
   });
 });
 
-describe('cold-start restore and takeover', () => {
-  it('restores the hint user scope and reports it to the authenticated mount', async () => {
-    const { scopes } = createFakeKv();
-    store.set(ACTIVE_USER_ID_KEY, 'u1');
-    scopes.set(
-      'cache:u1:1',
-      new Map([['read-cache', JSON.stringify(makePersistedClient({ id: 'u1' }))]])
-    );
-    const queryClient = new QueryClient();
-
-    await restorePersistedCacheOnColdStart(queryClient);
-
-    // The allowlisted getMe query was hydrated from the hint account's scope.
-    expect(queryClient.getQueryData(GET_ME_QUERY_KEY)).toEqual({ id: 'u1' });
-    expect(takeOverColdStartRestore()).toBe('cache:u1:1');
-    // A completed restore is reported exactly once.
-    expect(takeOverColdStartRestore()).toBeNull();
-  });
-
-  it('drops an expired blob instead of hydrating it', async () => {
+describe('owner-proved restore and cold-start isolation', () => {
+  const recentKey = [['cliSessionsV2', 'recentRepositories'], { type: 'query' }];
+  function contentBlob(userId: string) {
+    const blob = makePersistedClient({ id: userId, email: 'cached@example.test' });
+    const identity = blob.clientState.queries[0];
+    if (!identity) {
+      throw new Error('Missing fixture query');
+    }
+    blob.clientState.queries.push({
+      ...identity,
+      queryKey: recentKey,
+      queryHash: JSON.stringify(recentKey),
+      state: { ...identity.state, data: { private: userId } },
+    });
+    return blob;
+  }
+  async function restore(queryClient: QueryClient) {
+    const { restorePersistedCacheForOwner } = await import('./read-cache');
+    const owner = getAuthenticatedOwner();
+    await restorePersistedCacheForOwner(queryClient, owner, () => isAuthenticatedOwner(owner));
+  }
+  it('retains a cold hint without reading or exposing any cached content', async () => {
     const { kv, scopes } = createFakeKv();
     store.set(ACTIVE_USER_ID_KEY, 'u1');
-    const expired = makePersistedClient({ id: 'u1' });
+    scopes.set('cache:u1:1', new Map([['read-cache', JSON.stringify(contentBlob('u1'))]]));
+    const client = new QueryClient();
+    await restorePersistedCacheOnColdStart(client);
+    expect(client.getQueryData(GET_ME_QUERY_KEY)).toBeUndefined();
+    expect(client.getQueryData(recentKey)).toBeUndefined();
+    expect(kv.getItem).not.toHaveBeenCalled();
+    expect(takeOverColdStartRestore()).toBe('cache:u1:1');
+    expect(takeOverColdStartRestore()).toBeNull();
+  });
+  it('restores the stock session-list key after JSON omits undefined input fields', async () => {
+    const { scopes } = createFakeKv();
+    const listKey = [
+      ['cliSessionsV2', 'list'],
+      {
+        input: {
+          limit: 30,
+          orderBy: 'updated_at',
+          includeChildren: false,
+          createdOnPlatform: undefined,
+          gitUrl: undefined,
+          organizationId: null,
+        },
+        type: 'infinite',
+      },
+    ];
+    const blob = contentBlob('u1');
+    const fixture = blob.clientState.queries[0];
+    if (!fixture) {
+      throw new Error('Missing fixture');
+    }
+    const { hashKey } = await import('@tanstack/react-query');
+    const data = {
+      pages: [{ cliSessions: [{ session_id: 'saved-session' }] }],
+      pageParams: [null],
+    };
+    blob.clientState.queries.push({
+      ...fixture,
+      queryKey: listKey,
+      queryHash: hashKey(listKey),
+      state: { ...fixture.state, data },
+    });
+    scopes.set('cache:u1:1', new Map([['read-cache', JSON.stringify(blob)]]));
+    const client = makeAuthoritativeQueryClient('u1');
+    await restore(client);
+    expect(client.getQueryData(listKey)).toEqual(data);
+  });
+  it('restores only matching owner content and never restores getMe identity', async () => {
+    const { scopes } = createFakeKv();
+    scopes.set('cache:u1:1', new Map([['read-cache', JSON.stringify(contentBlob('u1'))]]));
+    const client = makeAuthoritativeQueryClient('u1');
+    await restore(client);
+    expect(client.getQueryData(recentKey)).toEqual({ private: 'u1' });
+    expect(client.getQueryData(GET_ME_QUERY_KEY)).toEqual({ id: 'u1' });
+  });
+  it('rejects a cached identity mismatch inside the proved owner scope', async () => {
+    const { scopes } = createFakeKv();
+    scopes.set('cache:u2:1', new Map([['read-cache', JSON.stringify(contentBlob('u1'))]]));
+    const client = makeAuthoritativeQueryClient('u2');
+    await restore(client);
+    expect(client.getQueryData(recentKey)).toBeUndefined();
+    expect(client.getQueryData(GET_ME_QUERY_KEY)).toEqual({ id: 'u2' });
+  });
+  it('drops an expired blob only after the owner is proved', async () => {
+    const { scopes } = createFakeKv();
+    const expired = contentBlob('u1');
     expired.timestamp = Date.now() - READ_CACHE_MAX_AGE_MS - 1;
     scopes.set('cache:u1:1', new Map([['read-cache', JSON.stringify(expired)]]));
-    const queryClient = new QueryClient();
-
-    await restorePersistedCacheOnColdStart(queryClient);
-
-    expect(queryClient.getQueryData(GET_ME_QUERY_KEY)).toBeUndefined();
-    expect(kv.removeItem).toHaveBeenCalledWith('cache:u1:1', 'read-cache');
-    expect(takeOverColdStartRestore()).toBe('cache:u1:1');
+    const client = makeAuthoritativeQueryClient('u1');
+    await restore(client);
+    expect(client.getQueryData(recentKey)).toBeUndefined();
+    expect(scopes.get('cache:u1:1')?.has('read-cache')).toBe(false);
   });
-
-  it('never restores a blob written by an older schema: it lives in another scope', async () => {
-    const { kv, scopes } = createFakeKv();
-    store.set(ACTIVE_USER_ID_KEY, 'u1');
-    // The previous schema version wrote into `cache:u1:0`; the current scope is
-    // `cache:u1:1`, so the old blob is never read and never hydrated.
-    const oldSchemaBlob = JSON.stringify(makePersistedClient({ id: 'u1' }));
-    scopes.set('cache:u1:0', new Map([['read-cache', oldSchemaBlob]]));
-    const queryClient = new QueryClient();
-
-    await restorePersistedCacheOnColdStart(queryClient);
-
-    expect(queryClient.getQueryData(GET_ME_QUERY_KEY)).toBeUndefined();
-    expect(kv.getItem).toHaveBeenCalledWith('cache:u1:1', 'read-cache');
-    expect(kv.getItem).not.toHaveBeenCalledWith('cache:u1:0', 'read-cache');
+  it('leaves an older schema isolated in its original scope', async () => {
+    const { scopes } = createFakeKv();
+    scopes.set('cache:u1:0', new Map([['read-cache', JSON.stringify(contentBlob('u1'))]]));
+    const client = makeAuthoritativeQueryClient('u1');
+    await restore(client);
+    expect(client.getQueryData(recentKey)).toBeUndefined();
+    expect(scopes.has('cache:u1:0')).toBe(true);
   });
-
-  it('is best effort: a corrupt blob never blocks startup and is discarded', async () => {
-    const { kv, scopes } = createFakeKv();
+  it('keeps a corrupt cold blob untouched until proof authorizes cache cleanup', async () => {
+    const { scopes } = createFakeKv();
     store.set(ACTIVE_USER_ID_KEY, 'u1');
     scopes.set('cache:u1:1', new Map([['read-cache', 'not-json']]));
-    const queryClient = new QueryClient();
-
-    await expect(restorePersistedCacheOnColdStart(queryClient)).resolves.toBeUndefined();
-
-    expect(kv.removeItem).toHaveBeenCalledWith('cache:u1:1', 'read-cache');
-    expect(takeOverColdStartRestore()).toBeNull();
+    const client = new QueryClient();
+    await restorePersistedCacheOnColdStart(client);
+    expect(scopes.get('cache:u1:1')?.get('read-cache')).toBe('not-json');
+    const proved = makeAuthoritativeQueryClient('u1');
+    await restore(proved);
+    expect(scopes.get('cache:u1:1')?.has('read-cache')).toBe(false);
   });
-
-  it('abandons a still-pending restore once the authenticated mount takes over', async () => {
-    createFakeKv();
-    const hintRead: { resolve: ((value: string | null) => void) | null } = { resolve: null };
-    vi.mocked(SecureStore.getItemAsync).mockImplementationOnce(
-      async () =>
-        new Promise<string | null>(resolve => {
-          hintRead.resolve = resolve;
-        })
-    );
-    const queryClient = new QueryClient();
-
-    const restorePromise = restorePersistedCacheOnColdStart(queryClient);
-    // The mount takes over while the hint read is still in flight.
-    expect(takeOverColdStartRestore()).toBeNull();
-    hintRead.resolve?.('u1');
-    await restorePromise;
-
-    // The late restore never claimed a scope.
-    expect(takeOverColdStartRestore()).toBeNull();
-  });
-
-  it('never hydrates when the mount takes over while the restore read is in flight', async () => {
-    const { kv, scopes } = createFakeKv();
-    store.set(ACTIVE_USER_ID_KEY, 'u1');
-    scopes.set(
-      'cache:u1:1',
-      new Map([['read-cache', JSON.stringify(makePersistedClient({ id: 'u1' }))]])
-    );
-    const restoreRead: { resolve: ((value: string | null) => void) | null } = { resolve: null };
-    kv.getItem.mockImplementationOnce(
-      async () =>
-        new Promise<string | null>(resolve => {
-          restoreRead.resolve = resolve;
-        })
-    );
-    const queryClient = new QueryClient();
-
-    const restorePromise = restorePersistedCacheOnColdStart(queryClient);
+  it.each(['takeover', 'account'])(
+    'abandons a pending hint after %s changes its generation',
+    async change => {
+      createFakeKv();
+      const gate = Promise.withResolvers<string | null>();
+      vi.mocked(SecureStore.getItemAsync).mockReturnValueOnce(gate.promise);
+      const restoring = restorePersistedCacheOnColdStart(new QueryClient());
+      if (change === 'account') {
+        bumpAuthEpoch();
+      } else {
+        takeOverColdStartRestore();
+      }
+      gate.resolve('u1');
+      await restoring;
+      expect(takeOverColdStartRestore()).toBeNull();
+    }
+  );
+  it('never hydrates a late old-account read after direct sign-in', async () => {
+    const { kv } = createFakeKv();
+    const client = makeAuthoritativeQueryClient('u1');
+    const gate = Promise.withResolvers<string | null>();
+    kv.getItem.mockReturnValueOnce(gate.promise);
+    const restoring = restore(client);
     await vi.waitFor(() => {
       expect(kv.getItem).toHaveBeenCalled();
     });
-    // The mount takes over while the KV read is still in flight: the restore
-    // must not hydrate after the authoritative identity has taken over.
-    expect(takeOverColdStartRestore()).toBeNull();
-    restoreRead.resolve?.(JSON.stringify(makePersistedClient({ id: 'u1' })));
-    await restorePromise;
-
-    expect(queryClient.getQueryData(GET_ME_QUERY_KEY)).toBeUndefined();
-    expect(takeOverColdStartRestore()).toBeNull();
+    bumpAuthEpoch();
+    beginAuthenticatedOwner();
+    confirmAuthenticatedOwner(getAuthenticatedOwner(), 'u2');
+    client.clear();
+    client.setQueryData(GET_ME_QUERY_KEY, { id: 'u2' });
+    gate.resolve(JSON.stringify(contentBlob('u1')));
+    await restoring;
+    expect(client.getQueryData(recentKey)).toBeUndefined();
+    expect(client.getQueryData(GET_ME_QUERY_KEY)).toEqual({ id: 'u2' });
   });
-
-  it('never hydrates when the auth epoch changes while the restore read is in flight', async () => {
+  it('does not let a late rejected restore delete another generation cache', async () => {
     const { kv, scopes } = createFakeKv();
-    store.set(ACTIVE_USER_ID_KEY, 'u1');
-    scopes.set(
-      'cache:u1:1',
-      new Map([['read-cache', JSON.stringify(makePersistedClient({ id: 'u1' }))]])
-    );
-    const restoreRead: { resolve: ((value: string | null) => void) | null } = { resolve: null };
-    kv.getItem.mockImplementationOnce(
-      async () =>
-        new Promise<string | null>(resolve => {
-          restoreRead.resolve = resolve;
-        })
-    );
-    const queryClient = new QueryClient();
-
-    const restorePromise = restorePersistedCacheOnColdStart(queryClient);
+    scopes.set('cache:u1:1', new Map([['read-cache', 'retained']]));
+    const client = makeAuthoritativeQueryClient('u1');
+    const gate = Promise.withResolvers<string | null>();
+    kv.getItem.mockReturnValueOnce(gate.promise);
+    const restoring = restore(client);
     await vi.waitFor(() => {
       expect(kv.getItem).toHaveBeenCalled();
     });
-    // A sign-out (or sign-in) bumps the epoch while the KV read is in flight,
-    // before the authenticated mount takes over: the restore must not hydrate
-    // the hint account into the query client.
-    bumpAuthEpoch();
-    restoreRead.resolve?.(JSON.stringify(makePersistedClient({ id: 'u1' })));
-    await restorePromise;
-
-    expect(queryClient.getQueryData(GET_ME_QUERY_KEY)).toBeUndefined();
-    expect(takeOverColdStartRestore()).toBeNull();
-  });
-
-  it('never restores when the auth epoch changes while the hint read is in flight', async () => {
-    const { kv } = createFakeKv();
-    const hintRead: { resolve: ((value: string | null) => void) | null } = { resolve: null };
-    vi.mocked(SecureStore.getItemAsync).mockImplementationOnce(
-      async () =>
-        new Promise<string | null>(resolve => {
-          hintRead.resolve = resolve;
-        })
-    );
-    const queryClient = new QueryClient();
-
-    const restorePromise = restorePersistedCacheOnColdStart(queryClient);
-    // The epoch moved before the hint read settled: the restore is abandoned
-    // before it can even read the cache.
-    bumpAuthEpoch();
-    hintRead.resolve?.('u1');
-    await restorePromise;
-
-    expect(kv.getItem).not.toHaveBeenCalled();
-    expect(takeOverColdStartRestore()).toBeNull();
-  });
-
-  it('does nothing when the identity hint is absent', async () => {
-    const { kv } = createFakeKv();
-    const queryClient = new QueryClient();
-
-    await restorePersistedCacheOnColdStart(queryClient);
-
-    expect(kv.getItem).not.toHaveBeenCalled();
-    expect(takeOverColdStartRestore()).toBeNull();
+    beginAuthenticatedOwner();
+    confirmAuthenticatedOwner(getAuthenticatedOwner(), 'u1');
+    gate.reject(new Error('late I/O error'));
+    await restoring;
+    expect(scopes.get('cache:u1:1')?.get('read-cache')).toBe('retained');
   });
 });
 

--- a/apps/mobile/src/lib/persist/read-cache.ts
+++ b/apps/mobile/src/lib/persist/read-cache.ts
@@ -1,5 +1,5 @@
 import * as SecureStore from 'expo-secure-store';
-import { type Query, type QueryClient } from '@tanstack/react-query';
+import { hashKey, type Query, type QueryClient } from '@tanstack/react-query';
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister';
 import {
   type AsyncStorage,
@@ -9,6 +9,11 @@ import {
 import { z } from 'zod';
 
 import { buildAgentSessionListInput } from '@/lib/agent-session-input';
+import {
+  type AuthenticatedOwner,
+  getAuthenticatedOwner,
+  isAuthenticatedOwner,
+} from '@/lib/context-scope';
 import { currentAuthEpoch, isCurrentAuthEpoch } from '@/lib/auth/auth-epoch';
 import { isSignOutActive, setSignOutActive } from '@/lib/auth/sign-out-state';
 import * as encryptedKv from '@/lib/persist/encrypted-kv';
@@ -62,11 +67,14 @@ type QueryCacheReader = { getQueryData?: QueryClient['getQueryData'] };
 
 const cachedUserSchema = z.object({ id: z.string().min(1) });
 
-/** Authoritative user id from the cached `user.getMe` result, or null. */
+/** Cached getMe identifies a user only after this generation's network response proves the same owner. */
 export function readCachedUserId(queryClient: QueryCacheReader): string | null {
   const data = queryClient.getQueryData?.(GET_ME_QUERY_KEY);
   const parsed = cachedUserSchema.safeParse(data);
-  return parsed.success ? parsed.data.id : null;
+  const owner = getAuthenticatedOwner();
+  return parsed.success && isAuthenticatedOwner(owner) && parsed.data.id === owner.userId
+    ? owner.userId
+    : null;
 }
 
 const queryKeyMetaSchema = z.object({ input: z.unknown().optional() });
@@ -95,6 +103,13 @@ type AllowedProcedure = {
  */
 const DEFAULT_SESSION_LIST_INPUT = buildAgentSessionListInput({ organizationId: null });
 const DEFAULT_SESSION_LIST_KEY_COUNT = Object.keys(DEFAULT_SESSION_LIST_INPUT).length;
+// JSON omits undefined input fields. Match the canonical stock key when restoring legacy blobs;
+// do not relax the live allowlist or change the query-key positions used by permission eviction.
+const SERIALIZED_SESSION_LIST_KEYS = new Set(
+  ['query', 'infinite'].map(type =>
+    hashKey([['cliSessionsV2', 'list'], { type, input: DEFAULT_SESSION_LIST_INPUT }])
+  )
+);
 
 // Initial allowlist. Verified against the mobile tRPC router
 // (`packages/trpc/src/mobile.ts`) before coding.
@@ -205,6 +220,7 @@ type ReadCachePersisterOptions = {
  */
 export function createReadCachePersister(options: ReadCachePersisterOptions): Persister {
   const { queryClient, userId, epoch } = options;
+  const owner = getAuthenticatedOwner();
   const scope = readCacheScope(userId);
 
   // Publication fence: every sign-in and sign-out bumps the epoch, and the
@@ -216,38 +232,70 @@ export function createReadCachePersister(options: ReadCachePersisterOptions): Pe
   // clearing scopes — even from a persister created at the current epoch while
   // the old user id is cached.
   const isPublicationAllowed = (): boolean =>
-    !isSignOutActive() && isCurrentAuthEpoch(epoch) && readCachedUserId(queryClient) === userId;
+    !isSignOutActive() &&
+    isCurrentAuthEpoch(epoch) &&
+    isAuthenticatedOwner(owner) &&
+    owner.userId === userId &&
+    readCachedUserId(queryClient) === userId;
 
   const storage: AsyncStorage = {
     getItem: async k => {
+      if (!isPublicationAllowed()) {
+        return null;
+      }
       const value = await encryptedKv.getItem(scope, k);
-      return value;
+      return isPublicationAllowed() ? value : null;
     },
     setItem: async (k, v) => {
-      // The fence also guards the storage write: the async-storage persister
-      // throttles saves, so the actual write can happen after teardown.
-      if (!isPublicationAllowed()) {
-        return;
+      if (isPublicationAllowed()) {
+        await encryptedKv.setItem(scope, k, v, isPublicationAllowed);
       }
-      await encryptedKv.setItem(scope, k, v);
     },
     removeItem: async k => {
-      await encryptedKv.removeItem(scope, k);
+      if (isPublicationAllowed()) {
+        await encryptedKv.removeItem(scope, k, isPublicationAllowed);
+      }
     },
   };
   const base = createAsyncStoragePersister({ storage, key: READ_CACHE_KEY });
 
   return {
     ...base,
+    restoreClient: async () => {
+      const client = await base.restoreClient();
+      if (!client || !isPublicationAllowed()) {
+        return undefined;
+      }
+      const identity = client.clientState.queries.find(
+        query => JSON.stringify(query.queryKey) === JSON.stringify(GET_ME_QUERY_KEY)
+      );
+      const cachedOwner = cachedUserSchema.safeParse(identity?.state.data);
+      if (!cachedOwner.success || cachedOwner.data.id !== userId) {
+        return undefined;
+      }
+      return {
+        ...client,
+        clientState: {
+          mutations: [],
+          // Identity and membership must come from this generation's server responses, not disk.
+          queries: client.clientState.queries.filter(query => {
+            const path = JSON.stringify(query.queryKey[0]);
+            return (
+              query.state.status === 'success' &&
+              (isReadCacheAllowedKey(query.queryKey) ||
+                SERIALIZED_SESSION_LIST_KEYS.has(hashKey(query.queryKey))) &&
+              path !== '["user","getMe"]' &&
+              path !== '["organizations","list"]'
+            );
+          }),
+        },
+      };
+    },
     persistClient: async client => {
       if (!isPublicationAllowed()) {
         return;
       }
-      const serialized = JSON.stringify(client);
-      if (utf8ByteLength(serialized) > READ_CACHE_MAX_BYTES) {
-        // Oversized blobs are never written partially: the previous blob for
-        // this scope is removed so a stale snapshot cannot survive the write
-        // that replaced it.
+      if (utf8ByteLength(JSON.stringify(client)) > READ_CACHE_MAX_BYTES) {
         await base.removeClient();
         return;
       }
@@ -256,80 +304,66 @@ export function createReadCachePersister(options: ReadCachePersisterOptions): Pe
   };
 }
 
+/** The caller's owner proof, not active-user-id or a cached getMe, authorizes hydration. */
+export async function restorePersistedCacheForOwner(
+  queryClient: QueryClient,
+  owner: AuthenticatedOwner,
+  isCurrent: () => boolean
+): Promise<void> {
+  if (!isAuthenticatedOwner(owner) || owner.userId === null || !isCurrent()) {
+    return;
+  }
+  const persister = createReadCachePersister({
+    queryClient,
+    userId: owner.userId,
+    epoch: owner.authEpoch,
+  });
+  try {
+    await persistQueryClientRestore({
+      queryClient,
+      maxAge: READ_CACHE_MAX_AGE_MS,
+      persister: {
+        ...persister,
+        restoreClient: async () => {
+          const client = await persister.restoreClient();
+          return isAuthenticatedOwner(owner) && isCurrent() ? client : undefined;
+        },
+      },
+    });
+  } catch {
+    // The library rethrows after its guarded cache cleanup. Cache failure must not block live data.
+  }
+}
+
 // ── Cold-start restore ─────────────────────────────────────────────────────
 
 let coldStartGeneration = 0;
 let coldStartRestoredScope: string | null = null;
 
 /**
- * Best-effort cold-start restore for the identity hint stored in
- * `ACTIVE_USER_ID_KEY`. Never blocks startup. A generation flag abandons the
- * restore once the authenticated mount takes over: a late restore no-ops —
- * including one whose KV read was still in flight at takeover, which never
- * hydrates — and never claims a scope, and the scope of a completed restore
- * is reported to the mount via {@link takeOverColdStartRestore}.
+ * Compatibility entry for the root layout. Capture the legacy identity hint without reading content.
+ * Only restorePersistedCacheForOwner can hydrate, after this generation's authoritative identity resolves.
+ * Remove the hint entry once the root layout no longer invokes the legacy cold-start contract.
  */
-export async function restorePersistedCacheOnColdStart(queryClient: QueryClient): Promise<void> {
-  // The generation bump is synchronous so the authenticated mount can abandon
-  // this restore immediately after scheduling it.
+export async function restorePersistedCacheOnColdStart(_queryClient: QueryClient): Promise<void> {
   coldStartGeneration += 1;
   const generation = coldStartGeneration;
-  // Capture the epoch before the first SecureStore read: a sign-in or sign-out
-  // that lands while the hint read or the KV read is in flight fences the
-  // whole restore, so it can never hydrate (or claim a scope) after the auth
-  // epoch moved — including after a logout that cleared the query client.
   const epoch = currentAuthEpoch();
   try {
     const hintUserId = await SecureStore.getItemAsync(ACTIVE_USER_ID_KEY);
-    if (generation !== coldStartGeneration || !hintUserId || !isCurrentAuthEpoch(epoch)) {
-      return;
+    if (generation === coldStartGeneration && hintUserId && isCurrentAuthEpoch(epoch)) {
+      // Compatibility entry for the root layout: retain only the hint, never hydrate content.
+      // The authenticated mount reads the cache only after this generation's getMe proves ownership.
+      coldStartRestoredScope = readCacheScope(hintUserId);
     }
-    const persister = createReadCachePersister({
-      queryClient,
-      userId: hintUserId,
-      epoch,
-    });
-    if (generation !== coldStartGeneration || !isCurrentAuthEpoch(epoch)) {
-      return;
-    }
-    // The mount bumps the generation when it takes over, and
-    // `persistQueryClientRestore` hydrates internally without a hook, so the
-    // fence lives in a wrapped `restoreClient`: it reports no blob (and the
-    // library therefore does nothing) whenever the generation moved or the
-    // auth epoch changed while the KV read was in flight. A late restore can
-    // never hydrate after the authoritative identity has taken over or a
-    // sign-in/sign-out has moved the epoch.
-    const fencedPersister: Persister = {
-      ...persister,
-      restoreClient: async () => {
-        const restored = await persister.restoreClient();
-        return generation === coldStartGeneration && isCurrentAuthEpoch(epoch)
-          ? restored
-          : undefined;
-      },
-    };
-    // No `buster`: the scope segment already carries the schema version, so a
-    // blob written by an older schema lives in another scope and is never read.
-    await persistQueryClientRestore({
-      queryClient,
-      persister: fencedPersister,
-      maxAge: READ_CACHE_MAX_AGE_MS,
-    });
-    if (generation !== coldStartGeneration || !isCurrentAuthEpoch(epoch)) {
-      // The mount took over, or the auth epoch changed, while the restore was
-      // in flight: the late restore is abandoned and must not claim a scope.
-      return;
-    }
-    coldStartRestoredScope = readCacheScope(hintUserId);
   } catch {
-    // Best effort: a failed or interrupted restore never blocks startup.
+    // A failed hint costs a warm start, never authorizes a different account.
   }
 }
 
 /**
  * Marks the authenticated mount as the cache owner: any still-pending cold-
- * start restore is abandoned, and the scope a completed restore hydrated is
- * returned (and cleared from the module) for identity comparison.
+ * start hint read is abandoned. Return and clear the hint scope; it never authorizes hydration.
  */
 export function takeOverColdStartRestore(): string | null {
   coldStartGeneration += 1;
@@ -350,9 +384,15 @@ export function takeOverColdStartRestore(): string | null {
  * abort sign-out; the stale blob only costs a future warm start.
  */
 export async function clearCacheScopeForSignOut(knownUserId: string | null): Promise<void> {
+  const owner = getAuthenticatedOwner();
+  const epoch = currentAuthEpoch();
+  const isCurrent = () =>
+    isCurrentAuthEpoch(epoch) && getAuthenticatedOwner().generation === owner.generation;
   try {
     await encryptedKv.clearScopePrefix(
-      knownUserId ? `${CACHE_SCOPE_PREFIX}${knownUserId}:` : CACHE_SCOPE_PREFIX
+      knownUserId ? `${CACHE_SCOPE_PREFIX}${knownUserId}:` : CACHE_SCOPE_PREFIX,
+      isCurrent,
+      Boolean(knownUserId)
     );
   } catch {
     // Best effort: query and auth state reset still run after this returns.

--- a/apps/mobile/src/lib/persist/scoped-draft-keys.test.ts
+++ b/apps/mobile/src/lib/persist/scoped-draft-keys.test.ts
@@ -1,0 +1,244 @@
+/* eslint-disable max-lines -- legacy migration cases share the same owner-bound KV fixture */
+/* eslint-disable require-await, typescript-eslint/require-await -- fake native methods resolve synchronously */
+/* eslint-disable max-params -- the KV fixture mirrors the four-argument guarded write API */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { bumpAuthEpoch } from '@/lib/auth/auth-epoch';
+import { setSignOutActive } from '@/lib/auth/sign-out-state';
+import {
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+  contextScope,
+  getAuthenticatedOwner,
+  isAuthenticatedOwner,
+} from '@/lib/context-scope';
+import { draftScope, isStringDraft, loadDraftResult } from './drafts';
+import {
+  type DraftTarget,
+  listLegacyDraftCandidates,
+  migrateLegacyDraft,
+  parseScopedDraftKey,
+  scopedDraftKey,
+} from './scoped-draft-keys';
+
+const mock = vi.hoisted(() => ({
+  bytes: new Map<string, string>(),
+  set: vi.fn(),
+  remove: vi.fn(),
+  session: vi.fn(),
+}));
+const storageKey = (scope: string, key: string) => JSON.stringify([scope, key]);
+vi.mock('@sentry/react-native', () => ({ captureException: vi.fn() }));
+vi.mock('@/lib/persist/encrypted-kv', () => ({
+  getItem: async (scope: string, key: string) => mock.bytes.get(storageKey(scope, key)) ?? null,
+  setItem: mock.set,
+  removeItem: mock.remove,
+  listEntries: async (scope: string) =>
+    [...mock.bytes.keys()].flatMap((raw, index) => {
+      const [storedScope, k] = JSON.parse(raw) as [string, string];
+      return storedScope === scope ? [{ k, updatedAt: index }] : [];
+    }),
+}));
+vi.mock('@/lib/trpc', () => ({ trpcClient: { cliSessionsV2: { get: { query: mock.session } } } }));
+
+function signIn(userId = 'oauth/a:用户') {
+  bumpAuthEpoch();
+  beginAuthenticatedOwner();
+  confirmAuthenticatedOwner(getAuthenticatedOwner(), userId);
+  return getAuthenticatedOwner();
+}
+function seed(key: string, value = 'legacy text', userId = 'oauth/a:用户') {
+  mock.bytes.set(storageKey(draftScope(userId), key), JSON.stringify(value));
+}
+function migration(
+  candidateKey: string,
+  target: DraftTarget,
+  organizationId: string | null = null
+) {
+  const owner = getAuthenticatedOwner();
+  return {
+    owner,
+    candidateKey,
+    destinationKey: scopedDraftKey(contextScope(organizationId), target),
+    selection: 'explicit' as const,
+    isCurrent: () => isAuthenticatedOwner(owner),
+  };
+}
+beforeEach(() => {
+  vi.resetAllMocks();
+  mock.bytes.clear();
+  setSignOutActive(false);
+  signIn();
+  mock.set.mockImplementation(
+    async (scope: string, key: string, value: string, guard?: () => boolean) => {
+      if (!guard || guard()) {
+        mock.bytes.set(storageKey(scope, key), value);
+      }
+    }
+  );
+  mock.remove.mockImplementation(async (scope: string, key: string, guard?: () => boolean) => {
+    if (!guard || guard()) {
+      mock.bytes.delete(storageKey(scope, key));
+    }
+  });
+  mock.session.mockImplementation(async ({ session_id }: { session_id: string }) => ({
+    session_id,
+    kilo_user_id: 'oauth/a:用户',
+    organization_id: null,
+  }));
+});
+
+describe('tagged draft keys', () => {
+  it('separates Personal, an organization named personal, session new, and all draft targets', () => {
+    const targets: DraftTarget[] = [
+      { kind: 'new-session' },
+      { kind: 'session', sessionId: 'new' },
+      { kind: 'search' },
+      { kind: 'quick-chat' },
+    ];
+    const keys = [null, 'personal', 'org:a\u0000b', 'org/a'].flatMap(org =>
+      targets.map(target => scopedDraftKey(contextScope(org), target))
+    );
+    expect(new Set(keys).size).toBe(16);
+    for (const key of keys) {
+      expect(parseScopedDraftKey(key)).not.toBeNull();
+    }
+  });
+  it('does not collide across delimiter positions or accept legacy keys as tagged keys', () => {
+    expect(scopedDraftKey(contextScope('a:b'), { kind: 'session', sessionId: 'c' })).not.toBe(
+      scopedDraftKey(contextScope('a'), { kind: 'session', sessionId: 'b:c' })
+    );
+    expect(parseScopedDraftKey('agent-composer:new')).toBeNull();
+    expect(
+      parseScopedDraftKey('context-draft:v1:[{"kind":"personal"},{"kind":"session"}]')
+    ).toBeNull();
+  });
+});
+
+describe('explicit legacy migration', () => {
+  it.each([
+    ['agent-composer:new', { kind: 'new-session' }],
+    ['agent-composer:new', { kind: 'session', sessionId: 'new' }],
+    ['agent-composer:session:a', { kind: 'session', sessionId: 'session:a' }],
+    ['session-search-query', { kind: 'search' }],
+    ['quick-chat:0:personal', { kind: 'quick-chat' }],
+    ['quick-chat:37:personal', { kind: 'quick-chat' }],
+  ] satisfies [string, DraftTarget][])(
+    'confirms replacement before removing legacy %s for %j',
+    async (legacy, target) => {
+      seed(legacy);
+      const input = migration(legacy, target);
+      expect(await migrateLegacyDraft(input)).toBe('committed');
+      expect(
+        await loadDraftResult('oauth/a:用户', input.destinationKey, isStringDraft)
+      ).toMatchObject({ status: 'present', value: 'legacy text' });
+      expect(mock.bytes.has(storageKey('draft:oauth/a:用户', legacy))).toBe(false);
+      expect(await migrateLegacyDraft(input)).toBe('absent');
+      expect(mock.bytes.get(storageKey('draft:oauth/a:用户', input.destinationKey))).toBe(
+        '"legacy text"'
+      );
+    }
+  );
+  it('lists multiple Quick Chat epochs without displaying or importing their text', async () => {
+    seed('quick-chat:1:personal', 'first');
+    seed('quick-chat:12:personal', 'second');
+    const candidates = await listLegacyDraftCandidates(getAuthenticatedOwner());
+    expect(candidates.map(candidate => candidate.key)).toEqual([
+      'quick-chat:1:personal',
+      'quick-chat:12:personal',
+    ]);
+    expect(JSON.stringify(candidates)).not.toContain('first');
+    expect(JSON.stringify(candidates)).not.toContain('second');
+    const input = migration('quick-chat:12:personal', { kind: 'quick-chat' });
+    expect(await migrateLegacyDraft(input)).toBe('committed');
+    expect(mock.bytes.get(storageKey('draft:oauth/a:用户', 'quick-chat:1:personal'))).toBe(
+      '"first"'
+    );
+    expect(mock.bytes.get(storageKey('draft:oauth/a:用户', input.destinationKey))).toBe('"second"');
+  });
+  it('requires matching Quick Chat context even after a deliberate choice', async () => {
+    seed('quick-chat:8:org-a');
+    expect(await migrateLegacyDraft(migration('quick-chat:8:org-a', { kind: 'quick-chat' }))).toBe(
+      'unavailable'
+    );
+    expect(mock.bytes.get(storageKey('draft:oauth/a:用户', 'quick-chat:8:org-a'))).toBe(
+      '"legacy text"'
+    );
+    expect(
+      await migrateLegacyDraft(migration('quick-chat:8:org-a', { kind: 'quick-chat' }, 'org-a'))
+    ).toBe('committed');
+  });
+  it('requires a tagged explicit destination and does not infer Personal for search/new drafts', async () => {
+    seed('session-search-query');
+    seed('agent-composer:new');
+    const input = migration('session-search-query', { kind: 'search' });
+    expect(await migrateLegacyDraft({ ...input, destinationKey: 'session-search-query' })).toBe(
+      'unavailable'
+    );
+    expect(mock.bytes.size).toBe(2);
+  });
+  it.each([
+    { kilo_user_id: 'another-user', organization_id: null },
+    { kilo_user_id: 'oauth/a:用户', organization_id: 'another-context' },
+  ])('does not trust session route parameters when the server reports %j', async proof => {
+    seed('agent-composer:s');
+    mock.session.mockResolvedValue({ session_id: 's', ...proof });
+    expect(
+      await migrateLegacyDraft(migration('agent-composer:s', { kind: 'session', sessionId: 's' }))
+    ).toBe('unavailable');
+    expect(mock.bytes.size).toBe(1);
+  });
+  it('keeps the source and the prior destination after a failed replacement write', async () => {
+    seed('agent-composer:new');
+    mock.set.mockRejectedValueOnce(new Error('disk unavailable'));
+    const input = migration('agent-composer:new', { kind: 'new-session' });
+    expect(await migrateLegacyDraft(input)).toBe('failed');
+    expect(mock.bytes.get(storageKey('draft:oauth/a:用户', 'agent-composer:new'))).toBe(
+      '"legacy text"'
+    );
+    expect(mock.bytes.has(storageKey('draft:oauth/a:用户', input.destinationKey))).toBe(false);
+    expect(await migrateLegacyDraft(input)).toBe('committed');
+  });
+  it('finishes an interrupted cleanup idempotently without overwriting the replacement', async () => {
+    seed('session-search-query');
+    mock.remove.mockRejectedValueOnce(new Error('temporary remove failure'));
+    const input = migration('session-search-query', { kind: 'search' });
+    expect(await migrateLegacyDraft(input)).toBe('committed');
+    expect(mock.bytes.size).toBe(2);
+    expect(await migrateLegacyDraft(input)).toBe('committed');
+    expect(mock.bytes.size).toBe(1);
+    expect(mock.bytes.get(storageKey('draft:oauth/a:用户', input.destinationKey))).toBe(
+      '"legacy text"'
+    );
+  });
+  it('does not overwrite a destination that already contains newer text', async () => {
+    seed('session-search-query');
+    const input = migration('session-search-query', { kind: 'search' });
+    seed(input.destinationKey, 'newer text');
+    expect(await migrateLegacyDraft(input)).toBe('conflict');
+    expect(mock.bytes.get(storageKey('draft:oauth/a:用户', input.destinationKey))).toBe(
+      '"newer text"'
+    );
+    expect(mock.bytes.size).toBe(2);
+  });
+  it('never cleans the source after its owner changes during a confirmed write', async () => {
+    seed('agent-composer:new');
+    const input = migration('agent-composer:new', { kind: 'new-session' });
+    mock.set.mockImplementationOnce(async (scope: string, key: string, value: string) => {
+      mock.bytes.set(storageKey(scope, key), value);
+      signIn('account-b');
+    });
+    expect(await migrateLegacyDraft(input)).toBe('stale');
+    expect(mock.bytes.get(storageKey('draft:oauth/a:用户', 'agent-composer:new'))).toBe(
+      '"legacy text"'
+    );
+    expect([...mock.bytes.keys()].every(key => !key.includes('account-b'))).toBe(true);
+  });
+  it('preserves malformed legacy bytes without creating a destination', async () => {
+    mock.bytes.set(storageKey('draft:oauth/a:用户', 'session-search-query'), '{broken');
+    expect(await migrateLegacyDraft(migration('session-search-query', { kind: 'search' }))).toBe(
+      'malformed'
+    );
+    expect([...mock.bytes.values()]).toEqual(['{broken']);
+  });
+});

--- a/apps/mobile/src/lib/persist/scoped-draft-keys.ts
+++ b/apps/mobile/src/lib/persist/scoped-draft-keys.ts
@@ -1,0 +1,185 @@
+import { z } from 'zod';
+
+import {
+  type AuthenticatedOwner,
+  type ContextScope,
+  contextScope,
+  contextScopeSchema,
+  isAuthenticatedOwner,
+  sameContext,
+} from '@/lib/context-scope';
+import {
+  agentComposerDraftKey,
+  clearDraftIfStill,
+  draftScope,
+  type DraftWriteResult,
+  isStringDraft,
+  loadDraftResult,
+  NEW_SESSION_DRAFT_KEY,
+  saveDraftConfirmed,
+  SCOPED_DRAFT_KEY_PREFIX,
+  SESSION_SEARCH_DRAFT_KEY,
+} from './drafts';
+import { listEntries } from './encrypted-kv';
+
+const draftTargetSchema = z.discriminatedUnion('kind', [
+  z.strictObject({ kind: z.literal('new-session') }),
+  z.strictObject({ kind: z.literal('session'), sessionId: z.string().min(1) }),
+  z.strictObject({ kind: z.literal('search') }),
+  z.strictObject({ kind: z.literal('quick-chat') }),
+]);
+export type DraftTarget = Readonly<z.infer<typeof draftTargetSchema>>;
+const scopedKeySchema = z.tuple([contextScopeSchema, draftTargetSchema]);
+
+/** Tagged JSON avoids Personal/organization and new/session collisions without changing draft scopes. */
+export function scopedDraftKey(context: ContextScope, target: DraftTarget): string {
+  return `${SCOPED_DRAFT_KEY_PREFIX}${JSON.stringify(scopedKeySchema.parse([context, target]))}`;
+}
+export function parseScopedDraftKey(
+  key: string
+): { context: ContextScope; target: DraftTarget } | null {
+  if (!key.startsWith(SCOPED_DRAFT_KEY_PREFIX)) {
+    return null;
+  }
+  try {
+    const parsed = scopedKeySchema.safeParse(JSON.parse(key.slice(SCOPED_DRAFT_KEY_PREFIX.length)));
+    return parsed.success ? { context: parsed.data[0], target: parsed.data[1] } : null;
+  } catch {
+    return null;
+  }
+}
+
+export type LegacyDraftCandidate = Readonly<{
+  key: string;
+  kind: 'new-or-session' | 'session' | 'search' | 'quick-chat';
+  updatedAt: number;
+}>;
+function legacyKind(key: string): LegacyDraftCandidate['kind'] | null {
+  if (key === NEW_SESSION_DRAFT_KEY) {
+    return 'new-or-session';
+  }
+  if (key.startsWith('agent-composer:') && key.length > 'agent-composer:'.length) {
+    return 'session';
+  }
+  if (key === SESSION_SEARCH_DRAFT_KEY) {
+    return 'search';
+  }
+  if (/^quick-chat:\d+:.+$/s.test(key)) {
+    return 'quick-chat';
+  }
+  return null;
+}
+
+/** Metadata only: discovering ambiguous bytes never displays text in an inferred context. */
+export async function listLegacyDraftCandidates(
+  owner: AuthenticatedOwner
+): Promise<LegacyDraftCandidate[]> {
+  if (!isAuthenticatedOwner(owner) || owner.userId === null) {
+    return [];
+  }
+  const entries = await listEntries(draftScope(owner.userId));
+  if (!isAuthenticatedOwner(owner)) {
+    return [];
+  }
+  return entries.flatMap(entry => {
+    const kind = legacyKind(entry.k);
+    return kind ? [{ key: entry.k, kind, updatedAt: entry.updatedAt }] : [];
+  });
+}
+
+type MigrationInput = {
+  owner: AuthenticatedOwner;
+  destinationKey: string;
+  candidateKey: string;
+  /** The activation UI must supply the exact candidate, including its epoch, after a deliberate choice. */
+  selection: 'explicit';
+  isCurrent: () => boolean;
+};
+export type DraftMigrationResult = DraftWriteResult | 'absent' | 'malformed' | 'unavailable';
+
+async function validateLegacyDestination(
+  input: MigrationInput,
+  destination: NonNullable<ReturnType<typeof parseScopedDraftKey>>
+): Promise<boolean> {
+  const { target, context } = destination;
+  if (target.kind === 'new-session') {
+    return input.candidateKey === NEW_SESSION_DRAFT_KEY;
+  }
+  if (target.kind === 'search') {
+    return input.candidateKey === SESSION_SEARCH_DRAFT_KEY;
+  }
+  if (target.kind === 'quick-chat') {
+    const match = /^quick-chat:\d+:(.+)$/s.exec(input.candidateKey);
+    // The old Personal sentinel also collides with an organization named personal. Explicit selection
+    // resolves that ambiguity; an epoch alone never proves either durable user or context.
+    return match?.[1] === (context.kind === 'personal' ? 'personal' : context.organizationId);
+  }
+  if (input.candidateKey !== agentComposerDraftKey(target.sessionId)) {
+    return false;
+  }
+  const { trpcClient } = await import('@/lib/trpc');
+  if (!isAuthenticatedOwner(input.owner) || !input.isCurrent()) {
+    return false;
+  }
+  // cliSessionsV2.get checks kilo_user_id and organization access on the server. Route params do not.
+  const session = await trpcClient.cliSessionsV2.get.query({ session_id: target.sessionId });
+  return (
+    session.kilo_user_id === input.owner.userId &&
+    session.session_id === target.sessionId &&
+    sameContext(contextScope(session.organization_id), context)
+  );
+}
+
+/** Preserve the source until a same-owner/generation destination commit is confirmed. */
+export async function migrateLegacyDraft(input: MigrationInput): Promise<DraftMigrationResult> {
+  const { owner, destinationKey, candidateKey } = input;
+  const isCurrent = () => isAuthenticatedOwner(owner) && input.isCurrent();
+  if (!isCurrent() || owner.userId === null) {
+    return 'stale';
+  }
+  const destination = parseScopedDraftKey(destinationKey);
+  if (!destination || !legacyKind(candidateKey)) {
+    return 'unavailable';
+  }
+  try {
+    if (!(await validateLegacyDestination(input, destination))) {
+      return 'unavailable';
+    }
+    if (!isCurrent()) {
+      return 'stale';
+    }
+    const source = await loadDraftResult(owner.userId, candidateKey, isStringDraft, isCurrent);
+    if (!isCurrent()) {
+      return 'stale';
+    }
+    if (source.status !== 'present') {
+      return source.status;
+    }
+    const target = await loadDraftResult(owner.userId, destinationKey, isStringDraft, isCurrent);
+    if (!isCurrent()) {
+      return 'stale';
+    }
+    if (target.status === 'failed' || target.status === 'malformed') {
+      return target.status;
+    }
+    if (target.status === 'present' && target.value !== source.value) {
+      return 'conflict';
+    }
+    if (target.status === 'absent') {
+      const outcome = await saveDraftConfirmed(owner.userId, destinationKey, source.value, {
+        isCurrent,
+        expectedSerialized: null,
+      });
+      if (outcome !== 'committed') {
+        return outcome;
+      }
+    }
+    if (!isCurrent()) {
+      return 'stale';
+    }
+    await clearDraftIfStill(owner.userId, candidateKey, source.serialized, isCurrent);
+    return isCurrent() ? 'committed' : 'stale';
+  } catch {
+    return isCurrent() ? 'failed' : 'stale';
+  }
+}

--- a/apps/mobile/src/lib/persist/scoped-draft-load.mounted.test.tsx
+++ b/apps/mobile/src/lib/persist/scoped-draft-load.mounted.test.tsx
@@ -1,0 +1,471 @@
+/* eslint-disable max-lines -- one mounted composer harness proves real-store recovery and generation fencing */
+/* eslint-disable typescript-eslint/no-deprecated -- React Native tests use the installed DOM-free renderer */
+/* eslint-disable require-await, typescript-eslint/require-await -- native fixtures and async act callbacks settle synchronously */
+// eslint-disable-next-line import/no-nodejs-modules -- the Expo adapter drives real SQLite through the installed Node runtime
+import { DatabaseSync, type SQLInputValue, type StatementSync } from 'node:sqlite';
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type AuthenticatedOwner } from '@/lib/context-scope';
+import type * as DraftHooks from './use-draft-load';
+
+const mocks = vi.hoisted(() => ({
+  secure: new Map<string, string>(),
+  readKey: vi.fn(),
+  open: vi.fn(),
+  removeDatabase: vi.fn(),
+  random: vi.fn(),
+  hasCipher: true,
+}));
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: mocks.readKey,
+  setItemAsync: async (key: string, value: string) => {
+    mocks.secure.set(key, value);
+  },
+}));
+vi.mock('expo-crypto', () => ({ getRandomBytesAsync: mocks.random }));
+vi.mock('expo-sqlite', () => ({
+  openDatabaseSync: mocks.open,
+  deleteDatabaseAsync: mocks.removeDatabase,
+}));
+vi.mock('@sentry/react-native', () => ({ captureException: vi.fn() }));
+
+let database: DatabaseSync | undefined = undefined;
+let renderer: TestRenderer.ReactTestRenderer | undefined = undefined;
+let hooks: typeof DraftHooks | undefined = undefined;
+let owner: AuthenticatedOwner = { authEpoch: 0, generation: 0, userId: null };
+let key = '';
+const observed: { current: ReturnType<typeof DraftHooks.useScopedDraftLoad<string>> | null } = {
+  current: null,
+};
+
+function nativeStatement(statement: StatementSync) {
+  const returnsRows = statement.columns().length > 0;
+  return {
+    executeSync: (params: SQLInputValue[] = []) => {
+      if (!returnsRows) {
+        const result = statement.run(...params);
+        return {
+          changes: result.changes,
+          lastInsertRowId: result.lastInsertRowid,
+          getAllSync: () => [],
+          getFirstSync: () => null,
+        };
+      }
+      const rows = statement.all(...params);
+      return {
+        changes: 0,
+        lastInsertRowId: 0,
+        getAllSync: () => rows,
+        getFirstSync: () => rows[0] ?? null,
+      };
+    },
+    executeForRawResultSync: (params: SQLInputValue[] = []) => ({
+      getAllSync: () => statement.all(...params).map(row => Object.values(row)),
+    }),
+  };
+}
+function nativeClient() {
+  const db = database;
+  if (!db) {
+    throw new Error('Database fixture is absent');
+  }
+  return {
+    getFirstSync: (source: string) => {
+      if (source === 'PRAGMA cipher_version') {
+        return mocks.hasCipher ? { cipher_version: '4.5' } : null;
+      }
+      return db.prepare(source).get() ?? null;
+    },
+    execSync: (source: string) => {
+      db.exec(source);
+    },
+    prepareSync: (source: string) => nativeStatement(db.prepare(source)),
+    // Native handles close independently of the durable file. The backing SQLite stays until teardown.
+    closeAsync: async () => undefined,
+  };
+}
+function Composer({
+  prefill = '',
+  selection = 0,
+  entityKey = key,
+}: {
+  prefill?: string;
+  selection?: number;
+  entityKey?: string;
+}) {
+  if (!hooks) {
+    throw new Error('Draft hooks are absent');
+  }
+  const draft = hooks.useScopedDraftLoad({
+    owner,
+    entityKey,
+    selectionGeneration: selection,
+    isReady: true,
+  });
+  observed.current = draft;
+  return createElement('composer', {
+    status: draft.status,
+    restored: draft.value,
+    prefill,
+    onChangeText: draft.save,
+  });
+}
+function currentDraft() {
+  if (!observed.current) {
+    throw new Error('Composer did not mount');
+  }
+  return observed.current;
+}
+async function mount(prefill = '') {
+  await act(async () => {
+    renderer = TestRenderer.create(createElement(Composer, { prefill }));
+  });
+}
+function stored(userId = 'account-a', entityKey = key) {
+  return database
+    ?.prepare('SELECT v FROM kv WHERE scope = ? AND k = ?')
+    .get(`draft:${userId}`, entityKey)?.v;
+}
+async function signIn(userId: string) {
+  const epochs = await import('@/lib/auth/auth-epoch');
+  const context = await import('@/lib/context-scope');
+  epochs.bumpAuthEpoch();
+  context.beginAuthenticatedOwner();
+  context.confirmAuthenticatedOwner(context.getAuthenticatedOwner(), userId);
+  owner = context.getAuthenticatedOwner();
+}
+beforeEach(async () => {
+  vi.resetModules();
+  vi.resetAllMocks();
+  database = new DatabaseSync(':memory:');
+  observed.current = null;
+  mocks.secure.clear();
+  mocks.hasCipher = true;
+  mocks.readKey.mockImplementation(
+    async (storageKey: string) => mocks.secure.get(storageKey) ?? null
+  );
+  mocks.random.mockResolvedValue(new Uint8Array(32).fill(9));
+  mocks.open.mockImplementation(nativeClient);
+  const keys = await import('./scoped-draft-keys');
+  key = keys.scopedDraftKey({ kind: 'personal' }, { kind: 'new-session' });
+  const store = await import('./encrypted-kv');
+  await store.setItem('draft:account-a', key, '"saved a"');
+  await store.setItem('draft:account-b', key, '"saved b"');
+  await store.setItem('draft:account-a', 'agent-composer:new', '"legacy a"');
+  // Simulate a cold process before the scenario. No module reset or test-only open reset runs after failure.
+  vi.resetModules();
+  vi.clearAllMocks();
+  hooks = await import('./use-draft-load');
+  await signIn('account-a');
+});
+afterEach(async () => {
+  await act(async () => {
+    renderer?.unmount();
+  });
+  const drafts = await import('./drafts');
+  drafts.resetDraftTimersForTests();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  database?.close();
+  database = undefined;
+});
+
+describe('strict mounted composer persistence', () => {
+  it('retains a typed malformed result after external repair until an explicit Retry restores the value', async () => {
+    database
+      ?.prepare('UPDATE kv SET v = ? WHERE scope = ? AND k = ?')
+      .run('42', 'draft:account-a', key);
+    await mount();
+    expect(currentDraft().status).toBe('malformed');
+    database
+      ?.prepare('UPDATE kv SET v = ? WHERE scope = ? AND k = ?')
+      .run('"repaired"', 'draft:account-a', key);
+    expect(currentDraft().canWrite).toBe(false);
+    await act(async () => {
+      await currentDraft().retry();
+    });
+    expect(currentDraft()).toMatchObject({ status: 'present', value: 'repaired', canWrite: true });
+    expect(stored()).toBe('"repaired"');
+  });
+  it('flushes already-admitted draft work on an ordinary unmount without granting unresolved writes', async () => {
+    await mount();
+    const admitted = currentDraft();
+    admitted.save('leaving text');
+    await act(async () => {
+      renderer?.unmount();
+    });
+    await admitted.flush();
+    expect(stored()).toBe('"leaving text"');
+  });
+  it.each(['debounce', 'flush'])(
+    'preserves an admitted edit across a context switch through %s while the replacement stays protected',
+    async completion => {
+      await mount();
+      vi.useFakeTimers();
+      const admitted = currentDraft();
+      const keys = await import('./scoped-draft-keys');
+      const replacementKey = keys.scopedDraftKey(
+        { kind: 'organization', organizationId: 'org-a' },
+        { kind: 'new-session' }
+      );
+      const store = await import('./encrypted-kv');
+      await store.setItem('draft:account-a', replacementKey, '"replacement text"');
+      const gate = Promise.withResolvers<string | null>();
+      const read = vi.spyOn(store, 'getItem').mockReturnValueOnce(gate.promise);
+      admitted.save('leaving context text');
+      await act(async () => {
+        renderer?.update(createElement(Composer, { entityKey: replacementKey, selection: 1 }));
+      });
+      expect(currentDraft()).toMatchObject({ status: 'unresolved', canWrite: false });
+      await act(async () => {
+        admitted.save('stale edit');
+        currentDraft().save('unresolved edit');
+        await currentDraft().flush();
+        expect(await currentDraft().clear()).toBe(false);
+        expect(await currentDraft().importLegacy('agent-composer:new')).toBe('stale');
+        await (completion === 'flush' ? admitted.flush() : vi.advanceTimersByTimeAsync(500));
+      });
+      expect(stored()).toBe('"leaving context text"');
+      expect(stored('account-a', replacementKey)).toBe('"replacement text"');
+      await act(async () => {
+        gate.resolve('"replacement text"');
+      });
+      read.mockRestore();
+      await act(async () => {
+        renderer?.update(createElement(Composer, { selection: 2 }));
+      });
+      expect(currentDraft()).toMatchObject({
+        status: 'present',
+        value: 'leaving context text',
+        canWrite: true,
+      });
+    }
+  );
+  it('rejects an admitted pending save after account replacement without changing either account draft', async () => {
+    await mount();
+    vi.useFakeTimers();
+    const admitted = currentDraft();
+    admitted.save('pending a');
+    await act(async () => {
+      await signIn('account-b');
+      renderer?.update(createElement(Composer));
+    });
+    await act(async () => {
+      await admitted.flush();
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(stored('account-a')).toBe('"saved a"');
+    expect(stored('account-b')).toBe('"saved b"');
+    expect(currentDraft()).toMatchObject({ status: 'present', value: 'saved b', canWrite: true });
+  });
+  it.each([
+    { replacement: 'account', restored: 'saved b' },
+    { replacement: 'key', restored: 'saved replacement' },
+    { replacement: 'selection', restored: 'saved a' },
+  ])(
+    'ignores the old Retry after $replacement replacement restores without revoking the replacement write grant',
+    async ({ replacement, restored }) => {
+      mocks.readKey.mockRejectedValueOnce(new Error('temporary keychain failure'));
+      await mount();
+      expect(currentDraft().status).toBe('failed');
+      const oldRetry = currentDraft().retry;
+      const keys = await import('./scoped-draft-keys');
+      const replacementKey =
+        replacement === 'key' ? keys.scopedDraftKey({ kind: 'personal' }, { kind: 'search' }) : key;
+      if (replacement === 'key') {
+        database
+          ?.prepare('INSERT INTO kv (scope, k, v, updated_at) VALUES (?, ?, ?, ?)')
+          .run('draft:account-a', replacementKey, '"saved replacement"', Date.now());
+      }
+      await act(async () => {
+        if (replacement === 'account') {
+          await signIn('account-b');
+        }
+        renderer?.update(createElement(Composer, { entityKey: replacementKey, selection: 1 }));
+      });
+      await act(async () => {
+        await currentDraft().retry();
+      });
+      expect(currentDraft()).toMatchObject({ status: 'present', value: restored, canWrite: true });
+      await act(async () => {
+        await oldRetry();
+      });
+      expect(currentDraft()).toMatchObject({ status: 'present', value: restored, canWrite: true });
+      await act(async () => {
+        currentDraft().save('edited replacement');
+        await currentDraft().flush();
+      });
+      expect(stored(replacement === 'account' ? 'account-b' : 'account-a', replacementKey)).toBe(
+        '"edited replacement"'
+      );
+    }
+  );
+  it('ignores a failed Retry callback after a newer retry restores the same draft', async () => {
+    mocks.readKey.mockRejectedValueOnce(new Error('temporary keychain failure'));
+    await mount();
+    const oldRetry = currentDraft().retry;
+    await act(async () => {
+      await currentDraft().retry();
+    });
+    await act(async () => {
+      await oldRetry();
+      currentDraft().save('edit after recovery');
+      await currentDraft().flush();
+    });
+    expect(stored()).toBe('"edit after recovery"');
+    expect(currentDraft()).toMatchObject({ status: 'present', canWrite: true });
+  });
+  it('restores saved text and permits editing only after the strict read succeeds', async () => {
+    await mount();
+    expect(renderer?.toJSON()).toMatchObject({ props: { status: 'present', restored: 'saved a' } });
+    await act(async () => {
+      currentDraft().save('edited');
+      await currentDraft().flush();
+    });
+    expect(stored()).toBe('"edited"');
+  });
+  it('blocks prefill, autosave, flush, clear, and import after a rejected key read, then Retry restores the real store', async () => {
+    mocks.readKey.mockRejectedValueOnce(new Error('temporary keychain failure'));
+    const savedKey = mocks.secure.get('persist-db-key');
+    await mount('prefilled text');
+    expect(currentDraft()).toMatchObject({
+      status: 'failed',
+      canWrite: false,
+      recovery: { status: 'retryable', reason: 'secure-store' },
+    });
+    await act(async () => {
+      currentDraft().save('must not overwrite');
+      await currentDraft().flush();
+      expect(await currentDraft().clear()).toBe(false);
+      expect(await currentDraft().importLegacy('agent-composer:new')).toBe('stale');
+    });
+    expect(stored()).toBe('"saved a"');
+    expect(stored('account-a', 'agent-composer:new')).toBe('"legacy a"');
+    const store = await import('./encrypted-kv');
+    await expect(store.getItem('draft:account-a', key)).rejects.toThrow('secure-store');
+    expect(mocks.open).not.toHaveBeenCalled();
+    await act(async () => {
+      await currentDraft().retry();
+    });
+    expect(renderer?.toJSON()).toMatchObject({ props: { status: 'present', restored: 'saved a' } });
+    expect(stored()).toBe('"saved a"');
+    expect(mocks.secure.get('persist-db-key')).toBe(savedKey);
+    expect(mocks.removeDatabase).not.toHaveBeenCalled();
+    expect(mocks.random).not.toHaveBeenCalled();
+  });
+  it('coalesces concurrent Retry and retains the successful native handle', async () => {
+    mocks.readKey.mockRejectedValueOnce(new Error('temporary keychain failure'));
+    await mount();
+    await act(async () => {
+      await Promise.all([currentDraft().retry(), currentDraft().retry(), currentDraft().retry()]);
+    });
+    expect(currentDraft()).toMatchObject({ status: 'present', value: 'saved a' });
+    await act(async () => {
+      currentDraft().save('after retry');
+      await currentDraft().flush();
+    });
+    expect(stored()).toBe('"after retry"');
+    expect(mocks.open).toHaveBeenCalledTimes(1);
+  });
+  it('preserves malformed draft bytes and keeps every write blocked through nondestructive Retry', async () => {
+    database
+      ?.prepare('UPDATE kv SET v = ? WHERE scope = ? AND k = ?')
+      .run('{broken', 'draft:account-a', key);
+    await mount('prefill');
+    expect(currentDraft()).toMatchObject({ status: 'malformed', canWrite: false });
+    await act(async () => {
+      currentDraft().save('lost text');
+      await currentDraft().flush();
+      expect(await currentDraft().clear()).toBe(false);
+      await currentDraft().retry();
+    });
+    expect(currentDraft().status).toBe('malformed');
+    expect(stored()).toBe('{broken');
+    expect(mocks.removeDatabase).not.toHaveBeenCalled();
+  });
+  it('treats a genuinely absent scoped record as empty and writable', async () => {
+    const keys = await import('./scoped-draft-keys');
+    const emptyKey = keys.scopedDraftKey({ kind: 'personal' }, { kind: 'search' });
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Composer, { entityKey: emptyKey }));
+    });
+    expect(currentDraft()).toMatchObject({ status: 'absent', canWrite: true, value: null });
+    await act(async () => {
+      currentDraft().save('query');
+      await currentDraft().flush();
+    });
+    expect(stored('account-a', emptyKey)).toBe('"query"');
+  });
+  it('abandons the old account restore and actions while the store open is pending', async () => {
+    const gate = Promise.withResolvers<string | null>();
+    mocks.readKey.mockReturnValueOnce(gate.promise);
+    await mount('prefill a');
+    const old = currentDraft();
+    expect(old.canWrite).toBe(false);
+    await act(async () => {
+      await signIn('account-b');
+      renderer?.update(createElement(Composer));
+    });
+    await act(async () => {
+      gate.resolve(mocks.secure.get('persist-db-key') ?? null);
+    });
+    expect(currentDraft()).toMatchObject({ status: 'present', value: 'saved b' });
+    await act(async () => {
+      old.save('stale a');
+      await old.flush();
+    });
+    expect(stored('account-a')).toBe('"saved a"');
+    expect(stored('account-b')).toBe('"saved b"');
+  });
+  it('revokes a previous restoration grant after selection generation changes', async () => {
+    await mount();
+    const old = currentDraft();
+    await act(async () => {
+      renderer?.update(createElement(Composer, { selection: 1 }));
+    });
+    await act(async () => {
+      old.save('stale selection');
+      await old.flush();
+      expect(await old.clear()).toBe(false);
+    });
+    expect(stored()).toBe('"saved a"');
+  });
+  it('protects MissingSQLCipher with rebuild guidance and never deletes or replaces stored bytes', async () => {
+    mocks.hasCipher = false;
+    const savedKey = mocks.secure.get('persist-db-key');
+    await mount();
+    expect(currentDraft()).toMatchObject({
+      status: 'failed',
+      canWrite: false,
+      recovery: { status: 'protected', reason: 'missing-sqlcipher', guidance: 'rebuild' },
+    });
+    await act(async () => {
+      await currentDraft().retry();
+    });
+    expect(currentDraft().status).toBe('failed');
+    expect(stored()).toBe('"saved a"');
+    expect(mocks.secure.get('persist-db-key')).toBe(savedKey);
+    expect(mocks.removeDatabase).not.toHaveBeenCalled();
+    expect(mocks.random).not.toHaveBeenCalled();
+  });
+  it('protects unknown open errors and permits only explicit nondestructive Retry', async () => {
+    mocks.open.mockImplementationOnce(() => {
+      throw new Error('opaque native failure');
+    });
+    await mount();
+    expect(currentDraft()).toMatchObject({
+      status: 'failed',
+      recovery: { status: 'protected', reason: 'unknown', guidance: 'retry-without-reset' },
+    });
+    const store = await import('./encrypted-kv');
+    await expect(store.getItem('draft:account-a', key)).rejects.toThrow('unknown');
+    expect(mocks.open).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await currentDraft().retry();
+    });
+    expect(currentDraft().value).toBe('saved a');
+    expect(stored()).toBe('"saved a"');
+    expect(mocks.removeDatabase).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/lib/persist/use-draft-load.test.ts
+++ b/apps/mobile/src/lib/persist/use-draft-load.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- legacy restoration and captured cleanup share the same KV and mounted hook harness */
 /* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (node env, no jsdom); see src/lib/persist/cache-persistence-mount.test.ts */
 /* eslint-disable require-await, @typescript-eslint/require-await -- the fake KV factories settle without await because they resolve immediately */
 import * as React from 'react';
@@ -24,8 +25,9 @@ vi.mock('@sentry/react-native', () => ({
 }));
 
 /* eslint-disable import/first */
-import { isMergeDraft, prMergeDraftKey } from './drafts';
-import { useFencedDraftLoad } from './use-draft-load';
+import { flushDraft, isMergeDraft, prMergeDraftKey, saveDraft } from './drafts';
+import { useFencedDraftLoad, useRemoteSpawnDraftCleanup } from './use-draft-load';
+import { bumpAuthEpoch } from '@/lib/auth/auth-epoch';
 /* eslint-enable import/first */
 
 function storageKey(scope: string, k: string): string {
@@ -275,5 +277,81 @@ describe('useFencedDraftLoad generic draft shape', () => {
 
     // B has no stored value. The stale A load must never publish A's value.
     expect(renders.at(-1)).toEqual({ settled: true, value: null });
+  });
+});
+
+const cleanupControl: { current: ReturnType<typeof useRemoteSpawnDraftCleanup> | null } = {
+  current: null,
+};
+function RemoteCleanupHarness({
+  entityKey,
+  isCurrent,
+}: {
+  entityKey: string;
+  isCurrent: () => boolean;
+}) {
+  cleanupControl.current = useRemoteSpawnDraftCleanup({
+    userId: 'u1',
+    entityKey,
+    isCurrent: () => isCurrent(),
+  });
+  return null;
+}
+async function mountCleanup() {
+  const context = await import('@/lib/context-scope');
+  const keys = await import('./scoped-draft-keys');
+  context.beginAuthenticatedOwner();
+  context.confirmAuthenticatedOwner(context.getAuthenticatedOwner(), 'u1');
+  const owner = context.getAuthenticatedOwner();
+  const isCurrent = () => context.isAuthenticatedOwner(owner);
+  const entityKey = keys.scopedDraftKey(context.contextScope('personal'), { kind: 'new-session' });
+  const rendererRef: { current: TestRenderer.ReactTestRenderer | null } = { current: null };
+  await act(async () => {
+    rendererRef.current = TestRenderer.create(
+      React.createElement(RemoteCleanupHarness, { entityKey, isCurrent })
+    );
+  });
+  if (!rendererRef.current) {
+    throw new Error('Cleanup harness did not mount');
+  }
+  return { renderer: rendererRef.current, entityKey, isCurrent };
+}
+describe('captured remote-spawn draft cleanup', () => {
+  it('clears the captured tagged key only on leave, not when its guard callback changes', async () => {
+    const { renderer, entityKey, isCurrent } = await mountCleanup();
+    seedStoredValue('draft:u1', entityKey, '"captured"');
+    seedStoredValue('draft:u1', 'agent-composer:new', '"legacy fallback"');
+    cleanupControl.current?.markRemoteSpawnAttempted();
+    await act(async () => {
+      renderer.update(React.createElement(RemoteCleanupHarness, { entityKey, isCurrent }));
+    });
+    expect(kvStore.get(storageKey('draft:u1', entityKey))?.v).toBe('"captured"');
+    await act(async () => {
+      renderer.unmount();
+    });
+    await flushMicrotasks();
+    expect(kvStore.has(storageKey('draft:u1', entityKey))).toBe(false);
+    expect(kvStore.get(storageKey('draft:u1', 'agent-composer:new'))?.v).toBe('"legacy fallback"');
+  });
+  it('flushes the exact captured key on a normal leave', async () => {
+    const { renderer, entityKey, isCurrent } = await mountCleanup();
+    saveDraft('u1', entityKey, 'unsent', isCurrent);
+    await act(async () => {
+      renderer.unmount();
+    });
+    await flushMicrotasks();
+    expect(kvStore.get(storageKey('draft:u1', entityKey))?.v).toBe('"unsent"');
+  });
+  it('keeps the old draft when auth changes before a recorded spawn leaves', async () => {
+    const { renderer, entityKey, isCurrent } = await mountCleanup();
+    saveDraft('u1', entityKey, 'preserved', isCurrent);
+    await flushDraft('u1', entityKey, isCurrent);
+    cleanupControl.current?.markRemoteSpawnAttempted();
+    bumpAuthEpoch();
+    await act(async () => {
+      renderer.unmount();
+    });
+    await flushMicrotasks();
+    expect(kvStore.get(storageKey('draft:u1', entityKey))?.v).toBe('"preserved"');
   });
 });

--- a/apps/mobile/src/lib/persist/use-draft-load.ts
+++ b/apps/mobile/src/lib/persist/use-draft-load.ts
@@ -1,138 +1,309 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { currentAuthEpoch, isCurrentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { type AuthenticatedOwner, isAuthenticatedOwner } from '@/lib/context-scope';
 import {
   clearDraft,
+  type DraftLoadResult,
   type DraftShapeValidator,
   flushDraft,
   isStringDraft,
   loadDraft,
+  loadDraftResult,
   NEW_SESSION_DRAFT_KEY,
+  saveDraft,
 } from '@/lib/persist/drafts';
+import { encryptedStoreRecovery, retryEncryptedKvOpen } from './encrypted-kv';
+import { migrateLegacyDraft, parseScopedDraftKey } from './scoped-draft-keys';
 
 type UseFencedDraftLoadInput<T> = {
   userId: string | undefined;
   isIdentityLoading: boolean;
-  /** Full draft entity key under `draft:<userId>` (e.g. `agent-composer:new`). */
   entityKey: string;
-  /** Shape validator for the loaded value; defaults to a string draft. */
   validate?: DraftShapeValidator<T>;
 };
 
-/**
- * Loads a durable draft under `draft:<userId>` once per identity/entity
- * generation. Resets to the not-settled state whenever the identity or entity
- * changes, and only the newest generation's load may publish: every effect run
- * captures the current generation and every cleanup (unmount or a superseding
- * run) bumps it, so a load started for an older account or session can never
- * publish into the newest screen. `value` stays null until a stored draft (or
- * the absence of one) has loaded. The draft shape is the caller's contract:
- * pass a `validate` guard for a non-string draft, or omit it for a string.
- */
+/** Compatibility only: unchanged PR/review/share callers retain nullable restoration. */
 export function useFencedDraftLoad<T = string>({
   userId,
   isIdentityLoading,
   entityKey,
   validate,
-}: UseFencedDraftLoadInput<T>): {
-  settled: boolean;
-  value: T | null;
-} {
-  const resolvedValidate = (validate ?? isStringDraft) as DraftShapeValidator<T>;
-  // Hold the resolved validator in a ref so the effect's dependency array stays
-  // limited to the identity/entity generation (the validator is a stable
-  // module-level guard for every caller).
-  const resolvedValidateRef = useRef(resolvedValidate);
-  resolvedValidateRef.current = resolvedValidate;
-  const [draftState, setDraftState] = useState<{ settled: boolean; value: T | null }>({
+}: UseFencedDraftLoadInput<T>): { settled: boolean; value: T | null } {
+  const resolvedValidateRef = useRef((validate ?? isStringDraft) as DraftShapeValidator<T>);
+  resolvedValidateRef.current = (validate ?? isStringDraft) as DraftShapeValidator<T>;
+  const epoch = currentAuthEpoch();
+  const identity = JSON.stringify([epoch, userId, entityKey]);
+  const activeIdentity = useRef(identity);
+  const generation = useRef(0);
+  if (activeIdentity.current !== identity) {
+    activeIdentity.current = identity;
+    generation.current += 1;
+  }
+  const [stored, setStored] = useState<{ identity: string; settled: boolean; value: T | null }>({
+    identity,
     settled: false,
     value: null,
   });
-  // Reset the settled draft state when the identity or entity changes, so the
-  // prompt stays hidden while the new generation's draft loads and never
-  // shows the previous account's or session's draft.
-  const draftIdentity = `${userId ?? 'anonymous'}\u0000${entityKey}`;
-  const [prevDraftIdentity, setPrevDraftIdentity] = useState(draftIdentity);
-  // The reset must be visible on THIS render, not the next: a deferred
-  // setDraftState would still return the previous account's or entity's
-  // settled value here, and a surface seeding from that stale value would
-  // pin the old text to the new key.
-  const identityChanged = prevDraftIdentity !== draftIdentity;
-  // Generation fence: a load applies only when its captured generation is
-  // still current. The identity-change render bumps the generation
-  // synchronously, so an in-flight load whose read already resolved can never
-  // publish the previous account's or entity's value before the effect
-  // cleanup runs. Cleanup (unmount or a superseding run) bumps it again, so a
-  // stale load can never publish after a newer run armed itself (refs dodge
-  // type-aware flow narrowing).
-  const draftLoadGenerationRef = useRef(0);
-  if (identityChanged) {
-    setPrevDraftIdentity(draftIdentity);
-    setDraftState({ settled: false, value: null });
-    draftLoadGenerationRef.current += 1;
-  }
   useEffect(() => {
-    draftLoadGenerationRef.current += 1;
-    const generation = draftLoadGenerationRef.current;
+    generation.current += 1;
+    const attempt = generation.current;
+    setStored({ identity, settled: false, value: null });
     if (!userId) {
       if (!isIdentityLoading) {
-        setDraftState({ settled: true, value: null });
+        setStored({ identity, settled: true, value: null });
       }
       return undefined;
     }
     void (async () => {
       const value = await loadDraft(userId, entityKey, resolvedValidateRef.current);
-      if (draftLoadGenerationRef.current === generation) {
-        setDraftState({ settled: true, value: value ?? null });
+      if (attempt === generation.current && isCurrentAuthEpoch(epoch)) {
+        setStored({ identity, settled: true, value });
       }
     })();
     return () => {
-      draftLoadGenerationRef.current += 1;
+      generation.current += 1;
     };
-  }, [userId, isIdentityLoading, entityKey]);
-  return identityChanged ? { settled: false, value: null } : draftState;
+  }, [identity, userId, entityKey, isIdentityLoading, epoch]);
+  return stored.identity === identity
+    ? { settled: stored.settled, value: stored.value }
+    : { settled: false, value: null };
+}
+
+export type ScopedDraftState<T> = DraftLoadResult<T> | Readonly<{ status: 'unresolved' }>;
+type ScopedDraftInput<T> = {
+  owner: AuthenticatedOwner;
+  entityKey: string;
+  selectionGeneration: number;
+  isReady: boolean;
+  validate?: DraftShapeValidator<T>;
+};
+
+/** The restored result, not initial/prefilled text, grants access to every persistence action. */
+export function useScopedDraftLoad<T = string>({
+  owner,
+  entityKey,
+  selectionGeneration,
+  isReady,
+  validate,
+}: ScopedDraftInput<T>) {
+  const identity = JSON.stringify([
+    owner.authEpoch,
+    owner.generation,
+    owner.userId,
+    entityKey,
+    selectionGeneration,
+    isReady,
+  ]);
+  const activeIdentity = useRef(identity);
+  const generation = useRef(0);
+  const writeGeneration = useRef<number | null>(null);
+  if (activeIdentity.current !== identity) {
+    activeIdentity.current = identity;
+    generation.current += 1;
+    writeGeneration.current = null;
+  }
+  const validateRef = useRef((validate ?? isStringDraft) as DraftShapeValidator<T>);
+  validateRef.current = (validate ?? isStringDraft) as DraftShapeValidator<T>;
+  const [stored, setStored] = useState<{
+    identity: string;
+    generation: number;
+    result: ScopedDraftState<T>;
+  }>({ identity, generation: 0, result: { status: 'unresolved' } });
+  const pending = useRef<{ identity: string; generation: number; promise: Promise<void> } | null>(
+    null
+  );
+
+  const load = useCallback(
+    async (retryStore: boolean): Promise<void> => {
+      if (!isReady || activeIdentity.current !== identity || !isAuthenticatedOwner(owner)) {
+        return;
+      }
+      if (
+        pending.current?.identity === identity &&
+        pending.current.generation === generation.current
+      ) {
+        return pending.current.promise;
+      }
+      generation.current += 1;
+      writeGeneration.current = null;
+      const attempt = generation.current;
+      const isCurrent = () =>
+        activeIdentity.current === identity &&
+        generation.current === attempt &&
+        isAuthenticatedOwner(owner);
+      setStored({ identity, generation: attempt, result: { status: 'unresolved' } });
+      const promise = (async () => {
+        if (owner.userId === null || !isCurrent()) {
+          return;
+        }
+        let result: ScopedDraftState<T> = { status: 'unresolved' };
+        try {
+          if (retryStore) {
+            await retryEncryptedKvOpen();
+          }
+          if (!isCurrent()) {
+            return;
+          }
+          result = parseScopedDraftKey(entityKey)
+            ? await loadDraftResult(owner.userId, entityKey, validateRef.current, isCurrent)
+            : { status: 'malformed', reason: 'shape' };
+        } catch (error) {
+          result = { status: 'failed', error };
+        }
+        if (isCurrent()) {
+          writeGeneration.current =
+            result.status === 'present' || result.status === 'absent' ? attempt : null;
+          setStored({ identity, generation: attempt, result });
+        }
+      })();
+      const flight = { identity, generation: attempt, promise };
+      pending.current = flight;
+      void (async () => {
+        await promise;
+        if (pending.current === flight) {
+          pending.current = null;
+        }
+      })();
+      await promise;
+    },
+    [identity, owner, entityKey, isReady]
+  );
+
+  useEffect(() => {
+    void load(false);
+    return () => {
+      generation.current += 1;
+    };
+  }, [load]);
+  const result: ScopedDraftState<T> =
+    stored.identity === identity && stored.generation === generation.current
+      ? stored.result
+      : { status: 'unresolved' };
+  const restored = result.status === 'present' || result.status === 'absent';
+  const persistenceAllowed = () => isAuthenticatedOwner(owner);
+  const allowed = () =>
+    isReady &&
+    persistenceAllowed() &&
+    activeIdentity.current === identity &&
+    stored.generation === generation.current &&
+    stored.generation === writeGeneration.current &&
+    restored;
+  const retry = async () => {
+    if (activeIdentity.current !== identity || !isAuthenticatedOwner(owner)) {
+      return;
+    }
+    if (
+      pending.current?.identity === identity &&
+      pending.current.generation === generation.current
+    ) {
+      await pending.current.promise;
+    } else if (
+      stored.generation === generation.current &&
+      (result.status === 'failed' || result.status === 'malformed')
+    ) {
+      await load(true);
+    }
+  };
+  const save = (value: T) => {
+    if (owner.userId !== null && allowed()) {
+      // Context changes close new edits, not persistence already admitted to this owner and key.
+      saveDraft(owner.userId, entityKey, value, persistenceAllowed);
+    }
+  };
+  const flush = async () => {
+    if (owner.userId !== null && restored && persistenceAllowed()) {
+      await flushDraft(owner.userId, entityKey, persistenceAllowed);
+    }
+  };
+  const clear = async () => {
+    if (owner.userId === null || !allowed()) {
+      return false;
+    }
+    const cleared = await clearDraft(owner.userId, entityKey, allowed);
+    return cleared;
+  };
+  const importLegacy = async (candidateKey: string) => {
+    if (!allowed()) {
+      return 'stale' as const;
+    }
+    const outcome = await migrateLegacyDraft({
+      owner,
+      destinationKey: entityKey,
+      candidateKey,
+      selection: 'explicit',
+      isCurrent: allowed,
+    });
+    if (outcome === 'committed' && allowed()) {
+      await load(false);
+    }
+    return outcome;
+  };
+  return {
+    status: result.status,
+    result,
+    value: result.status === 'present' ? result.value : null,
+    canWrite: allowed(),
+    isCurrent: allowed,
+    recovery: result.status === 'failed' ? encryptedStoreRecovery(result.error) : null,
+    retry,
+    save,
+    flush,
+    clear,
+    importLegacy,
+  };
 }
 
 type UseRemoteSpawnDraftCleanupInput = {
   userId: string | undefined;
+  /** New producers pass the exact captured scoped key; the fallback serves unchanged routes until a6. */
+  entityKey?: string;
+  isCurrent?: () => boolean;
 };
 
-/**
- * Owns the new-session draft's fate when the screen leaves after a remote
- * spawn attempt. The spawn dispatch consumes the outcome internally — a
- * success replaces the screen, a failure toasts and stays — and the route
- * arms the attempt marker only once the dispatch admits the spawn (voice
- * settlement and remote admission passed). The route's observable signal is
- * therefore the attempt marker plus the unmount itself: a successful spawn is
- * the one path that unmounts the screen with an attempt recorded. The leaving
- * route clears the consumed `agent-composer:new` entry (the prompt must not
- * reappear on the next new-session visit) instead of flushing it. Without an
- * attempt the unmount flushes the pending debounce, preserving the draft for
- * a normal leave (back button) or a tap that stopped before any spawn attempt
- * (blocked admission, cancelled voice submit).
- *
- * Boundary: a failed spawn followed by a manual leave also clears the draft.
- * The failed spawn itself never clears — the screen stays mounted, so the
- * retry-while-on-screen contract holds — and the recorded trade-off is that a
- * user who abandons the screen after a failed attempt loses the prompt, the
- * same as if the attempt had succeeded.
- */
-export function useRemoteSpawnDraftCleanup({ userId }: UseRemoteSpawnDraftCleanupInput) {
-  const spawnAttemptedRef = useRef(false);
+/** Preserve the existing attempted-spawn leave policy, but never retarget its captured draft. */
+export function useRemoteSpawnDraftCleanup({
+  userId,
+  entityKey = NEW_SESSION_DRAFT_KEY,
+  isCurrent,
+}: UseRemoteSpawnDraftCleanupInput) {
+  const epoch = currentAuthEpoch();
+  const identity = JSON.stringify([epoch, userId, entityKey]);
+  const guard = useRef({ identity, isCurrent });
+  guard.current = { identity, isCurrent };
+  const attempted = useRef<typeof guard.current | null>(null);
   const markRemoteSpawnAttempted = useCallback(() => {
-    spawnAttemptedRef.current = true;
-  }, []);
+    const current = guard.current;
+    if (
+      current.identity === identity &&
+      isCurrentAuthEpoch(epoch) &&
+      (!current.isCurrent || current.isCurrent())
+    ) {
+      attempted.current = current;
+    }
+  }, [epoch, identity]);
   useEffect(
     () => () => {
-      if (!userId) {
+      const current = guard.current;
+      const allowed = () =>
+        current.identity === identity &&
+        isCurrentAuthEpoch(epoch) &&
+        (!current.isCurrent || current.isCurrent());
+      if (!userId || !allowed()) {
         return;
       }
-      if (spawnAttemptedRef.current) {
-        void clearDraft(userId, NEW_SESSION_DRAFT_KEY);
+      const attempt = attempted.current;
+      if (attempt?.identity === identity && (!attempt.isCurrent || attempt.isCurrent())) {
+        void clearDraft(
+          userId,
+          entityKey,
+          () => allowed() && (!attempt.isCurrent || attempt.isCurrent())
+        );
       } else {
-        void flushDraft(userId, NEW_SESSION_DRAFT_KEY);
+        void flushDraft(userId, entityKey, allowed);
       }
     },
-    [userId]
+    [userId, entityKey, epoch, identity]
   );
   return { markRemoteSpawnAttempted };
 }

--- a/apps/mobile/src/lib/storage-keys.ts
+++ b/apps/mobile/src/lib/storage-keys.ts
@@ -1,5 +1,8 @@
+import * as z from 'zod';
+import { utf8ByteLength } from '@/lib/utf8-utils';
+
 /**
- * Centralized SecureStore key constants.
+ * Centralized SecureStore key constants and persisted draft contracts.
  *
  * All keys used with expo-secure-store should be defined here so they stay
  * consistent across reads, writes, and sign-out cleanup.
@@ -7,7 +10,10 @@
  */
 
 export const AUTH_TOKEN_KEY = 'auth-token';
+/** Legacy, ownerless selection. Read only as an explicit recovery candidate; never restore it automatically. */
 export const ORGANIZATION_STORAGE_KEY = 'selected-organization';
+/** Account-owned tagged context records survive sign-out. Remove the legacy fallback after explicit migration. */
+export const SELECTED_CONTEXT_KEY_PREFIX = 'selected-context-v1-';
 export const SESSION_FILTERS_KEY = 'agent-session-filters';
 export const NOTIFICATION_PROMPT_SEEN_KEY = 'notification-prompt-seen';
 export const LAST_ACTIVE_INSTANCE_KEY = 'last-active-chat-instance';
@@ -85,4 +91,127 @@ export function encodeStorageKey(prefix: string, userId: string): string {
   return `${prefix}${[...new TextEncoder().encode(userId)]
     .map(b => b.toString(16).padStart(2, '0'))
     .join('')}`;
+}
+
+// Legacy draft contracts remain re-exported from persist/drafts. Keep these exact serialized forms
+// until every producer adopts tagged keys and explicit recovery finishes; never rewrite them on read.
+const stringDraftSchema = z.string();
+export function isStringDraft(value: unknown): value is string {
+  return stringDraftSchema.safeParse(value).success;
+}
+export function agentComposerDraftKey(sessionId: string): string {
+  return `agent-composer:${sessionId}`;
+}
+export const NEW_SESSION_DRAFT_KEY = 'agent-composer:new';
+export const SHARE_PAYLOADS_DRAFT_KEY = 'share-payloads';
+export const SHARE_NAV_DRAFT_KEY = 'share-navigation';
+export const PENDING_SHARE_ID_DRAFT_KEY = 'pending-share-id';
+export const SESSION_SEARCH_DRAFT_KEY = 'session-search-query';
+export function prReviewDraftKey(owner: string, repo: string, number: number): string {
+  return `pr-review:${owner}/${repo}#${number}`;
+}
+export function prMergeDraftKey(owner: string, repo: string, number: number): string {
+  return `pr-merge:${owner}/${repo}#${number}`;
+}
+// eslint-disable-next-line max-params -- retain the legacy PR/comment key API
+export function prReplyDraftKey(
+  owner: string,
+  repo: string,
+  number: number,
+  commentId: number
+): string {
+  return `pr-reply:${owner}/${repo}#${number}:${commentId}`;
+}
+// eslint-disable-next-line max-params -- retain the legacy diff-position key API
+export function prCommentDraftKey(
+  owner: string,
+  repo: string,
+  number: number,
+  path: string,
+  side: string,
+  line: number,
+  startLine?: number
+): string {
+  return `pr-comment:${owner}/${repo}#${number}:${path}:${side}:${startLine ?? line}-${line}`;
+}
+const mergeDraftSchema = z.object({ title: z.string(), message: z.string() });
+export function isMergeDraft(value: unknown): value is { title: string; message: string } {
+  return mergeDraftSchema.safeParse(value).success;
+}
+const sharePayloadsDraftSchema = z.object({
+  order: z.array(z.string()),
+  entries: z.record(
+    z.string(),
+    z.object({
+      text: z.string(),
+      files: z.array(z.object({ name: z.string(), uri: z.string() })),
+      failedFiles: z.array(z.string()),
+    })
+  ),
+});
+export type SharePayloadsDraft = z.infer<typeof sharePayloadsDraftSchema>;
+export function isSharePayloadsDraft(value: unknown): value is SharePayloadsDraft {
+  return sharePayloadsDraftSchema.safeParse(value).success;
+}
+const shareNavigationDraftSchema = z.array(
+  z.object({ href: z.string(), shareId: z.string().nullable() })
+);
+export type ShareNavigationDraft = z.infer<typeof shareNavigationDraftSchema>;
+export function isShareNavigationDraft(value: unknown): value is ShareNavigationDraft {
+  return shareNavigationDraftSchema.safeParse(value).success;
+}
+export function securityDismissDraftKey(scope: string, findingId: string): string {
+  return `security-dismiss:${scope}:${findingId}`;
+}
+export function resolvePrefillOverDraft(
+  prefillText: string | null | undefined,
+  draftText: string | null | undefined
+): string | undefined {
+  return prefillText != null && prefillText.trim().length > 0
+    ? prefillText
+    : (draftText ?? undefined);
+}
+
+/** Serialize stored values without scheduling a write for unsupported or oversized data. */
+export function serializeStoredDraft(
+  value: unknown,
+  maxBytes: number,
+  onFailure: (error: unknown, fingerprint?: string) => void
+): string | null {
+  try {
+    // JSON.stringify's declared return omits unsupported top-level values such as undefined.
+    const serialized = JSON.stringify(value) as string | undefined;
+    if (serialized === undefined) {
+      onFailure(
+        new Error('draft value cannot be serialized to JSON'),
+        'draft-write-unsupported-value'
+      );
+      return null;
+    }
+    return utf8ByteLength(serialized) <= maxBytes ? serialized : null;
+  } catch (error) {
+    onFailure(error);
+    return null;
+  }
+}
+
+/** Validate unknown stored bytes without disclosing their contents in an error message. */
+export function parseStoredDraft<T>(
+  raw: string,
+  isValid: (value: unknown) => value is T,
+  maxBytes: number
+):
+  | Readonly<{ status: 'present'; value: T; serialized: string }>
+  | Readonly<{ status: 'malformed'; reason: 'size' | 'shape' | 'json' }> {
+  if (utf8ByteLength(raw) > maxBytes) {
+    return { status: 'malformed', reason: 'size' };
+  }
+  try {
+    const value: unknown = JSON.parse(raw);
+    return isValid(value)
+      ? { status: 'present', value, serialized: raw }
+      : { status: 'malformed', reason: 'shape' };
+  } catch {
+    return { status: 'malformed', reason: 'json' };
+  }
 }


### PR DESCRIPTION
- The app checks the current sign-in before it shows your account details.
- Changing accounts clears the previous account's temporary content and preferences before the new account opens.
- Each account keeps its own Personal or organization choice across sign-out and later sign-in.
- The app confirms organization access before applying a saved or new choice. A failed check preserves the saved choice without switching to Personal.
- Older organization choices shared between accounts no longer apply automatically.
- After a restart, saved session lists and recent repositories wait for an online check of the current account.
- Old screens cannot restore or erase drafts after you sign out and sign in again.
- If saved data cannot open, the app keeps the data and its drafts instead of automatically erasing them.

---

## Summary

`AuthenticatedOwner` binds a proved account to an immutable authentication epoch and generation, which `useCurrentUserId` returns alongside matching account fields.
`confirmAuthenticatedOwner` accepts only a current `user.getMe` response; cached identities and canceled or superseded requests cannot authorize content.
`beginAuthenticatedOwner` revokes that proof during sign-in and sign-out, while `captureAccountGeneration` guards queued work without changing token-refresh behavior.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/context-scope.ts` — Source; A (added), 130 changed lines. Adds observable ownership, generation checks, strict Personal/organization tags, context comparisons, and version-one selection records. Encodes account keys without collisions and separates missing, malformed, and wrong-owner records. Classifies FORBIDDEN, NOT_FOUND, and UNAUTHORIZED as unavailable access.
- `apps/mobile/src/lib/hooks/use-current-user-id.ts` — Source; M (modified), 46 changed lines. Restricts queries to active authentication, forwards cancellation, and preserves the existing query key. Fetches proof when another observer supplies unproved data, exposes the owner, and withholds mismatched identity fields.
- `apps/mobile/src/lib/context-scope.test.ts` — Test; A (added), 83 changed lines. Adds the context-scope test suite.

</details>

`AuthProvider` closes content access and removes account-bound state before publishing replacement credentials; sign-out captures identity before revoking ownership.
`writeAccountMetadata` adds generation and optional `isCurrent` checks without changing existing calls, while `runLogoutCleanup(userId)` requires the captured identity or null.
`initializeLocalAccess` binds secure storage, the authentication prompt, owner changes, and app lifecycle events without exposing biometric controls.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/auth/auth-context.tsx` — Source; M (modified), 109 changed lines. Closes sign-in admission, cancels queries, and clears metadata, preferences, session media, review history, consent outcomes, and telemetry identity before credential publication. Deletes the previous session's read cache during direct sign-in and rejects stale legacy exchange results. Keeps token-derived identity limited to navigation, captures the logout owner, retains selection records, and attempts independent cleanup despite individual failures. Connects local access to secure storage, ownership, lifecycle events, and a translated prompt.
- `apps/mobile/src/lib/auth/account-metadata-write.ts` — Source; M (modified), 14 changed lines. Checks the captured generation and optional caller guard inside each serialized write. Preserves unconditional, ordered deletion and the existing convenience setter.
- `apps/mobile/src/lib/auth/logout-cleanup.ts` — Source; M (modified), 11 changed lines. Takes the proved logout identity from the caller instead of querying cached identity. Uses it for failed push-unregister records and preserves the nonthrowing cleanup contract.
- `apps/mobile/src/lib/auth/auth-context.test.tsx` — Test; M (modified), 285 changed lines. Updates tests for authentication transitions.
- `apps/mobile/src/lib/auth/logout-cleanup.test.ts` — Test; M (modified), 60 changed lines. Adapts logout tests to the explicit identity argument.

</details>

`contextScopeSchema` and `selectedContextSchema` define account-owned `ContextScope` records under `SELECTED_CONTEXT_KEY_PREFIX`; `SelectedContextResult` distinguishes absent, malformed, and wrong-owner data.
`ContextState` and `OrganizationContextValue` separate readiness from failure; `isLoaded` equals `isReady`, so null `organizationId` identifies Personal only after readiness.
`organizations.list` verifies access and `permissionFailureSchema` classifies denial; sign-out preserves choices, but `ORGANIZATION_STORAGE_KEY` now requires explicit selection.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/organization-context.tsx` — Source; M (modified), 245 changed lines. Orders selection reads and writes, rejects superseded results, and waits for live membership checks and successful persistence before declaring readiness. Exposes the owner, selection generation, legacy candidate, deliberate selection, and retry actions. Distinguishes identity, storage, membership, and write failures without discarding saved choices. Selects Personal by default only when account-owned and legacy selections are absent. Updates local-access readiness and retries identity or the last failed request.
- `apps/mobile/src/lib/organization-context.mounted.test.tsx` — Test; A (added), 393 changed lines. Adds the mounted organization-provider test suite.

</details>

`restorePersistedCacheForOwner` and `createReadCachePersister` require current server-proved ownership and matching snapshot identity, then exclude stored identity, membership, and mutations from restoration.
`CachePersistenceMount` restores before subscription, while `restorePersistedCacheOnColdStart`, `takeOverColdStartRestore`, and `ACTIVE_USER_ID_KEY` retain hints without hydrating or clearing current queries.
`readCachedUserId` rejects unproved identities, and `clearCacheScopeForSignOut` checks the generation while restricting known-account deletion to numeric schema versions.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/persist/read-cache.ts` — Source; M (modified), 184 changed lines. Filters restored snapshots to successful allowed content and guards reads, writes, and removals against owner changes. Accepts serialized default session-list keys with omitted undefined fields without relaxing the live allowlist. Retains schema version 1, the 2,097,152-byte limit, and 24-hour expiry. Contains restore failures so live queries continue; unknown-owner cleanup clears cache scopes but leaves drafts intact.
- `apps/mobile/src/lib/persist/cache-persistence-mount.tsx` — Source; M (modified), 132 changed lines. Writes the identity hint, completes owner-checked restoration, and then starts persistence. Stops stale work after unmount or ownership changes and prevents conflicting hints from clearing the current query client. Removes the previous account's read cache when the account changes.
- `apps/mobile/src/lib/persist/read-cache.test.ts` — Test; M (modified), 338 changed lines. Updates the read-cache test suite.
- `apps/mobile/src/lib/persist/cache-persistence-mount.test.ts` — Test; M (modified), 614 changed lines. Updates the cache-persistence mount tests.

</details>

`EncryptedStoreRecovery` and `encryptedStoreRecovery` classify open failures without deleting stored data or replacing its key, retiring automatic reset recovery.
`retryEncryptedKvOpen` retries a failed open explicitly; `setItem`, `removeItem`, and `clearScope` preserve old calls and add optional checks immediately before mutation.
`clearScopePrefix` uses literal prefixes, an optional `isCurrent` guard, and `numericSuffixOnly` to restrict cleanup to one account's numeric cache versions.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/persist/encrypted-kv.ts` — Source; M (modified), 267 changed lines. Returns retry guidance for SecureStore and input/output failures, and protected outcomes for malformed keys, corruption, missing SQLCipher, or unknown errors. Supplies key restoration, database repair, native rebuild, and non-reset retry guidance without deleting data. Preserves empty or malformed keys and closes failed handles without resetting the database. Reuses a pending generated key after storage failure; concurrent opens share one attempt, and successful handles stay open. Keeps failures until explicit retry, reports sanitized errors instead of native SQL text, and checks mutation guards before and after opening. Replaces wildcard deletion with literal prefix matching and optional numeric suffix validation.
- `apps/mobile/src/lib/persist/encrypted-kv.test.ts` — Test; M (modified), 224 changed lines. Updates the encrypted-store test suite.

</details>

`DraftLoadResult` and `loadDraftResult` distinguish absence, malformed data, and read failure; legacy `loadDraft` still supplies nullable results.
`DraftWriteOptions` controls `saveDraftConfirmed`, which returns `DraftWriteResult`; `saveDraft`, `flushDraft`, `clearDraft`, and `clearDraftIfStill` reject work from superseded account generations.
`parseStoredDraft` and `serializeStoredDraft` centralize bounded formats, preserving old imports and stored values; tagged writes require owner guards and cannot evict legacy candidates.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/persist/drafts.ts` — Source; M (modified), 621 changed lines. Uses collision-free tuple queues and captures each write's owner, key, generation, and guard. Adds committed, failed, stale, and conflict outcomes with expected-byte comparisons for confirmed saves. Protects pending edits and unchanged source bytes during conditional removal, preserves malformed records, and contains storage errors. Retains account scopes, sign-out retention, the 500-millisecond debounce, the 65,536-byte limit, and the 100-entry cap. Tagged writes count only tagged entries for eviction; legacy exports remain available.
- `apps/mobile/src/lib/storage-keys.ts` — Source; M (modified), 131 changed lines. Moves composer, review, merge, reply, comment, share, search, security, and prefill contracts without changing their serialized forms. Adds bounded parsing and serialization with content-free parse errors, plus the account selection prefix and the legacy recovery marker.
- `apps/mobile/src/lib/persist/drafts.test.ts` — Test; M (modified), 103 changed lines. Updates the draft persistence tests.

</details>

`DraftTarget`, `draftTargetSchema`, and `scopedKeySchema` let `scopedDraftKey` and `parseScopedDraftKey` distinguish contexts and targets under `SCOPED_DRAFT_KEY_PREFIX`; existing producers retain their keys.
`listLegacyDraftCandidates` returns `LegacyDraftCandidate` metadata only; `migrateLegacyDraft` requires `MigrationInput.selection: 'explicit'`, checks session ownership through `cliSessionsV2.get`, and returns `DraftMigrationResult`.
Migration preserves conflicting or unreadable destinations and removes unchanged source bytes only after a confirmed destination write or a matching existing value.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/persist/scoped-draft-keys.ts` — Source; A (added), 185 changed lines. Adds strict new-session, session, search, and quick-chat targets within the existing account scopes. Discovers legacy names and timestamps without displaying draft content. Validates exact candidates and remote session account, session, and organization matches. Resolves ambiguous Personal and new-session names through explicit selection, protects destination content, and conditionally removes the source after destination confirmation. Adds migration helpers without moving existing draft producers to the new keys.
- `apps/mobile/src/lib/persist/scoped-draft-keys.test.ts` — Test; A (added), 244 changed lines. Adds the scoped-key and migration test suite.

</details>

`useScopedDraftLoad` consumes `ScopedDraftInput` and reports `ScopedDraftState`; only a ready selection with a present or absent result permits new persistence actions.
`useFencedDraftLoad` adds epoch checks; `UseRemoteSpawnDraftCleanupInput` extends `useRemoteSpawnDraftCleanup` with optional keys and guards, retaining clear-after-attempt and flush-without-attempt behavior.
Concurrent retries share work; prefills cannot authorize writes, and accepted saves remain bound to their original owner and key after selection changes.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/persist/use-draft-load.ts` — Source; M (modified), 337 changed lines. Adds unresolved, present, absent, malformed, and failed restoration states with recovery, retry, save, flush, clear, and explicit import actions. Invalidates late loads and new actions after owner, selection, retry, or unmount changes while preserving already accepted saves at their captured destination. Keeps nullable legacy restoration and the default new-session key. Cleanup retains the captured identity and still clears after any spawn attempt, including failure; leaving without an attempt flushes the draft.
- `apps/mobile/src/lib/persist/use-draft-load.test.ts` — Test; M (modified), 82 changed lines. Updates the legacy draft-hook tests.
- `apps/mobile/src/lib/persist/scoped-draft-load.mounted.test.tsx` — Test; A (added), 471 changed lines. Adds the mounted scoped-draft hook tests.

</details>

Tests: 11 changed files (4 added, 7 modified), totaling 2,897 changed lines: `auth-context.test.tsx`, `logout-cleanup.test.ts`, `context-scope.test.ts`, `organization-context.mounted.test.tsx`, `read-cache.test.ts`, `cache-persistence-mount.test.ts`, `encrypted-kv.test.ts`, `drafts.test.ts`, `scoped-draft-keys.test.ts`, `use-draft-load.test.ts`, `scoped-draft-load.mounted.test.tsx`.
Generated: none (0 files).

---

## Verification

- No manual verification is reported for this level.
- Full iOS and Android verification runs on the final stack level.
- Device verification remains with `bot-e2e`; the requesting human has no device-testing task.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Human steps

- No human steps are required before or after merge for this level.

### Supplied check results

- The implementer reports 285 passing focused tests: 262 prior tests, 15 existing cleanup tests, and eight new regressions.
- The handoff reports 40 executed mounted tests and passing scoped lint and formatting checks on the repaired files.

### Scope

- Repository: `Kilo-Org/cloud`.
- Worktree: `/Users/igor/Projects/.worktrees/mobile-context-lock-758a`.
- Branch: `mobile-context-lock-758a-s2`; base: `mobile-context-lock-758a`.
- This description covers level 2 only, commit `47c4d521001589b56a81c106e0125e16d08918ca`.
- The change contains 24 files, 3,750 insertions, and 1,559 deletions. Per-file sizes count changed lines from the supplied statistics.

### Notes

This level adds ownership and persistence boundaries without exposing biometric controls. Full iOS and Android verification runs on the final stack level.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-context-lock-758a` — #5642
2. `mobile-context-lock-758a-s2` — #5651 ← this PR
3. `mobile-context-lock-758a-s3` — #5658
4. `mobile-context-lock-758a-s4` — #5664
5. `mobile-context-lock-758a-s5` — #5683 (tip)
