### PR TITLE
ci(pr-review): enable checks for context stack bases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, 'mobile-pr-review-context-5458-s*']
 
 # Cancel in-progress runs when a new commit is pushed to the same PR
 concurrency:
@@ -45,6 +45,9 @@ jobs:
       - name: Test dependency change detection
         run: node --test scripts/changed-dependencies.test.mjs
 
+      - name: Test stack CI configuration
+        run: node --test scripts/stack-ci-config.test.mjs
+
       - name: Detect changes
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -72,6 +75,13 @@ jobs:
               - 'pnpm-lock.yaml'
             cloud_agent_next:
               - 'services/cloud-agent-next/**'
+            pr_review_fixtures:
+              - 'dev/local/scripts/pr-review-provider-*.ts'
+
+      - name: Test PR review provider fixtures
+        if: steps.filter.outputs.pr_review_fixtures == 'true'
+        run: pnpm exec tsx --test dev/local/scripts/pr-review-provider-*.test.ts
+
       - name: Detect changed workspaces with tests
         id: workspaces
         run: |

--- a/.github/workflows/kilo-app-ci.yml
+++ b/.github/workflows/kilo-app-ci.yml
@@ -7,6 +7,7 @@ on:
       - 'apps/mobile/**'
       - 'packages/trpc/**'
       - 'apps/web/src/routers/**'
+      - 'apps/web/src/lib/github-pr-review/**'
       - 'packages/app-shared/**'
       - 'packages/kilo-chat/**'
       - 'packages/kilo-chat-hooks/**'
@@ -16,11 +17,12 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/kilo-app-ci.yml'
   pull_request:
-    branches: [main]
+    branches: [main, 'mobile-pr-review-context-5458-s*']
     paths:
       - 'apps/mobile/**'
       - 'packages/trpc/**'
       - 'apps/web/src/routers/**'
+      - 'apps/web/src/lib/github-pr-review/**'
       - 'packages/app-shared/**'
       - 'packages/kilo-chat/**'
       - 'packages/kilo-chat-hooks/**'

--- a/apps/web/src/lib/admin/admin-permissions-migration.test.ts
+++ b/apps/web/src/lib/admin/admin-permissions-migration.test.ts
@@ -1,7 +1,7 @@
 import { cp, mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { Pool } from 'pg';
+import { Client, Pool } from 'pg';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
 
@@ -23,7 +23,7 @@ describe('admin permissions migration', () => {
     const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), 'admin-permissions-migration-'));
     const previousMigrations = path.join(temporaryRoot, 'migrations');
     const adminPool = new Pool({ connectionString: adminUrl.toString() });
