### PR TITLE
fix(mobile): enforce local access at final transport dispatch

### DIFF
--- a/apps/mobile/src/components/agents/mobile-session-manager.local-access.test.ts
+++ b/apps/mobile/src/components/agents/mobile-session-manager.local-access.test.ts
@@ -1,0 +1,334 @@
+/* eslint-disable max-lines -- one manager harness covers every cloud action and overlapping prepare continuations */
+/* eslint-disable promise/prefer-await-to-then -- race tests attach rejection handlers before changing the owner */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createStore } from 'jotai';
+import {
+  type CloudAgentSessionId,
+  type SessionManager,
+  type SessionManagerConfig,
+} from '@kilocode/cloud-agent-sdk';
+
+import { bumpAuthEpoch, currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import {
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+  getAuthenticatedOwner,
+} from '@/lib/context-scope';
+import {
+  initializeLocalAccess,
+  LocalAccessDeniedError,
+  lockLocalAccess,
+  requestLocalAccess,
+  setLocalAccessContextReady,
+  setLocalAccessOwner,
+} from '@/lib/local-access';
+import { type MobileUserWebConnection } from '@/lib/local-access-transport';
+import { createMobileAgentSessionManager } from './mobile-session-manager';
+
+const state = vi.hoisted(() => ({
+  config: null as SessionManagerConfig | null,
+  token: vi.fn(),
+  beforeDispatch: vi.fn(),
+  response: vi.fn(),
+  journal: [] as { path: string; user: string | null; input: unknown }[],
+  cached: [] as string[],
+  destroyed: 0,
+}));
+vi.mock('@kilocode/cloud-agent-sdk', () => ({
+  createSessionManager: (managerConfig: SessionManagerConfig) => {
+    state.config = managerConfig;
+    return {
+      atoms: {},
+      destroy: () => {
+        state.destroyed += 1;
+      },
+    } as unknown as SessionManager;
+  },
+}));
+vi.mock('sonner-native', () => ({ toast: { error: vi.fn() } }));
+vi.mock('@/i18n', () => ({ i18n: { t: (key: string) => key } }));
+vi.mock('@/lib/config', () => ({
+  API_BASE_URL: 'https://api.test',
+  CLOUD_AGENT_WS_URL: 'wss://cloud.test',
+  WEB_BASE_URL: 'https://web.test',
+}));
+vi.mock('@/lib/auth/token-owner', () => ({ getAuthTokenForRequest: state.token }));
+vi.mock('@/lib/user-web-connection-lifecycle', () => ({
+  createNativeUserWebConnectionLifecycleHooks: () => ({}),
+}));
+vi.mock('@/components/agents/mobile-session-transport-payload', () => ({
+  normalizeTransportPayload: (value: unknown) => value,
+}));
+vi.mock('@/components/agents/mobile-session-page-adapter', () => ({
+  fetchMobileSessionSnapshotPage: vi.fn(),
+}));
+vi.mock('@/components/agents/mobile-session-diagnostics', () => ({
+  formatSafeCloudAgentFailureDiagnostic: vi.fn(),
+  withCloudAgentDiagnostics: (_operation: string, _org: unknown, run: () => unknown) => run(),
+}));
+vi.mock('@/components/agents/tool-card-image-cache', () => ({
+  cacheToolAttachment: (id: string) => {
+    state.cached.push(id);
+  },
+}));
+vi.mock('@/components/agents/file-part-cache', () => ({
+  cacheFilePart: (id: string) => {
+    state.cached.push(id);
+  },
+}));
+vi.mock('@/lib/trpc', async () => {
+  const { captureTransportOperation } = await import('@/lib/local-access-transport');
+  function procedure(path: string) {
+    return {
+      mutate: async (input: unknown, options: { context: Record<string, unknown> }) => {
+        const operation = captureTransportOperation({
+          id: 1,
+          type: 'mutation',
+          path,
+          input,
+          context: options.context,
+          signal: undefined,
+        });
+        await state.beforeDispatch();
+        operation.assertDispatch();
+        state.journal.push({ path, user: operation.owner.userId, input });
+        const result: { cloudAgentSessionId: string; kiloSessionId: string } = await state.response(
+          path,
+          input
+        );
+        return result;
+      },
+    };
+  }
+  function cloud(prefix: string) {
+    return {
+      sendMessage: procedure(`${prefix}.sendMessage`),
+      interruptSession: procedure(`${prefix}.interruptSession`),
+      answerQuestion: procedure(`${prefix}.answerQuestion`),
+      rejectQuestion: procedure(`${prefix}.rejectQuestion`),
+      answerPermission: procedure(`${prefix}.answerPermission`),
+      prepareSession: procedure(`${prefix}.prepareSession`),
+      initiateFromPreparedSession: procedure(`${prefix}.initiateFromPreparedSession`),
+    };
+  }
+  return {
+    trpcClient: {
+      cloudAgentNext: cloud('cloudAgentNext'),
+      organizations: { cloudAgentNext: cloud('organizations.cloudAgentNext') },
+    },
+  };
+});
+
+let stop: (() => void) | undefined = undefined;
+const managers: SessionManager[] = [];
+beforeEach(async () => {
+  state.config = null;
+  state.journal.length = 0;
+  state.cached.length = 0;
+  state.destroyed = 0;
+  state.token.mockReset().mockResolvedValue('token-A');
+  state.beforeDispatch.mockReset().mockResolvedValue(undefined);
+  state.response
+    .mockReset()
+    .mockResolvedValue({ cloudAgentSessionId: 'cloud-1', kiloSessionId: 'kilo-1' });
+  confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'A');
+  stop = initializeLocalAccess({
+    storage: {
+      read: vi.fn().mockResolvedValue({ status: 'present', enabled: true }),
+      write: vi.fn().mockResolvedValue('committed'),
+    },
+    authenticate: vi.fn().mockResolvedValue({ status: 'authenticated' }),
+    lifecycle: { getCurrentState: () => 'active', subscribe: () => () => undefined },
+  });
+  await setLocalAccessOwner('A', currentAuthEpoch());
+  setLocalAccessContextReady(true);
+  await requestLocalAccess('unlock', true);
+});
+afterEach(() => {
+  for (const manager of managers.splice(0)) {
+    manager.destroy();
+  }
+  stop?.();
+  vi.unstubAllGlobals();
+});
+function config(organizationId?: string) {
+  const connection = {
+    owner: getAuthenticatedOwner(),
+    setSessionScope: vi.fn(),
+  } as unknown as MobileUserWebConnection;
+  managers.push(
+    createMobileAgentSessionManager({
+      store: createStore(),
+      userWebConnection: connection,
+      organizationId,
+    })
+  );
+  if (!state.config) {
+    throw new Error('Missing manager config');
+  }
+  return state.config;
+}
+const cloudId = 'cloud-1' as CloudAgentSessionId;
+const createInput = { prompt: 'hello', mode: 'code', model: 'model' };
+const actions: { name: string; run: (value: SessionManagerConfig) => Promise<unknown> }[] = [
+  {
+    name: 'send',
+    run: async value => {
+      await value.api.send({
+        sessionId: cloudId,
+        messageId: 'message-1',
+        payload: { type: 'prompt', prompt: 'hello' },
+      });
+    },
+  },
+  {
+    name: 'interrupt',
+    run: async value => {
+      await value.api.interrupt({ sessionId: cloudId });
+    },
+  },
+  {
+    name: 'answer',
+    run: async value => {
+      await value.api.answer({ sessionId: cloudId, requestId: 'q', answers: [['yes']] });
+    },
+  },
+  {
+    name: 'reject',
+    run: async value => {
+      await value.api.reject({ sessionId: cloudId, requestId: 'q' });
+    },
+  },
+  {
+    name: 'permission',
+    run: async value => {
+      await value.api.respondToPermission({ sessionId: cloudId, requestId: 'p', response: 'once' });
+    },
+  },
+  {
+    name: 'prepare',
+    run: async value => {
+      const result = await value.prepare(createInput);
+      return result;
+    },
+  },
+];
+
+describe('mobile manager final admission', () => {
+  it.each(actions)('keeps $name on its original lease through a dispatch wait', async action => {
+    const wait = Promise.withResolvers<undefined>();
+    state.beforeDispatch.mockReturnValue(wait.promise);
+    const pending = Promise.allSettled([action.run(config('org-A'))]);
+    lockLocalAccess();
+    await requestLocalAccess('unlock');
+    wait.resolve(undefined);
+    expect(await pending).toEqual([
+      { status: 'rejected', reason: expect.any(LocalAccessDeniedError) },
+    ]);
+    expect(state.journal).toEqual([]);
+  });
+
+  it('retains separate prepare leases across overlapping continuations', async () => {
+    const firstResponse = Promise.withResolvers<{
+      cloudAgentSessionId: string;
+      kiloSessionId: string;
+    }>();
+    state.response.mockReturnValueOnce(firstResponse.promise);
+    const manager = config();
+    const first = manager.prepare(createInput);
+    await vi.waitFor(() => {
+      expect(state.journal).toHaveLength(1);
+    });
+    lockLocalAccess();
+    await requestLocalAccess('unlock');
+    state.response.mockResolvedValue({ cloudAgentSessionId: 'cloud-2', kiloSessionId: 'kilo-2' });
+    const second = await manager.prepare(createInput);
+    firstResponse.resolve({ cloudAgentSessionId: 'cloud-1', kiloSessionId: 'kilo-1' });
+    const old = await first;
+    await expect(manager.initiate(old)).rejects.toBeInstanceOf(LocalAccessDeniedError);
+    await manager.initiate(second);
+    expect(
+      state.journal.filter(entry => entry.path.endsWith('initiateFromPreparedSession'))
+    ).toEqual([
+      {
+        path: 'cloudAgentNext.initiateFromPreparedSession',
+        user: 'A',
+        input: { cloudAgentSessionId: 'cloud-2' },
+      },
+    ]);
+  });
+
+  it('does not replace an old prepare lease when two operations resolve to the same session', async () => {
+    const response = Promise.withResolvers<{
+      cloudAgentSessionId: string;
+      kiloSessionId: string;
+    }>();
+    state.response.mockReturnValue(response.promise);
+    const manager = config();
+    // Match the SDK's adjacent prepare/initiate awaits, including concurrent completions.
+    const create = async () => {
+      const prepared = await manager.prepare(createInput);
+      await manager.initiate(prepared);
+    };
+    const first = Promise.allSettled([create()]);
+    await vi.waitFor(() => {
+      expect(state.journal).toHaveLength(1);
+    });
+    lockLocalAccess();
+    await requestLocalAccess('unlock');
+    const second = Promise.allSettled([create()]);
+    await vi.waitFor(() => {
+      expect(state.journal).toHaveLength(2);
+    });
+    response.resolve({ cloudAgentSessionId: 'same-session', kiloSessionId: 'same-kilo-session' });
+    expect(await first).toEqual([
+      { status: 'rejected', reason: expect.any(LocalAccessDeniedError) },
+    ]);
+    expect(await second).toEqual([{ status: 'fulfilled', value: undefined }]);
+    expect(
+      state.journal.filter(entry => entry.path.endsWith('initiateFromPreparedSession'))
+    ).toHaveLength(1);
+  });
+
+  it('destroys A callbacks and refuses A effects after B replaces the account', async () => {
+    const manager = config();
+    bumpAuthEpoch();
+    confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'B');
+    await setLocalAccessOwner('B', currentAuthEpoch());
+    setLocalAccessContextReady(true);
+    await requestLocalAccess('unlock', true);
+    manager.onToolAttachment?.('old-part', {
+      mime: 'image/png',
+      dataUrl: 'data:image/png;base64,AA==',
+    });
+    await expect(manager.api.interrupt({ sessionId: cloudId })).rejects.toBeInstanceOf(
+      LocalAccessDeniedError
+    );
+    expect(state.cached).toEqual([]);
+    expect(state.journal).toEqual([]);
+    expect(state.destroyed).toBe(1);
+  });
+
+  it('allows locked stream tickets but rejects a token wait crossing account replacement', async () => {
+    const manager = config();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(Response.json({ ticket: 'read-ticket', expiresAt: 123 }));
+    vi.stubGlobal('fetch', fetchMock);
+    lockLocalAccess();
+    await expect(manager.getTicket(cloudId)).resolves.toEqual({
+      ticket: 'read-ticket',
+      expiresAt: 123,
+    });
+    const token = Promise.withResolvers<string>();
+    state.token.mockReturnValue(token.promise);
+    const pending = Promise.allSettled([manager.getTicket(cloudId)]);
+    bumpAuthEpoch();
+    confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'B');
+    token.resolve('token-B');
+    expect(await pending).toEqual([
+      { status: 'rejected', reason: expect.any(LocalAccessDeniedError) },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/components/agents/mobile-session-manager.test.ts
+++ b/apps/mobile/src/components/agents/mobile-session-manager.test.ts
@@ -1,6 +1,17 @@
 /* eslint-disable require-await, @typescript-eslint/require-await -- injectable query/sleep fakes settle without await */
 /* eslint-disable max-lines -- the manager suite pins retry cadence and attachment mints in one file. */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import {
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+  getAuthenticatedOwner,
+} from '@/lib/context-scope';
+import {
+  initializeLocalAccess,
+  setLocalAccessContextReady,
+  setLocalAccessOwner,
+} from '@/lib/local-access';
 
 import { type AgentAttachmentSubmissionPayload } from '@/lib/agent-attachments/agent-attachment-types';
 import { SPAWNED_NOT_FOUND_MAX_ATTEMPTS } from '@/lib/spawned-not-found-retry';
@@ -9,6 +20,24 @@ import {
   type SessionManager,
   type SessionManagerConfig,
 } from '@kilocode/cloud-agent-sdk';
+
+let stopAccess: (() => void) | undefined = undefined;
+beforeEach(async () => {
+  confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'A');
+  stopAccess = initializeLocalAccess({
+    storage: {
+      read: vi.fn().mockResolvedValue({ status: 'absent' }),
+      write: vi.fn().mockResolvedValue('committed'),
+    },
+    authenticate: vi.fn().mockResolvedValue({ status: 'authenticated' }),
+    lifecycle: { getCurrentState: () => 'active', subscribe: () => () => undefined },
+  });
+  await setLocalAccessOwner('A', currentAuthEpoch());
+  setLocalAccessContextReady(true);
+});
+afterEach(() => {
+  stopAccess?.();
+});
 
 // Keep this suite on the pure vitest project: mock every RN / Expo / SDK
 // side-effect import that `mobile-session-manager.ts` pulls transitively
@@ -25,7 +54,7 @@ const { configHolder, mockCreateSessionManager } = vi.hoisted(() => {
   const holder: { current: SessionManagerConfig | null } = { current: null };
   const createSessionManagerMock = vi.fn((config: SessionManagerConfig): SessionManager => {
     holder.current = config;
-    return { atoms: {} } as unknown as SessionManager;
+    return { atoms: {}, destroy: vi.fn() } as unknown as SessionManager;
   });
   return { configHolder: holder, mockCreateSessionManager: createSessionManagerMock };
 });
@@ -415,7 +444,7 @@ describe('getTicket', () => {
   function setup(): SessionManagerConfig {
     const options = {
       store: {},
-      userWebConnection: {},
+      userWebConnection: { owner: getAuthenticatedOwner(), setSessionScope: vi.fn() },
     };
     createMobileAgentSessionManager(options as never);
     const config = configHolder.current;
@@ -477,7 +506,7 @@ describe('createMobileAgentSessionManager api.send', () => {
   function setup(): SessionManagerConfig {
     const options = {
       store: {},
-      userWebConnection: {},
+      userWebConnection: { owner: getAuthenticatedOwner(), setSessionScope: vi.fn() },
     };
     createMobileAgentSessionManager(options as never);
     const config = configHolder.current;

--- a/apps/mobile/src/components/agents/mobile-session-manager.ts
+++ b/apps/mobile/src/components/agents/mobile-session-manager.ts
@@ -9,7 +9,6 @@ import {
   type ResolvedSession,
   type SessionManager,
   type SessionSnapshot,
-  type UserWebConnection,
 } from '@kilocode/cloud-agent-sdk';
 import { normalizeTransportPayload } from '@/components/agents/mobile-session-transport-payload';
 import {
@@ -29,6 +28,17 @@ import { cacheFilePart } from '@/components/agents/file-part-cache';
 import { type inferRouterOutputs, type MobileRouter } from '@kilocode/trpc/mobile';
 import * as z from 'zod';
 import { i18n } from '@/i18n';
+import { subscribeAuthenticatedOwner } from '@/lib/context-scope';
+import {
+  assertMobileActionAdmission,
+  assertTransportOwner,
+  captureMobileActionAdmission,
+  getLocalAccessDenial,
+  isTransportOwner,
+  type MobileActionAdmission,
+  type MobileUserWebConnection,
+} from '@/lib/local-access-transport';
+import { LocalAccessDeniedError } from '@/lib/local-access';
 
 type SessionWithRuntimeState =
   inferRouterOutputs<MobileRouter>['cliSessionsV2']['getWithRuntimeState'];
@@ -147,35 +157,52 @@ export async function fetchSessionWithNotFoundRetry(
 
 type CreateMobileAgentSessionManagerOptions = {
   store: JotaiStore;
-  userWebConnection: UserWebConnection;
+  userWebConnection: MobileUserWebConnection;
   organizationId?: string;
 };
-
-const skipBatchOptions = { context: { skipBatch: true } };
 
 export function createMobileAgentSessionManager({
   store,
   userWebConnection,
   organizationId,
 }: Readonly<CreateMobileAgentSessionManagerOptions>): SessionManager {
-  return createSessionManager({
+  // This boundary requires the provider's immutable socket owner, not a fresh global account.
+  const owner = userWebConnection.owner;
+  const ownerOptions = { context: { localAccessOwner: owner } };
+  const preparations = new Map<CloudAgentSessionId, MobileActionAdmission[]>();
+  const captureOptions = (
+    admission = captureMobileActionAdmission(owner, organizationId ?? null)
+  ) => {
+    assertMobileActionAdmission(admission);
+    return {
+      context: { skipBatch: true, localAccessOwner: owner, localAccessAdmission: admission },
+    };
+  };
+  const manager = createSessionManager({
     store,
     websocketBaseUrl: CLOUD_AGENT_WS_URL,
     websocketHeaders: { Origin: WEB_BASE_URL },
     lifecycleHooks: createNativeUserWebConnectionLifecycleHooks(),
     userWebConnection,
     onToolAttachment: (partId, attachment) => {
-      cacheToolAttachment(partId, attachment);
+      if (isTransportOwner(owner)) {
+        cacheToolAttachment(partId, attachment);
+      }
     },
     onFilePart: (partId, file) => {
-      cacheFilePart(partId, file);
+      if (isTransportOwner(owner)) {
+        cacheFilePart(partId, file);
+      }
     },
     resolveSession: async (kiloSessionId: KiloSessionId): Promise<ResolvedSession> => {
-      // Read-only is only ever returned once we have successful evidence the
-      // session isn't cloud-agent or remote. A failed query here must
-      // propagate so it lands in the retryable error state instead of being
-      // silently misclassified as read-only.
-      const session = await trpcClient.cliSessionsV2.get.query({ session_id: kiloSessionId });
+      // Preserve loading failures; only successful evidence can classify a session as read-only.
+      assertTransportOwner(owner);
+      const session = await trpcClient.cliSessionsV2.get.query(
+        { session_id: kiloSessionId },
+        ownerOptions
+      );
+      assertTransportOwner(owner);
+      userWebConnection.setSessionScope(kiloSessionId, session.organization_id);
       if (session.cloud_agent_session_id) {
         return {
           type: 'cloud-agent',
@@ -183,17 +210,13 @@ export function createMobileAgentSessionManager({
           cloudAgentSessionId: session.cloud_agent_session_id as CloudAgentSessionId,
         };
       }
-      const active = await trpcClient.activeSessions.list.query();
+      const active = await trpcClient.activeSessions.list.query(undefined, ownerOptions);
+      assertTransportOwner(owner);
       const activeSession = active.sessions.find(s => s.id === kiloSessionId);
       if (!activeSession) {
         return { type: 'read-only', kiloSessionId };
       }
-      // Surface the owning CLI's per-session capabilities so the initial
-      // `supportsAttachments` gate reflects whatever the mobile adapter
-      // observed at resolution time. Heartbeat upgrades / downgrades
-      // arrive later via `onTransportCapabilitiesChange` from the
-      // cli-live-transport; the seed here just covers the window before
-      // the first heartbeat lands.
+      // Heartbeats can replace this initial capability seed without changing the loading contract.
       return {
         type: 'remote',
         kiloSessionId,
@@ -204,7 +227,9 @@ export function createMobileAgentSessionManager({
       sessionId: CloudAgentSessionId
     ): Promise<{ ticket: string; expiresAt: number }> => {
       const result = await withCloudAgentDiagnostics('getTicket', organizationId, async () => {
+        assertTransportOwner(owner);
         const token = await getAuthTokenForRequest();
+        assertTransportOwner(owner);
         const body = {
           cloudAgentSessionId: sessionId,
           ...(organizationId ? { organizationId } : {}),
@@ -221,6 +246,7 @@ export function createMobileAgentSessionManager({
           }
         );
         const data = StreamTicketResponseSchema.parse(await response.json());
+        assertTransportOwner(owner);
         if (!response.ok) {
           throw new Error(data.error ?? 'Failed to get stream ticket');
         }
@@ -235,10 +261,12 @@ export function createMobileAgentSessionManager({
       return result;
     },
     fetchSnapshot: async (id: KiloSessionId) => {
+      assertTransportOwner(owner);
       const [sessionData, messagesResult] = await Promise.all([
-        trpcClient.cliSessionsV2.get.query({ session_id: id }),
-        trpcClient.cliSessionsV2.getSessionMessages.query({ session_id: id }),
+        trpcClient.cliSessionsV2.get.query({ session_id: id }, ownerOptions),
+        trpcClient.cliSessionsV2.getSessionMessages.query({ session_id: id }, ownerOptions),
       ]);
+      assertTransportOwner(owner);
       const snapshotInfo = messagesResult.info as Partial<SessionSnapshot['info']>;
       return {
         info: {
@@ -249,9 +277,15 @@ export function createMobileAgentSessionManager({
         messages: messagesResult.messages as SessionSnapshot['messages'],
       };
     },
-    fetchSnapshotPage: fetchMobileSessionSnapshotPage,
+    fetchSnapshotPage: async (id, options) => {
+      assertTransportOwner(owner);
+      const page = await fetchMobileSessionSnapshotPage(id, options);
+      assertTransportOwner(owner);
+      return page;
+    },
     api: {
       send: async input => {
+        const options = captureOptions();
         await withCloudAgentDiagnostics('send', organizationId, async () => {
           const baseInput = {
             cloudAgentSessionId: input.sessionId as string,
@@ -262,29 +296,31 @@ export function createMobileAgentSessionManager({
           if (organizationId) {
             await trpcClient.organizations.cloudAgentNext.sendMessage.mutate(
               { ...baseInput, organizationId },
-              skipBatchOptions
+              options
             );
             return;
           }
-          await trpcClient.cloudAgentNext.sendMessage.mutate(baseInput, skipBatchOptions);
+          await trpcClient.cloudAgentNext.sendMessage.mutate(baseInput, options);
         });
       },
       interrupt: async payload => {
+        const options = captureOptions();
         await withCloudAgentDiagnostics('interrupt', organizationId, async () => {
           if (organizationId) {
             await trpcClient.organizations.cloudAgentNext.interruptSession.mutate(
               { organizationId, sessionId: payload.sessionId },
-              skipBatchOptions
+              options
             );
             return;
           }
           await trpcClient.cloudAgentNext.interruptSession.mutate(
             { sessionId: payload.sessionId },
-            skipBatchOptions
+            options
           );
         });
       },
       answer: async payload => {
+        const options = captureOptions();
         await withCloudAgentDiagnostics('answer', organizationId, async () => {
           const input = {
             sessionId: payload.sessionId,
@@ -294,14 +330,15 @@ export function createMobileAgentSessionManager({
           if (organizationId) {
             await trpcClient.organizations.cloudAgentNext.answerQuestion.mutate(
               { ...input, organizationId },
-              skipBatchOptions
+              options
             );
             return;
           }
-          await trpcClient.cloudAgentNext.answerQuestion.mutate(input, skipBatchOptions);
+          await trpcClient.cloudAgentNext.answerQuestion.mutate(input, options);
         });
       },
       reject: async payload => {
+        const options = captureOptions();
         await withCloudAgentDiagnostics('reject', organizationId, async () => {
           const input = {
             sessionId: payload.sessionId,
@@ -310,14 +347,15 @@ export function createMobileAgentSessionManager({
           if (organizationId) {
             await trpcClient.organizations.cloudAgentNext.rejectQuestion.mutate(
               { ...input, organizationId },
-              skipBatchOptions
+              options
             );
             return;
           }
-          await trpcClient.cloudAgentNext.rejectQuestion.mutate(input, skipBatchOptions);
+          await trpcClient.cloudAgentNext.rejectQuestion.mutate(input, options);
         });
       },
       respondToPermission: async payload => {
+        const options = captureOptions();
         await withCloudAgentDiagnostics('permission', organizationId, async () => {
           const input = {
             sessionId: payload.sessionId,
@@ -327,15 +365,17 @@ export function createMobileAgentSessionManager({
           if (organizationId) {
             await trpcClient.organizations.cloudAgentNext.answerPermission.mutate(
               { ...input, organizationId },
-              skipBatchOptions
+              options
             );
             return;
           }
-          await trpcClient.cloudAgentNext.answerPermission.mutate(input, skipBatchOptions);
+          await trpcClient.cloudAgentNext.answerPermission.mutate(input, options);
         });
       },
     },
     prepare: async input => {
+      const admission = captureMobileActionAdmission(owner, organizationId ?? null);
+      const options = captureOptions(admission);
       const prepared = await withCloudAgentDiagnostics('prepare', organizationId, async () => {
         const castInput = {
           ...input,
@@ -347,32 +387,54 @@ export function createMobileAgentSessionManager({
         const result = organizationId
           ? await trpcClient.organizations.cloudAgentNext.prepareSession.mutate(
               { ...castInput, organizationId },
-              skipBatchOptions
+              options
             )
-          : await trpcClient.cloudAgentNext.prepareSession.mutate(castInput, skipBatchOptions);
+          : await trpcClient.cloudAgentNext.prepareSession.mutate(castInput, options);
         return {
           cloudAgentSessionId: result.cloudAgentSessionId as CloudAgentSessionId,
           kiloSessionId: result.kiloSessionId as KiloSessionId,
         };
       });
+      assertTransportOwner(owner);
+      // SDK createAndStart initiates immediately after prepare resolves. Keep that resolution order
+      // when idempotent prepares share a session ID; a later operation must not replace an old lease.
+      const pending = preparations.get(prepared.cloudAgentSessionId) ?? [];
+      pending.push(admission);
+      preparations.set(prepared.cloudAgentSessionId, pending);
       return prepared;
     },
     initiate: async input => {
+      const pending = preparations.get(input.cloudAgentSessionId);
+      const admission = pending?.shift();
+      if (pending?.length === 0) {
+        preparations.delete(input.cloudAgentSessionId);
+      }
+      if (!admission) {
+        throw new LocalAccessDeniedError('stale');
+      }
+      const options = captureOptions(admission);
       await withCloudAgentDiagnostics('initiate', organizationId, async () => {
         if (organizationId) {
           await trpcClient.organizations.cloudAgentNext.initiateFromPreparedSession.mutate(
             { cloudAgentSessionId: input.cloudAgentSessionId, organizationId },
-            skipBatchOptions
+            options
           );
           return;
         }
         await trpcClient.cloudAgentNext.initiateFromPreparedSession.mutate(
           { cloudAgentSessionId: input.cloudAgentSessionId },
-          skipBatchOptions
+          options
         );
       });
     },
     onSendFailed: (_messageText, displayMessage, error) => {
+      if (!isTransportOwner(owner)) {
+        return;
+      }
+      const denial = getLocalAccessDenial(error);
+      if (denial) {
+        throw denial;
+      }
       toast.error(
         formatSafeCloudAgentFailureDiagnostic('send', error, organizationId) ??
           displayMessage ??
@@ -380,7 +442,18 @@ export function createMobileAgentSessionManager({
       );
     },
     fetchSession: async (kiloSessionId: KiloSessionId): Promise<FetchedSessionData> => {
-      const sessionResult = await fetchSessionWithNotFoundRetry(kiloSessionId);
+      assertTransportOwner(owner);
+      const sessionResult = await fetchSessionWithNotFoundRetry(kiloSessionId, {
+        query: async sessionId => {
+          const result = await trpcClient.cliSessionsV2.getWithRuntimeState.query(
+            { session_id: sessionId },
+            ownerOptions
+          );
+          return result;
+        },
+      });
+      assertTransportOwner(owner);
+      userWebConnection.setSessionScope(kiloSessionId, sessionResult.organization_id);
       const rs = sessionResult.runtimeState;
       return {
         kiloSessionId,
@@ -405,4 +478,19 @@ export function createMobileAgentSessionManager({
       };
     },
   });
+  const unsubscribeOwner = subscribeAuthenticatedOwner(() => {
+    if (!isTransportOwner(owner)) {
+      preparations.clear();
+      manager.destroy();
+      unsubscribeOwner();
+    }
+  });
+  return {
+    ...manager,
+    destroy() {
+      unsubscribeOwner();
+      preparations.clear();
+      manager.destroy();
+    },
+  };
 }

--- a/apps/mobile/src/components/agents/user-web-connection-provider.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/user-web-connection-provider.mounted.test.tsx
@@ -1,93 +1,249 @@
-/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/test/render-with-providers.tsx) */
-import { createElement } from 'react';
+/* eslint-disable typescript-eslint/no-deprecated -- the DOM-free renderer mounts the real provider and socket adapter */
+/* eslint-disable promise/prefer-await-to-then -- race tests attach rejection handlers before changing the owner */
+import { createElement, useEffect } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { UserWebConnectionProvider } from './user-web-connection-provider';
+import { bumpAuthEpoch, currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { beginAuthenticatedOwner, confirmAuthenticatedOwner } from '@/lib/context-scope';
+import {
+  initializeLocalAccess,
+  setLocalAccessContextReady,
+  setLocalAccessOwner,
+} from '@/lib/local-access';
+import { type MobileUserWebConnection } from '@/lib/local-access-transport';
+import { UserWebConnectionProvider, useUserWebConnection } from './user-web-connection-provider';
 
-type AuthConfig = { getAuthToken: () => Promise<string> };
-
-const mocks = vi.hoisted(() => ({
-  mutate: vi.fn(() => ({ token: 'ticket-1', expiresAt: 1_700_000_060 })),
-  query: vi.fn(),
-  createUserWebConnection: vi.fn(),
-  capturedConfig: null as AuthConfig | null,
-}));
-
-vi.mock('@kilocode/cloud-agent-sdk/user-web-connection', () => ({
-  createUserWebConnection: (config: AuthConfig) => {
-    mocks.capturedConfig = config;
-    mocks.createUserWebConnection(config);
-    return {
-      retain: vi.fn(() => vi.fn()),
-      connect: vi.fn(),
-      disconnect: vi.fn(),
-      destroy: vi.fn(),
-      isConnected: vi.fn(() => false),
-      onConnectionChange: vi.fn(() => vi.fn()),
-      isReconnectExhausted: vi.fn(() => false),
-      onReconnectExhaustionChange: vi.fn(() => vi.fn()),
-      retryConnection: vi.fn(),
-      subscribeToCliSession: vi.fn(() => vi.fn()),
-      sendCommand: vi.fn(),
-      sendCommandToConnection: vi.fn(),
-      onCliEvent: vi.fn(() => vi.fn()),
-      onSystemEvent: vi.fn(() => vi.fn()),
-      onReconnect: vi.fn(() => vi.fn()),
-      onSessionEvent: vi.fn(() => vi.fn()),
-    };
-  },
-}));
-
-vi.mock('@/lib/config', () => ({
-  SESSION_INGEST_WS_URL: 'wss://ingest.example.com',
-}));
-
+const mocks = vi.hoisted(() => ({ mutate: vi.fn() }));
+vi.mock('@/lib/config', () => ({ SESSION_INGEST_WS_URL: 'wss://ingest.example.com' }));
 vi.mock('@/lib/user-web-connection-lifecycle', () => ({
   createNativeUserWebConnectionLifecycleHooks: () => ({}),
 }));
-
+vi.mock('@/lib/organization-context', () => ({
+  useOrganization: () => ({ isReady: true, organizationId: 'org-A' }),
+}));
 vi.mock('@/lib/trpc', () => ({
-  trpcClient: {
-    activeSessions: {
-      createWebTicket: {
-        mutate: mocks.mutate,
-      },
-      getToken: {
-        query: mocks.query,
-      },
-    },
-  },
+  trpcClient: { activeSessions: { createWebTicket: { mutate: mocks.mutate } } },
 }));
 
-describe('UserWebConnectionProvider', () => {
-  beforeEach(() => {
-    mocks.capturedConfig = null;
-    mocks.mutate.mockClear();
-    mocks.query.mockClear();
-    mocks.createUserWebConnection.mockClear();
+type Frame = { type: string; id?: string; command?: string };
+const sockets: Socket[] = [];
+class Socket {
+  static OPEN = 1;
+  readonly url: string;
+  readyState = 0;
+  closeRequested = false;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  frames: Frame[] = [];
+  constructor(url: string) {
+    this.url = url;
+    sockets.push(this);
+  }
+  open() {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+  receive(value: unknown) {
+    this.onmessage?.({ data: JSON.stringify(value) });
+  }
+  send(value: string) {
+    this.frames.push(JSON.parse(value) as Frame);
+  }
+  // Model an OS socket that remains physically open after close was requested.
+  close() {
+    this.closeRequested = true;
+  }
+}
+let stop: (() => void) | undefined = undefined;
+let renderer: TestRenderer.ReactTestRenderer | undefined = undefined;
+let connection: MobileUserWebConnection | undefined = undefined;
+const events: string[] = [];
+function Probe() {
+  const current = useUserWebConnection();
+  connection = current;
+  useEffect(
+    () =>
+      current.onSystemEvent(() => {
+        events.push(current.owner.userId ?? 'none');
+      }),
+    [current]
+  );
+  return null;
+}
+beforeEach(async () => {
+  vi.stubGlobal('WebSocket', Socket);
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  sockets.length = 0;
+  events.length = 0;
+  connection = undefined;
+  confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'A');
+  stop = initializeLocalAccess({
+    storage: {
+      read: vi.fn().mockResolvedValue({ status: 'absent' }),
+      write: vi.fn().mockResolvedValue('committed'),
+    },
+    authenticate: vi.fn().mockResolvedValue({ status: 'authenticated' }),
+    lifecycle: { getCurrentState: () => 'active', subscribe: () => () => undefined },
   });
+  await setLocalAccessOwner('A', currentAuthEpoch());
+  setLocalAccessContextReady(true);
+  mocks.mutate
+    .mockReset()
+    .mockImplementation(
+      async (_input, options: { context: { localAccessOwner: { userId: string } } }) => {
+        await Promise.resolve();
+        return { token: `ticket-${options.context.localAccessOwner.userId}` };
+      }
+    );
+});
+afterEach(async () => {
+  await act(() => {
+    renderer?.unmount();
+  });
+  renderer = undefined;
+  connection?.destroy();
+  stop?.();
+  vi.unstubAllGlobals();
+});
+function socketAt(index: number) {
+  const socket = sockets.at(index);
+  if (!socket) {
+    throw new Error('Expected socket was not constructed');
+  }
+  return socket;
+}
+async function mount() {
+  await act(() => {
+    renderer = TestRenderer.create(
+      createElement(UserWebConnectionProvider, null, createElement(Probe))
+    );
+  });
+  await vi.waitFor(() => {
+    expect(sockets).toHaveLength(1);
+  });
+  return socketAt(0);
+}
+async function replace() {
+  await act(async () => {
+    bumpAuthEpoch();
+    confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'B');
+    await setLocalAccessOwner('B', currentAuthEpoch());
+    setLocalAccessContextReady(true);
+  });
+}
+function currentConnection() {
+  if (!connection) {
+    throw new Error('Provider did not publish a connection');
+  }
+  return connection;
+}
 
-  it('mints the ingest ticket via the createWebTicket mutation', async () => {
-    const holder: { renderer?: TestRenderer.ReactTestRenderer } = {};
-    await act(() => {
-      holder.renderer = TestRenderer.create(createElement(UserWebConnectionProvider, null));
+describe('immutable user-web socket ownership', () => {
+  it('mints the ingest ticket and opens the socket for the captured owner', async () => {
+    const socket = await mount();
+    expect(new URL(socket.url).searchParams.get('ticket')).toBe('ticket-A');
+    expect(currentConnection().owner.userId).toBe('A');
+  });
+  it('rejects pending A commands and fences late A events before B uses a new socket', async () => {
+    const a = await mount();
+    a.open();
+    const old = currentConnection();
+    const pending = Promise.allSettled([old.sendCommand('session-A', 'interrupt', {})]);
+    await vi.waitFor(() => {
+      expect(a.frames.some(frame => frame.command === 'interrupt')).toBe(true);
     });
-
-    expect(mocks.createUserWebConnection).toHaveBeenCalledTimes(1);
-    const config = mocks.capturedConfig;
-    if (!config) {
-      throw new Error('user web connection config not captured');
+    const lateMessage = a.onmessage;
+    await replace();
+    expect(a.closeRequested).toBe(true);
+    expect(a.readyState).toBe(Socket.OPEN);
+    expect(await pending).toEqual([
+      { status: 'rejected', reason: expect.objectContaining({ message: 'Connection destroyed' }) },
+    ]);
+    const b = socketAt(1);
+    b.open();
+    const system = { type: 'system', event: 'sessions.list', data: { sessions: [] } };
+    lateMessage?.({ data: JSON.stringify(system) });
+    b.receive(system);
+    expect(events).toEqual(['B']);
+    const bResult = currentConnection().sendCommand('session-B', 'interrupt', {});
+    await vi.waitFor(() => {
+      expect(b.frames.some(frame => frame.command === 'interrupt')).toBe(true);
+    });
+    const command = b.frames.find(frame => frame.command === 'interrupt');
+    b.receive({ type: 'response', id: command?.id, result: { acceptedBy: 'B' } });
+    await expect(bResult).resolves.toEqual({ acceptedBy: 'B' });
+    expect(a.frames.filter(frame => frame.type === 'command')).toHaveLength(1);
+    await expect(old.sendCommand('session-B', 'interrupt', {})).rejects.toMatchObject({
+      code: 'LOCAL_ACCESS_DENIED',
+    });
+  });
+  it('invalidates a delayed A ticket without connecting it under B', async () => {
+    const ticket = Promise.withResolvers<{ token: string }>();
+    mocks.mutate.mockReturnValueOnce(ticket.promise);
+    await act(() => {
+      renderer = TestRenderer.create(
+        createElement(UserWebConnectionProvider, null, createElement(Probe))
+      );
+    });
+    expect(sockets).toHaveLength(0);
+    await replace();
+    ticket.resolve({ token: 'late-A-ticket' });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(sockets).toHaveLength(1);
+    expect(new URL(socketAt(0).url).searchParams.get('ticket')).toBe('ticket-B');
+  });
+  it('does not renew a command after lock/unlock during waitForOpen', async () => {
+    const access = await import('@/lib/local-access');
+    const socket = await mount();
+    await access.requestLocalAccess('enable');
+    const pending = Promise.allSettled([
+      currentConnection().sendCommand('session-A', 'interrupt', {}),
+    ]);
+    access.lockLocalAccess();
+    await access.requestLocalAccess('unlock');
+    socket.open();
+    expect(await pending).toEqual([
+      { status: 'rejected', reason: expect.any(access.LocalAccessDeniedError) },
+    ]);
+    expect(socket.frames.filter(frame => frame.type === 'command')).toEqual([]);
+  });
+  it.each(['bound', 'explicit'] as const)(
+    'retains the %s command context through a socket wait',
+    async source => {
+      const transport = await import('@/lib/local-access-transport');
+      const access = await import('@/lib/local-access');
+      const capture = transport.captureMobileActionAdmission;
+      const scopedAuthority = vi
+        .spyOn(transport, 'captureMobileActionAdmission')
+        .mockImplementation((owner, organizationId) => {
+          if (organizationId !== 'target-org') {
+            throw new access.LocalAccessDeniedError('context');
+          }
+          return capture(owner, organizationId);
+        });
+      try {
+        const socket = await mount();
+        const current = currentConnection();
+        current.setSessionScope('session-A', source === 'bound' ? 'target-org' : 'source-org');
+        const command = source === 'bound' ? 'interrupt' : 'create_session';
+        const data = source === 'bound' ? {} : { orgId: 'target-org' };
+        const pending = current.sendCommand('session-A', command, data);
+        current.setSessionScope('session-A', 'later-org');
+        socket.open();
+        await vi.waitFor(() => {
+          expect(socket.frames.some(frame => frame.command === command)).toBe(true);
+        });
+        const frame = socket.frames.find(value => value.command === command);
+        socket.receive({ type: 'response', id: frame?.id, result: { accepted: true } });
+        await expect(pending).resolves.toEqual({ accepted: true });
+      } finally {
+        scopedAuthority.mockRestore();
+      }
     }
-
-    const token = await config.getAuthToken();
-
-    expect(token).toBe('ticket-1');
-    expect(mocks.mutate).toHaveBeenCalledTimes(1);
-    expect(mocks.query).not.toHaveBeenCalled();
-
-    await act(() => {
-      holder.renderer?.unmount();
-    });
-  });
+  );
 });

--- a/apps/mobile/src/components/agents/user-web-connection-provider.tsx
+++ b/apps/mobile/src/components/agents/user-web-connection-provider.tsx
@@ -1,50 +1,97 @@
-import { createContext, type ReactNode, useContext, useEffect, useRef } from 'react';
-import { type UserWebConnection } from '@kilocode/cloud-agent-sdk';
-// kilocode_change - K1/C2: `createUserWebConnection` must come from its
-// narrow subpath, not the `cloud-agent-sdk` barrel. The barrel's index.ts
-// also re-exports web-only transport code that imports a web-app `@/...`
-// alias unresolved under the mobile app's own `@` alias — this previously
-// went unnoticed because nothing under `apps/mobile` had a test that
-// actually imported this provider (and thus the barrel) at runtime until
-// the `kilo remote` spawn hook test did. See the matching
-// vitest.config.ts aliases for the full explanation.
-import { createUserWebConnection } from '@kilocode/cloud-agent-sdk/user-web-connection';
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
+import { z } from 'zod';
 
 import { SESSION_INGEST_WS_URL } from '@/lib/config';
 import { createNativeUserWebConnectionLifecycleHooks } from '@/lib/user-web-connection-lifecycle';
 import { trpcClient } from '@/lib/trpc';
+import { getAuthenticatedOwner, subscribeAuthenticatedOwner } from '@/lib/context-scope';
+import { LocalAccessDeniedError } from '@/lib/local-access';
+import {
+  assertMobileActionAdmission,
+  captureMobileActionAdmission,
+  createMobileUserWebConnection,
+  isTransportOwner,
+  type MobileUserWebConnection,
+} from '@/lib/local-access-transport';
+import { useOrganization } from '@/lib/organization-context';
 
-const UserWebConnectionContext = createContext<UserWebConnection | null>(null);
+const UserWebConnectionContext = createContext<MobileUserWebConnection | null>(null);
+const commandScopeSchema = z.object({ orgId: z.string().nullish() });
 
-type UserWebConnectionProviderProps = {
-  children: ReactNode;
-};
+type UserWebConnectionProviderProps = { children: ReactNode };
 
 export function UserWebConnectionProvider({ children }: Readonly<UserWebConnectionProviderProps>) {
-  const connectionRef = useRef<UserWebConnection | null>(null);
-  connectionRef.current ??= createUserWebConnection({
-    websocketUrl: `${SESSION_INGEST_WS_URL}/api/user/web`,
-    getAuthToken: async () => {
-      const result = await trpcClient.activeSessions.createWebTicket.mutate();
-      return result.token;
-    },
-    lifecycleHooks: createNativeUserWebConnectionLifecycleHooks(),
-  });
+  const owner = useSyncExternalStore(subscribeAuthenticatedOwner, getAuthenticatedOwner);
+  const organization = useOrganization();
+  const scopeRef = useRef(organization);
+  scopeRef.current = organization;
+  const connection = useMemo(
+    () =>
+      createMobileUserWebConnection({
+        owner,
+        websocketUrl: `${SESSION_INGEST_WS_URL}/api/user/web`,
+        getAuthToken: async () => {
+          const result = await trpcClient.activeSessions.createWebTicket.mutate(undefined, {
+            context: { localAccessOwner: owner },
+          });
+          return result.token;
+        },
+        captureActionAdmission: (target, boundScope) => {
+          const explicit = commandScopeSchema.safeParse(target.data);
+          const caller = scopeRef.current;
+          const targetOrganizationId = explicit.success ? explicit.data.orgId : undefined;
+          if (targetOrganizationId === undefined && !boundScope && !caller.isReady) {
+            throw new LocalAccessDeniedError('context');
+          }
+          const callerOrganizationId = boundScope
+            ? boundScope.organizationId
+            : caller.organizationId;
+          const organizationId =
+            targetOrganizationId === undefined ? callerOrganizationId : targetOrganizationId;
+          const admission = captureMobileActionAdmission(owner, organizationId);
+          return () => {
+            assertMobileActionAdmission(admission);
+          };
+        },
+        lifecycleHooks: createNativeUserWebConnectionLifecycleHooks(),
+      }),
+    [owner]
+  );
 
-  // Retain the connection for the provider lifetime. The retain return value
-  // IS the release, so the effect cleanup releases it; zero retains stops the
-  // socket reversibly. An effect replay (StrictMode development double-mount)
-  // re-retains and reconnects instead of destroying the connection.
-  useEffect(() => connectionRef.current?.retain(), []);
+  useEffect(() => {
+    // Revoke synchronously on owner publication, before React commits the replacement tree.
+    const invalidate = () => {
+      if (!isTransportOwner(owner)) {
+        connection.destroy();
+      }
+    };
+    const unsubscribe = subscribeAuthenticatedOwner(invalidate);
+    invalidate();
+    const release = owner.userId && isTransportOwner(owner) ? connection.retain() : undefined;
+    return () => {
+      unsubscribe();
+      // StrictMode can replay this effect. Final release is reversible; owner replacement is not.
+      release?.();
+    };
+  }, [connection, owner]);
 
+  const ownerKey = `${owner.authEpoch}:${owner.generation}:${owner.userId ?? ''}`;
   return (
-    <UserWebConnectionContext.Provider value={connectionRef.current}>
+    <UserWebConnectionContext.Provider key={ownerKey} value={connection}>
       {children}
     </UserWebConnectionContext.Provider>
   );
 }
 
-export function useUserWebConnection(): UserWebConnection {
+export function useUserWebConnection(): MobileUserWebConnection {
   const connection = useContext(UserWebConnectionContext);
   if (!connection) {
     throw new Error('useUserWebConnection must be used within UserWebConnectionProvider');

--- a/apps/mobile/src/components/quick-chat/quick-chat-gateway.local-access.test.ts
+++ b/apps/mobile/src/components/quick-chat/quick-chat-gateway.local-access.test.ts
@@ -1,0 +1,184 @@
+/* eslint-disable promise/prefer-await-to-then -- race tests attach rejection handlers before changing the owner */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { bumpAuthEpoch, currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import {
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+  getAuthenticatedOwner,
+} from '@/lib/context-scope';
+import {
+  initializeLocalAccess,
+  LocalAccessDeniedError,
+  lockLocalAccess,
+  requestLocalAccess,
+  setLocalAccessContextReady,
+  setLocalAccessOwner,
+} from '@/lib/local-access';
+import {
+  type AcceptedWorkReceipt,
+  assertAcceptedWorkReceipt,
+  captureMobileActionAdmission,
+} from '@/lib/local-access-transport';
+import { type QuickChatCompletionInput, streamQuickChatCompletion } from './quick-chat-gateway';
+
+vi.mock('@/lib/config', () => ({ API_BASE_URL: 'https://gateway.test' }));
+const fetchMock = vi.fn<typeof fetch>();
+let stop: (() => void) | undefined = undefined;
+beforeEach(async () => {
+  vi.stubGlobal('fetch', fetchMock);
+  fetchMock.mockReset();
+  confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'A');
+  stop = initializeLocalAccess({
+    storage: {
+      read: vi.fn().mockResolvedValue({ status: 'present', enabled: true }),
+      write: vi.fn().mockResolvedValue('committed'),
+    },
+    authenticate: vi.fn().mockResolvedValue({ status: 'authenticated' }),
+    lifecycle: { getCurrentState: () => 'active', subscribe: () => () => undefined },
+  });
+  await setLocalAccessOwner('A', currentAuthEpoch());
+  setLocalAccessContextReady(true);
+  await requestLocalAccess('unlock', true);
+});
+afterEach(() => {
+  stop?.();
+  vi.unstubAllGlobals();
+});
+async function collect(stream: AsyncGenerator<string>) {
+  const values: string[] = [];
+  for await (const value of stream) {
+    values.push(value);
+  }
+  return values.join('');
+}
+function input(): QuickChatCompletionInput {
+  return {
+    model: 'model',
+    messages: [{ role: 'user', content: 'hello' }],
+    organizationId: 'org-A',
+    authToken: 'token-A',
+    turnId: 'turn-A',
+    admission: captureMobileActionAdmission(getAuthenticatedOwner(), 'org-A'),
+    onDispatch: () => undefined,
+  };
+}
+function streamBody() {
+  const chunks = Promise.withResolvers<ReadableStreamDefaultController<Uint8Array>>();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      chunks.resolve(controller);
+    },
+  });
+  return { body, controller: chunks.promise };
+}
+function content(text: string) {
+  return new TextEncoder().encode(
+    `data: ${JSON.stringify({ choices: [{ delta: { content: text } }] })}\n\n`
+  );
+}
+
+describe('Quick Chat final dispatch', () => {
+  it.each(['lock/unlock', 'account replacement'] as const)(
+    'denies an original turn after %s without dispatch or a receipt',
+    async change => {
+      const captured = input();
+      const receipts: AcceptedWorkReceipt[] = [];
+      captured.onDispatch = receipt => {
+        receipts.push(receipt);
+      };
+      if (change === 'lock/unlock') {
+        lockLocalAccess();
+        await requestLocalAccess('unlock');
+      } else {
+        bumpAuthEpoch();
+        confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'B');
+      }
+      await expect(collect(streamQuickChatCompletion(captured))).rejects.toBeInstanceOf(
+        LocalAccessDeniedError
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(receipts).toEqual([]);
+    }
+  );
+  it('settles dispatch before headers arrive and preserves an accepted answer while locked', async () => {
+    const response = Promise.withResolvers<Response>();
+    const admitted = Promise.withResolvers<AcceptedWorkReceipt>();
+    fetchMock.mockReturnValue(response.promise);
+    const pending = collect(
+      streamQuickChatCompletion({ ...input(), onDispatch: admitted.resolve })
+    );
+    const receipt = await admitted.promise;
+    lockLocalAccess();
+    expect(() =>
+      assertAcceptedWorkReceipt(receipt, {
+        kind: 'quick-chat-turn',
+        organizationId: 'org-A',
+        workId: 'turn-A',
+      })
+    ).not.toThrow();
+    const stream = streamBody();
+    response.resolve(new Response(stream.body));
+    const controller = await stream.controller;
+    controller.enqueue(content('accepted reply'));
+    controller.close();
+    await expect(pending).resolves.toBe('accepted reply');
+  });
+  it('drops a parsed A delta after account replacement', async () => {
+    const stream = streamBody();
+    fetchMock.mockResolvedValue(new Response(stream.body));
+    const admitted = Promise.withResolvers<AcceptedWorkReceipt>();
+    const pending = Promise.allSettled([
+      collect(streamQuickChatCompletion({ ...input(), onDispatch: admitted.resolve })),
+    ]);
+    await admitted.promise;
+    bumpAuthEpoch();
+    confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'B');
+    const controller = await stream.controller;
+    controller.enqueue(content('private A reply'));
+    controller.close();
+    expect(await pending).toEqual([
+      { status: 'rejected', reason: expect.any(LocalAccessDeniedError) },
+    ]);
+  });
+  it('rejects a pre-aborted native signal without dispatch or a receipt', async () => {
+    const legacySignal = { aborted: true };
+    const receipts: AcceptedWorkReceipt[] = [];
+    await expect(
+      collect(
+        streamQuickChatCompletion({
+          ...input(),
+          signal: legacySignal as AbortSignal,
+          onDispatch: receipt => {
+            receipts.push(receipt);
+          },
+        })
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(receipts).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  it('denies a mismatched organization before reaching the gateway', async () => {
+    await expect(
+      collect(streamQuickChatCompletion({ ...input(), organizationId: 'org-B' }))
+    ).rejects.toMatchObject({ reason: 'context' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  it('does not publish a receipt when native fetch throws synchronously', async () => {
+    const receipts: AcceptedWorkReceipt[] = [];
+    fetchMock.mockImplementation(() => {
+      throw new Error('native dispatch failed');
+    });
+    await expect(
+      collect(
+        streamQuickChatCompletion({
+          ...input(),
+          onDispatch: receipt => {
+            receipts.push(receipt);
+          },
+        })
+      )
+    ).rejects.toThrow('native dispatch failed');
+    expect(receipts).toEqual([]);
+  });
+});

--- a/apps/mobile/src/components/quick-chat/quick-chat-gateway.test.ts
+++ b/apps/mobile/src/components/quick-chat/quick-chat-gateway.test.ts
@@ -1,5 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import {
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+  getAuthenticatedOwner,
+} from '@/lib/context-scope';
+import {
+  initializeLocalAccess,
+  setLocalAccessContextReady,
+  setLocalAccessOwner,
+} from '@/lib/local-access';
+import {
+  captureMobileActionAdmission,
+  type MobileActionAdmission,
+} from '@/lib/local-access-transport';
+
 import {
   parseSseDataLine,
   type QuickChatCompletionInput,
@@ -10,12 +26,27 @@ vi.mock('@/lib/config', () => ({ API_BASE_URL: 'https://gateway.test' }));
 
 const fetchMock = vi.hoisted(() => vi.fn());
 
-beforeEach(() => {
+let admission: MobileActionAdmission | undefined = undefined;
+let stopAccess: (() => void) | undefined = undefined;
+beforeEach(async () => {
   fetchMock.mockReset();
   vi.stubGlobal('fetch', fetchMock);
+  confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'A');
+  stopAccess = initializeLocalAccess({
+    storage: {
+      read: vi.fn().mockResolvedValue({ status: 'absent' }),
+      write: vi.fn().mockResolvedValue('committed'),
+    },
+    authenticate: vi.fn().mockResolvedValue({ status: 'authenticated' }),
+    lifecycle: { getCurrentState: () => 'active', subscribe: () => () => undefined },
+  });
+  await setLocalAccessOwner('A', currentAuthEpoch());
+  setLocalAccessContextReady(true);
+  admission = captureMobileActionAdmission(getAuthenticatedOwner(), 'org-1');
 });
 
 afterEach(() => {
+  stopAccess?.();
   vi.unstubAllGlobals();
 });
 
@@ -40,6 +71,14 @@ const baseInput: QuickChatCompletionInput = {
   ],
   organizationId: 'org-1',
   authToken: 'token-1',
+  get admission() {
+    if (!admission) {
+      throw new Error('Missing test admission');
+    }
+    return admission;
+  },
+  turnId: 'turn-1',
+  onDispatch: () => undefined,
 };
 
 async function collect(generator: AsyncGenerator<string>): Promise<string[]> {
@@ -112,7 +151,13 @@ describe('streamQuickChatCompletion', () => {
   it('omits the organization header when organizationId is absent', async () => {
     fetchMock.mockResolvedValue({ ok: true, body: chunkedStream(['data: [DONE]\n\n']) });
 
-    await collect(streamQuickChatCompletion({ ...baseInput, organizationId: null }));
+    await collect(
+      streamQuickChatCompletion({
+        ...baseInput,
+        organizationId: null,
+        admission: captureMobileActionAdmission(getAuthenticatedOwner(), null),
+      })
+    );
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     const headers = init.headers as Record<string, string>;

--- a/apps/mobile/src/components/quick-chat/quick-chat-gateway.ts
+++ b/apps/mobile/src/components/quick-chat/quick-chat-gateway.ts
@@ -1,4 +1,11 @@
 import { API_BASE_URL } from '@/lib/config';
+import { LocalAccessDeniedError } from '@/lib/local-access';
+import {
+  type AcceptedWorkReceipt,
+  assertTransportOwner,
+  dispatchAcceptedWork,
+  type MobileActionAdmission,
+} from '@/lib/local-access-transport';
 
 /**
  * The single Kilo gateway entry point for the quick-chat surface. Every call
@@ -16,6 +23,9 @@ export type QuickChatCompletionInput = {
   messages: QuickChatGatewayMessage[];
   organizationId: string | null | undefined;
   authToken: string;
+  admission: MobileActionAdmission;
+  turnId: string;
+  onDispatch: (receipt: AcceptedWorkReceipt) => void;
   signal?: AbortSignal;
 };
 
@@ -47,6 +57,9 @@ export async function* streamQuickChatCompletion({
   messages,
   organizationId,
   authToken,
+  admission,
+  turnId,
+  onDispatch,
   signal,
 }: QuickChatCompletionInput): AsyncGenerator<string> {
   const headers: QuickChatRequestHeaders = {
@@ -58,14 +71,33 @@ export async function* streamQuickChatCompletion({
     headers['X-KiloCode-OrganizationId'] = organizationId;
   }
 
-  const response = await fetch(`${API_BASE_URL}${GATEWAY_CHAT_COMPLETIONS_PATH}`, {
+  if (admission.lease.organizationId !== (organizationId ?? null)) {
+    throw new LocalAccessDeniedError('context');
+  }
+  const init = {
     method: 'POST',
     headers,
     // No `tools` key: quick-chat is a plain completion, never a tool loop.
     body: JSON.stringify({ model, messages, stream: true }),
     signal,
-  });
-
+  };
+  if (signal?.aborted) {
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new DOMException('Aborted', 'AbortError');
+  }
+  // eslint-disable-next-line typescript-eslint/promise-function-async -- a synchronous native dispatch failure must not issue a receipt
+  function dispatch() {
+    return fetch(`${API_BASE_URL}${GATEWAY_CHAT_COMPLETIONS_PATH}`, init);
+  }
+  const dispatched = dispatchAcceptedWork(
+    admission,
+    { kind: 'quick-chat-turn', workId: turnId },
+    dispatch
+  );
+  onDispatch(dispatched.receipt);
+  const response = await dispatched.result;
+  assertTransportOwner(admission.owner);
   if (!response.ok) {
     throw new Error(`Gateway request failed with status ${response.status}`);
   }
@@ -73,7 +105,11 @@ export async function* streamQuickChatCompletion({
     throw new Error('Gateway returned an empty stream');
   }
 
-  yield* readSseContent(response.body, signal);
+  for await (const delta of readSseContent(response.body, signal)) {
+    assertTransportOwner(admission.owner);
+    yield delta;
+  }
+  assertTransportOwner(admission.owner);
 }
 
 /**

--- a/apps/mobile/src/components/quick-chat/use-quick-chat.local-access.test.ts
+++ b/apps/mobile/src/components/quick-chat/use-quick-chat.local-access.test.ts
@@ -1,0 +1,339 @@
+/* eslint-disable typescript-eslint/no-deprecated -- the DOM-free renderer exercises the hook without a native screen */
+/* eslint-disable max-lines -- the mounted hook shares one real gateway and in-memory persistence harness */
+/* eslint-disable promise/prefer-await-to-then -- race tests attach rejection handlers before changing the owner */
+import { createElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import TestRenderer, { act } from 'react-test-renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type AppStateStatus } from 'react-native';
+
+import { bumpAuthEpoch, currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { beginAuthenticatedOwner, confirmAuthenticatedOwner } from '@/lib/context-scope';
+import {
+  initializeLocalAccess,
+  LocalAccessDeniedError,
+  lockLocalAccess,
+  requestLocalAccess,
+  setLocalAccessContextReady,
+  setLocalAccessOwner,
+} from '@/lib/local-access';
+import { type AcceptedWorkReceipt } from '@/lib/local-access-transport';
+import * as gateway from './quick-chat-gateway';
+import { useQuickChat } from './use-quick-chat';
+
+const state = vi.hoisted(() => ({
+  ready: true,
+  token: vi.fn(),
+  thread: vi.fn(),
+  toast: vi.fn(),
+  persisted: new Map<string, unknown>(),
+  reads: [] as string[],
+}));
+vi.mock('@/i18n', () => ({ i18n: { t: (key: string) => key } }));
+vi.mock('sonner-native', () => ({ toast: { error: state.toast } }));
+vi.mock('@/lib/config', () => ({ API_BASE_URL: 'https://gateway.test' }));
+vi.mock('@/lib/auth/token-owner', () => ({ getAuthTokenForRequest: state.token }));
+vi.mock('@/lib/organization-context', async () => {
+  const { useSyncExternalStore } = await import('react');
+  const { getAuthenticatedOwner: snapshot, subscribeAuthenticatedOwner: subscribe } =
+    await import('@/lib/context-scope');
+  return {
+    useOrganization: () => ({
+      owner: useSyncExternalStore(subscribe, snapshot),
+      isReady: state.ready,
+      organizationId: 'org-A',
+    }),
+  };
+});
+vi.mock('@/lib/trpc', async () => {
+  const { captureTransportOperation } = await import('@/lib/local-access-transport');
+  type Options = { context?: Record<string, unknown> };
+  return {
+    useTRPC: () => ({
+      quickChat: {
+        listMessages: { queryKey: (input: unknown) => [['quickChat', 'listMessages'], { input }] },
+      },
+    }),
+    trpcClient: {
+      quickChat: {
+        listMessages: {
+          query: async (input: unknown, options: Options = {}) => {
+            const operation = captureTransportOperation({
+              id: 1,
+              type: 'query',
+              path: 'quickChat.listMessages',
+              input,
+              context: options.context ?? {},
+              signal: undefined,
+            });
+            operation.assertDispatch();
+            state.reads.push(operation.owner.userId ?? 'none');
+            await Promise.resolve();
+            return { messages: [], nextCursor: null };
+          },
+        },
+        getOrCreateThread: {
+          mutate: async (input: unknown, options: Options = {}) => {
+            const operation = captureTransportOperation({
+              id: 2,
+              type: 'mutation',
+              path: 'quickChat.getOrCreateThread',
+              input,
+              context: options.context ?? {},
+              signal: undefined,
+            });
+            await state.thread();
+            operation.assertDispatch();
+            return { id: 'thread-A' };
+          },
+        },
+        appendMessages: {
+          mutate: async (
+            input: { organizationId: string; messages: unknown[] },
+            options: Options = {}
+          ) => {
+            const operation = captureTransportOperation({
+              id: 3,
+              type: 'mutation',
+              path: 'quickChat.appendMessages',
+              input,
+              context: options.context ?? {},
+              signal: undefined,
+            });
+            operation.assertDispatch();
+            state.persisted.set(
+              `${operation.owner.userId}:${input.organizationId}`,
+              input.messages
+            );
+            await Promise.resolve();
+            return { accepted: true };
+          },
+        },
+      },
+    },
+  };
+});
+
+let current: ReturnType<typeof useQuickChat> | undefined = undefined;
+let renderer: TestRenderer.ReactTestRenderer | undefined = undefined;
+let queryClient: QueryClient | undefined = undefined;
+let stop: (() => void) | undefined = undefined;
+let lifecycle: (next: AppStateStatus) => void = () => undefined;
+const fetchMock = vi.fn<typeof fetch>();
+function Probe() {
+  current = useQuickChat('model');
+  return null;
+}
+function hook() {
+  if (!current) {
+    throw new Error('Hook not mounted');
+  }
+  return current;
+}
+async function mount() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  queryClient = client;
+  await act(() => {
+    renderer = TestRenderer.create(
+      createElement(QueryClientProvider, { client }, createElement(Probe))
+    );
+  });
+}
+async function send(text = 'hello') {
+  let pending: Promise<PromiseSettledResult<AcceptedWorkReceipt>[]> = Promise.resolve([]);
+  await act(() => {
+    pending = Promise.allSettled([hook().onSend(text)]);
+  });
+  const [settlement] = await pending;
+  if (settlement?.status === 'fulfilled') {
+    return settlement.value;
+  }
+  const error: unknown = settlement?.reason;
+  throw error instanceof Error ? error : new Error('Missing dispatch settlement');
+}
+async function stream() {
+  const pending = Promise.withResolvers<ReadableStreamDefaultController<Uint8Array>>();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      pending.resolve(controller);
+    },
+  });
+  fetchMock.mockResolvedValue(new Response(body));
+  const controller = await pending.promise;
+  return controller;
+}
+async function finish(controller: ReadableStreamDefaultController<Uint8Array>, text = 'answer') {
+  await act(async () => {
+    controller.enqueue(
+      new TextEncoder().encode(
+        `data: ${JSON.stringify({ choices: [{ delta: { content: text } }] })}\n\ndata: [DONE]\n\n`
+      )
+    );
+    controller.close();
+    await Promise.resolve();
+  });
+}
+beforeEach(async () => {
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  fetchMock.mockReset();
+  state.ready = true;
+  state.token.mockReset().mockResolvedValue('token-A');
+  state.thread.mockReset().mockResolvedValue(undefined);
+  state.toast.mockReset();
+  state.persisted.clear();
+  state.reads.length = 0;
+  confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'A');
+  stop = initializeLocalAccess({
+    storage: {
+      read: vi.fn().mockResolvedValue({ status: 'absent' }),
+      write: vi.fn().mockResolvedValue('committed'),
+    },
+    authenticate: vi.fn().mockResolvedValue({ status: 'authenticated' }),
+    lifecycle: {
+      getCurrentState: () => 'active',
+      subscribe: listener => {
+        lifecycle = listener;
+        return () => undefined;
+      },
+    },
+  });
+  await setLocalAccessOwner('A', currentAuthEpoch());
+  setLocalAccessContextReady(true);
+});
+afterEach(async () => {
+  await act(() => {
+    renderer?.unmount();
+  });
+  renderer = undefined;
+  current = undefined;
+  queryClient?.clear();
+  stop?.();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('Quick Chat accepted completion ownership', () => {
+  it('persists a complete background turn with locking disabled and settles dispatch before its answer', async () => {
+    const controller = await stream();
+    await mount();
+    const nativePromises = vi.spyOn(Promise, 'withResolvers').mockImplementation(() => {
+      throw new Error('Native Promise lacks withResolvers');
+    });
+    try {
+      await send();
+    } finally {
+      nativePromises.mockRestore();
+    }
+    expect(hook().isStreaming).toBe(true);
+    expect(state.persisted.size).toBe(0);
+    lifecycle('background');
+    await finish(controller);
+    await vi.waitFor(() => {
+      expect(state.persisted.get('A:org-A')).toEqual([
+        expect.objectContaining({ role: 'user', content: 'hello', clientId: expect.any(String) }),
+        { role: 'assistant', content: 'answer' },
+      ]);
+    });
+  });
+
+  it('persists an admitted turn after locking and never starts a replacement turn automatically', async () => {
+    await requestLocalAccess('enable');
+    const controller = await stream();
+    await mount();
+    await send();
+    lockLocalAccess();
+    await finish(controller);
+    await vi.waitFor(() => {
+      expect(state.persisted.has('A:org-A')).toBe(true);
+    });
+    await requestLocalAccess('unlock');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects final dispatch after a token wait crosses lock/unlock and keeps persistence empty', async () => {
+    await requestLocalAccess('enable');
+    const token = Promise.withResolvers<string>();
+    state.token.mockReturnValue(token.promise);
+    await mount();
+    let outcome: PromiseSettledResult<AcceptedWorkReceipt>[] = [];
+    let pending: Promise<PromiseSettledResult<AcceptedWorkReceipt>[]> = Promise.resolve([]);
+    await act(() => {
+      pending = Promise.allSettled([hook().onSend('retain draft')]);
+    });
+    await vi.waitFor(() => {
+      expect(state.token).toHaveBeenCalled();
+    });
+    lockLocalAccess();
+    await requestLocalAccess('unlock');
+    token.resolve('token-A');
+    await act(async () => {
+      outcome = await pending;
+    });
+    expect(outcome).toEqual([{ status: 'rejected', reason: expect.any(LocalAccessDeniedError) }]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(state.persisted.size).toBe(0);
+    expect(hook().messages).toEqual([]);
+  });
+
+  it('cancels A completion and hides its rows when B replaces the account', async () => {
+    const controller = await stream();
+    await mount();
+    await send('private A prompt');
+    await act(async () => {
+      bumpAuthEpoch();
+      confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'B');
+      await setLocalAccessOwner('B', currentAuthEpoch());
+      setLocalAccessContextReady(true);
+    });
+    await finish(controller, 'private A answer');
+    expect(state.persisted.size).toBe(0);
+    expect(hook().messages).toEqual([]);
+    expect(
+      queryClient
+        ?.getQueryCache()
+        .getAll()
+        .map(query => query.queryKey)
+    ).toEqual(
+      expect.arrayContaining([expect.arrayContaining(['A']), expect.arrayContaining(['B'])])
+    );
+  });
+
+  it('does not read or create a thread before the context is ready', async () => {
+    state.ready = false;
+    await mount();
+    expect(() => {
+      void hook().onSend('draft');
+    }).toThrow(LocalAccessDeniedError);
+    expect(hook().isLoading).toBe(true);
+    expect(state.reads).toEqual([]);
+    expect(state.thread).not.toHaveBeenCalled();
+    expect(state.persisted.size).toBe(0);
+  });
+
+  it('normalizes a non-Error token failure without dispatch or persistence', async () => {
+    state.token.mockRejectedValueOnce('native token failure');
+    await mount();
+    let pending: Promise<PromiseSettledResult<AcceptedWorkReceipt>[]> = Promise.resolve([]);
+    await act(() => {
+      pending = Promise.allSettled([hook().onSend('draft')]);
+    });
+    expect(await pending).toEqual([{ status: 'rejected', reason: expect.any(Error) }]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(state.persisted.size).toBe(0);
+  });
+
+  it('rejects a forged gateway receipt instead of persisting the turn', async () => {
+    vi.spyOn(gateway, 'streamQuickChatCompletion').mockImplementation(
+      async function* forgedCompletion(input) {
+        await Promise.resolve();
+        const forged = {};
+        input.onDispatch(forged as AcceptedWorkReceipt);
+        yield 'forged answer';
+      }
+    );
+    await mount();
+    await expect(send()).rejects.toBeInstanceOf(LocalAccessDeniedError);
+    expect(state.persisted.size).toBe(0);
+  });
+});

--- a/apps/mobile/src/components/quick-chat/use-quick-chat.ts
+++ b/apps/mobile/src/components/quick-chat/use-quick-chat.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- paging and admitted turn completion share the same owner boundary */
 import { useQuery } from '@tanstack/react-query';
 import { type OlderMessagesError, type StoredMessage } from '@kilocode/cloud-agent-sdk';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -5,10 +6,20 @@ import { toast } from 'sonner-native';
 import { ulid } from 'ulid';
 
 import { i18n } from '@/i18n';
-import { useAuth } from '@/lib/auth/auth-context';
 import { getAuthTokenForRequest } from '@/lib/auth/token-owner';
 import { useOrganization } from '@/lib/organization-context';
 import { trpcClient, useTRPC } from '@/lib/trpc';
+import {
+  type AcceptedWorkReceipt,
+  assertAcceptedWorkReceipt,
+  assertMobileActionAdmission,
+  assertTransportOwner,
+  captureMobileActionAdmission,
+  getLocalAccessDenial,
+  isTransportOwner,
+  type MobileActionAdmission,
+} from '@/lib/local-access-transport';
+import { LocalAccessDeniedError } from '@/lib/local-access';
 
 import { type QuickChatGatewayMessage, streamQuickChatCompletion } from './quick-chat-gateway';
 import {
@@ -18,25 +29,26 @@ import {
   type QuickChatRow,
 } from './quick-chat-messages';
 
-/** One locally-accepted turn: the user row plus, once streaming starts, the assistant reply. */
 type HookLocalTurn = {
   clientId: string;
   user: QuickChatRow;
   assistant: QuickChatRow | null;
 };
 
-/**
- * Data layer for the quick-chat tab. Owns the `listMessages` query, older-page
- * paging, the locally-accepted turns, and the gateway stream/append pipeline.
- * All local state is torn down and in-flight streams aborted when the auth
- * epoch or organization changes, so no stale account data survives a scope
- * switch.
- */
+/** History and accepted turns stay bound to their captured account and context. */
 export function useQuickChat(model: string) {
-  const { organizationId, isLoaded: orgLoaded } = useOrganization();
-  const { authEpoch } = useAuth();
+  const { organizationId, isReady: orgReady, owner } = useOrganization();
+  const ready = orgReady && owner.userId !== null && isTransportOwner(owner);
   const trpc = useTRPC();
-
+  const scopeKey = JSON.stringify([
+    owner.userId,
+    owner.authEpoch,
+    owner.generation,
+    organizationId,
+  ]);
+  const scopeKeyRef = useRef(scopeKey);
+  const visibleScopeRef = useRef(scopeKey);
+  visibleScopeRef.current = scopeKey;
   const [localTurns, setLocalTurns] = useState<HookLocalTurn[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
   const [threadId, setThreadId] = useState<string | null>(null);
@@ -44,35 +56,34 @@ export function useQuickChat(model: string) {
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [isLoadingOlder, setIsLoadingOlder] = useState(false);
   const [olderError, setOlderError] = useState<OlderMessagesError | null>(null);
-
   const abortRef = useRef<AbortController | null>(null);
   const stopRef = useRef<(() => void) | null>(null);
   const nextCursorRef = useRef<string | null>(null);
   const olderLoadingRef = useRef(false);
-  // Bumped every time the newest page resets (or the scope changes), so an
-  // older-page load that raced the reset can drop its now-stale result instead
-  // of prepending rows contiguous with the old first page.
   const pageResetRef = useRef(0);
 
   const listQuery = useQuery({
-    // Key the page by the auth epoch so a sign-in can never render the previous
-    // account's cached page, and keep it disabled until the org scope hydrates
-    // (the context starts as null while SecureStore loads, so an early fetch
-    // would resolve the personal thread first and then swap when the stored org
-    // arrives).
-    queryKey: [...trpc.quickChat.listMessages.queryKey({ organizationId }), authEpoch],
-    queryFn: async () => {
-      const page = await trpcClient.quickChat.listMessages.query({ organizationId });
+    queryKey: [
+      ...trpc.quickChat.listMessages.queryKey({ organizationId }),
+      owner.userId,
+      owner.authEpoch,
+      owner.generation,
+    ],
+    queryFn: async ({ signal }) => {
+      assertTransportOwner(owner);
+      const page = await trpcClient.quickChat.listMessages.query(
+        { organizationId },
+        {
+          signal,
+          context: { localAccessOwner: owner },
+        }
+      );
+      assertTransportOwner(owner);
       return page;
     },
-    enabled: orgLoaded,
+    enabled: ready,
   });
 
-  const scopeKey = `${authEpoch}:${organizationId ?? 'personal'}`;
-  const scopeKeyRef = useRef(scopeKey);
-
-  // Remount all local state and drop any in-flight stream when the account or
-  // organization scope changes.
   useEffect(() => {
     if (scopeKeyRef.current === scopeKey) {
       return;
@@ -93,10 +104,6 @@ export function useQuickChat(model: string) {
     pageResetRef.current += 1;
   }, [scopeKey]);
 
-  // A plain unmount (flag-off redirect, tab teardown) leaves no scope-change:
-  // the effect above returns early on the first mount, so it never registers a
-  // cleanup. Abort the in-flight stream here so a completion never outlives the
-  // screen.
   useEffect(
     () => () => {
       abortRef.current?.abort();
@@ -106,58 +113,24 @@ export function useQuickChat(model: string) {
     []
   );
 
-  // Resolve the thread id for the transcript list's reset key. The id is
-  // cosmetic: listMessages/appendMessages resolve the thread server-side. The
-  // create is gated on the same org-hydration flag as listMessages, so a mount
-  // before SecureStore loads cannot write the personal thread by accident.
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      // The create is gated on the same org-hydration flag as listMessages, so
-      // a mount before SecureStore loads cannot write the personal thread.
-      if (!orgLoaded) {
-        return;
-      }
-      try {
-        const thread = await trpcClient.quickChat.getOrCreateThread.mutate({ organizationId });
-        // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- `cancelled` flips in the cleanup when the scope changes mid-flight
-        if (!cancelled) {
-          setThreadId(thread.id);
-        }
-      } catch {
-        // Keep `threadId` null; the screen falls back to the "pending" key.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [scopeKey, organizationId, orgLoaded]);
-
-  // A first-page refetch (send → append → refetch, or Retry) shifts the newest
-  // window, so the older rows and the cursor must reset together: keeping old
-  // `olderRows` while overwriting the cursor would leave a gap where the rows
-  // that fell off the first page live, and a later older load would prepend
-  // overlapping ids. Reset both so the next older load starts contiguous with
-  // the new first page.
+  // Reset the older window with every accepted first page. Keep the existing page-race fence.
   useEffect(() => {
     const data = listQuery.data;
-    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- `data` is undefined while the query is disabled before the org scope hydrates
+    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- the disabled query has no first page
     if (data) {
       pageResetRef.current += 1;
       setOlderRows([]);
       nextCursorRef.current = data.nextCursor;
       setNextCursor(data.nextCursor);
-      // A reset bumps `pageResetRef`, which makes an in-flight older load drop
-      // its result and skip releasing the lock in its `finally`. Release the
-      // lock here so pagination is not stuck behind the stale load.
       olderLoadingRef.current = false;
       setIsLoadingOlder(false);
     }
   }, [listQuery.data]);
 
+  const isVisibleOwner = () => isTransportOwner(owner) && visibleScopeRef.current === scopeKey;
   const onLoadOlderMessages = () => {
     const cursor = nextCursorRef.current;
-    if (cursor === null || olderLoadingRef.current) {
+    if (!ready || cursor === null || olderLoadingRef.current) {
       return;
     }
     const resetGen = pageResetRef.current;
@@ -166,28 +139,25 @@ export function useQuickChat(model: string) {
     setOlderError(null);
     void (async () => {
       try {
-        const result = await trpcClient.quickChat.listMessages.query({ organizationId, cursor });
-        // If a newest-page refetch or scope change reset the page since this
-        // load started, the row window moved: prepending these rows would leave
-        // a gap or duplicate ids. Drop the stale page.
-        // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- a dropped page must not mix into the newer window
-        if (pageResetRef.current !== resetGen) {
+        const result = await trpcClient.quickChat.listMessages.query(
+          { organizationId, cursor },
+          {
+            context: { localAccessOwner: owner },
+          }
+        );
+        if (!isVisibleOwner() || pageResetRef.current !== resetGen) {
           return;
         }
         setOlderRows(prev => [...result.messages, ...prev]);
         nextCursorRef.current = result.nextCursor;
         setNextCursor(result.nextCursor);
       } catch {
-        // A stale page's failure is not the current window's failure.
-        if (pageResetRef.current !== resetGen) {
+        if (!isVisibleOwner() || pageResetRef.current !== resetGen) {
           return;
         }
         setOlderError({ kind: 'retryable' });
       } finally {
-        // Only the load that still owns the reset generation clears the lock:
-        // a stale load's finally must not clobber a newer load's
-        // `olderLoadingRef`/loading indicator.
-        if (pageResetRef.current === resetGen) {
+        if (isVisibleOwner() && pageResetRef.current === resetGen) {
           olderLoadingRef.current = false;
           setIsLoadingOlder(false);
         }
@@ -196,144 +166,202 @@ export function useQuickChat(model: string) {
   };
 
   const mergedRows = useMemo<QuickChatRow[]>(() => {
-    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- `listQuery.data` is undefined until the first page resolves
+    if (scopeKeyRef.current !== scopeKey || !ready) {
+      return [];
+    }
+    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- history is absent until its first response
     const serverRows = [...olderRows, ...(listQuery.data?.messages ?? [])];
     const turns: LocalTurn[] = localTurns.map(turn => ({
       clientId: turn.clientId,
       rows: turn.assistant ? [turn.user, turn.assistant] : [turn.user],
     }));
     return mergeQuickChatRows(serverRows, turns);
-  }, [olderRows, listQuery.data, localTurns]);
-
+  }, [olderRows, listQuery.data, localTurns, scopeKey, ready]);
   const messages = useMemo<StoredMessage[]>(
     () => mergedRows.map(row => adaptQuickChatRow(row, threadId ?? 'pending')),
     [mergedRows, threadId]
   );
 
-  function gatewayHistory(): QuickChatGatewayMessage[] {
-    return mergedRows.map(row => ({ role: row.role, content: row.content }));
-  }
-
-  async function appendTurn(clientId: string, userContent: string, assistantContent: string) {
-    // Defensive last line: a stream that completed just as the scope swapped
-    // out (or before hydration ever finished) must never persist to the wrong
-    // thread.
-    if (!orgLoaded) {
+  async function appendTurn(
+    receipt: AcceptedWorkReceipt,
+    turn: HookLocalTurn,
+    assistantContent: string
+  ) {
+    if (!isTransportOwner(owner)) {
+      // Account replacement safely cancels publication; never request a replacement token.
       return;
     }
+    const { clientId } = turn;
     const outgoing: { role: 'user' | 'assistant'; content: string; clientId?: string }[] = [
-      { role: 'user', content: userContent, clientId },
+      { role: 'user', content: turn.user.content, clientId },
     ];
     if (assistantContent.trim() !== '') {
       outgoing.push({ role: 'assistant', content: assistantContent });
     }
     try {
-      await trpcClient.quickChat.appendMessages.mutate({ organizationId, messages: outgoing });
-      void listQuery.refetch();
+      assertAcceptedWorkReceipt(receipt, {
+        kind: 'quick-chat-turn',
+        organizationId,
+        workId: clientId,
+      });
+      await trpcClient.quickChat.appendMessages.mutate(
+        { organizationId, messages: outgoing },
+        {
+          context: { localAccessOwner: owner, localAccessReceipt: receipt },
+        }
+      );
+      if (isVisibleOwner()) {
+        void listQuery.refetch();
+      }
     } catch {
-      // Keep the local rows; the merge keeps the turn visible on retry. The
-      // failure copy is localized and generic: the gateway's raw error strings
-      // are technical and never user-facing.
-      toast.error(i18n.t('quickChat.sendError'));
+      if (isVisibleOwner()) {
+        toast.error(i18n.t('quickChat.sendError'));
+      }
     }
   }
 
+  // eslint-disable-next-line typescript-eslint/promise-function-async -- return the dispatch promise, not the streamed answer
   function startStream(
-    clientId: string,
-    userRow: QuickChatRow,
-    history: QuickChatGatewayMessage[]
-  ) {
+    acceptedTurn: HookLocalTurn,
+    history: QuickChatGatewayMessage[],
+    admission: MobileActionAdmission
+  ): Promise<AcceptedWorkReceipt> {
+    const { clientId, user: userRow } = acceptedTurn;
     onStop();
     const controller = new AbortController();
-    abortRef.current = controller;
-    setIsStreaming(true);
-    const assistantId = `local-${clientId}-assistant`;
-    let assistantText = '';
-
-    const finishTurn = () => {
-      if (abortRef.current !== controller) {
-        return;
-      }
-      abortRef.current = null;
-      stopRef.current = null;
-      setIsStreaming(false);
-      void appendTurn(clientId, userRow.content, assistantText);
-    };
-    stopRef.current = () => {
-      controller.abort();
-      finishTurn();
-    };
-
-    void (async () => {
-      try {
-        const authToken = await getAuthTokenForRequest();
-        if (abortRef.current !== controller) {
+    // Use the Promise constructor on Hermes versions without withResolvers.
+    return new Promise<AcceptedWorkReceipt>((resolve, reject) => {
+      abortRef.current = controller;
+      setIsStreaming(true);
+      const assistantId = `local-${clientId}-assistant`;
+      let assistantText = '';
+      let receipt: AcceptedWorkReceipt | undefined = undefined;
+      let finished = false;
+      const isCurrentStream = () => abortRef.current === controller && isVisibleOwner();
+      const finishTurn = () => {
+        if (finished) {
           return;
         }
-        if (!authToken) {
-          throw new Error('Missing auth token');
+        finished = true;
+        if (isCurrentStream()) {
+          abortRef.current = null;
+          stopRef.current = null;
+          setIsStreaming(false);
         }
-        for await (const delta of streamQuickChatCompletion({
-          model,
-          messages: [...history, { role: 'user', content: userRow.content }],
-          organizationId,
-          authToken,
-          signal: controller.signal,
-        })) {
-          if (abortRef.current !== controller) {
-            return;
+        if (receipt) {
+          void appendTurn(receipt, acceptedTurn, assistantText);
+        } else {
+          reject(new LocalAccessDeniedError('stale'));
+          if (isVisibleOwner()) {
+            setLocalTurns(prev => prev.filter(turn => turn.clientId !== clientId));
           }
-          assistantText += delta;
-          const content = assistantText;
-          setLocalTurns(prev =>
-            prev.map(turn =>
-              turn.clientId === clientId
-                ? {
-                    ...turn,
-                    assistant: {
-                      id: assistantId,
-                      role: 'assistant',
-                      content,
-                      createdAt: userRow.createdAt,
-                    },
-                  }
-                : turn
-            )
-          );
         }
-      } catch {
-        if (!controller.signal.aborted) {
-          toast.error(i18n.t('quickChat.sendError'));
-        }
-      } finally {
+      };
+      stopRef.current = () => {
+        controller.abort();
         finishTurn();
-      }
-    })();
+      };
+
+      void (async () => {
+        try {
+          // Thread creation is a new foreground effect, not a passive mount side effect.
+          const thread = await trpcClient.quickChat.getOrCreateThread.mutate(
+            { organizationId },
+            {
+              signal: controller.signal,
+              context: { localAccessOwner: owner, localAccessAdmission: admission },
+            }
+          );
+          assertMobileActionAdmission(admission);
+          if (!isCurrentStream()) {
+            throw new LocalAccessDeniedError('stale');
+          }
+          setThreadId(thread.id);
+          const authToken = await getAuthTokenForRequest();
+          assertMobileActionAdmission(admission);
+          if (!authToken) {
+            throw new Error('Missing auth token');
+          }
+          for await (const delta of streamQuickChatCompletion({
+            model,
+            messages: [...history, { role: 'user', content: userRow.content }],
+            organizationId,
+            authToken,
+            admission,
+            turnId: clientId,
+            onDispatch: accepted => {
+              assertAcceptedWorkReceipt(accepted, {
+                kind: 'quick-chat-turn',
+                organizationId,
+                workId: clientId,
+              });
+              receipt = accepted;
+              resolve(accepted);
+            },
+            signal: controller.signal,
+          })) {
+            if (!isCurrentStream()) {
+              return;
+            }
+            assistantText += delta;
+            const content = assistantText;
+            setLocalTurns(prev =>
+              prev.map(turn =>
+                turn.clientId === clientId
+                  ? {
+                      ...turn,
+                      assistant: {
+                        id: assistantId,
+                        role: 'assistant',
+                        content,
+                        createdAt: userRow.createdAt,
+                      },
+                    }
+                  : turn
+              )
+            );
+          }
+        } catch (error) {
+          const denial = getLocalAccessDenial(error);
+          // Once dispatch resolves, a later stream failure cannot change that settlement.
+          const failure =
+            denial ??
+            (error instanceof Error
+              ? error
+              : new Error('Quick Chat dispatch failed', { cause: error }));
+          reject(failure);
+          if (isVisibleOwner() && !controller.signal.aborted && !denial) {
+            toast.error(i18n.t('quickChat.sendError'));
+          }
+        } finally {
+          finishTurn();
+        }
+      })();
+    });
   }
 
-  function onSend(text: string): void {
-    if (!orgLoaded) {
-      // The org scope has not hydrated. Accepting would persist to the personal
-      // thread before the stored org swaps in. Throw so the composer preserves
-      // the draft (a plain return would clear it).
-      throw new Error('Organization scope not loaded');
+  // eslint-disable-next-line typescript-eslint/promise-function-async -- preserve synchronous entry denial and expose final dispatch settlement
+  function onSend(text: string): Promise<AcceptedWorkReceipt> {
+    if (!ready) {
+      throw new LocalAccessDeniedError('context');
     }
     if (!model) {
       toast.error(i18n.t('quickChat.catalogRetry'));
       throw new Error('No model selected');
     }
+    const admission = captureMobileActionAdmission(owner, organizationId);
     const clientId = ulid();
-    const now = new Date().toISOString();
     const userRow: QuickChatRow = {
       id: `local-${clientId}`,
       role: 'user',
       content: text,
-      createdAt: now,
+      createdAt: new Date().toISOString(),
       clientId,
     };
-    const history = gatewayHistory();
-    setLocalTurns(prev => [...prev, { clientId, user: userRow, assistant: null }]);
-    startStream(clientId, userRow, history);
+    const history = mergedRows.map(row => ({ role: row.role, content: row.content }));
+    const turn = { clientId, user: userRow, assistant: null };
+    setLocalTurns(prev => [...prev, turn]);
+    return startStream(turn, history, admission);
   }
 
   function onStop(): void {
@@ -341,10 +369,9 @@ export function useQuickChat(model: string) {
   }
 
   return {
-    threadId,
+    threadId: scopeKeyRef.current === scopeKey ? threadId : null,
     messages,
-    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- the query is disabled while the org scope hydrates, but the screen must still treat that window as loading
-    isLoading: listQuery.isLoading || !orgLoaded,
+    isLoading: listQuery.isLoading || !ready,
     isError: listQuery.isError,
     error: listQuery.error,
     refetch: listQuery.refetch,

--- a/apps/mobile/src/lib/active-sessions-live-sync-mount.tsx
+++ b/apps/mobile/src/lib/active-sessions-live-sync-mount.tsx
@@ -48,7 +48,13 @@ function useActiveSessionsLiveSync(): void {
     if (!isLoaded) {
       return undefined;
     }
-    const sync = new ActiveSessionsLiveSync({ connection, queryClient, queryKey, queryFn });
+    const sync = new ActiveSessionsLiveSync({
+      connection,
+      queryClient,
+      queryKey,
+      queryFn,
+      owner: connection.owner,
+    });
     return sync.attach();
   }, [connection, isLoaded, queryClient, queryFn, queryKey]);
 }

--- a/apps/mobile/src/lib/active-sessions-live-sync.attention.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.attention.test.ts
@@ -7,10 +7,10 @@ import {
   makeFakeQueryClient,
   makeQueryFn,
   QUERY_KEY,
-  setupTimers,
+  setupLiveSync,
 } from '@/lib/active-sessions-live-sync.test-helpers';
 
-setupTimers();
+setupLiveSync();
 
 describe('ActiveSessionsLiveSync — session.status.updated', () => {
   it('applies the lightweight sessionId payload and clears attention', async () => {
@@ -21,6 +21,7 @@ describe('ActiveSessionsLiveSync — session.status.updated', () => {
     });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn: makeQueryFn(),
@@ -49,6 +50,7 @@ describe('ActiveSessionsLiveSync — session.status.updated', () => {
     });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn: makeQueryFn(),
@@ -92,6 +94,7 @@ describe('ActiveSessionsLiveSync — session.status.updated', () => {
     setQueryDataCalls.mockClear();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn: makeQueryFn(),
@@ -114,6 +117,7 @@ describe('ActiveSessionsLiveSync — session.status.updated', () => {
     });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn: makeQueryFn(),

--- a/apps/mobile/src/lib/active-sessions-live-sync.departure.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.departure.test.ts
@@ -7,11 +7,11 @@ import {
   makeFakeQueryClient,
   makeQueryFn,
   QUERY_KEY,
-  setupTimers,
+  setupLiveSync,
   type SystemEvent,
 } from '@/lib/active-sessions-live-sync.test-helpers';
 
-setupTimers();
+setupLiveSync();
 
 describe('ActiveSessionsLiveSync — departure refetch hook still works', () => {
   // The departure-triggered stored refetch lives in use-agent-sessions
@@ -32,6 +32,7 @@ describe('ActiveSessionsLiveSync — departure refetch hook still works', () => 
     });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn: makeQueryFn(),

--- a/apps/mobile/src/lib/active-sessions-live-sync.enrichment.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.enrichment.test.ts
@@ -8,12 +8,12 @@ import {
   makeFakeQueryClient,
   makeQueryFn,
   QUERY_KEY,
+  setupLiveSync,
   setupNow,
-  setupTimers,
   type SystemEvent,
 } from '@/lib/active-sessions-live-sync.test-helpers';
 
-setupTimers();
+setupLiveSync();
 
 describe('ActiveSessionsLiveSync — enrichment retry policy', () => {
   it('schedules enrichment when the cache has an unenriched live id', async () => {
@@ -23,6 +23,7 @@ describe('ActiveSessionsLiveSync — enrichment retry policy', () => {
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -49,6 +50,7 @@ describe('ActiveSessionsLiveSync — enrichment retry policy', () => {
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -82,32 +84,6 @@ describe('ActiveSessionsLiveSync — enrichment retry policy', () => {
     expect(queryFn).toHaveBeenCalledTimes(1);
   });
 
-  it('does NOT schedule enrichment when every row is already enriched', async () => {
-    const conn = makeConnection();
-    const qc = makeFakeQueryClient();
-    qc.__setCached({ sessions: [makeCached({ id: 'a', createdOnPlatform: 'cli' })] });
-    const queryFn = makeQueryFn();
-    const sync = new ActiveSessionsLiveSync({
-      connection: conn,
-      queryClient: qc,
-      queryKey: QUERY_KEY,
-      queryFn,
-    });
-    sync.attach();
-    const heartbeat: SystemEvent = {
-      event: 'sessions.heartbeat',
-      data: {
-        connectionId: 'c1',
-        sessions: [{ id: 'a', status: 'running', title: 'A' }],
-      },
-    };
-    conn.__fireSystem(heartbeat);
-    await sync.getWriteQueue();
-    await sync.getFetchQueue();
-    expect(sync.getPendingReasons().has('enrichment')).toBe(false);
-    expect(queryFn).toHaveBeenCalledTimes(0);
-  });
-
   it('rate-limits enrichment retries ≥10s apart', async () => {
     const conn = makeConnection();
     const qc = makeFakeQueryClient();
@@ -116,6 +92,7 @@ describe('ActiveSessionsLiveSync — enrichment retry policy', () => {
     const { now, advance } = setupNow();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -170,6 +147,7 @@ describe('ActiveSessionsLiveSync — enrichment retry policy', () => {
     const { now, advance } = setupNow();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -212,6 +190,7 @@ describe('ActiveSessionsLiveSync — enrichment retry policy', () => {
     const { now, advance } = setupNow();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -259,6 +238,7 @@ describe('ActiveSessionsLiveSync — enrichment retry policy', () => {
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,

--- a/apps/mobile/src/lib/active-sessions-live-sync.manual-refresh.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.manual-refresh.test.ts
@@ -7,12 +7,12 @@ import {
   makeFakeQueryClient,
   makeQueryFn,
   QUERY_KEY,
-  setupTimers,
+  setupLiveSync,
   type SystemEvent,
 } from '@/lib/active-sessions-live-sync.test-helpers';
 import { refreshActiveSessionsNow } from '@/lib/active-sessions-live-sync';
 
-setupTimers();
+setupLiveSync();
 
 let sync: ActiveSessionsLiveSync | null = null;
 
@@ -31,6 +31,7 @@ describe('ActiveSessionsLiveSync — manual refresh', () => {
     const queryFn = makeQueryFn();
     sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -54,6 +55,7 @@ describe('ActiveSessionsLiveSync — manual refresh', () => {
     const queryFn = makeQueryFn();
     sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -82,6 +84,7 @@ describe('ActiveSessionsLiveSync — manual refresh', () => {
     const queryFn = makeQueryFn();
     sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -121,6 +124,7 @@ describe('ActiveSessionsLiveSync — manual refresh', () => {
     const queryFn = makeQueryFn();
     sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -161,6 +165,7 @@ describe('ActiveSessionsLiveSync — manual refresh', () => {
     const queryFn = makeQueryFn();
     sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,

--- a/apps/mobile/src/lib/active-sessions-live-sync.ownership.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.ownership.test.ts
@@ -1,0 +1,117 @@
+import { QueryClient } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { bumpAuthEpoch } from '@/lib/auth/auth-epoch';
+import { beginAuthenticatedOwner, confirmAuthenticatedOwner } from '@/lib/context-scope';
+import { lockLocalAccess } from '@/lib/local-access';
+import { ActiveSessionsLiveSync } from './active-sessions-live-sync';
+import {
+  type CachedActiveSessionsData,
+  deferred,
+  makeCached,
+  makeConnection,
+  QUERY_KEY,
+} from './active-sessions-live-sync.test-helpers';
+
+const releases: (() => void)[] = [];
+beforeEach(() => {
+  confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'A');
+});
+afterEach(() => {
+  for (const release of releases.splice(0)) {
+    release();
+  }
+});
+function replace() {
+  bumpAuthEpoch();
+  confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'B');
+}
+function setup(
+  queryFn = async (): Promise<CachedActiveSessionsData> => {
+    await Promise.resolve();
+    return { sessions: [] };
+  },
+  connection = makeConnection()
+) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const sync = new ActiveSessionsLiveSync({
+    connection,
+    queryClient,
+    queryKey: QUERY_KEY,
+    queryFn,
+    owner: connection.owner,
+  });
+  releases.push(sync.attach(), () => {
+    queryClient.clear();
+  });
+  return { connection, queryClient, sync };
+}
+const heartbeat = {
+  event: 'sessions.heartbeat' as const,
+  data: { connectionId: 'cli-A', sessions: [{ id: 'A', status: 'running', title: 'late A' }] },
+};
+
+describe('active session publication ownership', () => {
+  it('cannot give a retained A connection B authority when live sync mounts after replacement', async () => {
+    const connection = makeConnection();
+    connection.__setConnected(true);
+    releases.push(connection.retain());
+    replace();
+
+    const h = setup(undefined, connection);
+    const replacement = { sessions: [makeCached({ id: 'B', title: 'B cache' })] };
+    h.queryClient.setQueryData(QUERY_KEY, replacement);
+    connection.__fireSystem(heartbeat);
+    await h.sync.getWriteQueue();
+
+    expect(h.queryClient.getQueryData(QUERY_KEY)).toEqual(replacement);
+    expect(await h.sync.refreshNow()).toBe(false);
+  });
+  it('drops an A write held in cancelQueries and ignores late A events after replacement', async () => {
+    const h = setup();
+    const cancellation = deferred<undefined>();
+    const cancel = vi.spyOn(h.queryClient, 'cancelQueries').mockImplementationOnce(async () => {
+      await cancellation.promise;
+    });
+    h.connection.__fireSystem(heartbeat);
+    await vi.waitFor(() => {
+      expect(cancel).toHaveBeenCalled();
+    });
+    replace();
+    const replacement = { sessions: [makeCached({ id: 'B', title: 'B cache' })] };
+    h.queryClient.setQueryData(QUERY_KEY, replacement);
+    cancellation.resolve(undefined);
+    h.connection.__fireSystem(heartbeat);
+    await h.sync.getWriteQueue();
+    expect(h.queryClient.getQueryData(QUERY_KEY)).toEqual(replacement);
+    expect(await h.sync.refreshNow()).toBe(false);
+  });
+  it('cannot refill the shared cache from an A fetch after B has published', async () => {
+    const page = deferred<CachedActiveSessionsData>();
+    const h = setup(async () => {
+      const result = await page.promise;
+      return result;
+    });
+    const refresh = h.sync.refreshNow();
+    await h.sync.getFetchQueue();
+    replace();
+    const replacement = { sessions: [makeCached({ id: 'B', title: 'B cache' })] };
+    h.queryClient.setQueryData(QUERY_KEY, replacement);
+    page.resolve({ sessions: [makeCached({ id: 'A', title: 'late A' })] });
+    await refresh;
+    expect(h.queryClient.getQueryData(QUERY_KEY)).toEqual(replacement);
+  });
+  it('keeps same-owner live writes and refresh completion independent from the local lock', async () => {
+    const fetched = { sessions: [makeCached({ id: 'A', title: 'accepted server row' })] };
+    const h = setup(async () => {
+      await Promise.resolve();
+      return fetched;
+    });
+    lockLocalAccess();
+    h.connection.__fireSystem(heartbeat);
+    await h.sync.getWriteQueue();
+    await h.sync.refreshNow();
+    expect(h.queryClient.getQueryData(QUERY_KEY)).toEqual(fetched);
+    expect(h.sync.getPendingReasons()).toEqual(new Set());
+  });
+});

--- a/apps/mobile/src/lib/active-sessions-live-sync.pending.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.pending.test.ts
@@ -7,12 +7,12 @@ import {
   makeFakeQueryClient,
   makeQueryFn,
   QUERY_KEY,
+  setupLiveSync,
   setupNow,
-  setupTimers,
   type SystemEvent,
 } from '@/lib/active-sessions-live-sync.test-helpers';
 
-setupTimers();
+setupLiveSync();
 
 describe('ActiveSessionsLiveSync — pending-reason semantics', () => {
   it('enrichment clears only when its own fetch completes', async () => {
@@ -21,6 +21,7 @@ describe('ActiveSessionsLiveSync — pending-reason semantics', () => {
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -40,6 +41,7 @@ describe('ActiveSessionsLiveSync — pending-reason semantics', () => {
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -82,6 +84,7 @@ describe('ActiveSessionsLiveSync — pending-reason semantics', () => {
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -106,6 +109,7 @@ describe('ActiveSessionsLiveSync — pending-reason semantics', () => {
     const { now, advance } = setupNow();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -148,6 +152,7 @@ describe('ActiveSessionsLiveSync — pending-reason semantics', () => {
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -171,6 +176,7 @@ describe('ActiveSessionsLiveSync — pending-reason semantics', () => {
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -198,6 +204,7 @@ describe('ActiveSessionsLiveSync — pending-reason semantics', () => {
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -222,5 +229,34 @@ describe('ActiveSessionsLiveSync — pending-reason semantics', () => {
     qc.__triggerFetchResolve({ sessions: [] });
     await sync.getFetchCompletion();
     expect(sync.getPendingReasons().has('reconnect')).toBe(false);
+  });
+});
+
+describe('ActiveSessionsLiveSync — enrichment retry policy', () => {
+  it('does NOT schedule enrichment when every row is already enriched', async () => {
+    const conn = makeConnection();
+    const qc = makeFakeQueryClient();
+    qc.__setCached({ sessions: [makeCached({ id: 'a', createdOnPlatform: 'cli' })] });
+    const queryFn = makeQueryFn();
+    const sync = new ActiveSessionsLiveSync({
+      connection: conn,
+      owner: conn.owner,
+      queryClient: qc,
+      queryKey: QUERY_KEY,
+      queryFn,
+    });
+    sync.attach();
+    const heartbeat: SystemEvent = {
+      event: 'sessions.heartbeat',
+      data: {
+        connectionId: 'c1',
+        sessions: [{ id: 'a', status: 'running', title: 'A' }],
+      },
+    };
+    conn.__fireSystem(heartbeat);
+    await sync.getWriteQueue();
+    await sync.getFetchQueue();
+    expect(sync.getPendingReasons().has('enrichment')).toBe(false);
+    expect(queryFn).toHaveBeenCalledTimes(0);
   });
 });

--- a/apps/mobile/src/lib/active-sessions-live-sync.race.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.race.test.ts
@@ -9,11 +9,11 @@ import {
   makeFakeQueryClient,
   makeQueryFn,
   QUERY_KEY,
-  setupTimers,
+  setupLiveSync,
   type SystemEvent,
 } from '@/lib/active-sessions-live-sync.test-helpers';
 
-setupTimers();
+setupLiveSync();
 
 describe('ActiveSessionsLiveSync — race tests', () => {
   it('heartbeat wins over an in-flight fetch (cache reflects heartbeat)', async () => {
@@ -25,6 +25,7 @@ describe('ActiveSessionsLiveSync — race tests', () => {
     });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -62,6 +63,7 @@ describe('ActiveSessionsLiveSync — race tests', () => {
     });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -103,6 +105,7 @@ describe('ActiveSessionsLiveSync — race tests', () => {
     });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,

--- a/apps/mobile/src/lib/active-sessions-live-sync.reconnect.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.reconnect.test.ts
@@ -6,10 +6,11 @@ import {
   makeFakeQueryClient,
   makeQueryFn,
   QUERY_KEY,
-  setupTimers,
+  setupLiveSync,
+  type SystemEvent,
 } from '@/lib/active-sessions-live-sync.test-helpers';
 
-setupTimers();
+setupLiveSync();
 
 describe('ActiveSessionsLiveSync — reconnect (onConnectionChange rising edge)', () => {
   it('triggers exactly one refresh per false → true transition', async () => {
@@ -19,6 +20,7 @@ describe('ActiveSessionsLiveSync — reconnect (onConnectionChange rising edge)'
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -52,6 +54,7 @@ describe('ActiveSessionsLiveSync — reconnect (onConnectionChange rising edge)'
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -81,6 +84,7 @@ describe('ActiveSessionsLiveSync — scheduled fetch invokes the queryFn', () =>
     const queryFn = makeQueryFn({ sessions: [] });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -92,5 +96,26 @@ describe('ActiveSessionsLiveSync — scheduled fetch invokes the queryFn', () =>
     qc.__triggerFetchResolve({ sessions: [] });
     await sync.getFetchCompletion();
     expect(queryFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ActiveSessionsLiveSync — cli.connected', () => {
+  it('ignores a malformed payload', async () => {
+    const conn = makeConnection();
+    const qc = makeFakeQueryClient();
+    const queryFn = makeQueryFn();
+    const sync = new ActiveSessionsLiveSync({
+      connection: conn,
+      owner: conn.owner,
+      queryClient: qc,
+      queryKey: QUERY_KEY,
+      queryFn,
+    });
+    sync.attach();
+    const event: SystemEvent = { event: 'cli.connected', data: { connectionId: 42 } };
+    conn.__fireSystem(event);
+    await Promise.resolve();
+    expect(sync.getPendingReasons()).toEqual(new Set());
+    expect(queryFn).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/src/lib/active-sessions-live-sync.test-helpers.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.test-helpers.ts
@@ -11,6 +11,12 @@ import {
   type CachedActiveSessionsData,
 } from '@/lib/active-sessions-live';
 import { type UserWebSystemEvent } from '@kilocode/cloud-agent-sdk';
+import {
+  type AuthenticatedOwner,
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+  getAuthenticatedOwner,
+} from '@/lib/context-scope';
 
 export type { CachedActiveSessionsData };
 
@@ -18,6 +24,7 @@ type SystemEvent = UserWebSystemEvent;
 export type { SystemEvent };
 
 type FakeConnection = LiveSyncConnection & {
+  readonly owner: AuthenticatedOwner;
   __setConnected: (value: boolean) => void;
   __fireSystem: (event: SystemEvent) => void;
   __fireConnection: (value: boolean) => void;
@@ -45,6 +52,7 @@ export function makeConnection(over: Partial<LiveSyncConnection> = {}): FakeConn
     ...over,
   };
   return Object.assign(base, {
+    owner: getAuthenticatedOwner(),
     __setConnected(value: boolean) {
       connected = value;
     },
@@ -139,14 +147,16 @@ export function makeFakeQueryClient(
         staleTime?: number;
       }): Promise<CachedActiveSessionsData> => {
         fetchQueryCalls += 1;
-        // Drive the supplied queryFn so tests can assert it was invoked,
-        // but let the test control the resolved value via __triggerFetchResolve.
-        // QueryFunction requires a context arg; the fake only needs to observe the call.
-        await (opts.queryFn as unknown as () => Promise<unknown>)();
+        // Register cancellation before the guarded queryFn yields. Publish only
+        // after both the queryFn and the test-controlled response settle.
         const d = deferred<CachedActiveSessionsData>();
         pendingFetch = d;
         try {
-          const result = await d.promise;
+          const [, result] = await Promise.all([
+            (opts.queryFn as unknown as () => Promise<unknown>)(),
+            d.promise,
+          ]);
+          cache = result;
           return result;
         } finally {
           if (pendingFetch === d) {
@@ -164,7 +174,6 @@ export function makeFakeQueryClient(
       if (pendingFetch) {
         const d = pendingFetch;
         pendingFetch = null;
-        cache = data;
         d.resolve(data);
       }
     },
@@ -224,11 +233,13 @@ export function setupNow() {
   };
 }
 
-export function setupTimers(): void {
+export function setupLiveSync(): void {
   beforeEach(() => {
     vi.useRealTimers();
+    confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'A');
   });
   afterEach(() => {
+    beginAuthenticatedOwner();
     vi.useRealTimers();
   });
 }

--- a/apps/mobile/src/lib/active-sessions-live-sync.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.test.ts
@@ -8,11 +8,11 @@ import {
   makeFakeQueryClient,
   makeQueryFn,
   QUERY_KEY,
-  setupTimers,
+  setupLiveSync,
   type SystemEvent,
 } from '@/lib/active-sessions-live-sync.test-helpers';
 
-setupTimers();
+setupLiveSync();
 
 describe('ActiveSessionsLiveSync — attach / detach', () => {
   it('retains the connection on attach and releases on detach', () => {
@@ -21,6 +21,7 @@ describe('ActiveSessionsLiveSync — attach / detach', () => {
     const qc = makeFakeQueryClient();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn: makeQueryFn(),
@@ -38,6 +39,7 @@ describe('ActiveSessionsLiveSync — attach / detach', () => {
     const qc = makeFakeQueryClient();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn: makeQueryFn(),
@@ -75,6 +77,7 @@ describe('ActiveSessionsLiveSync — attach / detach', () => {
     });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn: makeQueryFn(),
@@ -131,6 +134,7 @@ describe('ActiveSessionsLiveSync — attach / detach', () => {
     const qc = makeFakeQueryClient();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn: makeQueryFn(),
@@ -155,6 +159,7 @@ describe('ActiveSessionsLiveSync — sessions.list', () => {
     qc.__setCached({ sessions: [makeCached({ id: 'old' })] });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn: makeQueryFn(),
@@ -188,6 +193,7 @@ describe('ActiveSessionsLiveSync — sessions.heartbeat', () => {
     qc.__setCached({ sessions: [makeCached({ id: 'x', connectionId: 'c2' })] });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn: makeQueryFn(),
@@ -216,6 +222,7 @@ describe('ActiveSessionsLiveSync — sessions.heartbeat', () => {
     });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn: makeQueryFn(),
@@ -247,6 +254,7 @@ describe('ActiveSessionsLiveSync — cli.disconnected', () => {
     const queryFn = makeQueryFn({ sessions: [] });
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -275,6 +283,7 @@ describe('ActiveSessionsLiveSync — cli.connected', () => {
     const queryFn = makeQueryFn();
     const sync = new ActiveSessionsLiveSync({
       connection: conn,
+      owner: conn.owner,
       queryClient: qc,
       queryKey: QUERY_KEY,
       queryFn,
@@ -288,23 +297,5 @@ describe('ActiveSessionsLiveSync — cli.connected', () => {
     await sync.getFetchQueue();
     expect(setQueryDataCalls).not.toHaveBeenCalled();
     expect(queryFn).toHaveBeenCalledTimes(1);
-  });
-
-  it('ignores a malformed payload', async () => {
-    const conn = makeConnection();
-    const qc = makeFakeQueryClient();
-    const queryFn = makeQueryFn();
-    const sync = new ActiveSessionsLiveSync({
-      connection: conn,
-      queryClient: qc,
-      queryKey: QUERY_KEY,
-      queryFn,
-    });
-    sync.attach();
-    const event: SystemEvent = { event: 'cli.connected', data: { connectionId: 42 } };
-    conn.__fireSystem(event);
-    await Promise.resolve();
-    expect(sync.getPendingReasons()).toEqual(new Set());
-    expect(queryFn).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/src/lib/active-sessions-live-sync.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- the serialized loading state machine retains its existing attachment and refresh contracts */
 /**
  * App-level owner for active-sessions live-sync: retains UserWebConnection,
  * applies onSystemEvent payloads to trpc.activeSessions.list via a serialized
@@ -16,6 +17,8 @@ import {
 } from './active-sessions-live';
 
 import { type UserWebConnection, type UserWebSystemEvent } from '@kilocode/cloud-agent-sdk';
+import { type AuthenticatedOwner, subscribeAuthenticatedOwner } from '@/lib/context-scope';
+import { assertTransportOwner, isTransportOwner } from '@/lib/local-access-transport';
 
 const ENRICHMENT_RETRY_MIN_INTERVAL_MS = 10_000;
 
@@ -41,6 +44,7 @@ type CreateLiveSyncOptions = {
   queryClient: LiveSyncQueryClient;
   queryKey: QueryKey;
   queryFn: QueryFunction<CachedActiveSessionsData>;
+  readonly owner: AuthenticatedOwner;
   now?: () => number;
 };
 
@@ -51,6 +55,8 @@ export class ActiveSessionsLiveSync {
   private readonly queryKey: QueryKey;
   private readonly queryFn: QueryFunction<CachedActiveSessionsData>;
   private readonly now: () => number;
+  private readonly owner: AuthenticatedOwner;
+  private ownerUnsubscribe: (() => void) | null = null;
 
   // eslint-disable-next-line promise/prefer-await-to-then
   private writeQueue: Promise<void> = Promise.resolve();
@@ -78,7 +84,13 @@ export class ActiveSessionsLiveSync {
     this.connection = options.connection;
     this.queryClient = options.queryClient;
     this.queryKey = options.queryKey;
-    this.queryFn = options.queryFn;
+    this.owner = options.owner;
+    this.queryFn = async context => {
+      assertTransportOwner(this.owner);
+      const result = await options.queryFn(context);
+      assertTransportOwner(this.owner);
+      return result;
+    };
     this.now = options.now ?? (() => Date.now());
     this.lastConnectedState = this.connection.isConnected();
   }
@@ -100,17 +112,30 @@ export class ActiveSessionsLiveSync {
     this.connectionListenerUnsubscribe = this.connection.onConnectionChange(connected => {
       this.handleConnectionChange(connected);
     });
+    this.ownerUnsubscribe = subscribeAuthenticatedOwner(() => {
+      if (!isTransportOwner(this.owner)) {
+        this.detach();
+      }
+    });
+    if (!isTransportOwner(this.owner)) {
+      this.detach();
+    }
     return () => {
       this.detach();
     };
   }
 
   detach(): void {
+    if (this.releaseRetain === null) {
+      return;
+    }
+    this.ownerUnsubscribe?.();
+    this.ownerUnsubscribe = null;
     this.attachmentEpoch += 1;
     this.pendingReasons.clear();
     this.systemListenerUnsubscribe?.();
     this.connectionListenerUnsubscribe?.();
-    this.releaseRetain?.();
+    this.releaseRetain();
     this.systemListenerUnsubscribe = null;
     this.connectionListenerUnsubscribe = null;
     this.releaseRetain = null;
@@ -215,7 +240,7 @@ export class ActiveSessionsLiveSync {
     // Serialized cancel+setQueryData; never awaits network.
     this.writeQueue = (async () => {
       await this.writeQueue;
-      if (attachmentEpoch !== this.attachmentEpoch) {
+      if (attachmentEpoch !== this.attachmentEpoch || !isTransportOwner(this.owner)) {
         return;
       }
       // Cancel in-flight fetch so stale results cannot overwrite.
@@ -223,7 +248,7 @@ export class ActiveSessionsLiveSync {
         this.inFlightFetchCanceled = true;
       }
       await this.queryClient.cancelQueries({ queryKey: this.queryKey });
-      if (attachmentEpoch !== this.attachmentEpoch) {
+      if (attachmentEpoch !== this.attachmentEpoch || !isTransportOwner(this.owner)) {
         return;
       }
       this.queryClient.setQueryData<CachedActiveSessionsData>(this.queryKey, current => {
@@ -295,7 +320,11 @@ export class ActiveSessionsLiveSync {
   }
 
   private async processFetchQueue(attachmentEpoch: number): Promise<void> {
-    if (attachmentEpoch !== this.attachmentEpoch || this.pendingReasons.size === 0) {
+    if (
+      attachmentEpoch !== this.attachmentEpoch ||
+      !isTransportOwner(this.owner) ||
+      this.pendingReasons.size === 0
+    ) {
       return;
     }
     if (this.isFetchInFlight) {
@@ -308,7 +337,7 @@ export class ActiveSessionsLiveSync {
     let success = false;
     try {
       await this.queryClient.cancelQueries({ queryKey: this.queryKey });
-      if (attachmentEpoch === this.attachmentEpoch) {
+      if (attachmentEpoch === this.attachmentEpoch && isTransportOwner(this.owner)) {
         // staleTime:0 forces a network call after setQueryData.
         const fetchPromise = this.queryClient.fetchQuery({
           queryKey: this.queryKey,
@@ -324,7 +353,7 @@ export class ActiveSessionsLiveSync {
     } finally {
       this.isFetchInFlight = false;
     }
-    if (attachmentEpoch !== this.attachmentEpoch) {
+    if (attachmentEpoch !== this.attachmentEpoch || !isTransportOwner(this.owner)) {
       this.inFlightReasons = null;
       this.notifyFetchCompletion();
       return;

--- a/apps/mobile/src/lib/local-access-transport.test.ts
+++ b/apps/mobile/src/lib/local-access-transport.test.ts
@@ -1,0 +1,373 @@
+/* eslint-disable max-lines -- receipt cases and the syntax-aware inventory share this boundary */
+/* eslint-disable import/no-nodejs-modules -- this CI inventory reads source files, never native runtime data */
+import { readdirSync, readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import ts from 'typescript';
+import { type Operation } from '@trpc/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { bumpAuthEpoch, currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { setSignOutActive } from '@/lib/auth/sign-out-state';
+import {
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+  getAuthenticatedOwner,
+} from '@/lib/context-scope';
+import {
+  initializeLocalAccess,
+  LocalAccessDeniedError,
+  lockLocalAccess,
+  requestLocalAccess,
+  setLocalAccessContextReady,
+  setLocalAccessOwner,
+} from './local-access';
+import {
+  assertAcceptedWorkReceipt,
+  captureMobileActionAdmission,
+  captureTransportOperation,
+  dispatchAcceptedWork,
+} from './local-access-transport';
+
+let stop: (() => void) | undefined = undefined;
+beforeEach(async () => {
+  setSignOutActive(false);
+  confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'A');
+  stop = initializeLocalAccess({
+    storage: {
+      read: vi.fn().mockResolvedValue({ status: 'present', enabled: true }),
+      write: vi.fn().mockResolvedValue('committed'),
+    },
+    authenticate: vi.fn().mockResolvedValue({ status: 'authenticated' }),
+    lifecycle: { getCurrentState: () => 'active', subscribe: () => () => undefined },
+  });
+  await setLocalAccessOwner('A', currentAuthEpoch());
+  setLocalAccessContextReady(true);
+  await requestLocalAccess('unlock', true);
+});
+afterEach(() => {
+  stop?.();
+  setSignOutActive(false);
+});
+function mutation(path: string, input?: unknown, context: Operation['context'] = {}): Operation {
+  return { id: 1, type: 'mutation', path, input, context, signal: undefined };
+}
+function turn(organizationId: string | null = 'org-A') {
+  const effects: string[] = [];
+  const admitted = captureMobileActionAdmission(getAuthenticatedOwner(), organizationId);
+  const dispatched = dispatchAcceptedWork(
+    admitted,
+    { kind: 'quick-chat-turn', workId: 'turn-1' },
+    () => {
+      effects.push('gateway accepted');
+      return 'accepted';
+    }
+  );
+  expect(effects).toEqual(['gateway accepted']);
+  return dispatched.receipt;
+}
+function append(receipt: unknown, organizationId: string | null = 'org-A', clientId = 'turn-1') {
+  return mutation(
+    'quickChat.appendMessages',
+    { organizationId, messages: [{ role: 'user', content: 'hi', clientId }] },
+    { localAccessReceipt: receipt }
+  );
+}
+
+describe('final transport admission', () => {
+  it.each([
+    'activeSessions.createWebTicket',
+    'user.registerPushToken',
+    'user.unregisterPushToken',
+    'user.revokeCurrentDeviceSession',
+    'kiloPass.completeAppStorePurchase',
+  ])('preserves owner-fenced %s while locked', path => {
+    lockLocalAccess();
+    const admitted = captureTransportOperation(mutation(path));
+    expect(() => {
+      admitted.assertDispatch();
+    }).not.toThrow();
+    bumpAuthEpoch();
+    confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'B');
+    expect(() => {
+      admitted.assertDispatch();
+    }).toThrow(LocalAccessDeniedError);
+  });
+  it('permits logout cleanup, but not registration, during teardown', () => {
+    setSignOutActive(true);
+    expect(() => {
+      captureTransportOperation(mutation('user.unregisterPushToken')).assertDispatch();
+    }).not.toThrow();
+    expect(() => {
+      captureTransportOperation(mutation('user.revokeCurrentDeviceSession')).assertDispatch();
+    }).not.toThrow();
+    expect(() => captureTransportOperation(mutation('user.registerPushToken'))).toThrow(
+      LocalAccessDeniedError
+    );
+  });
+  it.each(['quickChat.getOrCreateThread', 'new.unclassifiedMutation'])(
+    'denies new foreground %s and never renews an old action',
+    async path => {
+      const captured = captureTransportOperation(mutation(path, {}));
+      lockLocalAccess();
+      expect(() => captureTransportOperation(mutation(path, {}))).toThrow(LocalAccessDeniedError);
+      expect(() => {
+        captured.assertDispatch();
+      }).toThrow(LocalAccessDeniedError);
+      await requestLocalAccess('unlock');
+      expect(() => {
+        captured.assertDispatch();
+      }).toThrow(LocalAccessDeniedError);
+    }
+  );
+  it('fences the original credential generation even when the user and auth epoch stay unchanged', () => {
+    const operation = captureTransportOperation(mutation('cloudAgentNext.sendMessage', {}));
+    confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'A');
+    expect(() => {
+      operation.assertDispatch();
+    }).toThrow(LocalAccessDeniedError);
+  });
+  it('allows accepted completion after lock and context readiness changes', () => {
+    const receipt = turn();
+    lockLocalAccess();
+    setLocalAccessContextReady(false);
+    expect(() => {
+      captureTransportOperation(append(receipt)).assertDispatch();
+    }).not.toThrow();
+  });
+  it.each(['missing', 'forged', 'organization', 'turn', 'account'] as const)(
+    'rejects %s completion proof',
+    kind => {
+      const receipt = turn();
+      let operation = append(receipt);
+      if (kind === 'missing') {
+        operation = append(undefined);
+      }
+      if (kind === 'forged') {
+        operation = append({ ...receipt });
+      }
+      if (kind === 'organization') {
+        operation = append(receipt, 'org-B');
+      }
+      if (kind === 'turn') {
+        operation = append(receipt, 'org-A', 'turn-2');
+      }
+      if (kind === 'account') {
+        bumpAuthEpoch();
+        confirmAuthenticatedOwner(beginAuthenticatedOwner(), 'B');
+      }
+      expect(() => captureTransportOperation(operation)).toThrow(LocalAccessDeniedError);
+    }
+  );
+  it('never issues completion proof when final dispatch is denied', () => {
+    const admission = captureMobileActionAdmission(getAuthenticatedOwner(), null);
+    const effects: string[] = [];
+    lockLocalAccess();
+    expect(() =>
+      dispatchAcceptedWork(admission, { kind: 'quick-chat-turn', workId: 'turn-1' }, () =>
+        effects.push('sent')
+      )
+    ).toThrow(LocalAccessDeniedError);
+    expect(effects).toEqual([]);
+  });
+  it('rejects a Quick Chat receipt for paid purchase completion', () => {
+    const receipt = turn(null);
+    expect(() =>
+      captureTransportOperation(
+        mutation('kiloPass.completeAppStorePurchase', {}, { localAccessReceipt: receipt })
+      )
+    ).toThrow(LocalAccessDeniedError);
+    expect(() =>
+      assertAcceptedWorkReceipt(receipt, { kind: 'app-store-purchase', organizationId: null })
+    ).toThrow(LocalAccessDeniedError);
+  });
+  it('allows an original paid receipt while locked and rejects a copied receipt', () => {
+    const admission = captureMobileActionAdmission(getAuthenticatedOwner(), null);
+    const { receipt } = dispatchAcceptedWork(
+      admission,
+      { kind: 'app-store-purchase', workId: 'paid-1' },
+      () => 'StoreKit dispatch'
+    );
+    lockLocalAccess();
+    expect(() => {
+      captureTransportOperation(
+        mutation('kiloPass.completeAppStorePurchase', {}, { localAccessReceipt: receipt })
+      ).assertDispatch();
+    }).not.toThrow();
+    expect(() =>
+      captureTransportOperation(
+        mutation('kiloPass.completeAppStorePurchase', {}, { localAccessReceipt: { ...receipt } })
+      )
+    ).toThrow(LocalAccessDeniedError);
+  });
+  it('requires a genuine original admission when a caller supplies one', () => {
+    const admission = captureMobileActionAdmission(getAuthenticatedOwner(), 'org-A');
+    expect(() =>
+      captureTransportOperation(
+        mutation(
+          'cloudAgentNext.sendMessage',
+          { organizationId: 'org-B' },
+          { localAccessAdmission: admission }
+        )
+      )
+    ).toThrow(LocalAccessDeniedError);
+    expect(() =>
+      captureTransportOperation(
+        mutation(
+          'cloudAgentNext.sendMessage',
+          { organizationId: 'org-A' },
+          { localAccessAdmission: { ...admission } }
+        )
+      )
+    ).toThrow(LocalAccessDeniedError);
+  });
+});
+
+const transportNames = new Set([
+  'fetch',
+  'WebSocket',
+  'createConnection',
+  'createTRPCClient',
+  'httpLink',
+  'httpBatchLink',
+  'createUserWebConnection',
+  'createSessionManager',
+]);
+function transportCalls(text: string): string[] {
+  const source = ts.createSourceFile(
+    'transport.tsx',
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+  const aliases = new Map<string, string>();
+  const found: string[] = [];
+  function nameOf(expression: ts.Expression): string {
+    if (ts.isIdentifier(expression)) {
+      return aliases.get(expression.text) ?? expression.text;
+    }
+    if (ts.isPropertyAccessExpression(expression)) {
+      return expression.name.text;
+    }
+    if (
+      ts.isElementAccessExpression(expression) &&
+      ts.isStringLiteral(expression.argumentExpression)
+    ) {
+      return expression.argumentExpression.text;
+    }
+    return '';
+  }
+  function visit(node: ts.Node) {
+    if (ts.isImportSpecifier(node)) {
+      aliases.set(node.name.text, node.propertyName?.text ?? node.name.text);
+    }
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const alias = nameOf(node.initializer);
+      if (transportNames.has(alias)) {
+        aliases.set(node.name.text, alias);
+      }
+    }
+    if (ts.isCallExpression(node) || ts.isNewExpression(node)) {
+      const name = nameOf(node.expression);
+      if (transportNames.has(name)) {
+        found.push(name);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(source);
+  return found.toSorted();
+}
+
+// Categories describe purpose, not a claim that every passive consumer uses the local action gate.
+const inventory: Record<string, { purpose: string; calls: string[] }> = {
+  'lib/trpc.ts': {
+    purpose: 'owner-fenced reads and guarded mutation adapters',
+    calls: ['createTRPCClient', 'fetch', 'httpBatchLink', 'httpLink'],
+  },
+  'lib/local-access-transport.ts': {
+    purpose: 'guarded mobile SDK construction',
+    calls: ['createUserWebConnection'],
+  },
+  'components/quick-chat/quick-chat-gateway.ts': {
+    purpose: 'guarded gateway turn dispatch',
+    calls: ['fetch'],
+  },
+  'components/agents/mobile-session-manager.ts': {
+    purpose: 'guarded mutation adapters and owner-fenced stream tickets',
+    calls: ['createSessionManager', 'fetch'],
+  },
+  'components/code-reviewer/review-spectator-stream.ts': {
+    purpose: 'read-only review stream and ticket',
+    calls: ['createConnection', 'fetch'],
+  },
+  'components/kilo-chat/message-attachment-picker.ts': {
+    purpose: 'local file read before upload admission',
+    calls: ['fetch'],
+  },
+  'lib/auth/admission.ts': {
+    purpose: 'credential bootstrap attestation challenge',
+    calls: ['fetch'],
+  },
+  'lib/auth/auth-fetch.ts': { purpose: 'native sign-in credential endpoints', calls: ['fetch'] },
+  'lib/auth/credentials.ts': { purpose: 'epoch-fenced credential rotation', calls: ['fetch'] },
+  'lib/auth/device-auth-poll.ts': { purpose: 'credential bootstrap polling', calls: ['fetch'] },
+  'lib/auth/exchange-legacy-token.ts': {
+    purpose: 'epoch-fenced legacy credential exchange',
+    calls: ['fetch'],
+  },
+  'lib/auth/use-device-auth.ts': { purpose: 'credential bootstrap device code', calls: ['fetch'] },
+  'lib/hooks/use-available-models.ts': {
+    purpose: 'read-only model discovery and defaults',
+    calls: ['fetch', 'fetch'],
+  },
+  'lib/hooks/use-force-update.ts': { purpose: 'public minimum version read', calls: ['fetch'] },
+  'lib/hooks/use-unread-counts.ts': { purpose: 'read-only badge reconciliation', calls: ['fetch'] },
+};
+function assertClassified(file: string, text: string) {
+  const calls = transportCalls(text);
+  const entry = inventory[file];
+  if (calls.length === 0 && !entry) {
+    return;
+  }
+  expect(entry, `Unclassified transport: ${file}: ${calls.join(', ')}`).toBeDefined();
+  expect(calls, file).toEqual(entry.calls.toSorted());
+}
+function sources(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === 'test' ? [] : sources(path);
+    }
+    return /\.tsx?$/.test(entry.name) && !/\.test\.|test-helpers|test-utils/.test(entry.name)
+      ? [path]
+      : [];
+  });
+}
+
+describe('syntax-aware transport inventory', () => {
+  it('classifies every direct mobile transport site', () => {
+    const root = resolve('src');
+    for (const file of sources(root)) {
+      assertClassified(relative(root, file), readFileSync(file, 'utf8'));
+    }
+  });
+  it.each([
+    'globalThis.fetch("https://example.test");',
+    'const send = globalThis["fetch"]; send("https://example.test");',
+    'new WebSocket("wss://example.test");',
+    'import { createTRPCClient as construct } from "@trpc/client"; construct({ links: [] });',
+  ])('rejects an unclassified transport fixture: %s', source => {
+    expect(() => {
+      assertClassified('unclassified-fixture.ts', source);
+    }).toThrow();
+  });
+  it('rejects an additional transport in an otherwise classified file', () => {
+    expect(() => {
+      assertClassified(
+        'lib/local-access-transport.ts',
+        'createUserWebConnection({}); fetch("https://example.test");'
+      );
+    }).toThrow();
+  });
+});

--- a/apps/mobile/src/lib/local-access-transport.ts
+++ b/apps/mobile/src/lib/local-access-transport.ts
@@ -1,0 +1,316 @@
+import { type Operation } from '@trpc/client';
+import {
+  createUserWebConnection,
+  type UserWebActionTarget,
+  type UserWebConnection,
+  type UserWebConnectionConfig,
+} from '@kilocode/cloud-agent-sdk/user-web-connection';
+import { z } from 'zod';
+
+import { isCurrentAuthEpoch } from '@/lib/auth/auth-epoch';
+import { isSignOutActive } from '@/lib/auth/sign-out-state';
+import { type AuthenticatedOwner, getAuthenticatedOwner } from '@/lib/context-scope';
+import {
+  assertLocalAccessLease,
+  assertLocalAccessOwner,
+  captureLocalAccessLease,
+  LocalAccessDeniedError,
+  type LocalAccessLease,
+  type LocalAccessScope,
+} from '@/lib/local-access';
+
+/** Credential ownership also works before getMe and context restoration finish. */
+export function isTransportOwner(owner: AuthenticatedOwner, allowCleanup = false): boolean {
+  const current = getAuthenticatedOwner();
+  return (
+    (allowCleanup || !isSignOutActive()) &&
+    isCurrentAuthEpoch(owner.authEpoch) &&
+    owner.authEpoch === current.authEpoch &&
+    owner.generation === current.generation &&
+    (owner.userId === null || owner.userId === current.userId)
+  );
+}
+
+export function assertTransportOwner(owner: AuthenticatedOwner, allowCleanup = false): void {
+  if (!isTransportOwner(owner, allowCleanup)) {
+    throw new LocalAccessDeniedError('owner');
+  }
+}
+
+/** tRPC keeps transport denials in Error.cause; callers still receive the original typed denial. */
+export function getLocalAccessDenial(error: unknown): LocalAccessDeniedError | null {
+  if (error instanceof LocalAccessDeniedError) {
+    return error;
+  }
+  return error instanceof Error && error.cause instanceof LocalAccessDeniedError
+    ? error.cause
+    : null;
+}
+
+export type MobileActionAdmission = Readonly<{
+  owner: AuthenticatedOwner;
+  lease: LocalAccessLease;
+}>;
+const admissions = new WeakSet<MobileActionAdmission>();
+
+export function captureMobileActionAdmission(
+  owner: AuthenticatedOwner,
+  organizationId: string | null
+): MobileActionAdmission {
+  assertTransportOwner(owner);
+  if (!owner.userId) {
+    throw new LocalAccessDeniedError('owner');
+  }
+  const admission = Object.freeze({
+    owner,
+    lease: captureLocalAccessLease({ userId: owner.userId, organizationId }),
+  });
+  admissions.add(admission);
+  return admission;
+}
+
+export function assertMobileActionAdmission(admission: MobileActionAdmission): void {
+  if (!admissions.has(admission)) {
+    throw new LocalAccessDeniedError('stale');
+  }
+  assertTransportOwner(admission.owner);
+  assertLocalAccessLease(admission.lease);
+}
+
+const receiptBrand = Symbol('AcceptedWorkReceipt');
+type AcceptedWorkKind = 'quick-chat-turn' | 'app-store-purchase';
+export type AcceptedWorkReceipt = Readonly<{ [receiptBrand]: true }>;
+type AcceptedWorkIdentity = Readonly<{ kind: AcceptedWorkKind; workId: string }>;
+type AcceptedWork = MobileActionAdmission & AcceptedWorkIdentity;
+type AcceptedWorkTarget = Readonly<{
+  kind: AcceptedWorkKind;
+  organizationId: string | null;
+  workId?: string;
+}>;
+const acceptedWork = new WeakMap<AcceptedWorkReceipt, AcceptedWork>();
+
+/** Issue proof only after the synchronous dispatch boundary accepts the original lease. */
+export function dispatchAcceptedWork<T>(
+  admission: MobileActionAdmission,
+  work: AcceptedWorkIdentity,
+  dispatch: () => T
+) {
+  assertMobileActionAdmission(admission);
+  const result = dispatch();
+  const receipt: AcceptedWorkReceipt = Object.freeze({ [receiptBrand]: true });
+  acceptedWork.set(receipt, { ...admission, ...work });
+  return { result, receipt };
+}
+
+export function assertAcceptedWorkReceipt(
+  receipt: AcceptedWorkReceipt,
+  target: AcceptedWorkTarget
+): AcceptedWork {
+  const work = acceptedWork.get(receipt);
+  if (
+    !work ||
+    work.kind !== target.kind ||
+    work.lease.organizationId !== target.organizationId ||
+    (target.workId !== undefined && work.workId !== target.workId)
+  ) {
+    throw new LocalAccessDeniedError('stale');
+  }
+  assertTransportOwner(work.owner);
+  // Completion belongs to the admitted context, not the current global selection or unlock grant.
+  assertLocalAccessOwner(work.lease);
+  return work;
+}
+
+const ownerSchema = z.object({
+  authEpoch: z.number(),
+  generation: z.number(),
+  userId: z.string().nullable(),
+});
+const inputScopeSchema = z.object({ organizationId: z.string().nullish() }).optional();
+const appendInputSchema = z.object({
+  organizationId: z.string().nullish(),
+  messages: z.array(z.object({ clientId: z.string().optional() })),
+});
+const admissionSchema = z.custom<MobileActionAdmission>(value =>
+  admissions.has(value as MobileActionAdmission)
+);
+const receiptSchema = z.custom<AcceptedWorkReceipt>(value =>
+  acceptedWork.has(value as AcceptedWorkReceipt)
+);
+
+export type TransportOperation = Readonly<{
+  owner: AuthenticatedOwner;
+  type: Operation['type'];
+  path: string;
+  allowCleanup: boolean;
+  assertDispatch: () => void;
+}>;
+
+/** Exact exceptions only. A new mutation is a foreground action until explicitly classified. */
+export function captureTransportOperation(op: Operation): TransportOperation {
+  const allowCleanup =
+    op.type === 'mutation' &&
+    (op.path === 'user.unregisterPushToken' || op.path === 'user.revokeCurrentDeviceSession');
+  const owner =
+    op.context.localAccessOwner === undefined
+      ? getAuthenticatedOwner()
+      : ownerSchema.parse(op.context.localAccessOwner);
+  const assertOwner = () => {
+    assertTransportOwner(owner, allowCleanup);
+  };
+  assertOwner();
+  const operation = { owner, type: op.type, path: op.path, allowCleanup };
+  if (op.type !== 'mutation') {
+    return { ...operation, assertDispatch: assertOwner };
+  }
+  switch (op.path) {
+    case 'activeSessions.createWebTicket':
+    case 'user.registerPushToken':
+    case 'user.unregisterPushToken':
+    case 'user.revokeCurrentDeviceSession': {
+      return { ...operation, assertDispatch: assertOwner };
+    }
+    case 'kiloPass.completeAppStorePurchase': {
+      // Old StoreKit consumers have no local receipt. Keep backend signed-JWS/appAccountToken
+      // verification and this credential fence until a4 migrates every completion consumer.
+      if (op.context.localAccessReceipt === undefined) {
+        return { ...operation, assertDispatch: assertOwner };
+      }
+      const receipt = receiptSchema.safeParse(op.context.localAccessReceipt);
+      if (!receipt.success) {
+        throw new LocalAccessDeniedError('stale');
+      }
+      const assertDispatch = () => {
+        assertOwner();
+        const work = assertAcceptedWorkReceipt(receipt.data, {
+          kind: 'app-store-purchase',
+          organizationId: null,
+        });
+        if (work.owner.userId !== owner.userId) {
+          throw new LocalAccessDeniedError('owner');
+        }
+      };
+      assertDispatch();
+      return { ...operation, assertDispatch };
+    }
+    case 'quickChat.appendMessages': {
+      const receipt = receiptSchema.safeParse(op.context.localAccessReceipt);
+      const input = appendInputSchema.safeParse(op.input);
+      if (!receipt.success || !input.success || !input.data.messages[0]?.clientId) {
+        throw new LocalAccessDeniedError('stale');
+      }
+      const assertDispatch = () => {
+        assertOwner();
+        const work = assertAcceptedWorkReceipt(receipt.data, {
+          kind: 'quick-chat-turn',
+          organizationId: input.data.organizationId ?? null,
+          workId: input.data.messages[0]?.clientId,
+        });
+        if (work.owner.userId !== owner.userId) {
+          throw new LocalAccessDeniedError('owner');
+        }
+      };
+      assertDispatch();
+      return { ...operation, assertDispatch };
+    }
+    default: {
+      break;
+    }
+  }
+  const organizationId = inputScopeSchema.parse(op.input)?.organizationId ?? null;
+  const supplied = op.context.localAccessAdmission;
+  const parsed = supplied === undefined ? null : admissionSchema.safeParse(supplied);
+  if (parsed && !parsed.success) {
+    throw new LocalAccessDeniedError('stale');
+  }
+  const admission = parsed?.data ?? captureMobileActionAdmission(owner, organizationId);
+  const assertDispatch = () => {
+    assertOwner();
+    if (
+      admission.lease.organizationId !== organizationId ||
+      admission.owner.userId !== owner.userId
+    ) {
+      throw new LocalAccessDeniedError('context');
+    }
+    assertMobileActionAdmission(admission);
+  };
+  assertDispatch();
+  return { ...operation, assertDispatch };
+}
+
+export type MobileUserWebConnection = UserWebConnection &
+  Readonly<{
+    owner: AuthenticatedOwner;
+    setSessionScope: (sessionId: string, organizationId: string | null) => void;
+  }>;
+type MobileConnectionConfig = Omit<UserWebConnectionConfig, 'captureActionAdmission'> & {
+  owner: AuthenticatedOwner;
+  captureActionAdmission: (target: UserWebActionTarget, scope?: LocalAccessScope) => () => void;
+};
+
+/**
+ * Mobile requires admission. The SDK's old constructor without a hook remains for web,
+ * extension, and external callers until a breaking SDK release migrates those producers.
+ */
+export function createMobileUserWebConnection({
+  owner,
+  captureActionAdmission,
+  getAuthToken,
+  ...config
+}: MobileConnectionConfig): MobileUserWebConnection {
+  const scopes = new Map<string, LocalAccessScope>();
+  const assertOwner = () => {
+    assertTransportOwner(owner);
+    if (!owner.userId) {
+      throw new LocalAccessDeniedError('owner');
+    }
+  };
+  const connection = createUserWebConnection({
+    ...config,
+    getAuthToken: async () => {
+      assertOwner();
+      const token = await getAuthToken();
+      assertOwner();
+      return token;
+    },
+    captureActionAdmission: target => {
+      assertOwner();
+      const assert = captureActionAdmission(
+        target,
+        target.sessionId ? scopes.get(target.sessionId) : undefined
+      );
+      return () => {
+        assertOwner();
+        assert();
+      };
+    },
+  });
+  function whenCurrent<T extends unknown[]>(listener: (...args: T) => void) {
+    return (...args: T) => {
+      if (isTransportOwner(owner)) {
+        listener(...args);
+      }
+    };
+  }
+  return {
+    ...connection,
+    owner,
+    onSystemEvent: listener => connection.onSystemEvent(whenCurrent(listener)),
+    onCliEvent: (sessionId, listener) => connection.onCliEvent(sessionId, whenCurrent(listener)),
+    onSessionEvent: (event, listener) => connection.onSessionEvent(event, whenCurrent(listener)),
+    onReconnect: listener => connection.onReconnect(whenCurrent(listener)),
+    onConnectionChange: listener => connection.onConnectionChange(whenCurrent(listener)),
+    onReconnectExhaustionChange: listener =>
+      connection.onReconnectExhaustionChange(whenCurrent(listener)),
+    destroy() {
+      scopes.clear();
+      connection.destroy();
+    },
+    setSessionScope: (sessionId, organizationId) => {
+      assertOwner();
+      if (owner.userId) {
+        scopes.set(sessionId, { userId: owner.userId, organizationId });
+      }
+    },
+  };
+}

--- a/apps/mobile/src/lib/trpc.test.ts
+++ b/apps/mobile/src/lib/trpc.test.ts
@@ -1,308 +1,410 @@
+/* eslint-disable max-lines -- real tRPC delegates share one controlled credential and fetch harness */
+import { getUntypedClient } from '@trpc/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const httpLinkMock = vi.hoisted(() => vi.fn());
-const httpBatchLinkMock = vi.hoisted(() => vi.fn());
-const createTRPCClientMock = vi.hoisted(() => vi.fn());
-const splitLinkMock = vi.hoisted(() =>
-  vi.fn((opts: { condition: unknown; true: unknown; false: unknown }) => [opts.true, opts.false])
-);
-
-const secureStoreMock = vi.hoisted(() => {
-  const store = new Map<string, string>();
-  let heldExpiryRead: Promise<void> | null = null;
-  let releaseExpiryRead: (() => void) | null = null;
-  return {
-    store,
-    // Holds the TOKEN_EXPIRES_AT_KEY read open so a test can publish a newer
-    // owner while the cold expiry read is in flight.
-    holdExpiryRead(): void {
-      heldExpiryRead = new Promise<void>(resolve => {
-        releaseExpiryRead = resolve;
-      });
-    },
-    releaseHeldExpiryRead(): void {
-      releaseExpiryRead?.();
-      heldExpiryRead = null;
-      releaseExpiryRead = null;
-    },
-    getItemAsync: vi.fn(async (key: string) => {
-      if (key === 'token-expires-at' && heldExpiryRead) {
-        await heldExpiryRead;
-      }
-      await Promise.resolve();
-      return store.get(key) ?? null;
-    }),
-    setItemAsync: vi.fn(async (key: string, value: string) => {
-      await Promise.resolve();
-      store.set(key, value);
-    }),
-    deleteItemAsync: vi.fn(async (key: string) => {
-      await Promise.resolve();
-      store.delete(key);
-    }),
-  };
-});
-
-vi.mock('@trpc/client', () => ({
-  createTRPCClient: createTRPCClientMock,
-  httpLink: httpLinkMock,
-  httpBatchLink: httpBatchLinkMock,
-  splitLink: splitLinkMock,
+const secureStore = vi.hoisted(() => ({
+  values: new Map<string, string>(),
+  tokenWait: null as Promise<undefined> | null,
+  expiryWait: null as Promise<undefined> | null,
+  getItemAsync: vi.fn(),
 }));
-
-vi.mock('@trpc/tanstack-react-query', () => ({
-  createTRPCContext: vi.fn(() => ({
-    TRPCProvider: { $$typeof: Symbol.for('react.provider') },
-    useTRPC: vi.fn(),
-  })),
-}));
-
-vi.mock('expo-secure-store', () => ({
-  getItemAsync: secureStoreMock.getItemAsync,
-  setItemAsync: secureStoreMock.setItemAsync,
-  deleteItemAsync: secureStoreMock.deleteItemAsync,
-  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
-}));
-
+const refresh = vi.hoisted(() => vi.fn());
+const latency = vi.hoisted(() => ({ messages: 0, session: 0 }));
+vi.mock('expo-secure-store', () => ({ getItemAsync: secureStore.getItemAsync }));
 vi.mock('@/lib/config', () => ({
   API_BASE_URL: 'https://api.example.com',
-  E2E_LATENCY_MESSAGES_MS: 0,
-  E2E_LATENCY_SESSION_MS: 0,
+  get E2E_LATENCY_MESSAGES_MS() {
+    return latency.messages;
+  },
+  get E2E_LATENCY_SESSION_MS() {
+    return latency.session;
+  },
 }));
-
 vi.mock('@/lib/storage-keys', () => ({
   AUTH_TOKEN_KEY: 'auth-token',
   TOKEN_EXPIRES_AT_KEY: 'token-expires-at',
 }));
+vi.mock('@/lib/auth/credentials', () => ({ performRefresh: refresh, REFRESH_MARGIN_MS: 60_000 }));
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+vi.mock('expo-application', () => ({ nativeApplicationVersion: '1.0.4' }));
 
-// auth-context pulls in react-native, Sentry and the telemetry modules.
-// This test only inspects link options, so stub the two symbols trpc.ts uses.
-vi.mock('@/lib/auth/auth-context', () => ({
-  performRefresh: vi.fn().mockResolvedValue({ ok: false, refused: false }),
-  REFRESH_MARGIN_MS: 60_000,
-}));
-
-vi.mock('react-native', () => ({
-  Platform: { OS: 'ios' },
-}));
-
-vi.mock('expo-application', () => ({
-  nativeApplicationVersion: '1.0.4',
-}));
-
-afterEach(() => {
-  vi.resetModules();
-  httpLinkMock.mockClear();
-  httpBatchLinkMock.mockClear();
-  createTRPCClientMock.mockClear();
-});
-
-describe('tRPC client link options', () => {
-  it('passes methodOverride: "POST" to httpLink', async () => {
-    httpLinkMock.mockReturnValue({});
-    httpBatchLinkMock.mockReturnValue({});
-    createTRPCClientMock.mockReturnValue({});
-
-    await import('./trpc');
-
-    expect(httpLinkMock).toHaveBeenCalledTimes(1);
-    const httpLinkOpts = httpLinkMock.mock.calls[0]?.[0];
-    expect(httpLinkOpts).toHaveProperty('methodOverride', 'POST');
-  });
-
-  it('passes methodOverride: "POST" to httpBatchLink', async () => {
-    httpLinkMock.mockReturnValue({});
-    httpBatchLinkMock.mockReturnValue({});
-    createTRPCClientMock.mockReturnValue({});
-
-    await import('./trpc');
-
-    expect(httpBatchLinkMock).toHaveBeenCalledTimes(1);
-    const httpBatchLinkOpts = httpBatchLinkMock.mock.calls[0]?.[0];
-    expect(httpBatchLinkOpts).toHaveProperty('methodOverride', 'POST');
-  });
-});
-
-type AuthHeadersFn = () => Promise<Record<string, string>>;
-
-describe('getAuthHeaders', () => {
-  beforeEach(() => {
-    secureStoreMock.store.clear();
-    secureStoreMock.getItemAsync.mockClear();
-    httpLinkMock.mockClear();
-    httpBatchLinkMock.mockClear();
-    createTRPCClientMock.mockClear();
-  });
-
-  afterEach(() => {
-    secureStoreMock.getItemAsync.mockRestore();
-    secureStoreMock.releaseHeldExpiryRead();
-  });
-
-  async function loadHeaders(): Promise<AuthHeadersFn> {
-    httpLinkMock.mockReturnValue({});
-    httpBatchLinkMock.mockReturnValue({});
-    createTRPCClientMock.mockReturnValue({});
-
-    await import('./trpc');
-
-    const httpLinkOpts = httpLinkMock.mock.calls[0]?.[0] as { headers?: AuthHeadersFn } | undefined;
-    if (!httpLinkOpts?.headers) {
-      throw new Error('headers option was not captured from httpLink');
-    }
-    return httpLinkOpts.headers;
+const fetchMock = vi.fn<(url: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
+let stop: (() => void) | undefined = undefined;
+function firstRequest() {
+  const first = fetchMock.mock.calls.at(0);
+  if (!first) {
+    throw new Error('No native dispatch');
   }
-
-  it('reads TOKEN_EXPIRES_AT_KEY once on the cold path and reuses the owner expiry', async () => {
-    secureStoreMock.store.set('auth-token', 'stored-token');
-    secureStoreMock.store.set('token-expires-at', String(Date.now() + 3_600_000));
-    const headers = await loadHeaders();
-
-    await expect(headers()).resolves.toMatchObject({ Authorization: 'Bearer stored-token' });
-    // Cold path: one token read plus one expiry read.
-    expect(secureStoreMock.getItemAsync).toHaveBeenCalledTimes(2);
-
-    // The resolved expiry was published into the owner: a normal request
-    // rereads neither key.
-    await expect(headers()).resolves.toMatchObject({ Authorization: 'Bearer stored-token' });
-    expect(secureStoreMock.getItemAsync).toHaveBeenCalledTimes(2);
+  return first;
+}
+function urlString(url: RequestInfo | URL) {
+  return url instanceof Request ? url.url : url.toString();
+}
+async function outcome(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    return await promise;
+  } catch (error) {
+    return error;
+  }
+}
+beforeEach(() => {
+  vi.useRealTimers();
+  latency.messages = 0;
+  latency.session = 0;
+  secureStore.values.clear();
+  secureStore.tokenWait = null;
+  secureStore.expiryWait = null;
+  secureStore.getItemAsync.mockReset().mockImplementation(async (key: string) => {
+    if (key === 'auth-token') {
+      await secureStore.tokenWait;
+    }
+    if (key === 'token-expires-at') {
+      await secureStore.expiryWait;
+    }
+    return secureStore.values.get(key) ?? null;
   });
-
-  it('uses the newest owner token published while the cold expiry was read', async () => {
-    secureStoreMock.store.set('auth-token', 'stored-token');
-    secureStoreMock.store.set('token-expires-at', String(Date.now() - 1000));
-    const headers = await loadHeaders();
-
-    // The token read completes first and warms the owner with a null expiry;
-    // the held TOKEN_EXPIRES_AT_KEY read is where the race lands.
-    secureStoreMock.holdExpiryRead();
-    const pending = headers();
-    await vi.waitFor(() => {
-      expect(vi.mocked(secureStoreMock.getItemAsync)).toHaveBeenCalledWith('token-expires-at');
-    });
-    // Publish a newer owner while the cold expiry read is still in flight.
-    const { setActiveToken } = await import('@/lib/auth/token-owner');
-    setActiveToken('newer-token', Date.now() + 3_600_000);
-    secureStoreMock.releaseHeldExpiryRead();
-
-    // The request uses the newest owner token, not the cold-read token, and
-    // the newer owner's expiry is not overwritten by the stale read.
-    await expect(pending).resolves.toMatchObject({ Authorization: 'Bearer newer-token' });
+  refresh.mockReset().mockResolvedValue({ ok: false, refused: false });
+  fetchMock.mockReset().mockImplementation(async (url, init) => {
+    const source = new Headers(init?.headers).get('authorization');
+    const address = urlString(url);
+    const path = address.split('/api/trpc/')[1]?.split('?')[0] ?? '';
+    const response = { result: { data: { source } } };
+    await Promise.resolve();
+    return Response.json(
+      address.includes('batch=1') ? path.split(',').map(() => response) : response
+    );
   });
+  vi.stubGlobal('fetch', fetchMock);
+});
+afterEach(() => {
+  stop?.();
+  stop = undefined;
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.resetModules();
 });
 
-const mockFetch = vi.fn();
+async function setup(enabled = false) {
+  const owners = await import('@/lib/context-scope');
+  const epoch = await import('@/lib/auth/auth-epoch');
+  const access = await import('@/lib/local-access');
+  const tokens = await import('@/lib/auth/token-owner');
+  owners.confirmAuthenticatedOwner(owners.beginAuthenticatedOwner(), 'A');
+  stop = access.initializeLocalAccess({
+    storage: {
+      read: vi.fn().mockResolvedValue({ status: 'present', enabled }),
+      write: vi.fn().mockResolvedValue('committed'),
+    },
+    authenticate: vi.fn().mockResolvedValue({ status: 'authenticated' }),
+    lifecycle: { getCurrentState: () => 'active', subscribe: () => () => undefined },
+  });
+  await access.setLocalAccessOwner('A', epoch.currentAuthEpoch());
+  access.setLocalAccessContextReady(true);
+  await access.requestLocalAccess('unlock', true);
+  const module = await import('./trpc');
+  return {
+    client: getUntypedClient(module.trpcClient),
+    deadlineFetch: module.deadlineFetch,
+    access,
+    owners,
+    epoch,
+    tokens,
+    replace() {
+      epoch.bumpAuthEpoch();
+      owners.confirmAuthenticatedOwner(owners.beginAuthenticatedOwner(), 'B');
+      tokens.setActiveToken('token-B', Date.now() + 3_600_000);
+    },
+  };
+}
+const denied = { cause: { code: 'LOCAL_ACCESS_DENIED' } };
+async function waitForExpiry() {
+  await vi.waitFor(() => {
+    expect(secureStore.getItemAsync).toHaveBeenCalledWith('token-expires-at');
+  });
+}
 
-// Suppress Node.js 24 unhandledRejection from AbortController.abort()
-// with a non-DOMException reason during fake-timer tests.
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-function swallowUnhandledRejection(): void {}
+describe('operation-scoped tRPC transport', () => {
+  it.each([false, true])(
+    'preserves POST, metadata, input, and output with skipBatch=%s',
+    async skipBatch => {
+      const h = await setup();
+      h.tokens.setActiveToken('token-A', Date.now() + 3_600_000);
+      await expect(
+        h.client.query('user.getMe', { marker: 'input' }, { context: { skipBatch } })
+      ).resolves.toEqual({ source: 'Bearer token-A' });
+      const [url, init] = firstRequest();
+      expect(init?.method).toBe('POST');
+      expect(new Headers(init?.headers).get('x-kilo-client')).toBe('mobile');
+      expect(new Headers(init?.headers).get('x-kilo-app-platform')).toBe('ios');
+      expect(new Headers(init?.headers).get('x-kilo-app-version')).toBe('1.0.4');
+      expect(JSON.parse(init?.body as string)).toEqual(
+        skipBatch ? { marker: 'input' } : { '0': { marker: 'input' } }
+      );
+      expect(urlString(url).includes('batch=1')).toBe(!skipBatch);
+    }
+  );
+
+  it('warms cold token and expiry once without changing the wire headers', async () => {
+    const h = await setup();
+    secureStore.values.set('auth-token', 'stored-token');
+    secureStore.values.set('token-expires-at', String(Date.now() + 3_600_000));
+    await expect(h.client.query('user.getMe')).resolves.toEqual({ source: 'Bearer stored-token' });
+    await expect(h.client.query('organizations.list')).resolves.toEqual({
+      source: 'Bearer stored-token',
+    });
+    expect(secureStore.getItemAsync.mock.calls).toEqual([['auth-token'], ['token-expires-at']]);
+  });
+
+  it('uses a same-generation token rotation without overwriting its expiry', async () => {
+    const h = await setup();
+    secureStore.values.set('auth-token', 'stored-token');
+    secureStore.values.set('token-expires-at', String(Date.now() - 1000));
+    const wait = Promise.withResolvers<undefined>();
+    secureStore.expiryWait = wait.promise;
+    const pending = h.client.query('user.getMe');
+    await waitForExpiry();
+    h.tokens.setActiveToken('rotated-A', Date.now() + 3_600_000);
+    wait.resolve(undefined);
+    await expect(pending).resolves.toEqual({ source: 'Bearer rotated-A' });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('refreshes an expiring token within its captured credential generation', async () => {
+    const h = await setup();
+    h.tokens.setActiveToken('old-A', Date.now() - 1000);
+    refresh.mockImplementation(async () => {
+      h.tokens.setActiveToken('refreshed-A', Date.now() + 3_600_000);
+      await Promise.resolve();
+      return { ok: true };
+    });
+    await expect(h.client.query('user.getMe')).resolves.toEqual({ source: 'Bearer refreshed-A' });
+  });
+
+  it.each(['token', 'expiry', 'refresh'] as const)(
+    'rejects account replacement during the %s wait',
+    async stage => {
+      const h = await setup();
+      const wait = Promise.withResolvers<undefined>();
+      if (stage === 'token') {
+        secureStore.tokenWait = wait.promise;
+      } else if (stage === 'expiry') {
+        h.tokens.setActiveToken('token-A', null);
+        secureStore.expiryWait = wait.promise;
+      } else {
+        h.tokens.setActiveToken('token-A', 1);
+        refresh.mockReturnValue(wait.promise);
+      }
+      const pending = outcome(h.client.query('user.getMe'));
+      await vi.waitFor(() => {
+        expect(stage === 'refresh' ? refresh : secureStore.getItemAsync).toHaveBeenCalled();
+      });
+      h.replace();
+      wait.resolve(undefined);
+      expect(await pending).toMatchObject(denied);
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it('batches ordinary reads but isolates overlapping credential generations', async () => {
+    const h = await setup();
+    h.tokens.setActiveToken('token-A', Date.now() + 3_600_000);
+    const first = await Promise.all([
+      h.client.query('user.getMe'),
+      h.client.query('organizations.list'),
+    ]);
+    expect(first).toEqual([{ source: 'Bearer token-A' }, { source: 'Bearer token-A' }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const old = outcome(h.client.query('user.getMe'));
+    h.replace();
+    const replacement = h.client.query('organizations.list');
+    expect(await old).toMatchObject(denied);
+    await expect(replacement).resolves.toEqual({ source: 'Bearer token-B' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps an uncancelled query alive when its batch sibling is cancelled', async () => {
+    const h = await setup();
+    h.tokens.setActiveToken('token-A', Date.now() + 3_600_000);
+    const controller = new AbortController();
+    const cancelled = outcome(
+      h.client.query('user.getMe', undefined, { signal: controller.signal })
+    );
+    const active = h.client.query('organizations.list');
+    controller.abort(new Error('cancelled query'));
+    await cancelled;
+    await expect(active).resolves.toEqual({ source: 'Bearer token-A' });
+  });
+
+  it('allows bootstrap identity and membership reads before local restoration', async () => {
+    const h = await setup();
+    h.owners.beginAuthenticatedOwner();
+    stop?.();
+    stop = undefined;
+    h.tokens.setActiveToken('bootstrap', Date.now() + 3_600_000);
+    await expect(h.client.query('user.getMe')).resolves.toEqual({ source: 'Bearer bootstrap' });
+    await expect(h.client.query('organizations.list')).resolves.toEqual({
+      source: 'Bearer bootstrap',
+    });
+  });
+
+  it.each([
+    'activeSessions.createWebTicket',
+    'user.registerPushToken',
+    'user.unregisterPushToken',
+    'user.revokeCurrentDeviceSession',
+    'kiloPass.completeAppStorePurchase',
+  ])('dispatches the exact passive %s contract while locked', async path => {
+    const h = await setup(true);
+    h.tokens.setActiveToken('token-A', Date.now() + 3_600_000);
+    h.access.lockLocalAccess();
+    const input = { token: 'push-token', signedTransactionJws: 'paid-jws' };
+    await expect(h.client.mutation(path, input)).resolves.toEqual({ source: 'Bearer token-A' });
+    expect(JSON.parse(firstRequest()[1]?.body as string)).toEqual(input);
+    expect(urlString(firstRequest()[0])).not.toContain('batch=1');
+  });
+
+  it('rejects an unclassified mutation without dispatch while locked', async () => {
+    const h = await setup(true);
+    h.access.lockLocalAccess();
+    await expect(h.client.mutation('future.effect', {})).rejects.toMatchObject(denied);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rechecks the original admission after latency and never replays after unlock', async () => {
+    latency.session = 25;
+    const h = await setup(true);
+    h.tokens.setActiveToken('token-A', Date.now() + 3_600_000);
+    vi.useFakeTimers();
+    const pending = outcome(h.client.mutation('cliSessionsV2.get', {}));
+    await vi.advanceTimersByTimeAsync(5);
+    h.access.lockLocalAccess();
+    await vi.advanceTimersByTimeAsync(30);
+    expect(await pending).toMatchObject(denied);
+    await h.access.requestLocalAccess('unlock');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])(
+    'fences parsed publication, including stale unauthorized=%s',
+    async unauthorized => {
+      const h = await setup();
+      h.tokens.setActiveToken('token-A', Date.now() + 3_600_000);
+      const parsing = Promise.withResolvers<undefined>();
+      const began = Promise.withResolvers<undefined>();
+      const response = Response.json(null);
+      vi.spyOn(response, 'json').mockImplementation(async () => {
+        began.resolve(undefined);
+        await parsing.promise;
+        return unauthorized
+          ? [
+              {
+                error: {
+                  message: 'old unauthorized',
+                  code: -32_001,
+                  data: { code: 'UNAUTHORIZED', authRequired: true },
+                },
+              },
+            ]
+          : [{ result: { data: 'old account data' } }];
+      });
+      fetchMock.mockResolvedValue(response);
+      const pending = outcome(h.client.query('user.getMe'));
+      await began.promise;
+      h.replace();
+      parsing.resolve(undefined);
+      const error = await pending;
+      expect(error).toMatchObject(denied);
+      const handlers = await import('@/lib/auth/trpc-unauthorized');
+      let signedInUser: string | null = 'B';
+      const release = handlers.setTrpcUnauthorizedHandler(() => {
+        signedInUser = null;
+      });
+      await handlers.handleTrpcQueryError(error);
+      expect(signedInUser).toBe('B');
+      release();
+    }
+  );
+
+  it('preserves current-owner server error data and unauthorized handling', async () => {
+    const h = await setup();
+    fetchMock.mockResolvedValue(
+      Response.json([
+        {
+          error: {
+            message: 'not signed in',
+            code: -32_001,
+            data: { code: 'UNAUTHORIZED', authRequired: true },
+          },
+        },
+      ])
+    );
+    const error = await outcome(h.client.query('user.getMe'));
+    expect(error).toMatchObject({
+      message: 'not signed in',
+      data: { code: 'UNAUTHORIZED', authRequired: true },
+    });
+  });
+});
 
 describe('deadlineFetch', () => {
-  beforeEach(() => {
-    vi.useRealTimers();
-    mockFetch.mockReset();
-    vi.stubGlobal('fetch', mockFetch);
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    vi.resetModules();
-  });
-
-  it('returns the response when fetch completes before the deadline', async () => {
-    mockFetch.mockResolvedValue(new Response('ok', { status: 200 }));
-    const { deadlineFetch } = await import('./trpc');
-    const response = await deadlineFetch('https://api.example.com/api/trpc');
+  it('returns a successful response without changing its body', async () => {
+    const h = await setup();
+    fetchMock.mockResolvedValue(new Response('ok', { status: 200 }));
+    const response = await h.deadlineFetch('https://api.example.com/api/trpc');
     expect(response.status).toBe(200);
     expect(await response.text()).toBe('ok');
-    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
-
-  it('rejects with RequestDeadlineError when the deadline expires', async () => {
-    vi.useFakeTimers();
-    process.on('unhandledRejection', swallowUnhandledRejection);
-    try {
-      // Fetch never resolves unless its signal aborts — simulates a hanging
-      // backend where the only thing that cancels the request is the deadline.
-      mockFetch.mockImplementation(
-        // eslint-disable-next-line typescript-eslint/promise-function-async
-        (_url, init?: RequestInit) =>
-          new Promise<Response>((resolve, reject) => {
-            const signal = init?.signal;
-            if (signal?.aborted) {
-              reject(signal.reason as Error);
-              return;
-            }
-            const id = setTimeout(resolve, 60_000, new Response('never'));
-            signal?.addEventListener('abort', () => {
-              clearTimeout(id);
-              reject(signal.reason as Error);
-            });
-          })
+  it.each(['deadline', 'caller'] as const)(
+    'preserves the %s abort while fetch is pending',
+    async reason => {
+      const h = await setup();
+      vi.useFakeTimers();
+      fetchMock.mockImplementation(async (_url, init) => {
+        const response = await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const error: unknown = init.signal?.reason;
+            reject(error instanceof Error ? error : new Error('aborted'));
+          });
+        });
+        return response;
+      });
+      const controller = new AbortController();
+      const pending = outcome(
+        h.deadlineFetch('https://api.example.com/api/trpc', { signal: controller.signal })
       );
-      const { deadlineFetch } = await import('./trpc');
-      const promise = deadlineFetch('https://api.example.com/api/trpc');
-
-      vi.advanceTimersByTime(15_001);
-      // eslint-disable-next-line typescript-eslint/await-thenable
-      await vi.runAllTicks();
-
-      await expect(promise).rejects.toThrow('timed out after 15000ms');
-    } finally {
-      process.off('unhandledRejection', swallowUnhandledRejection);
-      vi.useRealTimers();
+      if (reason === 'deadline') {
+        await vi.advanceTimersByTimeAsync(15_001);
+      } else {
+        controller.abort(new Error('caller cancelled mid-flight'));
+      }
+      expect(await pending).toMatchObject({
+        message:
+          reason === 'deadline' ? 'Request timed out after 15000ms' : 'caller cancelled mid-flight',
+      });
     }
+  );
+  it('supports native signals without throwIfAborted', async () => {
+    const h = await setup();
+    const NativeAbortController = globalThis.AbortController;
+    class LegacyAbortController extends NativeAbortController {
+      constructor() {
+        super();
+        Object.defineProperty(this.signal, 'throwIfAborted', { value: undefined });
+      }
+    }
+    vi.stubGlobal('AbortController', LegacyAbortController);
+    fetchMock.mockResolvedValue(new Response('native response'));
+    const response = await h.deadlineFetch('https://api.example.com/api/trpc');
+    expect(await response.text()).toBe('native response');
   });
-
-  it('rejects immediately when the caller signal is already aborted', async () => {
-    const { deadlineFetch } = await import('./trpc');
+  it('rejects an already-aborted signal without dispatch', async () => {
+    const h = await setup();
     const controller = new AbortController();
     controller.abort(new Error('caller cancelled'));
-
-    const promise = deadlineFetch('https://api.example.com/api/trpc', {
-      signal: controller.signal,
-    });
-
-    await expect(promise).rejects.toThrow('caller cancelled');
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it('rejects with the caller abort reason when the signal is aborted during fetch', async () => {
-    vi.useFakeTimers();
-    try {
-      // Fetch hangs unless its signal aborts.
-      mockFetch.mockImplementation(
-        // eslint-disable-next-line typescript-eslint/promise-function-async
-        (_url, init?: RequestInit) =>
-          new Promise<Response>((_resolve, reject) => {
-            const signal = init?.signal;
-            if (signal?.aborted) {
-              reject(signal.reason as Error);
-              return;
-            }
-            signal?.addEventListener('abort', () => {
-              reject(signal.reason as Error);
-            });
-          })
-      );
-
-      const { deadlineFetch } = await import('./trpc');
-      const controller = new AbortController();
-      const promise = deadlineFetch('https://api.example.com/api/trpc', {
-        signal: controller.signal,
-      });
-
-      // Let the fetch start, then abort from the caller side.
-      await vi.advanceTimersByTimeAsync(0);
-      controller.abort(new Error('caller cancelled mid-flight'));
-
-      // eslint-disable-next-line typescript-eslint/await-thenable
-      await vi.runAllTicks();
-
-      await expect(promise).rejects.toThrow('caller cancelled mid-flight');
-    } finally {
-      vi.useRealTimers();
-    }
+    await expect(
+      h.deadlineFetch('https://api.example.com/api/trpc', { signal: controller.signal })
+    ).rejects.toThrow('caller cancelled');
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/src/lib/trpc.ts
+++ b/apps/mobile/src/lib/trpc.ts
@@ -1,5 +1,12 @@
 import { type MobileRouter } from '@kilocode/trpc/mobile';
-import { createTRPCClient, httpBatchLink, httpLink, splitLink } from '@trpc/client';
+import {
+  createTRPCClient,
+  httpBatchLink,
+  httpLink,
+  type Operation,
+  TRPCClientError,
+  type TRPCLink,
+} from '@trpc/client';
 import { createTRPCContext } from '@trpc/tanstack-react-query';
 import { CONTROL_PLANE_DEADLINE_MS, withDeadline } from '@kilocode/event-service';
 import * as SecureStore from 'expo-secure-store';
@@ -16,18 +23,19 @@ import {
   publishActiveTokenExpiry,
 } from '@/lib/auth/token-owner';
 import { TOKEN_EXPIRES_AT_KEY } from '@/lib/storage-keys';
+import { type AuthenticatedOwner } from '@/lib/context-scope';
+import { LocalAccessDeniedError } from '@/lib/local-access';
+import {
+  assertTransportOwner,
+  captureTransportOperation,
+  isTransportOwner,
+  type TransportOperation,
+} from '@/lib/local-access-transport';
 
 export const { TRPCProvider, useTRPC } = createTRPCContext<MobileRouter>();
-
 const trpcUrl = `${API_BASE_URL}/api/trpc`;
 
-/**
- * E2E-only artificial backend latency (repro for latency-dependent UI states,
- * e.g. the session-open empty flash). When E2E_LATENCY_* env vars are set at
- * Metro bundle time, matching procedure responses arrive late at the app —
- * the same condition a slow production backend creates. Disabled (0) unless
- * the env vars are explicitly set; never set them outside E2E.
- */
+/** E2E-only latency remains inside the extended deadline, before final admission. */
 const E2E_LATENCY_RULES: readonly (readonly [procedure: string, delayMs: number])[] = [
   ['cliSessionsV2.get', E2E_LATENCY_SESSION_MS],
   ['cliSessionsV2.getSessionMessagesPage', E2E_LATENCY_MESSAGES_MS],
@@ -53,66 +61,58 @@ function e2eLatencyForUrl(url: string): number {
   return delayMs;
 }
 
-const e2eLatencyFetch: typeof fetch = async (url, init) => {
-  const delayMs = e2eLatencyForUrl(requestUrlString(url));
-  if (delayMs > 0) {
-    await new Promise(resolve => {
-      setTimeout(resolve, delayMs);
-    });
-  }
-  return fetch(url, init);
-};
+function guardedDeadlineFetch(assertDispatch: () => void): typeof fetch {
+  return async (url, init) => {
+    const delayMs = e2eLatencyForUrl(requestUrlString(url));
+    const response = await withDeadline(
+      CONTROL_PLANE_DEADLINE_MS + delayMs,
+      async signal => {
+        if (delayMs > 0) {
+          await new Promise(resolve => {
+            setTimeout(resolve, delayMs);
+          });
+        }
+        // Hermes signals lack throwIfAborted; withDeadline already preserves the caller's reason.
+        if (signal.aborted) {
+          throw new DOMException('Aborted', 'AbortError');
+        }
+        assertDispatch();
+        const result = await fetch(url, { ...init, signal });
+        return result;
+      },
+      init?.signal ?? undefined
+    );
+    return response;
+  };
+}
 
-const e2eFetch =
-  E2E_LATENCY_SESSION_MS > 0 || E2E_LATENCY_MESSAGES_MS > 0 ? e2eLatencyFetch : fetch;
+/** Retain the standalone deadline helper; transport delegates always install their own assertion. */
+export const deadlineFetch: typeof fetch = guardedDeadlineFetch(() => undefined);
 
-/**
- * Fetch wrapper that adds a control-plane deadline (15 s). When E2E latency
- * values are set the deadline is extended by the applicable delay so the
- * synthetic latency does not eat into the real request budget.
- */
-export const deadlineFetch: typeof fetch = async (url, init) => {
-  const delayMs = e2eLatencyForUrl(requestUrlString(url));
-  const totalDeadline = CONTROL_PLANE_DEADLINE_MS + delayMs;
-  const response = await withDeadline(
-    totalDeadline,
-    async signal => {
-      const res = await e2eFetch(url, { ...init, signal });
-      return res;
-    },
-    init?.signal ?? undefined
-  );
-  return response;
-};
-
-async function getAuthHeaders() {
+async function getAuthHeaders(owner: AuthenticatedOwner, allowCleanup: boolean) {
+  const assertOwner = () => {
+    assertTransportOwner(owner, allowCleanup);
+  };
+  assertOwner();
   const token = await getAuthTokenForRequest();
+  assertOwner();
   if (!token) {
     return { ...buildAuthHeaders(token), ...buildClientMetadataHeaders() };
   }
 
-  // Proactive refresh: if the token is expiring within the margin, rotate
-  // before this request hits a 401. performRefresh handles single-flight
-  // so concurrent requests share one rotation. The expiry comes from the
-  // in-memory owner when available; only the cold path (owner warmed by
-  // getAuthTokenForRequest without an expiry) reads TOKEN_EXPIRES_AT_KEY,
-  // and the resolved value is published back into the owner so normal
-  // requests never reread it.
   const active = getActiveTokenSnapshot();
   let expiresAtMs = active?.expiresAtMs ?? null;
   if (expiresAtMs === null) {
+    assertOwner();
     const expiresAtStr = await SecureStore.getItemAsync(TOKEN_EXPIRES_AT_KEY);
+    assertOwner();
     const resolvedExpiresAtMs = expiresAtStr ? Number(expiresAtStr) : null;
-    // Publish the resolved expiry into the owner that the cold read warmed.
-    // A newer owner published while the expiry was read keeps its own token
-    // and expiry.
     if (active) {
       publishActiveTokenExpiry(active, resolvedExpiresAtMs);
     }
     expiresAtMs = resolvedExpiresAtMs;
   }
-  // Prefer the newest owner token: a sign-in or refresh may have published a
-  // newer one while the cold reads were in flight.
+  // A refresh can rotate the token within this credential generation, never across accounts.
   const newest = getActiveToken();
   const currentToken = newest?.token ?? token;
   const currentExpiresAtMs = newest ? newest.expiresAtMs : expiresAtMs;
@@ -120,36 +120,119 @@ async function getAuthHeaders() {
     currentExpiresAtMs !== null &&
     shouldRefreshBeforeRequest(currentExpiresAtMs, Date.now(), REFRESH_MARGIN_MS)
   ) {
+    assertOwner();
     await performRefresh();
+    assertOwner();
     const refreshedToken = getActiveToken()?.token ?? (await getAuthTokenForRequest());
+    assertOwner();
     return { ...buildAuthHeaders(refreshedToken), ...buildClientMetadataHeaders() };
   }
-
+  assertOwner();
   return { ...buildAuthHeaders(currentToken), ...buildClientMetadataHeaders() };
 }
 
-const singleLink = httpLink({
-  url: trpcUrl,
-  headers: getAuthHeaders,
-  fetch: deadlineFetch,
-  methodOverride: 'POST',
-});
+type Delegate = ReturnType<TRPCLink<MobileRouter>>;
+type Bucket = { owner: AuthenticatedOwner; delegate: Delegate; pending: Set<Operation> };
 
-const batchLink = httpBatchLink({
-  url: trpcUrl,
-  headers: getAuthHeaders,
-  fetch: deadlineFetch,
-  methodOverride: 'POST',
-});
+const transportLink: TRPCLink<MobileRouter> = runtime => {
+  const buckets = new Map<string, Bucket>();
+  // Keep cancelled members identifiable until the batch releases them; WeakMap owns no lifetime.
+  const operations = new WeakMap<Operation, TransportOperation>();
+  return operationOptions => {
+    const { op } = operationOptions;
+    // Capture before any token, header, batch scheduling, or connection wait.
+    const admission = captureTransportOperation(op);
+    operations.set(op, admission);
+    const { owner, allowCleanup } = admission;
+    const bucketKey = `${owner.authEpoch}:${owner.generation}`;
+    for (const [key, bucket] of buckets) {
+      if (key !== bucketKey && bucket.pending.size === 0) {
+        buckets.delete(key);
+      }
+    }
+    let bucket: Bucket | undefined = undefined;
+    let result: ReturnType<Delegate> | undefined = undefined;
+    if (op.type === 'mutation' || op.context.skipBatch === true) {
+      // One supported delegate per operation keeps its closure out of wire headers and input.
+      result = httpLink<MobileRouter>({
+        url: trpcUrl,
+        methodOverride: 'POST',
+        headers: async () => {
+          const headers = await getAuthHeaders(owner, allowCleanup);
+          return headers;
+        },
+        fetch: guardedDeadlineFetch(admission.assertDispatch),
+      })(runtime)(operationOptions);
+    } else {
+      bucket = buckets.get(bucketKey);
+      if (!bucket) {
+        const delegate = httpBatchLink<MobileRouter>({
+          url: trpcUrl,
+          methodOverride: 'POST',
+          headers: async ({ opList }) => {
+            for (const batchedOp of opList) {
+              const captured = operations.get(batchedOp);
+              if (
+                captured?.type !== 'query' ||
+                captured.owner.authEpoch !== owner.authEpoch ||
+                captured.owner.generation !== owner.generation
+              ) {
+                throw new LocalAccessDeniedError('owner');
+              }
+              assertTransportOwner(captured.owner);
+            }
+            const headers = await getAuthHeaders(owner, false);
+            return headers;
+          },
+          fetch: guardedDeadlineFetch(() => {
+            assertTransportOwner(owner);
+          }),
+        })(runtime);
+        bucket = { owner, delegate, pending: new Set() };
+        buckets.set(bucketKey, bucket);
+      }
+      bucket.pending.add(op);
+      result = bucket.delegate(operationOptions);
+    }
+    const finish = () => {
+      bucket?.pending.delete(op);
+      if (bucket?.pending.size === 0 && !isTransportOwner(bucket.owner)) {
+        buckets.delete(bucketKey);
+      }
+    };
+    // Decorate this operation's library observable, retaining its pipe and teardown implementation.
+    const subscribe = result.subscribe.bind(result);
+    result.subscribe = observer => {
+      const subscription = subscribe({
+        next(value) {
+          if (isTransportOwner(owner, allowCleanup)) {
+            observer.next?.(value);
+          } else {
+            observer.error?.(TRPCClientError.from(new LocalAccessDeniedError('owner')));
+          }
+        },
+        error(error) {
+          finish();
+          observer.error?.(
+            isTransportOwner(owner, allowCleanup)
+              ? error
+              : TRPCClientError.from(new LocalAccessDeniedError('owner'))
+          );
+        },
+        complete() {
+          finish();
+          observer.complete?.();
+        },
+      });
+      return {
+        unsubscribe() {
+          subscription.unsubscribe();
+          finish();
+        },
+      };
+    };
+    return result;
+  };
+};
 
-const trpcLinks = [
-  splitLink({
-    condition: op => op.context.skipBatch === true,
-    true: singleLink,
-    false: batchLink,
-  }),
-];
-
-export const trpcClient = createTRPCClient<MobileRouter>({
-  links: trpcLinks,
-});
+export const trpcClient = createTRPCClient<MobileRouter>({ links: [transportLink] });

--- a/packages/cloud-agent-sdk/src/cli-live-transport.local-access.test.ts
+++ b/packages/cloud-agent-sdk/src/cli-live-transport.local-access.test.ts
@@ -1,0 +1,379 @@
+import { createCliLiveTransport } from './cli-live-transport';
+import { createRemoteSessionOnConnection } from './create-session';
+import { configureCloudAgentSdkRuntime, resetCloudAgentSdkRuntime } from './runtime';
+import { kiloId } from './test-helpers';
+import type { CreateRemoteSessionInput, Transport } from './transport';
+import {
+  CommandDeliveredError,
+  createUserWebConnection,
+  type UserWebActionTarget,
+  type UserWebConnection,
+} from './user-web-connection';
+
+const SESSION_ID = kiloId('ses_11111111111111111111111111');
+const CREATED_SESSION_ID = 'ses_22222222222222222222222222';
+const CREATED = { protocolVersion: 1, sessionID: CREATED_SESSION_ID };
+const OWNER_ID = 'cli-owner-1';
+const originalWebSocket = globalThis.WebSocket;
+
+type WireFrame = {
+  type: string;
+  id: string;
+  command: string;
+  data: unknown;
+  sessionId?: string;
+  connectionId?: string;
+  mutationId?: string;
+};
+
+let sockets: TestSocket[] = [];
+const clients: UserWebConnection[] = [];
+const transports: Transport[] = [];
+
+class TestSocket {
+  static OPEN = 1;
+  readyState = 0;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  readonly frames: WireFrame[] = [];
+
+  constructor() {
+    sockets.push(this);
+  }
+
+  open() {
+    this.readyState = 1;
+    this.onopen?.({} as Event);
+  }
+
+  receive(value: unknown) {
+    this.onmessage?.({ data: JSON.stringify(value) } as MessageEvent);
+  }
+
+  send(value: string) {
+    const frame = JSON.parse(value) as WireFrame;
+    this.frames.push(frame);
+    if (frame.command === 'list_models') {
+      this.receive({ type: 'response', id: frame.id, error: 'unknown command' });
+    } else if (frame.command === 'list_commands') {
+      this.receive({
+        type: 'response',
+        id: frame.id,
+        result: { protocolVersion: 1, commands: [], canExitSession: true },
+      });
+    }
+  }
+
+  close() {
+    this.readyState = 3;
+  }
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  sockets = [];
+  Object.defineProperty(globalThis, 'WebSocket', {
+    value: TestSocket,
+    configurable: true,
+    writable: true,
+  });
+  let id = 0;
+  configureCloudAgentSdkRuntime({ randomUUID: () => `uuid-${++id}` });
+});
+
+afterEach(() => {
+  for (const transport of transports.splice(0)) transport.destroy();
+  for (const client of clients.splice(0)) client.destroy();
+  globalThis.WebSocket = originalWebSocket;
+  resetCloudAgentSdkRuntime();
+  jest.useRealTimers();
+});
+
+function effects() {
+  return sockets
+    .flatMap(socket => socket.frames)
+    .filter(
+      frame =>
+        frame.type === 'command' &&
+        frame.command !== 'list_models' &&
+        frame.command !== 'list_commands'
+    );
+}
+
+function setup(withAdmission = true) {
+  const owner = { userId: 'user-a', authEpoch: 1, unlockGeneration: 1, unlocked: true };
+  const callerScope = { organizationId: 'original-org' };
+  const captures: Array<{ target: UserWebActionTarget; organizationId: string }> = [];
+  const denied = new Error('Original action admission expired');
+  const client = createUserWebConnection({
+    websocketUrl: 'wss://localhost:9999/api/user/web',
+    getAuthToken: () => 'token',
+    ...(withAdmission
+      ? {
+          captureActionAdmission(target: UserWebActionTarget) {
+            const captured = { ...owner };
+            const organizationId =
+              (target.data as { orgId?: string }).orgId ?? callerScope.organizationId;
+            captures.push({ target, organizationId });
+            const assert = () => {
+              if (
+                !owner.unlocked ||
+                captured.userId !== owner.userId ||
+                captured.authEpoch !== owner.authEpoch ||
+                captured.unlockGeneration !== owner.unlockGeneration
+              )
+                throw denied;
+            };
+            assert();
+            return assert;
+          },
+        }
+      : {}),
+  });
+  clients.push(client);
+  const transport = createCliLiveTransport({
+    kiloSessionId: SESSION_ID,
+    userWebConnection: client,
+  })({
+    onChatEvent() {},
+    onServiceEvent() {},
+  });
+  transports.push(transport);
+  client.retain();
+  transport.connect();
+  const socket = sockets[0];
+  socket.open();
+  socket.receive({
+    type: 'system',
+    event: 'sessions.list',
+    data: {
+      sessions: [{ id: SESSION_ID, status: 'idle', title: 'Tracked', connectionId: OWNER_ID }],
+    },
+  });
+  const createSession = transport.createSession;
+  if (!createSession) throw new Error('Expected CLI createSession');
+  return {
+    owner,
+    callerScope,
+    captures,
+    denied,
+    client,
+    transport,
+    socket,
+    create(kind: 'session' | 'connection', input?: CreateRemoteSessionInput) {
+      return kind === 'session'
+        ? createSession(input)
+        : createRemoteSessionOnConnection(client, OWNER_ID, input);
+    },
+  };
+}
+
+describe.each(['session', 'connection'] as const)(
+  '%s-scoped create compatibility admission',
+  kind => {
+    it.each(['lock/unlock', 'account replacement', 'auth epoch'] as const)(
+      'does not recapture or send the bare retry after %s',
+      async change => {
+        const harness = setup();
+        await jest.advanceTimersByTimeAsync(0);
+        const result = harness
+          .create(kind, { agent: 'code', orgId: 'original-org', mutationId: 'intent' })
+          .catch((error: unknown) => error);
+        expect(harness.captures).toHaveLength(1);
+        await jest.advanceTimersByTimeAsync(0);
+        const first = effects()[0];
+        expect(first.command).toBe('create_session');
+        if (change === 'account replacement') harness.owner.userId = 'user-b';
+        else if (change === 'auth epoch') harness.owner.authEpoch += 1;
+        else {
+          harness.owner.unlocked = false;
+          harness.owner.unlockGeneration += 1;
+          harness.owner.unlocked = true;
+        }
+        harness.socket.receive({
+          type: 'response',
+          id: first.id,
+          error: 'invalid create_session command',
+        });
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(effects()).toEqual([first]);
+        await expect(result).resolves.toBe(harness.denied);
+        expect(harness.captures).toHaveLength(1);
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(effects()).toEqual([first]);
+      }
+    );
+
+    it.each([true, false])(
+      'preserves valid retries and wire IDs with admission=%s',
+      async withAdmission => {
+        const harness = setup(withAdmission);
+        await jest.advanceTimersByTimeAsync(0);
+        const result = harness.create(kind, {
+          agent: 'code',
+          orgId: 'original-org',
+          directory: 'src/app',
+          mutationId: 'intent',
+        });
+        await jest.advanceTimersByTimeAsync(0);
+        const first = effects()[0];
+        expect(first).toEqual({
+          type: 'command',
+          id: expect.any(String),
+          command: 'create_session',
+          connectionId: OWNER_ID,
+          ...(kind === 'session' ? { sessionId: SESSION_ID } : {}),
+          mutationId: kind === 'session' ? 'intent' : 'intent:ext',
+          data: { protocolVersion: 1, agent: 'code', orgId: 'original-org', directory: 'src/app' },
+        });
+        harness.callerScope.organizationId = 'later-global-org';
+        harness.socket.receive({
+          type: 'response',
+          id: first.id,
+          error: 'invalid create_session command',
+        });
+        await jest.advanceTimersByTimeAsync(0);
+        expect(effects()).toHaveLength(2);
+        const second = effects()[1];
+        expect(second).toEqual({
+          type: 'command',
+          id: expect.any(String),
+          command: 'create_session',
+          connectionId: OWNER_ID,
+          ...(kind === 'session' ? { sessionId: SESSION_ID } : {}),
+          mutationId: kind === 'session' ? expect.any(String) : 'intent:bare',
+          data: { protocolVersion: 1 },
+        });
+        expect(second.id).not.toBe(first.id);
+        expect(second.mutationId).not.toBe(first.mutationId);
+        expect(harness.captures).toHaveLength(withAdmission ? 1 : 0);
+        if (withAdmission) expect(harness.captures[0].organizationId).toBe('original-org');
+        harness.socket.receive({ type: 'response', id: second.id, result: CREATED });
+        await expect(result).resolves.toEqual(kind === 'session' ? CREATED_SESSION_ID : CREATED);
+      }
+    );
+
+    it.each([
+      ['no extended fields', undefined],
+      ['clone only', { cloneFromKiloSessionId: SESSION_ID }],
+      ['clone with extended fields', { cloneFromKiloSessionId: SESSION_ID, agent: 'code' }],
+    ] satisfies Array<[string, CreateRemoteSessionInput | undefined]>)(
+      'does not bare-retry with %s',
+      async (_name, input) => {
+        const harness = setup();
+        await jest.advanceTimersByTimeAsync(0);
+        const result = harness.create(kind, input).catch((error: unknown) => error);
+        await jest.advanceTimersByTimeAsync(0);
+        const first = effects()[0];
+        harness.socket.receive({
+          type: 'response',
+          id: first.id,
+          error: 'invalid create_session command',
+        });
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(effects()).toEqual([first]);
+        await expect(result).resolves.toBeInstanceOf(CommandDeliveredError);
+        expect(harness.captures).toHaveLength(1);
+      }
+    );
+  }
+);
+
+const actions: Array<{
+  command: string;
+  run: (transport: Transport) => Promise<unknown> | undefined;
+  data: unknown;
+  response?: unknown;
+  result?: unknown;
+}> = [
+  {
+    command: 'send_message',
+    run: transport => transport.send?.({ payload: { type: 'prompt', prompt: 'hello' } }),
+    data: { sessionID: SESSION_ID, parts: [{ type: 'text', text: 'hello' }] },
+  },
+  {
+    command: 'send_command',
+    run: transport =>
+      transport.send?.({ payload: { type: 'command', command: 'review', arguments: 'changes' } }),
+    data: { protocolVersion: 1, command: 'review', arguments: 'changes' },
+  },
+  { command: 'interrupt', run: transport => transport.interrupt?.(), data: {} },
+  {
+    command: 'question_reply',
+    run: transport => transport.answer?.({ requestId: 'q', answers: [['yes']] }),
+    data: { requestID: 'q', answers: [['yes']] },
+  },
+  {
+    command: 'question_reject',
+    run: transport => transport.reject?.({ requestId: 'q' }),
+    data: { requestID: 'q' },
+  },
+  {
+    command: 'permission_respond',
+    run: transport => transport.respondToPermission?.({ requestId: 'p', response: 'once' }),
+    data: { requestID: 'p', reply: 'once', interactive: true },
+  },
+  {
+    command: 'suggestion_accept',
+    run: transport => transport.acceptSuggestion?.({ requestId: 's', index: 1 }),
+    data: { requestID: 's', index: 1 },
+  },
+  {
+    command: 'suggestion_dismiss',
+    run: transport => transport.dismissSuggestion?.({ requestId: 's' }),
+    data: { requestID: 's' },
+  },
+  {
+    command: 'create_session',
+    run: transport => transport.createSession?.({ agent: 'code' }),
+    data: { protocolVersion: 1, agent: 'code' },
+    response: CREATED,
+    result: CREATED_SESSION_ID,
+  },
+  {
+    command: 'exit_cli',
+    run: transport => transport.exitSession?.(),
+    data: { protocolVersion: 1 },
+    response: {},
+  },
+];
+
+describe.each(actions)('CLI $command admission', action => {
+  it.each([true, false])('sends only with valid final admission=%s', async admitted => {
+    const harness = setup();
+    await jest.advanceTimersByTimeAsync(0);
+    const pending = action.run(harness.transport);
+    if (!pending) throw new Error(`Expected CLI action ${action.command}`);
+    const result = pending.catch((error: unknown) => error);
+    harness.owner.unlocked = admitted;
+    await jest.advanceTimersByTimeAsync(0);
+
+    if (!admitted) {
+      expect(effects()).toEqual([]);
+      await expect(result).resolves.toBe(harness.denied);
+      return;
+    }
+    expect(effects()).toHaveLength(1);
+    const frame = effects()[0];
+    expect(frame).toMatchObject({
+      type: 'command',
+      command: action.command,
+      sessionId: SESSION_ID,
+      connectionId: OWNER_ID,
+      data: action.data,
+    });
+    harness.socket.receive({
+      type: 'response',
+      id: frame.id,
+      result: action.response ?? { accepted: true },
+    });
+    await expect(result).resolves.toEqual(
+      action.command === 'exit_cli' ? undefined : (action.result ?? { accepted: true })
+    );
+    expect(harness.captures).toHaveLength(1);
+  });
+});

--- a/packages/cloud-agent-sdk/src/cli-live-transport.ts
+++ b/packages/cloud-agent-sdk/src/cli-live-transport.ts
@@ -30,6 +30,7 @@ import type {
 import {
   CommandDeliveredError,
   UserWebCommandError,
+  type SendCommandOptions,
   type UserWebCliEvent,
   type UserWebConnection,
 } from './user-web-connection';
@@ -608,10 +609,16 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
     async function sendCommand(
       command: string,
       data: unknown,
-      mutationId?: string
+      mutationId?: string,
+      options?: SendCommandOptions
     ): Promise<unknown> {
       const expectedOwnerConnectionId = ownerConnectionId;
       if (!expectedOwnerConnectionId) throw new Error('Remote session has no connected owner');
+      const localOptions: [mutationId?: string, options?: SendCommandOptions] = options
+        ? [mutationId, options]
+        : mutationId !== undefined
+          ? [mutationId]
+          : [];
 
       try {
         return await config.userWebConnection.sendCommand(
@@ -619,7 +626,7 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
           command,
           data,
           expectedOwnerConnectionId,
-          ...(mutationId !== undefined ? [mutationId] : [])
+          ...localOptions
         );
       } catch (error) {
         if (error instanceof UserWebCommandError && error.code === 'SESSION_OWNER_CHANGED') {
@@ -884,6 +891,16 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
         // old-CLI delivered error; other failures are hard rejects.
         const mutationId = input?.mutationId ?? cloudAgentSdkRuntime.randomUUID();
         const wireData = buildCreateSessionWireData(input);
+        if (!ownerConnectionId) throw new Error('Remote session has no connected owner');
+        // Old connection objects omit capture. Remove this fallback only after
+        // every supported producer exposes it; never recapture for the bare retry.
+        const actionAdmission = config.userWebConnection.captureActionAdmission?.({
+          command: 'create_session',
+          data: wireData,
+          sessionId: config.kiloSessionId,
+          connectionId: ownerConnectionId,
+        });
+        const options = actionAdmission ? { actionAdmission } : undefined;
         const hasExtendedFields =
           wireData.agent !== undefined ||
           wireData.model !== undefined ||
@@ -892,13 +909,14 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
         const hasCloneField = input?.cloneFromKiloSessionId !== undefined;
         let result: unknown;
         try {
-          result = await sendCommand('create_session', wireData, mutationId);
+          result = await sendCommand('create_session', wireData, mutationId, options);
         } catch (error) {
           // Only bare-retry when extended fields made the original wire differ
           // from `{ protocolVersion: 1 }`; otherwise the retry is identical.
           // Old form is one bare protocolVersion 1 retry for extended fields;
           // a clone id must never use that fallback because it would create a
-          // fresh session.
+          // fresh session. Remove this fallback when all supported CLIs accept
+          // the extended fields.
           if (
             !hasCloneField &&
             hasExtendedFields &&
@@ -908,7 +926,8 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
             result = await sendCommand(
               'create_session',
               { protocolVersion: 1 },
-              cloudAgentSdkRuntime.randomUUID()
+              cloudAgentSdkRuntime.randomUUID(),
+              options
             );
           } else {
             throw error;

--- a/packages/cloud-agent-sdk/src/create-session.test.ts
+++ b/packages/cloud-agent-sdk/src/create-session.test.ts
@@ -335,6 +335,24 @@ describe('createRemoteSessionOnConnection', () => {
     expect(connection.sendCommandToConnection).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    new Error('invalid create_session command'),
+    new CommandDeliveredError('invalid create_session command '),
+    new UserWebCommandError({
+      code: 'CLI_UPGRADE_REQUIRED',
+      message: 'invalid create_session command',
+    }),
+  ])('does not bare-retry a non-matching rejection: %s', async error => {
+    const connection = makeFakeConnection();
+    connection.sendCommandToConnection
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({ protocolVersion: 1, sessionID: VALID_SESSION_ID });
+
+    await expect(
+      createRemoteSessionOnConnection(connection, 'cli-owner-1', { agent: 'code' })
+    ).rejects.toBe(error);
+  });
+
   it('surfaces the shared bad-sessionId string after one bare retry', async () => {
     // Same delivered string covers malformed sessionId (harmless retry).
     const connection = makeFakeConnection();

--- a/packages/cloud-agent-sdk/src/create-session.ts
+++ b/packages/cloud-agent-sdk/src/create-session.ts
@@ -75,7 +75,7 @@ export type CreateRemoteSessionRawResult = unknown;
  * subclass contract.
  */
 export async function createRemoteSessionOnConnection(
-  connection: Pick<UserWebConnection, 'sendCommandToConnection'>,
+  connection: Pick<UserWebConnection, 'sendCommandToConnection' | 'captureActionAdmission'>,
   connectionId: string,
   input?: CreateRemoteSessionInput
 ): Promise<CreateRemoteSessionRawResult> {
@@ -89,6 +89,13 @@ export async function createRemoteSessionOnConnection(
       ? { cloneFromKiloSessionId: input.cloneFromKiloSessionId }
       : {}),
   };
+  // Capture before either attempt. Old connection objects omit this method;
+  // remove that fallback only after every supported producer exposes capture.
+  const actionAdmission = connection.captureActionAdmission?.({
+    command: 'create_session',
+    data,
+    connectionId,
+  });
   // `directory` is an extended field; the `:bare` retry omits it for old CLIs.
   // Remove `:bare` when every supported CLI accepts it.
   const hasExtendedFields =
@@ -106,6 +113,7 @@ export async function createRemoteSessionOnConnection(
       data,
       expectedConnectionId: connectionId,
       ...(extendedMutationId !== undefined ? { mutationId: extendedMutationId } : {}),
+      ...(actionAdmission ? { actionAdmission } : {}),
     });
   } catch (error) {
     // Only bare-retry when extended fields made the original wire differ from
@@ -124,6 +132,7 @@ export async function createRemoteSessionOnConnection(
         data: { protocolVersion: 1 },
         expectedConnectionId: connectionId,
         ...(bareMutationId !== undefined ? { mutationId: bareMutationId } : {}),
+        ...(actionAdmission ? { actionAdmission } : {}),
       });
     }
     throw error;

--- a/packages/cloud-agent-sdk/src/index.ts
+++ b/packages/cloud-agent-sdk/src/index.ts
@@ -74,6 +74,9 @@ export {
   UserWebCommandError,
 } from './user-web-connection';
 export type {
+  SendCommandOptions,
+  UserWebActionAdmission,
+  UserWebActionTarget,
   UserWebConnection,
   UserWebConnectionConfig,
   UserWebSessionEventName,

--- a/packages/cloud-agent-sdk/src/user-web-connection.test.ts
+++ b/packages/cloud-agent-sdk/src/user-web-connection.test.ts
@@ -5,6 +5,10 @@ import {
   UserWebCommandError,
   VIEWER_PING_INTERVAL_MS,
   VIEWER_PONG_TIMEOUT_MS,
+  type SendCommandOptions,
+  type UserWebActionTarget,
+  type UserWebConnection,
+  type UserWebConnectionConfig,
 } from './user-web-connection';
 
 const WS_URL = 'wss://localhost:9999/api/user/web';
@@ -1925,6 +1929,342 @@ describe('createUserWebConnection connection-state API', () => {
 
     releaseC();
     client.destroy();
+  });
+});
+
+describe('createUserWebConnection action admission', () => {
+  const clients: UserWebConnection[] = [];
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    for (const client of clients.splice(0)) client.destroy();
+    jest.useRealTimers();
+  });
+
+  function makeClient(config: Partial<UserWebConnectionConfig> = {}) {
+    const client = createUserWebConnection({
+      websocketUrl: WS_URL,
+      getAuthToken: () => 'token',
+      ...config,
+    });
+    clients.push(client);
+    return client;
+  }
+
+  function createAuthority() {
+    const owner = { userId: 'user-a', authEpoch: 1, unlockGeneration: 1, unlocked: true };
+    const targets: UserWebActionTarget[] = [];
+    const denied = new Error('Original action admission expired');
+    return {
+      owner,
+      targets,
+      denied,
+      captureActionAdmission(target: UserWebActionTarget) {
+        const captured = { ...owner };
+        targets.push(target);
+        const assert = () => {
+          if (
+            !owner.unlocked ||
+            captured.userId !== owner.userId ||
+            captured.authEpoch !== owner.authEpoch ||
+            captured.unlockGeneration !== owner.unlockGeneration
+          )
+            throw denied;
+        };
+        assert();
+        return assert;
+      },
+    };
+  }
+
+  function frames(ws = sockets.at(-1)): Record<string, unknown>[] {
+    return (ws?.send.mock.calls ?? []).map(([value]) => JSON.parse(value as string));
+  }
+
+  function acceptCommands(ws = sockets.at(-1)) {
+    ws?.send.mockImplementation((value: string) => {
+      const frame = JSON.parse(value) as { type: string; id: string };
+      if (frame.type === 'command') {
+        inbound({ type: 'response', id: frame.id, result: { accepted: true } }, ws);
+      }
+    });
+  }
+
+  describe.each(['session', 'connection'] as const)('%s commands', targetKind => {
+    function send(
+      client: UserWebConnection,
+      command: string,
+      data: unknown = {},
+      options?: SendCommandOptions
+    ) {
+      return targetKind === 'session'
+        ? client.sendCommand('ses-1', command, data, 'cli-owner-1', 'intent-1', options)
+        : client.sendCommandToConnection({
+            command,
+            data,
+            expectedConnectionId: 'cli-owner-1',
+            mutationId: 'intent-1',
+            ...options,
+          });
+    }
+
+    it.each([
+      'send_message',
+      'send_command',
+      'interrupt',
+      'question_reply',
+      'question_reject',
+      'permission_respond',
+      'suggestion_accept',
+      'suggestion_dismiss',
+      'create_session',
+      'exit_cli',
+    ])('requires final socket admission for %s', async command => {
+      const authority = createAuthority();
+      const client = makeClient(authority);
+      const pending = send(client, command);
+      authority.owner.unlocked = false;
+      acceptCommands();
+      open();
+
+      await expect(pending).rejects.toBe(authority.denied);
+      expect(frames()).toEqual([]);
+      expect(sockets[0].readyState).toBe(3);
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    describe.each(['auth', 'socket'] as const)('while waiting for %s', wait => {
+      it.each(['account replacement', 'auth epoch', 'lock/unlock'] as const)(
+        'rejects %s without replay and permits only a fresh action',
+        async change => {
+          const authority = createAuthority();
+          const auth = createDeferred<string>();
+          const client = makeClient({
+            captureActionAdmission: authority.captureActionAdmission,
+            getAuthToken: () => (wait === 'auth' ? auth.promise : 'token'),
+          });
+          const pending = send(client, 'create_session', { orgId: 'original-org' });
+          expect(authority.targets).toEqual([
+            {
+              command: 'create_session',
+              data: { orgId: 'original-org' },
+              connectionId: 'cli-owner-1',
+              ...(targetKind === 'session' ? { sessionId: 'ses-1' } : {}),
+            },
+          ]);
+          if (change === 'account replacement') authority.owner.userId = 'user-b';
+          else if (change === 'auth epoch') authority.owner.authEpoch += 1;
+          else {
+            authority.owner.unlocked = false;
+            authority.owner.unlockGeneration += 1;
+            authority.owner.unlocked = true;
+          }
+          auth.resolve('token');
+          await Promise.resolve();
+          acceptCommands();
+          open();
+
+          await expect(pending).rejects.toBe(authority.denied);
+          await jest.advanceTimersByTimeAsync(60_000);
+          expect(frames()).toEqual([]);
+          expect(authority.targets).toHaveLength(1);
+          expect(jest.getTimerCount()).toBe(0);
+
+          const fresh = send(client, 'create_session', { orgId: 'original-org' });
+          await Promise.resolve();
+          acceptCommands();
+          open();
+          await expect(fresh).resolves.toEqual({ accepted: true });
+          expect(frames()).toHaveLength(1);
+          expect(authority.targets).toHaveLength(2);
+        }
+      );
+    });
+
+    it('preserves a capture rejection before retaining or opening the socket', async () => {
+      const authority = createAuthority();
+      authority.owner.unlocked = false;
+      const client = makeClient(authority);
+
+      await expect(send(client, 'interrupt')).rejects.toBe(authority.denied);
+      expect(sockets).toEqual([]);
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('asserts after serialization, immediately before the socket send', async () => {
+      const authority = createAuthority();
+      const client = makeClient(authority);
+      const pending = send(client, 'send_message', {
+        toJSON() {
+          authority.owner.unlocked = false;
+          return { text: 'must not leave the client' };
+        },
+      });
+      acceptCommands();
+      open();
+
+      await expect(pending).rejects.toBe(authority.denied);
+      expect(frames()).toEqual([]);
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it.each(['serialization', 'socket'] as const)(
+      'preserves a %s failure and releases the command lifetime',
+      async failurePoint => {
+        const client = makeClient(createAuthority());
+        const failure = new Error('Local command failed');
+        const pending = send(
+          client,
+          'send_message',
+          failurePoint === 'serialization'
+            ? {
+                toJSON() {
+                  throw failure;
+                },
+              }
+            : {}
+        );
+        if (failurePoint === 'socket') {
+          sockets[0].send.mockImplementation(() => {
+            throw failure;
+          });
+        }
+        open();
+
+        await expect(pending).rejects.toBe(failure);
+        expect(sockets[0].readyState).toBe(3);
+        expect(jest.getTimerCount()).toBe(0);
+      }
+    );
+
+    it('reuses an explicit handle without serializing it or changing mutation IDs', async () => {
+      const authority = createAuthority();
+      const client = makeClient(authority);
+      const actionAdmission = client.captureActionAdmission?.({
+        command: 'create_session',
+        data: { orgId: 'original-org' },
+        connectionId: 'cli-owner-1',
+        ...(targetKind === 'session' ? { sessionId: 'ses-1' } : {}),
+      });
+      const pending = send(client, 'create_session', { protocolVersion: 1 }, { actionAdmission });
+      acceptCommands();
+      open();
+
+      await expect(pending).resolves.toEqual({ accepted: true });
+      expect(frames()).toEqual([
+        {
+          type: 'command',
+          id: 'uuid-2',
+          command: 'create_session',
+          data: { protocolVersion: 1 },
+          connectionId: 'cli-owner-1',
+          ...(targetKind === 'session' ? { sessionId: 'ses-1' } : {}),
+          mutationId: 'intent-1',
+        },
+      ]);
+      expect(authority.targets).toHaveLength(1);
+    });
+
+    it('rejects unknown commands when admission is configured', async () => {
+      const client = makeClient(createAuthority());
+      await expect(send(client, 'future_effect')).rejects.toThrow(
+        'Unknown command requires action admission classification'
+      );
+      expect(sockets).toEqual([]);
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('preserves unknown-command compatibility without a construction hook', async () => {
+      const client = makeClient();
+      const pending = send(client, 'future_effect', { old: 'payload' });
+      acceptCommands();
+      open();
+
+      await expect(pending).resolves.toEqual({ accepted: true });
+      expect(frames()).toEqual([
+        {
+          type: 'command',
+          id: 'uuid-2',
+          command: 'future_effect',
+          data: { old: 'payload' },
+          connectionId: 'cli-owner-1',
+          ...(targetKind === 'session' ? { sessionId: 'ses-1' } : {}),
+          mutationId: 'intent-1',
+        },
+      ]);
+    });
+
+    it.each(['list_models', 'list_commands', 'list_directories'])(
+      'keeps %s and read subscriptions independent from denied effects',
+      async command => {
+        const authority = createAuthority();
+        authority.owner.unlocked = false;
+        const client = makeClient(authority);
+        const release = client.subscribeToCliSession('ses-1');
+        acceptCommands();
+        open();
+        await expect(send(client, command, { protocolVersion: 1 })).resolves.toEqual({
+          accepted: true,
+        });
+        release();
+
+        expect(frames()).toEqual([
+          { type: 'subscribe', sessionId: 'ses-1' },
+          {
+            type: 'command',
+            id: 'uuid-2',
+            command,
+            data: { protocolVersion: 1 },
+            connectionId: 'cli-owner-1',
+            ...(targetKind === 'session' ? { sessionId: 'ses-1' } : {}),
+            mutationId: 'intent-1',
+          },
+          { type: 'unsubscribe', sessionId: 'ses-1' },
+        ]);
+        expect(authority.targets).toEqual([]);
+      }
+    );
+  });
+
+  it.each([
+    { command: 'exit_cli', sessionId: 'ses-1', connectionId: 'cli-owner-1' },
+    { command: 'create_session', sessionId: 'ses-2', connectionId: 'cli-owner-1' },
+    { command: 'create_session', sessionId: 'ses-1', connectionId: 'cli-owner-2' },
+  ])('rejects a handle reused for a different target: %j', async target => {
+    const client = makeClient(createAuthority());
+    const actionAdmission = client.captureActionAdmission?.({
+      command: 'create_session',
+      data: {},
+      sessionId: 'ses-1',
+      connectionId: 'cli-owner-1',
+    });
+    await expect(
+      client.sendCommand(target.sessionId, target.command, {}, target.connectionId, undefined, {
+        actionAdmission,
+      })
+    ).rejects.toThrow('Action admission does not match this command target');
+    expect(sockets).toEqual([]);
+  });
+
+  it('rejects a handle from another connection instead of bypassing admission', async () => {
+    const source = makeClient(createAuthority());
+    const actionAdmission = source.captureActionAdmission?.({
+      command: 'create_session',
+      data: {},
+      connectionId: 'cli-owner-1',
+    });
+    const destination = makeClient();
+    await expect(
+      destination.sendCommandToConnection({
+        command: 'create_session',
+        data: {},
+        expectedConnectionId: 'cli-owner-1',
+        actionAdmission,
+      })
+    ).rejects.toThrow('Action admission does not match this command target');
+    expect(sockets).toEqual([]);
   });
 });
 

--- a/packages/cloud-agent-sdk/src/user-web-connection.ts
+++ b/packages/cloud-agent-sdk/src/user-web-connection.ts
@@ -54,6 +54,23 @@ class CommandDeliveredError extends Error {
   }
 }
 
+const actionAdmissionBrand = Symbol('UserWebActionAdmission');
+
+/** Local-only authority captured for one command target, including its compatibility retry. */
+type UserWebActionAdmission = Readonly<{ [actionAdmissionBrand]: true }>;
+
+type UserWebActionTarget = Readonly<{
+  command: string;
+  data: unknown;
+  sessionId?: string;
+  connectionId?: string;
+}>;
+
+type SendCommandOptions = {
+  /** Opaque handle from this connection. Never serialized or used as a wire mutation ID. */
+  actionAdmission?: UserWebActionAdmission;
+};
+
 type UserWebConnectionConfig = {
   websocketUrl: string;
   getAuthToken: () => string | Promise<string>;
@@ -61,9 +78,20 @@ type UserWebConnectionConfig = {
   onReconnect?: () => void;
   lifecycleHooks?: ConnectionLifecycleHooks;
   maxReconnectAttempts?: number;
+  /**
+   * Capture authority synchronously from the target or the caller's bound scope.
+   * The returned assertion must validate that original authority, not recapture
+   * a later global context. It runs immediately before each effect socket send.
+   * Discovery, directory listing, and subscriptions do not call this hook.
+   *
+   * The old constructor omits this hook and keeps unrestricted command admission.
+   * Remove that fallback only in a breaking SDK release after web, extension,
+   * and external producers supply admission hooks.
+   */
+  captureActionAdmission?: (target: UserWebActionTarget) => () => void;
 };
 
-type SendCommandToConnectionInput = {
+type SendCommandToConnectionInput = SendCommandOptions & {
   command: string;
   data: unknown;
   expectedConnectionId: string;
@@ -97,6 +125,12 @@ type UserWebConnection = {
   onReconnectExhaustionChange: (listener: (exhausted: boolean) => void) => () => void;
   retryConnection: () => void;
   subscribeToCliSession: (sessionId: string) => () => void;
+  /**
+   * Capture once at a logical action's entry and forward the handle on every attempt.
+   * Old custom connection objects can omit this method. Remove that fallback only
+   * after every supported connection producer exposes admission capture.
+   */
+  captureActionAdmission?: (target: UserWebActionTarget) => UserWebActionAdmission | undefined;
   sendCommand: (
     sessionId: string,
     command: string,
@@ -104,7 +138,8 @@ type UserWebConnection = {
     expectedOwnerConnectionId?: string,
     // Stable intent id forwarded to the relay for durable dedupe.
     // Absent on legacy paths that do not re-issue (D5).
-    mutationId?: string
+    mutationId?: string,
+    options?: SendCommandOptions
   ) => Promise<unknown>;
   /**
    * Send a viewer command that is scoped to a specific CLI connection and has
@@ -581,6 +616,45 @@ function createUserWebConnection(
     mutationId?: string;
   };
 
+  const actionAdmissions = new WeakMap<
+    UserWebActionAdmission,
+    { target: UserWebActionTarget; assert: () => void }
+  >();
+
+  function captureActionAdmission(target: UserWebActionTarget): UserWebActionAdmission | undefined {
+    if (!config.captureActionAdmission) return undefined;
+    switch (target.command) {
+      case 'list_models':
+      case 'list_commands':
+        return undefined; // Catalog discovery is not an effect.
+      case 'list_directories':
+        return undefined; // Directory reads are separate from action admission.
+      case 'send_message':
+      case 'send_command':
+      case 'interrupt':
+      case 'question_reply':
+      case 'question_reject':
+      case 'permission_respond':
+      case 'suggestion_accept':
+      case 'suggestion_dismiss':
+      case 'create_session':
+      case 'exit_cli':
+        break;
+      default:
+        throw new Error('Unknown command requires action admission classification');
+    }
+    const capturedTarget = Object.freeze({
+      command: target.command,
+      data: target.data,
+      ...(target.sessionId !== undefined ? { sessionId: target.sessionId } : {}),
+      ...(target.connectionId !== undefined ? { connectionId: target.connectionId } : {}),
+    });
+    const assert = config.captureActionAdmission(capturedTarget);
+    const admission: UserWebActionAdmission = Object.freeze({ [actionAdmissionBrand]: true });
+    actionAdmissions.set(admission, { target: capturedTarget, assert });
+    return admission;
+  }
+
   /**
    * Shared private sender for both `sendCommand` and `sendCommandToConnection`.
    * Owns the command-scoped connection retain, the pending-commands map
@@ -588,7 +662,29 @@ function createUserWebConnection(
    * the wire shape (`sessionId` present vs omitted). `connectionId` is always
    * serialized; the relay tolerates it without a `sessionId`.
    */
-  function sendRawCommand(wire: RawCommandWire): Promise<unknown> {
+  function sendRawCommand(wire: RawCommandWire, options?: SendCommandOptions): Promise<unknown> {
+    let assertActionAdmission: (() => void) | undefined;
+    try {
+      // Old direct callers omit the handle, so capture at sender entry, before
+      // auth or socket waits. Remove this fallback only when all effect callers
+      // forward a handle captured at their logical action's entry.
+      const admission = options?.actionAdmission ?? captureActionAdmission(wire);
+      if (admission) {
+        const captured = actionAdmissions.get(admission);
+        if (
+          !captured ||
+          captured.target.command !== wire.command ||
+          captured.target.sessionId !== wire.sessionId ||
+          captured.target.connectionId !== wire.connectionId
+        ) {
+          throw new Error('Action admission does not match this command target');
+        }
+        assertActionAdmission = captured.assert;
+      }
+    } catch (error) {
+      return Promise.reject(error);
+    }
+
     const hasOwnerLifetime = retainCount > commandRetainCount;
     const releaseCommandLifetime = hasOwnerLifetime ? null : retainConnection();
     if (releaseCommandLifetime) commandRetainCount += 1;
@@ -607,7 +703,7 @@ function createUserWebConnection(
         releaseLifetime();
         resolve(value);
       };
-      const rejectCommand = (reason: Error) => {
+      const rejectCommand = (reason: unknown) => {
         releaseLifetime();
         reject(reason);
       };
@@ -626,8 +722,8 @@ function createUserWebConnection(
             rejectCommand(new Error('Command timed out'));
           }, COMMAND_TIMEOUT_MS);
           pendingCommands.set(id, { resolve: resolveCommand, reject: rejectCommand, timer });
-          ws.send(
-            JSON.stringify({
+          try {
+            const frame = JSON.stringify({
               type: 'command',
               id,
               command: wire.command,
@@ -635,8 +731,14 @@ function createUserWebConnection(
               ...(wire.connectionId ? { connectionId: wire.connectionId } : {}),
               ...(wire.mutationId ? { mutationId: wire.mutationId } : {}),
               data: wire.data,
-            })
-          );
+            });
+            assertActionAdmission?.();
+            ws.send(frame);
+          } catch (error) {
+            clearTimeout(timer);
+            pendingCommands.delete(id);
+            rejectCommand(error);
+          }
         },
         reason => {
           rejectCommand(reason instanceof Error ? reason : new Error('WebSocket is not connected'));
@@ -708,25 +810,32 @@ function createUserWebConnection(
         releaseConnection();
       };
     },
-    sendCommand(sessionId, command, data, expectedOwnerConnectionId, mutationId) {
-      return sendRawCommand({
-        command,
-        // `expectedOwnerConnectionId` undefined still flows through `connectionId`
-        // as a top-level field on the wire (the relay tolerates a `connectionId`
-        // without a `sessionId`), so reuse the shared sender.
-        ...(expectedOwnerConnectionId ? { connectionId: expectedOwnerConnectionId } : {}),
-        sessionId,
-        data,
-        ...(mutationId ? { mutationId } : {}),
-      });
+    ...(config.captureActionAdmission ? { captureActionAdmission } : {}),
+    sendCommand(sessionId, command, data, expectedOwnerConnectionId, mutationId, options) {
+      return sendRawCommand(
+        {
+          command,
+          // `expectedOwnerConnectionId` undefined still flows through `connectionId`
+          // as a top-level field on the wire (the relay tolerates a `connectionId`
+          // without a `sessionId`), so reuse the shared sender.
+          ...(expectedOwnerConnectionId ? { connectionId: expectedOwnerConnectionId } : {}),
+          sessionId,
+          data,
+          ...(mutationId ? { mutationId } : {}),
+        },
+        options
+      );
     },
     sendCommandToConnection(input) {
-      return sendRawCommand({
-        command: input.command,
-        connectionId: input.expectedConnectionId,
-        data: input.data,
-        ...(input.mutationId ? { mutationId: input.mutationId } : {}),
-      });
+      return sendRawCommand(
+        {
+          command: input.command,
+          connectionId: input.expectedConnectionId,
+          data: input.data,
+          ...(input.mutationId ? { mutationId: input.mutationId } : {}),
+        },
+        input
+      );
     },
     onCliEvent(sessionId, listener) {
       const listeners = cliListeners.get(sessionId) ?? new Set<(event: CliEvent) => void>();
@@ -759,7 +868,10 @@ function createUserWebConnection(
 
 export { createUserWebConnection, CommandDeliveredError, UserWebCommandError };
 export type {
+  SendCommandOptions,
   SendCommandToConnectionInput,
+  UserWebActionAdmission,
+  UserWebActionTarget,
   UserWebConnection,
   UserWebConnectionConfig,
   UserWebSessionEventName,


### PR DESCRIPTION
- If you change accounts, switch organizations, or put the app in the background, pending chat and session actions cannot start afterward.
- After an account change, Quick Chat, session history, and the active session list ignore results from the previous account.
- Quick Chat can save sent messages and received replies to the original conversation when you switch organizations or put the app in the background.
- Quick Chat removes messages that fail before sending instead of keeping them in the conversation or saved history.

---

## Summary

The software development kit (SDK) adds optional `captureActionAdmission` to `UserWebConnectionConfig` and `UserWebConnection`, binding `UserWebActionAdmission` to `UserWebActionTarget` before waits.
Both `SendCommandOptions` and `SendCommandToConnectionInput` accept this local proof; senders validate it immediately before sending without changing the wire format.
Existing connections without hooks keep unrestricted commands, while guarded connections reject unclassified commands and require retries to preserve the original proof.

<details>
<summary>Files</summary>

- `packages/cloud-agent-sdk/src/user-web-connection.ts` — Source, M (modified), 162 changed lines; adds frozen admission handles and a registry specific to each connection. Matches the command, session, and connection before waiting, then asserts the captured authority immediately before sending. Requires admission for `send_message`, `send_command`, `interrupt`, `question_reply`, `question_reject`, `permission_respond`, `suggestion_accept`, `suggestion_dismiss`, `create_session`, and `exit_cli`. Leaves `list_models`, `list_commands`, `list_directories`, and subscriptions outside action admission. Captures omitted proof at sender entry, but never puts proof in the wire frame or `mutationId`. Handles serialization, admission, and socket-send failures by rejecting the command, clearing its timer and pending entry, and releasing its retain.
- `packages/cloud-agent-sdk/src/index.ts` — Source, M (modified), 3 changed lines; makes `SendCommandOptions`, `UserWebActionAdmission`, and `UserWebActionTarget` available from the public SDK entry point.
- `packages/cloud-agent-sdk/src/user-web-connection.test.ts` — Test, M (modified), 340 changed lines; expands the connection admission tests.

</details>

`MobileActionAdmission` gives new mutations a foreground lease; `AcceptedWorkReceipt` permits dispatched `quick-chat-turn` and `app-store-purchase` completion under the original account and organization.
`quickChat.appendMessages` now requires `localAccessReceipt`; `kiloPass.completeAppStorePurchase` still accepts older StoreKit callers without it and retains backend verification.
Queries and `activeSessions.createWebTicket` need ownership; `user.registerPushToken` does too, while `user.unregisterPushToken` and `user.revokeCurrentDeviceSession` can also run during sign-out cleanup.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/local-access-transport.ts` — Source, A (added), 316 changed lines; introduces shared checks for credential ownership, foreground admission, and accepted completion. Validates authentication epochs, credential generations, and known user identities while allowing bootstrap reads before account restoration finishes. Uses registries to reject copied admissions and receipts, and issues receipts only after synchronous dispatch returns. Completion checks the original owner, organization, work kind, and applicable work identifier without requiring the current foreground lease or unlock grant. Quick Chat completion must match the first message's `clientId`; supplied mutation admission must match the request's account and organization. Captures admission when a mutation caller omits it. Adds a mandatory mobile connection wrapper that checks ownership around token waits and event delivery, records session scopes, and clears them on destruction. Imports the narrow SDK connection entry point and recovers typed denials from `Error.cause`.
- `apps/mobile/src/lib/local-access-transport.test.ts` — Test, A (added), 373 changed lines; introduces tests for transport admission and completion rules.

</details>

`TransportOperation` captures `localAccessOwner` and `localAccessAdmission` before authentication waits; `trpcClient` now sends mutations individually instead of batching them.
Query batches require one authentication epoch and credential generation; `skipBatch` still requests a single operation.
`deadlineFetch` keeps its deadline and abort contract; transport assertions run after artificial latency, and expired ownership produces `LocalAccessDeniedError` before dispatch or result delivery.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/trpc.ts` — Source, M (modified), 235 changed lines; replaces shared delegates with a delegate for each mutation and query batches for each owner. Rechecks ownership around token acquisition, stored expiry reads, refreshes, and observable delivery. Accepts token rotation within the captured credential generation but prevents requests from using a replacement account. Places the final dispatch assertion after test latency and the cancellation check, while preserving deadline extension, caller abort reasons, and client metadata. Keeps the library observable's pipe and teardown behavior. Tracks cancelled batch members in a weak registry until release and removes empty batches for stale owners.
- `apps/mobile/src/lib/trpc.test.ts` — Test, M (modified), 660 changed lines; revises request tests for owner checks and separate mutation requests.

</details>

`MobileConnectionConfig` requires `captureActionAdmission`, and `useUserWebConnection` returns `MobileUserWebConnection` with `owner` and `setSessionScope`.
`commandScopeSchema` gives explicit `orgId` precedence over the session scope and ready organization selection; unresolved targets fail.
`UserWebConnectionProvider` destroys stale sockets and remounts consumers when ownership changes, but organization changes and StrictMode cleanup retain a reusable connection.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/user-web-connection-provider.tsx` — Source, M (modified), 109 changed lines; subscribes to published owners and creates a connection for each owner. Sends ticket requests with the captured owner and keeps the latest organization selection in a ref for action capture. Rejects commands without a resolved target organization. Invalidates the old connection synchronously during owner publication rather than waiting for React's replacement commit. Uses the account, authentication epoch, and credential generation as the provider key. Ordinary cleanup unsubscribes and releases the retain so StrictMode can replay the effect.
- `apps/mobile/src/components/agents/user-web-connection-provider.mounted.test.tsx` — Test, M (modified), 320 changed lines; revises mounted tests for the provider's owner-bound connection.

</details>

`CreateMobileAgentSessionManagerOptions` now requires `MobileUserWebConnection`, so session reads, tickets, attachment caches, and failures retain their captured account owner.
Personal and organization calls to `sendMessage`, `interruptSession`, `answerQuestion`, `rejectQuestion`, and `answerPermission` carry admission.
`prepareSession` saves admission for `initiateFromPreparedSession` in resolution order; missing or expired admission prevents initiation, and owner replacement destroys the manager.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/mobile-session-manager.ts` — Source, M (modified), 162 changed lines; takes ownership from the connection instead of a later global account. Checks ownership around session resolution, snapshot reads, history pages, authentication waits, and stream-ticket responses. Keeps session-load retries with that owner and records each loaded or resolved session's organization through `setSessionScope`. Prevents stale attachment callbacks from writing caches. Adds admission to personal and organization mutations, and queues preparation admissions by completion order when requests share a session identifier. Initiation consumes the corresponding queued admission rather than capturing another lease. Destruction clears the queue and owner subscription; stale failures stop silently, while local-access denials propagate without a generic toast.
- `apps/mobile/src/components/agents/mobile-session-manager.local-access.test.ts` — Test, A (added), 334 changed lines; introduces session-manager admission tests.
- `apps/mobile/src/components/agents/mobile-session-manager.test.ts` — Test, M (modified), 37 changed lines; revises existing session-manager tests for captured ownership.

</details>

`createCliLiveTransport` and `createRemoteSessionOnConnection` capture `create_session` authority once and pass it to both the extended attempt and compatibility retry.
A retry therefore cannot acquire permission from a later context, and connection objects without capture keep their existing arguments.
Only the delivered `invalid create_session command` error permits one bare retry; clone requests never use that fallback.

<details>
<summary>Files</summary>

- `packages/cloud-agent-sdk/src/cli-live-transport.ts` — Source, M (modified), 29 changed lines; carries local command options through the session sender. Requires a connected command-line interface (CLI) owner before admission capture and forwards the same admission to the bare retry. Preserves separate mutation identities and omits extra arguments when callers provide no local options.
- `packages/cloud-agent-sdk/src/create-session.ts` — Source, M (modified), 11 changed lines; extends the connection input with optional admission capture. Captures proof before the extended request and includes it again on the bare request, preserving distinct `:ext` and `:bare` mutation identities.
- `packages/cloud-agent-sdk/src/cli-live-transport.local-access.test.ts` — Test, A (added), 379 changed lines; introduces local-admission tests for the live transport.
- `packages/cloud-agent-sdk/src/create-session.test.ts` — Test, M (modified), 18 changed lines; adds checks for admission reuse during session creation.

</details>

`QuickChatCompletionInput` makes `admission`, `turnId`, and `onDispatch` mandatory; `useQuickChat.onSend` resolves `Promise<AcceptedWorkReceipt>` when the fetch call returns, before its response.
`quickChat.getOrCreateThread` runs on send rather than mount, and `quickChat.appendMessages` uses the dispatched turn's proof instead of requesting new foreground permission.
Dispatched turns can finish saving to their original organization after backgrounding or context changes; account replacement blocks both saving and visible updates.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/quick-chat/quick-chat-gateway.ts` — Source, M (modified), 44 changed lines; validates the organization and cancellation signal before calling fetch. Issues the dispatch receipt only after that call returns, then checks ownership after the response, before each content delta, and at completion. Keeps the existing streaming request free of tools.
- `apps/mobile/src/components/quick-chat/use-quick-chat.ts` — Source, M (modified), 385 changed lines; keys history and local state by user, authentication epoch, credential generation, and organization. Waits for a ready authenticated context before showing history, and prevents stale pages, errors, or loading callbacks from updating the visible scope. Moves thread creation into the send flow and revalidates admission after thread creation and token acquisition. Separates the dispatch promise from streaming completion, removes turns without receipts, and completes each dispatched turn at most once for its original organization. Stops streams on explicit stop, scope replacement, and unmount; restricts refetches, notices, and visible updates to the current scope. Propagates local-access denials without a generic toast and uses the Promise constructor for Hermes support. Adds a line-count exception so paging and turn completion keep one ownership boundary.
- `apps/mobile/src/components/quick-chat/quick-chat-gateway.local-access.test.ts` — Test, A (added), 184 changed lines; introduces gateway admission tests.
- `apps/mobile/src/components/quick-chat/quick-chat-gateway.test.ts` — Test, M (modified), 49 changed lines; supplies the new completion inputs in existing gateway tests.
- `apps/mobile/src/components/quick-chat/use-quick-chat.local-access.test.ts` — Test, A (added), 339 changed lines; introduces tests for Quick Chat admission and completion.

</details>

`ActiveSessionsLiveSync` requires `CreateLiveSyncOptions.owner` and checks that owner around every query and queued cache update.
Ownership loss detaches subscriptions, cancels pending queries, and releases the retained connection before stale work can update the cache.
Callers keep context-specific query keys, serialized refreshes, enrichment, reconnect behavior, and manual refresh.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/active-sessions-live-sync.ts` — Source, M (modified), 43 changed lines; wraps queries and queued writes with ownership checks before and after waits. Detaches on owner replacement, clears pending refresh reasons, and treats repeated detach calls as no-ops. Adds a line-count exception to keep the serialized refresh state machine together.
- `apps/mobile/src/lib/active-sessions-live-sync-mount.tsx` — Source, M (modified), 8 changed lines; supplies the connection's owner when creating synchronization. Preserves the standing retain that keeps the socket open across organization changes.
- `apps/mobile/src/lib/active-sessions-live-sync.attention.test.ts` — Test, M (modified), 8 changed lines; supplies captured ownership to the attention tests.
- `apps/mobile/src/lib/active-sessions-live-sync.departure.test.ts` — Test, M (modified), 5 changed lines; supplies captured ownership to the departure tests.
- `apps/mobile/src/lib/active-sessions-live-sync.enrichment.test.ts` — Test, M (modified), 36 changed lines; revises enrichment tests for owner-bound synchronization.
- `apps/mobile/src/lib/active-sessions-live-sync.manual-refresh.test.ts` — Test, M (modified), 9 changed lines; passes the owner in manual-refresh tests.
- `apps/mobile/src/lib/active-sessions-live-sync.ownership.test.ts` — Test, A (added), 117 changed lines; introduces tests for synchronization after ownership changes.
- `apps/mobile/src/lib/active-sessions-live-sync.pending.test.ts` — Test, M (modified), 40 changed lines; revises pending-refresh tests for captured ownership.
- `apps/mobile/src/lib/active-sessions-live-sync.race.test.ts` — Test, M (modified), 7 changed lines; passes the owner in synchronization race tests.
- `apps/mobile/src/lib/active-sessions-live-sync.reconnect.test.ts` — Test, M (modified), 29 changed lines; revises reconnect tests for owner-bound synchronization.
- `apps/mobile/src/lib/active-sessions-live-sync.test-helpers.ts` — Test, M (modified), 25 changed lines; supplies ownership through the shared synchronization helpers.
- `apps/mobile/src/lib/active-sessions-live-sync.test.ts` — Test, M (modified), 31 changed lines; updates core synchronization tests to pass the owner.

</details>

Tests: 6 added files and 15 modified files (21 total). Added (6): `mobile-session-manager.local-access.test.ts`, `quick-chat-gateway.local-access.test.ts`, `use-quick-chat.local-access.test.ts`, `active-sessions-live-sync.ownership.test.ts`, `local-access-transport.test.ts`, `cli-live-transport.local-access.test.ts`. Modified (15): `mobile-session-manager.test.ts`, `user-web-connection-provider.mounted.test.tsx`, `quick-chat-gateway.test.ts`, `active-sessions-live-sync.attention.test.ts`, `active-sessions-live-sync.departure.test.ts`, `active-sessions-live-sync.enrichment.test.ts`, `active-sessions-live-sync.manual-refresh.test.ts`, `active-sessions-live-sync.pending.test.ts`, `active-sessions-live-sync.race.test.ts`, `active-sessions-live-sync.reconnect.test.ts`, `active-sessions-live-sync.test-helpers.ts`, `active-sessions-live-sync.test.ts`, `trpc.test.ts`, `create-session.test.ts`, `user-web-connection.test.ts`.
Generated: 0 generated files.

---

## Verification

- No manual runtime paths were tested for level 3; full iOS and Android verification runs on the final stack level.

Runtime verification remains bot-e2e, not human delegation.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Human steps

No human steps are required before merge or after merge.

### Automated evidence

- The handoff reports 206 passing focused tests for the software development kit.
- The final mobile checks passed 161 tests across 17 suites and all six scoped checks.
- These results are automated evidence, not manual device verification.

### Scope

- Repository: `Kilo-Org/cloud`.
- Worktree: `/Users/igor/Projects/.worktrees/mobile-context-lock-758a`.
- Review range: `mobile-context-lock-758a-s2...mobile-context-lock-758a-s3`.
- This description covers level 3 of eight planned levels; levels 1–5 now have PRs, and levels 6–8 remain unfinished.
- The change contains 33 files, with 4,047 insertions and 800 deletions; each file's size counts added and deleted lines.

### Notes

This level adds transport admission and ownership boundaries without exposing biometric controls. Full iOS and Android verification runs on the final stack level.

Device verification remains bot-e2e, not human delegation.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-context-lock-758a` — #5642
2. `mobile-context-lock-758a-s2` — #5651
3. `mobile-context-lock-758a-s3` — #5658 ← this PR
4. `mobile-context-lock-758a-s4` — #5664
5. `mobile-context-lock-758a-s5` — #5683 (tip)
