### PR TITLE
fix(mobile): use current Lucide icon paths

### DIFF
--- a/apps/mobile/.oxlintrc.json
+++ b/apps/mobile/.oxlintrc.json
@@ -220,6 +220,12 @@
   },
   "overrides": [
     {
+      "files": ["src/components/ui/icons.test.ts"],
+      "rules": {
+        "import/no-nodejs-modules": "off"
+      }
+    },
+    {
       "files": ["src/lib/expo-router-linking.mounted.test.tsx"],
       "rules": {
         "import/no-nodejs-modules": "off",

--- a/apps/mobile/src/components/ui/icons.test.ts
+++ b/apps/mobile/src/components/ui/icons.test.ts
@@ -1,0 +1,12 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+import { expect, it } from 'vitest';
+
+it('uses Lucide icon subpaths with runtime files', () => {
+  const source = readFileSync(new URL('icons.ts', import.meta.url), 'utf8');
+  const imports = source.match(/(?<=from ')lucide-react-native\/icons\/[^']+/g) ?? [];
+
+  expect(imports.length).toBeGreaterThan(0);
+  const missing = imports.filter(specifier => !existsSync(new URL(import.meta.resolve(specifier))));
+  expect(missing).toEqual([]);
+});

--- a/apps/mobile/src/components/ui/icons.ts
+++ b/apps/mobile/src/components/ui/icons.ts
@@ -69,7 +69,7 @@ export { default as GitPullRequestClosed } from 'lucide-react-native/icons/git-p
 export { default as GitPullRequestDraft } from 'lucide-react-native/icons/git-pull-request-draft';
 export { default as Globe } from 'lucide-react-native/icons/globe';
 export { default as HelpCircle } from 'lucide-react-native/icons/circle-question-mark';
-export { default as History } from 'lucide-react-native/icons/history';
+export { default as History } from 'lucide-react-native/icons/rotate-ccw-clock';
 export { default as House } from 'lucide-react-native/icons/house';
 export { default as ImageOff } from 'lucide-react-native/icons/image-off';
 export { default as Inbox } from 'lucide-react-native/icons/inbox';
@@ -139,7 +139,7 @@ export { default as ShieldOff } from 'lucide-react-native/icons/shield-off';
 export { default as Shuffle } from 'lucide-react-native/icons/shuffle';
 export { default as SlidersHorizontal } from 'lucide-react-native/icons/sliders-horizontal';
 export { default as Smartphone } from 'lucide-react-native/icons/smartphone';
-export { default as SmilePlus } from 'lucide-react-native/icons/smile-plus';
+export { default as SmilePlus } from 'lucide-react-native/icons/face-slightly-smiling-plus';
 export { default as Sparkles } from 'lucide-react-native/icons/sparkles';
 export { default as Square } from 'lucide-react-native/icons/square';
 export { default as Star } from 'lucide-react-native/icons/star';


### PR DESCRIPTION
## Summary

- Fix the JavaScript bundling failure in [release run 33173634592](https://github.com/Kilo-Org/cloud/actions/runs/33173634592/job/98864911437).
- Replace the obsolete `history` and `smile-plus` subpaths with their canonical Lucide paths. Preserve the existing local exports.
- Add a regression test for every icon runtime path. Allow Node imports only in that test.

## Verification

- [x] Ran the failed bundling phase locally for Android: `CI=true SENTRY_DISABLE_AUTO_UPLOAD=true pnpm exec expo export:embed --eager --platform android --dev false`.
- [x] Ran the failed bundling phase locally for iOS: `CI=true SENTRY_DISABLE_AUTO_UPLOAD=true pnpm exec expo export:embed --eager --platform ios --dev false`.
- Both local bundles passed with the committed environment defaults. I did not run signed native builds or store submissions.
- No device tests: this fix selects the same icons through their supported module paths.

## Visual Changes

N/A

## Reviewer Notes

- Lucide 1.33.0 retains declarations for both aliases but omits their runtime files. Typecheck alone does not detect this failure.
- The regression test failed on both old paths before the fix and passed afterward.
- Automated checks passed: 6,497 mobile tests, mobile typecheck, lint, unused-code checks, formatting, and `git diff --check`.
- An independent review found no remaining issues.