### PR TITLE
fix(mobile): use informal imperatives in starter chips

### DIFF
--- a/apps/mobile/src/i18n/locales/am.json
+++ b/apps/mobile/src/i18n/locales/am.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "አባሪዎችን ያስወግዱ?",
       "charactersRemaining": "{{count}} ቁምፊዎች ይቀራሉ",
       "insertNewline": "አዲስ መስመር ያስገቡ",
-      "starterChipBuild": "ባህሪ ይገንቡ",
-      "starterChipEmpty": "በሀሳብ ይጀምሩ",
-      "starterChipFix": "ስህተት ያስተካክሉ",
-      "starterChipPrepare": "የስራ አካባቢዬን ያዋቅሩ",
-      "starterChipWrapUp": "ክፍለ ጊዜዬን ያጠናቅቁ",
-      "starterChipWriteTests": "ሙከራዎችን ይፃፉ"
+      "starterChipBuild": "ባህሪ ገንባ",
+      "starterChipEmpty": "በሀሳብ ጀምር",
+      "starterChipFix": "ስህተት አስተካክል",
+      "starterChipPrepare": "የስራ አካባቢዬን አዋቅር",
+      "starterChipWrapUp": "ክፍለ ጊዜዬን አጠናቅቅ",
+      "starterChipWriteTests": "ሙከራዎችን ጻፍ"
     },
     "chatLink": {
       "linkCopied": "አገናኝ ተቀድቷል",

--- a/apps/mobile/src/i18n/locales/ar.json
+++ b/apps/mobile/src/i18n/locales/ar.json
@@ -2185,12 +2185,12 @@
       "discardAttachmentsTitle": "تجاهل المرفقات؟",
       "charactersRemaining": "الأحرف المتبقية: {{count}}",
       "insertNewline": "إدراج سطر جديد",
-      "starterChipBuild": "إنشاء ميزة",
-      "starterChipEmpty": "البدء بفكرة",
-      "starterChipFix": "إصلاح خلل",
-      "starterChipPrepare": "إعداد بيئتي",
-      "starterChipWrapUp": "إنهاء جلستي",
-      "starterChipWriteTests": "كتابة اختبارات"
+      "starterChipBuild": "أنشئ ميزة",
+      "starterChipEmpty": "ابدأ بفكرة",
+      "starterChipFix": "أصلح خللًا",
+      "starterChipPrepare": "جهّز بيئتي",
+      "starterChipWrapUp": "أنهِ جلستي",
+      "starterChipWriteTests": "اكتب اختبارات"
     },
     "chatLink": {
       "linkCopied": "تم نسخ الرابط",

--- a/apps/mobile/src/i18n/locales/az.json
+++ b/apps/mobile/src/i18n/locales/az.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Əlavələr ləğv edilsin?",
       "charactersRemaining": "{{count}} simvol qalıb",
       "insertNewline": "Yeni sətir daxil edin",
-      "starterChipBuild": "Funksiya yaradın",
-      "starterChipEmpty": "Bir ideya ilə başlayın",
-      "starterChipFix": "Səhvi düzəldin",
-      "starterChipPrepare": "Mühitimi qurun",
-      "starterChipWrapUp": "Sessiyamı tamamlayın",
-      "starterChipWriteTests": "Testlər yazın"
+      "starterChipBuild": "Funksiya yarat",
+      "starterChipEmpty": "Bir ideya ilə başla",
+      "starterChipFix": "Səhvi düzəlt",
+      "starterChipPrepare": "Mühitimi qur",
+      "starterChipWrapUp": "Sessiyamı tamamla",
+      "starterChipWriteTests": "Testlər yaz"
     },
     "chatLink": {
       "linkCopied": "Keçid kopyalandı",

--- a/apps/mobile/src/i18n/locales/be.json
+++ b/apps/mobile/src/i18n/locales/be.json
@@ -2629,12 +2629,12 @@
       "discardAttachmentsTitle": "Выдаліць укладанні?",
       "charactersRemaining": "Засталося сімвалаў: {{count}}",
       "insertNewline": "Уставіць новы радок",
-      "starterChipBuild": "Стварыць функцыю",
-      "starterChipEmpty": "Пачаць з ідэі",
-      "starterChipFix": "Выправіць памылку",
-      "starterChipPrepare": "Наладзіць маё асяроддзе",
-      "starterChipWrapUp": "Завяршыць мой сеанс",
-      "starterChipWriteTests": "Напісаць тэсты"
+      "starterChipBuild": "Ствары функцыю",
+      "starterChipEmpty": "Пачні з ідэі",
+      "starterChipFix": "Выправі памылку",
+      "starterChipPrepare": "Наладзь маё асяроддзе",
+      "starterChipWrapUp": "Завяршы мой сеанс",
+      "starterChipWriteTests": "Напішы тэсты"
     },
     "chatLink": {
       "linkCopied": "Спасылка скапіраваная",

--- a/apps/mobile/src/i18n/locales/bg.json
+++ b/apps/mobile/src/i18n/locales/bg.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Да отхвърлим прикачените файлове?",
       "charactersRemaining": "Остават {{count}} знака",
       "insertNewline": "Вмъкнете нов ред",
-      "starterChipBuild": "Разработете функция",
-      "starterChipEmpty": "Започнете с идея",
-      "starterChipFix": "Отстранете грешка",
-      "starterChipPrepare": "Настройте моята среда",
-      "starterChipWrapUp": "Приключете моята сесия",
-      "starterChipWriteTests": "Напишете тестове"
+      "starterChipBuild": "Разработи функция",
+      "starterChipEmpty": "Започни с идея",
+      "starterChipFix": "Отстрани грешка",
+      "starterChipPrepare": "Настрой моята среда",
+      "starterChipWrapUp": "Приключи моята сесия",
+      "starterChipWriteTests": "Напиши тестове"
     },
     "chatLink": {
       "linkCopied": "Линкът е копиран",

--- a/apps/mobile/src/i18n/locales/bn.json
+++ b/apps/mobile/src/i18n/locales/bn.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "সংযুক্তিগুলি বাতিল করবেন?",
       "charactersRemaining": "{{count}}টি অক্ষর বাকি",
       "insertNewline": "নতুন লাইন যোগ করুন",
-      "starterChipBuild": "একটি ফিচার তৈরি করুন",
-      "starterChipEmpty": "একটি ধারণা দিয়ে শুরু করুন",
-      "starterChipFix": "একটি ত্রুটি ঠিক করুন",
-      "starterChipPrepare": "আমার পরিবেশ প্রস্তুত করুন",
-      "starterChipWrapUp": "আমার সেশন শেষ করুন",
-      "starterChipWriteTests": "পরীক্ষা লিখুন"
+      "starterChipBuild": "একটি ফিচার তৈরি করো",
+      "starterChipEmpty": "একটি ধারণা দিয়ে শুরু করো",
+      "starterChipFix": "একটি ত্রুটি ঠিক করো",
+      "starterChipPrepare": "আমার পরিবেশ প্রস্তুত করো",
+      "starterChipWrapUp": "আমার সেশন শেষ করো",
+      "starterChipWriteTests": "পরীক্ষা লেখো"
     },
     "chatLink": {
       "linkCopied": "লিঙ্ক কপি হয়েছে",

--- a/apps/mobile/src/i18n/locales/bs.json
+++ b/apps/mobile/src/i18n/locales/bs.json
@@ -2610,12 +2610,12 @@
       "discardAttachmentsTitle": "Odbaciti privitke?",
       "charactersRemaining": "Preostalo znakova: {{count}}",
       "insertNewline": "Umetnite novi red",
-      "starterChipBuild": "Izradite funkciju",
-      "starterChipEmpty": "Počnite s idejom",
-      "starterChipFix": "Ispravite grešku",
-      "starterChipPrepare": "Postavite moje okruženje",
-      "starterChipWrapUp": "Završite moju sesiju",
-      "starterChipWriteTests": "Napišite testove"
+      "starterChipBuild": "Izradi funkciju",
+      "starterChipEmpty": "Počni s idejom",
+      "starterChipFix": "Ispravi grešku",
+      "starterChipPrepare": "Postavi moje okruženje",
+      "starterChipWrapUp": "Završi moju sesiju",
+      "starterChipWriteTests": "Napiši testove"
     },
     "chatLink": {
       "linkCopied": "Veza kopirana",

--- a/apps/mobile/src/i18n/locales/ckb.json
+++ b/apps/mobile/src/i18n/locales/ckb.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "فڕێدانی هاوپێچەکان؟",
       "charactersRemaining": "{{count}} پیت ماوە",
       "insertNewline": "تێخستنی دێڕێکی نوێ",
-      "starterChipBuild": "دروستکردنی تایبەتمەندییەک",
-      "starterChipEmpty": "دەستپێکردن بە بیرۆکەیەک",
-      "starterChipFix": "چاککردنەوەی هەڵەیەک",
-      "starterChipPrepare": "ڕێکخستنی ژینگەکەم",
-      "starterChipWrapUp": "تەواوکردنی سێشنەکەم",
-      "starterChipWriteTests": "نووسینی تاقیکردنەوەکان"
+      "starterChipBuild": "تایبەتمەندییەک دروست بکە",
+      "starterChipEmpty": "بە بیرۆکەیەک دەست پێ بکە",
+      "starterChipFix": "هەڵەیەک چاک بکەرەوە",
+      "starterChipPrepare": "ژینگەکەم ڕێک بخە",
+      "starterChipWrapUp": "سێشنەکەم تەواو بکە",
+      "starterChipWriteTests": "تاقیکردنەوەکان بنووسە"
     },
     "chatLink": {
       "linkCopied": "بەستەرەکە کۆپی کرا",

--- a/apps/mobile/src/i18n/locales/cs.json
+++ b/apps/mobile/src/i18n/locales/cs.json
@@ -2629,12 +2629,12 @@
       "discardAttachmentsTitle": "Zahodit přílohy?",
       "charactersRemaining": "Zbývající počet znaků: {{count}}",
       "insertNewline": "Vložit nový řádek",
-      "starterChipBuild": "Vytvořit funkci",
-      "starterChipEmpty": "Začít nápadem",
-      "starterChipFix": "Opravit chybu",
-      "starterChipPrepare": "Nastavit mé prostředí",
-      "starterChipWrapUp": "Dokončit mou relaci",
-      "starterChipWriteTests": "Napsat testy"
+      "starterChipBuild": "Vytvoř funkci",
+      "starterChipEmpty": "Začni nápadem",
+      "starterChipFix": "Oprav chybu",
+      "starterChipPrepare": "Nastav mé prostředí",
+      "starterChipWrapUp": "Dokonči mou relaci",
+      "starterChipWriteTests": "Napiš testy"
     },
     "chatLink": {
       "linkCopied": "Odkaz zkopírován",

--- a/apps/mobile/src/i18n/locales/cy.json
+++ b/apps/mobile/src/i18n/locales/cy.json
@@ -2667,12 +2667,12 @@
       "discardAttachmentsTitle": "Taflu atodiadau?",
       "charactersRemaining": "{{count}} nod yn weddill",
       "insertNewline": "Mewnosod llinell newydd",
-      "starterChipBuild": "Adeiladu nodwedd",
+      "starterChipBuild": "Adeilada nodwedd",
       "starterChipEmpty": "Dechrau gyda syniad",
-      "starterChipFix": "Trwsio nam",
+      "starterChipFix": "Trwsia nam",
       "starterChipPrepare": "Gosod fy amgylchedd",
       "starterChipWrapUp": "Gorffen fy sesiwn",
-      "starterChipWriteTests": "Ysgrifennu profion"
+      "starterChipWriteTests": "Ysgrifenna brofion"
     },
     "chatLink": {
       "linkCopied": "Copïwyd y ddolen",

--- a/apps/mobile/src/i18n/locales/de.json
+++ b/apps/mobile/src/i18n/locales/de.json
@@ -2137,12 +2137,12 @@
       "discardAttachmentsTitle": "Anhänge verwerfen?",
       "charactersRemaining": "Noch {{count}} Zeichen",
       "insertNewline": "Zeilenumbruch einfügen",
-      "starterChipBuild": "Eine Funktion entwickeln",
-      "starterChipEmpty": "Mit einer Idee beginnen",
-      "starterChipFix": "Einen Fehler beheben",
-      "starterChipPrepare": "Meine Umgebung einrichten",
-      "starterChipWrapUp": "Meine Sitzung abschließen",
-      "starterChipWriteTests": "Tests schreiben"
+      "starterChipBuild": "Entwickle eine Funktion",
+      "starterChipEmpty": "Beginne mit einer Idee",
+      "starterChipFix": "Behebe einen Fehler",
+      "starterChipPrepare": "Richte meine Umgebung ein",
+      "starterChipWrapUp": "Schließe meine Sitzung ab",
+      "starterChipWriteTests": "Schreibe Tests"
     },
     "chatLink": {
       "linkCopied": "Link kopiert",

--- a/apps/mobile/src/i18n/locales/el.json
+++ b/apps/mobile/src/i18n/locales/el.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Απόρριψη συνημμένων;",
       "charactersRemaining": "Απομένουν {{count}} χαρακτήρες",
       "insertNewline": "Εισαγωγή νέας γραμμής",
-      "starterChipBuild": "Δημιουργία λειτουργίας",
-      "starterChipEmpty": "Ξεκινήστε με μια ιδέα",
-      "starterChipFix": "Διόρθωση σφάλματος",
-      "starterChipPrepare": "Ρύθμιση του περιβάλλοντός μου",
-      "starterChipWrapUp": "Ολοκλήρωση της συνεδρίας μου",
-      "starterChipWriteTests": "Σύνταξη δοκιμών"
+      "starterChipBuild": "Δημιούργησε μια λειτουργία",
+      "starterChipEmpty": "Ξεκίνα με μια ιδέα",
+      "starterChipFix": "Διόρθωσε ένα σφάλμα",
+      "starterChipPrepare": "Ρύθμισε το περιβάλλον μου",
+      "starterChipWrapUp": "Ολοκλήρωσε τη συνεδρία μου",
+      "starterChipWriteTests": "Γράψε δοκιμές"
     },
     "chatLink": {
       "linkCopied": "Ο σύνδεσμος αντιγράφηκε",

--- a/apps/mobile/src/i18n/locales/es.json
+++ b/apps/mobile/src/i18n/locales/es.json
@@ -2149,12 +2149,12 @@
       "discardAttachmentsTitle": "¿Descartar adjuntos?",
       "charactersRemaining": "Quedan {{count}} caracteres",
       "insertNewline": "Insertar salto de línea",
-      "starterChipBuild": "Crear una función",
-      "starterChipEmpty": "Empezar con una idea",
-      "starterChipFix": "Corregir un error",
-      "starterChipPrepare": "Configurar mi entorno",
-      "starterChipWrapUp": "Finalizar mi sesión",
-      "starterChipWriteTests": "Escribir pruebas"
+      "starterChipBuild": "Crea una función",
+      "starterChipEmpty": "Empieza con una idea",
+      "starterChipFix": "Corrige un error",
+      "starterChipPrepare": "Configura mi entorno",
+      "starterChipWrapUp": "Finaliza mi sesión",
+      "starterChipWriteTests": "Escribe pruebas"
     },
     "chatLink": {
       "linkCopied": "Enlace copiado",

--- a/apps/mobile/src/i18n/locales/et.json
+++ b/apps/mobile/src/i18n/locales/et.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Kas loobuda manustest?",
       "charactersRemaining": "{{count}} tähemärki jäänud",
       "insertNewline": "Lisage reavahetus",
-      "starterChipBuild": "Looge funktsioon",
-      "starterChipEmpty": "Alustage ideest",
-      "starterChipFix": "Parandage viga",
-      "starterChipPrepare": "Seadistage minu keskkond",
-      "starterChipWrapUp": "Lõpetage minu seanss",
-      "starterChipWriteTests": "Kirjutage testid"
+      "starterChipBuild": "Loo funktsioon",
+      "starterChipEmpty": "Alusta ideest",
+      "starterChipFix": "Paranda viga",
+      "starterChipPrepare": "Seadista minu keskkond",
+      "starterChipWrapUp": "Lõpeta minu seanss",
+      "starterChipWriteTests": "Kirjuta testid"
     },
     "chatLink": {
       "linkCopied": "Link kopeeritud",

--- a/apps/mobile/src/i18n/locales/fa.json
+++ b/apps/mobile/src/i18n/locales/fa.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "پیوست‌ها دور انداخته شوند؟",
       "charactersRemaining": "{{count}} نویسه باقی مانده",
       "insertNewline": "درج خط جدید",
-      "starterChipBuild": "ساخت یک ویژگی",
-      "starterChipEmpty": "شروع با یک ایده",
-      "starterChipFix": "رفع یک اشکال",
-      "starterChipPrepare": "راه‌اندازی محیط من",
-      "starterChipWrapUp": "پایان دادن به نشست من",
-      "starterChipWriteTests": "نوشتن آزمون‌ها"
+      "starterChipBuild": "یک ویژگی بساز",
+      "starterChipEmpty": "با یک ایده شروع کن",
+      "starterChipFix": "یک اشکال را رفع کن",
+      "starterChipPrepare": "محیط من را راه‌اندازی کن",
+      "starterChipWrapUp": "به نشست من پایان بده",
+      "starterChipWriteTests": "آزمون‌ها را بنویس"
     },
     "chatLink": {
       "linkCopied": "پیوند کپی شد",

--- a/apps/mobile/src/i18n/locales/fil.json
+++ b/apps/mobile/src/i18n/locales/fil.json
@@ -2593,10 +2593,10 @@
       "insertNewline": "Magpasok ng bagong linya",
       "starterChipBuild": "Gumawa ng feature",
       "starterChipEmpty": "Magsimula sa isang ideya",
-      "starterChipFix": "Ayusin ang depekto",
-      "starterChipPrepare": "Ihanda ang aking environment",
-      "starterChipWrapUp": "Tapusin ang aking session",
-      "starterChipWriteTests": "Sumulat ng mga pagsubok"
+      "starterChipFix": "Ayusin ang bug",
+      "starterChipPrepare": "Ihanda ang environment ko",
+      "starterChipWrapUp": "Tapusin ang session ko",
+      "starterChipWriteTests": "Sumulat ng mga test"
     },
     "chatLink": {
       "linkCopied": "Na-kopya ang link",

--- a/apps/mobile/src/i18n/locales/fr.json
+++ b/apps/mobile/src/i18n/locales/fr.json
@@ -2065,12 +2065,12 @@
       "discardAttachmentsTitle": "Abandonner les pièces jointes ?",
       "charactersRemaining": "{{count}} caractères restants",
       "insertNewline": "Insérer un saut de ligne",
-      "starterChipBuild": "Créer une fonctionnalité",
-      "starterChipEmpty": "Commencer par une idée",
-      "starterChipFix": "Corriger un bogue",
-      "starterChipPrepare": "Configurer mon environnement",
-      "starterChipWrapUp": "Terminer ma session",
-      "starterChipWriteTests": "Écrire des tests"
+      "starterChipBuild": "Crée une fonctionnalité",
+      "starterChipEmpty": "Commence par une idée",
+      "starterChipFix": "Corrige un bogue",
+      "starterChipPrepare": "Configure mon environnement",
+      "starterChipWrapUp": "Termine ma session",
+      "starterChipWriteTests": "Écris des tests"
     },
     "chatLink": {
       "linkCopied": "Lien copié",

--- a/apps/mobile/src/i18n/locales/gl.json
+++ b/apps/mobile/src/i18n/locales/gl.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Descartar os anexos?",
       "charactersRemaining": "Quedan {{count}} caracteres",
       "insertNewline": "Inserir un salto de liña",
-      "starterChipBuild": "Crear unha funcionalidade",
-      "starterChipEmpty": "Comezar cunha idea",
-      "starterChipFix": "Corrixir un erro",
-      "starterChipPrepare": "Configurar o meu ambiente",
-      "starterChipWrapUp": "Rematar a miña sesión",
-      "starterChipWriteTests": "Escribir probas"
+      "starterChipBuild": "Crea unha funcionalidade",
+      "starterChipEmpty": "Comeza cunha idea",
+      "starterChipFix": "Corrixe un erro",
+      "starterChipPrepare": "Configura o meu ambiente",
+      "starterChipWrapUp": "Remata a miña sesión",
+      "starterChipWriteTests": "Escribe probas"
     },
     "chatLink": {
       "linkCopied": "Ligazón copiada",

--- a/apps/mobile/src/i18n/locales/gu.json
+++ b/apps/mobile/src/i18n/locales/gu.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "એટેચમેન્ટ્સ કાઢી નાખવા છે?",
       "charactersRemaining": "{{count}} અક્ષરો બાકી",
       "insertNewline": "નવી લાઇન દાખલ કરો",
-      "starterChipBuild": "સુવિધા બનાવો",
-      "starterChipEmpty": "વિચારથી શરૂઆત કરો",
-      "starterChipFix": "ભૂલ સુધારો",
-      "starterChipPrepare": "મારું એન્વાયર્નમેન્ટ સેટ કરો",
-      "starterChipWrapUp": "મારું સત્ર પૂર્ણ કરો",
-      "starterChipWriteTests": "પરીક્ષણો લખો"
+      "starterChipBuild": "સુવિધા બનાવ",
+      "starterChipEmpty": "વિચારથી શરૂઆત કર",
+      "starterChipFix": "ભૂલ સુધાર",
+      "starterChipPrepare": "મારું એન્વાયર્નમેન્ટ સેટ કર",
+      "starterChipWrapUp": "મારું સત્ર પૂર્ણ કર",
+      "starterChipWriteTests": "પરીક્ષણો લખ"
     },
     "chatLink": {
       "linkCopied": "લિંક કૉપિ થઈ",

--- a/apps/mobile/src/i18n/locales/hi.json
+++ b/apps/mobile/src/i18n/locales/hi.json
@@ -2103,12 +2103,12 @@
       "discardAttachmentsTitle": "संलग्नक ख़ारिज करें?",
       "charactersRemaining": "{{count}} अक्षर शेष",
       "insertNewline": "नई पंक्ति डालें",
-      "starterChipBuild": "एक सुविधा बनाएँ",
-      "starterChipEmpty": "एक विचार से शुरू करें",
-      "starterChipFix": "एक त्रुटि ठीक करें",
-      "starterChipPrepare": "मेरा परिवेश तैयार करें",
-      "starterChipWrapUp": "मेरा सत्र समाप्त करें",
-      "starterChipWriteTests": "परीक्षण लिखें"
+      "starterChipBuild": "एक सुविधा बनाओ",
+      "starterChipEmpty": "एक विचार से शुरू करो",
+      "starterChipFix": "एक त्रुटि ठीक करो",
+      "starterChipPrepare": "मेरा परिवेश तैयार करो",
+      "starterChipWrapUp": "मेरा सत्र समाप्त करो",
+      "starterChipWriteTests": "परीक्षण लिखो"
     },
     "chatLink": {
       "linkCopied": "लिंक कॉपी किया गया",

--- a/apps/mobile/src/i18n/locales/hr.json
+++ b/apps/mobile/src/i18n/locales/hr.json
@@ -2610,12 +2610,12 @@
       "discardAttachmentsTitle": "Odbaciti privitke?",
       "charactersRemaining": "Preostalo znakova: {{count}}",
       "insertNewline": "Umetnite novi redak",
-      "starterChipBuild": "Izradite značajku",
-      "starterChipEmpty": "Započnite s idejom",
-      "starterChipFix": "Ispravite pogrešku",
-      "starterChipPrepare": "Postavite moje okruženje",
-      "starterChipWrapUp": "Dovršite moju sesiju",
-      "starterChipWriteTests": "Napišite testove"
+      "starterChipBuild": "Izradi značajku",
+      "starterChipEmpty": "Započni s idejom",
+      "starterChipFix": "Ispravi pogrešku",
+      "starterChipPrepare": "Postavi moje okruženje",
+      "starterChipWrapUp": "Dovrši moju sesiju",
+      "starterChipWriteTests": "Napiši testove"
     },
     "chatLink": {
       "linkCopied": "Poveznica kopirana",

--- a/apps/mobile/src/i18n/locales/hu.json
+++ b/apps/mobile/src/i18n/locales/hu.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Elveti a csatolmányokat?",
       "charactersRemaining": "{{count}} karakter maradt",
       "insertNewline": "Új sor beszúrása",
-      "starterChipBuild": "Funkció fejlesztése",
-      "starterChipEmpty": "Kezdés egy ötlettel",
-      "starterChipFix": "Hiba javítása",
-      "starterChipPrepare": "A környezetem beállítása",
-      "starterChipWrapUp": "A munkamenetem lezárása",
-      "starterChipWriteTests": "Tesztek írása"
+      "starterChipBuild": "Fejlessz egy funkciót",
+      "starterChipEmpty": "Kezdj egy ötlettel",
+      "starterChipFix": "Javíts ki egy hibát",
+      "starterChipPrepare": "Állítsd be a környezetemet",
+      "starterChipWrapUp": "Zárd le a munkamenetemet",
+      "starterChipWriteTests": "Írj teszteket"
     },
     "chatLink": {
       "linkCopied": "Hivatkozás másolva",

--- a/apps/mobile/src/i18n/locales/hy.json
+++ b/apps/mobile/src/i18n/locales/hy.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Մերժե՞լ կցորդները",
       "charactersRemaining": "Մնացել է {{count}} նիշ",
       "insertNewline": "Տեղադրել նոր տող",
-      "starterChipBuild": "Ստեղծել գործառույթ",
-      "starterChipEmpty": "Սկսել գաղափարից",
-      "starterChipFix": "Շտկել սխալը",
-      "starterChipPrepare": "Կարգավորել իմ միջավայրը",
-      "starterChipWrapUp": "Ավարտել իմ նիստը",
-      "starterChipWriteTests": "Գրել թեստեր"
+      "starterChipBuild": "Ստեղծիր գործառույթ",
+      "starterChipEmpty": "Սկսիր գաղափարից",
+      "starterChipFix": "Շտկիր սխալը",
+      "starterChipPrepare": "Կարգավորիր իմ միջավայրը",
+      "starterChipWrapUp": "Ավարտիր իմ նիստը",
+      "starterChipWriteTests": "Գրիր թեստեր"
     },
     "chatLink": {
       "linkCopied": "Հղումը պատճենված է",

--- a/apps/mobile/src/i18n/locales/is.json
+++ b/apps/mobile/src/i18n/locales/is.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Farga viðhengjum?",
       "charactersRemaining": "{{count}} stafir eftir",
       "insertNewline": "Setja inn línuskil",
-      "starterChipBuild": "Búa til eiginleika",
-      "starterChipEmpty": "Byrja með hugmynd",
-      "starterChipFix": "Laga villu",
-      "starterChipPrepare": "Setja upp umhverfið mitt",
-      "starterChipWrapUp": "Ljúka lotunni minni",
-      "starterChipWriteTests": "Skrifa próf"
+      "starterChipBuild": "Búðu til eiginleika",
+      "starterChipEmpty": "Byrjaðu með hugmynd",
+      "starterChipFix": "Lagaðu villu",
+      "starterChipPrepare": "Settu upp umhverfið mitt",
+      "starterChipWrapUp": "Ljúktu lotunni minni",
+      "starterChipWriteTests": "Skrifaðu próf"
     },
     "chatLink": {
       "linkCopied": "Krækja afrituð",

--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -2137,12 +2137,12 @@
       "discardAttachmentsTitle": "添付ファイルを破棄しますか？",
       "charactersRemaining": "残り{{count}}文字",
       "insertNewline": "改行を挿入",
-      "starterChipBuild": "機能を作成",
-      "starterChipEmpty": "アイデアから開始",
-      "starterChipFix": "バグを修正",
-      "starterChipPrepare": "環境をセットアップ",
-      "starterChipWrapUp": "セッションをまとめる",
-      "starterChipWriteTests": "テストを作成"
+      "starterChipBuild": "機能を作って",
+      "starterChipEmpty": "アイデアから始めて",
+      "starterChipFix": "バグを直して",
+      "starterChipPrepare": "私の環境をセットアップして",
+      "starterChipWrapUp": "私のセッションを締めくくって",
+      "starterChipWriteTests": "テストを書いて"
     },
     "chatLink": {
       "linkCopied": "リンクをコピーしました",

--- a/apps/mobile/src/i18n/locales/ka.json
+++ b/apps/mobile/src/i18n/locales/ka.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "გავაუქმოთ დანართები?",
       "charactersRemaining": "დარჩენილია {{count}} სიმბოლო",
       "insertNewline": "ახალი ხაზის ჩასმა",
-      "starterChipBuild": "შექმენით ფუნქცია",
-      "starterChipEmpty": "დაიწყეთ იდეით",
-      "starterChipFix": "შეასწორეთ შეცდომა",
-      "starterChipPrepare": "გამართეთ ჩემი გარემო",
-      "starterChipWrapUp": "დაასრულეთ ჩემი სესია",
-      "starterChipWriteTests": "დაწერეთ ტესტები"
+      "starterChipBuild": "შექმენი ფუნქცია",
+      "starterChipEmpty": "დაიწყე იდეით",
+      "starterChipFix": "შეასწორე შეცდომა",
+      "starterChipPrepare": "გამართე ჩემი გარემო",
+      "starterChipWrapUp": "დაასრულე ჩემი სესია",
+      "starterChipWriteTests": "დაწერე ტესტები"
     },
     "chatLink": {
       "linkCopied": "ბმული დაკოპირდა",

--- a/apps/mobile/src/i18n/locales/kk.json
+++ b/apps/mobile/src/i18n/locales/kk.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Қосымшаларды жою керек пе?",
       "charactersRemaining": "{{count}} таңба қалды",
       "insertNewline": "Жаңа жол енгізу",
-      "starterChipBuild": "Мүмкіндік жасау",
-      "starterChipEmpty": "Идеядан бастау",
-      "starterChipFix": "Қатені түзету",
-      "starterChipPrepare": "Ортамды баптау",
-      "starterChipWrapUp": "Сессиямды аяқтау",
-      "starterChipWriteTests": "Тесттер жазу"
+      "starterChipBuild": "Мүмкіндік жаса",
+      "starterChipEmpty": "Идеядан баста",
+      "starterChipFix": "Қатені түзет",
+      "starterChipPrepare": "Ортамды бапта",
+      "starterChipWrapUp": "Сессиямды аяқта",
+      "starterChipWriteTests": "Тесттер жаз"
     },
     "chatLink": {
       "linkCopied": "Сілтеме көшірілді",

--- a/apps/mobile/src/i18n/locales/kn.json
+++ b/apps/mobile/src/i18n/locales/kn.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "ಲಗತ್ತುಗಳನ್ನು ತೆಗೆದುಹಾಕಬೇಕೆ?",
       "charactersRemaining": "{{count}} ಅಕ್ಷರಗಳು ಉಳಿದಿವೆ",
       "insertNewline": "ಹೊಸ ಸಾಲನ್ನು ಸೇರಿಸಿ",
-      "starterChipBuild": "ವೈಶಿಷ್ಟ್ಯವನ್ನು ನಿರ್ಮಿಸಿ",
-      "starterChipEmpty": "ಒಂದು ಆಲೋಚನೆಯೊಂದಿಗೆ ಪ್ರಾರಂಭಿಸಿ",
-      "starterChipFix": "ದೋಷವನ್ನು ಸರಿಪಡಿಸಿ",
-      "starterChipPrepare": "ನನ್ನ ಪರಿಸರವನ್ನು ಹೊಂದಿಸಿ",
-      "starterChipWrapUp": "ನನ್ನ ಸೆಶನ್ ಮುಕ್ತಾಯಗೊಳಿಸಿ",
-      "starterChipWriteTests": "ಪರೀಕ್ಷೆಗಳನ್ನು ಬರೆಯಿರಿ"
+      "starterChipBuild": "ವೈಶಿಷ್ಟ್ಯವನ್ನು ನಿರ್ಮಿಸು",
+      "starterChipEmpty": "ಒಂದು ಆಲೋಚನೆಯೊಂದಿಗೆ ಪ್ರಾರಂಭಿಸು",
+      "starterChipFix": "ದೋಷವನ್ನು ಸರಿಪಡಿಸು",
+      "starterChipPrepare": "ನನ್ನ ಪರಿಸರವನ್ನು ಹೊಂದಿಸು",
+      "starterChipWrapUp": "ನನ್ನ ಸೆಶನ್ ಮುಕ್ತಾಯಗೊಳಿಸು",
+      "starterChipWriteTests": "ಪರೀಕ್ಷೆಗಳನ್ನು ಬರೆ"
     },
     "chatLink": {
       "linkCopied": "ಲಿಂಕ್ ನಕಲಿಸಲಾಗಿದೆ",

--- a/apps/mobile/src/i18n/locales/ko.json
+++ b/apps/mobile/src/i18n/locales/ko.json
@@ -2137,12 +2137,12 @@
       "discardAttachmentsTitle": "첨부 파일을 삭제할까요?",
       "charactersRemaining": "{{count}}자 남음",
       "insertNewline": "줄바꿈 삽입",
-      "starterChipBuild": "기능 구현",
-      "starterChipEmpty": "아이디어로 시작",
-      "starterChipFix": "버그 수정",
-      "starterChipPrepare": "내 환경 설정",
-      "starterChipWrapUp": "내 세션 마무리",
-      "starterChipWriteTests": "테스트 작성"
+      "starterChipBuild": "기능을 구현해",
+      "starterChipEmpty": "아이디어로 시작해",
+      "starterChipFix": "버그를 고쳐",
+      "starterChipPrepare": "내 환경을 설정해",
+      "starterChipWrapUp": "내 세션을 마무리해",
+      "starterChipWriteTests": "테스트를 작성해"
     },
     "chatLink": {
       "linkCopied": "링크 복사됨",

--- a/apps/mobile/src/i18n/locales/lt.json
+++ b/apps/mobile/src/i18n/locales/lt.json
@@ -2629,12 +2629,12 @@
       "discardAttachmentsTitle": "Atmesti priedus?",
       "charactersRemaining": "Liko simbolių: {{count}}",
       "insertNewline": "Įterpti naują eilutę",
-      "starterChipBuild": "Sukurti funkciją",
-      "starterChipEmpty": "Pradėti nuo idėjos",
-      "starterChipFix": "Ištaisyti klaidą",
-      "starterChipPrepare": "Paruošti mano aplinką",
-      "starterChipWrapUp": "Užbaigti mano sesiją",
-      "starterChipWriteTests": "Parašyti testus"
+      "starterChipBuild": "Sukurk funkciją",
+      "starterChipEmpty": "Pradėk nuo idėjos",
+      "starterChipFix": "Ištaisyk klaidą",
+      "starterChipPrepare": "Paruošk mano aplinką",
+      "starterChipWrapUp": "Užbaik mano sesiją",
+      "starterChipWriteTests": "Parašyk testus"
     },
     "chatLink": {
       "linkCopied": "Nuoroda nukopijuota",

--- a/apps/mobile/src/i18n/locales/lv.json
+++ b/apps/mobile/src/i18n/locales/lv.json
@@ -2610,12 +2610,12 @@
       "discardAttachmentsTitle": "Atmest pielikumus?",
       "charactersRemaining": "Atlikušās rakstzīmes: {{count}}",
       "insertNewline": "Ievietot jaunu rindu",
-      "starterChipBuild": "Izveidot funkciju",
-      "starterChipEmpty": "Sākt ar ideju",
-      "starterChipFix": "Izlabot kļūdu",
-      "starterChipPrepare": "Iestatīt manu vidi",
-      "starterChipWrapUp": "Pabeigt manu sesiju",
-      "starterChipWriteTests": "Rakstīt testus"
+      "starterChipBuild": "Izveido funkciju",
+      "starterChipEmpty": "Sāc ar ideju",
+      "starterChipFix": "Izlabo kļūdu",
+      "starterChipPrepare": "Iestati manu vidi",
+      "starterChipWrapUp": "Pabeidz manu sesiju",
+      "starterChipWriteTests": "Raksti testus"
     },
     "chatLink": {
       "linkCopied": "Saite kopēta",

--- a/apps/mobile/src/i18n/locales/mi.json
+++ b/apps/mobile/src/i18n/locales/mi.json
@@ -2595,7 +2595,7 @@
       "starterChipEmpty": "Tīmata ki tētahi whakaaro",
       "starterChipFix": "Whakatikahia he hapa",
       "starterChipPrepare": "Whakaritea taku taiao",
-      "starterChipWrapUp": "Whakakapihia taku wātūtū",
+      "starterChipWrapUp": "Whakakapia taku wātū",
       "starterChipWriteTests": "Tuhia ngā whakamātau"
     },
     "chatLink": {

--- a/apps/mobile/src/i18n/locales/mk.json
+++ b/apps/mobile/src/i18n/locales/mk.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Да се отфрлат прилозите?",
       "charactersRemaining": "Преостануваат {{count}} знаци",
       "insertNewline": "Вметнете нов ред",
-      "starterChipBuild": "Изградете функционалност",
-      "starterChipEmpty": "Започнете со идеја",
-      "starterChipFix": "Поправете грешка",
-      "starterChipPrepare": "Поставете ја мојата околина",
-      "starterChipWrapUp": "Завршете ја мојата сесија",
-      "starterChipWriteTests": "Напишете тестови"
+      "starterChipBuild": "Изгради функционалност",
+      "starterChipEmpty": "Започни со идеја",
+      "starterChipFix": "Поправи грешка",
+      "starterChipPrepare": "Постави ја мојата околина",
+      "starterChipWrapUp": "Заврши ја мојата сесија",
+      "starterChipWriteTests": "Напиши тестови"
     },
     "chatLink": {
       "linkCopied": "Линкот е копиран",

--- a/apps/mobile/src/i18n/locales/ml.json
+++ b/apps/mobile/src/i18n/locales/ml.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "അറ്റാച്ച്മെന്റുകൾ ഉപേക്ഷിക്കണോ?",
       "charactersRemaining": "{{count}} അക്ഷരങ്ങൾ ശേഷിക്കുന്നു",
       "insertNewline": "പുതിയ വരി ചേർക്കുക",
-      "starterChipBuild": "ഒരു ഫീച്ചർ നിർമ്മിക്കുക",
-      "starterChipEmpty": "ഒരു ആശയത്തോടെ ആരംഭിക്കുക",
-      "starterChipFix": "ഒരു ബഗ് പരിഹരിക്കുക",
-      "starterChipPrepare": "എന്റെ എൻവയോൺമെന്റ് സജ്ജീകരിക്കുക",
-      "starterChipWrapUp": "എന്റെ സെഷൻ പൂർത്തിയാക്കുക",
-      "starterChipWriteTests": "ടെസ്റ്റുകൾ എഴുതുക"
+      "starterChipBuild": "ഒരു ഫീച്ചർ നിർമ്മിക്ക്",
+      "starterChipEmpty": "ഒരു ആശയത്തോടെ ആരംഭിക്ക്",
+      "starterChipFix": "ഒരു ബഗ് പരിഹരിക്ക്",
+      "starterChipPrepare": "എന്റെ എൻവയോൺമെന്റ് സജ്ജീകരിക്ക്",
+      "starterChipWrapUp": "എന്റെ സെഷൻ പൂർത്തിയാക്ക്",
+      "starterChipWriteTests": "ടെസ്റ്റുകൾ എഴുത്"
     },
     "chatLink": {
       "linkCopied": "ലിങ്ക് പകർത്തി",

--- a/apps/mobile/src/i18n/locales/mn.json
+++ b/apps/mobile/src/i18n/locales/mn.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Хавсралтуудыг хаях уу?",
       "charactersRemaining": "{{count}} тэмдэгт үлдсэн",
       "insertNewline": "Шинэ мөр оруулах",
-      "starterChipBuild": "Шинэ функц бүтээх",
-      "starterChipEmpty": "Санаанаас эхлэх",
-      "starterChipFix": "Алдаа засах",
-      "starterChipPrepare": "Орчноо тохируулах",
-      "starterChipWrapUp": "Сессээ дуусгах",
-      "starterChipWriteTests": "Тест бичих"
+      "starterChipBuild": "Шинэ функц бүтээ",
+      "starterChipEmpty": "Санаанаас эхэл",
+      "starterChipFix": "Алдаа зас",
+      "starterChipPrepare": "Миний орчныг тохируул",
+      "starterChipWrapUp": "Миний сессийг дуусга",
+      "starterChipWriteTests": "Тест бич"
     },
     "chatLink": {
       "linkCopied": "Холбоос хуулагдлаа",

--- a/apps/mobile/src/i18n/locales/mr.json
+++ b/apps/mobile/src/i18n/locales/mr.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "संलग्नता टाकून द्यायच्या?",
       "charactersRemaining": "{{count}} अक्षरे शिल्लक",
       "insertNewline": "नवीन ओळ घाला",
-      "starterChipBuild": "वैशिष्ट्य तयार करा",
-      "starterChipEmpty": "कल्पनेपासून सुरुवात करा",
-      "starterChipFix": "त्रुटी दुरुस्त करा",
-      "starterChipPrepare": "माझे वातावरण तयार करा",
-      "starterChipWrapUp": "माझे सत्र पूर्ण करा",
-      "starterChipWriteTests": "चाचण्या लिहा"
+      "starterChipBuild": "वैशिष्ट्य तयार कर",
+      "starterChipEmpty": "कल्पनेपासून सुरुवात कर",
+      "starterChipFix": "त्रुटी दुरुस्त कर",
+      "starterChipPrepare": "माझे वातावरण तयार कर",
+      "starterChipWrapUp": "माझे सत्र पूर्ण कर",
+      "starterChipWriteTests": "चाचण्या लिही"
     },
     "chatLink": {
       "linkCopied": "लिंक कॉपी केली",

--- a/apps/mobile/src/i18n/locales/my.json
+++ b/apps/mobile/src/i18n/locales/my.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "ပူးတွဲဖိုင်များကို ပယ်ဖျက်မည်လား။",
       "charactersRemaining": "အက္ခရာ {{count}} လုံး ကျန်သည်",
       "insertNewline": "စာကြောင်းအသစ် ထည့်ပါ",
-      "starterChipBuild": "လုပ်ဆောင်ချက်တစ်ခု တည်ဆောက်ပါ",
-      "starterChipEmpty": "စိတ်ကူးတစ်ခုဖြင့် စတင်ပါ",
-      "starterChipFix": "ချို့ယွင်းချက်တစ်ခု ပြင်ဆင်ပါ",
-      "starterChipPrepare": "ကျွန်ုပ်၏ လုပ်ငန်းပတ်ဝန်းကျင်ကို ပြင်ဆင်ပါ",
-      "starterChipWrapUp": "ကျွန်ုပ်၏ ဆက်ရှင်ကို အဆုံးသတ်ပါ",
-      "starterChipWriteTests": "စမ်းသပ်မှုများ ရေးပါ"
+      "starterChipBuild": "လုပ်ဆောင်ချက်တစ်ခု တည်ဆောက်",
+      "starterChipEmpty": "စိတ်ကူးတစ်ခုနဲ့ စလိုက်",
+      "starterChipFix": "ချို့ယွင်းချက်တစ်ခု ပြင်",
+      "starterChipPrepare": "ငါ့လုပ်ငန်းပတ်ဝန်းကျင်ကို ပြင်ဆင်",
+      "starterChipWrapUp": "ငါ့ဆက်ရှင်ကို အဆုံးသတ်",
+      "starterChipWriteTests": "စမ်းသပ်မှုတွေ ရေး"
     },
     "chatLink": {
       "linkCopied": "link ကို ကူးယူပြီးပါပြီ",

--- a/apps/mobile/src/i18n/locales/ne.json
+++ b/apps/mobile/src/i18n/locales/ne.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "संलग्नकहरू खारेज गर्ने?",
       "charactersRemaining": "{{count}} अक्षर बाँकी छन्",
       "insertNewline": "नयाँ पङ्क्ति घुसाउनुहोस्",
-      "starterChipBuild": "सुविधा बनाउनुहोस्",
-      "starterChipEmpty": "एउटा विचारबाट सुरु गर्नुहोस्",
-      "starterChipFix": "त्रुटि सच्याउनुहोस्",
-      "starterChipPrepare": "मेरो वातावरण तयार गर्नुहोस्",
-      "starterChipWrapUp": "मेरो सत्र समाप्त गर्नुहोस्",
-      "starterChipWriteTests": "परीक्षणहरू लेख्नुहोस्"
+      "starterChipBuild": "सुविधा बनाऊ",
+      "starterChipEmpty": "एउटा विचारबाट सुरु गर",
+      "starterChipFix": "त्रुटि सच्याऊ",
+      "starterChipPrepare": "मेरो वातावरण तयार गर",
+      "starterChipWrapUp": "मेरो सत्र समाप्त गर",
+      "starterChipWriteTests": "परीक्षणहरू लेख"
     },
     "chatLink": {
       "linkCopied": "लिंक प्रतिलिपि गरियो",

--- a/apps/mobile/src/i18n/locales/nl.json
+++ b/apps/mobile/src/i18n/locales/nl.json
@@ -2137,12 +2137,12 @@
       "discardAttachmentsTitle": "Bijlagen weggooien?",
       "charactersRemaining": "{{count}} tekens resterend",
       "insertNewline": "Nieuwe regel invoegen",
-      "starterChipBuild": "Een functie bouwen",
-      "starterChipEmpty": "Beginnen met een idee",
-      "starterChipFix": "Een fout oplossen",
-      "starterChipPrepare": "Mijn omgeving instellen",
-      "starterChipWrapUp": "Mijn sessie afronden",
-      "starterChipWriteTests": "Tests schrijven"
+      "starterChipBuild": "Bouw een functie",
+      "starterChipEmpty": "Begin met een idee",
+      "starterChipFix": "Los een fout op",
+      "starterChipPrepare": "Stel mijn omgeving in",
+      "starterChipWrapUp": "Rond mijn sessie af",
+      "starterChipWriteTests": "Schrijf tests"
     },
     "chatLink": {
       "linkCopied": "Link gekopieerd",

--- a/apps/mobile/src/i18n/locales/om.json
+++ b/apps/mobile/src/i18n/locales/om.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Faayiloota qabachiifaman haqnaa?",
       "charactersRemaining": "Qubeelaa {{count}} hafe",
       "insertNewline": "Sarara haaraa galchaa",
-      "starterChipBuild": "Amala haaraa ijaaraa",
-      "starterChipEmpty": "Yaada tokkoon jalqabaa",
-      "starterChipFix": "Dogoggora sirreessaa",
-      "starterChipPrepare": "Naannoo koo qopheessaa",
-      "starterChipWrapUp": "Xalayyii koo xumuraa",
-      "starterChipWriteTests": "Qormaata barreessaa"
+      "starterChipBuild": "Amala haaraa ijaari",
+      "starterChipEmpty": "Yaada tokkoon jalqabi",
+      "starterChipFix": "Dogoggora sirreessi",
+      "starterChipPrepare": "Naannoo koo qopheessi",
+      "starterChipWrapUp": "Turtii koo xumuri",
+      "starterChipWriteTests": "Qormaata barreessi"
     },
     "chatLink": {
       "linkCopied": "Geessituun maxxanameera",

--- a/apps/mobile/src/i18n/locales/or.json
+++ b/apps/mobile/src/i18n/locales/or.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "ସଂଲଗ୍ନକଗୁଡ଼ିକ ପରିତ୍ୟାଗ କରିବେ?",
       "charactersRemaining": "{{count}}ଟି ଅକ୍ଷର ବାକି ଅଛି",
       "insertNewline": "ନୂଆ ଧାଡ଼ି ଯୋଡ଼ନ୍ତୁ",
-      "starterChipBuild": "ଏକ ବୈଶିଷ୍ଟ୍ୟ ତିଆରି କରନ୍ତୁ",
-      "starterChipEmpty": "ଏକ ଧାରଣାରୁ ଆରମ୍ଭ କରନ୍ତୁ",
-      "starterChipFix": "ଏକ ତ୍ରୁଟି ଠିକ୍ କରନ୍ତୁ",
-      "starterChipPrepare": "ମୋ ପରିବେଶ ପ୍ରସ୍ତୁତ କରନ୍ତୁ",
-      "starterChipWrapUp": "ମୋ ସେସନ୍ ସମାପ୍ତ କରନ୍ତୁ",
-      "starterChipWriteTests": "ପରୀକ୍ଷା ଲେଖନ୍ତୁ"
+      "starterChipBuild": "ଏକ ବୈଶିଷ୍ଟ୍ୟ ତିଆରି କର",
+      "starterChipEmpty": "ଏକ ଧାରଣାରୁ ଆରମ୍ଭ କର",
+      "starterChipFix": "ଏକ ତ୍ରୁଟି ଠିକ୍ କର",
+      "starterChipPrepare": "ମୋ ପରିବେଶ ପ୍ରସ୍ତୁତ କର",
+      "starterChipWrapUp": "ମୋ ସେସନ୍ ସମାପ୍ତ କର",
+      "starterChipWriteTests": "ପରୀକ୍ଷା ଲେଖ"
     },
     "chatLink": {
       "linkCopied": "ଲିଙ୍କ କପି ହେଲା",

--- a/apps/mobile/src/i18n/locales/pa.json
+++ b/apps/mobile/src/i18n/locales/pa.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "ਅਟੈਚਮੈਂਟਾਂ ਮਿਟਾਈਏ?",
       "charactersRemaining": "{{count}} ਅੱਖਰ ਬਾਕੀ ਹਨ",
       "insertNewline": "ਨਵੀਂ ਲਾਈਨ ਪਾਓ",
-      "starterChipBuild": "ਇੱਕ ਵਿਸ਼ੇਸ਼ਤਾ ਬਣਾਓ",
-      "starterChipEmpty": "ਇੱਕ ਵਿਚਾਰ ਨਾਲ ਸ਼ੁਰੂ ਕਰੋ",
-      "starterChipFix": "ਇੱਕ ਤਰੁੱਟੀ ਠੀਕ ਕਰੋ",
-      "starterChipPrepare": "ਮੇਰਾ ਵਾਤਾਵਰਨ ਸੈੱਟ ਕਰੋ",
-      "starterChipWrapUp": "ਮੇਰਾ ਸੈਸ਼ਨ ਮੁਕੰਮਲ ਕਰੋ",
-      "starterChipWriteTests": "ਟੈਸਟ ਲਿਖੋ"
+      "starterChipBuild": "ਇੱਕ ਵਿਸ਼ੇਸ਼ਤਾ ਬਣਾ",
+      "starterChipEmpty": "ਇੱਕ ਵਿਚਾਰ ਨਾਲ ਸ਼ੁਰੂ ਕਰ",
+      "starterChipFix": "ਇੱਕ ਤਰੁੱਟੀ ਠੀਕ ਕਰ",
+      "starterChipPrepare": "ਮੇਰਾ ਵਾਤਾਵਰਨ ਸੈੱਟ ਕਰ",
+      "starterChipWrapUp": "ਮੇਰਾ ਸੈਸ਼ਨ ਮੁਕੰਮਲ ਕਰ",
+      "starterChipWriteTests": "ਟੈਸਟ ਲਿਖ"
     },
     "chatLink": {
       "linkCopied": "ਲਿੰਕ ਕਾਪੀ ਹੋ ਗਿਆ",

--- a/apps/mobile/src/i18n/locales/ps.json
+++ b/apps/mobile/src/i18n/locales/ps.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "ضمیمې لغوه کړئ؟",
       "charactersRemaining": "{{count}} توري پاتې دي",
       "insertNewline": "نوې کرښه دننه کړئ",
-      "starterChipBuild": "یوه ځانګړتیا جوړه کړئ",
-      "starterChipEmpty": "له یوې مفکورې پیل وکړئ",
-      "starterChipFix": "یوه تېروتنه سمه کړئ",
-      "starterChipPrepare": "زما چاپېریال چمتو کړئ",
-      "starterChipWrapUp": "زما ناسته پای ته ورسوئ",
-      "starterChipWriteTests": "ازموینې ولیکئ"
+      "starterChipBuild": "یوه ځانګړتیا جوړه کړه",
+      "starterChipEmpty": "له یوې مفکورې پیل وکړه",
+      "starterChipFix": "یوه تېروتنه سمه کړه",
+      "starterChipPrepare": "زما چاپېریال چمتو کړه",
+      "starterChipWrapUp": "زما ناسته پای ته ورسوه",
+      "starterChipWriteTests": "ازموینې ولیکه"
     },
     "chatLink": {
       "linkCopied": "لینک کاپي شو",

--- a/apps/mobile/src/i18n/locales/pt-BR.json
+++ b/apps/mobile/src/i18n/locales/pt-BR.json
@@ -2131,12 +2131,12 @@
       "discardAttachmentsTitle": "Descartar anexos?",
       "charactersRemaining": "{{count}} caracteres restantes",
       "insertNewline": "Inserir quebra de linha",
-      "starterChipBuild": "Criar uma funcionalidade",
-      "starterChipEmpty": "Começar com uma ideia",
-      "starterChipFix": "Corrigir um erro",
-      "starterChipPrepare": "Configurar meu ambiente",
-      "starterChipWrapUp": "Encerrar minha sessão",
-      "starterChipWriteTests": "Escrever testes"
+      "starterChipBuild": "Cria uma funcionalidade",
+      "starterChipEmpty": "Começa com uma ideia",
+      "starterChipFix": "Corrige um erro",
+      "starterChipPrepare": "Configura meu ambiente",
+      "starterChipWrapUp": "Encerra minha sessão",
+      "starterChipWriteTests": "Escreve testes"
     },
     "chatLink": {
       "linkCopied": "Link copiado",

--- a/apps/mobile/src/i18n/locales/pt.json
+++ b/apps/mobile/src/i18n/locales/pt.json
@@ -2610,12 +2610,12 @@
       "discardAttachmentsTitle": "Descartar anexos?",
       "charactersRemaining": "{{count}} caracteres restantes",
       "insertNewline": "Inserir nova linha",
-      "starterChipBuild": "Criar uma funcionalidade",
-      "starterChipEmpty": "Começar com uma ideia",
-      "starterChipFix": "Corrigir um erro",
-      "starterChipPrepare": "Configurar o meu ambiente",
-      "starterChipWrapUp": "Concluir a minha sessão",
-      "starterChipWriteTests": "Escrever testes"
+      "starterChipBuild": "Cria uma funcionalidade",
+      "starterChipEmpty": "Começa com uma ideia",
+      "starterChipFix": "Corrige um erro",
+      "starterChipPrepare": "Configura o meu ambiente",
+      "starterChipWrapUp": "Conclui a minha sessão",
+      "starterChipWriteTests": "Escreve testes"
     },
     "chatLink": {
       "linkCopied": "Ligação copiada",

--- a/apps/mobile/src/i18n/locales/ru.json
+++ b/apps/mobile/src/i18n/locales/ru.json
@@ -2161,12 +2161,12 @@
       "discardAttachmentsTitle": "Удалить вложения?",
       "charactersRemaining": "Осталось символов: {{count}}",
       "insertNewline": "Вставить новую строку",
-      "starterChipBuild": "Создать функцию",
-      "starterChipEmpty": "Начать с идеи",
-      "starterChipFix": "Исправить ошибку",
-      "starterChipPrepare": "Настроить мое окружение",
-      "starterChipWrapUp": "Завершить мой сеанс",
-      "starterChipWriteTests": "Написать тесты"
+      "starterChipBuild": "Создай функцию",
+      "starterChipEmpty": "Начни с идеи",
+      "starterChipFix": "Исправь ошибку",
+      "starterChipPrepare": "Настрой мое окружение",
+      "starterChipWrapUp": "Заверши мой сеанс",
+      "starterChipWriteTests": "Напиши тесты"
     },
     "chatLink": {
       "linkCopied": "Ссылка скопирована",

--- a/apps/mobile/src/i18n/locales/sk.json
+++ b/apps/mobile/src/i18n/locales/sk.json
@@ -2629,12 +2629,12 @@
       "discardAttachmentsTitle": "Zahodiť prílohy?",
       "charactersRemaining": "Počet zostávajúcich znakov: {{count}}",
       "insertNewline": "Vložiť nový riadok",
-      "starterChipBuild": "Vytvoriť funkciu",
-      "starterChipEmpty": "Začať nápadom",
-      "starterChipFix": "Opraviť chybu",
-      "starterChipPrepare": "Nastaviť moje prostredie",
-      "starterChipWrapUp": "Dokončiť moje sedenie",
-      "starterChipWriteTests": "Napísať testy"
+      "starterChipBuild": "Vytvor funkciu",
+      "starterChipEmpty": "Začni nápadom",
+      "starterChipFix": "Oprav chybu",
+      "starterChipPrepare": "Nastav moje prostredie",
+      "starterChipWrapUp": "Dokonči moje sedenie",
+      "starterChipWriteTests": "Napíš testy"
     },
     "chatLink": {
       "linkCopied": "Odkaz skopírovaný",

--- a/apps/mobile/src/i18n/locales/sl.json
+++ b/apps/mobile/src/i18n/locales/sl.json
@@ -2629,12 +2629,12 @@
       "discardAttachmentsTitle": "Zavreči priloge?",
       "charactersRemaining": "Preostalo znakov: {{count}}",
       "insertNewline": "Vstavite novo vrstico",
-      "starterChipBuild": "Razvijte funkcijo",
-      "starterChipEmpty": "Začnite z zamislijo",
-      "starterChipFix": "Odpravite napako",
-      "starterChipPrepare": "Nastavite moje okolje",
-      "starterChipWrapUp": "Zaključite mojo sejo",
-      "starterChipWriteTests": "Napišite preizkuse"
+      "starterChipBuild": "Razvij funkcijo",
+      "starterChipEmpty": "Začni z zamislijo",
+      "starterChipFix": "Odpravi napako",
+      "starterChipPrepare": "Nastavi moje okolje",
+      "starterChipWrapUp": "Zaključi mojo sejo",
+      "starterChipWriteTests": "Napiši preizkuse"
     },
     "chatLink": {
       "linkCopied": "Povezava kopirana",

--- a/apps/mobile/src/i18n/locales/sq.json
+++ b/apps/mobile/src/i18n/locales/sq.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Të hiqen bashkëngjitjet?",
       "charactersRemaining": "Mbeten {{count}} karaktere",
       "insertNewline": "Shtoni një rresht të ri",
-      "starterChipBuild": "Krijoni një veçori",
-      "starterChipEmpty": "Filloni me një ide",
-      "starterChipFix": "Rregulloni një gabim",
-      "starterChipPrepare": "Konfiguroni mjedisin tim",
-      "starterChipWrapUp": "Përfundoni seancën time",
-      "starterChipWriteTests": "Shkruani teste"
+      "starterChipBuild": "Krijo një veçori",
+      "starterChipEmpty": "Fillo me një ide",
+      "starterChipFix": "Rregullo një gabim",
+      "starterChipPrepare": "Konfiguro mjedisin tim",
+      "starterChipWrapUp": "Përfundo seancën time",
+      "starterChipWriteTests": "Shkruaj teste"
     },
     "chatLink": {
       "linkCopied": "Lidhja u kopjua",

--- a/apps/mobile/src/i18n/locales/sr.json
+++ b/apps/mobile/src/i18n/locales/sr.json
@@ -2610,12 +2610,12 @@
       "discardAttachmentsTitle": "Odbaciti priloge?",
       "charactersRemaining": "Preostalo znakova: {{count}}",
       "insertNewline": "Unesite novi red",
-      "starterChipBuild": "Napravite funkciju",
-      "starterChipEmpty": "Počnite od ideje",
-      "starterChipFix": "Ispravite grešku",
-      "starterChipPrepare": "Podesite moje okruženje",
-      "starterChipWrapUp": "Završite moju sesiju",
-      "starterChipWriteTests": "Napišite testove"
+      "starterChipBuild": "Napravi funkciju",
+      "starterChipEmpty": "Počni od ideje",
+      "starterChipFix": "Ispravi grešku",
+      "starterChipPrepare": "Podesi moje okruženje",
+      "starterChipWrapUp": "Završi moju sesiju",
+      "starterChipWriteTests": "Napiši testove"
     },
     "chatLink": {
       "linkCopied": "Link kopiran",

--- a/apps/mobile/src/i18n/locales/ta.json
+++ b/apps/mobile/src/i18n/locales/ta.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "இணைப்புகளை நிராகரிக்கவா?",
       "charactersRemaining": "{{count}} எழுத்துகள் மீதமுள்ளன",
       "insertNewline": "புதிய வரியைச் செருகவும்",
-      "starterChipBuild": "ஓர் அம்சத்தை உருவாக்கவும்",
-      "starterChipEmpty": "ஓர் யோசனையுடன் தொடங்கவும்",
-      "starterChipFix": "ஒரு பிழையைச் சரிசெய்யவும்",
-      "starterChipPrepare": "எனது சூழலை அமைக்கவும்",
-      "starterChipWrapUp": "எனது அமர்வை முடிக்கவும்",
-      "starterChipWriteTests": "சோதனைகளை எழுதவும்"
+      "starterChipBuild": "ஓர் அம்சத்தை உருவாக்கு",
+      "starterChipEmpty": "ஓர் யோசனையுடன் தொடங்கு",
+      "starterChipFix": "ஒரு பிழையைச் சரிசெய்",
+      "starterChipPrepare": "எனது சூழலை அமை",
+      "starterChipWrapUp": "எனது அமர்வை முடி",
+      "starterChipWriteTests": "சோதனைகளை எழுது"
     },
     "chatLink": {
       "linkCopied": "இணைப்பு நகலெடுக்கப்பட்டது",

--- a/apps/mobile/src/i18n/locales/te.json
+++ b/apps/mobile/src/i18n/locales/te.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "జోడింపులను విస్మరించాలా?",
       "charactersRemaining": "{{count}} అక్షరాలు మిగిలి ఉన్నాయి",
       "insertNewline": "కొత్త పంక్తిని చేర్చండి",
-      "starterChipBuild": "ఒక ఫీచర్ను రూపొందించండి",
-      "starterChipEmpty": "ఒక ఆలోచనతో ప్రారంభించండి",
-      "starterChipFix": "ఒక లోపాన్ని పరిష్కరించండి",
-      "starterChipPrepare": "నా వాతావరణాన్ని సిద్ధం చేయండి",
-      "starterChipWrapUp": "నా సెషన్ను ముగించండి",
-      "starterChipWriteTests": "పరీక్షలు రాయండి"
+      "starterChipBuild": "ఒక ఫీచర్ను రూపొందించు",
+      "starterChipEmpty": "ఒక ఆలోచనతో ప్రారంభించు",
+      "starterChipFix": "ఒక లోపాన్ని పరిష్కరించు",
+      "starterChipPrepare": "నా వాతావరణాన్ని సిద్ధం చేయి",
+      "starterChipWrapUp": "నా సెషన్ను ముగించు",
+      "starterChipWriteTests": "పరీక్షలు రాయి"
     },
     "chatLink": {
       "linkCopied": "లింక్ కాపీ చేయబడింది",

--- a/apps/mobile/src/i18n/locales/tr.json
+++ b/apps/mobile/src/i18n/locales/tr.json
@@ -2137,12 +2137,12 @@
       "discardAttachmentsTitle": "Ekler silinsin mi?",
       "charactersRemaining": "{{count}} karakter kaldı",
       "insertNewline": "Yeni satır ekleyin",
-      "starterChipBuild": "Bir özellik geliştirin",
-      "starterChipEmpty": "Bir fikirle başlayın",
-      "starterChipFix": "Bir hatayı düzeltin",
-      "starterChipPrepare": "Ortamımı kurun",
-      "starterChipWrapUp": "Oturumumu tamamlayın",
-      "starterChipWriteTests": "Testler yazın"
+      "starterChipBuild": "Bir özellik geliştir",
+      "starterChipEmpty": "Bir fikirle başla",
+      "starterChipFix": "Bir hatayı düzelt",
+      "starterChipPrepare": "Ortamımı kur",
+      "starterChipWrapUp": "Oturumumu tamamla",
+      "starterChipWriteTests": "Testler yaz"
     },
     "chatLink": {
       "linkCopied": "Bağlantı kopyalandı",

--- a/apps/mobile/src/i18n/locales/uk.json
+++ b/apps/mobile/src/i18n/locales/uk.json
@@ -2161,12 +2161,12 @@
       "discardAttachmentsTitle": "Відкинути вкладення?",
       "charactersRemaining": "Залишилося символів: {{count}}",
       "insertNewline": "Вставити новий рядок",
-      "starterChipBuild": "Створити функцію",
-      "starterChipEmpty": "Почати з ідеї",
-      "starterChipFix": "Виправити помилку",
-      "starterChipPrepare": "Налаштувати моє середовище",
-      "starterChipWrapUp": "Завершити мій сеанс",
-      "starterChipWriteTests": "Написати тести"
+      "starterChipBuild": "Створи функцію",
+      "starterChipEmpty": "Почни з ідеї",
+      "starterChipFix": "Виправ помилку",
+      "starterChipPrepare": "Налаштуй моє середовище",
+      "starterChipWrapUp": "Заверши мій сеанс",
+      "starterChipWriteTests": "Напиши тести"
     },
     "chatLink": {
       "linkCopied": "Посилання скопійовано",

--- a/apps/mobile/src/i18n/locales/ur.json
+++ b/apps/mobile/src/i18n/locales/ur.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "اٹیچمنٹس ضائع کریں؟",
       "charactersRemaining": "{{count}} حروف باقی ہیں",
       "insertNewline": "نئی سطر داخل کریں",
-      "starterChipBuild": "ایک فیچر بنائیں",
-      "starterChipEmpty": "ایک خیال سے شروع کریں",
-      "starterChipFix": "ایک خرابی درست کریں",
-      "starterChipPrepare": "میرا ماحول ترتیب دیں",
-      "starterChipWrapUp": "میرا سیشن مکمل کریں",
-      "starterChipWriteTests": "ٹیسٹ لکھیں"
+      "starterChipBuild": "ایک فیچر بناؤ",
+      "starterChipEmpty": "ایک خیال سے شروع کرو",
+      "starterChipFix": "ایک خرابی درست کرو",
+      "starterChipPrepare": "میرا ماحول ترتیب دو",
+      "starterChipWrapUp": "میرا سیشن مکمل کرو",
+      "starterChipWriteTests": "ٹیسٹ لکھو"
     },
     "chatLink": {
       "linkCopied": "لنک کاپی ہو گیا",

--- a/apps/mobile/src/i18n/locales/uz.json
+++ b/apps/mobile/src/i18n/locales/uz.json
@@ -2591,12 +2591,12 @@
       "discardAttachmentsTitle": "Biriktirilgan fayllar bekor qilinsinmi?",
       "charactersRemaining": "{{count}} ta belgi qoldi",
       "insertNewline": "Yangi qator kiritish",
-      "starterChipBuild": "Funksiya yaratish",
-      "starterChipEmpty": "G'oya bilan boshlash",
-      "starterChipFix": "Xatoni tuzatish",
-      "starterChipPrepare": "Muhitimni sozlash",
-      "starterChipWrapUp": "Sessiyamni yakunlash",
-      "starterChipWriteTests": "Sinovlar yozish"
+      "starterChipBuild": "Funksiya yarat",
+      "starterChipEmpty": "G'oya bilan boshla",
+      "starterChipFix": "Xatoni tuzat",
+      "starterChipPrepare": "Muhitimni sozla",
+      "starterChipWrapUp": "Sessiyamni yakunla",
+      "starterChipWriteTests": "Sinovlar yoz"
     },
     "chatLink": {
       "linkCopied": "Havola nusxalandi",

--- a/apps/mobile/src/i18n/locales/vi.json
+++ b/apps/mobile/src/i18n/locales/vi.json
@@ -2140,8 +2140,8 @@
       "starterChipBuild": "Xây dựng một tính năng",
       "starterChipEmpty": "Bắt đầu với một ý tưởng",
       "starterChipFix": "Sửa lỗi",
-      "starterChipPrepare": "Thiết lập môi trường của bạn",
-      "starterChipWrapUp": "Kết thúc phiên của bạn",
+      "starterChipPrepare": "Thiết lập môi trường của mình",
+      "starterChipWrapUp": "Kết thúc phiên của mình",
       "starterChipWriteTests": "Viết kiểm thử"
     },
     "chatLink": {

--- a/apps/mobile/src/i18n/locales/yo.json
+++ b/apps/mobile/src/i18n/locales/yo.json
@@ -2595,7 +2595,7 @@
       "starterChipEmpty": "Bẹrẹ pẹlu imọran kan",
       "starterChipFix": "Ṣatunṣe aṣiṣe kan",
       "starterChipPrepare": "Ṣeto ayika mi",
-      "starterChipWrapUp": "Pari akoko mi",
+      "starterChipWrapUp": "Pari igba-ijiroro mi",
       "starterChipWriteTests": "Kọ awọn idanwo"
     },
     "chatLink": {


### PR DESCRIPTION
## Summary

- Review all six composer chips across all 87 mobile locales.
- Update 329 labels in 58 catalogs to use informal commands and preserve prompt meaning.
- Leave existing informal commands unchanged. Translation keys and composer behavior do not change.

## Verification

Manual device tests were not run because this change only updates catalog strings.

## Automated Checks

All commands passed from `apps/mobile/`:

- `pnpm format`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:unused`
- `pnpm check:i18n`: all 87 catalogs match the English keys.
- `pnpm test --project mobile-pure src/i18n chat-composer.test.ts new-session-prompt-initial-prompt.test.ts`: 142 tests passed across five files.
- `git diff --check`

## Visual Changes

Copy changes only; no layout changes. Device screenshots were not captured.

| Locale | Before | After |
|---|---|---|
| Serbian | Napišite testove | Napiši testove |
| French | Écrire des tests | Écris des tests |
| German | Tests schreiben | Schreibe Tests |

## Reviewer Notes

Only `agentChat.composer.starterChip*` values change. Native-speaker validation has not been performed.
