### PR TITLE
fix(web): normalize Snowflake hostnames for result fetching

### DIFF
--- a/apps/web/src/lib/snowflake.test.ts
+++ b/apps/web/src/lib/snowflake.test.ts
@@ -1,0 +1,146 @@
+import {
+  executeSnowflakeStatement,
+  resolveSnowflakeConfig,
+  type SnowflakeConfig,
+} from '@/lib/snowflake';
+
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 'test-token') }));
+
+const CONFIG = {
+  accountHost: 'test-account.snowflakecomputing.com',
+  jwtAccountIdentifier: 'TEST_ACCOUNT',
+  username: 'TEST_USER',
+  role: 'TEST_ROLE',
+  warehouse: 'TEST_WAREHOUSE',
+  database: 'TEST_DATABASE',
+  schema: 'TEST_SCHEMA',
+  privateKeyPem: 'test-private-key',
+  publicKeyFingerprint: 'SHA256:test-fingerprint',
+} satisfies SnowflakeConfig;
+
+const STATEMENT_PATH = '/api/v2/statements/test-handle';
+const STATEMENT_URL = `https://${CONFIG.accountHost}${STATEMENT_PATH}`;
+
+beforeEach(() => {
+  jest.replaceProperty(process, 'env', {
+    ...process.env,
+    SNOWFLAKE_ACCOUNT_HOST: CONFIG.accountHost,
+    SNOWFLAKE_JWT_ACCOUNT_IDENTIFIER: CONFIG.jwtAccountIdentifier,
+    SNOWFLAKE_USERNAME: CONFIG.username,
+    SNOWFLAKE_ROLE: CONFIG.role,
+    SNOWFLAKE_WAREHOUSE: CONFIG.warehouse,
+    SNOWFLAKE_DATABASE: CONFIG.database,
+    SNOWFLAKE_SCHEMA: CONFIG.schema,
+    SNOWFLAKE_PRIVATE_KEY_PEM: CONFIG.privateKeyPem,
+    SNOWFLAKE_PUBLIC_KEY_FINGERPRINT: CONFIG.publicKeyFingerprint,
+  });
+  jest.spyOn(global, 'fetch').mockRejectedValue(new Error('Unexpected fetch'));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('resolveSnowflakeConfig', () => {
+  test.each([
+    'test-account.snowflakecomputing.com',
+    'TEST-ACCOUNT.SNOWFLAKECOMPUTING.COM',
+    ' Test-Account.snowflakecomputing.com ',
+    ' https://Test-Account.snowflakecomputing.com/ ',
+    ' HTTPS://TEST-ACCOUNT.SNOWFLAKECOMPUTING.COM/ ',
+  ])('normalizes the hostname without changing other configuration: %s', accountHost => {
+    process.env.SNOWFLAKE_ACCOUNT_HOST = accountHost;
+
+    expect(resolveSnowflakeConfig()).toEqual(CONFIG);
+  });
+});
+
+describe.each([CONFIG.accountHost, 'Test-Account.SNOWFLAKECOMPUTING.COM'])(
+  'executeSnowflakeStatement with accountHost %s',
+  accountHost => {
+    const config = { ...CONFIG, accountHost };
+
+    test.each([undefined, STATEMENT_PATH, STATEMENT_URL])(
+      'fetches additional partitions using status URL %s',
+      async statementStatusUrl => {
+        const request = jest.mocked(global.fetch);
+        request
+          .mockResolvedValueOnce(
+            Response.json({
+              statementHandle: 'test-handle',
+              statementStatusUrl,
+              resultSetMetaData: { partitionInfo: [{}, {}] },
+              data: [['first']],
+            })
+          )
+          .mockResolvedValueOnce(Response.json({ data: [['second']] }));
+
+        await expect(executeSnowflakeStatement({ config, statement: 'SELECT 1' })).resolves.toEqual(
+          [['first'], ['second']]
+        );
+        expect(request).toHaveBeenCalledTimes(2);
+        expect(request).toHaveBeenNthCalledWith(
+          2,
+          new URL(`${STATEMENT_URL}?partition=1`),
+          expect.objectContaining({
+            headers: expect.objectContaining({ authorization: 'Bearer test-token' }),
+          })
+        );
+      }
+    );
+
+    test.each([STATEMENT_PATH, STATEMENT_URL])(
+      'polls an asynchronous statement using status URL %s',
+      async statementStatusUrl => {
+        const request = jest.mocked(global.fetch);
+        request
+          .mockResolvedValueOnce(Response.json({ statementStatusUrl }, { status: 202 }))
+          .mockResolvedValueOnce(Response.json({ data: [['complete']] }));
+
+        await expect(executeSnowflakeStatement({ config, statement: 'SELECT 1' })).resolves.toEqual(
+          [['complete']]
+        );
+        expect(request).toHaveBeenCalledTimes(2);
+        expect(request).toHaveBeenNthCalledWith(
+          2,
+          new URL(STATEMENT_URL),
+          expect.objectContaining({
+            headers: expect.objectContaining({ authorization: 'Bearer test-token' }),
+          })
+        );
+      }
+    );
+
+    test.each([
+      'https://other.snowflakecomputing.com/api/v2/statements/test-handle',
+      '//test-account.snowflakecomputing.com.attacker.example/api/v2/statements/test-handle',
+    ])('rejects a foreign partition host without fetching it: %s', async statementStatusUrl => {
+      const request = jest.mocked(global.fetch);
+      request.mockResolvedValueOnce(
+        Response.json({
+          statementStatusUrl,
+          resultSetMetaData: { partitionInfo: [{}, {}] },
+          data: [['first']],
+        })
+      );
+
+      await expect(executeSnowflakeStatement({ config, statement: 'SELECT 1' })).rejects.toThrow(
+        'Snowflake returned unexpected result host:'
+      );
+      expect(request).toHaveBeenCalledTimes(1);
+    });
+
+    test.each([
+      'https://other.snowflakecomputing.com/api/v2/statements/test-handle',
+      '//test-account.snowflakecomputing.com.attacker.example/api/v2/statements/test-handle',
+    ])('rejects a foreign polling host without fetching it: %s', async statementStatusUrl => {
+      const request = jest.mocked(global.fetch);
+      request.mockResolvedValueOnce(Response.json({ statementStatusUrl }, { status: 202 }));
+
+      await expect(executeSnowflakeStatement({ config, statement: 'SELECT 1' })).rejects.toThrow(
+        'Snowflake returned unexpected poll host:'
+      );
+      expect(request).toHaveBeenCalledTimes(1);
+    });
+  }
+);

--- a/apps/web/src/lib/snowflake.ts
+++ b/apps/web/src/lib/snowflake.ts
@@ -66,6 +66,7 @@ export function resolveSnowflakeConfig(): SnowflakeConfig | null {
   return {
     accountHost: accountHost
       .trim()
+      .toLowerCase()
       .replace(/^https?:\/\//, '')
       .replace(/\/$/, ''),
     jwtAccountIdentifier: getEnvVariable('SNOWFLAKE_JWT_ACCOUNT_IDENTIFIER'),
@@ -198,7 +199,7 @@ async function parseAllRows(
   }
 
   const url = new URL(statusUrl, `https://${config.accountHost}`);
-  if (url.hostname !== config.accountHost) {
+  if (url.hostname !== config.accountHost.toLowerCase()) {
     throw new Error(`Snowflake returned unexpected result host: ${url.hostname}`);
   }
 
@@ -231,7 +232,7 @@ async function pollStatement(
 ): Promise<SnowflakeApiResponse> {
   const url = new URL(statusUrl, `https://${config.accountHost}`);
 
-  if (url.hostname !== config.accountHost) {
+  if (url.hostname !== config.accountHost.toLowerCase()) {
     throw new Error(`Snowflake returned unexpected poll host: ${url.hostname}`);
   }
 


### PR DESCRIPTION
## Summary
- Normalize `SNOWFLAKE_ACCOUNT_HOST` to lowercase before removing optional scheme/trailing slash.
- Compare normalized hostnames when fetching additional result partitions and polling asynchronous statements, including callers that supply a mixed-case config directly.
- Keep rejection of genuinely different hosts before any follow-up request. JWT identifiers, credentials, query text, and logging are unchanged.

## Context
A reported Sentry event for `/api/public/leaderboard-model-usage` failed at the unexpected-result-host guard in `parseAllRows`. JavaScript normalizes URL hostnames to lowercase, while the configured host previously retained its original casing. A mixed-case configured hostname therefore rejects a legitimate same-host result URL. The same bug affects polling.

This reproduces and fixes that case mismatch; the actual deployed host values have not been inspected. This is a fresh branch from main, separate from the merged schema fix #5669, and does not reintroduce the discarded diagnostics work.

## Tests
- Added 23 client cases covering config normalization, lowercase and mixed-case configs, relative/absolute result URLs, statement-handle fallback, partition row aggregation, async polling, and foreign-host rejection without credential-bearing follow-up requests.
- Before the fix: 9 regression cases failed and 14 passed. After the fix: all 23 passed.
- `pnpm --filter web test --runInBand --runTestsByPath src/lib/snowflake.test.ts src/app/api/public/leaderboard-provider-race/route.test.ts src/routers/usage-analytics-router.test.ts` — 61 tests passed across 3 suites.
- `pnpm --filter web lint` — passed.
- `pnpm --filter web typecheck` — passed, with Rollup external-dependency warnings.
- `pnpm format apps/web/src/lib/snowflake.ts apps/web/src/lib/snowflake.test.ts` and changed-file formatting check — passed.
- `git diff --check` — passed.
- Independent read-only review found no actionable issues.

## Deployment verification
No live Snowflake requests or environment changes were performed. After deployment, confirm the affected leaderboard returns its full partitioned result and the unexpected-result-host error no longer occurs.