### PR TITLE
fix(mobile): bind Kilo Chat effects to local access

### DIFF
--- a/apps/mobile/src/components/kilo-chat/hooks/use-conversation-mark-read.ts
+++ b/apps/mobile/src/components/kilo-chat/hooks/use-conversation-mark-read.ts
@@ -1,4 +1,4 @@
-import { type KiloChatClient, type Message } from '@kilocode/kilo-chat';
+import { type KiloChatClient, type KiloChatOperation, type Message } from '@kilocode/kilo-chat';
 import {
   attemptMarkCurrentConversationRead,
   clearMarkReadRetry,
@@ -8,6 +8,8 @@ import {
 } from '@kilocode/kilo-chat-hooks';
 import { useCallback, useEffect, useRef } from 'react';
 
+import { subscribeAuthenticatedOwner } from '@/lib/context-scope';
+import { subscribeLocalAccess } from '@/lib/local-access';
 import { useAppActiveAndFocused } from './use-app-active-and-focused';
 import { useMarkRead } from './use-mark-read';
 import { shouldMarkLatestMessageRead } from '../message-history-state';
@@ -30,84 +32,113 @@ export function useConversationMarkRead({
   sandboxId,
 }: Params) {
   const latestMessageId = latestMarkReadMessageId(messages);
-  const latestMarkReadMessageSenderId =
-    latestMessageId === null
-      ? null
-      : (messages.find(message => message.id === latestMessageId)?.senderId ?? null);
+  const latestSenderId = messages.find(message => message.id === latestMessageId)?.senderId ?? null;
   const activeAndFocused = useAppActiveAndFocused();
   const markRead = useMarkRead(client);
   const markReadStateRef = useRef(createMarkReadState());
   const markReadRetryStateRef = useRef(createMarkReadRetryState());
-  const currentMarkReadMarker =
-    latestMessageId === null ? null : `${conversationId}:${latestMessageId}`;
-  const currentMarkReadMarkerRef = useRef<string | null>(currentMarkReadMarker);
+  const currentMarker = latestMessageId === null ? null : `${conversationId}:${latestMessageId}`;
+  const currentMarkerRef = useRef(currentMarker);
   const activeAndFocusedRef = useRef(activeAndFocused);
-  const markCurrentConversationReadRef = useRef<(() => void) | null>(null);
-  currentMarkReadMarkerRef.current = currentMarkReadMarker;
+  const operationRef = useRef<KiloChatOperation | null>(null);
+  currentMarkerRef.current = currentMarker;
   activeAndFocusedRef.current = activeAndFocused;
 
   const markCurrentConversationRead = useCallback(() => {
-    if (!hasInitialMessages || latestMessageId === null || currentMarkReadMarker === null) {
-      return;
-    }
     if (
+      !hasInitialMessages ||
+      latestMessageId === null ||
+      currentMarker === null ||
+      !activeAndFocusedRef.current ||
       !shouldMarkLatestMessageRead({
         currentUserId,
-        latestMessageSenderId: latestMarkReadMessageSenderId,
+        latestMessageSenderId: latestSenderId,
       })
     ) {
       return;
     }
-    const marker = currentMarkReadMarker;
-    void attemptMarkCurrentConversationRead({
-      marker,
-      markReadState: markReadStateRef.current,
-      retryState: markReadRetryStateRef.current,
-      currentMarker: () => currentMarkReadMarkerRef.current,
-      isActive: () => activeAndFocusedRef.current,
-      markRead: async () => {
-        await markRead(sandboxId, conversationId, latestMessageId);
-      },
-      retry: () => {
-        markCurrentConversationReadRef.current?.();
-      },
-    });
+    // A rerender cannot replace the closure behind an already scheduled retry.
+    if (markReadRetryStateRef.current.marker === currentMarker) {
+      return;
+    }
+    let operation: KiloChatOperation | undefined = undefined;
+    try {
+      operation = client.captureOperation();
+    } catch {
+      return;
+    }
+    operationRef.current = operation;
+    const retryState = markReadRetryStateRef.current;
+    const isActive = () => {
+      try {
+        operation.assertDispatch();
+        return activeAndFocusedRef.current;
+      } catch {
+        clearMarkReadRetry(retryState);
+        return false;
+      }
+    };
+    const attempt = () => {
+      if (!isActive()) {
+        return;
+      }
+      void attemptMarkCurrentConversationRead({
+        marker: currentMarker,
+        markReadState: markReadStateRef.current,
+        retryState,
+        currentMarker: () => currentMarkerRef.current,
+        isActive,
+        markRead: async () => {
+          await markRead(sandboxId, conversationId, latestMessageId, operation);
+        },
+        retry: attempt,
+      });
+    };
+    attempt();
   }, [
+    client,
     conversationId,
-    currentMarkReadMarker,
+    currentMarker,
     currentUserId,
     hasInitialMessages,
     latestMessageId,
-    latestMarkReadMessageSenderId,
+    latestSenderId,
     markRead,
     sandboxId,
   ]);
-  markCurrentConversationReadRef.current = markCurrentConversationRead;
 
   useEffect(() => {
-    if (!activeAndFocused || currentMarkReadMarker === null) {
-      clearMarkReadRetry(markReadRetryStateRef.current);
-      return;
-    }
     if (
-      markReadRetryStateRef.current.marker !== null &&
-      markReadRetryStateRef.current.marker !== currentMarkReadMarker
+      !activeAndFocused ||
+      currentMarker === null ||
+      (markReadRetryStateRef.current.marker !== null &&
+        markReadRetryStateRef.current.marker !== currentMarker)
     ) {
       clearMarkReadRetry(markReadRetryStateRef.current);
     }
-  }, [activeAndFocused, currentMarkReadMarker]);
+  }, [activeAndFocused, currentMarker]);
 
   useEffect(() => {
     const retryState = markReadRetryStateRef.current;
+    const cancelInvalidRetry = () => {
+      try {
+        operationRef.current?.assertDispatch();
+      } catch {
+        clearMarkReadRetry(retryState);
+      }
+    };
+    const offAccess = subscribeLocalAccess(cancelInvalidRetry);
+    const offOwner = subscribeAuthenticatedOwner(cancelInvalidRetry);
     return () => {
+      offAccess();
+      offOwner();
       clearMarkReadRetry(retryState);
     };
   }, []);
 
   useEffect(() => {
-    if (!activeAndFocused) {
-      return;
+    if (activeAndFocused) {
+      markCurrentConversationRead();
     }
-    markCurrentConversationRead();
   }, [activeAndFocused, markCurrentConversationRead]);
 }

--- a/apps/mobile/src/components/kilo-chat/hooks/use-kilo-chat-token.local-access.test.ts
+++ b/apps/mobile/src/components/kilo-chat/hooks/use-kilo-chat-token.local-access.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { bumpAuthEpoch } from '@/lib/auth/auth-epoch';
+import {
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+  getAuthenticatedOwner,
+} from '@/lib/context-scope';
+import {
+  clearKiloChatTokenCache,
+  subscribeToKiloChatTokenResponses,
+  useKiloChatTokenResponseGetter,
+} from './use-kilo-chat-token';
+
+const mocks = vi.hoisted(() => ({
+  authToken: vi.fn<() => Promise<string | null>>(),
+  query: vi.fn<() => Promise<{ userId: string; token: string; expiresAt: string }>>(),
+}));
+vi.mock('react', () => ({ useCallback: <T>(fn: T) => fn }));
+vi.mock('@/lib/auth/token-owner', () => ({ getAuthTokenForRequest: mocks.authToken }));
+vi.mock('@/lib/trpc', () => ({ trpcClient: { kiloChat: { getToken: { query: mocks.query } } } }));
+vi.mock('@/lib/utils', () => ({ parseTimestamp: (value: string) => new Date(value) }));
+
+function replaceOwner(userId: string) {
+  bumpAuthEpoch();
+  confirmAuthenticatedOwner(beginAuthenticatedOwner(), userId);
+  return getAuthenticatedOwner();
+}
+function response(userId: string, token = `chat-${userId}`) {
+  return { userId, token, expiresAt: '2099-01-01T00:00:00Z' };
+}
+const cleanups: (() => void)[] = [];
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  clearKiloChatTokenCache();
+  mocks.authToken.mockResolvedValue('credential');
+  replaceOwner('a');
+});
+afterEach(() => {
+  for (const off of cleanups.splice(0)) {
+    off();
+  }
+});
+
+describe('chat token original ownership', () => {
+  it('rejects A after direct replacement and publishes only B to subscribers', async () => {
+    const old = Promise.withResolvers<ReturnType<typeof response>>();
+    const entered = Promise.withResolvers<undefined>();
+    mocks.query.mockImplementationOnce(async () => {
+      entered.resolve(undefined);
+      const result = await old.promise;
+      return result;
+    });
+    const seen: string[] = [];
+    cleanups.push(
+      subscribeToKiloChatTokenResponses(value => {
+        seen.push(value.userId);
+      })
+    );
+    const getA = useKiloChatTokenResponseGetter(getAuthenticatedOwner());
+    const pending = getA();
+    await entered.promise;
+    const ownerB = replaceOwner('b');
+    mocks.query.mockResolvedValue(response('b'));
+    const getB = useKiloChatTokenResponseGetter(ownerB);
+    await expect(getB()).resolves.toMatchObject({ token: 'chat-b' });
+    old.resolve(response('a'));
+    await expect(pending).rejects.toMatchObject({ code: 'LOCAL_ACCESS_DENIED', reason: 'owner' });
+    await expect(getA()).rejects.toMatchObject({ reason: 'owner' });
+    await expect(getB()).resolves.toMatchObject({ token: 'chat-b' });
+    expect(seen).toEqual(['b']);
+  });
+
+  it('fences the credential wait before token minting starts', async () => {
+    const credential = Promise.withResolvers<string>();
+    mocks.authToken.mockReturnValueOnce(credential.promise);
+    mocks.query.mockResolvedValue(response('b'));
+    const pending = useKiloChatTokenResponseGetter(getAuthenticatedOwner())();
+    replaceOwner('b');
+    credential.resolve('old-credential');
+    await expect(pending).rejects.toMatchObject({ reason: 'owner' });
+    expect(mocks.query.mock.calls).toEqual([]);
+  });
+
+  it('does not repopulate a cleared cache from the pre-retry token request', async () => {
+    const old = Promise.withResolvers<ReturnType<typeof response>>();
+    const entered = Promise.withResolvers<undefined>();
+    mocks.query.mockImplementationOnce(async () => {
+      entered.resolve(undefined);
+      const result = await old.promise;
+      return result;
+    });
+    const getter = useKiloChatTokenResponseGetter(getAuthenticatedOwner());
+    const pending = getter();
+    await entered.promise;
+    clearKiloChatTokenCache();
+    mocks.query.mockResolvedValue(response('a', 'fresh'));
+    await expect(getter()).resolves.toMatchObject({ token: 'fresh' });
+    old.resolve(response('a', 'stale'));
+    await expect(pending).rejects.toMatchObject({ reason: 'stale' });
+    await expect(getter()).resolves.toMatchObject({ token: 'fresh' });
+  });
+
+  it('rejects a token response whose user differs from the authenticated owner', async () => {
+    mocks.query.mockResolvedValueOnce(response('b')).mockResolvedValueOnce(response('a'));
+    const seen: string[] = [];
+    cleanups.push(
+      subscribeToKiloChatTokenResponses(value => {
+        seen.push(value.userId);
+      })
+    );
+    const getter = useKiloChatTokenResponseGetter(getAuthenticatedOwner());
+    await expect(getter()).rejects.toMatchObject({ reason: 'owner' });
+    await expect(getter()).resolves.toMatchObject({ userId: 'a' });
+    expect(seen).toEqual(['a']);
+  });
+
+  it('keeps the manual retry admission through a delayed credential read', async () => {
+    let generation = 0;
+    const admitted = generation;
+    const credential = Promise.withResolvers<string>();
+    mocks.authToken.mockReturnValueOnce(credential.promise);
+    const pending = useKiloChatTokenResponseGetter(getAuthenticatedOwner())(() => {
+      if (admitted !== generation) {
+        throw new Error('stale retry');
+      }
+    });
+    generation += 1;
+    credential.resolve('credential');
+    await expect(pending).rejects.toThrow('stale retry');
+    expect(mocks.query.mock.calls).toEqual([]);
+  });
+});

--- a/apps/mobile/src/components/kilo-chat/hooks/use-kilo-chat-token.ts
+++ b/apps/mobile/src/components/kilo-chat/hooks/use-kilo-chat-token.ts
@@ -1,27 +1,33 @@
 import { useCallback } from 'react';
 
 import { getAuthTokenForRequest } from '@/lib/auth/token-owner';
+import { type AuthenticatedOwner, getAuthenticatedOwner } from '@/lib/context-scope';
+import { LocalAccessDeniedError } from '@/lib/local-access';
+import { assertTransportOwner, isTransportOwner } from '@/lib/local-access-transport';
 import { parseTimestamp } from '@/lib/utils';
 import { trpcClient } from '@/lib/trpc';
 
 type KiloChatTokenResponse = Awaited<ReturnType<typeof trpcClient.kiloChat.getToken.query>>;
-
 type TokenCache = {
   authToken: string;
+  owner: AuthenticatedOwner;
   response: KiloChatTokenResponse;
   expiresAtMs: number;
 };
+type TokenResponseListener = (response: KiloChatTokenResponse, owner: AuthenticatedOwner) => void;
+type TokenResponseGetter = (assertDispatch?: () => void) => Promise<KiloChatTokenResponse>;
 
-type TokenResponseListener = (response: KiloChatTokenResponse) => void;
-
-// Module-level cache keyed on the user's auth token, so a sign-out followed by
-// a different sign-in within the JWT window doesn't return the previous user's
-// token. The in-flight ref is keyed the same way for the same reason.
 let cache: TokenCache | null = null;
-let inFlight: { authToken: string; promise: Promise<KiloChatTokenResponse> } | null = null;
+let inFlight: {
+  authToken: string;
+  owner: AuthenticatedOwner;
+  promise: Promise<KiloChatTokenResponse>;
+} | null = null;
+let cacheGeneration = 0;
 const tokenResponseListeners = new Set<TokenResponseListener>();
 
 export function clearKiloChatTokenCache(): void {
+  cacheGeneration += 1;
   cache = null;
   inFlight = null;
 }
@@ -33,58 +39,93 @@ export function subscribeToKiloChatTokenResponses(listener: TokenResponseListene
   };
 }
 
