### PR TITLE
fix(web): use configured Snowflake schema for leaderboards

### DIFF
--- a/apps/web/src/app/api/public/leaderboard-model-provider-usage/route.ts
+++ b/apps/web/src/app/api/public/leaderboard-model-provider-usage/route.ts
@@ -20,7 +20,7 @@ select
     , sum(mu.total_cache_hit_tokens) as "sum_cache_hit_tokens"
     , sum(mu.request_count) as "sum_request_count"
     , sum(mu.error_count) as "sum_error_count"
-from kilo_dw.dbt_prod.microdollar_usage_daily as mu
+from microdollar_usage_daily as mu
 where
     mu.usage_date >= dateadd(week, -1, current_date())
     and mu.usage_date < current_date()
@@ -157,9 +157,9 @@ function parseAndAggregateUsage(rows: string[][]): ModelProviderUsage[] {
       costPerMillionTokens: ratio(usage.sumCost, usage.sumTokens),
       cacheRatio: ratio(usage.sumCacheHitTokens, usage.sumInputTokens),
       errorRate: ratio(usage.sumErrorCount, usage.sumRequestCount),
-      percentageOfModel:
-        ratio(usage.sumTokens, totalTokensByModel.get(usage.model) ?? 0) * 100,
-    })).filter(usage => usage.errorRate < MAXIMUM_ERROR_RATE);
+      percentageOfModel: ratio(usage.sumTokens, totalTokensByModel.get(usage.model) ?? 0) * 100,
+    }))
+    .filter(usage => usage.errorRate < MAXIMUM_ERROR_RATE);
 }
 
 export const GET = createPublicSnowflakeReport({

--- a/apps/web/src/app/api/public/leaderboard-model-usage/route.ts
+++ b/apps/web/src/app/api/public/leaderboard-model-usage/route.ts
@@ -20,7 +20,7 @@ select
         else null
       end as mode
     , sum(coalesce(mu.total_input_tokens, 0)) + sum(coalesce(mu.total_output_tokens, 0)) as "tokens"
-from kilo_dw.dbt_prod.microdollar_usage_daily as mu
+from microdollar_usage_daily as mu
 where
     mu.usage_date >= dateadd(week, -1, current_date())
     and mu.usage_date < current_date()

--- a/apps/web/src/app/api/public/leaderboard-provider-race/route.test.ts
+++ b/apps/web/src/app/api/public/leaderboard-provider-race/route.test.ts
@@ -18,7 +18,17 @@ jest.mock('@/lib/snowflake', () => ({
 
 type SnowflakeConfig = ReturnType<typeof resolveSnowflakeConfig>;
 
-const FAKE_CONFIG = { accountHost: 'test.snowflakecomputing.com' } as SnowflakeConfig;
+const FAKE_CONFIG = {
+  accountHost: 'test.snowflakecomputing.com',
+  jwtAccountIdentifier: 'TEST_ACCOUNT',
+  username: 'TEST_USER',
+  role: 'TEST_ROLE',
+  warehouse: 'TEST_WAREHOUSE',
+  database: 'TEST_DATABASE',
+  schema: 'TEST_SCHEMA',
+  privateKeyPem: 'test-private-key',
+  publicKeyFingerprint: 'SHA256:test-fingerprint',
+} satisfies NonNullable<SnowflakeConfig>;
 
 // The route builds a module-level in-process cache (1h TTL) at import time, so
 // each test loads it in an isolated module registry to keep that cache from
@@ -93,6 +103,44 @@ describe('GET /api/public/leaderboard-provider-race', () => {
     const response = await GET();
 
     expect(response.status).toBe(502);
+  });
+});
+
+describe('leaderboard Snowflake database and schema', () => {
+  test.each([
+    {
+      route: 'leaderboard-model-usage',
+      loadRoute: () => import('../leaderboard-model-usage/route'),
+      table: 'microdollar_usage_daily',
+    },
+    {
+      route: 'leaderboard-model-provider-usage',
+      loadRoute: () => import('../leaderboard-model-provider-usage/route'),
+      table: 'microdollar_usage_daily',
+    },
+    {
+      route: 'leaderboard-provider-race',
+      loadRoute: () => import('./route'),
+      table: 'usage_daily',
+    },
+  ])('$route uses the configured database and schema', async ({ loadRoute, table }) => {
+    await jest.isolateModulesAsync(async () => {
+      const snowflake = await import('@/lib/snowflake');
+      jest.mocked(snowflake.resolveSnowflakeConfig).mockReturnValue(FAKE_CONFIG);
+      const executeStatement = jest.mocked(snowflake.executeSnowflakeStatement);
+      executeStatement.mockReset().mockResolvedValue([]);
+      const { GET } = await loadRoute();
+
+      const response = await GET();
+
+      expect(response.status).toBe(200);
+      expect(executeStatement).toHaveBeenCalledTimes(1);
+      expect(executeStatement).toHaveBeenCalledWith({
+        config: FAKE_CONFIG,
+        statement: expect.stringMatching(new RegExp(`\\bfrom\\s+${table}\\s+as\\b`, 'i')),
+        timeoutSeconds: 30,
+      });
+    });
   });
 });
 

--- a/apps/web/src/app/api/public/leaderboard-provider-race/route.ts
+++ b/apps/web/src/app/api/public/leaderboard-provider-race/route.ts
@@ -25,7 +25,7 @@ select
     , ud.model_provider_company as provider
     , ud.is_open_weights
     , sum(ud.total_tokens) as tokens
-from kilo_dw.dbt_prod.usage_daily as ud
+from usage_daily as ud
 where
     ud.usage_date >= '2025-07-01'
     and date_trunc('week', ud.usage_date) < date_trunc('week', current_date())


### PR DESCRIPTION
## Summary
- Remove the legacy `kilo_dw.dbt_prod` qualification from all three public leaderboard queries.
- Resolve `microdollar_usage_daily` and `usage_daily` through the existing SQL API database/schema context (`SNOWFLAKE_DATABASE` and `SNOWFLAKE_SCHEMA`), matching Usage analytics. This allows the current `KILO_TRANSITION.KILO_CORE` target without hardcoding it in SQL.
- Add regression coverage for all three routes, verifying unqualified table references and forwarding the resolved configuration.

The endpoints restored by #5660 still targeted the old namespace. This PR is a fresh branch from main and contains no discarded Snowflake diagnostics changes. Response contracts, filters, aggregation semantics, caching, and credentials are unchanged.

## Validation
- Confirmed all three new regression cases fail with the original hardcoded prefixes and pass after the fix.
- `pnpm --filter web test --runInBand --runTestsByPath src/app/api/public/leaderboard-provider-race/route.test.ts src/lib/cached-fetch.test.ts` — 14 tests passed.
- `pnpm --filter web lint` — passed.
- `pnpm --filter web typecheck` — passed, with Rollup external-dependency warnings.
- Changed files formatted and checked using oxfmt with `--ignore-path .gitignore` because `.prettierignore` otherwise excludes API paths named `public`.
- `git diff --check` — passed.

## Deployment verification
No live Snowflake queries or environment changes were performed. After deployment, verify all three public endpoints return successful reports and the configured role can read the two rollups in the configured database/schema.