-    let testPool: Pool | undefined;
+    let testClient: Client | undefined;
 
     try {
       await adminPool.query(`CREATE DATABASE "${databaseName}"`);
@@ -37,9 +37,10 @@ describe('admin permissions migration', () => {
       journal.entries = journal.entries.filter(entry => entry.tag !== migrationTag);
       await writeFile(journalPath, JSON.stringify(journal, null, 2));
 
-      testPool = new Pool({ connectionString: databaseUrl.toString() });
-      await migrate(drizzle(testPool), { migrationsFolder: previousMigrations });
-      await testPool.query(
+      testClient = new Client({ connectionString: databaseUrl.toString() });
+      await testClient.connect();
+      await migrate(drizzle(testClient), { migrationsFolder: previousMigrations });
+      await testClient.query(
         `INSERT INTO kilocode_users
           (id, google_user_email, google_user_name, google_user_image_url, stripe_customer_id, hosted_domain, is_admin, blocked_reason)
          VALUES
@@ -55,9 +56,9 @@ describe('admin permissions migration', () => {
         path.join(migrationsSource, `${migrationTag}.sql`),
         'utf8'
       );
-      await testPool.query(migrationSql);
+      await testClient.query(migrationSql);
 
-      const migrated = await testPool.query<{
+      const migrated = await testClient.query<{
         id: string;
         is_super_admin: boolean;
         can_view_sessions: boolean;
@@ -83,7 +84,7 @@ describe('admin permissions migration', () => {
         { id: 'wrong-email-admin', is_super_admin: false, can_view_sessions: false },
       ]);
 
-      const inserted = await testPool.query<{
+      const inserted = await testClient.query<{
         is_super_admin: boolean;
         can_view_sessions: boolean;
       }>(
@@ -94,8 +95,8 @@ describe('admin permissions migration', () => {
       );
       expect(inserted.rows).toEqual([{ is_super_admin: false, can_view_sessions: false }]);
     } finally {
-      await testPool?.end();
-      await adminPool.query(`DROP DATABASE IF EXISTS "${databaseName}" WITH (FORCE)`);
+      await testClient?.end();
+      await adminPool.query(`DROP DATABASE IF EXISTS "${databaseName}"`);
       await adminPool.end();
       await rm(temporaryRoot, { recursive: true, force: true });
     }

--- a/scripts/stack-ci-config.test.mjs
+++ b/scripts/stack-ci-config.test.mjs
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { matchesGlob } from 'node:path';
+import test from 'node:test';
+import { load } from 'js-yaml';
+
+const workflows = ['ci', 'kilo-app-ci'].map(name =>
+  load(readFileSync(new URL(`../.github/workflows/${name}.yml`, import.meta.url), 'utf8'))
+);
+const matches = (value, patterns) => patterns.some(pattern => matchesGlob(value, pattern));
+
+function assertStackCoverage([root, mobile]) {
+  for (const workflow of [root, mobile]) {
+    assert.deepEqual(workflow.on.push.branches, ['main'], 'pushes must remain main-only');
+    const branches = workflow.on.pull_request.branches;
+    for (const base of [
+      'main',
+      ...Array.from({ length: 17 }, (_, i) => `mobile-pr-review-context-5458-s${i + 1}`),
+    ]) {
+      assert.ok(matches(base, branches), `missing PR base: ${base}`);
+    }
+    for (const base of [
+      'feature/unrelated',
+      'mainly',
+      'mobile-pr-review-context-5459-s1',
+      'mobile-pr-review-context-5458',
+    ]) {
+      assert.ok(!matches(base, branches), `unrelated PR base: ${base}`);
+    }
+  }
+  assert.ok(Object.hasOwn(mobile.on, 'workflow_call'), 'mobile workflow_call must remain');
+  for (const event of ['push', 'pull_request']) {
+    assert.ok(
+      matches('apps/web/src/lib/github-pr-review/context-dtos.ts', mobile.on[event].paths),
+      `missing mobile helper coverage: ${event}`
+    );
+    for (const path of [
+      'apps/web/src/lib/unrelated.ts',
+      'dev/local/scripts/pr-review-provider-mock.ts',
+      'apps/extension/src/index.ts',
+    ]) {
+      assert.ok(!matches(path, mobile.on[event].paths), `unrelated mobile path: ${event}: ${path}`);
+    }
+  }
+  assert.equal(root.jobs.changes.if, undefined, 'changes job must be unconditional');
+  const steps = root.jobs.changes.steps;
+  const dependencyTest = steps.findIndex(
+    step => step.run === 'node --test scripts/changed-dependencies.test.mjs'
+  );
+  assert.ok(dependencyTest >= 0, 'missing dependency test');
+  const configTest = steps[dependencyTest + 1];
+  assert.equal(
+    configTest?.run,
+    'node --test scripts/stack-ci-config.test.mjs',
+    'missing adjacent configuration test'
+  );
+  assert.equal(configTest.if, undefined, 'configuration test must be unconditional');
+  const filter = steps.find(step => step.id === 'filter');
+  const filters = load(filter.with.filters);
+  for (const name of ['mock', 'control', 'scenarios']) {
+    for (const suffix of ['ts', 'test.ts']) {
+      assert.ok(
+        matches(
+          `dev/local/scripts/pr-review-provider-${name}.${suffix}`,
+          filters.pr_review_fixtures ?? []
+        ),
+        'missing dev-fixture filter'
+      );
+    }
+  }
+  for (const path of [
+    'dev/local/scripts/unrelated.test.ts',
+    'apps/web/src/lib/github-pr-review/context-dtos.ts',
+  ]) {
+    assert.ok(!matches(path, filters.pr_review_fixtures), `unrelated dev-fixture path: ${path}`);
+  }
+  const fixtureTest = steps.find(
+    step => step.run === 'pnpm exec tsx --test dev/local/scripts/pr-review-provider-*.test.ts'
+  );
+  assert.equal(
+    fixtureTest?.if,
+    "steps.filter.outputs.pr_review_fixtures == 'true'",
+    'missing focused dev-fixture test'
+  );
+  assert.ok(
+    steps.indexOf(fixtureTest) > steps.indexOf(filter),
+    'dev-fixture test must follow filtering'
+  );
+}
+
+test('main and every stacked PR run the required configuration and source suites', () => {
+  assertStackCoverage(workflows);
+});
+
+for (const [index, name] of ['root', 'mobile'].entries()) {
+  test(`rejects a missing ${name} stack pattern`, () => {
+    const fixture = structuredClone(workflows);
+    fixture[index].on.pull_request.branches = ['main'];
+    assert.throws(() => assertStackCoverage(fixture), /missing PR base/);
+  });
+  test(`rejects non-main ${name} pushes and unrelated PR bases`, () => {
+    const fixture = structuredClone(workflows);
+    fixture[index].on.push.branches.push('feature');
+    assert.throws(() => assertStackCoverage(fixture), /main-only/);
+    fixture[index].on.push.branches = ['main'];
+    fixture[index].on.pull_request.branches.push('**');
+    assert.throws(() => assertStackCoverage(fixture), /unrelated PR base/);
+  });
+}
+
+for (const event of ['push', 'pull_request']) {
+  test(`rejects missing mobile helper coverage on ${event}`, () => {
+    const fixture = structuredClone(workflows);
+    fixture[1].on[event].paths = fixture[1].on[event].paths.filter(
+      path => !path.includes('github-pr-review')
+    );
+    assert.throws(() => assertStackCoverage(fixture), /missing mobile helper coverage/);
+  });
+  for (const path of ['apps/web/src/lib/**', 'dev/**', 'apps/extension/**']) {
+    test(`rejects broad mobile filter ${path} on ${event}`, () => {
+      const fixture = structuredClone(workflows);
+      fixture[1].on[event].paths.push(path);
+      assert.throws(() => assertStackCoverage(fixture), /unrelated mobile path/);
+    });
+  }
+}
+
+for (const path of ['dev/**', 'apps/web/src/**']) {
+  test(`rejects broad dev-fixture filter ${path}`, () => {
+    const fixture = structuredClone(workflows);
+    const filter = fixture[0].jobs.changes.steps.find(step => step.id === 'filter');
+    filter.with.filters = `pr_review_fixtures: ["dev/local/scripts/pr-review-provider-*.ts", "${path}"]`;
+    assert.throws(() => assertStackCoverage(fixture), /unrelated dev-fixture path/);
+  });
+}
+
+test('rejects removed mobile calls, gated configuration tests, and skipped fixture tests', () => {
+  const fixture = structuredClone(workflows);
+  delete fixture[1].on.workflow_call;
+  assert.throws(() => assertStackCoverage(fixture), /workflow_call/);
+  fixture[1].on.workflow_call = null;
+  fixture[0].jobs.changes.if = 'false';
+  assert.throws(() => assertStackCoverage(fixture), /changes job must be unconditional/);
+  delete fixture[0].jobs.changes.if;
+  const steps = fixture[0].jobs.changes.steps;
+  const configTest = steps.find(
+    step => step.run === 'node --test scripts/stack-ci-config.test.mjs'
+  );
+  configTest.if = 'false';
+  assert.throws(() => assertStackCoverage(fixture), /unconditional/);
+  delete configTest.if;
+  const configIndex = steps.indexOf(configTest);
+  steps.splice(configIndex, 1);
+  assert.throws(() => assertStackCoverage(fixture), /missing adjacent configuration test/);
+  steps.splice(configIndex, 0, configTest);
+  const filter = steps.find(step => step.id === 'filter');
+  const filters = filter.with.filters;
+  filter.with.filters = 'pr_review_fixtures: []';
+  assert.throws(() => assertStackCoverage(fixture), /missing dev-fixture filter/);
+  filter.with.filters = filters;
+  const fixtureTest = steps.find(step => step.run?.includes('pr-review-provider-*.test.ts'));
+  fixtureTest.if = 'false';
+  assert.throws(() => assertStackCoverage(fixture), /missing focused dev-fixture test/);
+});


### PR DESCRIPTION
No new behavior — this update changes development checks and test cleanup, not the application.

---

## Summary

Continuous integration (CI) now accepts `pull_request` targets matching `mobile-pr-review-context-5458-s*`; `push` remains limited to `main`, and mobile `workflow_call` remains available. Shared review helpers now select mobile checks, while `pr_review_fixtures` selects provider tests only when their source or tests change. Unconditional configuration checks enforce these limits and their position after dependency checks, so regressions fail before dependent jobs run.

<details>
<summary>Files</summary>

- `.github/workflows/ci.yml` — modified (+11/−1 lines). Adds the stack branch pattern, checks the configuration before filtering, and gates provider tests on `dev/local/scripts/pr-review-provider-*.ts`.
- `.github/workflows/kilo-app-ci.yml` — modified (+3/−1 lines). Watches `apps/web/src/lib/github-pr-review/**` for both event types and adds the stack branch pattern.
- `scripts/stack-ci-config.test.mjs` — added (+164/−0 lines). Validates both workflows, `main`, stack bases 1–17, helper paths, provider selection, and test ordering. Rejects altered configurations that broaden filters, omit coverage, gate configuration checks, or remove `workflow_call`.

</details>

The admin permissions migration test replaces its test pool with one connected `pg.Client`, which owns the migration, fixture, and assertion queries. Cleanup awaits `Client.end()` before plain `DROP DATABASE IF EXISTS`; the administrative pool stays, and cleanup no longer uses `WITH (FORCE)`. The migration inputs, fixture SQL, normal assertions, and application behavior stay unchanged.

<details>
<summary>Files</summary>

- `apps/web/src/lib/admin/admin-permissions-migration.test.ts` — modified (+11/−10 lines). Connects the test client before migration and reuses it throughout the test. Awaits its closure, drops the database without force, and retains temporary-directory removal.

</details>

Tests: 2 files changed — `scripts/stack-ci-config.test.mjs` added (+164/−0 lines); `apps/web/src/lib/admin/admin-permissions-migration.test.ts` updated (+11/−10 lines).
Generated: 0 changed files.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual application checks were not run because the owner prohibits new slots and bundles.
- End-to-end (E2E) application verification remains pending; no report is attached.
- Level 2 supplied stack-base CI evidence in cloud run `33225548604` and mobile run `33225548635`; later fixture proof remains required.

## Reviewer Notes

### Scoped automated evidence

- The recorded migration proof covers test blob `09ce5b23bb8a2f26486facbd04eeba22c4150fbb` in owning tree `1e5b3dddaa74b7ee4172ea233337256864487d48` and cumulative tree `4cbe426ce1baeb2affcff2adba7d397d4e17ad7f`.
- Four full migration tests passed with both unchanged assertions. Two further tests failed only with `MigrationFixtureInsertFailure_g19` after the complete prior migrations; both cleanup checks passed.
- Each run recorded completed `Client.end()` before the plain database drop. Independent checks found zero owned databases, sessions, and migration temporary directories after every run.
- Both publication snapshots passed scoped test-root type checks, lint, and formatting. Repository-wide checks remain assigned to CI.
- After resource shutdown, no owner container, network, service session, or open service port remained. The dormant Compose volume remains; no live resource remains.
- This proof covers successful tests and an injected fixture-insertion failure, not every database failure. It proves closure ordering, not the exact historical SQL causing PostgreSQL `57P01`.

### Human steps

- **before merge** — The owner must lift the resource hold before required runtime verification.

No deployment or manual migration step applies to this test-only repair. The owner retains product merges.

### Notes

This level changes CI and test cleanup only; application runtime verification remains pending for the complete section.

The 22 prefix snapshots pass static checks but still lack their required live checks and publication.

Named visual variants are owner-descoped: large text/font scaling, theme variants, contrast rendering, scaled-text layout, and screen-reader presentation.

Functional accessibility, default appearance, provider controls, complete-stack runtime proof, reviews, translations, and final readiness gates remain required.

Levels 24 and 25 retain prepared but unpublished repairs, pending the previously recorded workflow operation.
Their owning/cumulative tests and formatting pass; their type and publication gates remain incomplete.

No human-ready label, assignment, or product merge is authorized by this update.

This interim description update does not replace the final section refresh.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679 ← this PR
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)