-/**
- * Returns a stable getter function that fetches a kilo-chat JWT, caching it
- * until 60 seconds before expiry. Concurrent callers share a single in-flight
- * fetch via a module-level dedup ref.
- *
- * The auth token is read at call time through `getAuthTokenForRequest`
- * (matching `trpcClient`) rather than captured from `useAuth()`, so a getter
- * constructed before auth has loaded — or before the user signs in — picks up
- * the correct token on its next call instead of permanently capturing
- * `undefined`.
- */
-export function useKiloChatTokenGetter(): () => Promise<string> {
-  const getTokenResponse = useKiloChatTokenResponseGetter();
+/** The provider supplies its immutable owner; standalone reads capture their owner at invocation. */
+export function useKiloChatTokenGetter(owner?: AuthenticatedOwner): () => Promise<string> {
+  const getTokenResponse = useKiloChatTokenResponseGetter(owner);
   return useCallback(async () => {
     const response = await getTokenResponse();
     return response.token;
   }, [getTokenResponse]);
 }
 
-export function useKiloChatTokenResponseGetter(): () => Promise<KiloChatTokenResponse> {
-  return useCallback(async () => {
-    const authToken = await getAuthTokenForRequest();
-    if (!authToken) {
-      throw new Error('Cannot fetch kilo-chat token: not authenticated');
-    }
-
-    if (cache?.authToken === authToken && cache.expiresAtMs - Date.now() > 60_000) {
-      return cache.response;
-    }
-
-    if (inFlight?.authToken === authToken) {
-      return inFlight.promise;
-    }
-
-    const slot = { authToken, promise: fetchAndCacheToken(authToken) };
-    inFlight = slot;
-    try {
-      return await slot.promise;
-    } finally {
-      // Only clear the slot if a concurrent caller hasn't replaced it.
-      if (inFlight === slot) {
-        inFlight = null;
-      }
-    }
-  }, []);
+function sameGeneration(left: AuthenticatedOwner, right: AuthenticatedOwner): boolean {
+  return left.authEpoch === right.authEpoch && left.generation === right.generation;
 }
 
-async function fetchAndCacheToken(authToken: string): Promise<KiloChatTokenResponse> {
-  const response = await trpcClient.kiloChat.getToken.query();
-  cache = { authToken, response, expiresAtMs: parseTimestamp(response.expiresAt).getTime() };
-  for (const listener of tokenResponseListeners) {
-    listener(response);
+export function useKiloChatTokenResponseGetter(owner?: AuthenticatedOwner): TokenResponseGetter {
+  return useCallback(
+    async assertDispatch => {
+      const capturedOwner = owner ?? getAuthenticatedOwner();
+      const generation = cacheGeneration;
+      const assertCurrent = () => {
+        assertTransportOwner(capturedOwner);
+        if (generation !== cacheGeneration) {
+          throw new LocalAccessDeniedError('stale');
+        }
+        assertDispatch?.();
+      };
+      assertCurrent();
+      const authToken = await getAuthTokenForRequest();
+      assertCurrent();
+      if (!authToken) {
+        throw new Error('Cannot fetch kilo-chat token: not authenticated');
+      }
+      if (
+        cache?.authToken === authToken &&
+        sameGeneration(cache.owner, capturedOwner) &&
+        cache.expiresAtMs - Date.now() > 60_000
+      ) {
+        return cache.response;
+      }
+      if (inFlight?.authToken === authToken && sameGeneration(inFlight.owner, capturedOwner)) {
+        const response = await inFlight.promise;
+        assertCurrent();
+        return response;
+      }
+      const slot = {
+        authToken,
+        owner: capturedOwner,
+        promise: fetchAndCacheToken(authToken, capturedOwner, generation),
+      };
+      inFlight = slot;
+      try {
+        const response = await slot.promise;
+        assertCurrent();
+        return response;
+      } finally {
+        if (inFlight === slot) {
+          inFlight = null;
+        }
+      }
+    },
+    [owner]
+  );
+}
+
+async function fetchAndCacheToken(
+  authToken: string,
+  owner: AuthenticatedOwner,
+  generation: number
+): Promise<KiloChatTokenResponse> {
+  assertTransportOwner(owner);
+  const response = await trpcClient.kiloChat.getToken.query(undefined, {
+    context: { localAccessOwner: owner },
+  });
+  assertTransportOwner(owner);
+  if (generation !== cacheGeneration) {
+    throw new LocalAccessDeniedError('stale');
   }
+  const userId = getAuthenticatedOwner().userId;
+  if (userId !== null && response.userId !== userId) {
+    throw new LocalAccessDeniedError('owner');
+  }
+  cache = { authToken, owner, response, expiresAtMs: parseTimestamp(response.expiresAt).getTime() };
+  for (const listener of tokenResponseListeners) {
+    if (!isTransportOwner(owner)) {
+      break;
+    }
+    listener(response, owner);
+  }
+  assertTransportOwner(owner);
   return response;
 }

--- a/apps/mobile/src/components/kilo-chat/hooks/use-mark-read.ts
+++ b/apps/mobile/src/components/kilo-chat/hooks/use-mark-read.ts
@@ -1,9 +1,13 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import * as Sentry from '@sentry/react-native';
 import * as Notifications from 'expo-notifications';
 
-import { type KiloChatClient, type MarkConversationReadResponse } from '@kilocode/kilo-chat';
+import {
+  type KiloChatClient,
+  type KiloChatOperation,
+  type MarkConversationReadResponse,
+} from '@kilocode/kilo-chat';
 import { type BadgeCountRow } from '@kilocode/notifications';
 import { useMarkConversationRead } from '@kilocode/kilo-chat-hooks';
 
@@ -15,69 +19,97 @@ type MarkReadInput = {
   sandboxId: string;
   conversationId: string;
   lastSeenMessageId: string;
+  operation: KiloChatOperation;
+  userId: string | null;
+  markConversationRead: ReturnType<typeof useMarkConversationRead>['mutateAsync'];
 };
 
 export function useMarkRead(client: KiloChatClient) {
   const queryClient = useQueryClient();
   const userId = useCurrentUserId();
   const markConversationRead = useMarkConversationRead(client);
-
   const mutation = useMutation({
     mutationFn: async ({
-      sandboxId,
-      conversationId,
-      lastSeenMessageId,
+      operation,
+      markConversationRead: mark,
+      ...input
     }: MarkReadInput): Promise<MarkConversationReadResponse> => {
+      operation.assertDispatch();
       const result = await markReadConversation({
-        sandboxId,
-        conversationId,
-        lastSeenMessageId,
-        markConversationRead: markConversationRead.mutateAsync,
+        ...input,
+        markConversationRead: async variables => {
+          const response = await mark(variables, undefined, operation);
+          return response;
+        },
       });
       return result;
     },
-    // Mark-read runs in the background (e.g. on scroll/focus) — a user-visible
-    // toast for a background failure is noise. Retry happens naturally on the
-    // next mark-read trigger; just log so we can see failure rates.
-    onError: error => {
+    // Background failures retain the existing error state; they never announce locked content.
+    onError: (error, input) => {
+      if (!input.operation.canPublish()) {
+        return;
+      }
       Sentry.captureException(error, {
-        tags: {
-          'error.subsystem': 'kilo-chat',
-          'error.operation': 'mark-conversation-read',
-        },
-        extra: { hasUser: userId !== null },
+        tags: { 'error.subsystem': 'kilo-chat', 'error.operation': 'mark-conversation-read' },
+        extra: { hasUser: input.userId !== null },
       });
     },
-    onMutate: () => ({ startBadgeFreshnessEpoch: advanceBadgeFreshnessEpoch() }),
-    onSuccess: (result, _variables, context) => {
-      const currentBadgeFreshnessEpoch = readBadgeFreshnessEpoch();
+    onMutate: input => {
+      input.operation.assertDispatch();
+      return { startBadgeFreshnessEpoch: advanceBadgeFreshnessEpoch() };
+    },
+    onSuccess: (result, input, context) => {
+      if (!input.operation.canPublish()) {
+        return;
+      }
       applyBadgeClearResult({
         badgeClear: result.badgeClear,
         startBadgeFreshnessEpoch: context.startBadgeFreshnessEpoch,
-        currentBadgeFreshnessEpoch,
-        userId,
+        currentBadgeFreshnessEpoch: readBadgeFreshnessEpoch(),
+        userId: input.userId,
         updateBadgeRows: (queryKey, updater) => {
-          queryClient.setQueryData<BadgeCountRow[]>(queryKey, updater);
+          if (input.operation.canPublish()) {
+            queryClient.setQueryData<BadgeCountRow[]>(queryKey, updater);
+          }
         },
-        setBadgeCount: Notifications.setBadgeCountAsync,
+        setBadgeCount: async count => {
+          if (input.operation.canPublish()) {
+            await Notifications.setBadgeCountAsync(count);
+          }
+        },
       });
     },
-    onSettled: () => {
-      if (userId !== null) {
-        void queryClient.invalidateQueries({ queryKey: ['badges', userId] });
+    onSettled: (_data, _error, input) => {
+      if (input.userId !== null && input.operation.canPublish()) {
+        void queryClient.invalidateQueries({ queryKey: ['badges', input.userId] });
       }
     },
   });
 
+  const sharedMutationRef = useRef(markConversationRead.mutateAsync);
+  sharedMutationRef.current = markConversationRead.mutateAsync;
+  const { mutateAsync } = mutation;
   return useCallback(
-    async (sandboxId: string, conversationId: string, lastSeenMessageId: string) => {
-      const result = await mutation.mutateAsync({
+    // eslint-disable-next-line max-params -- preserve the positional API and carry an outer admission
+    async (
+      sandboxId: string,
+      conversationId: string,
+      lastSeenMessageId: string,
+      supplied?: KiloChatOperation
+    ) => {
+      // This capture precedes the OUTER mutation's offline/onMutate queue.
+      const operation = client.captureOperation(supplied);
+      const result = await mutateAsync({
         sandboxId,
         conversationId,
         lastSeenMessageId,
+        operation,
+        userId,
+        markConversationRead: sharedMutationRef.current,
       });
+      client.assertOwner();
       return result;
     },
-    [mutation]
+    [client, mutateAsync, userId]
   );
 }

--- a/apps/mobile/src/components/kilo-chat/kilo-chat-admission.test.ts
+++ b/apps/mobile/src/components/kilo-chat/kilo-chat-admission.test.ts
@@ -1,0 +1,387 @@
+/* eslint-disable typescript-eslint/no-deprecated -- this collected suite mounts both mobile mark-read queues without a DOM */
+/* eslint-disable require-await, typescript-eslint/require-await -- async doubles and act callbacks preserve native promise contracts */
+/* eslint-disable init-declarations -- beforeEach and act establish the owner and mounted fixtures before use */
+/* eslint-disable max-lines -- both mark-read queues and mobile admission races share this mounted fixture */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import {
+  MutationCache,
+  onlineManager,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
+import { KiloChatClient, type Message } from '@kilocode/kilo-chat';
+import { EventServiceClient } from '@kilocode/event-service';
+import { useSendMessage } from '@kilocode/kilo-chat-hooks';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { bumpAuthEpoch, currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import {
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+  getAuthenticatedOwner,
+} from '@/lib/context-scope';
+import {
+  initializeLocalAccess,
+  lockLocalAccess,
+  requestLocalAccess,
+  setLocalAccessContextReady,
+  setLocalAccessOwner,
+} from '@/lib/local-access';
+import {
+  assertMobileActionAdmission,
+  captureMobileActionAdmission,
+  isTransportOwner,
+} from '@/lib/local-access-transport';
+import { useMarkRead } from './hooks/use-mark-read';
+import { useConversationMarkRead } from './hooks/use-conversation-mark-read';
+import { clearSubmittedMessageInputDraft, submitMessageInputDraft } from './message-input-state';
+import { mobilePerformUpload } from './mobile-perform-upload';
+
+// Queue inventory: useMarkRead (outer mutation), useMarkConversationRead
+// (shared mutation), and useConversationMarkRead (delayed retry). Each keeps
+// the operation captured before its first wait.
+const native = vi.hoisted(() => ({ badges: [] as number[] }));
+vi.mock('@sentry/react-native', () => ({ captureException: vi.fn<() => void>() }));
+vi.mock('expo-notifications', () => ({
+  setBadgeCountAsync: async (count: number) => {
+    native.badges.push(count);
+    return true;
+  },
+}));
+vi.mock('./hooks/use-current-user-id', () => ({
+  useCurrentUserId: () => getAuthenticatedOwner().userId,
+}));
+vi.mock('./hooks/use-app-active-and-focused', () => ({ useAppActiveAndFocused: () => true }));
+
+const messageId = '01HV0000000000000000000001';
+const conversationId = '01HV0000000000000000000000';
+const message: Message = {
+  id: messageId,
+  senderId: 'bot:assistant',
+  content: [],
+  inReplyToMessageId: null,
+  replyTo: null,
+  updatedAt: null,
+  clientUpdatedAt: null,
+  deleted: false,
+  deliveryFailed: false,
+  reactions: [],
+};
+const success = {
+  ok: true,
+  applied: true,
+  lastReadAt: 42,
+  badgeClear: { badgeBucket: 'bucket', badgeCount: 0 },
+};
+let renderer: TestRenderer.ReactTestRenderer | undefined;
+let disposeAccess: (() => void) | undefined;
+let queryClient: QueryClient;
+let client: KiloChatClient;
+let requests: string[];
+let respond: () => Promise<Response>;
+let markRead: ReturnType<typeof useMarkRead> | undefined;
+let send: ReturnType<typeof useSendMessage> | undefined;
+function ManualProbe() {
+  markRead = useMarkRead(client);
+  send = useSendMessage(client, conversationId, getAuthenticatedOwner().userId);
+  return null;
+}
+function AutomaticProbe() {
+  useConversationMarkRead({
+    client,
+    conversationId,
+    currentUserId: getAuthenticatedOwner().userId,
+    hasInitialMessages: true,
+    messages: [message],
+    sandboxId: 's',
+  });
+  return null;
+}
+async function selectOwner(userId: string) {
+  bumpAuthEpoch();
+  confirmAuthenticatedOwner(beginAuthenticatedOwner(), userId);
+  await setLocalAccessOwner(userId, currentAuthEpoch());
+  setLocalAccessContextReady(true);
+  await requestLocalAccess('unlock');
+}
+async function mount(automatic = false) {
+  await act(async () => {
+    renderer = TestRenderer.create(
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(automatic ? AutomaticProbe : ManualProbe)
+      )
+    );
+  });
+}
+async function mark() {
+  if (!markRead) {
+    throw new Error('mark-read hook not mounted');
+  }
+  return markRead('s', conversationId, messageId);
+}
+
+beforeEach(async () => {
+  requests = [];
+  native.badges = [];
+  markRead = undefined;
+  send = undefined;
+  onlineManager.setOnline(true);
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  disposeAccess = initializeLocalAccess({
+    storage: {
+      read: async () => ({ status: 'present', enabled: true }),
+      write: async () => 'committed',
+    },
+    authenticate: async () => ({ status: 'authenticated' }),
+    lifecycle: { getCurrentState: () => 'active', subscribe: () => vi.fn<() => void>() },
+  });
+  await selectOwner('a');
+  const owner = getAuthenticatedOwner();
+  respond = async () => Response.json(success);
+  client = new KiloChatClient({
+    eventService: new EventServiceClient({ url: 'https://events.test', getToken: async () => 'a' }),
+    baseUrl: 'https://chat.test',
+    getToken: async () => 'a',
+    fetch: async input => {
+      requests.push(input instanceof Request ? input.url : input.toString());
+      return respond();
+    },
+    canPublish: () => isTransportOwner(owner),
+    captureOperationAdmission: () => {
+      const admission = captureMobileActionAdmission(owner, null);
+      return () => {
+        assertMobileActionAdmission(admission);
+      };
+    },
+  });
+  queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  queryClient.setQueryData(['badges', 'a'], [{ badgeBucket: 'bucket', badgeCount: 2 }]);
+});
+afterEach(async () => {
+  await act(async () => {
+    renderer?.unmount();
+  });
+  renderer = undefined;
+  client.dispose();
+  queryClient.clear();
+  disposeAccess?.();
+  onlineManager.setOnline(true);
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('mobile mark-read queue inventory', () => {
+  it.each(['lock/unlock', 'account replacement'] as const)(
+    'keeps outer admission through an offline pause and %s',
+    async change => {
+      onlineManager.setOnline(false);
+      await mount();
+      let pending!: Promise<unknown>;
+      await act(async () => {
+        pending = mark();
+      });
+      const rejected = expect(pending).rejects.toThrow();
+      expect(
+        queryClient
+          .getMutationCache()
+          .getAll()
+          .some(mutation => mutation.state.isPaused)
+      ).toBe(true);
+      await act(async () => {
+        if (change === 'lock/unlock') {
+          lockLocalAccess();
+          await requestLocalAccess('unlock');
+        } else {
+          await selectOwner('b');
+        }
+        onlineManager.setOnline(true);
+        await rejected;
+      });
+      expect(requests).toEqual([]);
+      expect(queryClient.getQueryData(['badges', 'a'])).toEqual([
+        { badgeBucket: 'bucket', badgeCount: 2 },
+      ]);
+      expect(native.badges).toEqual([]);
+    }
+  );
+
+  it('keeps outer admission through its global onMutate wait', async () => {
+    const waiting = Promise.withResolvers<undefined>();
+    const entered = Promise.withResolvers<undefined>();
+    queryClient = new QueryClient({
+      mutationCache: new MutationCache({
+        onMutate: async () => {
+          entered.resolve(undefined);
+          await waiting.promise;
+        },
+      }),
+    });
+    await mount();
+    const pending = mark();
+    const rejected = expect(pending).rejects.toThrow();
+    await entered.promise;
+    lockLocalAccess();
+    await requestLocalAccess('unlock');
+    await act(async () => {
+      waiting.resolve(undefined);
+      await rejected;
+    });
+    expect(requests).toEqual([]);
+    expect(native.badges).toEqual([]);
+  });
+
+  it('retries a network failure under the original operation when access remains valid', async () => {
+    vi.useFakeTimers();
+    respond = async () =>
+      requests.length === 1
+        ? Response.json({ error: 'offline' }, { status: 503 })
+        : Response.json(success);
+    await mount(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(requests).toHaveLength(2);
+    expect(native.badges).toEqual([0]);
+    expect(queryClient.getQueryData(['badges', 'a'])).toEqual([]);
+  });
+
+  it.each(['lock/unlock', 'account replacement'] as const)(
+    'cancels the delayed retry after %s without recapturing admission',
+    async change => {
+      vi.useFakeTimers();
+      respond = async () => Response.json({ error: 'offline' }, { status: 503 });
+      await mount(true);
+      expect(requests).toHaveLength(1);
+      await act(async () => {
+        if (change === 'lock/unlock') {
+          lockLocalAccess();
+          await requestLocalAccess('unlock');
+        } else {
+          await selectOwner('b');
+        }
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(requests).toHaveLength(1);
+      expect(native.badges).toEqual([]);
+    }
+  );
+
+  it('does not publish an accepted A badge response into B or update the native badge', async () => {
+    const response = Promise.withResolvers<Response>();
+    respond = async () => response.promise;
+    await mount();
+    const pending = mark();
+    const rejected = expect(pending).rejects.toThrow('owner is no longer active');
+    await vi.waitFor(() => {
+      expect(requests).toHaveLength(1);
+    });
+    await act(async () => {
+      await selectOwner('b');
+      queryClient.clear();
+      queryClient.setQueryData(['badges', 'b'], [{ badgeBucket: 'bucket', badgeCount: 7 }]);
+      response.resolve(Response.json(success));
+      await rejected;
+    });
+    expect(queryClient.getQueryData(['badges', 'b'])).toEqual([
+      { badgeBucket: 'bucket', badgeCount: 7 },
+    ]);
+    expect(queryClient.getQueryData(['badges', 'a'])).toBeUndefined();
+    expect(native.badges).toEqual([]);
+  });
+
+  it('does not mark locked incoming content as read', async () => {
+    lockLocalAccess();
+    await mount(true);
+    expect(requests).toEqual([]);
+    expect(native.badges).toEqual([]);
+  });
+});
+
+describe('mobile draft and upload admission', () => {
+  it('retains text and attachment chips when a shared send wait crosses lock/unlock', async () => {
+    const waiting = Promise.withResolvers<undefined>();
+    const entered = Promise.withResolvers<undefined>();
+    vi.spyOn(queryClient, 'cancelQueries').mockImplementation(async () => {
+      entered.resolve(undefined);
+      await waiting.promise;
+    });
+    await mount();
+    const valueRef = { current: 'keep this text' };
+    let chips = ['photo'];
+    const submission = submitMessageInputDraft({
+      valueRef,
+      onSend: vi.fn<() => void>(),
+      onSendContentBlocks: async (content, _reply, controls) => {
+        if (!send) {
+          throw new Error('send hook not mounted');
+        }
+        await send.mutateAsync({ conversationId, clientId: '01HV0000000000000000000002', content });
+        clearSubmittedMessageInputDraft({
+          controls,
+          submittedAttachmentTempIds: ['photo'],
+          clearSubmittedFiles: () => {
+            chips = [];
+          },
+        });
+      },
+      clearInput: vi.fn<() => void>(),
+      setCanSend: vi.fn<() => void>(),
+      readyAttachmentBlocks: [
+        {
+          type: 'attachment',
+          attachmentId: messageId,
+          filename: 'a.png',
+          mimeType: 'image/png',
+          size: 4,
+        },
+      ],
+    });
+    if (!submission) {
+      throw new Error('draft did not submit');
+    }
+    const rejected = expect(submission.completion).rejects.toThrow();
+    await entered.promise;
+    lockLocalAccess();
+    await requestLocalAccess('unlock');
+    await act(async () => {
+      waiting.resolve(undefined);
+      await rejected;
+    });
+    expect(valueRef.current).toBe('keep this text');
+    expect(chips).toEqual(['photo']);
+    expect(requests).toEqual([]);
+  });
+
+  it('requires mobile upload admission and checks it after XHR preparation', async () => {
+    const sent: Blob[] = [];
+    class Upload {
+      upload = { addEventListener: vi.fn<() => void>() };
+      open = vi.fn(() => {
+        lockLocalAccess();
+      });
+      setRequestHeader = vi.fn<() => void>();
+      addEventListener = vi.fn<() => void>();
+      send = vi.fn<(blob: Blob) => void>(blob => {
+        sent.push(blob);
+      });
+    }
+    vi.stubGlobal('XMLHttpRequest', Upload);
+    const options = { signal: new AbortController().signal, onProgress: vi.fn<() => void>() };
+    await expect(
+      mobilePerformUpload(new Blob(['private']), 'https://upload.test', {}, options)
+    ).rejects.toMatchObject({ code: 'LOCAL_ACCESS_DENIED' });
+    const operation = client.captureOperation();
+    await expect(
+      mobilePerformUpload(
+        new Blob(['private']),
+        'https://upload.test',
+        {},
+        { ...options, operation }
+      )
+    ).rejects.toMatchObject({ code: 'LOCAL_ACCESS_DENIED' });
+    expect(sent).toEqual([]);
+  });
+});

--- a/apps/mobile/src/components/kilo-chat/kilo-chat-provider.mounted.test.tsx
+++ b/apps/mobile/src/components/kilo-chat/kilo-chat-provider.mounted.test.tsx
@@ -1,166 +1,687 @@
-/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React trees under vitest (same pattern as src/test/render-with-providers.tsx) */
-/* eslint-disable eslint/max-classes-per-file -- hoisted mock classes for two different packages */
-import { createElement, type ReactElement, type ReactNode } from 'react';
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer mounts the native provider without a DOM */
+/* eslint-disable require-await, typescript-eslint/require-await -- async doubles and act callbacks preserve the native promise contracts */
+/* eslint-disable max-lines -- keep shared mutation regressions in the owned mounted harness with its installed renderer */
+import { createElement, StrictMode, useCallback, useContext, useEffect, useRef } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as EventService from '@kilocode/event-service';
+import { KiloChatClient } from '@kilocode/kilo-chat';
+import { MutationCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  clearMarkReadRetry,
+  createMarkReadRetryState,
+  createMarkReadState,
+  finishMarkReadAttempt,
+  scheduleMarkReadRetry,
+  shouldStartMarkReadAttempt,
+  startMarkReadAttempt,
+  succeedMarkReadAttempt,
+  useEventServiceClient,
+  useKiloChatClient,
+  useKiloChatMutation,
+  useMarkConversationRead,
+} from '@kilocode/kilo-chat-hooks';
 
-import { KiloChatProvider } from './kilo-chat-provider';
-
-// ── Hoisted mocks ──────────────────────────────────────────────────────────
+import { bumpAuthEpoch, currentAuthEpoch } from '@/lib/auth/auth-epoch';
+import {
+  type AuthenticatedOwner,
+  beginAuthenticatedOwner,
+  confirmAuthenticatedOwner,
+} from '@/lib/context-scope';
+import {
+  initializeLocalAccess,
+  lockLocalAccess,
+  requestLocalAccess,
+  setLocalAccessContextReady,
+  setLocalAccessOwner,
+} from '@/lib/local-access';
+import {
+  KiloChatCurrentUserContext,
+  KiloChatProvider,
+  useKiloChatTokenError,
+} from './kilo-chat-provider';
 
 const mocks = vi.hoisted(() => {
-  const acquire = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
-  const release = vi.fn();
-
-  // Must be a real class (not vi.fn()) because it is instantiated with `new`.
-  class MockEventServiceClient {
-    acquire = acquire;
-    release = release;
+  type Handler = (context: string, payload: unknown) => void;
+  class EventClient {
+    static instances: EventClient[] = [];
+    readonly config: EventService.EventServiceConfig;
+    connected = false;
+    handlers = new Map<string, Set<Handler>>();
+    constructor(config: EventService.EventServiceConfig) {
+      this.config = config;
+      EventClient.instances.push(this);
+    }
+    async acquire() {
+      this.connected = true;
+    }
+    release() {
+      this.connected = false;
+    }
+    isConnected() {
+      return this.connected;
+    }
+    subscribe = vi.fn<() => void>();
+    on(name: string, handler: Handler) {
+      const handlers = this.handlers.get(name) ?? new Set<Handler>();
+      handlers.add(handler);
+      this.handlers.set(name, handlers);
+      return () => {
+        handlers.delete(handler);
+      };
+    }
+    onConnected(handler: () => void) {
+      return this.on('connected', handler);
+    }
+    onReconnect(handler: () => void) {
+      return this.on('reconnect', handler);
+    }
+    onResync(handler: () => void) {
+      return this.on('resync', handler);
+    }
+    emit(name: string, context: string, payload: unknown) {
+      for (const handler of this.handlers.get(name) ?? []) {
+        handler(context, payload);
+      }
+    }
   }
-
-  // eslint-disable-next-line typescript-eslint/no-extraneous-class -- hoisted mock stub for constructor
-  class MockKiloChatClient {}
-
-  const subscribeToKiloChatTokenResponses = vi.fn(() => vi.fn());
-  const clearKiloChatTokenCache = vi.fn();
-  const useKiloChatTokenGetter = vi.fn(() => vi.fn().mockResolvedValue('mock-token'));
-  const useKiloChatTokenResponseGetter = vi.fn(() =>
-    vi.fn().mockResolvedValue({ userId: 'test-user', token: 'mock-token' })
-  );
-
-  const useAppActiveAndFocused = vi.fn<() => boolean>();
-
   return {
-    acquire,
-    release,
-    EventServiceClient: MockEventServiceClient,
-    KiloChatClient: MockKiloChatClient,
-    subscribeToKiloChatTokenResponses,
-    clearKiloChatTokenCache,
-    useKiloChatTokenGetter,
-    useKiloChatTokenResponseGetter,
-    useAppActiveAndFocused,
+    EventClient,
+    active: true,
+    tokenReads: [] as string[],
+    messages: [] as string[],
+    statuses: [] as boolean[],
+    resyncs: 0,
   };
 });
-
-// ── Module mocks ───────────────────────────────────────────────────────────
-
-vi.mock('@kilocode/event-service', () => ({
-  EventServiceClient: mocks.EventServiceClient,
+vi.mock('@kilocode/event-service', async original => ({
+  ...(await original<typeof EventService>()),
+  EventServiceClient: mocks.EventClient,
 }));
-
-vi.mock('@kilocode/kilo-chat', () => ({
-  KiloChatClient: mocks.KiloChatClient,
-}));
-
-vi.mock('@kilocode/kilo-chat-hooks', () => ({
-  KiloChatHooksProvider: ({ children }: { children: ReactNode; value: unknown }) =>
-    children as ReactElement,
-}));
-
 vi.mock('@/lib/config', () => ({
   EVENT_SERVICE_URL: 'https://events.test',
   KILO_CHAT_URL: 'https://chat.test',
 }));
-
 vi.mock('./hooks/use-app-active-and-focused', () => ({
-  useAppActiveAndFocused: mocks.useAppActiveAndFocused,
+  useAppActiveAndFocused: () => mocks.active,
 }));
-
 vi.mock('./hooks/use-kilo-chat-token', () => ({
-  subscribeToKiloChatTokenResponses: mocks.subscribeToKiloChatTokenResponses,
-  clearKiloChatTokenCache: mocks.clearKiloChatTokenCache,
-  useKiloChatTokenGetter: mocks.useKiloChatTokenGetter,
-  useKiloChatTokenResponseGetter: mocks.useKiloChatTokenResponseGetter,
+  clearKiloChatTokenCache: vi.fn<() => void>(),
+  subscribeToKiloChatTokenResponses: () => vi.fn<() => void>(),
+  useKiloChatTokenResponseGetter: (owner: AuthenticatedOwner) =>
+    useCallback(async () => {
+      mocks.tokenReads.push(owner.userId ?? 'absent');
+      return {
+        userId: owner.userId,
+        token: `chat-${owner.userId}`,
+        expiresAt: '2099-01-01T00:00:00Z',
+      };
+    }, [owner]),
 }));
 
-// ── Flat render helper ─────────────────────────────────────────────────────
-
-async function mountProvider(): Promise<TestRenderer.ReactTestRenderer> {
-  const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
-  await act(async () => {
-    ref.current = TestRenderer.create(createElement(KiloChatProvider, null));
-    await Promise.resolve();
-  });
-  const created = ref.current;
-  if (!created) {
-    throw new Error('mountProvider: renderer was not created');
+type ProbeValue = { client: KiloChatClient; userId: string | null; retry: () => void };
+let probe: ProbeValue | undefined = undefined;
+function Probe() {
+  const client = useKiloChatClient();
+  const eventService = useEventServiceClient();
+  const userId = useContext(KiloChatCurrentUserContext);
+  const { retry } = useKiloChatTokenError();
+  probe = { client, userId, retry };
+  useEffect(() => {
+    const offs = [
+      client.onMessageCreated((_context, event) => {
+        mocks.messages.push(event.senderId);
+      }),
+      client.onBotStatus((_context, event) => {
+        mocks.statuses.push(event.online);
+      }),
+      eventService.onResync(() => {
+        mocks.resyncs += 1;
+      }),
+    ];
+    return () => {
+      for (const off of offs) {
+        off();
+      }
+    };
+  }, [client, eventService]);
+  return null;
+}
+function current() {
+  if (!probe) {
+    throw new Error('provider not mounted');
   }
-  return created;
+  return probe;
 }
-
-async function unmountProvider(renderer: TestRenderer.ReactTestRenderer): Promise<void> {
+function tree() {
+  return createElement(KiloChatProvider, null, createElement(Probe));
+}
+let renderer: TestRenderer.ReactTestRenderer | undefined = undefined;
+let disposeAccess: (() => void) | undefined = undefined;
+async function selectOwner(userId: string) {
+  bumpAuthEpoch();
+  confirmAuthenticatedOwner(beginAuthenticatedOwner(), userId);
+  await setLocalAccessOwner(userId, currentAuthEpoch());
+  setLocalAccessContextReady(true);
+  await requestLocalAccess('unlock');
+}
+async function mount() {
   await act(async () => {
-    renderer.unmount();
-    await Promise.resolve();
+    renderer = TestRenderer.create(tree());
   });
 }
+const messageEvent = {
+  messageId: '01HV0000000000000000000001',
+  senderId: 'a',
+  content: [{ type: 'text', text: 'private' }],
+  inReplyToMessageId: null,
+  replyTo: null,
+  clientId: null,
+};
 
-// ── Tests ──────────────────────────────────────────────────────────────────
-
-describe('KiloChatProvider lifecycle', () => {
-  it('mounts active, calls acquire, unmounts and releases the hold', async () => {
-    mocks.useAppActiveAndFocused.mockReturnValue(true);
-    vi.clearAllMocks();
-
-    const renderer = await mountProvider();
-
-    expect(mocks.acquire).toHaveBeenCalledTimes(1);
-    expect(mocks.release).not.toHaveBeenCalled();
-
-    await unmountProvider(renderer);
-
-    // Active mount → cleanup must release the hold.
-    expect(mocks.release).toHaveBeenCalledTimes(1);
+beforeEach(async () => {
+  mocks.EventClient.instances = [];
+  mocks.active = true;
+  mocks.messages = [];
+  mocks.statuses = [];
+  mocks.tokenReads = [];
+  mocks.resyncs = 0;
+  probe = undefined;
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  vi.stubGlobal('fetch', async () => Response.json({}));
+  disposeAccess = initializeLocalAccess({
+    storage: {
+      read: async () => ({ status: 'present', enabled: true }),
+      write: async () => 'committed',
+    },
+    authenticate: async () => ({ status: 'authenticated' }),
+    lifecycle: { getCurrentState: () => 'active', subscribe: () => vi.fn<() => void>() },
   });
-
-  it('mounts inactive, calls neither acquire nor release', async () => {
-    mocks.useAppActiveAndFocused.mockReturnValue(false);
-    vi.clearAllMocks();
-
-    const renderer = await mountProvider();
-
-    // Inactive: acquires nothing, releases nothing — no unpaired release.
-    expect(mocks.acquire).not.toHaveBeenCalled();
-    expect(mocks.release).not.toHaveBeenCalled();
-
-    await unmountProvider(renderer);
-
-    // Cleanup: holding was false, so no release on unmount either.
-    expect(mocks.release).not.toHaveBeenCalled();
+  await selectOwner('a');
+});
+afterEach(async () => {
+  await act(async () => {
+    renderer?.unmount();
   });
+  renderer = undefined;
+  disposeAccess?.();
+  vi.unstubAllGlobals();
+});
 
-  it('handles active → inactive → active transition without unmounting', async () => {
-    mocks.useAppActiveAndFocused.mockReturnValue(true);
-    vi.clearAllMocks();
-
-    const renderer = await mountProvider();
-    expect(mocks.acquire).toHaveBeenCalledTimes(1);
-    expect(mocks.release).not.toHaveBeenCalled();
-
-    // Transition to inactive — cleanup from previous active effect releases the hold.
-    mocks.useAppActiveAndFocused.mockReturnValue(false);
-    vi.clearAllMocks();
+describe('KiloChatProvider owner lifecycle', () => {
+  it('replaces disposed clients during effect replay without reviving their queues', async () => {
     await act(async () => {
-      renderer.update(createElement(KiloChatProvider, null));
-      await Promise.resolve();
+      renderer = TestRenderer.create(createElement(StrictMode, null, tree()));
     });
-    expect(mocks.release).toHaveBeenCalledTimes(1);
-    expect(mocks.acquire).not.toHaveBeenCalled();
-
-    // Transition back to active — reacquires.
-    mocks.useAppActiveAndFocused.mockReturnValue(true);
-    vi.clearAllMocks();
+    await expect(current().client.sendTyping('c')).resolves.toBeUndefined();
+    expect(mocks.EventClient.instances.filter(instance => instance.connected)).toHaveLength(1);
     await act(async () => {
-      renderer.update(createElement(KiloChatProvider, null));
-      await Promise.resolve();
+      renderer?.unmount();
     });
-    expect(mocks.acquire).toHaveBeenCalledTimes(1);
-    expect(mocks.release).not.toHaveBeenCalled();
-
-    // Unmount releases the reacquired hold.
-    vi.clearAllMocks();
-    await unmountProvider(renderer);
-    expect(mocks.release).toHaveBeenCalledTimes(1);
+    renderer = undefined;
+    expect(mocks.EventClient.instances.filter(instance => instance.connected)).toEqual([]);
   });
+
+  it('pairs active/inactive holds without replacing the same owner clients', async () => {
+    await mount();
+    const original = current().client;
+    const socket = mocks.EventClient.instances[0];
+    expect(socket?.connected).toBe(true);
+    mocks.active = false;
+    await act(async () => {
+      renderer?.update(tree());
+    });
+    expect(socket?.connected).toBe(false);
+    mocks.active = true;
+    await act(async () => {
+      renderer?.update(tree());
+    });
+    expect(socket?.connected).toBe(true);
+    expect(current().client).toBe(original);
+    await act(async () => {
+      renderer?.unmount();
+    });
+    renderer = undefined;
+    expect(socket?.connected).toBe(false);
+    await expect(original.sendTyping('c')).rejects.toThrow('owner is no longer active');
+  });
+
+  it('keeps an inactive mount disconnected', async () => {
+    mocks.active = false;
+    await mount();
+    expect(mocks.EventClient.instances.map(instance => instance.connected)).toEqual([false]);
+  });
+
+  it('replaces A directly with B while requests, queued sends, callbacks, and token retry remain outstanding', async () => {
+    const response = Promise.withResolvers<Response>();
+    const requests: string[] = [];
+    vi.stubGlobal('fetch', async (url: RequestInfo | URL) => {
+      requests.push(url instanceof Request ? url.url : url.toString());
+      return response.promise;
+    });
+    await mount();
+    const old = current();
+    const oldSocket = mocks.EventClient.instances[0];
+    const queuedEvents = [...(oldSocket?.handlers.get('message.created') ?? [])];
+    const queuedResyncs = [...(oldSocket?.handlers.get('resync') ?? [])];
+    const first = old.client.sendMessage({
+      conversationId: 'c',
+      content: [{ type: 'text', text: 'A' }],
+    });
+    const queued = old.client.sendMessage({
+      conversationId: 'c',
+      content: [{ type: 'text', text: 'queued A' }],
+    });
+    const read = old.client.listConversations();
+    // eslint-disable-next-line promise/prefer-await-to-then -- attach all rejections before replacing the owner
+    const settled = Promise.allSettled([first, queued, read]);
+    await vi.waitFor(() => {
+      expect(requests).toHaveLength(2);
+    });
+    await act(async () => {
+      const replacement = selectOwner('b');
+      // The subscription closes A before React mounts B.
+      expect(oldSocket?.connected).toBe(false);
+      await replacement;
+    });
+    const results = await settled;
+    expect(results.map(result => result.status)).toEqual(['rejected', 'rejected', 'rejected']);
+    response.resolve(Response.json({}));
+    for (const handler of queuedEvents) {
+      handler('old-context', messageEvent);
+    }
+    for (const handler of queuedResyncs) {
+      handler('', undefined);
+    }
+    const tokenReads = [...mocks.tokenReads];
+    old.retry();
+    await expect(oldSocket?.config.getToken()).rejects.toMatchObject({ reason: 'owner' });
+    expect(mocks.messages).toEqual([]);
+    expect(mocks.resyncs).toBe(0);
+    expect(mocks.tokenReads).toEqual(tokenReads);
+    expect(current().userId).toBe('b');
+    expect(current().client).not.toBe(old.client);
+    expect(mocks.EventClient.instances.at(-1)?.connected).toBe(true);
+    expect(requests).toHaveLength(2);
+  });
+
+  it('delivers same-owner messages and status while locked but rejects foreground commands', async () => {
+    await mount();
+    const owner = current().client;
+    lockLocalAccess();
+    const socket = mocks.EventClient.instances[0];
+    socket?.emit(
+      'message.created',
+      EventService.kiloclawConversationContext('s', 'c'),
+      messageEvent
+    );
+    socket?.emit('bot.status', 'instance', { sandboxId: 's', online: true, at: 1 });
+    expect(mocks.messages).toEqual(['a']);
+    expect(mocks.statuses).toEqual([true]);
+    expect(socket?.connected).toBe(true);
+    await expect(owner.sendTyping('c')).rejects.toMatchObject({
+      code: 'LOCAL_ACCESS_DENIED',
+      reason: 'locked',
+    });
+    await expect(owner.sendTypingStop('c')).resolves.toBeUndefined();
+  });
+});
+
+describe('mounted shared mutation callbacks', () => {
+  let queryClient: QueryClient | undefined = undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      renderer?.unmount();
+    });
+    renderer = undefined;
+    queryClient?.clear();
+    vi.useRealTimers();
+  });
+
+  async function mountQueryHook<T>(useHook: () => T) {
+    let value: T | undefined = undefined;
+    function HookProbe() {
+      value = useHook();
+      return null;
+    }
+    function hookTree() {
+      if (!queryClient) {
+        throw new Error('missing test query client');
+      }
+      return createElement(QueryClientProvider, { client: queryClient }, createElement(HookProbe));
+    }
+    await act(async () => {
+      renderer = TestRenderer.create(hookTree());
+    });
+    return {
+      get current() {
+        if (value === undefined) {
+          throw new Error('mutation hook not mounted');
+        }
+        return value;
+      },
+      async rerender() {
+        await act(async () => {
+          renderer?.update(hookTree());
+        });
+      },
+    };
+  }
+
+  function legacyClient(fetch: typeof globalThis.fetch) {
+    return new KiloChatClient({
+      eventService: new EventService.EventServiceClient({
+        url: 'https://events.test',
+        getToken: async () => 'legacy',
+      }),
+      baseUrl: 'https://chat.test',
+      getToken: async () => 'legacy',
+      fetch,
+    });
+  }
+
+  it('delays and bounds failed mark-read requests with the web effect dependency', async () => {
+    const firstResponse = Promise.withResolvers<Response>();
+    const requestTimes: number[] = [];
+    const client = legacyClient(async () => {
+      requestTimes.push(Date.now());
+      return requestTimes.length === 1
+        ? firstResponse.promise
+        : Response.json({ error: 'unavailable' }, { status: 500 });
+    });
+    const hook = await mountQueryHook(function useWebMarkReadEffect() {
+      const sandboxId = 's';
+      const conversationId = 'c';
+      const latestMessageId = '01HV0000000000000000000001';
+      const marker = `${conversationId}:${latestMessageId}`;
+      const visible = mocks.active;
+      const markRead = useMarkConversationRead(client);
+      const { mutate } = markRead;
+      const stateRef = useRef(createMarkReadState());
+      const retryStateRef = useRef(createMarkReadRetryState());
+      const currentMarkerRef = useRef(marker);
+      const visibleRef = useRef(visible);
+      const retryRef = useRef<() => void>(() => undefined);
+      currentMarkerRef.current = marker;
+      visibleRef.current = visible;
+      // Match MessageArea's mutate -> callback -> effect dependency chain.
+      const markCurrentConversationRead = useCallback(() => {
+        const state = stateRef.current;
+        if (!shouldStartMarkReadAttempt(state, marker)) {
+          return;
+        }
+        startMarkReadAttempt(state, marker);
+        mutate(
+          { sandboxId, conversationId, lastSeenMessageId: latestMessageId },
+          {
+            onSuccess: () => {
+              succeedMarkReadAttempt(state, marker);
+              clearMarkReadRetry(retryStateRef.current);
+            },
+            onSettled: () => {
+              finishMarkReadAttempt(state, marker);
+              if (state.lastSucceededMarker !== marker) {
+                scheduleMarkReadRetry(retryStateRef.current, {
+                  marker,
+                  currentMarker: () => currentMarkerRef.current,
+                  isActive: () => visibleRef.current,
+                  lastSucceededMarker: () => stateRef.current.lastSucceededMarker,
+                  retry: () => {
+                    retryRef.current();
+                  },
+                });
+              }
+            },
+          }
+        );
+      }, [conversationId, latestMessageId, marker, mutate, sandboxId]);
+      retryRef.current = markCurrentConversationRead;
+      useEffect(() => {
+        if (visible) {
+          markCurrentConversationRead();
+        }
+      }, [markCurrentConversationRead, visible]);
+      useEffect(() => {
+        const retryState = retryStateRef.current;
+        return () => {
+          clearMarkReadRetry(retryState);
+        };
+      }, []);
+      return markRead;
+    });
+    const initial = hook.current;
+    await act(async () => {
+      firstResponse.resolve(Response.json({ error: 'unavailable' }, { status: 500 }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(requestTimes).toEqual([0]);
+    expect(hook.current.status).toBe('error');
+    await hook.rerender();
+    expect(hook.current.mutate).toBe(initial.mutate);
+    expect(hook.current.mutateAsync).toBe(initial.mutateAsync);
+    expect(requestTimes).toEqual([0]);
+
+    for (const [elapsed, expected] of [
+      [249, [0]],
+      [1, [0, 250]],
+      [499, [0, 250]],
+      [1, [0, 250, 750]],
+      [749, [0, 250, 750]],
+      [1, [0, 250, 750, 1500]],
+      [60_000, [0, 250, 750, 1500]],
+    ] as const) {
+      // eslint-disable-next-line no-await-in-loop -- observe each deadline before advancing to the next retry
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(elapsed);
+      });
+      expect(requestTimes).toEqual(expected);
+    }
+    await hook.rerender();
+    expect(requestTimes).toEqual([0, 250, 750, 1500]);
+    expect(hook.current.status).toBe('error');
+  });
+
+  it.each([
+    ['mutate', 200],
+    ['mutateAsync', 200],
+    ['mutate', 500],
+    ['mutateAsync', 500],
+  ] as const)('captures current callbacks once for %s with status %s', async (method, status) => {
+    const entered = Promise.withResolvers<undefined>();
+    const release = Promise.withResolvers<undefined>();
+    const finished = Promise.withResolvers<undefined>();
+    const receipts: string[] = [];
+    const requests: string[] = [];
+    queryClient = new QueryClient({
+      mutationCache: new MutationCache({
+        onMutate: async () => {
+          entered.resolve(undefined);
+          await release.promise;
+        },
+      }),
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const client = legacyClient(async input => {
+      requests.push(input instanceof Request ? input.url : input.toString());
+      return Response.json({}, { status });
+    });
+    let revision = 'mounted';
+    const hook = await mountQueryHook(function useCallbackProbe() {
+      const label = revision;
+      return useKiloChatMutation(client, {
+        mutationFn: async (conversationId: string, operation) =>
+          client.sendTyping(`${label}-${conversationId}`, operation),
+        onMutate: conversationId => {
+          receipts.push(`${label}:mutate`);
+          return `${label}-${conversationId}`;
+        },
+        onSuccess: (_data, _variables, context) => {
+          receipts.push(`${label}:success:${context ?? 'absent'}`);
+        },
+        onError: (_error, _variables, context) => {
+          receipts.push(`${label}:error:${context ?? 'absent'}`);
+        },
+        onSettled: () => {
+          receipts.push(`${label}:settled`);
+        },
+      });
+    });
+    const initial = hook.current;
+    revision = 'invoked';
+    await hook.rerender();
+    expect(hook.current.mutate).toBe(initial.mutate);
+    expect(hook.current.mutateAsync).toBe(initial.mutateAsync);
+    const callbacks = {
+      onSuccess: () => {
+        receipts.push('call:success');
+      },
+      onError: () => {
+        receipts.push('call:error');
+      },
+      onSettled: () => {
+        receipts.push('call:settled');
+        finished.resolve(undefined);
+      },
+    };
+    const settlement = Promise.withResolvers<PromiseSettledResult<void>[]>();
+    await act(async () => {
+      if (method === 'mutateAsync') {
+        settlement.resolve(Promise.allSettled([initial.mutateAsync('c', callbacks)]));
+      } else {
+        initial.mutate('c', callbacks);
+        settlement.resolve([]);
+      }
+      await entered.promise;
+    });
+    revision = 'waiting';
+    await hook.rerender();
+    await act(async () => {
+      release.resolve(undefined);
+      await finished.promise;
+      await settlement.promise;
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const outcome = status === 200 ? 'success' : 'error';
+    expect(requests).toEqual(['https://chat.test/v1/conversations/invoked-c/typing']);
+    expect(receipts).toEqual([
+      'invoked:mutate',
+      `invoked:${outcome}:invoked-c`,
+      'invoked:settled',
+      `call:${outcome}`,
+      'call:settled',
+    ]);
+    expect(hook.current.status).toBe(outcome);
+    expect(hook.current.mutate).toBe(initial.mutate);
+    expect(hook.current.mutateAsync).toBe(initial.mutateAsync);
+    if (method === 'mutateAsync') {
+      const results = await settlement.promise;
+      expect(results.map(result => result.status)).toEqual([
+        status === 200 ? 'fulfilled' : 'rejected',
+      ]);
+    }
+  });
+
+  it.each(['before dispatch', 'during request'] as const)(
+    'does not redirect an accepted operation when the client changes %s',
+    async checkpoint => {
+      const entered = Promise.withResolvers<undefined>();
+      const release = Promise.withResolvers<undefined>();
+      const requests: string[] = [];
+      const receipts: string[] = [];
+      let owner = 'a';
+      queryClient = new QueryClient({
+        mutationCache: new MutationCache({
+          onMutate: async () => {
+            if (checkpoint === 'before dispatch') {
+              entered.resolve(undefined);
+              await release.promise;
+            }
+          },
+        }),
+        defaultOptions: { mutations: { retry: false } },
+      });
+      function clientFor(userId: string) {
+        return new KiloChatClient({
+          eventService: new EventService.EventServiceClient({
+            url: 'https://events.test',
+            getToken: async () => userId,
+          }),
+          baseUrl: 'https://chat.test',
+          getToken: async () => userId,
+          canPublish: () => owner === userId,
+          fetch: async () => {
+            requests.push(userId);
+            if (userId === 'a') {
+              entered.resolve(undefined);
+              await release.promise;
+            }
+            return Response.json({});
+          },
+        });
+      }
+      let client = clientFor('a');
+      const replacement = clientFor('b');
+      const hook = await mountQueryHook(function useOwnerProbe() {
+        const capturedClient = client;
+        const capturedOwner = owner;
+        return useKiloChatMutation(capturedClient, {
+          mutationFn: async (conversationId: string, operation) =>
+            capturedClient.sendTyping(conversationId, operation),
+          onSuccess: () => {
+            receipts.push(`${capturedOwner}:success`);
+          },
+          onError: () => {
+            receipts.push(`${capturedOwner}:error`);
+          },
+          onSettled: () => {
+            receipts.push(`${capturedOwner}:settled`);
+          },
+        });
+      });
+      const initial = hook.current;
+      const settlement = Promise.withResolvers<PromiseSettledResult<void>[]>();
+      await act(async () => {
+        settlement.resolve(
+          Promise.allSettled([
+            initial.mutateAsync('c', {
+              onSettled: () => {
+                receipts.push('a:call:settled');
+              },
+            }),
+          ])
+        );
+        await entered.promise;
+      });
+      owner = 'b';
+      client = replacement;
+      await hook.rerender();
+      expect(hook.current.mutate).not.toBe(initial.mutate);
+      expect(hook.current.mutateAsync).not.toBe(initial.mutateAsync);
+      await act(async () => {
+        release.resolve(undefined);
+        await settlement.promise;
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(await settlement.promise).toEqual([
+        { status: 'rejected', reason: new Error('Kilo Chat owner is no longer active') },
+      ]);
+      expect(requests).toEqual(checkpoint === 'during request' ? ['a'] : []);
+      expect(receipts).toEqual([]);
+      await act(async () => {
+        await hook.current.mutateAsync('new');
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(requests.at(-1)).toBe('b');
+      expect(receipts).toEqual(['b:success', 'b:settled']);
+    }
+  );
 });

--- a/apps/mobile/src/components/kilo-chat/kilo-chat-provider.tsx
+++ b/apps/mobile/src/components/kilo-chat/kilo-chat-provider.tsx
@@ -1,33 +1,46 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 
 import { EventServiceClient } from '@kilocode/event-service';
-import { KiloChatClient } from '@kilocode/kilo-chat';
+import {
+  KiloChatClient,
+  type KiloChatClientConfig,
+  type KiloChatOperation,
+} from '@kilocode/kilo-chat';
 import { KiloChatHooksProvider } from '@kilocode/kilo-chat-hooks';
 
 import { EVENT_SERVICE_URL, KILO_CHAT_URL } from '@/lib/config';
+import {
+  type AuthenticatedOwner,
+  getAuthenticatedOwner,
+  isAuthenticatedOwner,
+  subscribeAuthenticatedOwner,
+} from '@/lib/context-scope';
+import { LocalAccessDeniedError } from '@/lib/local-access';
+import {
+  assertMobileActionAdmission,
+  captureMobileActionAdmission,
+} from '@/lib/local-access-transport';
 
 import { useAppActiveAndFocused } from './hooks/use-app-active-and-focused';
 import {
   clearKiloChatTokenCache,
   subscribeToKiloChatTokenResponses,
-  useKiloChatTokenGetter,
   useKiloChatTokenResponseGetter,
 } from './hooks/use-kilo-chat-token';
 
-type KiloChatProviderProps = {
-  children: React.ReactNode;
-};
-
+type KiloChatProviderProps = { children: React.ReactNode };
 export const KiloChatCurrentUserContext = createContext<string | null>(null);
-
-type KiloChatTokenErrorState = {
-  hasError: boolean;
-  retry: () => void;
-};
-
+type KiloChatTokenErrorState = { hasError: boolean; retry: () => void };
 const KiloChatTokenErrorContext = createContext<KiloChatTokenErrorState | undefined>(undefined);
 
-/** Whether the initial kilo-chat token fetch failed, plus a way to retry it. */
 export function useKiloChatTokenError(): KiloChatTokenErrorState {
   const context = useContext(KiloChatTokenErrorContext);
   if (!context) {
@@ -36,98 +49,198 @@ export function useKiloChatTokenError(): KiloChatTokenErrorState {
   return context;
 }
 
+type MobileKiloChatConfig = Pick<KiloChatClientConfig, 'getToken'> &
+  Required<Pick<KiloChatClientConfig, 'captureOperationAdmission' | 'canPublish'>>;
+
+/** Mobile requires both guards; the shared constructors retain their old optional form. */
+export function createMobileKiloChatClients(config: MobileKiloChatConfig) {
+  let disposed = false;
+  let holding = false;
+  const canPublish = () => !disposed && config.canPublish();
+  const assertOwner = () => {
+    if (!canPublish()) {
+      throw new LocalAccessDeniedError('owner');
+    }
+  };
+  const getToken = async () => {
+    assertOwner();
+    const token = await config.getToken();
+    assertOwner();
+    return token;
+  };
+  const onUnauthorized = () => {
+    if (!canPublish()) {
+      return 'stop' as const;
+    }
+    clearKiloChatTokenCache();
+    return 'retry' as const;
+  };
+  const eventService = new EventServiceClient({ url: EVENT_SERVICE_URL, getToken, onUnauthorized });
+  // Guard the existing instance, including callbacks already queued before release.
+  // Do not change EventServiceClient behavior for web or other package consumers.
+  function whenCurrent<T extends unknown[]>(handler: (...args: T) => void) {
+    return (...args: T) => {
+      if (canPublish()) {
+        handler(...args);
+      }
+    };
+  }
+  const on = eventService.on.bind(eventService);
+  const onConnected = eventService.onConnected.bind(eventService);
+  const onReconnect = eventService.onReconnect.bind(eventService);
+  const onResync = eventService.onResync.bind(eventService);
+  const subscribe = eventService.subscribe.bind(eventService);
+  const isConnected = eventService.isConnected.bind(eventService);
+  eventService.on = (event, handler) => on(event, whenCurrent(handler));
+  eventService.onConnected = handler => onConnected(whenCurrent(handler));
+  eventService.onReconnect = handler => onReconnect(whenCurrent(handler));
+  eventService.onResync = handler => onResync(whenCurrent(handler));
+  eventService.subscribe = contexts => {
+    if (canPublish()) {
+      subscribe(contexts);
+    }
+  };
+  eventService.isConnected = () => canPublish() && isConnected();
+  const kiloChatClient = new KiloChatClient({
+    eventService,
+    baseUrl: KILO_CHAT_URL,
+    getToken,
+    onUnauthorized,
+    canPublish,
+    captureOperationAdmission: config.captureOperationAdmission,
+  });
+  function setActive(active: boolean) {
+    if (active && canPublish() && !holding) {
+      holding = true;
+      void eventService.acquire();
+    } else if (!active && holding) {
+      holding = false;
+      eventService.release();
+    }
+  }
+  function dispose() {
+    disposed = true;
+    kiloChatClient.dispose();
+    setActive(false);
+  }
+  return { eventService, kiloChatClient, setActive, dispose };
+}
+
 export function KiloChatProvider({ children }: KiloChatProviderProps) {
-  const getToken = useKiloChatTokenGetter();
-  const getTokenResponse = useKiloChatTokenResponseGetter();
+  const owner = useSyncExternalStore(subscribeAuthenticatedOwner, getAuthenticatedOwner);
+  return (
+    <OwnedKiloChatProvider
+      key={`${owner.authEpoch}:${owner.generation}:${owner.userId ?? ''}`}
+      owner={owner}
+    >
+      {children}
+    </OwnedKiloChatProvider>
+  );
+}
+
+function OwnedKiloChatProvider({
+  children,
+  owner,
+}: KiloChatProviderProps & { owner: AuthenticatedOwner }) {
+  const getTokenResponse = useKiloChatTokenResponseGetter(owner);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [tokenError, setTokenError] = useState(false);
-  const [retryCount, setRetryCount] = useState(0);
   const activeAndFocused = useAppActiveAndFocused();
-
-  const [value] = useState(() => {
-    const eventService = new EventServiceClient({
-      url: EVENT_SERVICE_URL,
-      getToken,
-      onUnauthorized: () => {
-        clearKiloChatTokenCache();
-        return 'retry';
-      },
-    });
-    const kiloChatClient = new KiloChatClient({
-      eventService,
-      baseUrl: KILO_CHAT_URL,
-      getToken,
-      onUnauthorized: () => {
-        clearKiloChatTokenCache();
-        return 'retry';
-      },
-    });
-    return { eventService, kiloChatClient };
-  });
+  const createClients = useCallback(
+    () =>
+      createMobileKiloChatClients({
+        getToken: async () => {
+          const response = await getTokenResponse();
+          return response.token;
+        },
+        canPublish: () => isAuthenticatedOwner(owner),
+        captureOperationAdmission: () => {
+          const admission = captureMobileActionAdmission(owner, null);
+          return () => {
+            assertMobileActionAdmission(admission);
+          };
+        },
+      }),
+    [getTokenResponse, owner]
+  );
+  const [value, setValue] = useState(createClients);
 
   useEffect(() => {
-    let holding = false;
-    if (activeAndFocused) {
-      void value.eventService.acquire();
-      holding = true;
+    // Effect replay must create a fresh pair, never revive a disposed queue.
+    if (isAuthenticatedOwner(owner) && !value.kiloChatClient.canPublish()) {
+      setValue(createClients());
+      return undefined;
     }
-    return () => {
-      if (holding) {
-        value.eventService.release();
+    const unsubscribe = subscribeAuthenticatedOwner(() => {
+      if (!isAuthenticatedOwner(owner)) {
+        value.dispose();
       }
+    });
+    return () => {
+      unsubscribe();
+      value.dispose();
+    };
+  }, [createClients, owner, value]);
+
+  useEffect(() => {
+    value.setActive(activeAndFocused);
+    return () => {
+      value.setActive(false);
     };
   }, [value, activeAndFocused]);
 
-  useEffect(() => {
-    let cancelled = false;
-    const unsubscribe = subscribeToKiloChatTokenResponses(response => {
-      if (!cancelled) {
-        setCurrentUserId(response.userId);
-        setTokenError(false);
-      }
-    });
-
-    async function resolveCurrentUserId() {
+  const resolveCurrentUserId = useCallback(
+    async (operation?: KiloChatOperation) => {
       try {
-        const response = await getTokenResponse();
-        if (!cancelled) {
+        const response = await getTokenResponse(operation?.assertDispatch);
+        if (value.kiloChatClient.canPublish()) {
           setCurrentUserId(response.userId);
           setTokenError(false);
         }
       } catch {
-        // Surface the failure instead of swallowing it — the composer would
-        // otherwise stay stuck behind "Loading user..." with no way out.
-        if (!cancelled) {
+        if (value.kiloChatClient.canPublish()) {
           setTokenError(true);
         }
       }
+    },
+    [getTokenResponse, value]
+  );
+
+  useEffect(() => {
+    const unsubscribe = subscribeToKiloChatTokenResponses((response, responseOwner) => {
+      if (
+        value.kiloChatClient.canPublish() &&
+        responseOwner.authEpoch === owner.authEpoch &&
+        responseOwner.generation === owner.generation &&
+        response.userId === owner.userId
+      ) {
+        setCurrentUserId(response.userId);
+        setTokenError(false);
+      }
+    });
+    if (owner.userId !== null) {
+      void resolveCurrentUserId();
     }
-
-    void resolveCurrentUserId();
-
-    return () => {
-      cancelled = true;
-      unsubscribe();
-    };
-  }, [getTokenResponse, retryCount]);
+    return unsubscribe;
+  }, [owner, resolveCurrentUserId, value]);
 
   const retryTokenFetch = useCallback(() => {
-    setTokenError(false);
-    setRetryCount(count => count + 1);
-  }, []);
+    try {
+      const operation = value.kiloChatClient.captureOperation();
+      setTokenError(false);
+      void resolveCurrentUserId(operation);
+    } catch {
+      // The existing token error stays available; unlock does not retry this action.
+    }
+  }, [resolveCurrentUserId, value]);
   const tokenErrorValue = useMemo(
     () => ({ hasError: tokenError, retry: retryTokenFetch }),
     [tokenError, retryTokenFetch]
   );
-
   return (
     <KiloChatCurrentUserContext.Provider value={currentUserId}>
       <KiloChatTokenErrorContext.Provider value={tokenErrorValue}>
-        <KiloChatHooksProvider
-          value={{ kiloChatClient: value.kiloChatClient, eventService: value.eventService }}
-        >
-          {children}
-        </KiloChatHooksProvider>
+        <KiloChatHooksProvider value={value}>{children}</KiloChatHooksProvider>
       </KiloChatTokenErrorContext.Provider>
     </KiloChatCurrentUserContext.Provider>
   );

--- a/apps/mobile/src/components/kilo-chat/message-input-attachment-queue.tsx
+++ b/apps/mobile/src/components/kilo-chat/message-input-attachment-queue.tsx
@@ -2,7 +2,12 @@ import { useActionSheet } from '@expo/react-native-action-sheet';
 import { useCallback, useRef } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { toast } from 'sonner-native';
-import { type AddFileInput, useAttachmentQueue } from '@kilocode/kilo-chat-hooks';
+import {
+  type AddFileInput,
+  useAttachmentQueue,
+  type UseAttachmentQueueOptions,
+} from '@kilocode/kilo-chat-hooks';
+import { type KiloChatOperation } from '@kilocode/kilo-chat';
 
 import { i18n } from '@/i18n';
 import {
@@ -40,27 +45,32 @@ export function MessageInputWithAttachmentQueue({
     onSendContentBlocks: MessageInputContentBlocksOnSend;
   }) {
   const localUrisRef = useRef<Map<string, string>>(new Map());
-
-  const onSizeRejected = useCallback((input: AddFileInput) => {
-    toast.error(buildAttachmentSizeRejectionToast(input.filename));
-  }, []);
-
-  const queue = useAttachmentQueue(client, conversationId, {
+  const onSizeRejected = useCallback(
+    (input: AddFileInput) => {
+      if (client.canStartOperation()) {
+        toast.error(buildAttachmentSizeRejectionToast(input.filename));
+      }
+    },
+    [client]
+  );
+  const queueOptions = {
     performUpload: mobilePerformUpload,
     maxBytes: MOBILE_ATTACHMENT_MAX_BYTES,
     onSizeRejected,
-  });
+    captureOperation: () => client.captureOperation(),
+  } satisfies UseAttachmentQueueOptions &
+    Required<Pick<UseAttachmentQueueOptions, 'captureOperation'>>;
+  const queue = useAttachmentQueue(client, conversationId, queueOptions);
   const { showActionSheetWithOptions } = useActionSheet();
   const { bottom } = useSafeAreaInsets();
 
   const addSelectedAttachments = useCallback(
-    async (selected: readonly MessageAttachment[]) => {
+    async (selected: readonly MessageAttachment[], operation: KiloChatOperation) => {
       if (selected.length === 0) {
         return;
       }
-
-      // Gate on size and capacity before any bytes are read: materializing an
-      // oversized file is what runs the device out of memory.
+      operation.assertDispatch();
+      // Gate size/capacity before reading bytes. Materialize sequentially to bound memory.
       const { accepted, toast: rejectionToast } = selectAllowedAttachments({
         existingCount: queue.rows.length,
         selected,
@@ -68,44 +78,49 @@ export function MessageInputWithAttachmentQueue({
       if (rejectionToast) {
         toast.error(rejectionToast);
       }
-
-      // Sequential on purpose: concurrent materialize multiplies peak memory by
-      // the selection size. eslint no-await-in-loop wants Promise.all; refuse.
       for (const attachment of accepted) {
-        // Per-file, so one unreadable file in a multi-select does not discard the
-        // rest. Same message as the gate's unreadable rejection: from the user's
-        // side "we could not read this file" is the same fact whether the size
-        // stat or the read itself failed.
         try {
+          operation.assertDispatch();
           // eslint-disable-next-line no-await-in-loop -- sequential materialize bounds peak memory
           const picked = await materializeAttachment(attachment);
-          const tempId = queue.addFile(picked.input);
+          const tempId = queue.addFile({ ...picked.input, operation });
           if (tempId) {
             localUrisRef.current.set(tempId, picked.localUri);
           }
         } catch {
-          toast.error(buildAttachmentUnreadableToast(attachment.filename));
+          if (client.canStartOperation()) {
+            toast.error(buildAttachmentUnreadableToast(attachment.filename));
+          }
         }
       }
     },
-    [queue]
+    [client, queue]
   );
 
   const pickFromSource = useCallback(
-    async (source: 'camera' | 'library' | 'files') => {
+    async (source: 'camera' | 'library' | 'files', operation: KiloChatOperation) => {
       try {
+        operation.assertDispatch();
         const selected = await pickAttachmentsFromSource(source);
-        await addSelectedAttachments(selected);
+        await addSelectedAttachments(selected, operation);
       } catch (error) {
-        toast.error(
-          error instanceof Error ? error.message : i18n.t('chat.attachment.attachFailed')
-        );
+        if (client.canStartOperation()) {
+          toast.error(
+            error instanceof Error ? error.message : i18n.t('chat.attachment.attachFailed')
+          );
+        }
       }
     },
-    [addSelectedAttachments]
+    [addSelectedAttachments, client]
   );
 
   const openPicker = useCallback(() => {
+    let operation: KiloChatOperation | undefined = undefined;
+    try {
+      operation = client.captureOperation();
+    } catch {
+      return;
+    }
     const actionSheet = getAttachmentActionSheetConfig();
     showActionSheetWithOptions(
       {
@@ -115,22 +130,22 @@ export function MessageInputWithAttachmentQueue({
       },
       index => {
         if (index === 0) {
-          void pickFromSource('camera');
+          void pickFromSource('camera', operation);
         } else if (index === 1) {
-          void pickFromSource('library');
+          void pickFromSource('library', operation);
         } else if (index === 2) {
-          void pickFromSource('files');
+          void pickFromSource('files', operation);
         }
       }
     );
-  }, [bottom, pickFromSource, showActionSheetWithOptions]);
+  }, [bottom, client, pickFromSource, showActionSheetWithOptions]);
 
   const addClipboardImage = useCallback(
     async (file: ClipboardImageFile) => {
-      const attachment = clipboardImageToSelection(file);
-      await addSelectedAttachments([attachment]);
+      const operation = client.captureOperation();
+      await addSelectedAttachments([clipboardImageToSelection(file)], operation);
     },
-    [addSelectedAttachments]
+    [addSelectedAttachments, client]
   );
 
   const attachmentQueue: ComposerAttachmentQueue = {
@@ -149,7 +164,6 @@ export function MessageInputWithAttachmentQueue({
     },
     addClipboardImage,
   };
-
   return (
     <MessageInputContent
       {...props}

--- a/apps/mobile/src/components/kilo-chat/mobile-perform-upload.ts
+++ b/apps/mobile/src/components/kilo-chat/mobile-perform-upload.ts
@@ -1,3 +1,14 @@
-import { createXhrPerformUpload } from '@kilocode/kilo-chat-hooks';
+import { createXhrPerformUpload, type PerformUpload } from '@kilocode/kilo-chat-hooks';
 
-export const mobilePerformUpload = createXhrPerformUpload();
+import { LocalAccessDeniedError } from '@/lib/local-access';
+
+const performUpload = createXhrPerformUpload();
+
+// The shared uploader permits old web callers without admission; mobile never does.
+// eslint-disable-next-line max-params -- preserve the shared PerformUpload contract
+export const mobilePerformUpload: PerformUpload = async (blob, putUrl, putHeaders, options) => {
+  if (!options.operation) {
+    throw new LocalAccessDeniedError('stale');
+  }
+  await performUpload(blob, putUrl, putHeaders, options);
+};

--- a/packages/kilo-chat-hooks/src/use-attachment-queue.test.ts
+++ b/packages/kilo-chat-hooks/src/use-attachment-queue.test.ts
@@ -1,4 +1,190 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { KiloChatClient } from '@kilocode/kilo-chat';
+import { EventServiceClient } from '@kilocode/event-service';
+import { useAttachmentQueue, type PerformUpload } from './use-attachment-queue';
+
+const queueHarness = vi.hoisted(() => ({
+  state: { rows: [] } as AttachmentQueueState,
+  refs: [] as { current: unknown }[],
+  cursor: 0,
+}));
+vi.mock('react', () => ({
+  useCallback: <T>(fn: T) => fn,
+  useMemo: <T>(fn: () => T) => fn(),
+  useEffect: () => {},
+  useRef: <T>(initial: T) => {
+    const index = queueHarness.cursor++;
+    queueHarness.refs[index] ??= { current: initial };
+    return queueHarness.refs[index] as { current: T };
+  },
+  useReducer: (reducer: typeof attachmentQueueReducer) => [
+    queueHarness.state,
+    (action: AttachmentQueueAction) => {
+      queueHarness.state = reducer(queueHarness.state, action);
+    },
+  ],
+}));
+function uploadDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+const initializedUpload = {
+  attachmentId: '01HV0000000000000000000001',
+  putUrl: 'https://upload.test/a',
+  putHeaders: {},
+  putUrlExpiresAt: 4_000_000_000,
+};
+function uploadOwner(fetch: typeof globalThis.fetch) {
+  const state = { current: true, generation: 0 };
+  const client = new KiloChatClient({
+    eventService: new EventServiceClient({ url: 'https://events.test', getToken: async () => 'a' }),
+    baseUrl: 'https://chat.test',
+    getToken: async () => 'a',
+    fetch,
+    canPublish: () => state.current,
+    captureOperationAdmission: () => {
+      const generation = state.generation;
+      return () => {
+        if (generation !== state.generation) throw new Error('stale admission');
+      };
+    },
+  });
+  return { client, state };
+}
+function renderQueue(client: KiloChatClient, performUpload: PerformUpload) {
+  queueHarness.cursor = 0;
+  return useAttachmentQueue(client, 'c', {
+    performUpload,
+    maxBytes: 1000,
+    generateTempId: () => 'tmp-1',
+  });
+}
+
+describe('attachment queue operation ownership', () => {
+  beforeEach(() => {
+    queueHarness.state = { rows: [] };
+    queueHarness.refs = [];
+    queueHarness.cursor = 0;
+  });
+
+  it('retains bytes and rejects an initialized upload after lock/unlock', async () => {
+    const response = uploadDeferred<Response>();
+    const entered = uploadDeferred<void>();
+    const { client, state } = uploadOwner(async () => {
+      entered.resolve();
+      return response.promise;
+    });
+    const uploads: string[] = [];
+    const queue = renderQueue(client, async blob => {
+      uploads.push(await blob.text());
+    });
+    queue.addFile({ blob: new Blob(['photo']), filename: 'a.png', mimeType: 'image/png' });
+    await entered.promise;
+    state.generation++;
+    response.resolve(Response.json(initializedUpload));
+    await vi.waitFor(() => expect(queueHarness.state.rows[0]?.status).toBe('failed'));
+    expect(queueHarness.state.rows[0]).toMatchObject({
+      attachmentId: initializedUpload.attachmentId,
+      error: 'stale admission',
+    });
+    expect(await queue.getBlob('tmp-1')?.text()).toBe('photo');
+    await Promise.resolve();
+    expect(uploads).toEqual([]);
+  });
+
+  it('keeps the explicit retry admission through renewed initialization', async () => {
+    const second = uploadDeferred<Response>();
+    let initializations = 0;
+    const { client, state } = uploadOwner(async () => {
+      initializations++;
+      return initializations === 1
+        ? Response.json({ ...initializedUpload, putUrlExpiresAt: 1 })
+        : second.promise;
+    });
+    const uploads: string[] = [];
+    const upload: PerformUpload = async blob => {
+      uploads.push(await blob.text());
+      throw new Error('network');
+    };
+    renderQueue(client, upload).addFile({
+      blob: new Blob(['photo']),
+      filename: 'a.png',
+      mimeType: 'image/png',
+    });
+    await vi.waitFor(() => expect(queueHarness.state.rows[0]?.status).toBe('failed'));
+    const queue = renderQueue(client, upload);
+    queue.retryFile('tmp-1');
+    await vi.waitFor(() => expect(initializations).toBe(2));
+    state.generation++;
+    second.resolve(Response.json(initializedUpload));
+    await vi.waitFor(() => expect(queueHarness.state.rows[0]?.error).toBe('stale admission'));
+    expect(uploads).toEqual(['photo']);
+    expect(await queue.getBlob('tmp-1')?.text()).toBe('photo');
+  });
+
+  it('does not publish A initialization after the owner becomes B', async () => {
+    const response = uploadDeferred<Response>();
+    const entered = uploadDeferred<void>();
+    const { client, state } = uploadOwner(async () => {
+      entered.resolve();
+      return response.promise;
+    });
+    const uploads: string[] = [];
+    const queue = renderQueue(client, async blob => {
+      uploads.push(await blob.text());
+    });
+    queue.addFile({ blob: new Blob(['A']), filename: 'a.png', mimeType: 'image/png' });
+    await entered.promise;
+    state.current = false;
+    response.resolve(Response.json(initializedUpload));
+    await vi.waitFor(() => expect(client.canPublish()).toBe(false));
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(queueHarness.state.rows[0]).toMatchObject({ status: 'uploading' });
+    expect(queueHarness.state.rows[0]?.attachmentId).toBeUndefined();
+    expect(uploads).toEqual([]);
+  });
+
+  it('stores accepted upload completion for the original owner while locked', async () => {
+    const accepted = uploadDeferred<void>();
+    const entered = uploadDeferred<void>();
+    const { client, state } = uploadOwner(async () => Response.json(initializedUpload));
+    const queue = renderQueue(client, async (_blob, _url, _headers, options) => {
+      options.operation?.assertDispatch();
+      entered.resolve();
+      await accepted.promise;
+    });
+    queue.addFile({ blob: new Blob(['photo']), filename: 'a.png', mimeType: 'image/png' });
+    await entered.promise;
+    state.generation++;
+    accepted.resolve();
+    await vi.waitFor(() => expect(queueHarness.state.rows[0]?.status).toBe('ready'));
+    expect(selectReadyBlocks(queueHarness.state.rows)[0]?.attachmentId).toBe(
+      initializedUpload.attachmentId
+    );
+    expect(await queue.getBlob('tmp-1')?.text()).toBe('photo');
+  });
+
+  it('preserves a legacy producer without client or queue admission hooks', async () => {
+    const client = new KiloChatClient({
+      eventService: new EventServiceClient({
+        url: 'https://events.test',
+        getToken: async () => 'a',
+      }),
+      baseUrl: 'https://chat.test',
+      getToken: async () => 'legacy',
+      fetch: async () => Response.json(initializedUpload),
+    });
+    const uploads: string[] = [];
+    renderQueue(client, async blob => {
+      uploads.push(await blob.text());
+    }).addFile({ blob: new Blob(['legacy']), filename: 'a', mimeType: 'image/png' });
+    await vi.waitFor(() => expect(queueHarness.state.rows[0]?.status).toBe('ready'));
+    expect(uploads).toEqual(['legacy']);
+  });
+});
 
 import {
   attachmentQueueReducer,

--- a/packages/kilo-chat-hooks/src/use-attachment-queue.ts
+++ b/packages/kilo-chat-hooks/src/use-attachment-queue.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
-import type { AttachmentBlock, KiloChatClient } from '@kilocode/kilo-chat';
+import type { AttachmentBlock, KiloChatClient, KiloChatOperation } from '@kilocode/kilo-chat';
 
 export type QueuedAttachmentStatus = 'uploading' | 'ready' | 'failed';
 
@@ -129,22 +129,19 @@ export type PerformUpload = (
   blob: Blob,
   putUrl: string,
   putHeaders: Record<string, string>,
-  opts: { onProgress: (fraction: number) => void; signal: AbortSignal }
+  opts: {
+    onProgress: (fraction: number) => void;
+    signal: AbortSignal;
+    // Old web/package uploaders omit admission. Remove the fallback only after
+    // all producers migrate in a breaking release; the mobile adapter requires it.
+    operation?: KiloChatOperation;
+  }
 ) => Promise<void>;
 
 function mapXhrUploadResultToOutcome(result: XhrUploadResult): XhrUploadOutcome {
-  if (result.aborted) {
-    return { kind: 'aborted' };
-  }
-
-  if (result.status === 0) {
-    return { kind: 'error', message: 'Network error during upload' };
-  }
-
-  if (result.status >= 200 && result.status < 300) {
-    return { kind: 'ok' };
-  }
-
+  if (result.aborted) return { kind: 'aborted' };
+  if (result.status === 0) return { kind: 'error', message: 'Network error during upload' };
+  if (result.status >= 200 && result.status < 300) return { kind: 'ok' };
   return { kind: 'error', message: `Upload failed (${result.status})` };
 }
 
@@ -153,15 +150,12 @@ export function createXhrPerformUpload(): PerformUpload {
     new Promise<void>((resolve, reject) => {
       const xhr = new XMLHttpRequest();
       let aborted = false;
-
       function cleanup() {
         opts.signal.removeEventListener('abort', onAbort);
       }
-
       function createAbortError(): DOMException {
         return new DOMException('Aborted', 'AbortError');
       }
-
       function onAbort() {
         aborted = true;
         try {
@@ -172,41 +166,38 @@ export function createXhrPerformUpload(): PerformUpload {
         cleanup();
         reject(createAbortError());
       }
-
       if (opts.signal.aborted) {
         onAbort();
         return;
       }
-
       opts.signal.addEventListener('abort', onAbort, { once: true });
       xhr.open('PUT', putUrl, true);
-
       for (const [key, value] of Object.entries(putHeaders)) {
-        if (key.toLowerCase() !== 'content-length') {
-          xhr.setRequestHeader(key, value);
-        }
+        if (key.toLowerCase() !== 'content-length') xhr.setRequestHeader(key, value);
       }
-
       xhr.upload.addEventListener('progress', event => {
-        if (!event.lengthComputable || event.total === 0) {
-          return;
-        }
-        opts.onProgress(event.loaded / event.total);
+        if (!event.lengthComputable || event.total === 0) return;
+        if (opts.operation?.canPublish() ?? true) opts.onProgress(event.loaded / event.total);
       });
-
       xhr.addEventListener('loadend', () => {
         cleanup();
         const outcome = mapXhrUploadResultToOutcome({ status: xhr.status, aborted });
-        if (outcome.kind === 'ok') {
-          resolve();
-        } else if (outcome.kind === 'aborted') {
-          reject(createAbortError());
-        } else {
-          reject(new Error(outcome.message));
-        }
+        if (outcome.kind === 'ok') resolve();
+        else if (outcome.kind === 'aborted') reject(createAbortError());
+        else reject(new Error(outcome.message));
       });
-
-      xhr.send(blob);
+      try {
+        // This is the final boundary, after initialization and any adapter work.
+        opts.operation?.assertDispatch();
+        if (opts.signal.aborted) {
+          onAbort();
+          return;
+        }
+        xhr.send(blob);
+      } catch (error) {
+        cleanup();
+        reject(error);
+      }
     });
 }
 
@@ -214,6 +205,7 @@ export type AddFileInput = {
   blob: Blob;
   filename: string;
   mimeType: string;
+  operation?: KiloChatOperation;
 };
 
 export type UseAttachmentQueueOptions = {
@@ -221,13 +213,16 @@ export type UseAttachmentQueueOptions = {
   maxBytes: number;
   generateTempId?: () => string;
   onSizeRejected?: (input: AddFileInput) => void;
+  // The old web/package form captures through the client when absent. Remove
+  // the fallback only after all producers migrate; mobile supplies this hook.
+  captureOperation?: () => KiloChatOperation;
 };
 
 export type UseAttachmentQueueResult = {
   rows: QueuedAttachment[];
   addFile: (input: AddFileInput) => string | null;
   removeFile: (tempId: string) => void;
-  retryFile: (tempId: string) => void;
+  retryFile: (tempId: string, operation?: KiloChatOperation) => void;
   clear: () => void;
   clearFiles: (tempIds: string[]) => void;
   getBlob: (tempId: string) => Blob | null;
@@ -246,47 +241,59 @@ export function useAttachmentQueue(
   options: UseAttachmentQueueOptions
 ): UseAttachmentQueueResult {
   const [state, dispatch] = useReducer(attachmentQueueReducer, { rows: [] });
-  const { performUpload, maxBytes, generateTempId, onSizeRejected } = options;
+  const { performUpload, maxBytes, generateTempId, onSizeRejected, captureOperation } = options;
   const generate = generateTempId ?? defaultTempId;
-
   type Pending = {
     abort: AbortController;
+    client: KiloChatClient;
+    operation: KiloChatOperation;
     putUrl?: string;
     putHeaders?: Record<string, string>;
     putUrlExpiresAtMs?: number;
   };
   const pendingRef = useRef<Map<string, Pending>>(new Map());
-  // Blobs are tracked separately so previews keep working after the upload
-  // completes — pendingRef releases its entry on setReady to free upload
-  // bookkeeping, but the local bytes are still useful for the preview chip
-  // until the user sends or removes the attachment.
+  // Retain local bytes through errors and completion until explicit send/remove.
   const blobsRef = useRef<Map<string, Blob>>(new Map());
-
+  const capture = useCallback(
+    (supplied?: KiloChatOperation): KiloChatOperation => {
+      try {
+        return client.captureOperation(supplied ?? captureOperation?.());
+      } catch (error) {
+        return {
+          assertDispatch: () => {
+            throw error;
+          },
+          canPublish: () => client.canPublish(),
+        };
+      }
+    },
+    [client, captureOperation]
+  );
   type UploadArgs = { tempId: string; filename: string; mimeType: string; size: number };
-
   const startUpload = useCallback(
-    async (args: UploadArgs) => {
-      const { tempId, filename, mimeType, size } = args;
+    async ({ tempId, filename, mimeType, size }: UploadArgs) => {
       const pending = pendingRef.current.get(tempId);
       const blob = blobsRef.current.get(tempId);
       if (!pending || !blob) return;
-
+      const { operation } = pending;
       try {
+        operation.assertDispatch();
         let putUrl = pending.putUrl;
         let putHeaders = pending.putHeaders;
         const expiresAtMs = pending.putUrlExpiresAtMs ?? 0;
-        // Treat the URL as expired a minute early to avoid racing R2 at the boundary.
-        const putUrlExpired = Date.now() > expiresAtMs - 60 * 1000;
-
-        if (!putUrl || !putHeaders || putUrlExpired) {
-          const res = await client.initAttachment({
-            conversationId,
-            mimeType,
-            size,
-            filename,
-            idempotencyKey: tempId,
-          });
-          if (pending.abort.signal.aborted) return;
+        // Expire a minute early to avoid racing R2 at the boundary.
+        if (!putUrl || !putHeaders || Date.now() > expiresAtMs - 60 * 1000) {
+          const res = await pending.client.initAttachment(
+            {
+              conversationId,
+              mimeType,
+              size,
+              filename,
+              idempotencyKey: tempId,
+            },
+            operation
+          );
+          if (pending.abort.signal.aborted || !operation.canPublish()) return;
           pending.putUrl = res.putUrl;
           pending.putHeaders = res.putHeaders;
           pending.putUrlExpiresAtMs = res.putUrlExpiresAt * 1000;
@@ -294,35 +301,42 @@ export function useAttachmentQueue(
           putHeaders = res.putHeaders;
           dispatch({ type: 'setInited', tempId, attachmentId: res.attachmentId });
         }
-
+        operation.assertDispatch();
         await performUpload(blob, putUrl, putHeaders, {
+          operation,
           signal: pending.abort.signal,
-          onProgress: fraction => dispatch({ type: 'setProgress', tempId, progress: fraction }),
+          onProgress: fraction => {
+            if (operation.canPublish())
+              dispatch({ type: 'setProgress', tempId, progress: fraction });
+          },
         });
-        if (pending.abort.signal.aborted) return;
+        if (pending.abort.signal.aborted || !operation.canPublish()) return;
         dispatch({ type: 'setReady', tempId });
-        // Release upload bookkeeping; blobsRef keeps the bytes alive for the
-        // preview chip until send or remove.
         pendingRef.current.delete(tempId);
       } catch (err) {
-        if (pending.abort.signal.aborted) return;
-        const message = err instanceof Error ? err.message : 'Upload failed';
-        dispatch({ type: 'setFailed', tempId, error: message });
+        if (pending.abort.signal.aborted || !operation.canPublish()) return;
+        dispatch({
+          type: 'setFailed',
+          tempId,
+          error: err instanceof Error ? err.message : 'Upload failed',
+        });
       }
     },
-    [client, conversationId, performUpload]
+    [conversationId, performUpload]
   );
 
   const addFile = useCallback(
     (input: AddFileInput): string | null => {
+      if (!client.canPublish() || (input.operation && !input.operation.canPublish())) return null;
       if (input.blob.size > maxBytes) {
         onSizeRejected?.(input);
         return null;
       }
+      const operation = capture(input.operation);
       const tempId = generate();
       const size = input.blob.size;
       blobsRef.current.set(tempId, input.blob);
-      pendingRef.current.set(tempId, { abort: new AbortController() });
+      pendingRef.current.set(tempId, { abort: new AbortController(), client, operation });
       dispatch({
         type: 'add',
         row: {
@@ -337,41 +351,31 @@ export function useAttachmentQueue(
       void startUpload({ tempId, filename: input.filename, mimeType: input.mimeType, size });
       return tempId;
     },
-    [conversationId, generate, maxBytes, onSizeRejected, startUpload]
+    [capture, client, generate, maxBytes, onSizeRejected, startUpload]
   );
 
   const removeFile = useCallback((tempId: string) => {
-    const pending = pendingRef.current.get(tempId);
-    pending?.abort.abort();
+    pendingRef.current.get(tempId)?.abort.abort();
     pendingRef.current.delete(tempId);
     blobsRef.current.delete(tempId);
     dispatch({ type: 'remove', tempId });
   }, []);
 
   const retryFile = useCallback(
-    (tempId: string) => {
+    (tempId: string, supplied?: KiloChatOperation) => {
       const existing = pendingRef.current.get(tempId);
-      if (!existing) return;
+      if (!existing || existing.client !== client || !existing.operation.canPublish()) return;
       if (!blobsRef.current.has(tempId)) return;
       const row = state.rows.find(r => r.tempId === tempId);
       if (!row) return;
+      // An explicit retry is a new action. Capture at this call, never after a wait.
+      const operation = capture(supplied);
       existing.abort.abort();
-      const fresh: Pending = {
-        abort: new AbortController(),
-        putUrl: existing.putUrl,
-        putHeaders: existing.putHeaders,
-        putUrlExpiresAtMs: existing.putUrlExpiresAtMs,
-      };
-      pendingRef.current.set(tempId, fresh);
+      pendingRef.current.set(tempId, { ...existing, abort: new AbortController(), operation });
       dispatch({ type: 'retry', tempId });
-      void startUpload({
-        tempId,
-        filename: row.filename,
-        mimeType: row.mimeType,
-        size: row.size,
-      });
+      void startUpload({ tempId, filename: row.filename, mimeType: row.mimeType, size: row.size });
     },
-    [startUpload, state.rows]
+    [capture, client, startUpload, state.rows]
   );
 
   const clear = useCallback(() => {
@@ -380,31 +384,26 @@ export function useAttachmentQueue(
     blobsRef.current.clear();
     dispatch({ type: 'clear' });
   }, []);
-
   const clearFiles = useCallback((tempIds: string[]) => {
     for (const tempId of tempIds) {
-      const pending = pendingRef.current.get(tempId);
-      pending?.abort.abort();
+      pendingRef.current.get(tempId)?.abort.abort();
       pendingRef.current.delete(tempId);
       blobsRef.current.delete(tempId);
     }
     dispatch({ type: 'clearFiles', tempIds });
   }, []);
-
   const getBlob = useCallback((tempId: string) => blobsRef.current.get(tempId) ?? null, []);
-
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       for (const pending of pendingRef.current.values()) pending.abort.abort();
       pendingRef.current.clear();
       blobsRef.current.clear();
-    };
-  }, []);
-
+    },
+    []
+  );
   const readyBlocks = useMemo(() => selectReadyBlocks(state.rows), [state.rows]);
   const isUploading = useMemo(() => selectIsUploading(state.rows), [state.rows]);
   const hasFailed = useMemo(() => selectHasFailed(state.rows), [state.rows]);
-
   return {
     rows: state.rows,
     addFile,

--- a/packages/kilo-chat-hooks/src/use-conversations.test.ts
+++ b/packages/kilo-chat-hooks/src/use-conversations.test.ts
@@ -5,8 +5,148 @@ import type {
 } from '@kilocode/kilo-chat';
 import { ulidToTimestamp } from '@kilocode/kilo-chat';
 import { kiloclawInstanceContext } from '@kilocode/event-service';
-import { QueryClient } from '@tanstack/react-query';
-import { describe, expect, it } from 'vitest';
+import { MutationCache, QueryClient, type UseMutationOptions } from '@tanstack/react-query';
+import type * as ReactQuery from '@tanstack/react-query';
+import type * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { KiloChatClient } from '@kilocode/kilo-chat';
+import { EventServiceClient } from '@kilocode/event-service';
+import {
+  useCreateConversation,
+  useLeaveConversation,
+  useMarkConversationRead,
+} from './use-conversations';
+
+const conversationHarness = vi.hoisted(() => ({ queryClient: null as QueryClient | null }));
+vi.mock('react', async original => ({
+  ...(await original<typeof React>()),
+  useMemo: <T>(create: () => T) => create(),
+  useRef: <T>(current: T) => ({ current }),
+}));
+vi.mock('@tanstack/react-query', async original => {
+  const actual = await original<typeof ReactQuery>();
+  return {
+    ...actual,
+    useQueryClient: () => conversationHarness.queryClient,
+    useMutation: <D, V, C>(options: UseMutationOptions<D, Error, V, C>) => {
+      if (!conversationHarness.queryClient) throw new Error('missing test query client');
+      const observer = new actual.MutationObserver(conversationHarness.queryClient, options);
+      observer.subscribe(() => {});
+      return {
+        ...observer.getCurrentResult(),
+        mutateAsync: (variables: V) => observer.mutate(variables),
+        mutate: (variables: V) => {
+          void observer.mutate(variables).catch(() => {});
+        },
+      };
+    },
+  };
+});
+function conversationDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+function conversationOwner(fetch: typeof globalThis.fetch) {
+  const state = { current: true, generation: 0 };
+  const client = new KiloChatClient({
+    eventService: new EventServiceClient({ url: 'https://events.test', getToken: async () => 'a' }),
+    baseUrl: 'https://chat.test',
+    getToken: async () => 'a',
+    fetch,
+    canPublish: () => state.current,
+    captureOperationAdmission: () => {
+      const generation = state.generation;
+      return () => {
+        if (generation !== state.generation) throw new Error('stale admission');
+      };
+    },
+  });
+  return { client, state };
+}
+
+describe('conversation mutation admission', () => {
+  beforeEach(() => {
+    conversationHarness.queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+  });
+
+  it('captures before the global onMutate wait for conversation creation', async () => {
+    const waiting = conversationDeferred<void>();
+    const entered = conversationDeferred<void>();
+    conversationHarness.queryClient = new QueryClient({
+      mutationCache: new MutationCache({
+        onMutate: async () => {
+          entered.resolve();
+          await waiting.promise;
+        },
+      }),
+    });
+    const requests: string[] = [];
+    const { client, state } = conversationOwner(async input => {
+      requests.push(input instanceof Request ? input.url : input.toString());
+      return Response.json({});
+    });
+    const mutation = useCreateConversation(client);
+    const pending = mutation.mutateAsync({ sandboxId: 's' });
+    await entered.promise;
+    state.generation++;
+    waiting.resolve();
+    await expect(pending).rejects.toThrow('stale admission');
+    expect(requests).toEqual([]);
+  });
+
+  it('honors an outer mark-read admission instead of capturing a new one', async () => {
+    const queryClient = conversationHarness.queryClient!;
+    const requests: string[] = [];
+    const { client, state } = conversationOwner(async input => {
+      requests.push(input instanceof Request ? input.url : input.toString());
+      return Response.json({});
+    });
+    const original = client.captureOperation();
+    queryClient.setQueryData(
+      conversationsKey('s'),
+      conversationsData([[conversation('c', { lastReadAt: 1 })]], [null])
+    );
+    state.generation++;
+    await expect(
+      useMarkConversationRead(client).mutateAsync(
+        { sandboxId: 's', conversationId: 'c', lastSeenMessageId: '01K8ZB8B3H9BRWZ6KCN39AX09G' },
+        undefined,
+        original
+      )
+    ).rejects.toThrow('stale admission');
+    expect(firstConversationLastReadAt(queryClient.getQueryData(conversationsKey('s')))).toBe(1);
+    expect(requests).toEqual([]);
+  });
+
+  it('does not restore A conversation rows into B after a failed leave', async () => {
+    const queryClient = conversationHarness.queryClient!;
+    const response = conversationDeferred<Response>();
+    const entered = conversationDeferred<void>();
+    const { client, state } = conversationOwner(async () => {
+      entered.resolve();
+      return response.promise;
+    });
+    const key = conversationsKey('s');
+    queryClient.setQueryData(key, conversationsData([[conversation('a', {})]], [null]));
+    const pending = useLeaveConversation(client).mutateAsync({
+      sandboxId: 's',
+      conversationId: 'a',
+    });
+    await entered.promise;
+    expect(flattenedIds(queryClient.getQueryData(key))).toEqual([]);
+    state.current = false;
+    queryClient.setQueryData(key, conversationsData([[conversation('b', {})]], [null]));
+    response.resolve(Response.json({ error: 'failed' }, { status: 500 }));
+    await expect(pending).rejects.toThrow('owner is no longer active');
+    expect(flattenedIds(queryClient.getQueryData(key))).toEqual(['b']);
+    expect(queryClient.getQueryState(key)?.isInvalidated).toBe(false);
+  });
+});
 
 import { conversationKey, conversationsKey, messagesKey } from './query-keys';
 import {

--- a/packages/kilo-chat-hooks/src/use-conversations.ts
+++ b/packages/kilo-chat-hooks/src/use-conversations.ts
@@ -1,4 +1,5 @@
-import { useQuery, useMutation, useQueryClient, useInfiniteQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient, useInfiniteQuery } from '@tanstack/react-query';
+import { useKiloChatMutation } from './use-messages';
 import type { InfiniteData, QueryClient, QueryKey } from '@tanstack/react-query';
 import { kiloclawInstanceContext } from '@kilocode/event-service';
 import {
@@ -89,12 +90,15 @@ export function useConversationDetail(client: KiloChatClient, conversationId: st
 
 export function useCreateConversation(client: KiloChatClient, options?: MutationErrorOptions) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (req: CreateConversationRequest) => client.createConversation(req),
+  return useKiloChatMutation(client, {
+    mutationFn: (req: CreateConversationRequest, operation) =>
+      client.createConversation(req, operation),
     onSuccess: (response, variables) => {
       settleCreateConversation(queryClient, variables, response);
     },
-    onError: options?.onError,
+    onError: error => {
+      if (client.canStartOperation()) options?.onError?.(error);
+    },
   });
 }
 
@@ -106,13 +110,15 @@ type RenameConversationMutationVariables = {
 
 export function useRenameConversation(client: KiloChatClient, options?: MutationErrorOptions) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (variables: RenameConversationMutationVariables) =>
-      client.renameConversation(variables.conversationId, { title: variables.title }),
+  return useKiloChatMutation(client, {
+    mutationFn: (variables: RenameConversationMutationVariables, operation) =>
+      client.renameConversation(variables.conversationId, { title: variables.title }, operation),
     onSuccess: (_data, variables) => {
       settleRenameConversation(queryClient, variables);
     },
-    onError: options?.onError,
+    onError: error => {
+      if (client.canStartOperation()) options?.onError?.(error);
+    },
   });
 }
 
@@ -123,13 +129,13 @@ type LeaveConversationMutationVariables = {
 
 export function useLeaveConversation(client: KiloChatClient, options?: MutationErrorOptions) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (variables: LeaveConversationMutationVariables) =>
-      client.leaveConversation(variables.conversationId),
+  return useKiloChatMutation(client, {
+    mutationFn: (variables: LeaveConversationMutationVariables, operation) =>
+      client.leaveConversation(variables.conversationId, operation),
     onMutate: variables => applyOptimisticLeaveConversation(queryClient, variables),
-    onError: (_err, _variables, context) => {
+    onError: (err, _variables, context) => {
       rollbackOptimisticLeaveConversation(queryClient, context);
-      options?.onError?.(_err);
+      if (client.canStartOperation()) options?.onError?.(err);
     },
     onSuccess: (_data, variables) => {
       settleLeaveConversation(queryClient, variables);
@@ -733,9 +739,11 @@ export function settleMarkConversationRead(
 
 export function useMarkConversationRead(client: KiloChatClient) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ conversationId, lastSeenMessageId }: MarkConversationReadMutationVariables) =>
-      client.markConversationRead(conversationId, { lastSeenMessageId }),
+  return useKiloChatMutation(client, {
+    mutationFn: (
+      { conversationId, lastSeenMessageId }: MarkConversationReadMutationVariables,
+      operation
+    ) => client.markConversationRead(conversationId, { lastSeenMessageId }, operation),
     onMutate: variables => applyOptimisticMarkConversationRead(queryClient, variables),
     onError: (_err, _variables, context) => {
       rollbackOptimisticMarkConversationRead(queryClient, context);

--- a/packages/kilo-chat-hooks/src/use-messages.test.ts
+++ b/packages/kilo-chat-hooks/src/use-messages.test.ts
@@ -1,6 +1,266 @@
-import { describe, expect, it } from 'vitest';
-import { QueryClient } from '@tanstack/react-query';
-import { KiloChatApiError, type Message, type MessageListResponse } from '@kilocode/kilo-chat';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as React from 'react';
+import type * as ReactQuery from '@tanstack/react-query';
+import { QueryClient, type UseMutationOptions } from '@tanstack/react-query';
+import {
+  KiloChatApiError,
+  KiloChatClient,
+  type KiloChatClientConfig,
+  type Message,
+  type MessageListResponse,
+} from '@kilocode/kilo-chat';
+import { useSendMessage, useExecuteAction, useMessageCacheUpdater } from './use-messages';
+import { EventServiceClient, kiloclawConversationContext } from '@kilocode/event-service';
+
+const hookHarness = vi.hoisted(() => ({
+  queryClient: null as QueryClient | null,
+  effects: [] as (() => void | (() => void))[],
+}));
+vi.mock('react', async original => ({
+  ...(await original<typeof React>()),
+  useMemo: <T>(create: () => T) => create(),
+  useRef: <T>(current: T) => ({ current }),
+  useEffect: (effect: () => void | (() => void)) => {
+    hookHarness.effects.push(effect);
+  },
+}));
+vi.mock('@tanstack/react-query', async original => {
+  const actual = await original<typeof ReactQuery>();
+  return {
+    ...actual,
+    useQueryClient: () => hookHarness.queryClient,
+    useMutation: <D, V, C>(options: UseMutationOptions<D, Error, V, C>) => {
+      if (!hookHarness.queryClient) throw new Error('missing test query client');
+      const observer = new actual.MutationObserver(hookHarness.queryClient, options);
+      observer.subscribe(() => {});
+      return {
+        ...observer.getCurrentResult(),
+        mutateAsync: (variables: V, callbacks?: Parameters<typeof observer.mutate>[1]) =>
+          observer.mutate(variables, callbacks),
+        mutate: (variables: V, callbacks?: Parameters<typeof observer.mutate>[1]) => {
+          void observer.mutate(variables, callbacks).catch(() => {});
+        },
+      };
+    },
+  };
+});
+
+function messageDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+function messageOwner(fetch: typeof globalThis.fetch) {
+  const state = { generation: 0, current: true, locked: false };
+  const handlers = new Map<string, (context: string, event: unknown) => void>();
+  const client = new KiloChatClient({
+    baseUrl: 'https://chat.test',
+    getToken: async () => 'a',
+    fetch,
+    eventService: {
+      on: (name: string, handler: (context: string, event: unknown) => void) => {
+        handlers.set(name, handler);
+        return () => {
+          handlers.delete(name);
+        };
+      },
+    } as KiloChatClientConfig['eventService'],
+    canPublish: () => state.current,
+    captureOperationAdmission: () => {
+      const generation = state.generation;
+      return () => {
+        if (state.locked || generation !== state.generation) throw new Error('stale admission');
+      };
+    },
+  });
+  return { client, state, handlers };
+}
+
+describe('message hook ownership and admission', () => {
+  beforeEach(() => {
+    hookHarness.queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    hookHarness.effects = [];
+  });
+
+  it('preserves legacy send bodies, cache settlement, callbacks, and API errors without hooks', async () => {
+    const queryClient = hookHarness.queryClient!;
+    const requests: unknown[] = [];
+    const receipts: string[] = [];
+    const serverMessage = message({ senderId: 'legacy', content: textContent('hello') });
+    const client = new KiloChatClient({
+      eventService: new EventServiceClient({
+        url: 'https://events.test',
+        getToken: async () => 'legacy',
+      }),
+      baseUrl: 'https://chat.test',
+      getToken: async () => 'legacy',
+      fetch: async (_url, init) => {
+        if (typeof init?.body !== 'string') throw new Error('Expected JSON');
+        requests.push(JSON.parse(init.body));
+        return requests.length === 1
+          ? Response.json({ messageId: serverMessage.id, message: serverMessage })
+          : Response.json({ error: 'forbidden' }, { status: 403 });
+      },
+    });
+    const mutation = useSendMessage(client, 'c', 'legacy');
+    const first = { conversationId: 'c', clientId: 'first', content: textContent('hello') };
+    await mutation.mutateAsync(first, {
+      onSuccess: (_response, variables) => {
+        receipts.push(variables.clientId);
+      },
+    });
+    const second = { conversationId: 'c', clientId: 'second', content: textContent('unsent') };
+    await expect(mutation.mutateAsync(second)).rejects.toMatchObject({
+      status: 403,
+      body: { error: 'forbidden' },
+    });
+    expect(requests).toEqual([first, second]);
+    expect(receipts).toEqual(['first']);
+    expect(
+      queryClient.getQueryData<MessageInfiniteData>(messagesKey('c'))?.pages[0]?.messages
+    ).toEqual([serverMessage]);
+  });
+
+  it.each(['send', 'approval'] as const)(
+    'rejects %s after an optimistic wait crosses lock/unlock',
+    async kind => {
+      const queryClient = hookHarness.queryClient!;
+      const waiting = messageDeferred<void>();
+      const entered = messageDeferred<void>();
+      vi.spyOn(queryClient, 'cancelQueries').mockImplementation(async () => {
+        entered.resolve();
+        await waiting.promise;
+      });
+      const requests: string[] = [];
+      const { client, state } = messageOwner(async input => {
+        requests.push(input instanceof Request ? input.url : input.toString());
+        return Response.json({});
+      });
+      const original = message({ content: actionContent(false) });
+      const key = messagesKey('c');
+      queryClient.setQueryData(key, { pages: [messagePage([original])], pageParams: [undefined] });
+      const send = useSendMessage(client, 'c', 'a');
+      const approval = useExecuteAction(client, 'c', 'a');
+      const pending =
+        kind === 'send'
+          ? send.mutateAsync({
+              conversationId: 'c',
+              clientId: 'draft',
+              content: textContent('retain me'),
+            })
+          : approval.mutateAsync({
+              messageId: original.id,
+              groupId: 'approval-1',
+              value: 'allow-once',
+            });
+      await entered.promise;
+      state.generation++;
+      waiting.resolve();
+      await expect(pending).rejects.toThrow('stale admission');
+      expect(requests).toEqual([]);
+      expect(queryClient.getQueryData<MessageInfiniteData>(key)?.pages[0]?.messages).toEqual([
+        original,
+      ]);
+      expect(
+        queryClient
+          .getMutationCache()
+          .getAll()
+          .map(mutation => mutation.state.status)
+      ).toContain('error');
+    }
+  );
+
+  it('does not insert A optimistic content after B replaces the cache during cancellation', async () => {
+    const queryClient = hookHarness.queryClient!;
+    const waiting = messageDeferred<void>();
+    const entered = messageDeferred<void>();
+    vi.spyOn(queryClient, 'cancelQueries').mockImplementation(async () => {
+      entered.resolve();
+      await waiting.promise;
+    });
+    const { client, state } = messageOwner(async () => Response.json({}));
+    const mutation = useSendMessage(client, 'c', 'a');
+    const pending = mutation.mutateAsync({
+      conversationId: 'c',
+      clientId: 'draft',
+      content: textContent('A'),
+    });
+    await entered.promise;
+    state.current = false;
+    const replacement = {
+      pages: [messagePage([message({ senderId: 'b', content: textContent('B') })])],
+      pageParams: [undefined],
+    };
+    queryClient.setQueryData(messagesKey('c'), replacement);
+    waiting.resolve();
+    await expect(pending).rejects.toThrow('owner is no longer active');
+    expect(queryClient.getQueryData(messagesKey('c'))).toEqual(replacement);
+  });
+
+  it('does not roll back B when an A send fails after its optimistic insert', async () => {
+    const queryClient = hookHarness.queryClient!;
+    const response = messageDeferred<Response>();
+    const entered = messageDeferred<void>();
+    const { client, state } = messageOwner(async () => {
+      entered.resolve();
+      return response.promise;
+    });
+    const mutation = useSendMessage(client, 'c', 'a');
+    const pending = mutation.mutateAsync({
+      conversationId: 'c',
+      clientId: 'draft',
+      content: textContent('A'),
+    });
+    await entered.promise;
+    state.current = false;
+    const replacement = {
+      pages: [
+        messagePage([message({ id: 'pending-draft', senderId: 'b', content: textContent('B') })]),
+      ],
+      pageParams: [undefined],
+    };
+    queryClient.setQueryData(messagesKey('c'), replacement);
+    response.resolve(Response.json({ error: 'failed' }, { status: 500 }));
+    await expect(pending).rejects.toThrow('owner is no longer active');
+    expect(queryClient.getQueryData(messagesKey('c'))).toEqual(replacement);
+    expect(queryClient.getQueryState(messagesKey('c'))?.isInvalidated).toBe(false);
+  });
+
+  it('stores same-owner incoming failures while locked without announcing them', () => {
+    const queryClient = hookHarness.queryClient!;
+    const { client, state, handlers } = messageOwner(async () => Response.json({}));
+    const original = message({});
+    queryClient.setQueryData(messagesKey('c'), {
+      pages: [messagePage([original])],
+      pageParams: [undefined],
+    });
+    const announcements: string[] = [];
+    useMessageCacheUpdater(
+      client,
+      's',
+      'c',
+      undefined,
+      () => {
+        announcements.push('action');
+      },
+      () => {
+        announcements.push('delivery');
+      }
+    );
+    hookHarness.effects[0]?.();
+    state.locked = true;
+    handlers.get('message.delivery_failed')?.(kiloclawConversationContext('s', 'c'), {
+      messageId: original.id,
+    });
+    expect(
+      queryClient.getQueryData<MessageInfiniteData>(messagesKey('c'))?.pages[0]?.messages[0]
+        ?.deliveryFailed
+    ).toBe(true);
+    expect(announcements).toEqual([]);
+  });
+});
 import {
   applyExecuteActionResponseToPages,
   applyCreateMessageResponseToPages,
@@ -38,8 +298,8 @@ function message(overrides: Partial<Message>): Message {
   };
 }
 
-function textContent(text: string): Message['content'] {
-  return [{ type: 'text', text }];
+function textContent(text: string) {
+  return [{ type: 'text', text }] satisfies Message['content'];
 }
 
 function actionContent(resolved = false): Message['content'] {

--- a/packages/kilo-chat-hooks/src/use-messages.ts
+++ b/packages/kilo-chat-hooks/src/use-messages.ts
@@ -1,6 +1,12 @@
 import { useMutation, useQueryClient, useInfiniteQuery } from '@tanstack/react-query';
-import type { InfiniteData, QueryClient, QueryKey } from '@tanstack/react-query';
-import { KiloChatApiError, type KiloChatClient } from '@kilocode/kilo-chat';
+import type {
+  InfiniteData,
+  MutateOptions,
+  QueryClient,
+  QueryKey,
+  UseMutationOptions,
+} from '@tanstack/react-query';
+import { KiloChatApiError, type KiloChatClient, type KiloChatOperation } from '@kilocode/kilo-chat';
 import type {
   Message,
   ReactionSummary,
@@ -20,12 +26,139 @@ import type {
   CreateMessageResponse,
   ExecuteActionResponse,
 } from '@kilocode/kilo-chat';
-import { useEffect } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { kiloclawConversationContext } from '@kilocode/event-service';
 
 import { messagesKey } from './query-keys';
 
 export const PAGE_SIZE = 50;
+
+type KiloChatMutationOptions<TData, TVariables, TContext> = Omit<
+  UseMutationOptions<TData, Error, TVariables, TContext | undefined>,
+  'mutationFn' | 'onMutate'
+> & {
+  mutationFn: (variables: TVariables, operation: KiloChatOperation) => Promise<TData>;
+  onMutate?: (variables: TVariables, operation: KiloChatOperation) => TContext | Promise<TContext>;
+};
+
+/**
+ * Capture before React Query's global onMutate, optimistic waits, offline pause,
+ * and retry queues. The optional third mutate argument carries an outer lease.
+ * Old web/package producers omit it and use the client's optional-hook fallback;
+ * remove that form only when a breaking release migrates those producers.
+ */
+export function useKiloChatMutation<TData, TVariables, TContext = unknown>(
+  client: KiloChatClient,
+  options: KiloChatMutationOptions<TData, TVariables, TContext>
+) {
+  type Input = {
+    variables: TVariables;
+    operation: KiloChatOperation;
+    options: typeof options;
+  };
+  // Retained functions read their client's latest options, never a replacement client's options.
+  const optionsRef = useRef({ client, options });
+  if (optionsRef.current.client !== client) {
+    optionsRef.current = { client, options };
+  }
+  const currentOptions = optionsRef.current;
+  currentOptions.options = options;
+
+  const mutation = useMutation<TData, Error, Input, TContext | undefined>({
+    ...options,
+    mutationFn: input => {
+      input.operation.assertDispatch();
+      return input.options.mutationFn(input.variables, input.operation);
+    },
+    onMutate: input => {
+      input.operation.assertDispatch();
+      return input.options.onMutate?.(input.variables, input.operation);
+    },
+    onSuccess: (data, input, context, mutationContext) =>
+      input.operation.canPublish()
+        ? input.options.onSuccess?.(data, input.variables, context, mutationContext)
+        : undefined,
+    onError: (error, input, context, mutationContext) =>
+      input.operation.canPublish()
+        ? input.options.onError?.(error, input.variables, context, mutationContext)
+        : undefined,
+    onSettled: (data, error, input, context, mutationContext) =>
+      input.operation.canPublish()
+        ? input.options.onSettled?.(data, error, input.variables, context, mutationContext)
+        : undefined,
+  });
+  const { mutate, mutateAsync } = mutation;
+  const actions = useMemo(() => {
+    function capture(variables: TVariables, supplied?: KiloChatOperation): Input {
+      let operation: KiloChatOperation;
+      try {
+        operation = client.captureOperation(supplied);
+      } catch (error) {
+        // Let React Query retain its existing error state and the unsent variables.
+        operation = {
+          assertDispatch: () => {
+            throw error;
+          },
+          canPublish: () => client.canPublish(),
+        };
+      }
+      // Pin the callbacks too: a rerender cannot redirect A's settlement into B.
+      return { variables, operation, options: currentOptions.options };
+    }
+    function callbacks(
+      input: Input,
+      supplied?: MutateOptions<TData, Error, TVariables, TContext | undefined>
+    ): MutateOptions<TData, Error, Input, TContext | undefined> {
+      const canNotify = () => {
+        try {
+          input.operation.assertDispatch();
+          return true;
+        } catch {
+          return false;
+        }
+      };
+      return {
+        onSuccess: (data, _input, context, mutationContext) => {
+          if (canNotify()) supplied?.onSuccess?.(data, input.variables, context, mutationContext);
+        },
+        onError: (error, _input, context, mutationContext) => {
+          if (canNotify()) supplied?.onError?.(error, input.variables, context, mutationContext);
+        },
+        onSettled: (data, error, _input, context, mutationContext) => {
+          // Settlement can release a pending UI action while locked, but not for B.
+          if (input.operation.canPublish()) {
+            supplied?.onSettled?.(data, error, input.variables, context, mutationContext);
+          }
+        },
+      };
+    }
+    return {
+      mutate: (
+        variables: TVariables,
+        opts?: MutateOptions<TData, Error, TVariables, TContext | undefined>,
+        operation?: KiloChatOperation
+      ) => {
+        const input = capture(variables, operation);
+        mutate(input, callbacks(input, opts));
+      },
+      mutateAsync: async (
+        variables: TVariables,
+        opts?: MutateOptions<TData, Error, TVariables, TContext | undefined>,
+        operation?: KiloChatOperation
+      ) => {
+        const input = capture(variables, operation);
+        const result = await mutateAsync(input, callbacks(input, opts));
+        client.assertOwner();
+        return result;
+      },
+    };
+  }, [client, currentOptions, mutate, mutateAsync]);
+  return {
+    ...mutation,
+    variables: mutation.variables?.variables,
+    ...actions,
+  };
+}
 
 export type MessagePage = MessageListResponse;
 export type MessageInfiniteData<TPageParam = string | undefined> = InfiniteData<
@@ -456,6 +589,7 @@ export function useMessages(client: KiloChatClient, conversationId: string | nul
         before: pageParam,
         limit: PAGE_SIZE,
       });
+      client.assertOwner();
       return messagesFromListPage(page);
     },
     initialPageParam: undefined as string | undefined,
@@ -656,12 +790,13 @@ export function useSendMessage(
   options?: MutationErrorOptions
 ) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (req: SendMessageVariables) => client.sendMessage(req),
-    onMutate: async (variables: SendMessageVariables) => {
+  return useKiloChatMutation(client, {
+    mutationFn: (req: SendMessageVariables, operation) => client.sendMessage(req, operation),
+    onMutate: async (variables: SendMessageVariables, operation) => {
       if (!conversationId || currentUserId === null) return;
       const queryKey = messagesKey(conversationId);
       await queryClient.cancelQueries({ queryKey });
+      operation.assertDispatch();
       const pendingId = `pending-${variables.clientId}`;
       const optimisticMessage: Message = {
         id: pendingId,
@@ -682,23 +817,25 @@ export function useSendMessage(
       settleSendMessageSuccess(queryClient, response, context);
     },
     onError: (err, _variables, context) => {
-      if (!context) return;
-      removeMessageFromCache(queryClient, context.queryKey, context.pendingId);
-      invalidateColdSeededMessages(queryClient, context);
-      options?.onError?.(err);
+      if (context) {
+        removeMessageFromCache(queryClient, context.queryKey, context.pendingId);
+        invalidateColdSeededMessages(queryClient, context);
+      }
+      if (client.canStartOperation()) options?.onError?.(err);
     },
   });
 }
 
 export function useEditMessage(client: KiloChatClient, conversationId: string | null) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ messageId, ...req }: EditMessageRequest & { messageId: string }) =>
-      client.editMessage(messageId, req),
-    onMutate: async variables => {
+  return useKiloChatMutation(client, {
+    mutationFn: ({ messageId, ...req }: EditMessageRequest & { messageId: string }, operation) =>
+      client.editMessage(messageId, req, operation),
+    onMutate: async (variables, operation) => {
       if (!conversationId) return;
       const queryKey = messagesKey(conversationId);
       await queryClient.cancelQueries({ queryKey });
+      operation.assertDispatch();
       const snapshot = findMessageInCache(queryClient, queryKey, variables.messageId);
       const optimisticMessage = snapshot
         ? { ...snapshot, content: variables.content, clientUpdatedAt: variables.timestamp }
@@ -727,26 +864,15 @@ export function useEditMessage(client: KiloChatClient, conversationId: string | 
 }
 
 /**
- * Retries bot delivery of an existing delivery-failed message. The server
- * re-attempts delivery of the same message row (no new message) and pushes
- * `message.redelivered` (clears `deliveryFailed`) right before the attempt,
- * then `message.delivery_failed` again if the retry fails.
- *
- * Not optimistic: an `onMutate` clear would race those events (a rejected
- * redelivery is indistinguishable from a committed one on an ambiguous HTTP
- * error), and a reconciling invalidate/refetch can capture a stale
- * pre-failure snapshot. Instead the clear is applied on HTTP SUCCESS, once the
- * server has confirmed the redelivery — a targeted single-message write, not a
- * refetch. This also covers a dropped `message.redelivered` event (the push is
- * best-effort), which would otherwise strand the flag until an unrelated
- * refetch. A subsequent, strictly-later `message.delivery_failed` event still
- * restores failure if the retry ultimately fails.
+ * Redelivery is not optimistic: an ambiguous failure cannot prove whether the
+ * server accepted it. Clear deliveryFailed only after confirmed HTTP success;
+ * a later message.delivery_failed event can still restore the failure.
  */
 export function useRedeliverMessage(client: KiloChatClient, conversationId: string | null) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ messageId }: { messageId: string }) =>
-      client.redeliverMessage(conversationId ?? '', messageId),
+  return useKiloChatMutation(client, {
+    mutationFn: ({ messageId }: { messageId: string }, operation) =>
+      client.redeliverMessage(conversationId ?? '', messageId, operation),
     onSuccess: (_data, variables) => {
       if (!conversationId) return;
       const queryKey = messagesKey(conversationId);
@@ -764,13 +890,16 @@ export function useRedeliverMessage(client: KiloChatClient, conversationId: stri
 
 export function useDeleteMessage(client: KiloChatClient, conversationId: string | null) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ messageId, conversationId }: { messageId: string; conversationId: string }) =>
-      client.deleteMessage(messageId, { conversationId }),
-    onMutate: async variables => {
+  return useKiloChatMutation(client, {
+    mutationFn: (
+      { messageId, conversationId }: { messageId: string; conversationId: string },
+      operation
+    ) => client.deleteMessage(messageId, { conversationId }, operation),
+    onMutate: async (variables, operation) => {
       if (!conversationId) return;
       const queryKey = messagesKey(conversationId);
       await queryClient.cancelQueries({ queryKey });
+      operation.assertDispatch();
       const snapshot = findMessageInCache(queryClient, queryKey, variables.messageId);
       const optimisticMessage = snapshot ? { ...snapshot, deleted: true } : undefined;
       queryClient.setQueryData<MessageInfiniteData>(queryKey, old => {
@@ -798,13 +927,14 @@ export function useAddReaction(
   currentUserId: string | null
 ) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ messageId, emoji }: { messageId: string; emoji: string }) =>
-      client.addReaction(messageId, { conversationId: conversationId ?? '', emoji }),
-    onMutate: async variables => {
+  return useKiloChatMutation(client, {
+    mutationFn: ({ messageId, emoji }: { messageId: string; emoji: string }, operation) =>
+      client.addReaction(messageId, { conversationId: conversationId ?? '', emoji }, operation),
+    onMutate: async (variables, operation) => {
       if (!conversationId || currentUserId === null) return;
       const queryKey = messagesKey(conversationId);
       await queryClient.cancelQueries({ queryKey });
+      operation.assertDispatch();
       const snapshot = findMessageInCache(queryClient, queryKey, variables.messageId);
       const optimisticMessage = snapshot
         ? {
@@ -854,13 +984,14 @@ export function useRemoveReaction(
   currentUserId: string | null
 ) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ messageId, emoji }: { messageId: string; emoji: string }) =>
-      client.removeReaction(messageId, { conversationId: conversationId ?? '', emoji }),
-    onMutate: async variables => {
+  return useKiloChatMutation(client, {
+    mutationFn: ({ messageId, emoji }: { messageId: string; emoji: string }, operation) =>
+      client.removeReaction(messageId, { conversationId: conversationId ?? '', emoji }, operation),
+    onMutate: async (variables, operation) => {
       if (!conversationId || currentUserId === null) return;
       const queryKey = messagesKey(conversationId);
       await queryClient.cancelQueries({ queryKey });
+      operation.assertDispatch();
       const snapshot = findMessageInCache(queryClient, queryKey, variables.messageId);
       const optimisticMessage = snapshot
         ? {
@@ -910,20 +1041,24 @@ export function useExecuteAction(
   currentUserId: string | null
 ) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({
-      messageId,
-      groupId,
-      value,
-    }: {
-      messageId: string;
-      groupId: string;
-      value: ExecApprovalDecision;
-    }) => client.executeAction(conversationId ?? '', messageId, { groupId, value }),
-    onMutate: async variables => {
+  return useKiloChatMutation(client, {
+    mutationFn: (
+      {
+        messageId,
+        groupId,
+        value,
+      }: {
+        messageId: string;
+        groupId: string;
+        value: ExecApprovalDecision;
+      },
+      operation
+    ) => client.executeAction(conversationId ?? '', messageId, { groupId, value }, operation),
+    onMutate: async (variables, operation) => {
       if (!conversationId || currentUserId === null) return;
       const queryKey = messagesKey(conversationId);
       await queryClient.cancelQueries({ queryKey });
+      operation.assertDispatch();
       const snapshot = findMessageInCache(queryClient, queryKey, variables.messageId);
       const optimisticResolution = {
         value: variables.value,
@@ -935,17 +1070,9 @@ export function useExecuteAction(
         : undefined;
       queryClient.setQueryData<MessageInfiniteData>(queryKey, old => {
         if (!old) return old;
-        return updateMessageInPages(old, variables.messageId, msg => ({
-          ...msg,
-          content: msg.content.map(block => {
-            if (block.type !== 'actions') return block;
-            if (block.groupId !== variables.groupId) return block;
-            return {
-              ...block,
-              resolved: optimisticResolution,
-            };
-          }),
-        }));
+        return updateMessageInPages(old, variables.messageId, msg =>
+          applyActionResolution(msg, variables.groupId, optimisticResolution)
+        );
       });
       return { queryKey, snapshot, optimisticMessage, optimisticResolution };
     },
@@ -1049,7 +1176,7 @@ export function useMessageCacheUpdater(
         if (!old) return old;
         return updateMessageInPages(old, e.messageId, msg => ({ ...msg, deliveryFailed: true }));
       });
-      onMessageDeliveryFailed?.();
+      if (client.canStartOperation()) onMessageDeliveryFailed?.();
     };
 
     const onRedelivered = (ctx: string, e: MessageRedeliveredEvent) => {
@@ -1073,7 +1200,7 @@ export function useMessageCacheUpdater(
           }),
         }));
       });
-      onActionFailed?.();
+      if (client.canStartOperation()) onActionFailed?.();
     };
 
     const onReactionAdded = (ctx: string, e: ReactionAddedEvent) => {

--- a/packages/kilo-chat-hooks/src/xhr-perform-upload.test.ts
+++ b/packages/kilo-chat-hooks/src/xhr-perform-upload.test.ts
@@ -29,7 +29,10 @@ class FakeXMLHttpRequest {
     this.listeners.set(event, listeners);
   }
 
+  sent = false;
+
   send() {
+    this.sent = true;
     if (!FakeXMLHttpRequest.completeOnSend) {
       return;
     }
@@ -71,6 +74,32 @@ describe('createXhrPerformUpload', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it('rejects stale admission immediately before send and removes abort listeners', async () => {
+    const abort = new AbortController();
+    const upload = createXhrPerformUpload();
+    await expect(
+      upload(
+        new Blob(['private']),
+        'https://upload.example.test',
+        {},
+        {
+          signal: abort.signal,
+          onProgress: () => {},
+          operation: {
+            canPublish: () => true,
+            assertDispatch: () => {
+              throw new Error('stale lease');
+            },
+          },
+        }
+      )
+    ).rejects.toThrow('stale lease');
+    abort.abort();
+    expect(
+      FakeXMLHttpRequest.instances.map(xhr => ({ sent: xhr.sent, aborted: xhr.aborted }))
+    ).toEqual([{ sent: false, aborted: false }]);
   });
 
   it('resolves successful 2xx uploads', async () => {

--- a/packages/kilo-chat/src/client.ts
+++ b/packages/kilo-chat/src/client.ts
@@ -31,6 +31,7 @@ import {
 } from './events';
 import type {
   KiloChatClientConfig,
+  KiloChatOperation,
   ConversationListResponse,
   MessageListResponse,
   ConversationDetailResponse,
@@ -82,11 +83,12 @@ export class KiloChatClient {
   private readonly getToken: () => Promise<string>;
   private readonly onUnauthorized: KiloChatClientConfig['onUnauthorized'];
   private readonly fetchFn: typeof globalThis.fetch;
-  // Per-conversation send queues. Each sendMessage call chains onto the tail
-  // of its conversation's queue so concurrent callers cannot race ahead of
-  // earlier sends and get a lower server-assigned ULID than a later send.
-  // See services/kilo-chat/src/do/conversation-do.ts (nextUlid is monotonic
-  // in DO arrival order, not caller send order).
+  private readonly captureAdmission: KiloChatClientConfig['captureOperationAdmission'];
+  private readonly ownerCanPublish: KiloChatClientConfig['canPublish'];
+  private readonly lifetime = new AbortController();
+  private readonly operations = new WeakSet<KiloChatOperation>();
+  private readonly subscriptions = new Set<() => void>();
+  // Per-conversation send queues preserve caller order for server-assigned ULIDs.
   private readonly sendQueues = new Map<string, Promise<unknown>>();
 
   constructor(config: KiloChatClientConfig) {
@@ -95,42 +97,79 @@ export class KiloChatClient {
     this.getToken = config.getToken;
     this.onUnauthorized = config.onUnauthorized;
     this.fetchFn = config.fetch ?? globalThis.fetch.bind(globalThis);
+    this.captureAdmission = config.captureOperationAdmission;
+    this.ownerCanPublish = config.canPublish;
+  }
+
+  canPublish(): boolean {
+    return !this.lifetime.signal.aborted && (this.ownerCanPublish?.() ?? true);
+  }
+
+  assertOwner(): void {
+    if (!this.canPublish()) throw new Error('Kilo Chat owner is no longer active');
+  }
+
+  /** Capture before any caller queue; a supplied operation is never re-admitted. */
+  captureOperation(operation?: KiloChatOperation): KiloChatOperation {
+    this.assertOwner();
+    if (operation) {
+      if (!this.operations.has(operation)) throw new Error('Invalid Kilo Chat operation');
+      operation.assertDispatch();
+      return operation;
+    }
+    const assertAdmission = this.captureAdmission?.();
+    const captured: KiloChatOperation = Object.freeze({
+      assertDispatch: () => {
+        this.assertOwner();
+        assertAdmission?.();
+      },
+      canPublish: () => this.canPublish(),
+    });
+    captured.assertDispatch();
+    this.operations.add(captured);
+    return captured;
+  }
+
+  /** Protected announcements are not passive cache publication. */
+  canStartOperation(): boolean {
+    try {
+      this.captureOperation();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Opt-in teardown. Old callers that never dispose retain their lifecycle. */
+  dispose(): void {
+    this.lifetime.abort(new Error('Kilo Chat owner is no longer active'));
+    this.sendQueues.clear();
+    for (const off of this.subscriptions) off();
   }
 
   // ── Mutations via HTTP ────────────────────────────────────────────────────
 
   /**
-   * Send a message into a conversation. The send is queued per conversation so
-   * concurrent callers cannot race ahead and get a lower server-assigned ULID.
-   *
-   * **Timeout is uncertain.** When the deadline fires the server may already
-   * have accepted the message. Callers must reconcile the conversation state
-   * via `listMessages` (or event-service events) before retrying the send.
+   * Queue sends per conversation without renewing their original admission.
+   * Timeout is uncertain: reconcile accepted server work before retrying.
    */
-  async sendMessage(req: CreateMessageRequest): Promise<CreateMessageResponse> {
-    const body = req satisfies CreateMessageRequest;
+  async sendMessage(
+    req: CreateMessageRequest,
+    operation?: KiloChatOperation
+  ): Promise<CreateMessageResponse> {
+    const captured = this.captureOperation(operation);
+    const send = () =>
+      this.httpRequest('/v1/messages', {
+        method: 'POST',
+        body: req,
+        schema: createMessageResponseSchema,
+        deadlineMs: SEND_DEADLINE_MS,
+        operation: captured,
+      });
     const prev = this.sendQueues.get(req.conversationId) ?? Promise.resolve();
-    const next = prev.then(
-      () =>
-        this.httpRequest('/v1/messages', {
-          method: 'POST',
-          body,
-          schema: createMessageResponseSchema,
-          deadlineMs: SEND_DEADLINE_MS,
-        }),
-      // A failed prior send must not block subsequent sends — swallow the
-      // rejection on the chain; the original caller already received it.
-      () =>
-        this.httpRequest('/v1/messages', {
-          method: 'POST',
-          body,
-          schema: createMessageResponseSchema,
-          deadlineMs: SEND_DEADLINE_MS,
-        })
-    );
+    // A failed prior send must not block subsequent sends.
+    const next = prev.then(send, send);
     this.sendQueues.set(req.conversationId, next);
-    // Best-effort cleanup so the map doesn't grow unbounded for long-lived
-    // clients. Only clear if this send is still the tail.
     const cleanup = (): void => {
       if (this.sendQueues.get(req.conversationId) === next) {
         this.sendQueues.delete(req.conversationId);
@@ -140,63 +179,70 @@ export class KiloChatClient {
     return next;
   }
 
-  async editMessage(messageId: string, req: EditMessageRequest): Promise<EditMessageResponse> {
-    const body = req satisfies EditMessageRequest;
-
+  async editMessage(
+    messageId: string,
+    req: EditMessageRequest,
+    operation?: KiloChatOperation
+  ): Promise<EditMessageResponse> {
     return this.httpRequest(`/v1/messages/${messageId}`, {
       method: 'PATCH',
-      body,
+      body: req,
       schema: editMessageResponseSchema,
+      operation,
     });
   }
 
   async deleteMessage(
     messageId: string,
-    req: z.input<typeof deleteMessageQuerySchema>
+    req: z.input<typeof deleteMessageQuerySchema>,
+    operation?: KiloChatOperation
   ): Promise<void> {
-    const query = req satisfies z.input<typeof deleteMessageQuerySchema>;
-
     await this.httpRequest(`/v1/messages/${messageId}`, {
       method: 'DELETE',
-      query,
+      query: req,
       schema: voidSchema,
+      operation,
     });
   }
 
-  async createConversation(req: CreateConversationRequest): Promise<CreateConversationResponse> {
-    const body = req satisfies CreateConversationRequest;
-
+  async createConversation(
+    req: CreateConversationRequest,
+    operation?: KiloChatOperation
+  ): Promise<CreateConversationResponse> {
     return this.httpRequest('/v1/conversations', {
       method: 'POST',
-      body,
+      body: req,
       schema: createConversationResponseSchema,
+      operation,
     });
   }
 
   async renameConversation(
     conversationId: string,
-    req: RenameConversationRequest
+    req: RenameConversationRequest,
+    operation?: KiloChatOperation
   ): Promise<{ ok: true }> {
-    const body = req satisfies RenameConversationRequest;
-
     return this.httpRequest(`/v1/conversations/${conversationId}`, {
       method: 'PATCH',
-      body,
+      body: req,
       schema: okResponseSchema,
+      operation,
     });
   }
 
-  async leaveConversation(conversationId: string): Promise<void> {
+  async leaveConversation(conversationId: string, operation?: KiloChatOperation): Promise<void> {
     await this.httpRequest(`/v1/conversations/${conversationId}/leave`, {
       method: 'POST',
       schema: voidSchema,
+      operation,
     });
   }
 
-  async sendTyping(conversationId: string): Promise<void> {
+  async sendTyping(conversationId: string, operation?: KiloChatOperation): Promise<void> {
     await this.httpRequest(`/v1/conversations/${conversationId}/typing`, {
       method: 'POST',
       schema: voidSchema,
+      operation,
     });
   }
 
@@ -204,74 +250,82 @@ export class KiloChatClient {
     await this.httpRequest(`/v1/conversations/${conversationId}/typing/stop`, {
       method: 'POST',
       schema: voidSchema,
+      ownerOnly: true,
     });
   }
 
   async markConversationRead(
     conversationId: string,
-    req: MarkConversationReadRequest
+    req: MarkConversationReadRequest,
+    operation?: KiloChatOperation
   ): Promise<MarkConversationReadResponse> {
-    const body = req satisfies MarkConversationReadRequest;
-
     return this.httpRequest(`/v1/conversations/${conversationId}/mark-read`, {
       method: 'POST',
-      body,
+      body: req,
       schema: markConversationReadResponseSchema,
+      operation,
     });
   }
 
   async addReaction(
     messageId: string,
-    req: z.input<typeof reactionRequestBodySchema>
+    req: z.input<typeof reactionRequestBodySchema>,
+    operation?: KiloChatOperation
   ): Promise<AddReactionResponse> {
-    const body = req satisfies z.input<typeof reactionRequestBodySchema>;
-
     return this.httpRequest(`/v1/messages/${messageId}/reactions`, {
       method: 'POST',
-      body,
+      body: req,
       schema: addReactionResponseSchema,
+      operation,
     });
   }
 
   async removeReaction(
     messageId: string,
-    req: z.input<typeof reactionRequestBodySchema>
+    req: z.input<typeof reactionRequestBodySchema>,
+    operation?: KiloChatOperation
   ): Promise<RemoveReactionResponse> {
-    const query = req satisfies z.input<typeof reactionRequestBodySchema>;
-
     return this.httpRequest(`/v1/messages/${messageId}/reactions`, {
       method: 'DELETE',
-      query,
+      query: req,
       schema: removeReactionResponseSchema,
+      operation,
     });
   }
 
-  async redeliverMessage(conversationId: string, messageId: string): Promise<{ ok: true }> {
+  async redeliverMessage(
+    conversationId: string,
+    messageId: string,
+    operation?: KiloChatOperation
+  ): Promise<{ ok: true }> {
     return this.httpRequest(`/v1/conversations/${conversationId}/messages/${messageId}/redeliver`, {
       method: 'POST',
       schema: okResponseSchema,
+      operation,
     });
   }
 
   async executeAction(
     conversationId: string,
     messageId: string,
-    req: z.input<typeof executeActionRequestSchema>
+    req: z.input<typeof executeActionRequestSchema>,
+    operation?: KiloChatOperation
   ): Promise<ExecuteActionResponse> {
-    const body = req satisfies z.input<typeof executeActionRequestSchema>;
-
     return this.httpRequest(
       `/v1/conversations/${conversationId}/messages/${messageId}/execute-action`,
-      { method: 'POST', body, schema: executeActionResponseSchema }
+      { method: 'POST', body: req, schema: executeActionResponseSchema, operation }
     );
   }
 
-  async initAttachment(req: AttachmentInitRequest): Promise<AttachmentInitResponse> {
-    const body = req satisfies AttachmentInitRequest;
+  async initAttachment(
+    req: AttachmentInitRequest,
+    operation?: KiloChatOperation
+  ): Promise<AttachmentInitResponse> {
     return this.httpRequest('/v1/attachments/init', {
       method: 'POST',
-      body,
+      body: req,
       schema: attachmentInitResponseSchema,
+      operation,
     });
   }
 
@@ -293,11 +347,7 @@ export class KiloChatClient {
       limit: opts?.limit,
       cursor: opts?.cursor,
     } satisfies z.input<typeof listConversationsQuerySchema>;
-
-    return this.httpRequest('/v1/conversations', {
-      query,
-      schema: conversationListResponseSchema,
-    });
+    return this.httpRequest('/v1/conversations', { query, schema: conversationListResponseSchema });
   }
 
   async getConversation(conversationId: string): Promise<ConversationDetailResponse> {
@@ -312,15 +362,12 @@ export class KiloChatClient {
     });
   }
 
-  // Nudges the bot to push a fresh `bot.status` event over event-service.
-  // Returns cached status when available so the caller can paint the UI
-  // immediately without waiting for the WS event. Server dedupes within a
-  // short window; subscribed clients call this every ~15s while on a chat
-  // surface.
+  // Status subscriptions nudge cached status; they do not admit foreground actions.
   async requestBotStatus(sandboxId: string): Promise<RequestBotStatusResponse> {
     return this.httpRequest(`/v1/sandboxes/${sandboxId}/request-bot-status`, {
       method: 'POST',
       schema: requestBotStatusResponseSchema,
+      ownerOnly: true,
     });
   }
 
@@ -335,6 +382,7 @@ export class KiloChatClient {
     opts?: z.input<typeof listMessagesQuerySchema>
   ): Promise<Message[]> {
     const res = await this.listMessagesPage(conversationId, opts);
+    this.assertOwner();
     return res.messages;
   }
 
@@ -342,11 +390,9 @@ export class KiloChatClient {
     conversationId: string,
     opts?: z.input<typeof listMessagesQuerySchema>
   ): Promise<MessageListResponse> {
-    const query = {
-      before: opts?.before,
-      limit: opts?.limit,
-    } satisfies z.input<typeof listMessagesQuerySchema>;
-
+    const query = { before: opts?.before, limit: opts?.limit } satisfies z.input<
+      typeof listMessagesQuerySchema
+    >;
     return this.httpRequest(`/v1/conversations/${conversationId}/messages`, {
       query,
       schema: messageListResponseSchema,
@@ -359,12 +405,20 @@ export class KiloChatClient {
     event: N,
     handler: (ctx: string, payload: KiloChatEventOf<N>) => void
   ): () => void {
+    if (!this.canPublish()) return () => {};
     const payloadSchema = getKiloChatEventPayloadSchema(event);
-    return this.es.on(event, (context, payload) => {
+    const unsubscribe = this.es.on(event, (context, payload) => {
+      if (!this.canPublish()) return;
       const result = payloadSchema.safeParse(payload);
       if (!result.success) return;
       handler(context, result.data);
     });
+    const off = () => {
+      unsubscribe();
+      this.subscriptions.delete(off);
+    };
+    this.subscriptions.add(off);
+    return off;
   }
 
   onMessageCreated(handler: (ctx: string, e: MessageCreatedEvent) => void): () => void {
@@ -446,31 +500,41 @@ export class KiloChatClient {
       body?: unknown;
       query?: Record<string, unknown>;
       schema: z.ZodType<T>;
-      signal?: AbortSignal;
       deadlineMs?: number;
+      operation?: KiloChatOperation;
+      ownerOnly?: boolean;
     }
   ): Promise<T> {
-    const deadline = opts.deadlineMs ?? CONTROL_PLANE_DEADLINE_MS;
-    return withDeadline(
-      deadline,
+    this.assertOwner();
+    const operation =
+      opts.method && opts.method !== 'GET' && !opts.ownerOnly
+        ? this.captureOperation(opts.operation)
+        : undefined;
+    const assertDispatch = () => {
+      this.assertOwner();
+      operation?.assertDispatch();
+    };
+    const result = await withDeadline(
+      opts.deadlineMs ?? CONTROL_PLANE_DEADLINE_MS,
       async signal => {
+        const request = { ...opts, signal, assertDispatch };
         try {
-          return await this.httpRequestOnce(path, { ...opts, signal });
+          return await this.httpRequestOnce(path, request);
         } catch (err) {
           // Deadline/timeout errors must NOT trigger unauthorized recovery.
           const onUnauthorized = this.onUnauthorized;
-          if (!this.shouldRecoverFromUnauthorized(err) || onUnauthorized === undefined) {
-            throw err;
-          }
+          if (!this.shouldRecoverFromUnauthorized(err) || onUnauthorized === undefined) throw err;
+          assertDispatch();
           const decision = await onUnauthorized();
-          if (decision !== 'retry') {
-            throw err;
-          }
-          return this.httpRequestOnce(path, { ...opts, signal });
+          assertDispatch();
+          if (decision !== 'retry') throw err;
+          return this.httpRequestOnce(path, request);
         }
       },
-      opts.signal
+      this.lifetime.signal
     );
+    this.assertOwner();
+    return result;
   }
 
   private shouldRecoverFromUnauthorized(err: unknown): err is KiloChatApiError {
@@ -488,12 +552,14 @@ export class KiloChatClient {
       body?: unknown;
       query?: Record<string, unknown>;
       schema: z.ZodType<T>;
-      signal?: AbortSignal;
+      signal: AbortSignal;
+      assertDispatch: () => void;
     }
   ): Promise<T> {
+    opts.assertDispatch();
+    if (opts.signal.aborted) throw opts.signal.reason;
     const token = await this.getToken();
     let url = `${this.baseUrl}${path}`;
-
     if (opts.query) {
       const params = new URLSearchParams();
       for (const [k, v] of Object.entries(opts.query)) {
@@ -503,24 +569,26 @@ export class KiloChatClient {
       const qs = params.toString();
       if (qs) url += `?${qs}`;
     }
-
     const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
     if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
-
+    opts.assertDispatch();
+    if (opts.signal.aborted) throw opts.signal.reason;
     const res = await this.fetchFn(url, {
       method: opts.method ?? 'GET',
       headers,
       body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
       signal: opts.signal,
     });
-
+    // A lock cannot undo accepted server work; replacement cannot publish it.
+    this.assertOwner();
     if (!res.ok) {
       const body: unknown = await res.json().catch(() => null);
+      this.assertOwner();
       throw new KiloChatApiError(res.status, body);
     }
-
     if (res.status === 204) return opts.schema.parse(undefined);
     const json: unknown = await res.json();
+    this.assertOwner();
     return opts.schema.parse(json);
   }
 }

--- a/packages/kilo-chat/src/types.ts
+++ b/packages/kilo-chat/src/types.ts
@@ -72,12 +72,24 @@ import type {
 } from './events';
 
 // ── Configuration ───────────────────────────────────────────────────
+export type KiloChatOperation = Readonly<{
+  assertDispatch: () => void;
+  canPublish: () => boolean;
+}>;
+
 export type KiloChatClientConfig = {
   eventService: EventServiceClient;
   baseUrl: string;
   getToken: () => Promise<string>;
   onUnauthorized?: () => Promise<'retry' | 'stop'> | 'retry' | 'stop';
   fetch?: typeof globalThis.fetch;
+  // The old constructor omits these hooks. Preserve web EventServiceContext,
+  // web Kilo Chat context/typing, kilo-chat-hooks, package tests, and external
+  // package users until a breaking release migrates all those producers.
+  captureOperationAdmission?: () => () => void;
+  // Publication checks ownership only, not foreground access. Accepted server
+  // work and incoming messages/status can complete for the same locked owner.
+  canPublish?: () => boolean;
 };
 
 // ── Content blocks ──────────────────────────────────────────────────

--- a/packages/kilo-chat/test/client.attachments.test.ts
+++ b/packages/kilo-chat/test/client.attachments.test.ts
@@ -19,7 +19,7 @@ function makeClient(fetchFn: typeof globalThis.fetch) {
 describe('KiloChatClient.getAttachmentUrl', () => {
   it('GETs /v1/attachments/:id/url with conversationId query and parses the response', async () => {
     const fetchFn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe(
+      expect(input instanceof Request ? input.url : input.toString()).toBe(
         'https://chat.test/v1/attachments/01HV0000000000000000000001/url' +
           '?conversationId=01HV0000000000000000000000'
       );
@@ -47,13 +47,54 @@ describe('KiloChatClient.getAttachmentUrl', () => {
   });
 });
 
+describe('attachment admission', () => {
+  it('keeps downloads available while refusing new uploads for a locked owner', async () => {
+    const requests: string[] = [];
+    const client = new KiloChatClient({
+      eventService: noopEventService,
+      baseUrl: 'https://chat.test',
+      getToken: async () => 'tok',
+      canPublish: () => true,
+      captureOperationAdmission: () => {
+        throw new Error('locked');
+      },
+      fetch: async input => {
+        requests.push(input instanceof Request ? input.url : input.toString());
+        return Response.json({
+          url: 'https://r2.test/download',
+          mimeType: 'image/png',
+          size: 42,
+          filename: 'a.png',
+          expiresAt: 1_700_000_000,
+        });
+      },
+    });
+    await expect(
+      client.initAttachment({
+        conversationId: 'c1',
+        mimeType: 'image/png',
+        filename: 'a.png',
+        size: 42,
+        idempotencyKey: 'tmp-1',
+      })
+    ).rejects.toThrow('locked');
+    await expect(
+      client.getAttachmentUrl({ conversationId: 'c1', attachmentId: 'a1' })
+    ).resolves.toMatchObject({ url: 'https://r2.test/download' });
+    expect(requests).toEqual(['https://chat.test/v1/attachments/a1/url?conversationId=c1']);
+  });
+});
+
 describe('KiloChatClient.initAttachment', () => {
   it('POSTs body to /v1/attachments/init and parses the response', async () => {
     const fetchFn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe('https://chat.test/v1/attachments/init');
+      expect(input instanceof Request ? input.url : input.toString()).toBe(
+        'https://chat.test/v1/attachments/init'
+      );
       expect(init?.method).toBe('POST');
       expect(init?.headers).toMatchObject({ Authorization: 'Bearer tok' });
-      const body = JSON.parse(String(init?.body));
+      if (typeof init?.body !== 'string') throw new Error('Expected a JSON request body');
+      const body = JSON.parse(init.body);
       expect(body).toMatchObject({
         conversationId: '01HV0000000000000000000000',
         mimeType: 'image/png',

--- a/packages/kilo-chat/test/client.test.ts
+++ b/packages/kilo-chat/test/client.test.ts
@@ -21,6 +21,261 @@ function mockFetch(status: number, body: unknown): typeof globalThis.fetch {
   });
 }
 
+type MethodCase =
+  | { kind: 'action'; invoke: (client: KiloChatClient) => Promise<unknown> }
+  | { kind: 'read' | 'event' | 'control' };
+
+// Exhaustive public-method inventory. New methods must choose an admission class.
+const methodInventory: Record<keyof KiloChatClient, MethodCase> = {
+  sendMessage: { kind: 'action', invoke: c => c.sendMessage({ conversationId: 'c', content: [] }) },
+  editMessage: {
+    kind: 'action',
+    invoke: c => c.editMessage('m', { conversationId: 'c', content: [], timestamp: 1 }),
+  },
+  deleteMessage: { kind: 'action', invoke: c => c.deleteMessage('m', { conversationId: 'c' }) },
+  createConversation: { kind: 'action', invoke: c => c.createConversation({ sandboxId: 's' }) },
+  renameConversation: {
+    kind: 'action',
+    invoke: c => c.renameConversation('c', { title: 'renamed' }),
+  },
+  leaveConversation: { kind: 'action', invoke: c => c.leaveConversation('c') },
+  sendTyping: { kind: 'action', invoke: c => c.sendTyping('c') },
+  markConversationRead: {
+    kind: 'action',
+    invoke: c => c.markConversationRead('c', { lastSeenMessageId: 'm' }),
+  },
+  addReaction: {
+    kind: 'action',
+    invoke: c => c.addReaction('m', { conversationId: 'c', emoji: '+1' }),
+  },
+  removeReaction: {
+    kind: 'action',
+    invoke: c => c.removeReaction('m', { conversationId: 'c', emoji: '+1' }),
+  },
+  redeliverMessage: { kind: 'action', invoke: c => c.redeliverMessage('c', 'm') },
+  executeAction: {
+    kind: 'action',
+    invoke: c => c.executeAction('c', 'm', { groupId: 'g', value: 'allow-once' }),
+  },
+  initAttachment: {
+    kind: 'action',
+    invoke: c =>
+      c.initAttachment({
+        conversationId: 'c',
+        filename: 'a.png',
+        mimeType: 'image/png',
+        size: 1,
+        idempotencyKey: 'a',
+      }),
+  },
+  getAttachmentUrl: { kind: 'read' },
+  listConversations: { kind: 'read' },
+  getConversation: { kind: 'read' },
+  getBotStatus: { kind: 'read' },
+  requestBotStatus: { kind: 'read' },
+  getConversationStatus: { kind: 'read' },
+  listMessages: { kind: 'read' },
+  listMessagesPage: { kind: 'read' },
+  sendTypingStop: { kind: 'control' },
+  captureOperation: { kind: 'control' },
+  canPublish: { kind: 'control' },
+  canStartOperation: { kind: 'control' },
+  assertOwner: { kind: 'control' },
+  dispose: { kind: 'control' },
+  on: { kind: 'event' },
+  onMessageCreated: { kind: 'event' },
+  onMessageUpdated: { kind: 'event' },
+  onMessageDeleted: { kind: 'event' },
+  onMessageDeliveryFailed: { kind: 'event' },
+  onMessageRedelivered: { kind: 'event' },
+  onActionDeliveryFailed: { kind: 'event' },
+  onTyping: { kind: 'event' },
+  onTypingStop: { kind: 'event' },
+  onReactionAdded: { kind: 'event' },
+  onReactionRemoved: { kind: 'event' },
+  onConversationCreated: { kind: 'event' },
+  onConversationRenamed: { kind: 'event' },
+  onConversationLeft: { kind: 'event' },
+  onConversationRead: { kind: 'event' },
+  onConversationActivity: { kind: 'event' },
+  onBotStatus: { kind: 'event' },
+  onConversationStatus: { kind: 'event' },
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function ownedClient(overrides: Partial<KiloChatClientConfig> = {}) {
+  const state = { generation: 0, unlocked: true, owner: true };
+  const requests: string[] = [];
+  const client = new KiloChatClient({
+    ...createMockConfig(async input => {
+      requests.push(input instanceof Request ? input.url : input.toString());
+      return Response.json({ conversations: [], hasMore: false, nextCursor: null });
+    }),
+    canPublish: () => state.owner,
+    captureOperationAdmission: () => {
+      const generation = state.generation;
+      return () => {
+        if (!state.unlocked || generation !== state.generation) throw new Error('stale admission');
+      };
+    },
+    ...overrides,
+  });
+  return { client, state, requests };
+}
+
+const admittedMessage = {
+  id: 'm1',
+  senderId: 'user-a',
+  content: [{ type: 'text', text: 'accepted' }],
+  inReplyToMessageId: null,
+  replyTo: null,
+  updatedAt: null,
+  clientUpdatedAt: null,
+  deleted: false,
+  deliveryFailed: false,
+  reactions: [],
+};
+
+describe('operation admission and ownership', () => {
+  for (const [name, entry] of Object.entries(methodInventory)) {
+    if (entry.kind !== 'action') continue;
+    it(`denies ${name} before credentials or HTTP when locked`, async () => {
+      let tokenReads = 0;
+      const { client, state, requests } = ownedClient({
+        getToken: async () => {
+          tokenReads++;
+          return 'a';
+        },
+      });
+      state.unlocked = false;
+      await expect(entry.invoke(client)).rejects.toThrow('stale admission');
+      expect({ tokenReads, requests }).toEqual({ tokenReads: 0, requests: [] });
+    });
+  }
+
+  it('rejects a delayed token after lock/unlock without sending the draft', async () => {
+    const token = deferred<string>();
+    const entered = deferred<void>();
+    const { client, state, requests } = ownedClient({
+      getToken: () => {
+        entered.resolve();
+        return token.promise;
+      },
+    });
+    const pending = client.sendMessage({
+      conversationId: 'c',
+      content: [{ type: 'text', text: 'unsent' }],
+    });
+    await entered.promise;
+    state.generation++;
+    token.resolve('a');
+    await expect(pending).rejects.toThrow('stale admission');
+    expect(requests).toEqual([]);
+  });
+
+  it('keeps an accepted send but rejects the queued send after lock/unlock', async () => {
+    const response = deferred<Response>();
+    const requests: string[] = [];
+    const { client, state } = ownedClient({
+      fetch: async (_url, init) => {
+        if (typeof init?.body !== 'string') throw new Error('Expected a JSON request body');
+        requests.push(init.body);
+        return response.promise;
+      },
+    });
+    const accepted = client.sendMessage({
+      conversationId: 'c',
+      content: [{ type: 'text', text: 'accepted' }],
+    });
+    const queued = client.sendMessage({
+      conversationId: 'c',
+      content: [{ type: 'text', text: 'unsent' }],
+    });
+    const rejected = expect(queued).rejects.toThrow('stale admission');
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+    state.generation++;
+    response.resolve(Response.json({ messageId: 'm1', message: admittedMessage }));
+    await expect(accepted).resolves.toMatchObject({ messageId: 'm1' });
+    await rejected;
+    expect(requests.map(body => JSON.parse(body).content[0].text)).toEqual(['accepted']);
+  });
+
+  it('does not renew admission across an unauthorized retry', async () => {
+    const recovery = deferred<'retry'>();
+    const recovering = deferred<void>();
+    const requests: string[] = [];
+    const { client, state } = ownedClient({
+      fetch: async input => {
+        requests.push(input instanceof Request ? input.url : input.toString());
+        return Response.json({ error: 'expired' }, { status: 401 });
+      },
+      onUnauthorized: () => {
+        recovering.resolve();
+        return recovery.promise;
+      },
+    });
+    const pending = client.executeAction('c', 'm', { groupId: 'g', value: 'allow-once' });
+    await recovering.promise;
+    state.generation++;
+    recovery.resolve('retry');
+    await expect(pending).rejects.toThrow('stale admission');
+    expect(requests).toEqual([
+      'https://chat.example.com/v1/conversations/c/messages/m/execute-action',
+    ]);
+  });
+
+  it('disposes token waits and queued sends without waiting for their deadlines', async () => {
+    const token = deferred<string>();
+    const entered = deferred<void>();
+    const { client, requests } = ownedClient({
+      getToken: () => {
+        entered.resolve();
+        return token.promise;
+      },
+    });
+    const first = client.sendMessage({ conversationId: 'c', content: [] });
+    const queued = client.sendMessage({ conversationId: 'c', content: [] });
+    const settled = Promise.allSettled([first, queued]);
+    await entered.promise;
+    client.dispose();
+    expect((await settled).map(result => result.status)).toEqual(['rejected', 'rejected']);
+    token.resolve('old');
+    await Promise.resolve();
+    expect(requests).toEqual([]);
+  });
+
+  it('rejects an old read response instead of returning it to a replacement owner', async () => {
+    const response = deferred<Response>();
+    const { client, state } = ownedClient({ fetch: () => response.promise });
+    const pending = client.listConversations();
+    await Promise.resolve();
+    state.owner = false;
+    response.resolve(Response.json({ conversations: [], hasMore: false, nextCursor: null }));
+    await expect(pending).rejects.toThrow('owner is no longer active');
+  });
+
+  it('allows owner-fenced reads and stop-typing cleanup while locked', async () => {
+    const requests: string[] = [];
+    const { client, state } = ownedClient({
+      fetch: async input => {
+        requests.push(input instanceof Request ? input.url : input.toString());
+        return Response.json({ conversations: [], hasMore: false, nextCursor: null });
+      },
+    });
+    state.unlocked = false;
+    await expect(client.listConversations()).resolves.toMatchObject({ conversations: [] });
+    await expect(client.sendTypingStop('c')).resolves.toBeUndefined();
+    expect(requests).toHaveLength(2);
+  });
+});
+
 describe('KiloChatClient', () => {
   const sentMessage = {
     id: 'm1',


### PR DESCRIPTION
- Signing out or switching accounts stops mobile chat actions that have not been sent. This includes messages, edits, deletions, reactions, typing updates, and conversation changes.
- When your sign-in changes, late chat results and live updates no longer change the conversations for your new sign-in.
- After your sign-in changes, delayed file choices, photo selections, and pasted images cannot add attachments or update upload progress for the new account.
- Delayed read confirmations from your earlier sign-in no longer change unread conversations or the notification count for your current account.
- While the mobile app is inactive, chat delivery, conversation, and attachment errors do not open new pop-ups.

---

## Summary

`KiloChatOperation` keeps immutable dispatch admission through queues and unauthorized retries; owner-only publication lets already accepted work settle without renewed foreground access.
`KiloChatClientConfig` adds optional `captureOperationAdmission` and `canPublish` callbacks, preserving existing callers; reads, typing cleanup, and status refresh require ownership only.
`KiloChatClient.captureOperation` rejects foreign operations, `canStartOperation` gates announcements, and `dispose` aborts requests, clears queues, and removes subscriptions.

<details>
<summary>Files</summary>

- `packages/kilo-chat/src/client.ts` — Source, modified, 280 lines changed; guards token waits, response decoding, events, and mutation dispatch while preserving per-conversation send order.
- `packages/kilo-chat/src/types.ts` — Source, modified, 12 lines changed; adds the readonly operation type and optional constructor callbacks.
- `packages/kilo-chat/test/client.test.ts` — Test, modified, 255 lines changed; extends the shared client tests.

</details>

`MobileKiloChatConfig` makes both guards mandatory in `createMobileKiloChatClients`, keeping connections, callbacks, and recovery tied to one `AuthenticatedOwner`.
`KiloChatProvider` remounts on ownership changes and replaces disposed clients during effect replay, rather than restoring old queues.
`KiloChatTokenErrorState.retry` checks admission at invocation; denial leaves the existing error and does not schedule that retry after access returns.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/kilo-chat/kilo-chat-provider.tsx` — Source, modified, 267 lines changed; scopes clients and token identity by authentication epoch, generation, and user; guards subscriptions, reconnects, resyncs, activation, and teardown.
- `apps/mobile/src/components/kilo-chat/kilo-chat-admission.test.ts` — Test, added, 387 lines changed; adds mobile admission tests.
- `apps/mobile/src/components/kilo-chat/kilo-chat-provider.mounted.test.tsx` — Test, modified, 783 lines changed; extends the mounted provider tests.

</details>

`TokenCache` now includes `AuthenticatedOwner`; `clearKiloChatTokenCache` invalidates older pending fills, and cache reuse or request sharing requires matching credentials and ownership.
`TokenResponseListener` receives the owner, while `kiloChat.getToken` carries `localAccessOwner` and rejects stale or mismatched user responses.
`TokenResponseGetter` accepts an optional dispatch check; `useKiloChatTokenGetter` and `useKiloChatTokenResponseGetter` accept optional owners and capture the current owner when omitted.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/kilo-chat/hooks/use-kilo-chat-token.ts` — Source, modified, 143 lines changed; rechecks ownership around waits and listeners, matches authentication generations, and retains the early-expiry rule.
- `apps/mobile/src/components/kilo-chat/hooks/use-kilo-chat-token.local-access.test.ts` — Test, added, 134 lines changed; adds token access tests.

</details>

`useKiloChatMutation` and `KiloChatMutationOptions` capture variables, callbacks, and admission before React Query queues work, so rerenders cannot redirect settlement.
`mutate` and `mutateAsync` retain stable identities, accept an optional third `KiloChatOperation`, and preserve existing call forms and rejected variables.
`canPublish` gates cache settlement, original admission gates per-call success/error callbacks, and `onSettled` can release pending controls for the same locked owner.

<details>
<summary>Files</summary>

- `packages/kilo-chat-hooks/src/use-messages.ts` — Source, modified, 261 lines changed; guards sends, edits, deletions, reactions, redelivery, action execution, and message reads. It suppresses blocked notices and reuses the action-resolution helper.
- `packages/kilo-chat-hooks/src/use-conversations.ts` — Source, modified, 40 lines changed; guards creation, rename, leave, and mark-read; keeps reconciliation and suppresses blocked error notices.
- `packages/kilo-chat-hooks/src/use-messages.test.ts` — Test, modified, 270 lines changed; extends the message hook tests.
- `packages/kilo-chat-hooks/src/use-conversations.test.ts` — Test, modified, 144 lines changed; extends the conversation hook tests.

</details>

`PerformUpload`, `AddFileInput.operation`, and `UseAttachmentQueueOptions.captureOperation` carry captured admission from attachment selection through initialization and final upload dispatch, without renewing permission after waits.
`mobilePerformUpload` requires an operation; shared callers retain the optional form, and owner checks prevent stale progress, completion, or failure updates.
`UseAttachmentQueueResult.retryFile` accepts an optional operation; explicit retries validate supplied admission or capture a new operation while retaining local bytes.

<details>
<summary>Files</summary>

- `packages/kilo-chat-hooks/src/use-attachment-queue.ts` — Source, modified, 203 lines changed; pins upload ownership and validates initialization, final dispatch, and retries with cached upload links. It guards progress and settlement while retaining local bytes.
- `apps/mobile/src/components/kilo-chat/message-input-attachment-queue.tsx` — Source, modified, 86 lines changed; captures admission before camera, library, file, or clipboard preparation; carries it through selection and gates attachment error notices.
- `apps/mobile/src/components/kilo-chat/mobile-perform-upload.ts` — Source, modified, 15 lines changed; rejects missing admission before calling the shared uploader.
- `packages/kilo-chat-hooks/src/use-attachment-queue.test.ts` — Test, modified, 188 lines changed; extends the attachment queue tests.
- `packages/kilo-chat-hooks/src/xhr-perform-upload.test.ts` — Test, modified, 29 lines changed; extends the shared upload adapter tests.
- `packages/kilo-chat/test/client.attachments.test.ts` — Test, modified, 47 lines changed; extends the attachment request tests.

</details>

`useConversationMarkRead` keeps each scheduled attempt's original `KiloChatOperation` and callback, cancelling retries when access, ownership, focus, or the message marker changes.
`useMarkRead` adds an optional operation argument; `MarkReadInput` preserves that operation, the user, and the inner mutation before the outer queue waits.
Badge updates, native counts, diagnostics, and invalidation require the original owner; accepted responses can settle without foreground access, with existing freshness checks intact.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/kilo-chat/hooks/use-conversation-mark-read.ts` — Source, modified, 113 lines changed; retains the scheduled retry closure and admission; cancels invalid timers and removes listeners on unmount.
- `apps/mobile/src/components/kilo-chat/hooks/use-mark-read.ts` — Source, modified, 96 lines changed; captures the user and inner mutation before queuing; guards badge effects, diagnostics, invalidation, and returned results.

</details>

Tests: 9 files: 2 added, 7 modified; 2,237 changed lines across `client.test.ts`, `kilo-chat-admission.test.ts`, `kilo-chat-provider.mounted.test.tsx`, `use-kilo-chat-token.local-access.test.ts`, `use-messages.test.ts`, `use-conversations.test.ts`, `use-attachment-queue.test.ts`, `xhr-perform-upload.test.ts`, and `client.attachments.test.ts`.
Generated: 0 files.

---

## Visual Changes

Visual Changes: N/A

## Verification

- No manual runtime verification ran for this level. Full iOS and Android verification runs on the final stack level.
- No end-to-end (E2E) report accompanies the handoff.

## Reviewer Notes

- Scope: level 4 only, from `mobile-context-lock-758a-s3` to `mobile-context-lock-758a-s4`.
- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-context-lock-758a`.
- Size: 20 changed files, with 3,081 insertions and 672 deletions. File sizes count added and removed lines.
- Automated evidence: the handoff reports that 137 targeted tests and seven new mounted regressions passed. These are automated checks, not manual runtime evidence.
- This level does not establish device proof or integrated tool-bridge protection.
- The section uses eight levels; levels 6–8 remain unfinished.

### Human steps

- **before merge:** No required human setup step.
- **after merge, for an existing mobile checkout:** Refresh the copied hooks with `pnpm install --filter kilo-app...` from the repository root.
- **after merge, for an existing mobile checkout:** Clear the Metro cache with `rm -rf "$TMPDIR/metro-cache" "$TMPDIR"/metro-file-map-*`.
- **after merge, for an existing mobile checkout:** Restart Metro through the repository dev runner.
- **after merge, for an existing mobile checkout:** Force-quit the app.

### Notes

This level adds Kilo Chat admission and ownership boundaries without exposing biometric controls. Full iOS and Android verification runs on the final stack level.

Runtime verification remains bot-e2e, not human delegation.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-context-lock-758a` — #5642
2. `mobile-context-lock-758a-s2` — #5651
3. `mobile-context-lock-758a-s3` — #5658
4. `mobile-context-lock-758a-s4` — #5664 ← this PR
5. `mobile-context-lock-758a-s5` — #5683 (tip)
