### PR TITLE
feat(cloud-agent-sdk): support browser provider jobs

### DIFF
--- a/packages/cloud-agent-sdk/src/index.ts
+++ b/packages/cloud-agent-sdk/src/index.ts
@@ -4,7 +4,14 @@ export type { CloudAgentEvent, StreamError, StreamErrorCode } from './event-type
 export { formatError as formatSessionError } from './session-manager';
 export { createSessionManager } from './session-manager';
 export { customerBillingFailureSchema, parseCustomerBillingFailure } from './schemas';
-export type { CustomerBillingFailure } from './schemas';
+export type {
+  BrowserJobHandle,
+  BrowserJobSnapshot,
+  BrowserProviderInboundMessage,
+  BrowserProviderOutboundMessage,
+  BrowserResult,
+  CustomerBillingFailure,
+} from './schemas';
 export { CLI_MODEL_ID, cliModelLabel } from './cli-model';
 export type {
   ActiveSessionType,
@@ -70,10 +77,23 @@ export type { CliLiveTransportConfig } from './cli-live-transport';
 
 export {
   createUserWebConnection,
+  BrowserProviderError,
   CommandDeliveredError,
   UserWebCommandError,
 } from './user-web-connection';
 export type {
+  BrowserProviderApprovalInput,
+  BrowserProviderCancelInput,
+  BrowserProviderConnection,
+  BrowserProviderErrorCode,
+  BrowserProviderLease,
+  BrowserProviderQuiescenceInput,
+  BrowserProviderRegistration,
+  BrowserProviderResultInput,
+  BrowserProviderSnapshot,
+  BrowserProviderState,
+  BrowserProviderStatusResult,
+  BrowserProviderUnavailableInput,
   UserWebConnection,
   UserWebConnectionConfig,
   UserWebSessionEventName,

--- a/packages/cloud-agent-sdk/src/user-web-connection.test.ts
+++ b/packages/cloud-agent-sdk/src/user-web-connection.test.ts
@@ -2578,6 +2578,98 @@ describe('createUserWebConnection browser provider', () => {
     expect(client.getBrowserProviderState().status).toBe('registered');
   });
 
+  it.each(['provider_snapshot', 'provider_status_result'] as const)(
+    'preserves queue metadata across %s pages and later job phases',
+    async type => {
+      const client = await registered();
+      const messages: BrowserProviderInboundMessage[] = [];
+      client.onBrowserProviderMessage(message => messages.push(message));
+      const first = job(1, {
+        status: 'queued',
+        ownerLabel: 'ses_parent_z',
+        queuePosition: 100,
+      });
+      const second = job(2, {
+        status: 'queued',
+        ownerLabel: 'ses_parent_a',
+        queuePosition: 1,
+      });
+      const third = job(3, {
+        status: 'queued',
+        ownerLabel: 'ses_parent_m',
+        queuePosition: 42,
+      });
+      const active = job(1, { ownerLabel: first.ownerLabel });
+      const pages: {
+        cursor?: BrowserJobSnapshot['jobId'];
+        nextCursor?: BrowserJobSnapshot['jobId'];
+        jobs: BrowserJobSnapshot[];
+      }[] = [
+        { jobs: [first, second], nextCursor: second.jobId },
+        { cursor: second.jobId, jobs: [third, job(4, { status: 'queued' })] },
+        {
+          jobs: [
+            { ...first, queuePosition: 99 },
+            { ...third, queuePosition: 41 },
+          ],
+        },
+        { jobs: [active] },
+        { jobs: [{ ...active, status: 'running', approvedTab: tab }] },
+        {
+          jobs: [
+            {
+              ...active,
+              status: 'succeeded',
+              approvedTab: tab,
+              result: completion(active).result,
+            },
+            job(2, {
+              status: 'cancelled',
+              ownerLabel: second.ownerLabel,
+              result: {
+                ...completion(second).result,
+                status: 'cancelled',
+                reason: 'cancelled',
+                effectsUncertain: false,
+              },
+            }),
+            // A legacy refresh must not inherit either field from an earlier page.
+            job(3, { status: 'queued' }),
+          ],
+        },
+        { jobs: [] },
+      ];
+      const expected: BrowserProviderInboundMessage[] = [];
+      for (const { cursor, nextCursor, jobs } of pages) {
+        const pending =
+          type === 'provider_snapshot'
+            ? client.heartbeatBrowserProvider(cursor)
+            : client.requestBrowserProviderStatus(cursor);
+        const request =
+          type === 'provider_snapshot'
+            ? lastFrame('provider_heartbeat')
+            : lastFrame('provider_status');
+        expect(request.cursor).toBe(cursor);
+        if (request.type === 'provider_heartbeat') leaseAck(request);
+        const fields = {
+          requestId: request.requestId,
+          providerId: registration.providerId,
+          jobs,
+          ...(nextCursor === undefined ? {} : { nextCursor }),
+        };
+        const reply =
+          type === 'provider_snapshot' ? { type, generation: 1, ...fields } : { type, ...fields };
+        inbound(reply);
+        await expect(pending).resolves.toStrictEqual(reply);
+        expected.push(reply);
+      }
+      // Check retained callbacks too: a later rank or phase must not mutate an earlier page.
+      expect(messages.filter(message => message.type !== 'provider_lease_ack')).toStrictEqual(
+        expected
+      );
+    }
+  );
+
   it('deduplicates jobs and cancellations and rejects stale or foreign generations', async () => {
     const client = await registered(2);
     const received: string[] = [];
@@ -2903,29 +2995,21 @@ describe('createUserWebConnection browser provider', () => {
     expect(frames().map(frame => frame.type)).toEqual(['ping']);
   });
 
-  it('correlates history without renewing a lease or buffering running and terminal work', async () => {
+  it('keeps queue metadata read-only while correlating history and preserving the live lease', async () => {
     const client = await registered(2);
-    const current = job(1, { generation: 2 });
+    const current = job(1, { generation: 2, ownerLabel: 'ses_live_parent' });
     dispatch(current);
     client.approveBrowserProviderJob({
       ...binding(current),
       approval: { decision: 'approved', tab },
     });
     const before = client.getBrowserProviderState();
-    const histories: BrowserProviderInboundMessage[] = [];
-    const actions: string[] = [];
-    client.onBrowserProviderMessage(message => {
-      if (message.type === 'provider_status_result') histories.push(message);
-      if (
-        message.type === 'provider_snapshot' &&
-        message.jobs.some(job => job.status === 'running')
-      ) {
-        actions.push('browser action');
-      }
-    });
+    const messages: BrowserProviderInboundMessage[] = [];
+    client.onBrowserProviderMessage(message => messages.push(message));
     jest.setSystemTime(now + 1_000);
     const pending = client.requestBrowserProviderStatus();
     const request = lastFrame('provider_status');
+    const sent = frames();
     const unresolvedFence = { invocationId: current.invocationId, tabId: tab.tabId };
     inbound({
       type: 'provider_status_result',
@@ -2948,37 +3032,104 @@ describe('createUserWebConnection browser provider', () => {
       generation: 2,
       leaseExpiresAt: new Date(now + 30_000).toISOString(),
     });
-    expect(histories).toEqual([]);
+    expect(messages).toEqual([]);
     const terminal = job(2, {
       generation: 2,
+      ownerLabel: 'ses_completed_parent',
       status: 'succeeded',
       approvedTab: tab,
       result: completion(job(2)).result,
     });
+    const queued = job(3, {
+      generation: 2,
+      status: 'queued',
+      ownerLabel: 'ses_queued_parent',
+      queuePosition: 47,
+    });
+    const awaiting = job(4, { generation: 2, ownerLabel: 'ses_other_parent' });
     const history = {
       type: 'provider_status_result',
       requestId: request.requestId,
       providerId: request.providerId,
-      jobs: [{ ...current, status: 'running', approvedTab: tab }, terminal],
+      jobs: [{ ...current, status: 'running', approvedTab: tab }, terminal, queued, awaiting],
       unresolvedFence,
     } satisfies BrowserProviderInboundMessage;
     inbound(history);
     await expect(pending).resolves.toStrictEqual(history);
     inbound(history);
-    expect(histories).toStrictEqual([history]);
-    expect(actions).toEqual([]);
+    expect(messages).toStrictEqual([history]);
     expect(client.getBrowserProviderState()).toEqual(before);
-    expect(() => client.sendBrowserProviderResult(completion(current))).toThrow(
-      BrowserProviderError
-    );
+    expect(() => client.sendBrowserProviderResult(completion(current))).toThrow('invalid_request');
+    expect(() => client.cancelBrowserProviderJob(binding(queued))).toThrow('owner_mismatch');
+    expect(() =>
+      client.approveBrowserProviderJob({
+        ...binding(awaiting),
+        approval: { decision: 'approved', tab },
+      })
+    ).toThrow('owner_mismatch');
     expect(() =>
       client.quiesceBrowserProviderJob({ ...binding(terminal), tabId: tab.tabId })
-    ).toThrow(BrowserProviderError);
-    expect(
-      frames().filter(
-        frame => frame.type === 'provider_result' || frame.type === 'provider_quiesced'
-      )
-    ).toEqual([]);
+    ).toThrow('owner_mismatch');
+    expect(frames()).toStrictEqual(sent);
+
+    update({ ...current, status: 'running', approvedTab: tab });
+    client.sendBrowserProviderResult(completion(current));
+    expect(lastFrame('provider_result')).toStrictEqual({
+      type: 'provider_result',
+      ...completion(current),
+    });
+    jest.setSystemTime(now + 15_001);
+    await expect(client.heartbeatBrowserProvider()).rejects.toMatchObject({
+      code: 'lease_expired',
+      retryable: true,
+    });
+  });
+
+  it('does not turn queued history into registration or adopted work', async () => {
+    const client = createProvider();
+    client.retain();
+    negotiate();
+    const registrationResult = client.registerBrowserProvider(registration);
+    inbound({
+      type: 'response',
+      id: lastFrame('provider_register').requestId,
+      error: { source: 'relay', code: 'provider_unavailable', retryable: true },
+    });
+    await expect(registrationResult).rejects.toMatchObject({ code: 'provider_unavailable' });
+    const unavailable = client.getBrowserProviderState();
+    const messages: BrowserProviderInboundMessage[] = [];
+    client.onBrowserProviderMessage(message => messages.push(message));
+    const queued = job(1, {
+      status: 'queued',
+      ownerLabel: 'ses_historical_parent',
+      queuePosition: 100,
+    });
+    const awaiting = job(2, { ownerLabel: 'ses_other_parent' });
+    const sent = frames();
+    const history = statusReply([queued, awaiting]);
+    inbound(history);
+    dispatch(awaiting);
+    update({ ...awaiting, status: 'running', approvedTab: tab });
+    await jest.advanceTimersByTimeAsync(15_000);
+
+    expect(messages).toStrictEqual([history]);
+    expect(client.getBrowserProviderState()).toStrictEqual(unavailable);
+    await expect(client.heartbeatBrowserProvider()).rejects.toMatchObject({
+      code: 'provider_unavailable',
+      retryable: true,
+    });
+    expect(() => client.cancelBrowserProviderJob(binding(queued))).toThrow('provider_unavailable');
+    expect(() =>
+      client.approveBrowserProviderJob({
+        ...binding(awaiting),
+        approval: { decision: 'approved', tab },
+      })
+    ).toThrow('provider_unavailable');
+    expect(() => client.sendBrowserProviderResult(completion(awaiting))).toThrow(
+      'provider_unavailable'
+    );
+    expect(() => client.quiesceBrowserProviderJob(binding(awaiting))).toThrow('owner_mismatch');
+    expect(frames()).toStrictEqual(sent);
   });
 
   it('finishes an in-flight history read after registration loss without restoring availability', async () => {
@@ -3396,7 +3547,8 @@ describe('createUserWebConnection browser provider', () => {
       const recovered = f.messages
         .filter(message => message.type === 'provider_status_result')
         .at(-1);
-      expect(recovered?.jobs).toEqual([completed]);
+      expect(recovered?.jobs).toStrictEqual([{ ...completed, ownerLabel: 'ses_parent' }]);
+      expect(f.snapshot(current.jobId)).toStrictEqual(completed);
       expect(recovered?.jobs[0]).toMatchObject({
         generation: current.generation,
         status: 'succeeded',

--- a/packages/cloud-agent-sdk/src/user-web-connection.test.ts
+++ b/packages/cloud-agent-sdk/src/user-web-connection.test.ts
@@ -2552,8 +2552,15 @@ describe('createUserWebConnection browser provider', () => {
     }
   );
 
-  it('returns an empty status page and renews a short lease before viewer ping', async () => {
+  it('preserves empty legacy status and renews a short lease before viewer ping', async () => {
     const client = await registered();
+    const messages: BrowserProviderInboundMessage[] = [];
+    client.onBrowserProviderMessage(message => messages.push(message));
+    const status = client.requestBrowserProviderStatus();
+    const history = statusReply();
+    await expect(status).resolves.toStrictEqual(history);
+    expect(messages).toStrictEqual([history]);
+
     const pending = client.heartbeatBrowserProvider(`bj_${uuid(9)}`);
     expect(lastFrame('provider_heartbeat').cursor).toBe(`bj_${uuid(9)}`);
     const snapshot = heartbeatReply();
@@ -2693,10 +2700,10 @@ describe('createUserWebConnection browser provider', () => {
       approval: { decision: 'approved', tab },
     });
     const before = client.getBrowserProviderState();
-    const histories: BrowserJobSnapshot[][] = [];
+    const histories: BrowserProviderInboundMessage[] = [];
     const actions: string[] = [];
     client.onBrowserProviderMessage(message => {
-      if (message.type === 'provider_status_result') histories.push(message.jobs);
+      if (message.type === 'provider_status_result') histories.push(message);
       if (
         message.type === 'provider_snapshot' &&
         message.jobs.some(job => job.status === 'running')
@@ -2707,17 +2714,20 @@ describe('createUserWebConnection browser provider', () => {
     jest.setSystemTime(now + 1_000);
     const pending = client.requestBrowserProviderStatus();
     const request = lastFrame('provider_status');
+    const unresolvedFence = { invocationId: current.invocationId, tabId: tab.tabId };
     inbound({
       type: 'provider_status_result',
       requestId: uuid(999),
       providerId: registration.providerId,
       jobs: [],
+      unresolvedFence,
     });
     inbound({
       type: 'provider_status_result',
       requestId: request.requestId,
       providerId: `bp_${uuid(2)}`,
       jobs: [],
+      unresolvedFence,
     });
     inbound({
       type: 'provider_lease_ack',
@@ -2733,10 +2743,17 @@ describe('createUserWebConnection browser provider', () => {
       approvedTab: tab,
       result: completion(job(2)).result,
     });
-    const history = statusReply([{ ...current, status: 'running', approvedTab: tab }, terminal]);
-    await expect(pending).resolves.toEqual(history);
+    const history = {
+      type: 'provider_status_result',
+      requestId: request.requestId,
+      providerId: request.providerId,
+      jobs: [{ ...current, status: 'running', approvedTab: tab }, terminal],
+      unresolvedFence,
+    } satisfies BrowserProviderInboundMessage;
     inbound(history);
-    expect(histories).toEqual([history.jobs]);
+    await expect(pending).resolves.toStrictEqual(history);
+    inbound(history);
+    expect(histories).toStrictEqual([history]);
     expect(actions).toEqual([]);
     expect(client.getBrowserProviderState()).toEqual(before);
     expect(() => client.sendBrowserProviderResult(completion(current))).toThrow(
@@ -3209,7 +3226,8 @@ describe('createUserWebConnection browser provider', () => {
     const recovered = f.messages
       .filter(message => message.type === 'provider_status_result')
       .at(-1);
-    expect(recovered?.jobs).toEqual([interrupted]);
+    const unresolvedFence = { invocationId: current.invocationId, tabId: tab.tabId };
+    expect(recovered).toMatchObject({ jobs: [interrupted], unresolvedFence });
     expect(interrupted).toMatchObject({
       generation: current.generation,
       status: 'interrupted',
@@ -3222,7 +3240,7 @@ describe('createUserWebConnection browser provider', () => {
     });
     const status = f.client.requestBrowserProviderStatus(current.jobId);
     await f.flush();
-    await expect(status).resolves.toMatchObject({ jobs: [] });
+    await expect(status).resolves.toMatchObject({ jobs: [], unresolvedFence });
     expect(() => f.client.sendBrowserProviderResult(completion(current))).toThrow(
       BrowserProviderError
     );
@@ -3244,6 +3262,91 @@ describe('createUserWebConnection browser provider', () => {
       )
     ).toEqual([]);
   });
+
+  it.each(['approved', 'unapproved'] as const)(
+    'delivers an expired %s fence after refused registration without execution authority',
+    async phase => {
+      const f = await relayRegistered();
+      const current = await f.invoke();
+      if (phase === 'approved') {
+        f.client.approveBrowserProviderJob({
+          ...binding(current),
+          approval: { decision: 'approved', tab },
+        });
+        await f.flush();
+      }
+      await f.disconnect(4001);
+      jest.setSystemTime(Date.parse(current.expiresAt) + 1);
+      await f.alarm();
+      expect(() => f.snapshot(current.jobId)).toThrow('Expected a persisted job');
+      await jest.advanceTimersByTimeAsync(0);
+
+      const messageCount = f.messages.length;
+      await f.connect();
+      const unresolvedFence =
+        phase === 'approved'
+          ? { invocationId: current.invocationId, tabId: tab.tabId }
+          : { invocationId: current.invocationId };
+      const automaticHistory = {
+        type: 'provider_status_result',
+        requestId: lastFrame('provider_status').requestId,
+        providerId: registration.providerId,
+        jobs: [],
+        unresolvedFence,
+      } satisfies BrowserProviderInboundMessage;
+      expect(f.messages.slice(messageCount)).toStrictEqual([automaticHistory]);
+      const unavailable = f.client.getBrowserProviderState();
+      expect(unavailable).toEqual({
+        status: 'unavailable',
+        reason: 'provider_unavailable',
+        retryable: true,
+      });
+
+      const status = f.client.requestBrowserProviderStatus();
+      const history = { ...automaticHistory, requestId: lastFrame('provider_status').requestId };
+      await f.flush();
+      await expect(status).resolves.toStrictEqual(history);
+      dispatch(current);
+      update({ ...current, status: 'running', approvedTab: tab });
+      expect(f.messages.slice(messageCount)).toStrictEqual([automaticHistory, history]);
+      expect(f.client.getBrowserProviderState()).toEqual(unavailable);
+      await expect(f.client.heartbeatBrowserProvider()).rejects.toMatchObject({
+        code: 'provider_unavailable',
+        retryable: true,
+      });
+      expect(() =>
+        f.client.approveBrowserProviderJob({
+          ...binding(current),
+          approval: { decision: 'approved', tab },
+        })
+      ).toThrow(BrowserProviderError);
+      expect(() => f.client.sendBrowserProviderResult(completion(current))).toThrow(
+        BrowserProviderError
+      );
+      expect(() =>
+        f.client.quiesceBrowserProviderJob({ ...binding(current), tabId: tab.tabId })
+      ).toThrow(BrowserProviderError);
+
+      const retry = f.client
+        .registerBrowserProvider({ ...registration, generation: current.generation })
+        .catch(error => error);
+      await f.flush();
+      await expect(retry).resolves.toMatchObject({ code: 'provider_unavailable' });
+      expect(f.messages.slice(messageCount)).toStrictEqual([
+        automaticHistory,
+        history,
+        { ...history, requestId: lastFrame('provider_status').requestId },
+      ]);
+      expect(frames().map(frame => frame.type)).toEqual([
+        'ping',
+        'provider_register',
+        'provider_status',
+        'provider_status',
+        'provider_register',
+        'provider_status',
+      ]);
+    }
+  );
 
   it('stops later callbacks when a listener releases the connection and ignores late socket events', async () => {
     const client = createProvider();

--- a/packages/cloud-agent-sdk/src/user-web-connection.test.ts
+++ b/packages/cloud-agent-sdk/src/user-web-connection.test.ts
@@ -2657,6 +2657,218 @@ describe('createUserWebConnection browser provider', () => {
     expect(frames().filter(frame => frame.type === 'command')).toEqual([]);
   });
 
+  it.each([
+    ['approval denial', 'failed', 'approval_denied'],
+    ['provider cancellation', 'cancelled', 'cancelled'],
+  ] as const)(
+    'releases the next queued consent through no-tab quiescence after %s',
+    async (event, status, reason) => {
+      const f = await relayRegistered();
+      const current = await f.invoke();
+      const queued = await f.invoke(2);
+      const registeredState = f.client.getBrowserProviderState();
+      expect(queued.status).toBe('queued');
+      if (event === 'approval denial') {
+        f.client.approveBrowserProviderJob({
+          ...binding(current),
+          approval: { decision: 'denied', reason: 'approval_denied' },
+        });
+      } else {
+        f.client.cancelBrowserProviderJob(binding(current));
+      }
+      // Sending a denial or Stop does not confirm terminal state at the relay.
+      expect(() => f.client.quiesceBrowserProviderJob(binding(current))).toThrow('invalid_request');
+      await f.flush();
+      const terminal = f.snapshot(current.jobId);
+      expect(terminal).toMatchObject({
+        status,
+        result: { status, reason, effectsUncertain: false },
+      });
+      expect(terminal).not.toHaveProperty('approvedTab');
+      expect(f.snapshot(queued.jobId)).toEqual(queued);
+      expect(
+        f.messages
+          .filter(message => message.type === 'provider_job')
+          .map(message => message.job.jobId)
+      ).toEqual([current.jobId]);
+      expect(frames().filter(frame => frame.type === 'provider_quiesced')).toEqual([]);
+
+      f.client.quiesceBrowserProviderJob(binding(current));
+      await f.flush();
+      expect(lastFrame('provider_quiesced')).toStrictEqual({
+        type: 'provider_quiesced',
+        ...binding(current),
+      });
+      expect(
+        f.messages
+          .filter(message => message.type === 'provider_job')
+          .map(message => message.job.jobId)
+      ).toEqual([current.jobId, queued.jobId]);
+      const next = f.snapshot(queued.jobId);
+      expect(next).toMatchObject({ status: 'awaiting_approval', generation: current.generation });
+      expect(next).not.toHaveProperty('approvedTab');
+      expect(next.deadlines).not.toHaveProperty('execution');
+      expect(f.client.getBrowserProviderState()).toEqual(registeredState);
+      expect(() => f.client.sendBrowserProviderResult(completion(next))).toThrow('invalid_request');
+      expect(() =>
+        f.client.approveBrowserProviderJob({
+          ...binding(current),
+          approval: { decision: 'approved', tab },
+        })
+      ).toThrow('invalid_request');
+      expect(frames().filter(frame => frame.type === 'provider_result')).toEqual([]);
+
+      f.client.approveBrowserProviderJob({
+        ...binding(next),
+        approval: { decision: 'approved', tab },
+      });
+      await f.flush();
+      expect(f.snapshot(next.jobId)).toMatchObject({ status: 'running', approvedTab: tab });
+      expect(f.snapshot(current.jobId)).toEqual(terminal);
+    }
+  );
+
+  it.each([0, tab.tabId])(
+    'requires exact approved tab %s for SDK quiescence before releasing queued consent',
+    async tabId => {
+      const f = await relayRegistered();
+      const current = await f.invoke();
+      const queued = await f.invoke(2);
+      const approvedTab = { ...tab, tabId };
+      f.client.approveBrowserProviderJob({
+        ...binding(current),
+        approval: { decision: 'approved', tab: approvedTab },
+      });
+      await f.flush();
+      f.client.sendBrowserProviderResult({ ...completion(current), tab: approvedTab });
+      await f.flush();
+      const terminal = f.snapshot(current.jobId);
+      expect(terminal).toMatchObject({ status: 'succeeded', approvedTab });
+
+      for (const fields of [{}, { tabId: tabId + 1 }]) {
+        expect(() =>
+          f.client.quiesceBrowserProviderJob({ ...binding(current), ...fields })
+        ).toThrow('invalid_request');
+        await f.flush();
+        expect(f.snapshot(current.jobId)).toEqual(terminal);
+        expect(f.snapshot(queued.jobId)).toEqual(queued);
+      }
+      expect(frames().filter(frame => frame.type === 'provider_quiesced')).toEqual([]);
+      f.client.quiesceBrowserProviderJob({ ...binding(current), tabId });
+      await f.flush();
+      expect(lastFrame('provider_quiesced')).toStrictEqual({
+        type: 'provider_quiesced',
+        ...binding(current),
+        tabId,
+      });
+      expect(f.snapshot(queued.jobId)).toMatchObject({ status: 'awaiting_approval' });
+      expect(f.snapshot(queued.jobId)).not.toHaveProperty('approvedTab');
+      expect(
+        f.messages
+          .filter(message => message.type === 'provider_job')
+          .map(message => message.job.jobId)
+      ).toEqual([current.jobId, queued.jobId]);
+    }
+  );
+
+  it.each([
+    ['wrong provider', { providerId: `bp_${uuid(9)}` }],
+    ['wrong conversation', { browserTaskId: `bt_${uuid(9)}` }],
+    ['wrong job', { jobId: `bj_${uuid(9)}` }],
+    ['wrong invocation', { invocationId: `b1.${now}.${'f'.repeat(64)}` }],
+    ['stale generation', { generation: 1 }],
+  ] as const)('rejects no-tab quiescence with %s at the SDK boundary', async (_variant, fields) => {
+    const f = await relayRegistered();
+    f.client.markBrowserProviderUnavailable({
+      providerId: registration.providerId,
+      generation: 1,
+      reason: 'provider_unavailable',
+      effectsUncertain: false,
+    });
+    await f.flush();
+    const renewed = f.client.registerBrowserProvider({ ...registration, generation: 1 });
+    await f.flush();
+    await expect(renewed).resolves.toMatchObject({ generation: 2 });
+    const current = await f.invoke();
+    const queued = await f.invoke(2);
+    f.client.cancelBrowserProviderJob(binding(current));
+    await f.flush();
+    const terminal = f.snapshot(current.jobId);
+    expect(terminal).toMatchObject({ status: 'cancelled', generation: 2 });
+
+    expect(() => f.client.quiesceBrowserProviderJob({ ...binding(current), ...fields })).toThrow(
+      'owner_mismatch'
+    );
+    await f.flush();
+    expect(frames().filter(frame => frame.type === 'provider_quiesced')).toEqual([]);
+    expect(f.snapshot(current.jobId)).toEqual(terminal);
+    expect(f.snapshot(queued.jobId)).toEqual(queued);
+    f.client.quiesceBrowserProviderJob(binding(current));
+    await f.flush();
+    expect(f.snapshot(queued.jobId)).toMatchObject({ status: 'awaiting_approval' });
+  });
+
+  it.each(['queued', 'awaiting_approval', 'running'] as const)(
+    'rejects SDK quiescence for nonterminal %s work with or without a tab',
+    async phase => {
+      const f = await relayRegistered();
+      const current = await f.invoke();
+      const queued = await f.invoke(2);
+      if (phase === 'running') {
+        f.client.approveBrowserProviderJob({
+          ...binding(current),
+          approval: { decision: 'approved', tab },
+        });
+        await f.flush();
+      }
+      const target = f.snapshot(phase === 'queued' ? queued.jobId : current.jobId);
+      expect(target.status).toBe(phase);
+      for (const fields of [{}, { tabId: tab.tabId }]) {
+        expect(() => f.client.quiesceBrowserProviderJob({ ...binding(target), ...fields })).toThrow(
+          'invalid_request'
+        );
+      }
+      await f.flush();
+      expect(frames().filter(frame => frame.type === 'provider_quiesced')).toEqual([]);
+      expect(f.snapshot(target.jobId)).toEqual(target);
+      expect(f.snapshot(queued.jobId)).toEqual(queued);
+      expect(
+        f.messages
+          .filter(message => message.type === 'provider_job')
+          .map(message => message.job.jobId)
+      ).toEqual([current.jobId]);
+    }
+  );
+
+  it('does not let a replacement SDK socket quiesce prior no-tab terminal work from history', async () => {
+    const f = await relayRegistered();
+    const current = await f.invoke();
+    f.client.cancelBrowserProviderJob(binding(current));
+    await f.flush();
+    const terminal = f.snapshot(current.jobId);
+    expect(terminal).toMatchObject({ status: 'cancelled', result: { effectsUncertain: false } });
+    expect(terminal).not.toHaveProperty('approvedTab');
+    await f.disconnect(4001);
+    await jest.advanceTimersByTimeAsync(0);
+    await f.connect();
+
+    expect(() => f.client.quiesceBrowserProviderJob(binding(current))).toThrow('owner_mismatch');
+    const status = f.client.requestBrowserProviderStatus();
+    await f.flush();
+    await expect(status).resolves.toMatchObject({
+      jobs: [terminal],
+      unresolvedFence: { invocationId: current.invocationId },
+    });
+    expect((await status).unresolvedFence).not.toHaveProperty('tabId');
+    expect(f.client.getBrowserProviderState()).toEqual({
+      status: 'unavailable',
+      reason: 'provider_unavailable',
+      retryable: true,
+    });
+    expect(frames().filter(frame => frame.type === 'provider_quiesced')).toEqual([]);
+    expect(f.snapshot(current.jobId)).toEqual(terminal);
+  });
+
   it('makes unavailable explicit while permitting drained-work acknowledgement and disabling automatic registration', async () => {
     const client = await registered();
     const current = job();

--- a/packages/cloud-agent-sdk/src/user-web-connection.test.ts
+++ b/packages/cloud-agent-sdk/src/user-web-connection.test.ts
@@ -2995,6 +2995,227 @@ describe('createUserWebConnection browser provider', () => {
     expect(frames().map(frame => frame.type)).toEqual(['ping']);
   });
 
+  it('reads status with explicit proof after withdrawal without restoring authority', async () => {
+    const f = await relayRegistered();
+    const { client } = f;
+    const identity = {
+      providerId: registration.providerId,
+      providerProof: registration.providerProof,
+    };
+    const current = await f.invoke();
+    client.approveBrowserProviderJob({
+      ...binding(current),
+      approval: { decision: 'approved', tab },
+    });
+    await f.flush();
+    client.markBrowserProviderUnavailable({
+      providerId: current.providerId,
+      generation: current.generation,
+      reason: 'effects_uncertain',
+      effectsUncertain: true,
+    });
+    await f.flush();
+    const terminal = f.snapshot(current.jobId);
+    expect(terminal.result).toMatchObject({ effectsUncertain: true });
+    const unavailable = client.getBrowserProviderState();
+    const frameCount = frames().length;
+    const messageCount = f.messages.length;
+    await expect(client.requestBrowserProviderStatus()).rejects.toMatchObject({
+      code: 'provider_unavailable',
+      retryable: true,
+    });
+
+    const pending = client.requestBrowserProviderStatus(undefined, identity);
+    await f.flush();
+    const history = await pending;
+    const unresolvedFence = { invocationId: current.invocationId, tabId: tab.tabId };
+    expect(history).toMatchObject({
+      type: 'provider_status_result',
+      providerId: current.providerId,
+      jobs: [terminal],
+      unresolvedFence,
+    });
+    expect(client.getBrowserProviderState()).toEqual(unavailable);
+    await expect(client.requestBrowserProviderStatus()).rejects.toMatchObject({
+      code: 'provider_unavailable',
+      retryable: true,
+    });
+    await expect(client.heartbeatBrowserProvider()).rejects.toMatchObject({
+      code: 'effects_uncertain',
+      retryable: false,
+    });
+    expect(() =>
+      client.approveBrowserProviderJob({
+        ...binding(current),
+        approval: { decision: 'approved', tab },
+      })
+    ).toThrow('effects_uncertain');
+    expect(() => client.sendBrowserProviderResult(completion(current))).toThrow(
+      'effects_uncertain'
+    );
+    await jest.advanceTimersByTimeAsync(15_000);
+    await f.flush();
+    expect(f.snapshot(current.jobId)).toStrictEqual(terminal);
+    expect(f.messages.slice(messageCount)).toStrictEqual([history]);
+    expect(
+      frames()
+        .slice(frameCount)
+        .map(frame => frame.type)
+    ).toEqual(['provider_status']);
+
+    await f.disconnect(4001);
+    await jest.advanceTimersByTimeAsync(0);
+    await f.connect();
+    expect(frames().map(frame => frame.type)).toEqual(['ping']);
+    await expect(client.requestBrowserProviderStatus()).rejects.toMatchObject({
+      code: 'provider_unavailable',
+      retryable: true,
+    });
+    const nextPage = client.requestBrowserProviderStatus(current.jobId, identity);
+    await f.flush();
+    await expect(nextPage).resolves.toMatchObject({ jobs: [], unresolvedFence });
+    expect(client.getBrowserProviderState()).toEqual({ status: 'ready' });
+    expect(frames().map(frame => frame.type)).toEqual(['ping', 'provider_status']);
+  });
+
+  it('uses explicit status identity without replacing cached registration', async () => {
+    const client = await registered();
+    const before = client.getBrowserProviderState();
+    const identity = {
+      providerId: `bp_${uuid(2)}`,
+      providerProof: 'e'.repeat(64),
+    } satisfies Pick<BrowserProviderRegistration, 'providerId' | 'providerProof'>;
+    const cursor = job(3).jobId;
+    const pending = client.requestBrowserProviderStatus(cursor, identity).catch(error => error);
+    expect(lastFrame('provider_status')).toStrictEqual({
+      type: 'provider_status',
+      requestId: expect.any(String),
+      ...identity,
+      cursor,
+    });
+    const history = statusReply([job(4, { providerId: identity.providerId })]);
+    await expect(pending).resolves.toStrictEqual(history);
+
+    const cached = client.requestBrowserProviderStatus(cursor);
+    expect(lastFrame('provider_status')).toMatchObject({
+      providerId: registration.providerId,
+      providerProof: registration.providerProof,
+      cursor,
+    });
+    const cachedHistory = statusReply();
+    await expect(cached).resolves.toStrictEqual(cachedHistory);
+    expect(client.getBrowserProviderState()).toEqual(before);
+  });
+
+  it('keeps explicit status proof subject to relay authorization', async () => {
+    const f = await relayRegistered();
+    const current = await f.invoke();
+    const before = f.client.getBrowserProviderState();
+    const messageCount = f.messages.length;
+    const pending = f.client
+      .requestBrowserProviderStatus(undefined, {
+        providerId: registration.providerId,
+        providerProof: 'e'.repeat(64),
+      })
+      .catch(error => error);
+    await f.flush();
+    await expect(pending).resolves.toMatchObject({
+      code: 'owner_mismatch',
+      retryable: false,
+      message: 'Browser provider request failed: owner_mismatch',
+    });
+    expect(f.messages.slice(messageCount)).toEqual([]);
+    expect(f.client.getBrowserProviderState()).toEqual(before);
+
+    const cached = f.client.requestBrowserProviderStatus(current.jobId);
+    await f.flush();
+    await expect(cached).resolves.toMatchObject({ jobs: [] });
+    expect(lastFrame('provider_status').providerProof).toBe(registration.providerProof);
+  });
+
+  it.each([
+    { condition: 'disabled', code: 'disabled', retryable: false },
+    { condition: 'unretained', code: 'disconnected', retryable: true },
+    { condition: 'unnegotiated', code: 'not_negotiated', retryable: true },
+    { condition: 'unsupported', code: 'unsupported', retryable: false },
+  ])('keeps explicit status blocked while $condition', async ({ condition, code, retryable }) => {
+    const client = createProvider({ browserProvider: condition !== 'disabled' });
+    if (condition !== 'unretained') {
+      client.retain();
+      open();
+    }
+    if (condition === 'unsupported') {
+      inbound({ type: 'pong', nonce: lastFrame('ping').nonce });
+    }
+    const sent = sockets.length ? frames() : [];
+    await expect(
+      client.requestBrowserProviderStatus(undefined, registration)
+    ).rejects.toMatchObject({ code, retryable });
+    expect(sockets).toHaveLength(condition === 'unretained' ? 0 : 1);
+    expect(sockets.length ? frames() : []).toStrictEqual(sent);
+  });
+
+  it.each([
+    [
+      'provider ID',
+      {
+        ...registration,
+        providerId: 'invalid-provider' as BrowserProviderRegistration['providerId'],
+      },
+      undefined,
+    ],
+    ['provider proof', { ...registration, providerProof: 'invalid-proof' }, undefined],
+    ['cursor', registration, 'invalid-cursor'],
+  ] as const)(
+    'rejects invalid explicit status %s before transport',
+    async (_field, identity, cursor) => {
+      const client = await registered();
+      const sent = frames();
+      const before = client.getBrowserProviderState();
+      await expect(client.requestBrowserProviderStatus(cursor, identity)).rejects.toMatchObject({
+        code: 'invalid_request',
+        retryable: false,
+        message: 'Browser provider request failed: invalid_request',
+      });
+      expect(frames()).toStrictEqual(sent);
+      expect(client.getBrowserProviderState()).toEqual(before);
+    }
+  );
+
+  it.each(['release', 'destroy', 'disconnect'] as const)(
+    'rejects pending explicit status after %s and ignores late replies',
+    async loss => {
+      const client = createProvider();
+      const release = client.retain();
+      negotiate();
+      const messages: BrowserProviderInboundMessage[] = [];
+      client.onBrowserProviderMessage(message => messages.push(message));
+      const pending = client
+        .requestBrowserProviderStatus(undefined, registration)
+        .catch(error => error);
+      const request = lastFrame('provider_status');
+      const ws = sockets[0];
+      if (loss === 'release') release();
+      else if (loss === 'destroy') client.destroy();
+      else ws.onclose?.({ code: 4001 } as CloseEvent);
+      await expect(pending).resolves.toMatchObject({ code: 'disconnected', retryable: true });
+      inbound(
+        {
+          type: 'provider_status_result',
+          requestId: request.requestId,
+          providerId: request.providerId,
+          jobs: [job()],
+        },
+        ws
+      );
+      expect(messages).toEqual([]);
+      await expect(
+        client.requestBrowserProviderStatus(undefined, registration)
+      ).rejects.toMatchObject({ code: 'disconnected', retryable: true });
+      expect(frames(ws).map(frame => frame.type)).toEqual(['ping', 'provider_status']);
+    }
+  );
+
   it('keeps queue metadata read-only while correlating history and preserving the live lease', async () => {
     const client = await registered(2);
     const current = job(1, { generation: 2, ownerLabel: 'ses_live_parent' });
@@ -3007,7 +3228,7 @@ describe('createUserWebConnection browser provider', () => {
     const messages: BrowserProviderInboundMessage[] = [];
     client.onBrowserProviderMessage(message => messages.push(message));
     jest.setSystemTime(now + 1_000);
-    const pending = client.requestBrowserProviderStatus();
+    const pending = client.requestBrowserProviderStatus(undefined, registration);
     const request = lastFrame('provider_status');
     const sent = frames();
     const unresolvedFence = { invocationId: current.invocationId, tabId: tab.tabId };
@@ -3023,6 +3244,13 @@ describe('createUserWebConnection browser provider', () => {
       requestId: request.requestId,
       providerId: `bp_${uuid(2)}`,
       jobs: [],
+      unresolvedFence,
+    });
+    inbound({
+      type: 'provider_status_result',
+      requestId: request.requestId,
+      providerId: registration.providerId,
+      jobs: [{ ...current, providerId: `bp_${uuid(2)}` }],
       unresolvedFence,
     });
     inbound({

--- a/packages/cloud-agent-sdk/src/user-web-connection.test.ts
+++ b/packages/cloud-agent-sdk/src/user-web-connection.test.ts
@@ -1,11 +1,45 @@
 import { configureCloudAgentSdkRuntime, resetCloudAgentSdkRuntime } from './runtime';
 import {
+  browserCLIInboundMessageSchema,
+  browserJobSnapshotSchema,
+  webOutboundWithBrowserMessageSchema,
+  type BrowserJobSnapshot,
+  type BrowserProviderInboundMessage,
+  type BrowserProviderOutboundMessage,
+} from './schemas';
+import {
+  BrowserProviderError,
   CommandDeliveredError,
   createUserWebConnection,
   UserWebCommandError,
   VIEWER_PING_INTERVAL_MS,
   VIEWER_PONG_TIMEOUT_MS,
+  type BrowserProviderRegistration,
+  type BrowserProviderState,
 } from './user-web-connection';
+
+jest.mock(
+  'cloudflare:workers',
+  () => ({
+    DurableObject: class {
+      constructor(
+        readonly ctx: unknown,
+        readonly env: unknown
+      ) {}
+    },
+  }),
+  { virtual: true }
+);
+jest.mock('../../../services/session-ingest/src/dos/SessionIngestDO', () => ({
+  getSessionIngestDO: () => {
+    throw new Error('Unexpected session ingest access');
+  },
+}));
+jest.mock('../../../services/session-ingest/src/services/session-access', () => ({
+  resolveAccessibleKiloSession: () => {
+    throw new Error('Unexpected session access lookup');
+  },
+}));
 
 const WS_URL = 'wss://localhost:9999/api/user/web';
 
@@ -1993,5 +2027,1348 @@ describe('createUserWebConnection reconnect-exhaustion API', () => {
 
     expect(listener).not.toHaveBeenCalled();
     expect(client.isReconnectExhausted()).toBe(false);
+  });
+});
+
+describe('createUserWebConnection browser provider', () => {
+  const now = Date.UTC(2026, 7, 28);
+  const uuid = (n: number) => `00000000-0000-4000-8000-${n.toString(16).padStart(12, '0')}`;
+  const registration = {
+    providerId: `bp_${uuid(1)}`,
+    providerProof: 'c'.repeat(64),
+    generation: 0,
+    label: 'Work profile',
+  } satisfies BrowserProviderRegistration;
+  const tab = {
+    tabId: 42,
+    title: 'Approved page',
+    url: 'https://example.com/',
+    effectiveMode: 'safe' as const,
+  };
+  let clients: ReturnType<typeof createUserWebConnection>[];
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(now);
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    let nextId = 100;
+    configureCloudAgentSdkRuntime({ randomUUID: () => uuid(++nextId) });
+    clients = [];
+  });
+
+  afterEach(() => {
+    for (const client of clients) client.destroy();
+    jest.useRealTimers();
+  });
+
+  function createProvider(options: Partial<Parameters<typeof createUserWebConnection>[0]> = {}) {
+    const client = createUserWebConnection({
+      websocketUrl: WS_URL,
+      getAuthToken: () => 'private-ticket',
+      browserProvider: true,
+      ...options,
+    });
+    clients.push(client);
+    return client;
+  }
+
+  function frames(ws = sockets.at(-1)) {
+    if (!ws) throw new Error('Expected a socket');
+    return ws.send.mock.calls.map(call =>
+      webOutboundWithBrowserMessageSchema.parse(JSON.parse(call[0] as string))
+    );
+  }
+
+  function lastFrame<T extends ReturnType<typeof frames>[number]['type']>(
+    type: T,
+    ws = sockets.at(-1)
+  ) {
+    const frame = frames(ws)
+      .reverse()
+      .find(message => message.type === type);
+    if (!frame) throw new Error(`Expected a ${type} frame`);
+    return frame as Extract<ReturnType<typeof frames>[number], { type: T }>;
+  }
+
+  function negotiate(ws = sockets.at(-1)) {
+    open(ws);
+    const ping = lastFrame('ping', ws);
+    inbound({ type: 'pong', nonce: ping.nonce, capabilities: { browserJobsV1: true } }, ws);
+  }
+
+  function leaseAck(
+    request: Extract<
+      BrowserProviderOutboundMessage,
+      { type: 'provider_register' | 'provider_heartbeat' }
+    >,
+    generation = 1,
+    ws = sockets.at(-1)
+  ) {
+    const ack = {
+      type: 'provider_lease_ack',
+      requestId: request.requestId,
+      providerId: request.providerId,
+      generation,
+      leaseExpiresAt: new Date(Date.now() + 15_000).toISOString(),
+    } as const;
+    inbound(ack, ws);
+    return ack;
+  }
+
+  function heartbeatReply(jobs: BrowserJobSnapshot[] = [], ws = sockets.at(-1)) {
+    const request = lastFrame('provider_heartbeat', ws);
+    leaseAck(request, request.generation, ws);
+    const snapshot = {
+      type: 'provider_snapshot',
+      requestId: request.requestId,
+      providerId: request.providerId,
+      generation: request.generation,
+      jobs,
+    } as const;
+    inbound(snapshot, ws);
+    return snapshot;
+  }
+
+  function statusReply(jobs: BrowserJobSnapshot[] = [], ws = sockets.at(-1)) {
+    const request = lastFrame('provider_status', ws);
+    const history = {
+      type: 'provider_status_result',
+      requestId: request.requestId,
+      providerId: request.providerId,
+      jobs,
+    } as const;
+    inbound(history, ws);
+    return history;
+  }
+
+  async function registered(
+    generation = 1,
+    options: Partial<Parameters<typeof createUserWebConnection>[0]> = {}
+  ) {
+    const client = createProvider(options);
+    client.retain();
+    negotiate();
+    const pending = client.registerBrowserProvider(registration);
+    leaseAck(lastFrame('provider_register'), generation);
+    await pending;
+    statusReply();
+    return client;
+  }
+
+  function job(n = 1, changes: Partial<BrowserJobSnapshot> = {}): BrowserJobSnapshot {
+    return {
+      providerId: registration.providerId,
+      browserTaskId: `bt_${uuid(n)}`,
+      jobId: `bj_${uuid(n)}`,
+      invocationId: `b1.${now}.${n.toString(16).padStart(64, '0')}`,
+      generation: 1,
+      payloadFingerprint: 'd'.repeat(64),
+      createdAt: new Date(now).toISOString(),
+      expiresAt: new Date(now + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      deadlines: {
+        queue: new Date(now + 60_000).toISOString(),
+        approval: new Date(now + 60_000).toISOString(),
+      },
+      status: 'awaiting_approval',
+      ...changes,
+    };
+  }
+
+  function dispatch(snapshot = job(), ws = sockets.at(-1)) {
+    inbound(
+      {
+        type: 'provider_job',
+        job: snapshot,
+        goal: 'Observe the requested page',
+        ownerLabel: 'ses_parent',
+      },
+      ws
+    );
+  }
+
+  function binding(snapshot: BrowserJobSnapshot) {
+    return {
+      providerId: snapshot.providerId,
+      browserTaskId: snapshot.browserTaskId,
+      jobId: snapshot.jobId,
+      invocationId: snapshot.invocationId,
+      generation: snapshot.generation,
+    };
+  }
+
+  function update(snapshot: BrowserJobSnapshot, ws = sockets.at(-1)) {
+    inbound(
+      {
+        type: 'provider_snapshot',
+        providerId: snapshot.providerId,
+        generation: snapshot.generation,
+        jobs: [snapshot],
+      },
+      ws
+    );
+  }
+
+  function completion(snapshot: BrowserJobSnapshot) {
+    return {
+      ...binding(snapshot),
+      tab,
+      result: {
+        providerId: snapshot.providerId,
+        browserTaskId: snapshot.browserTaskId,
+        jobId: snapshot.jobId,
+        invocationId: snapshot.invocationId,
+        status: 'succeeded' as const,
+        reason: 'completed' as const,
+        effectsUncertain: false as const,
+        summary: 'Observed the requested page.',
+        evidence: [{ text: 'The page contains the requested value.', url: tab.url }],
+      },
+    };
+  }
+
+  async function relayRegistered(
+    options: Partial<Parameters<typeof createUserWebConnection>[0]> = {}
+  ) {
+    // Load the real relay without adding Worker-only ambient types to the browser SDK project.
+    const { UserConnectionDO } = jest.requireActual<{
+      UserConnectionDO: new (
+        ctx: unknown,
+        env: unknown
+      ) => {
+        webSocketMessage(ws: unknown, message: string): Promise<void>;
+        webSocketClose(
+          ws: unknown,
+          code: number,
+          reason: string,
+          clean: boolean
+        ): void | Promise<void>;
+        alarm(): Promise<void>;
+      };
+    }>('../../../services/session-ingest/src/dos/UserConnectionDO');
+    type RelaySocket = {
+      role: 'cli' | 'web';
+      readyState: number;
+      send: (data: string) => void;
+      close: () => void;
+      serializeAttachment: (value: unknown) => void;
+      deserializeAttachment: () => unknown;
+    };
+    const records = new Map<string, unknown>();
+    function kv(data: Map<string, unknown>) {
+      return {
+        async get(key: string) {
+          return structuredClone(data.get(key));
+        },
+        async put(key: string, value: unknown) {
+          data.set(key, structuredClone(value));
+        },
+        async delete(key: string) {
+          return data.delete(key);
+        },
+        async list(options: { prefix?: string; limit?: number } = {}) {
+          return new Map(
+            [...data]
+              .filter(([key]) => key.startsWith(options.prefix ?? ''))
+              .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+              .slice(0, options.limit)
+              .map(([key, value]) => [key, structuredClone(value)])
+          );
+        },
+      };
+    }
+    let serial: Promise<unknown> = Promise.resolve();
+    let alarmAt: number | null = null;
+    const storage = {
+      ...kv(records),
+      transaction<T>(run: (tx: ReturnType<typeof kv>) => Promise<T>): Promise<T> {
+        const next = serial.then(async () => {
+          const working = new Map(records);
+          const result = await run(kv(working));
+          records.clear();
+          for (const [key, value] of working) records.set(key, value);
+          return result;
+        });
+        serial = next.catch(() => undefined);
+        return next;
+      },
+      async setAlarm(at: number) {
+        alarmAt = at;
+      },
+      async getAlarm() {
+        return alarmAt;
+      },
+      async deleteAlarm() {
+        alarmAt = null;
+      },
+    };
+    const peers: RelaySocket[] = [];
+    const queued: Array<() => Promise<void>> = [];
+    const background: Promise<unknown>[] = [];
+    const relay = new UserConnectionDO(
+      {
+        storage,
+        getWebSockets: (role?: string) => peers.filter(peer => !role || peer.role === role),
+        waitUntil: (work: Promise<unknown>) => background.push(work),
+      },
+      {}
+    );
+    function peer(role: 'cli' | 'web', send: (data: string) => void): RelaySocket {
+      let attachment: unknown = {
+        role,
+        connectionId: uuid(1_000 + peers.length),
+        kiloUserId: 'usr_1',
+        sessions: [],
+        subscribedSessions: [],
+      };
+      const socket: RelaySocket = {
+        role,
+        readyState: 1,
+        send,
+        close: () => {
+          socket.readyState = 3;
+        },
+        serializeAttachment: value => {
+          attachment = structuredClone(value);
+        },
+        deserializeAttachment: () => structuredClone(attachment),
+      };
+      peers.push(socket);
+      return socket;
+    }
+    async function flush() {
+      while (queued.length || background.length) {
+        for (const work of queued.splice(0)) await work();
+        await Promise.all(background.splice(0));
+      }
+    }
+    const cliMessages: ReturnType<typeof browserCLIInboundMessageSchema.parse>[] = [];
+    const cli = peer('cli', data => {
+      const parsed = browserCLIInboundMessageSchema.safeParse(JSON.parse(data));
+      if (parsed.success) cliMessages.push(parsed.data);
+    });
+    const client = createProvider(options);
+    const messages: BrowserProviderInboundMessage[] = [];
+    client.onBrowserProviderMessage(message => messages.push(message));
+    const panels = new Map<MockWebSocket, RelaySocket>();
+    async function connect(ws = sockets.at(-1)) {
+      if (!ws) throw new Error('Expected an SDK socket');
+      const panel = peer('web', data => ws.onmessage?.({ data } as MessageEvent));
+      panels.set(ws, panel);
+      ws.send.mockImplementation((data: string) => {
+        queued.push(() => relay.webSocketMessage(panel, data));
+      });
+      open(ws);
+      await flush();
+    }
+    function snapshot(jobId: string) {
+      const row = records.get(`browser/job/${jobId}`);
+      if (!row || typeof row !== 'object' || !('snapshot' in row)) {
+        throw new Error('Expected a persisted job');
+      }
+      return browserJobSnapshotSchema.parse(row.snapshot);
+    }
+    client.retain();
+    await connect();
+    const pending = client.registerBrowserProvider(registration);
+    await flush();
+    await pending;
+    return {
+      client,
+      messages,
+      connect,
+      flush,
+      snapshot,
+      async invoke(n = 1, createdAt = now) {
+        await relay.webSocketMessage(
+          cli,
+          JSON.stringify({ type: 'heartbeat', sessions: [], capabilities: { browserJobsV1: true } })
+        );
+        const requestId = uuid(2_000 + n);
+        await relay.webSocketMessage(
+          cli,
+          JSON.stringify({
+            type: 'browser_request',
+            operation: 'invoke',
+            requestId,
+            owner: { parentSessionId: 'ses_parent', parentProof: 'a'.repeat(64) },
+            providerId: registration.providerId,
+            invocationId: `b1.${createdAt}.${n.toString(16).padStart(64, '0')}`,
+            goal: 'Observe the requested page',
+          })
+        );
+        await flush();
+        const reply = [...cliMessages].reverse().find(message => message.requestId === requestId);
+        if (reply?.type !== 'browser_event' || reply.event !== 'progress') {
+          throw new Error('Expected admitted browser work');
+        }
+        return snapshot(reply.job.jobId);
+      },
+      async disconnect(code: number, ws = sockets.at(-1)) {
+        if (!ws) throw new Error('Expected an SDK socket');
+        const panel = panels.get(ws);
+        if (!panel) throw new Error('Expected a relay socket');
+        ws.readyState = 3;
+        panel.readyState = 3;
+        ws.onclose?.({ code } as CloseEvent);
+        await relay.webSocketClose(panel, code, '', false);
+        await flush();
+      },
+      async alarm() {
+        await relay.alarm();
+        await flush();
+      },
+    };
+  }
+
+  it('leaves legacy callers disabled and keeps their wire protocol unchanged', async () => {
+    const client = createProvider({ browserProvider: undefined });
+    const received: BrowserProviderInboundMessage[] = [];
+    client.onBrowserProviderMessage(message => received.push(message));
+    expect(sockets).toHaveLength(0);
+    client.retain();
+    open();
+    expect(frames()).toEqual([]);
+    await expect(client.registerBrowserProvider(registration)).rejects.toMatchObject({
+      code: 'disabled',
+      retryable: false,
+    });
+    dispatch();
+    jest.advanceTimersByTime(VIEWER_PING_INTERVAL_MS);
+    expect(frames()).toEqual([{ type: 'ping', nonce: expect.any(String) }]);
+    expect(received).toEqual([]);
+    expect(client.getBrowserProviderState()).toEqual({ status: 'disabled' });
+  });
+
+  it('requires a matching capability pong before registration or dispatch', async () => {
+    const client = createProvider();
+    const goals: string[] = [];
+    client.onBrowserProviderMessage(message => {
+      if (message.type === 'provider_job') goals.push(message.goal);
+    });
+    client.retain();
+    open();
+    const ping = lastFrame('ping');
+    expect(ping.capabilities).toEqual({ browserJobsV1: true });
+    await expect(client.registerBrowserProvider(registration)).rejects.toMatchObject({
+      code: 'not_negotiated',
+    });
+    inbound({ type: 'pong', nonce: uuid(999), capabilities: { browserJobsV1: true } });
+    dispatch();
+    expect(client.getBrowserProviderState()).toEqual({ status: 'negotiating' });
+    expect(frames()).toHaveLength(1);
+    expect(goals).toEqual([]);
+
+    inbound({ type: 'pong', nonce: ping.nonce, capabilities: { browserJobsV1: true } });
+    const pending = client.registerBrowserProvider(registration);
+    const request = lastFrame('provider_register');
+    leaseAck({ ...request, requestId: uuid(999) });
+    dispatch();
+    expect(client.getBrowserProviderState()).toEqual({ status: 'ready' });
+    const ack = leaseAck(request);
+    await expect(pending).resolves.toEqual(ack);
+    expect(frames().map(frame => frame.type)).toEqual([
+      'ping',
+      'provider_register',
+      'provider_status',
+    ]);
+    statusReply();
+    dispatch();
+    expect(goals).toEqual(['Observe the requested page']);
+  });
+
+  it.each([undefined, {}, { browserJobsV1: false }])(
+    'reports unsupported capability acknowledgement %j without breaking legacy commands',
+    async capabilities => {
+      const client = createProvider();
+      client.retain();
+      open();
+      inbound({ type: 'pong', nonce: lastFrame('ping').nonce, capabilities });
+      expect(client.getBrowserProviderState()).toEqual({
+        status: 'unavailable',
+        reason: 'unsupported',
+        retryable: false,
+      });
+      await expect(client.registerBrowserProvider(registration)).rejects.toMatchObject({
+        code: 'unsupported',
+        retryable: false,
+      });
+      expect(frames().map(frame => frame.type)).toEqual(['ping']);
+      const command = client.sendCommand('ses-1', 'list_models', {});
+      await Promise.resolve();
+      inbound({ type: 'response', id: lastFrame('command').id, result: { models: [] } });
+      await expect(command).resolves.toEqual({ models: [] });
+    }
+  );
+
+  it('times out missing registration acknowledgement and ignores a late grant', async () => {
+    const client = createProvider();
+    client.retain();
+    negotiate();
+    const pending = client.registerBrowserProvider(registration);
+    const request = lastFrame('provider_register');
+    jest.advanceTimersByTime(10_000);
+    await expect(pending).rejects.toMatchObject({ code: 'request_timeout', retryable: true });
+    leaseAck(request);
+    expect(client.getBrowserProviderState()).toEqual({
+      status: 'unavailable',
+      reason: 'request_timeout',
+      retryable: true,
+    });
+    expect(frames().map(frame => frame.type)).toEqual([
+      'ping',
+      'provider_register',
+      'provider_status',
+    ]);
+  });
+
+  it.each(['ack', 'snapshot'])(
+    'requires both correlated heartbeat replies when %s is missing',
+    async missing => {
+      const client = await registered();
+      const snapshots: BrowserJobSnapshot[][] = [];
+      client.onBrowserProviderMessage(message => {
+        if (message.type === 'provider_snapshot') snapshots.push(message.jobs);
+      });
+      const pending = client.heartbeatBrowserProvider();
+      const request = lastFrame('provider_heartbeat');
+      if (missing === 'ack') {
+        inbound({
+          type: 'provider_snapshot',
+          providerId: registration.providerId,
+          generation: 1,
+          requestId: request.requestId,
+          jobs: [job()],
+        });
+      } else {
+        leaseAck(request);
+      }
+      jest.advanceTimersByTime(10_000);
+      await expect(pending).rejects.toMatchObject({ code: 'request_timeout' });
+      expect(snapshots).toEqual([]);
+      expect(client.getBrowserProviderState()).toMatchObject({
+        status: 'unavailable',
+        reason: 'request_timeout',
+      });
+    }
+  );
+
+  it('returns an empty status page and renews a short lease before viewer ping', async () => {
+    const client = await registered();
+    const pending = client.heartbeatBrowserProvider(`bj_${uuid(9)}`);
+    expect(lastFrame('provider_heartbeat').cursor).toBe(`bj_${uuid(9)}`);
+    const snapshot = heartbeatReply();
+    await expect(pending).resolves.toEqual(snapshot);
+    jest.advanceTimersByTime(7_500);
+    expect(frames().filter(frame => frame.type === 'ping')).toHaveLength(1);
+    heartbeatReply();
+    jest.advanceTimersByTime(8_000);
+    dispatch();
+    client.approveBrowserProviderJob({
+      ...binding(job()),
+      approval: { decision: 'approved', tab },
+    });
+    expect(lastFrame('provider_approval').approval).toEqual({ decision: 'approved', tab });
+    expect(client.getBrowserProviderState().status).toBe('registered');
+  });
+
+  it('deduplicates jobs and cancellations and rejects stale or foreign generations', async () => {
+    const client = await registered(2);
+    const received: string[] = [];
+    client.onBrowserProviderMessage(message => {
+      if (message.type === 'provider_job') received.push(`job:${message.job.jobId}`);
+      if (message.type === 'provider_job_cancel') received.push(`cancel:${message.reason}`);
+    });
+    const current = job(1, { generation: 2 });
+    dispatch(job());
+    dispatch({ ...current, providerId: `bp_${uuid(2)}` });
+    dispatch(current);
+    dispatch(current);
+    inbound({ type: 'provider_job_cancel', ...binding(job()), reason: 'cancelled' });
+    inbound({
+      type: 'provider_job_cancel',
+      ...binding(current),
+      invocationId: `b1.${now}.${'f'.repeat(64)}`,
+      reason: 'cancelled',
+    });
+    const cancellation = { type: 'provider_job_cancel', ...binding(current), reason: 'cancelled' };
+    inbound(cancellation);
+    inbound(cancellation);
+    dispatch(current);
+    expect(received).toEqual([`job:${current.jobId}`, 'cancel:cancelled']);
+    expect(() =>
+      client.approveBrowserProviderJob({
+        ...binding(current),
+        approval: { decision: 'approved', tab },
+      })
+    ).toThrow(BrowserProviderError);
+    expect(frames().filter(frame => frame.type === 'provider_approval')).toEqual([]);
+  });
+
+  it('sends approval, result, quiescence, denial, and provider Stop on exact job bindings', async () => {
+    const client = await registered();
+    const current = job();
+    dispatch(current);
+    client.approveBrowserProviderJob({
+      ...binding(current),
+      approval: { decision: 'approved', tab },
+    });
+    expect(lastFrame('provider_approval')).toEqual({
+      type: 'provider_approval',
+      ...binding(current),
+      approval: { decision: 'approved', tab },
+    });
+    const result = completion(current);
+    expect(() => client.sendBrowserProviderResult(result)).toThrow(BrowserProviderError);
+    const running = { ...current, status: 'running' as const, approvedTab: tab };
+    update(running);
+    expect(() =>
+      client.sendBrowserProviderResult({ ...result, tab: { ...tab, tabId: 99 } })
+    ).toThrow(BrowserProviderError);
+    client.sendBrowserProviderResult(result);
+    expect(lastFrame('provider_result')).toEqual({ type: 'provider_result', ...result });
+    update({ ...running, status: 'succeeded', result: result.result });
+    client.quiesceBrowserProviderJob({ ...binding(current), tabId: tab.tabId });
+    expect(lastFrame('provider_quiesced')).toEqual({
+      type: 'provider_quiesced',
+      ...binding(current),
+      tabId: tab.tabId,
+    });
+    const denied = job(2);
+    dispatch(denied);
+    client.approveBrowserProviderJob({
+      ...binding(denied),
+      approval: { decision: 'denied', reason: 'approval_denied' },
+    });
+    expect(lastFrame('provider_approval').approval).toEqual({
+      decision: 'denied',
+      reason: 'approval_denied',
+    });
+    const queued = job(3, { status: 'queued' });
+    update(queued);
+    client.cancelBrowserProviderJob(binding(queued));
+    expect(lastFrame('provider_cancel')).toEqual({ type: 'provider_cancel', ...binding(queued) });
+    expect(frames().filter(frame => frame.type === 'command')).toEqual([]);
+  });
+
+  it('makes unavailable explicit while permitting drained-work acknowledgement and disabling automatic registration', async () => {
+    const client = await registered();
+    const current = job();
+    dispatch(current);
+    update({ ...current, status: 'running', approvedTab: tab });
+    client.markBrowserProviderUnavailable({
+      providerId: current.providerId,
+      generation: 1,
+      reason: 'effects_uncertain',
+      effectsUncertain: true,
+    });
+    expect(lastFrame('provider_unavailable')).toEqual({
+      type: 'provider_unavailable',
+      providerId: current.providerId,
+      generation: 1,
+      reason: 'effects_uncertain',
+      effectsUncertain: true,
+    });
+    expect(client.getBrowserProviderState()).toMatchObject({
+      status: 'unavailable',
+      reason: 'effects_uncertain',
+    });
+    expect(() => client.sendBrowserProviderResult(completion(current))).toThrow(
+      BrowserProviderError
+    );
+    inbound({ type: 'provider_job_cancel', ...binding(current), reason: 'effects_uncertain' });
+    client.quiesceBrowserProviderJob({ ...binding(current), tabId: tab.tabId });
+    expect(lastFrame('provider_quiesced').tabId).toBe(tab.tabId);
+    sockets[0].onclose?.({ code: 4001 } as CloseEvent);
+    await jest.advanceTimersByTimeAsync(0);
+    negotiate();
+    expect(frames().map(frame => frame.type)).toEqual(['ping']);
+  });
+
+  it('correlates history without renewing a lease or buffering running and terminal work', async () => {
+    const client = await registered(2);
+    const current = job(1, { generation: 2 });
+    dispatch(current);
+    client.approveBrowserProviderJob({
+      ...binding(current),
+      approval: { decision: 'approved', tab },
+    });
+    const before = client.getBrowserProviderState();
+    const histories: BrowserJobSnapshot[][] = [];
+    const actions: string[] = [];
+    client.onBrowserProviderMessage(message => {
+      if (message.type === 'provider_status_result') histories.push(message.jobs);
+      if (
+        message.type === 'provider_snapshot' &&
+        message.jobs.some(job => job.status === 'running')
+      ) {
+        actions.push('browser action');
+      }
+    });
+    jest.setSystemTime(now + 1_000);
+    const pending = client.requestBrowserProviderStatus();
+    const request = lastFrame('provider_status');
+    inbound({
+      type: 'provider_status_result',
+      requestId: uuid(999),
+      providerId: registration.providerId,
+      jobs: [],
+    });
+    inbound({
+      type: 'provider_status_result',
+      requestId: request.requestId,
+      providerId: `bp_${uuid(2)}`,
+      jobs: [],
+    });
+    inbound({
+      type: 'provider_lease_ack',
+      requestId: request.requestId,
+      providerId: registration.providerId,
+      generation: 2,
+      leaseExpiresAt: new Date(now + 30_000).toISOString(),
+    });
+    expect(histories).toEqual([]);
+    const terminal = job(2, {
+      generation: 2,
+      status: 'succeeded',
+      approvedTab: tab,
+      result: completion(job(2)).result,
+    });
+    const history = statusReply([{ ...current, status: 'running', approvedTab: tab }, terminal]);
+    await expect(pending).resolves.toEqual(history);
+    inbound(history);
+    expect(histories).toEqual([history.jobs]);
+    expect(actions).toEqual([]);
+    expect(client.getBrowserProviderState()).toEqual(before);
+    expect(() => client.sendBrowserProviderResult(completion(current))).toThrow(
+      BrowserProviderError
+    );
+    expect(() =>
+      client.quiesceBrowserProviderJob({ ...binding(terminal), tabId: tab.tabId })
+    ).toThrow(BrowserProviderError);
+    expect(
+      frames().filter(
+        frame => frame.type === 'provider_result' || frame.type === 'provider_quiesced'
+      )
+    ).toEqual([]);
+  });
+
+  it('finishes an in-flight history read after registration loss without restoring availability', async () => {
+    const client = await registered();
+    const current = job();
+    dispatch(current);
+    const pending = client.requestBrowserProviderStatus();
+    inbound({ type: 'provider_job_cancel', ...binding(current), reason: 'lease_expired' });
+    const interrupted = {
+      ...current,
+      status: 'interrupted',
+      result: {
+        ...completion(current).result,
+        status: 'interrupted',
+        reason: 'lease_expired',
+        effectsUncertain: true,
+      },
+    } satisfies BrowserJobSnapshot;
+    const history = statusReply([interrupted]);
+    await expect(pending).resolves.toEqual(history);
+    expect(client.getBrowserProviderState()).toEqual({
+      status: 'unavailable',
+      reason: 'lease_expired',
+      retryable: true,
+    });
+  });
+
+  it.each([
+    { code: 'request_timeout', retryable: true },
+    { code: 'owner_mismatch', retryable: false },
+  ])('keeps history failure $code separate from the live lease', async failure => {
+    const client = await registered();
+    const current = job();
+    dispatch(current);
+    update({ ...current, status: 'running', approvedTab: tab });
+    const pending = client.requestBrowserProviderStatus().catch(error => error);
+    if (failure.code === 'request_timeout') {
+      jest.advanceTimersByTime(10_000);
+    } else {
+      inbound({
+        type: 'response',
+        id: lastFrame('provider_status').requestId,
+        error: { source: 'relay', ...failure, message: registration.providerProof },
+      });
+    }
+    await expect(pending).resolves.toMatchObject({
+      ...failure,
+      message: `Browser provider request failed: ${failure.code}`,
+    });
+    expect(client.getBrowserProviderState().status).toBe('registered');
+    client.sendBrowserProviderResult(completion(current));
+    expect(lastFrame('provider_result').result).toEqual(completion(current).result);
+  });
+
+  it('does not retain or buffer provider requests without an owner lifetime', async () => {
+    const client = createProvider();
+    const messages: BrowserProviderInboundMessage[] = [];
+    client.onBrowserProviderMessage(message => messages.push(message));
+    await expect(client.registerBrowserProvider(registration)).rejects.toMatchObject({
+      code: 'disconnected',
+    });
+    await expect(client.requestBrowserProviderStatus()).rejects.toMatchObject({
+      code: 'disconnected',
+    });
+    expect(() => client.sendBrowserProviderResult(completion(job()))).toThrow('disconnected');
+    expect(sockets).toHaveLength(0);
+    client.retain();
+    negotiate();
+    expect(frames().map(frame => frame.type)).toEqual(['ping']);
+    expect(messages).toEqual([]);
+  });
+
+  it('delivers a correlated lease acknowledgement only once while status is pending', async () => {
+    const client = await registered();
+    const grants: string[] = [];
+    client.onBrowserProviderMessage(message => {
+      if (message.type === 'provider_lease_ack') grants.push(message.requestId);
+    });
+    const pending = client.heartbeatBrowserProvider();
+    const request = lastFrame('provider_heartbeat');
+    const ack = leaseAck(request);
+    inbound(ack);
+    heartbeatReply();
+    await expect(pending).resolves.toMatchObject({ jobs: [] });
+    inbound(ack);
+    expect(grants).toEqual([request.requestId]);
+  });
+
+  it('does not renew an expired lease when its acknowledgement beats a suspended timer', async () => {
+    const client = await registered();
+    const pending = client.heartbeatBrowserProvider();
+    const outcome = pending.catch(error => error);
+    jest.setSystemTime(now + 15_001);
+    leaseAck(lastFrame('provider_heartbeat'));
+    expect(client.getBrowserProviderState()).toMatchObject({
+      status: 'unavailable',
+      reason: 'lease_expired',
+    });
+    await expect(outcome).resolves.toMatchObject({ code: 'lease_expired' });
+  });
+
+  it('notifies the owner when an action detects a closed socket before its close event', async () => {
+    const client = await registered();
+    dispatch();
+    const states: string[] = [];
+    client.onBrowserProviderStateChange(state => states.push(state.status));
+    sockets[0].readyState = 3;
+    expect(() =>
+      client.approveBrowserProviderJob({
+        ...binding(job()),
+        approval: { decision: 'approved', tab },
+      })
+    ).toThrow('disconnected');
+    expect(states).toEqual(['disconnected']);
+    expect(frames().filter(frame => frame.type === 'provider_approval')).toEqual([]);
+  });
+
+  it('stops approved work when a running snapshot beats the expired lease timer', async () => {
+    const client = await registered();
+    const current = job();
+    dispatch(current);
+    client.approveBrowserProviderJob({
+      ...binding(current),
+      approval: { decision: 'approved', tab },
+    });
+    const events: string[] = [];
+    let canRun = true;
+    client.onBrowserProviderStateChange(state => {
+      if (state.status === 'unavailable') {
+        canRun = false;
+        events.push(state.reason);
+      }
+    });
+    client.onBrowserProviderMessage(message => {
+      if (
+        message.type === 'provider_snapshot' &&
+        message.jobs.some(job => job.status === 'running') &&
+        canRun
+      ) {
+        events.push('browser action');
+      }
+    });
+    // Move wall time without running the suspended lease timer.
+    jest.setSystemTime(now + 15_001);
+    update({ ...current, status: 'running', approvedTab: tab });
+    expect(events).toEqual(['lease_expired']);
+    expect(client.getBrowserProviderState()).toMatchObject({
+      status: 'unavailable',
+      reason: 'lease_expired',
+    });
+    expect(() => client.sendBrowserProviderResult(completion(current))).toThrow('lease_expired');
+  });
+
+  it.each(['approval_timeout', 'execution_timeout', 'invocation_expired'] as const)(
+    'reports %s revocation before cancellation and permits drained acknowledgement',
+    async reason => {
+      const f = await relayRegistered();
+      const current = await f.invoke(
+        1,
+        reason === 'invocation_expired' ? now - 7 * 24 * 60 * 60 * 1_000 + 10_000 : now
+      );
+      if (reason !== 'approval_timeout') {
+        f.client.approveBrowserProviderJob({
+          ...binding(current),
+          approval: { decision: 'approved', tab },
+        });
+        await f.flush();
+      }
+      const active = f.snapshot(current.jobId);
+      const deadlineText =
+        reason === 'invocation_expired'
+          ? active.expiresAt
+          : active.deadlines[reason === 'approval_timeout' ? 'approval' : 'execution'];
+      if (!deadlineText) throw new Error('Expected a relay deadline');
+      const deadline = Date.parse(deadlineText);
+      for (let time = now + 10_000; time < deadline; time += 10_000) {
+        jest.setSystemTime(time);
+        const heartbeat = f.client.heartbeatBrowserProvider();
+        await f.flush();
+        await heartbeat;
+      }
+      const events: string[] = [];
+      f.client.onBrowserProviderStateChange(state => {
+        if (state.status === 'unavailable') events.push(state.reason);
+      });
+      f.client.onBrowserProviderMessage(message => {
+        if (message.type === 'provider_job_cancel') {
+          events.push(`cancel:${f.client.getBrowserProviderState().status}`);
+        }
+      });
+      jest.setSystemTime(deadline);
+      await f.alarm();
+      expect(events).toEqual([reason, 'cancel:unavailable']);
+      expect(f.client.getBrowserProviderState()).toEqual({
+        status: 'unavailable',
+        reason,
+        retryable: true,
+      });
+      f.client.quiesceBrowserProviderJob({ ...binding(current), tabId: tab.tabId });
+      await f.flush();
+      const registrationResult = f.client.registerBrowserProvider({
+        ...registration,
+        generation: current.generation,
+      });
+      await f.flush();
+      await expect(registrationResult).resolves.toMatchObject({ generation: 2 });
+    }
+  );
+
+  it.each(['queued', 'unapproved'] as const)(
+    'preserves registration when Stop cancels %s work without revoking the relay lease',
+    async phase => {
+      const f = await relayRegistered();
+      const active = await f.invoke();
+      const cancelled = phase === 'queued' ? await f.invoke(2) : active;
+      const cancellationStates: string[] = [];
+      f.client.onBrowserProviderMessage(message => {
+        if (message.type === 'provider_job_cancel') {
+          cancellationStates.push(f.client.getBrowserProviderState().status);
+        }
+      });
+      f.client.cancelBrowserProviderJob(binding(cancelled));
+      await f.flush();
+      expect(f.client.getBrowserProviderState().status).toBe('registered');
+      expect(cancellationStates).toEqual(phase === 'queued' ? [] : ['registered']);
+      expect(f.snapshot(cancelled.jobId)).toMatchObject({
+        status: 'cancelled',
+        result: { effectsUncertain: false },
+      });
+      if (phase === 'unapproved') {
+        f.client.quiesceBrowserProviderJob({ ...binding(cancelled), tabId: tab.tabId });
+        await f.flush();
+      }
+      const next = phase === 'queued' ? active : await f.invoke(3);
+      f.client.approveBrowserProviderJob({
+        ...binding(next),
+        approval: { decision: 'approved', tab },
+      });
+      await f.flush();
+      expect(f.snapshot(next.jobId)).toMatchObject({
+        status: 'running',
+        generation: active.generation,
+      });
+    }
+  );
+
+  it('reports running Stop revocation before cancellation and retains safe quiescence', async () => {
+    const f = await relayRegistered();
+    const current = await f.invoke();
+    f.client.approveBrowserProviderJob({
+      ...binding(current),
+      approval: { decision: 'approved', tab },
+    });
+    await f.flush();
+    const events: string[] = [];
+    f.client.onBrowserProviderStateChange(state => {
+      if (state.status === 'unavailable') events.push(state.reason);
+    });
+    f.client.onBrowserProviderMessage(message => {
+      if (message.type === 'provider_job_cancel') {
+        events.push(`cancel:${f.client.getBrowserProviderState().status}`);
+      }
+    });
+    f.client.cancelBrowserProviderJob(binding(current));
+    await f.flush();
+    expect(events).toEqual(['cancelled', 'cancel:unavailable']);
+    expect(f.snapshot(current.jobId)).toMatchObject({
+      status: 'cancelled',
+      result: { effectsUncertain: true },
+    });
+    const retry = f.client
+      .registerBrowserProvider({ ...registration, generation: current.generation })
+      .catch(error => error);
+    await f.flush();
+    await expect(retry).resolves.toMatchObject({ code: 'provider_unavailable' });
+    f.client.quiesceBrowserProviderJob({ ...binding(current), tabId: tab.tabId });
+    await f.flush();
+    const registrationResult = f.client.registerBrowserProvider({
+      ...registration,
+      generation: current.generation,
+    });
+    await f.flush();
+    await expect(registrationResult).resolves.toMatchObject({ generation: 2 });
+  });
+
+  it('fences relay lease loss before cancellation callbacks or another job can run', async () => {
+    const client = await registered();
+    const current = job();
+    dispatch(current);
+    const events: string[] = [];
+    client.onBrowserProviderStateChange(state => {
+      if (state.status === 'unavailable') events.push(state.reason);
+    });
+    client.onBrowserProviderMessage(message => {
+      if (message.type === 'provider_job_cancel') events.push('cancel');
+      if (message.type === 'provider_job') events.push('execute');
+    });
+    inbound({ type: 'provider_job_cancel', ...binding(current), reason: 'lease_expired' });
+    dispatch(job(2));
+    expect(events).toEqual(['lease_expired', 'cancel']);
+    expect(client.getBrowserProviderState()).toMatchObject({
+      status: 'unavailable',
+      reason: 'lease_expired',
+    });
+    client.quiesceBrowserProviderJob({ ...binding(current), tabId: tab.tabId });
+    expect(lastFrame('provider_quiesced').jobId).toBe(current.jobId);
+  });
+
+  it.each(['send failure', 'disconnect'])(
+    'does not re-enable an unavailable provider after %s',
+    async loss => {
+      const client = await registered();
+      if (loss === 'send failure') {
+        sockets[0].send.mockImplementationOnce(() => {
+          throw new Error('socket closed');
+        });
+      } else {
+        sockets[0].onclose?.({ code: 4001 } as CloseEvent);
+      }
+      expect(() =>
+        client.markBrowserProviderUnavailable({
+          providerId: registration.providerId,
+          generation: 1,
+          reason: 'provider_unavailable',
+          effectsUncertain: false,
+        })
+      ).toThrow(BrowserProviderError);
+      await jest.advanceTimersByTimeAsync(0);
+      negotiate();
+      expect(frames().map(frame => frame.type)).toEqual(['ping']);
+    }
+  );
+
+  it('fences an expired lease before owner callbacks can send another action', async () => {
+    const client = await registered();
+    const current = job();
+    dispatch(current);
+    const ordering: string[] = [];
+    client.onBrowserProviderStateChange(state => {
+      if (state.status !== 'unavailable') return;
+      ordering.push(state.reason);
+      try {
+        client.approveBrowserProviderJob({
+          ...binding(current),
+          approval: { decision: 'approved', tab },
+        });
+      } catch (error) {
+        ordering.push(error instanceof BrowserProviderError ? error.code : 'wrong error');
+      }
+    });
+    jest.advanceTimersByTime(15_000);
+    expect(ordering).toEqual(['lease_expired', 'lease_expired']);
+    leaseAck(lastFrame('provider_heartbeat'));
+    dispatch(job(2));
+    expect(client.getBrowserProviderState()).toMatchObject({
+      status: 'unavailable',
+      reason: 'lease_expired',
+    });
+    expect(frames().filter(frame => frame.type === 'provider_approval')).toEqual([]);
+  });
+
+  it.each([1006, 4001, 1008])(
+    'recovers prior-generation terminal history after ticket loss (%i) without replay',
+    async code => {
+      const auth = createDeferred<string>();
+      let authCalls = 0;
+      const f = await relayRegistered({
+        getAuthToken: () => (++authCalls === 1 ? 'old-ticket' : auth.promise),
+      });
+      const { client } = f;
+      const current = await f.invoke();
+      client.approveBrowserProviderJob({
+        ...binding(current),
+        approval: { decision: 'approved', tab },
+      });
+      await f.flush();
+      client.sendBrowserProviderResult(completion(current));
+      await f.flush();
+      client.quiesceBrowserProviderJob({ ...binding(current), tabId: tab.tabId });
+      await f.flush();
+      const completed = f.snapshot(current.jobId);
+      const order: string[] = [];
+      client.onBrowserProviderStateChange(state => {
+        if (state.status !== 'disconnected') return;
+        order.push('stop');
+        try {
+          client.sendBrowserProviderResult(completion(current));
+        } catch (error) {
+          order.push(error instanceof BrowserProviderError ? error.code : 'wrong error');
+        }
+      });
+      client.onConnectionChange(connected => {
+        if (!connected) order.push('connection lost');
+      });
+      const pending = client.requestBrowserProviderStatus().catch(error => error);
+      const oldSocket = sockets[0];
+      await f.disconnect(code, oldSocket);
+      await expect(pending).resolves.toMatchObject({ code: 'disconnected' });
+      expect(order).toEqual(['stop', 'disconnected', 'connection lost']);
+      if (code === 1006) jest.advanceTimersByTime(500);
+      expect(sockets).toHaveLength(1);
+      dispatch(job(2), oldSocket);
+      expect(() => client.sendBrowserProviderResult(completion(current))).toThrow(
+        BrowserProviderError
+      );
+      auth.resolve('new-ticket');
+      await jest.advanceTimersByTimeAsync(0);
+      expect(sockets).toHaveLength(2);
+      expect(
+        new URL(webSocketConstructor.mock.calls[1][0] as string).searchParams.get('ticket')
+      ).toBe('new-ticket');
+      await f.connect();
+      expect(lastFrame('provider_register')).toMatchObject({ ...registration, generation: 1 });
+      expect(lastFrame('provider_register')).not.toHaveProperty('recovery');
+      const recovered = f.messages
+        .filter(message => message.type === 'provider_status_result')
+        .at(-1);
+      expect(recovered?.jobs).toEqual([completed]);
+      expect(recovered?.jobs[0]).toMatchObject({
+        generation: current.generation,
+        status: 'succeeded',
+        result: completion(current).result,
+      });
+      expect(client.getBrowserProviderState()).toMatchObject({
+        status: 'registered',
+        lease: { generation: 2 },
+      });
+      const heartbeat = client.heartbeatBrowserProvider();
+      await f.flush();
+      await expect(heartbeat).resolves.toMatchObject({ generation: 2, jobs: [] });
+      dispatch(current, oldSocket);
+      dispatch(current);
+      expect(f.messages.filter(message => message.type === 'provider_job')).toHaveLength(1);
+      expect(() => client.sendBrowserProviderResult(completion(current))).toThrow(
+        BrowserProviderError
+      );
+      expect(
+        frames().filter(
+          frame => frame.type === 'provider_result' || frame.type === 'provider_approval'
+        )
+      ).toEqual([]);
+    }
+  );
+
+  it('recovers fenced interruption history even when reconnect registration is rejected', async () => {
+    const f = await relayRegistered();
+    const current = await f.invoke();
+    f.client.approveBrowserProviderJob({
+      ...binding(current),
+      approval: { decision: 'approved', tab },
+    });
+    await f.flush();
+    await f.disconnect(4001);
+    await jest.advanceTimersByTimeAsync(0);
+    await f.connect();
+    const interrupted = f.snapshot(current.jobId);
+    const recovered = f.messages
+      .filter(message => message.type === 'provider_status_result')
+      .at(-1);
+    expect(recovered?.jobs).toEqual([interrupted]);
+    expect(interrupted).toMatchObject({
+      generation: current.generation,
+      status: 'interrupted',
+      result: { reason: 'provider_lost', effectsUncertain: true },
+    });
+    expect(f.client.getBrowserProviderState()).toEqual({
+      status: 'unavailable',
+      reason: 'provider_unavailable',
+      retryable: true,
+    });
+    const status = f.client.requestBrowserProviderStatus(current.jobId);
+    await f.flush();
+    await expect(status).resolves.toMatchObject({ jobs: [] });
+    expect(() => f.client.sendBrowserProviderResult(completion(current))).toThrow(
+      BrowserProviderError
+    );
+    expect(() =>
+      f.client.quiesceBrowserProviderJob({ ...binding(current), tabId: tab.tabId })
+    ).toThrow(BrowserProviderError);
+    const retry = f.client
+      .registerBrowserProvider({ ...registration, generation: current.generation })
+      .catch(error => error);
+    await f.flush();
+    await expect(retry).resolves.toMatchObject({ code: 'provider_unavailable' });
+    expect(f.messages.filter(message => message.type === 'provider_job')).toHaveLength(1);
+    expect(
+      frames().filter(
+        frame =>
+          frame.type === 'provider_approval' ||
+          frame.type === 'provider_result' ||
+          frame.type === 'provider_quiesced'
+      )
+    ).toEqual([]);
+  });
+
+  it('stops later callbacks when a listener releases the connection and ignores late socket events', async () => {
+    const client = createProvider();
+    const release = client.retain();
+    negotiate();
+    const pending = client.registerBrowserProvider(registration);
+    leaseAck(lastFrame('provider_register'));
+    await pending;
+    statusReply();
+    const actions: string[] = [];
+    const unsubscribe = client.onBrowserProviderMessage(message => {
+      if (message.type === 'provider_job') {
+        actions.push('stop');
+        release();
+      }
+    });
+    client.onBrowserProviderMessage(message => {
+      if (message.type === 'provider_job') actions.push('execute');
+    });
+    dispatch();
+    expect(actions).toEqual(['stop']);
+    const oldSocket = sockets[0];
+    unsubscribe();
+    client.retain();
+    open(oldSocket);
+    dispatch(job(2), oldSocket);
+    expect(client.getBrowserProviderState()).toEqual({ status: 'disconnected' });
+    expect(actions).toEqual(['stop']);
+    client.destroy();
+    const states: BrowserProviderState[] = [];
+    client.onBrowserProviderStateChange(state => states.push(state));
+    open();
+    dispatch(job(3));
+    expect(states).toEqual([]);
+    expect(actions).toEqual(['stop']);
+  });
+
+  it('never repeats an explicit recovery assertion after its registration acknowledgement is lost', async () => {
+    const client = createProvider();
+    client.retain();
+    negotiate();
+    const pending = client.registerBrowserProvider({
+      ...registration,
+      recovery: {
+        invocationId: job().invocationId,
+        tabId: 42,
+        tabClosed: true,
+        locksDrained: true,
+      },
+    });
+    sockets[0].onclose?.({ code: 4001 } as CloseEvent);
+    await expect(pending).rejects.toMatchObject({ code: 'disconnected' });
+    await jest.advanceTimersByTimeAsync(0);
+    negotiate();
+    expect(lastFrame('provider_register')).not.toHaveProperty('recovery');
+    expect(lastFrame('provider_register').providerProof).toBe(registration.providerProof);
+  });
+
+  it.each([
+    { code: 'owner_mismatch', retryable: false },
+    { code: 'provider_unavailable', retryable: true },
+  ])(
+    'surfaces safe relay failure $code without exposing the proof-bearing error text',
+    async failure => {
+      const client = createProvider();
+      client.retain();
+      negotiate();
+      await expect(
+        client.registerBrowserProvider({
+          ...registration,
+          providerProof: `private-proof:${registration.providerProof}`,
+        })
+      ).rejects.toMatchObject({ message: 'Browser provider request failed: invalid_request' });
+      const pending = client.registerBrowserProvider(registration);
+      inbound({
+        type: 'response',
+        id: lastFrame('provider_register').requestId,
+        error: {
+          source: 'relay',
+          ...failure,
+          message: `private-ticket ${registration.providerProof}`,
+          [registration.providerProof]: 'secret',
+        },
+      });
+      await expect(pending).rejects.toMatchObject({
+        ...failure,
+        message: `Browser provider request failed: ${failure.code}`,
+      });
+      expect(client.getBrowserProviderState()).toEqual({
+        status: 'unavailable',
+        reason: failure.code,
+        retryable: failure.retryable,
+      });
+    }
+  );
+
+  it('redacts socket send failures and refresh failures before the base connection logs them', async () => {
+    const logs: string[] = [];
+    jest.spyOn(console, 'error').mockImplementation((...values: unknown[]) => {
+      logs.push(
+        values.map(value => (value instanceof Error ? value.message : String(value))).join(' ')
+      );
+    });
+    let calls = 0;
+    const client = createProvider({
+      getAuthToken: () => {
+        if (++calls === 1) return 'private-ticket';
+        throw new Error(`private-ticket ${registration.providerProof}`);
+      },
+    });
+    client.retain();
+    negotiate();
+    sockets[0].send.mockImplementationOnce(() => {
+      throw new Error(registration.providerProof);
+    });
+    await expect(client.registerBrowserProvider(registration)).rejects.toMatchObject({
+      code: 'disconnected',
+      message: 'Browser provider request failed: disconnected',
+    });
+    await jest.advanceTimersByTimeAsync(0);
+    // Exercise the base connection's logging auth-close path on the replacement socket.
+    sockets.at(-1)?.onclose?.({ code: 4001 } as CloseEvent);
+    await jest.advanceTimersByTimeAsync(0);
+    expect(logs.join('\n')).toContain('Failed to refresh auth');
+    expect(logs.join('\n')).not.toContain('private-ticket');
+    expect(logs.join('\n')).not.toContain(registration.providerProof);
   });
 });

--- a/packages/cloud-agent-sdk/src/user-web-connection.ts
+++ b/packages/cloud-agent-sdk/src/user-web-connection.ts
@@ -1,3 +1,4 @@
+import * as z from 'zod';
 import {
   createBaseConnection,
   type Connection,
@@ -5,13 +6,23 @@ import {
 } from './base-connection';
 import { cloudAgentSdkRuntime } from './runtime';
 import {
+  browserFailureReasonSchema,
+  browserProviderOutboundMessageSchema,
+  normalizedBrowserCapabilitiesSchema,
   sessionEventPayloadSchema,
   userWebCommandErrorDataSchema,
   webInboundMessageSchema,
+  webInboundWithBrowserMessageSchema,
+  type BrowserJobHandle,
+  type BrowserJobSnapshot,
+  type BrowserProviderInboundMessage,
+  type BrowserProviderOutboundMessage,
   type SessionEventPayload,
   type WebInboundMessage,
+  type WebInboundWithBrowserMessage,
 } from './schemas';
 
+const BROWSER_PROVIDER_REQUEST_TIMEOUT_MS = 10_000;
 const COMMAND_TIMEOUT_MS = 30_000;
 const INITIAL_AUTH_RETRY_BASE_MS = 1_000;
 const INITIAL_AUTH_RETRY_CAP_MS = 30_000;
@@ -54,6 +65,102 @@ class CommandDeliveredError extends Error {
   }
 }
 
+type BrowserProviderLease = Extract<BrowserProviderInboundMessage, { type: 'provider_lease_ack' }>;
+type BrowserProviderSnapshot = Extract<
+  BrowserProviderInboundMessage,
+  { type: 'provider_snapshot' }
+>;
+type BrowserProviderStatusResult = Extract<
+  BrowserProviderInboundMessage,
+  { type: 'provider_status_result' }
+>;
+type BrowserProviderRegisterWire = Extract<
+  BrowserProviderOutboundMessage,
+  { type: 'provider_register' }
+>;
+type BrowserProviderHeartbeatWire = Extract<
+  BrowserProviderOutboundMessage,
+  { type: 'provider_heartbeat' }
+>;
+type BrowserProviderStatusWire = Extract<
+  BrowserProviderOutboundMessage,
+  { type: 'provider_status' }
+>;
+type BrowserProviderRegistration = Omit<
+  BrowserProviderRegisterWire,
+  'type' | 'requestId' | 'enabled'
+>;
+type BrowserProviderApprovalInput = Omit<
+  Extract<BrowserProviderOutboundMessage, { type: 'provider_approval' }>,
+  'type'
+>;
+type BrowserProviderCancelInput = Omit<
+  Extract<BrowserProviderOutboundMessage, { type: 'provider_cancel' }>,
+  'type'
+>;
+type BrowserProviderResultInput = Omit<
+  Extract<BrowserProviderOutboundMessage, { type: 'provider_result' }>,
+  'type'
+>;
+type BrowserProviderQuiescenceInput = Omit<
+  Extract<BrowserProviderOutboundMessage, { type: 'provider_quiesced' }>,
+  'type'
+>;
+type BrowserProviderUnavailableInput = Omit<
+  Extract<BrowserProviderOutboundMessage, { type: 'provider_unavailable' }>,
+  'type'
+>;
+type BrowserProviderErrorCode =
+  | BrowserProviderUnavailableInput['reason']
+  | 'disabled'
+  | 'disconnected'
+  | 'not_negotiated'
+  | 'request_timeout';
+
+class BrowserProviderError extends Error {
+  constructor(
+    readonly code: BrowserProviderErrorCode,
+    readonly retryable: boolean
+  ) {
+    // Never include relay text, validation issues, registration proofs, or socket errors.
+    super(`Browser provider request failed: ${code}`);
+    this.name = 'BrowserProviderError';
+  }
+}
+
+const browserProviderErrorSchema = z.object({
+  source: z.literal('relay'),
+  code: browserFailureReasonSchema,
+  retryable: z.boolean(),
+});
+
+type BrowserProviderState =
+  | { status: 'disabled' | 'disconnected' | 'negotiating' | 'ready' }
+  | { status: 'registered'; lease: BrowserProviderLease }
+  | { status: 'unavailable'; reason: BrowserProviderErrorCode; retryable: boolean };
+
+/** Additive API; the legacy UserWebConnection structural contract remains unchanged. */
+type BrowserProviderConnection = {
+  getBrowserProviderState: () => BrowserProviderState;
+  onBrowserProviderStateChange: (listener: (state: BrowserProviderState) => void) => () => void;
+  /** Snapshots and history reconcile persisted state. Only provider_job offers new work for approval. */
+  onBrowserProviderMessage: (
+    listener: (message: BrowserProviderInboundMessage) => void
+  ) => () => void;
+  /** Requires an explicitly retained, negotiated connection. Keeps only stable registration data for reconnect. */
+  registerBrowserProvider: (input: BrowserProviderRegistration) => Promise<BrowserProviderLease>;
+  /** Renews the current lease and reconciles only its generation. */
+  heartbeatBrowserProvider: (cursor?: string) => Promise<BrowserProviderSnapshot>;
+  /** Reads history with the stable proof, even without registration. Never authorizes execution. */
+  requestBrowserProviderStatus: (cursor?: string) => Promise<BrowserProviderStatusResult>;
+  /** Sends consent only. Wait for a running snapshot before starting browser actions. */
+  approveBrowserProviderJob: (input: BrowserProviderApprovalInput) => void;
+  cancelBrowserProviderJob: (input: BrowserProviderCancelInput) => void;
+  sendBrowserProviderResult: (input: BrowserProviderResultInput) => void;
+  quiesceBrowserProviderJob: (input: BrowserProviderQuiescenceInput) => void;
+  markBrowserProviderUnavailable: (input: BrowserProviderUnavailableInput) => void;
+};
+
 type UserWebConnectionConfig = {
   websocketUrl: string;
   getAuthToken: () => string | Promise<string>;
@@ -61,6 +168,8 @@ type UserWebConnectionConfig = {
   onReconnect?: () => void;
   lifecycleHooks?: ConnectionLifecycleHooks;
   maxReconnectAttempts?: number;
+  /** Old callers omit this flag and stay disabled. This compatibility default is permanent. */
+  browserProvider?: boolean;
 };
 
 type SendCommandToConnectionInput = {
@@ -145,8 +254,37 @@ function parseCommandError(error: unknown): Error {
 
 function createUserWebConnection(
   config: UserWebConnectionConfig
-): UserWebConnection & { retain: () => () => void } {
+): UserWebConnection & BrowserProviderConnection {
   const connectionId = cloudAgentSdkRuntime.randomUUID();
+  const browserProviderEnabled = config.browserProvider ?? false;
+  let providerNegotiated = false;
+  let providerEpoch = 0;
+  let providerState: BrowserProviderState = {
+    status: browserProviderEnabled ? 'disconnected' : 'disabled',
+  };
+  let providerRegistration: BrowserProviderRegistration | null = null;
+  let providerLease: BrowserProviderLease | null = null;
+  // A lost lease can still acknowledge drained work, but cannot authorize another action.
+  let providerBinding: Pick<BrowserProviderLease, 'providerId' | 'generation'> | null = null;
+  let providerLeaseTimer: ReturnType<typeof setTimeout> | null = null;
+  let providerHeartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  const providerListeners = new Set<(message: BrowserProviderInboundMessage) => void>();
+  const providerStateListeners = new Set<(state: BrowserProviderState) => void>();
+  const providerSnapshots = new Map<string, BrowserJobSnapshot>();
+  const dispatchedProviderJobs = new Set<string>();
+  const cancelledProviderJobs = new Set<string>();
+  const pendingProviderRequests = new Map<
+    string,
+    {
+      wire: BrowserProviderRegisterWire | BrowserProviderHeartbeatWire | BrowserProviderStatusWire;
+      acknowledged: boolean;
+      resolve: (
+        reply: BrowserProviderLease | BrowserProviderSnapshot | BrowserProviderStatusResult
+      ) => void;
+      reject: (error: BrowserProviderError) => void;
+      timer: ReturnType<typeof setTimeout>;
+    }
+  >();
   let token = '';
   let baseConnection: Connection | null = null;
   let currentWs: WebSocket | null = null;
@@ -209,6 +347,485 @@ function createUserWebConnection(
     if (exhausted === value) return;
     exhausted = value;
     for (const listener of exhaustionChangeListeners) listener(value);
+  }
+
+  function setProviderState(state: BrowserProviderState): void {
+    if (state.status === providerState.status && state.status !== 'registered') {
+      if (state.status !== 'unavailable') return;
+      if (
+        providerState.status === 'unavailable' &&
+        state.reason === providerState.reason &&
+        state.retryable === providerState.retryable
+      )
+        return;
+    }
+    providerState = state;
+    for (const listener of providerStateListeners) {
+      if (providerState !== state) break;
+      listener(state);
+    }
+  }
+
+  function invalidateProvider(error: BrowserProviderError, disconnected = false): void {
+    if (!browserProviderEnabled) return;
+    providerEpoch += 1;
+    providerLease = null;
+    if (providerLeaseTimer !== null) clearTimeout(providerLeaseTimer);
+    if (providerHeartbeatTimer !== null) clearTimeout(providerHeartbeatTimer);
+    providerLeaseTimer = null;
+    providerHeartbeatTimer = null;
+    for (const [id, pending] of pendingProviderRequests) {
+      if (!disconnected && pending.wire.type === 'provider_status') continue;
+      clearTimeout(pending.timer);
+      pendingProviderRequests.delete(id);
+      pending.reject(error);
+    }
+    if (disconnected) {
+      currentWs = null;
+      providerNegotiated = false;
+      providerBinding = null;
+      providerSnapshots.clear();
+      dispatchedProviderJobs.clear();
+      cancelledProviderJobs.clear();
+    }
+    // Fence actions and reject requests before notifying the owner, including during teardown.
+    setProviderState(
+      disconnected
+        ? { status: 'disconnected' }
+        : { status: 'unavailable', reason: error.code, retryable: error.retryable }
+    );
+  }
+
+  function requireProviderSocket(): WebSocket {
+    if (!browserProviderEnabled) throw new BrowserProviderError('disabled', false);
+    if (destroyed || !hasLifetime() || !currentWs || currentWs.readyState !== WebSocket.OPEN) {
+      const error = new BrowserProviderError('disconnected', true);
+      if (currentWs) {
+        invalidateProvider(error, true);
+        clearLiveness();
+        setConnected(false);
+      }
+      throw error;
+    }
+    if (!providerNegotiated) {
+      if (providerState.status === 'unavailable')
+        throw new BrowserProviderError(providerState.reason, providerState.retryable);
+      throw new BrowserProviderError('not_negotiated', true);
+    }
+    return currentWs;
+  }
+
+  function requireProviderLease(): BrowserProviderLease {
+    requireProviderSocket();
+    if (providerLease && Date.parse(providerLease.leaseExpiresAt) <= Date.now()) {
+      invalidateProvider(new BrowserProviderError('lease_expired', true));
+    }
+    if (!providerLease) {
+      throw providerState.status === 'unavailable'
+        ? new BrowserProviderError(providerState.reason, providerState.retryable)
+        : new BrowserProviderError('provider_unavailable', true);
+    }
+    return providerLease;
+  }
+
+  function validateProviderMessage(input: unknown): BrowserProviderOutboundMessage {
+    const parsed = browserProviderOutboundMessageSchema.safeParse(input);
+    if (!parsed.success) throw new BrowserProviderError('invalid_request', false);
+    return parsed.data;
+  }
+
+  function sendProviderWire(wire: BrowserProviderOutboundMessage): void {
+    const ws = requireProviderSocket();
+    try {
+      ws.send(JSON.stringify(wire));
+    } catch {
+      const error = new BrowserProviderError('disconnected', true);
+      invalidateProvider(error, true);
+      replaceUnresponsiveSocket();
+      throw error;
+    }
+  }
+
+  function rejectProviderRequest(requestId: string, error: BrowserProviderError): void {
+    const pending = pendingProviderRequests.get(requestId);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    pendingProviderRequests.delete(requestId);
+    pending.reject(error);
+  }
+
+  function requestProvider(
+    wire: BrowserProviderRegisterWire | BrowserProviderHeartbeatWire | BrowserProviderStatusWire
+  ): Promise<BrowserProviderLease | BrowserProviderSnapshot | BrowserProviderStatusResult> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const error = new BrowserProviderError('request_timeout', true);
+        if (wire.type === 'provider_status') rejectProviderRequest(wire.requestId, error);
+        else invalidateProvider(error);
+      }, BROWSER_PROVIDER_REQUEST_TIMEOUT_MS);
+      pendingProviderRequests.set(wire.requestId, {
+        wire,
+        acknowledged: false,
+        resolve,
+        reject,
+        timer,
+      });
+      try {
+        sendProviderWire(wire);
+      } catch {
+        rejectProviderRequest(wire.requestId, new BrowserProviderError('disconnected', true));
+      }
+    });
+  }
+
+  function finishProviderRequest(
+    requestId: string,
+    reply: BrowserProviderLease | BrowserProviderSnapshot | BrowserProviderStatusResult
+  ): void {
+    const pending = pendingProviderRequests.get(requestId);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    pendingProviderRequests.delete(requestId);
+    pending.resolve(reply);
+  }
+
+  async function registerBrowserProvider(
+    input: BrowserProviderRegistration
+  ): Promise<BrowserProviderLease> {
+    const ws = requireProviderSocket();
+    if (
+      providerLease ||
+      [...pendingProviderRequests.values()].some(
+        pending => pending.wire.type === 'provider_register'
+      )
+    ) {
+      throw new BrowserProviderError('invalid_request', false);
+    }
+    const wire = validateProviderMessage({
+      ...input,
+      type: 'provider_register',
+      enabled: true,
+      requestId: cloudAgentSdkRuntime.randomUUID(),
+    });
+    if (wire.type !== 'provider_register') throw new BrowserProviderError('invalid_request', false);
+    // Recovery is an explicit, one-shot assertion. Never replay it after a lost acknowledgement.
+    const registration = {
+      providerId: wire.providerId,
+      providerProof: wire.providerProof,
+      generation: wire.generation,
+      label: wire.label,
+    };
+    providerRegistration = registration;
+    try {
+      const reply = await requestProvider(wire);
+      if (reply.type !== 'provider_lease_ack')
+        throw new BrowserProviderError('invalid_request', false);
+      return reply;
+    } finally {
+      // A rejected registration can leave a fence whose history still needs reconciliation.
+      if (
+        currentWs === ws &&
+        providerRegistration === registration &&
+        providerNegotiated &&
+        hasLifetime() &&
+        !destroyed
+      )
+        void requestBrowserProviderStatus().catch(() => {});
+    }
+  }
+
+  async function requestBrowserProviderStatus(
+    cursor?: string
+  ): Promise<BrowserProviderStatusResult> {
+    requireProviderSocket();
+    if (!providerRegistration) throw new BrowserProviderError('provider_unavailable', true);
+    const wire = validateProviderMessage({
+      type: 'provider_status',
+      requestId: cloudAgentSdkRuntime.randomUUID(),
+      providerId: providerRegistration.providerId,
+      providerProof: providerRegistration.providerProof,
+      ...(cursor === undefined ? {} : { cursor }),
+    });
+    if (wire.type !== 'provider_status') throw new BrowserProviderError('invalid_request', false);
+    const reply = await requestProvider(wire);
+    if (reply.type !== 'provider_status_result')
+      throw new BrowserProviderError('invalid_request', false);
+    return reply;
+  }
+
+  async function heartbeatBrowserProvider(cursor?: string): Promise<BrowserProviderSnapshot> {
+    const lease = requireProviderLease();
+    const wire = validateProviderMessage({
+      type: 'provider_heartbeat',
+      requestId: cloudAgentSdkRuntime.randomUUID(),
+      providerId: lease.providerId,
+      generation: lease.generation,
+      ...(cursor === undefined ? {} : { cursor }),
+    });
+    if (wire.type !== 'provider_heartbeat')
+      throw new BrowserProviderError('invalid_request', false);
+    const reply = await requestProvider(wire);
+    if (reply.type !== 'provider_snapshot')
+      throw new BrowserProviderError('invalid_request', false);
+    return reply;
+  }
+
+  function renewProviderLease(lease: BrowserProviderLease): void {
+    if (providerLeaseTimer !== null) clearTimeout(providerLeaseTimer);
+    if (providerHeartbeatTimer !== null) clearTimeout(providerHeartbeatTimer);
+    const remaining = Date.parse(lease.leaseExpiresAt) - Date.now();
+    if (remaining <= 0) {
+      invalidateProvider(new BrowserProviderError('lease_expired', true));
+      return;
+    }
+    providerLease = lease;
+    providerLeaseTimer = setTimeout(
+      () => invalidateProvider(new BrowserProviderError('lease_expired', true)),
+      remaining
+    );
+    providerHeartbeatTimer = setTimeout(
+      () => {
+        providerHeartbeatTimer = null;
+        void heartbeatBrowserProvider().catch(() => {});
+      },
+      Math.max(1, Math.floor(remaining / 2))
+    );
+    setProviderState({ status: 'registered', lease });
+  }
+
+  function matchesProviderJob(left: BrowserJobHandle, right: BrowserJobHandle): boolean {
+    return (
+      left.providerId === right.providerId &&
+      left.browserTaskId === right.browserTaskId &&
+      left.jobId === right.jobId &&
+      left.invocationId === right.invocationId
+    );
+  }
+
+  function sendProviderUpdate(input: BrowserProviderOutboundMessage): void {
+    const wire = validateProviderMessage(input);
+    if (
+      wire.type === 'provider_register' ||
+      wire.type === 'provider_heartbeat' ||
+      wire.type === 'provider_status'
+    )
+      throw new BrowserProviderError('invalid_request', false);
+    if (
+      wire.type === 'provider_unavailable' &&
+      wire.providerId === providerRegistration?.providerId &&
+      wire.generation === providerRegistration.generation
+    ) {
+      // Keep the owner's disable intent even if this socket cannot deliver it.
+      providerRegistration = null;
+      if (!providerLease) invalidateProvider(new BrowserProviderError(wire.reason, false));
+    }
+    requireProviderSocket();
+    const binding = wire.type === 'provider_quiesced' ? providerBinding : requireProviderLease();
+    if (
+      !binding ||
+      wire.providerId !== binding.providerId ||
+      wire.generation !== binding.generation
+    )
+      throw new BrowserProviderError('owner_mismatch', false);
+    if (wire.type !== 'provider_unavailable') {
+      const job = providerSnapshots.get(wire.jobId);
+      if (!job || !matchesProviderJob(job, wire) || job.generation !== wire.generation)
+        throw new BrowserProviderError('owner_mismatch', false);
+      if (wire.type === 'provider_approval' || wire.type === 'provider_result') {
+        if (
+          !dispatchedProviderJobs.has(wire.jobId) ||
+          cancelledProviderJobs.has(wire.jobId) ||
+          job.status !== (wire.type === 'provider_approval' ? 'awaiting_approval' : 'running')
+        )
+          throw new BrowserProviderError('invalid_request', false);
+      }
+      if (wire.type === 'provider_result') {
+        const tab = job.approvedTab;
+        if (
+          !tab ||
+          tab.tabId !== wire.tab.tabId ||
+          tab.title !== wire.tab.title ||
+          tab.url !== wire.tab.url ||
+          tab.effectiveMode !== wire.tab.effectiveMode
+        )
+          throw new BrowserProviderError('invalid_request', false);
+      }
+      if (
+        wire.type === 'provider_quiesced' &&
+        ((!job.result && !cancelledProviderJobs.has(job.jobId)) ||
+          (job.approvedTab && job.approvedTab.tabId !== wire.tabId))
+      )
+        throw new BrowserProviderError('invalid_request', false);
+    }
+    sendProviderWire(wire);
+    if (wire.type === 'provider_unavailable') {
+      providerRegistration = null;
+      invalidateProvider(new BrowserProviderError(wire.reason, false));
+    }
+  }
+
+  function emitProviderMessage(message: BrowserProviderInboundMessage, epoch: number): void {
+    for (const listener of providerListeners) {
+      if (
+        destroyed ||
+        !hasLifetime() ||
+        !currentWs ||
+        !providerNegotiated ||
+        epoch !== providerEpoch
+      )
+        break;
+      listener(message);
+    }
+  }
+
+  function handleProviderMessage(message: BrowserProviderInboundMessage): void {
+    if (!providerNegotiated || !currentWs || destroyed || !hasLifetime()) return;
+    const epoch = providerEpoch;
+    switch (message.type) {
+      case 'provider_lease_ack': {
+        const pending = pendingProviderRequests.get(message.requestId);
+        if (
+          !pending ||
+          pending.wire.type === 'provider_status' ||
+          pending.acknowledged ||
+          message.providerId !== pending.wire.providerId
+        )
+          return;
+        const registering = pending.wire.type === 'provider_register';
+        if (
+          registering
+            ? message.generation <= pending.wire.generation
+            : message.generation !== providerLease?.generation ||
+              message.generation !== pending.wire.generation
+        )
+          return;
+        // A suspended timer cannot turn a late heartbeat into renewed execution authority.
+        if (
+          !registering &&
+          providerLease &&
+          Date.parse(providerLease.leaseExpiresAt) <= Date.now()
+        ) {
+          invalidateProvider(new BrowserProviderError('lease_expired', true));
+          return;
+        }
+        if (registering) {
+          providerBinding = { providerId: message.providerId, generation: message.generation };
+          providerSnapshots.clear();
+          dispatchedProviderJobs.clear();
+          cancelledProviderJobs.clear();
+          if (providerRegistration) providerRegistration.generation = message.generation;
+        }
+        pending.acknowledged = true;
+        renewProviderLease(message);
+        if (epoch !== providerEpoch || !providerLease) return;
+        if (registering) finishProviderRequest(message.requestId, message);
+        emitProviderMessage(message, epoch);
+        return;
+      }
+      case 'provider_status_result': {
+        const pending = pendingProviderRequests.get(message.requestId);
+        if (
+          !pending ||
+          pending.wire.type !== 'provider_status' ||
+          message.providerId !== pending.wire.providerId
+        )
+          return;
+        // History never enters the live snapshot cache or changes execution authority.
+        finishProviderRequest(message.requestId, message);
+        emitProviderMessage(message, epoch);
+        return;
+      }
+      case 'provider_snapshot': {
+        if (
+          message.providerId !== providerBinding?.providerId ||
+          message.generation !== providerBinding.generation
+        )
+          return;
+        if (message.requestId) {
+          const pending = pendingProviderRequests.get(message.requestId);
+          if (!pending || pending.wire.type !== 'provider_heartbeat' || !pending.acknowledged)
+            return;
+        }
+        if (providerLease && Date.parse(providerLease.leaseExpiresAt) <= Date.now()) {
+          invalidateProvider(new BrowserProviderError('lease_expired', true));
+          return;
+        }
+        const jobs = message.jobs.filter(job => {
+          if (job.status === 'running' && !providerLease) return false;
+          const previous = providerSnapshots.get(job.jobId);
+          if (
+            previous &&
+            (!matchesProviderJob(previous, job) ||
+              (previous.result && previous.status !== job.status) ||
+              (previous.status === 'running' &&
+                (job.status === 'queued' || job.status === 'awaiting_approval')))
+          )
+            return false;
+          providerSnapshots.set(job.jobId, job);
+          return true;
+        });
+        const snapshot = { ...message, jobs };
+        if (message.requestId) finishProviderRequest(message.requestId, snapshot);
+        emitProviderMessage(snapshot, epoch);
+        return;
+      }
+      case 'provider_job': {
+        if (
+          message.job.providerId !== providerLease?.providerId ||
+          message.job.generation !== providerLease.generation
+        )
+          return;
+        if (Date.parse(providerLease.leaseExpiresAt) <= Date.now()) {
+          invalidateProvider(new BrowserProviderError('lease_expired', true));
+          return;
+        }
+        const job = message.job;
+        const previous = providerSnapshots.get(job.jobId);
+        if (
+          dispatchedProviderJobs.has(job.jobId) ||
+          cancelledProviderJobs.has(job.jobId) ||
+          (previous &&
+            (!matchesProviderJob(previous, job) ||
+              (previous.status !== 'queued' && previous.status !== 'awaiting_approval')))
+        )
+          return;
+        providerSnapshots.set(job.jobId, job);
+        dispatchedProviderJobs.add(job.jobId);
+        emitProviderMessage(message, epoch);
+        return;
+      }
+      case 'provider_job_cancel': {
+        if (
+          message.providerId !== providerBinding?.providerId ||
+          message.generation !== providerBinding.generation ||
+          cancelledProviderJobs.has(message.jobId)
+        )
+          return;
+        const job = providerSnapshots.get(message.jobId);
+        if (job && !matchesProviderJob(job, message)) return;
+        cancelledProviderJobs.add(message.jobId);
+        const leaseLost =
+          message.reason === 'lease_expired' ||
+          message.reason === 'provider_lost' ||
+          message.reason === 'provider_unavailable' ||
+          message.reason === 'effects_uncertain' ||
+          message.reason === 'approval_timeout' ||
+          message.reason === 'execution_timeout' ||
+          message.reason === 'invocation_expired' ||
+          (message.reason === 'cancelled' && job?.approvedTab !== undefined);
+        if (leaseLost) {
+          invalidateProvider(
+            new BrowserProviderError(message.reason, message.reason !== 'effects_uncertain')
+          );
+        }
+        emitProviderMessage(message, leaseLost ? epoch + 1 : epoch);
+        return;
+      }
+      default: {
+        const exhaustive: never = message;
+        return exhaustive;
+      }
+    }
   }
 
   function hasLifetime(): boolean {
@@ -316,7 +933,11 @@ function createUserWebConnection(
 
     const nonce = cloudAgentSdkRuntime.randomUUID();
     outstandingPingNonce = nonce;
-    sendWire({ type: 'ping', nonce });
+    sendWire({
+      type: 'ping',
+      nonce,
+      ...(browserProviderEnabled ? { capabilities: { browserJobsV1: true } } : {}),
+    });
     pongTimeout = setTimeout(replaceUnresponsiveSocket, VIEWER_PONG_TIMEOUT_MS);
   }
 
@@ -381,37 +1002,73 @@ function createUserWebConnection(
     });
   }
 
-  function handleInboundMessage(msg: WebInboundMessage): void {
-    if (msg.type === 'pong') {
-      if (msg.nonce === outstandingPingNonce) clearPongTimeout();
-      return;
-    }
-
-    if (msg.type === 'event') {
-      for (const key of [msg.sessionId, msg.parentSessionId]) {
-        if (!key) continue;
-        for (const listener of cliListeners.get(key) ?? []) listener(msg);
-      }
-      return;
-    }
-
-    if (msg.type === 'system') {
-      for (const listener of systemListeners) listener(msg);
-      const parsed = sessionEventPayloadSchema.safeParse({ type: msg.event, data: msg.data });
-      if (parsed.success) {
-        for (const listener of sessionListeners.get(parsed.data.type) ?? []) {
-          listener(parsed.data.data as never);
+  function handleInboundMessage(msg: WebInboundWithBrowserMessage): void {
+    if (destroyed || !hasLifetime() || !currentWs) return;
+    switch (msg.type) {
+      case 'pong': {
+        if (msg.nonce !== outstandingPingNonce) return;
+        clearPongTimeout();
+        if (!browserProviderEnabled) return;
+        const supported = normalizedBrowserCapabilitiesSchema.parse(msg.capabilities).browserJobsV1;
+        if (!supported) {
+          providerNegotiated = false;
+          invalidateProvider(new BrowserProviderError('unsupported', false));
+        } else if (!providerNegotiated) {
+          providerNegotiated = true;
+          setProviderState({ status: 'ready' });
+          if (providerRegistration && providerNegotiated && hasLifetime() && !destroyed) {
+            void registerBrowserProvider(providerRegistration).catch(() => {});
+          }
         }
+        return;
       }
-      return;
+      case 'event':
+        for (const key of [msg.sessionId, msg.parentSessionId]) {
+          if (!key) continue;
+          for (const listener of cliListeners.get(key) ?? []) listener(msg);
+        }
+        return;
+      case 'system': {
+        for (const listener of systemListeners) listener(msg);
+        const parsed = sessionEventPayloadSchema.safeParse({ type: msg.event, data: msg.data });
+        if (parsed.success) {
+          for (const listener of sessionListeners.get(parsed.data.type) ?? []) {
+            listener(parsed.data.data as never);
+          }
+        }
+        return;
+      }
+      case 'response': {
+        const providerRequest = pendingProviderRequests.get(msg.id);
+        if (providerRequest) {
+          const parsed = browserProviderErrorSchema.safeParse(msg.error);
+          const error = parsed.success
+            ? new BrowserProviderError(parsed.data.code, parsed.data.retryable)
+            : new BrowserProviderError('invalid_request', false);
+          if (providerRequest.wire.type === 'provider_status') rejectProviderRequest(msg.id, error);
+          else invalidateProvider(error);
+          return;
+        }
+        const pending = pendingCommands.get(msg.id);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        pendingCommands.delete(msg.id);
+        if (msg.error) pending.reject(parseCommandError(msg.error));
+        else pending.resolve(msg.result);
+        return;
+      }
+      case 'provider_lease_ack':
+      case 'provider_snapshot':
+      case 'provider_status_result':
+      case 'provider_job':
+      case 'provider_job_cancel':
+        handleProviderMessage(msg);
+        return;
+      default: {
+        const exhaustive: never = msg;
+        return exhaustive;
+      }
     }
-
-    const pending = pendingCommands.get(msg.id);
-    if (!pending) return;
-    clearTimeout(pending.timer);
-    pendingCommands.delete(msg.id);
-    if (msg.error) pending.reject(parseCommandError(msg.error));
-    else pending.resolve(msg.result);
   }
 
   function createLifecycleHooks(): ConnectionLifecycleHooks | undefined {
@@ -447,7 +1104,8 @@ function createUserWebConnection(
     if (baseConnection) return;
     removePreSocketLifecycleListeners();
     hasEverOpened = false;
-    baseConnection = createBaseConnection({
+    const expectedGeneration = generation;
+    baseConnection = createBaseConnection<WebInboundWithBrowserMessage>({
       lifecycleHooks: createLifecycleHooks(),
       maxReconnectAttempts: config.maxReconnectAttempts,
       onReconnectExhaustionChange: setExhausted,
@@ -456,7 +1114,11 @@ function createUserWebConnection(
         if (typeof data !== 'string') return null;
         try {
           const parsed: unknown = JSON.parse(data);
-          const result = webInboundMessageSchema.safeParse(parsed);
+          const schema =
+            browserProviderEnabled && providerNegotiated
+              ? webInboundWithBrowserMessageSchema
+              : webInboundMessageSchema;
+          const result = schema.safeParse(parsed);
           if (!result.success) return null;
           return { type: 'event', payload: result.data };
         } catch {
@@ -465,12 +1127,22 @@ function createUserWebConnection(
       },
       onEvent: handleInboundMessage,
       onOpen: ws => {
+        if (
+          destroyed ||
+          expectedGeneration !== generation ||
+          !hasLifetime() ||
+          ws.readyState !== WebSocket.OPEN
+        )
+          return;
         hasEverOpened = true;
-        if (!hasLifetime()) return;
         currentWs = ws;
         resolveOpenWaiters(ws);
         for (const sessionId of subscriptionCounts.keys()) sendSubscribe(sessionId);
         startLiveness();
+        if (browserProviderEnabled) {
+          setProviderState({ status: 'negotiating' });
+          sendPing();
+        }
       },
       onConnected: () => {
         setConnected(true);
@@ -481,14 +1153,22 @@ function createUserWebConnection(
         for (const listener of reconnectListeners) listener();
       },
       onReplacingConnection: () => {
+        invalidateProvider(new BrowserProviderError('disconnected', true), true);
+        if (browserProviderEnabled) {
+          clearLiveness();
+          setConnected(false);
+        }
         rejectPending('Connection lost during reconnect');
       },
       onDisconnected: () => {
         currentWs = null;
         clearLiveness();
+        invalidateProvider(new BrowserProviderError('disconnected', true), true);
         setConnected(false);
       },
       onUnexpectedDisconnect: () => {
+        invalidateProvider(new BrowserProviderError('disconnected', true), true);
+        if (browserProviderEnabled) clearLiveness();
         rejectPending('Connection lost during reconnect');
         setConnected(false);
       },
@@ -501,7 +1181,24 @@ function createUserWebConnection(
       // `hasEverOpened` (set on first `onOpen`) scopes the refresh to reconnects.
       shouldRefreshAuthBeforeConnect: () => hasEverOpened,
       refreshAuth: async () => {
-        token = await config.getAuthToken();
+        if (browserProviderEnabled) {
+          invalidateProvider(new BrowserProviderError('disconnected', true), true);
+          clearLiveness();
+          setConnected(false);
+          token = '';
+        }
+        try {
+          const refreshed = await config.getAuthToken();
+          if (
+            !browserProviderEnabled ||
+            (!destroyed && expectedGeneration === generation && hasLifetime())
+          )
+            token = refreshed;
+        } catch (error) {
+          // The base connection logs refresh failures. Never pass it a proof-bearing error.
+          if (browserProviderEnabled) throw new Error('Failed to get auth token');
+          throw error;
+        }
       },
     });
   }
@@ -526,6 +1223,7 @@ function createUserWebConnection(
     const rejectAuthFailure = (): void => {
       if (expectedGeneration !== generation) return;
       started = false;
+      invalidateProvider(new BrowserProviderError('provider_unavailable', true));
       rejectPending('Failed to get auth token');
       config.onError?.('Failed to get auth token');
       scheduleInitialAuthRetry(expectedGeneration);
@@ -554,6 +1252,7 @@ function createUserWebConnection(
     clearLiveness();
     clearInitialAuthRetry();
     removePreSocketLifecycleListeners();
+    invalidateProvider(new BrowserProviderError('disconnected', true), true);
     rejectPending(message);
     baseConnection?.destroy();
     baseConnection = null;
@@ -646,6 +1345,30 @@ function createUserWebConnection(
   }
 
   return {
+    getBrowserProviderState: () => providerState,
+    onBrowserProviderStateChange(listener) {
+      if (destroyed) return () => {};
+      providerStateListeners.add(listener);
+      return () => {
+        providerStateListeners.delete(listener);
+      };
+    },
+    onBrowserProviderMessage(listener) {
+      if (destroyed) return () => {};
+      providerListeners.add(listener);
+      return () => {
+        providerListeners.delete(listener);
+      };
+    },
+    registerBrowserProvider,
+    heartbeatBrowserProvider,
+    requestBrowserProviderStatus,
+    approveBrowserProviderJob: input => sendProviderUpdate({ ...input, type: 'provider_approval' }),
+    cancelBrowserProviderJob: input => sendProviderUpdate({ ...input, type: 'provider_cancel' }),
+    sendBrowserProviderResult: input => sendProviderUpdate({ ...input, type: 'provider_result' }),
+    quiesceBrowserProviderJob: input => sendProviderUpdate({ ...input, type: 'provider_quiesced' }),
+    markBrowserProviderUnavailable: input =>
+      sendProviderUpdate({ ...input, type: 'provider_unavailable' }),
     retain: retainConnection,
     connect,
     disconnect() {
@@ -661,6 +1384,9 @@ function createUserWebConnection(
       retainCount = 0;
       commandRetainCount = 0;
       stopConnection('Connection destroyed');
+      providerRegistration = null;
+      providerListeners.clear();
+      providerStateListeners.clear();
       subscriptionCounts.clear();
       cliListeners.clear();
       systemListeners.clear();
@@ -757,8 +1483,25 @@ function createUserWebConnection(
   };
 }
 
-export { createUserWebConnection, CommandDeliveredError, UserWebCommandError };
+export {
+  createUserWebConnection,
+  BrowserProviderError,
+  CommandDeliveredError,
+  UserWebCommandError,
+};
 export type {
+  BrowserProviderApprovalInput,
+  BrowserProviderCancelInput,
+  BrowserProviderConnection,
+  BrowserProviderErrorCode,
+  BrowserProviderLease,
+  BrowserProviderQuiescenceInput,
+  BrowserProviderRegistration,
+  BrowserProviderResultInput,
+  BrowserProviderSnapshot,
+  BrowserProviderState,
+  BrowserProviderStatusResult,
+  BrowserProviderUnavailableInput,
   SendCommandToConnectionInput,
   UserWebConnection,
   UserWebConnectionConfig,

--- a/packages/cloud-agent-sdk/src/user-web-connection.ts
+++ b/packages/cloud-agent-sdk/src/user-web-connection.ts
@@ -151,8 +151,11 @@ type BrowserProviderConnection = {
   registerBrowserProvider: (input: BrowserProviderRegistration) => Promise<BrowserProviderLease>;
   /** Renews the current lease and reconciles only its generation. */
   heartbeatBrowserProvider: (cursor?: string) => Promise<BrowserProviderSnapshot>;
-  /** Reads history with the stable proof, even without registration. Never authorizes execution. */
-  requestBrowserProviderStatus: (cursor?: string) => Promise<BrowserProviderStatusResult>;
+  /** Reads history without execution authority. Explicit proof is used only for this request. */
+  requestBrowserProviderStatus: (
+    cursor?: string,
+    identity?: Pick<BrowserProviderRegistration, 'providerId' | 'providerProof'>
+  ) => Promise<BrowserProviderStatusResult>;
   /** Sends consent only. Wait for a running snapshot before starting browser actions. */
   approveBrowserProviderJob: (input: BrowserProviderApprovalInput) => void;
   cancelBrowserProviderJob: (input: BrowserProviderCancelInput) => void;
@@ -535,15 +538,17 @@ function createUserWebConnection(
   }
 
   async function requestBrowserProviderStatus(
-    cursor?: string
+    cursor?: string,
+    identity?: Pick<BrowserProviderRegistration, 'providerId' | 'providerProof'>
   ): Promise<BrowserProviderStatusResult> {
     requireProviderSocket();
-    if (!providerRegistration) throw new BrowserProviderError('provider_unavailable', true);
+    const provider = identity ?? providerRegistration;
+    if (!provider) throw new BrowserProviderError('provider_unavailable', true);
     const wire = validateProviderMessage({
       type: 'provider_status',
       requestId: cloudAgentSdkRuntime.randomUUID(),
-      providerId: providerRegistration.providerId,
-      providerProof: providerRegistration.providerProof,
+      providerId: provider.providerId,
+      providerProof: provider.providerProof,
       ...(cursor === undefined ? {} : { cursor }),
     });
     if (wire.type !== 'provider_status') throw new BrowserProviderError('invalid_request', false);


### PR DESCRIPTION
No new behavior — this change prepares browser task support without changing the product's current controls.

---

## Summary

The software development kit (SDK) adds `BrowserProviderConnection` through `UserWebConnectionConfig.browserProvider`; omitted values stay permanently disabled. After `browserJobsV1` negotiation, retained connections use typed callbacks and short requests; lease loss blocks actions before owner callbacks. Only `provider_job` offers new work; owners must wait for a running snapshot, and reconnect recovers history without execution replay.

<details>
<summary>Files</summary>

- `packages/cloud-agent-sdk/src/user-web-connection.ts` — Source; M (modified), 813 changed lines. Requires a matching capability ping/pong before registration or composite parsing. Adds state subscriptions and typed registration, heartbeat, status, approval, cancellation, result, quiescence, and unavailable methods. Validates outbound messages, bounds correlated requests to 10 seconds, and renews leases halfway to expiry. Heartbeat requests require both the matching lease acknowledgement and snapshot. Separates proof-authenticated, cursor-based history from live snapshots, including history after rejected registration or lease loss. History failures leave live leases unchanged. Reconnect retains stable registration data, clears live snapshots, and never replays work, results, or one-shot recovery assertions. Rejects duplicate, foreign, stale, cancelled, or regressive job messages before callbacks. Validates job bindings; results must match the running job and all approved-tab metadata. Expiry, revocation, connection replacement, ticket refresh, and teardown invalidate authority before owner callbacks. Cancelling approved work revokes the lease; cancelling queued or unapproved work preserves it. Allows quiescence for completed or cancelled jobs after lease loss while the binding survives. Explicit unavailability prevents automatic registration, even when sending fails. Sanitizes provider and authentication errors, ignores late sockets and stale refreshes, and stops callbacks after release or destruction.
- `packages/cloud-agent-sdk/src/user-web-connection.test.ts` — Test; M (modified), 1,377 added lines. Adds fake-timer fixtures and an in-process harness using the real relay. Covers legacy compatibility, negotiation, request timeouts, generation checks, job updates, cancellation, lease expiry, ticket loss, historical recovery, teardown, and error redaction.

</details>

Public exports add `BrowserProviderConnection`, `BrowserProviderState`, `BrowserProviderError`, and `BrowserProviderErrorCode`; the private `browserProviderErrorSchema` validates relay failures without exposing their text. Lease and history callers receive `BrowserProviderRegistration`, `BrowserProviderLease`, `BrowserProviderSnapshot`, `BrowserProviderStatusResult`, `BrowserJobHandle`, `BrowserJobSnapshot`, `BrowserProviderInboundMessage`, `BrowserProviderOutboundMessage`, and `BrowserResult`. Typed operations use `BrowserProviderApprovalInput`, `BrowserProviderCancelInput`, `BrowserProviderResultInput`, `BrowserProviderQuiescenceInput`, and `BrowserProviderUnavailableInput`, without changing the existing `UserWebConnection` contract or legacy inbound union.

<details>
<summary>Files</summary>

- `packages/cloud-agent-sdk/src/index.ts` — Source; M (modified), 22 changed lines. Exposes the provider error class and provider connection, state, operation, message, job, lease, and history types through the package entry point.

</details>

Tests: 1 modified test file, `packages/cloud-agent-sdk/src/user-web-connection.test.ts`, with 1,377 added lines.
Generated: 0 files changed.

---

## Verification

The handoff reports no manual verification. Runtime verification remains pending on the stack tips. The handoff includes no end-to-end (E2E) report.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Human steps

- before merge — **After all section pull requests receive human-ready, merge each repository's levels from bottom to top.**
- after merge — Existing callers need no manual setup, new environment values, secrets, migrations, or flag changes.

### Automated checks

The recorded scoped checks passed 5/5. The evidence covers local checks only; it does not establish continuous integration (CI) or live verification.

| Recorded local check | Result |
| --- | --- |
| `oxfmt --write` on the three changed files | Passed |
| `oxlint --deny-warnings` on the three changed files | Passed |
| Scoped `user-web-connection.test.ts` Jest suite | Passed; 114 tests |
| `oxfmt --check` on the three changed files | Passed |
| `git diff --check` on the three changed files | Passed |

### Scope and dependencies

This description covers Cloud level 4 only. The lower levels own the prerequisite history contracts, ledger reads, and relay routing.

- Immediate base: [Cloud #5648](https://github.com/Kilo-Org/cloud/pull/5648).
- Lower Cloud levels: [Cloud #5638](https://github.com/Kilo-Org/cloud/pull/5638) and [Cloud #5644](https://github.com/Kilo-Org/cloud/pull/5644).
- Command-line interface (CLI) contracts: [kilocode #13535](https://github.com/Kilo-Org/kilocode/pull/13535). Matching base contracts have landed; history contract parity remains pending.

### Worktrees

- `Kilo-Org/cloud`: `/Users/igor/Projects/.worktrees/browser-task-0787`, branch `browser-task-0787-s4`; comparison base `browser-task-0787-s3`.
- `Kilo-Org/kilocode`: `/Users/igor/Projects/.worktrees/browser-task-0787-kilocode`, branch `browser-task-0787`; related contracts only, outside this level's diff.

### Notes

Runtime verification remains pending on the stack tips. The provider transport is opt-in; the extension integration follows in later levels.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `browser-task-0787` — #5638
2. `browser-task-0787-s2` — #5644
3. `browser-task-0787-s3` — #5648
4. `browser-task-0787-s4` — #5653 ← this PR
7. `browser-task-0787-s7` — #5681
8. `browser-task-0787-s8` — #5694
9. `browser-task-0787-s9` — #5698
10. `browser-task-0787-s10` — #5702
11. `browser-task-0787-s11` — #5716
12. `browser-task-0787-s12` — #5734
13. `browser-task-0787-s13` — #5742 (tip)

