### PR TITLE
fix(extension): expose honest browser runner outcomes

### DIFF
--- a/apps/extension/entrypoints/sidepanel/agent-llm-turn-runner.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-llm-turn-runner.test.ts
@@ -135,16 +135,21 @@ describe('dangerous turn runner workflow wiring', () => {
     }) as Parameters<typeof runDangerousLlmTurn>[0];
 
   const outcomeCases: {
+    assistantMessages?: string[];
     completion?: KiloGatewayChatCompletion;
     confirmed?: number;
     error?: Error;
-    expected: Pick<LlmTurnOutcome, 'reason' | 'status'> & Partial<Pick<LlmTurnOutcome, 'summary'>>;
+    expected: Pick<LlmTurnOutcome, 'reason' | 'status'> & {
+      summary?: string;
+      toolResults?: Partial<LlmTurnOutcome['toolResults'][number]>[];
+    };
     label: string;
     nextCompletion?: KiloGatewayChatCompletion;
     requests: number;
     rounds?: number;
     stop?: 'cancelled' | 'lease_lost';
     uncertain?: boolean;
+    workflowTools?: KiloGatewayToolDefinition[];
   }[] = [
     {
       error: new ExecutionStoppedError('execution_timeout', 'interrupted', true),
@@ -217,6 +222,59 @@ describe('dangerous turn runner workflow wiring', () => {
       label: 'confirmed action without final answer',
       requests: 1,
       rounds: 1,
+    },
+    {
+      assistantMessages: ['Creating the workflow now.', 'Creating the workflow now.'],
+      completion: {
+        finishReason: 'tool_calls',
+        toolCalls: [{ arguments: {}, id: 'read-1', name: 'get_page_snapshot' }],
+      },
+      confirmed: 1,
+      expected: {
+        reason: 'incomplete_response',
+        status: 'failed',
+        summary: 'Creating the workflow now.',
+        toolResults: [{ effectsUncertain: false, ok: true, value: 'safe' }],
+      },
+      label: 'unconfirmed announcement after continuation exhaustion',
+      nextCompletion: {
+        content: 'Creating the workflow now.',
+        finishReason: 'stop',
+        toolCalls: [],
+      },
+      requests: 3,
+    },
+    {
+      completion: {
+        finishReason: 'tool_calls',
+        toolCalls: [
+          { arguments: {}, id: 'read-1', name: 'get_page_snapshot' },
+          ...Array.from({ length: 25 }, (_value, index) => ({
+            arguments: { workflowId: `missing-${String(index)}` },
+            id: `failure-${String(index)}`,
+            name: 'get_workflow' as const,
+          })),
+          { arguments: { query: 'must not run' }, id: 'read-after-cap', name: 'find_in_page' },
+        ],
+      },
+      confirmed: 26,
+      expected: {
+        reason: 'tool_failure_limit',
+        status: 'failed',
+        toolResults: [
+          { effectsUncertain: false, ok: true, value: 'safe' },
+          ...Array.from({ length: 25 }, () => ({
+            effectsUncertain: false,
+            error: 'Workflow tool get_workflow is no longer available.',
+            ok: false as const,
+          })),
+        ],
+      },
+      label: 'tool failure cap with a pending read',
+      nextCompletion: { content: 'False success.', finishReason: 'stop', toolCalls: [] },
+      requests: 1,
+      // Missing workflow context exercises the wrapper's real confirmed failure path.
+      workflowTools: [makeToolDef('get_workflow')],
     },
     {
       completion: {
@@ -323,6 +381,7 @@ describe('dangerous turn runner workflow wiring', () => {
             );
           },
           signal: controller.signal,
+          workflowTools: entry.workflowTools,
         })
       );
       await vi.runAllTimersAsync();
@@ -331,12 +390,17 @@ describe('dangerous turn runner workflow wiring', () => {
         ...entry.expected,
         effectsUncertain: entry.uncertain ?? false,
       });
-      expect(appended.filter(event => event.type === 'message')).toMatchObject([
-        { role: 'assistant', text: result.summary },
-      ]);
+      expect(appended.filter(event => event.type === 'message')).toMatchObject(
+        (entry.assistantMessages ?? [result.summary]).map(text => ({ role: 'assistant', text }))
+      );
       expect(result.toolResults).toHaveLength(entry.confirmed ?? 0);
-      expect(actions).toHaveLength(entry.confirmed ?? 0);
-      expect(requests).toBe(entry.requests);
+      expect(result.toolResults).toStrictEqual(
+        appended.filter(event => event.type === 'tool-result')
+      );
+      expect({ actions: actions.length, requests }).toStrictEqual({
+        actions: entry.confirmed ?? 0,
+        requests: entry.requests,
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/apps/extension/entrypoints/sidepanel/agent-llm-turn-runner.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-llm-turn-runner.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable consistent-type-imports, no-unsafe-type-assertion, jest/no-untyped-mock-factory, no-useless-undefined, vitest/prefer-called-once, vitest/prefer-called-times, import/first -- test mock factories and fixture constraints */
+/* eslint-disable import/max-dependencies, max-lines, jest/no-conditional-in-test, consistent-type-imports, no-unsafe-type-assertion, jest/no-untyped-mock-factory, no-useless-undefined, vitest/prefer-called-once, vitest/prefer-called-times, import/first -- Outcome matrices use stateful executor fakes and typed module mocks. */
 import { describe, expect, it, vi } from 'vitest';
 
 // eslint-disable-next-line vitest/prefer-import-in-mock, jest/no-untyped-mock-factory
@@ -15,7 +15,13 @@ vi.mock('#imports', () => ({
 
 // eslint-disable-next-line vitest/prefer-import-in-mock
 vi.mock('@/src/shared/agent-llm-turn-runner-core', () => ({
-  runLlmTurn: vi.fn().mockResolvedValue(undefined),
+  runLlmTurn: vi.fn().mockResolvedValue({
+    effectsUncertain: false,
+    reason: 'completed',
+    status: 'succeeded',
+    summary: 'Done.',
+    toolResults: [],
+  }),
 }));
 
 // eslint-disable-next-line vitest/prefer-import-in-mock
@@ -50,9 +56,44 @@ import { executeWorkflowToolCall } from './agent-workflow-tool-runtime';
 // eslint-disable-next-line import/first
 import { discoverWebMcpTools, executeWebMcpToolCall } from './agent-web-mcp-tool-runtime';
 // eslint-disable-next-line import/first
-import type { KiloGatewayToolDefinition, KiloGatewayToolName } from '@/src/shared/kilo-api-client';
+import type {
+  KiloGatewayChatCompletion,
+  KiloGatewayToolDefinition,
+  KiloGatewayToolName,
+} from '@/src/shared/kilo-api-client';
+import type { LlmTurnOutcome } from '@/src/shared/agent-llm-turn-runner-core';
+import { ExecutionStoppedError } from '@/src/shared/agent-tool-results';
+import { browser } from '#imports';
+import {
+  evalInTabWithScripting,
+  EVAL_TAB_MESSAGE,
+  isTabDebuggerRequest,
+} from '@/src/shared/tab-debugger';
+import { hashWorkflowScript } from '@/src/shared/agent-workflows';
+import { evalInTab } from './agent-workflow-runtime';
 // eslint-disable-next-line import/first
 import { maxAgentToolRounds } from '@/src/shared/agent-tool-round-limit';
+
+const gatewayResponse = (completion: KiloGatewayChatCompletion): Response =>
+  new Response(
+    `data: ${JSON.stringify({
+      choices: [
+        {
+          delta: {
+            content: completion.content,
+            reasoning: completion.reasoning,
+            tool_calls: completion.toolCalls.map((call, index) => ({
+              function: { arguments: JSON.stringify(call.arguments), name: call.name },
+              id: call.id,
+              index,
+            })),
+          },
+          finish_reason: completion.finishReason,
+        },
+      ],
+    })}\n\n`,
+    { headers: { 'Content-Type': 'text/event-stream' } }
+  );
 
 const makeToolDef = (name: string): KiloGatewayToolDefinition =>
   ({
@@ -93,6 +134,446 @@ describe('dangerous turn runner workflow wiring', () => {
       ...overrides,
     }) as Parameters<typeof runDangerousLlmTurn>[0];
 
+  const outcomeCases: {
+    completion?: KiloGatewayChatCompletion;
+    confirmed?: number;
+    error?: Error;
+    expected: Pick<LlmTurnOutcome, 'reason' | 'status'> & Partial<Pick<LlmTurnOutcome, 'summary'>>;
+    label: string;
+    nextCompletion?: KiloGatewayChatCompletion;
+    requests: number;
+    rounds?: number;
+    stop?: 'cancelled' | 'lease_lost';
+    uncertain?: boolean;
+  }[] = [
+    {
+      error: new ExecutionStoppedError('execution_timeout', 'interrupted', true),
+      expected: { reason: 'execution_timeout', status: 'interrupted' },
+      label: 'uncertain execution timeout',
+      requests: 1,
+      uncertain: true,
+    },
+    {
+      completion: { content: 'Final answer.', finishReason: 'stop', toolCalls: [] },
+      expected: { reason: 'completed', status: 'succeeded', summary: 'Final answer.' },
+      label: 'complete answer without evidence',
+      requests: 1,
+    },
+    {
+      completion: { finishReason: 'stop', toolCalls: [] },
+      expected: { reason: 'empty_response', status: 'failed' },
+      label: 'empty response',
+      requests: 1,
+    },
+    {
+      completion: { finishReason: 'model_context_window_exceeded', toolCalls: [] },
+      expected: {
+        reason: 'context_overflow',
+        status: 'failed',
+        summary: 'The model did not return a response.',
+      },
+      label: 'empty context overflow',
+      requests: 1,
+    },
+    {
+      completion: { finishReason: 'length', toolCalls: [] },
+      expected: {
+        reason: 'truncated_response',
+        status: 'failed',
+        summary: 'The model did not return a response.',
+      },
+      label: 'exhausted empty truncation',
+      requests: 3,
+    },
+    {
+      completion: { content: 'Partial answer.', finishReason: 'length', toolCalls: [] },
+      expected: { reason: 'truncated_response', status: 'failed', summary: 'Partial answer.' },
+      label: 'partial final output',
+      requests: 3,
+    },
+    {
+      completion: {
+        content: 'Partial answer.',
+        finishReason: 'model_context_window_exceeded',
+        toolCalls: [],
+      },
+      expected: { reason: 'context_overflow', status: 'failed', summary: 'Partial answer.' },
+      label: 'context overflow',
+      requests: 1,
+    },
+    {
+      expected: { reason: 'rounds_exhausted', status: 'failed' },
+      label: 'exhausted rounds',
+      requests: 0,
+      rounds: 0,
+    },
+    {
+      completion: {
+        finishReason: 'tool_calls',
+        toolCalls: [{ arguments: {}, id: 'read-1', name: 'get_page_snapshot' }],
+      },
+      confirmed: 1,
+      expected: { reason: 'rounds_exhausted', status: 'failed' },
+      label: 'confirmed action without final answer',
+      requests: 1,
+      rounds: 1,
+    },
+    {
+      completion: {
+        finishReason: 'tool_calls',
+        toolCalls: [
+          { arguments: {}, id: 'read-1', name: 'get_page_snapshot' },
+          { arguments: {}, id: 'unknown-1', name: 'unknown_tool' as KiloGatewayToolName },
+        ],
+      },
+      expected: { reason: 'unsafe_tool_call', status: 'failed' },
+      label: 'unknown call in a mixed batch',
+      nextCompletion: { content: 'False success.', finishReason: 'stop', toolCalls: [] },
+      requests: 1,
+    },
+    {
+      completion: {
+        toolCalls: [{ arguments: {}, id: 'unfinished-1', name: 'get_page_snapshot' }],
+      },
+      expected: { reason: 'truncated_response', status: 'failed' },
+      label: 'tool batch without finish metadata',
+      nextCompletion: { content: 'False success.', finishReason: 'stop', toolCalls: [] },
+      requests: 1,
+    },
+    {
+      error: new TypeError('Gateway stream tool call did not include a supported tool name.'),
+      expected: { reason: 'completed', status: 'succeeded', summary: 'Recovered.' },
+      label: 'transport TypeError with the same message as an unsupported tool',
+      nextCompletion: { content: 'Recovered.', finishReason: 'stop', toolCalls: [] },
+      requests: 2,
+    },
+    {
+      error: new Error('Model failed.'),
+      expected: {
+        reason: 'model_failure',
+        status: 'failed',
+        summary: 'LLM request failed: Model failed.',
+      },
+      label: 'model failure',
+      requests: 1,
+    },
+    {
+      error: new TypeError('Network failed.'),
+      expected: { reason: 'retry_exhausted', status: 'failed' },
+      label: 'retry exhaustion',
+      requests: 3,
+    },
+    {
+      expected: { reason: 'cancelled', status: 'cancelled' },
+      label: 'Stop before a model round',
+      requests: 0,
+      stop: 'cancelled',
+    },
+    {
+      expected: { reason: 'lease_lost', status: 'interrupted' },
+      label: 'lost lease before a model round',
+      requests: 0,
+      stop: 'lease_lost',
+    },
+  ];
+
+  it.each(outcomeCases)('returns the real stream outcome for $label', async entry => {
+    const core = await vi.importActual<typeof import('@/src/shared/agent-llm-turn-runner-core')>(
+      '@/src/shared/agent-llm-turn-runner-core'
+    );
+    let requests = 0;
+    const actions: string[] = [];
+    const appended: Parameters<Parameters<typeof runDangerousLlmTurn>[0]['appendEvents']>[0] = [];
+    vi.mocked(discoverWebMcpTools).mockResolvedValue(undefined);
+    vi.mocked(runLlmTurn).mockImplementationOnce(options =>
+      core.runLlmTurn({
+        ...options,
+        executeToolCall: toolCall => {
+          actions.push(toolCall.name);
+          return options.executeToolCall(toolCall);
+        },
+        maxToolRounds: entry.rounds ?? 5,
+      })
+    );
+    const controller = new AbortController();
+    if (entry.stop === 'cancelled') {
+      controller.abort();
+    }
+    vi.useFakeTimers();
+    try {
+      const pending = runDangerousLlmTurn(
+        buildOptions({
+          appendEvents: events => appended.push(...events),
+          executionGuard: () => {
+            if (entry.stop === 'lease_lost') {
+              throw new ExecutionStoppedError('lease_lost');
+            }
+          },
+          fetch: () => {
+            requests += 1;
+            if (
+              entry.error !== undefined &&
+              (requests === 1 || entry.nextCompletion === undefined)
+            ) {
+              throw entry.error;
+            }
+            return gatewayResponse(
+              (requests > 1 ? entry.nextCompletion : undefined) ??
+                entry.completion ?? { content: 'Done.', finishReason: 'stop', toolCalls: [] }
+            );
+          },
+          signal: controller.signal,
+        })
+      );
+      await vi.runAllTimersAsync();
+      const result = await pending;
+      expect(result).toMatchObject({
+        ...entry.expected,
+        effectsUncertain: entry.uncertain ?? false,
+      });
+      expect(appended.filter(event => event.type === 'message')).toMatchObject([
+        { role: 'assistant', text: result.summary },
+      ]);
+      expect(result.toolResults).toHaveLength(entry.confirmed ?? 0);
+      expect(actions).toHaveLength(entry.confirmed ?? 0);
+      expect(requests).toBe(entry.requests);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { confirmed: false, reason: 'lease_lost', status: 'interrupted' as const },
+    { confirmed: false, reason: 'owner_cancelled', status: 'cancelled' as const },
+    { confirmed: true, reason: 'owner_cancelled', status: 'cancelled' as const },
+  ])(
+    'retains $reason after an issued search (confirmed=$confirmed)',
+    async ({ confirmed, reason, status }) => {
+      const core = await vi.importActual<typeof import('@/src/shared/agent-llm-turn-runner-core')>(
+        '@/src/shared/agent-llm-turn-runner-core'
+      );
+      const controller = new AbortController();
+      const request = Promise.withResolvers<Response>();
+      const issued = Promise.withResolvers<void>();
+      const requests: string[] = [];
+      const actions: string[] = [];
+      const searchResult = { results: [{ url: 'https://example.com/observed' }] };
+      vi.mocked(discoverWebMcpTools).mockResolvedValue(undefined);
+      vi.mocked(runLlmTurn).mockImplementationOnce(options =>
+        core.runLlmTurn({
+          ...options,
+          executeToolCall: toolCall => {
+            actions.push(toolCall.name);
+            return options.executeToolCall(toolCall);
+          },
+        })
+      );
+      const pending = runDangerousLlmTurn(
+        buildOptions({
+          fetch: (input, init) => {
+            requests.push(String(input));
+            if (input === 'https://api.example.com/api/exa/search') {
+              init?.signal?.addEventListener(
+                'abort',
+                () => {
+                  request.reject(init.signal?.reason);
+                },
+                {
+                  once: true,
+                }
+              );
+              issued.resolve();
+              return request.promise;
+            }
+            return gatewayResponse(
+              requests.length === 1
+                ? {
+                    finishReason: 'tool_calls',
+                    toolCalls: [
+                      {
+                        arguments: { query: 'observed result' },
+                        id: 'search-1',
+                        name: 'web_search',
+                      },
+                      { arguments: {}, id: 'read-2', name: 'get_page_snapshot' },
+                    ],
+                  }
+                : { content: 'False success.', finishReason: 'stop', toolCalls: [] }
+            );
+          },
+          signal: controller.signal,
+        })
+      );
+      await issued.promise;
+      if (confirmed) {
+        request.resolve(Response.json(searchResult));
+      }
+      controller.abort(new ExecutionStoppedError(reason, status));
+      const result = await pending;
+
+      expect(result).toMatchObject({ effectsUncertain: !confirmed, reason, status });
+      expect(result.toolResults).toMatchObject(
+        confirmed ? [{ effectsUncertain: false, ok: true, value: searchResult }] : []
+      );
+      expect(actions).toStrictEqual(['web_search']);
+      expect(requests).toStrictEqual([
+        'https://api.example.com/api/gateway/v1/chat/completions',
+        'https://api.example.com/api/exa/search',
+      ]);
+    }
+  );
+
+  it('propagates a scripting timeout through the workflow adapter to the core', async () => {
+    const core = await vi.importActual<typeof import('@/src/shared/agent-llm-turn-runner-core')>(
+      '@/src/shared/agent-llm-turn-runner-core'
+    );
+    const runtime = await vi.importActual<typeof import('./agent-workflow-tool-runtime')>(
+      './agent-workflow-tool-runtime'
+    );
+    const gateway = await import('@/src/shared/kilo-api-client');
+    const script = 'return { done: true, result: "observed" };';
+    const workflow = {
+      approvedScriptHash: await hashWorkflowScript(script),
+      createdAt: 1,
+      description: 'Test',
+      id: 'wf-1',
+      name: 'Test',
+      scopeOrigin: 'https://example.com',
+      script,
+      updatedAt: 1,
+    };
+    const release = Promise.withResolvers<void>();
+    const finished = Promise.withResolvers<void>();
+    const actions: string[] = [];
+    const appended: Parameters<Parameters<typeof runDangerousLlmTurn>[0]['appendEvents']>[0] = [];
+    let requests = 0;
+    const stream = vi
+      .spyOn(gateway, 'fetchKiloGatewayChatCompletionStream')
+      .mockImplementation(() => {
+        requests += 1;
+        return Promise.resolve(
+          requests === 1
+            ? {
+                finishReason: 'tool_calls',
+                toolCalls: [1, 2].map(index => ({
+                  arguments: { workflowId: 'wf-1' },
+                  id: `workflow-${String(index)}`,
+                  name: 'run_workflow',
+                })),
+              }
+            : { content: 'Done.', finishReason: 'stop', toolCalls: [] }
+        );
+      });
+    vi.mocked(runLlmTurn).mockImplementationOnce(core.runLlmTurn);
+    vi.mocked(executeWorkflowToolCall).mockImplementation(runtime.executeWorkflowToolCall);
+    vi.mocked(discoverWebMcpTools).mockResolvedValue(undefined);
+    vi.mocked(browser.runtime.sendMessage).mockReset();
+    // eslint-disable-next-line typescript-eslint/no-misused-promises -- The browser overload includes a void callback form; this fake implements its Promise form.
+    vi.mocked(browser.runtime.sendMessage).mockImplementation(async (message: unknown) => {
+      if (!isTabDebuggerRequest(message) || message.type !== EVAL_TAB_MESSAGE) {
+        throw new Error('Unexpected browser message.');
+      }
+      return {
+        ok: true,
+        result: await evalInTabWithScripting({
+          code: message.code,
+          scriptingApi: {
+            executeScript: async () => {
+              actions.push('eval');
+              await release.promise;
+              actions.push('issued action completed later');
+              finished.resolve();
+              return [{ result: { ok: true, value: { done: true, result: 'observed' } } }];
+            },
+          },
+          tabId: message.tabId,
+          timeoutMs: 1,
+        }),
+        type: EVAL_TAB_MESSAGE,
+      };
+    });
+    try {
+      const result = await runDangerousLlmTurn(
+        buildOptions({
+          appendEvents: events => appended.push(...events),
+          maxToolRounds: 3,
+          workflowToolContext: {
+            ...makeWorkflowCtx(),
+            evalInTab,
+            getTabUrl: () => Promise.resolve('https://example.com/page'),
+            storage: {
+              getItem: () => Promise.resolve([workflow]),
+              removeItem: () => {},
+              setItem: () => {},
+            },
+          },
+          workflowTools: [makeToolDef('run_workflow')],
+        })
+      );
+      expect(result).toMatchObject({
+        effectsUncertain: true,
+        reason: 'effects_uncertain',
+        status: 'interrupted',
+        toolResults: [],
+      });
+      expect(appended).toContainEqual(
+        expect.objectContaining({ effectsUncertain: true, ok: false, type: 'tool-result' })
+      );
+      expect({
+        actions,
+        requests,
+        sends: vi.mocked(browser.runtime.sendMessage).mock.calls.length,
+      }).toStrictEqual({ actions: ['eval'], requests: 1, sends: 1 });
+      release.resolve();
+      await finished.promise;
+      expect({ actions, requests }).toStrictEqual({
+        actions: ['eval', 'issued action completed later'],
+        requests: 1,
+      });
+    } finally {
+      release.resolve();
+      stream.mockRestore();
+      vi.mocked(executeWorkflowToolCall)
+        .mockReset()
+        .mockResolvedValue({ effectsUncertain: false, ok: true, value: 'workflow' });
+      vi.mocked(browser.runtime.sendMessage).mockReset();
+    }
+  });
+
+  it('keeps cancellation and uncertainty when an issued eval aborts', async () => {
+    const core = await vi.importActual<typeof import('@/src/shared/agent-llm-turn-runner-core')>(
+      '@/src/shared/agent-llm-turn-runner-core'
+    );
+    const gateway = await import('@/src/shared/kilo-api-client');
+    const stream = vi.spyOn(gateway, 'fetchKiloGatewayChatCompletionStream').mockResolvedValue({
+      finishReason: 'tool_calls',
+      toolCalls: [1, 2].map(index => ({
+        arguments: { code: 'return 1;' },
+        id: `eval-${String(index)}`,
+        name: 'eval',
+      })),
+    });
+    vi.mocked(runLlmTurn).mockImplementationOnce(core.runLlmTurn);
+    vi.mocked(discoverWebMcpTools).mockResolvedValue(undefined);
+    vi.mocked(browser.runtime.sendMessage)
+      .mockReset()
+      .mockRejectedValue(new DOMException('Stopped.', 'AbortError'));
+    try {
+      const result = await runDangerousLlmTurn(buildOptions());
+      expect(result).toMatchObject({
+        effectsUncertain: true,
+        reason: 'cancelled',
+        status: 'cancelled',
+        toolResults: [],
+      });
+      expect(browser.runtime.sendMessage).toHaveBeenCalledOnce();
+      expect(stream).toHaveBeenCalledOnce();
+    } finally {
+      stream.mockRestore();
+      vi.mocked(browser.runtime.sendMessage).mockReset();
+    }
+  });
+
   it('routes workflow tool calls to executeWorkflowToolCall', async () => {
     vi.mocked(runLlmTurn).mockClear();
     vi.mocked(executeWorkflowToolCall).mockClear();
@@ -106,6 +587,13 @@ describe('dangerous turn runner workflow wiring', () => {
         type: 'tool-call' as const,
       };
       await options.executeToolCall(toolCall);
+      return {
+        effectsUncertain: false,
+        reason: 'completed',
+        status: 'succeeded',
+        summary: 'Done.',
+        toolResults: [],
+      };
     });
 
     await runDangerousLlmTurn(
@@ -191,7 +679,7 @@ describe('dangerous turn runner workflow wiring', () => {
 
     const prepared = await prepareTools!();
 
-    expect(discoverWebMcpTools).toHaveBeenCalledWith(7);
+    expect(discoverWebMcpTools).toHaveBeenCalledWith(7, expect.any(Function));
     expect(prepared).toHaveLength(tools.length + 1);
     expect(prepared.at(-1)!.function.name).toBe('double');
   });
@@ -248,6 +736,13 @@ describe('dangerous turn runner workflow wiring', () => {
         webMcpOrigin: 'https://example.com',
       };
       await options.executeToolCall(toolCall);
+      return {
+        effectsUncertain: false,
+        reason: 'completed',
+        status: 'succeeded',
+        summary: 'Done.',
+        toolResults: [],
+      };
     });
 
     await runDangerousLlmTurn(buildOptions({ workflowToolContext: makeWorkflowCtx() }));

--- a/apps/extension/entrypoints/sidepanel/agent-llm-turn-runner.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-llm-turn-runner.ts
@@ -9,7 +9,9 @@ import {
   createSafeToolDefinitions,
 } from '@/src/shared/agent-llm-harness';
 import { runLlmTurn } from '@/src/shared/agent-llm-turn-runner-core';
-import type { OnTurnUsage } from '@/src/shared/agent-llm-turn-runner-core';
+import type { LlmTurnOutcome, OnTurnUsage } from '@/src/shared/agent-llm-turn-runner-core';
+import { normalizeExecutionGuard } from '@/src/shared/agent-tool-results';
+import type { ExecutionGuard } from '@/src/shared/agent-tool-results';
 import { maxAgentToolRounds } from '@/src/shared/agent-tool-round-limit';
 import type { FetchLike } from '@/src/shared/auth';
 import type {
@@ -19,7 +21,8 @@ import type {
 import type { EvalTabResult } from '@/src/shared/tab-debugger';
 import { buildWebMcpToolDefinitions } from '@/src/shared/web-mcp-tools';
 import type { WebMcpToolRoute } from '@/src/shared/web-mcp-tools';
-import { executeEvalToolCall } from './agent-eval-runtime';
+import { DEFAULT_EVAL_TIMEOUT_MS } from '@/src/shared/tab-debugger';
+import { evalInTab } from './agent-workflow-runtime';
 import { createSafeToolExecutor } from './agent-safe-tool-runtime';
 import {
   isRemoteMcpToolCallEvent,
@@ -39,12 +42,16 @@ interface RunDangerousLlmTurnOptions {
   readonly apiBaseUrl: string;
   readonly appendEvents: (events: AgentConversationEvent[]) => void;
   readonly conversationEvents: AgentConversationEvent[];
+  readonly executionGuard?: ExecutionGuard | undefined;
   readonly fetch: FetchLike;
   readonly model: string;
   readonly organizationId?: string | undefined;
   readonly remoteMcpTools?: KiloGatewayToolDefinition[] | undefined;
   readonly executeRemoteMcpToolCall?:
-    | ((toolCall: RemoteMcpToolCallEvent) => Promise<EvalTabResult>)
+    | ((
+        toolCall: RemoteMcpToolCallEvent,
+        executionGuard?: ExecutionGuard
+      ) => Promise<EvalTabResult>)
     | undefined;
   readonly toRemoteMcpToolCallEvents?:
     | ((toolCalls: KiloGatewayToolCallRequest[]) => RemoteMcpToolCallEvent[])
@@ -79,12 +86,17 @@ export const runDangerousLlmTurn = ({
   workflowToolContext,
   workflowTools = [],
   ...options
-}: RunDangerousLlmTurnOptions): Promise<void> => {
+}: RunDangerousLlmTurnOptions): Promise<LlmTurnOutcome> => {
+  const guard = normalizeExecutionGuard(
+    options.executionGuard ?? workflowToolContext?.executionGuard,
+    options.signal
+  );
   // One executor per turn: a fresh unchanged-snapshot memory, so a new conversation's first snapshot is served in full.
-  const executeSafeToolCall = createSafeToolExecutor();
+  const executeSafeToolCall = createSafeToolExecutor(guard);
   // One executor per turn: it carries the abort signal and caps the searches this turn may bill.
   const runWebSearch = createWebSearchExecutor({
     apiBaseUrl: options.apiBaseUrl,
+    executionGuard: guard,
     fetch: options.fetch,
     organizationId: options.organizationId,
     signal: options.signal,
@@ -105,28 +117,34 @@ export const runDangerousLlmTurn = ({
     ...options,
     // eslint-disable-next-line require-await -- async normalizes the sync no-executor error branch into the Promise<EvalTabResult> the runner expects.
     executeToolCall: async (toolCall): Promise<EvalTabResult> => {
+      guard();
       if (isWebMcpToolCallEvent(toolCall)) {
-        return executeWebMcpToolCall(toolCall);
+        return executeWebMcpToolCall(toolCall, guard);
       }
 
       if (isWorkflowToolCallEvent(toolCall)) {
         if (workflowToolContext === undefined) {
           return {
+            effectsUncertain: false,
             error: `Workflow tool ${toolCall.name} is no longer available.`,
             ok: false,
           };
         }
-        return executeWorkflowToolCall(toolCall, workflowToolContext);
+        return executeWorkflowToolCall(toolCall, { ...workflowToolContext, executionGuard: guard });
       }
 
       if (isRemoteMcpToolCallEvent(toolCall)) {
         return executeRemoteMcpToolCall === undefined
-          ? { error: `Remote MCP tool ${toolCall.name} is no longer available.`, ok: false }
-          : executeRemoteMcpToolCall(toolCall);
+          ? {
+              effectsUncertain: false,
+              error: `Remote MCP tool ${toolCall.name} is no longer available.`,
+              ok: false,
+            }
+          : executeRemoteMcpToolCall(toolCall, guard);
       }
 
       if (toolCall.name === 'eval') {
-        return executeEvalToolCall(toolCall);
+        return evalInTab(toolCall.tabId, toolCall.code, guard, DEFAULT_EVAL_TIMEOUT_MS);
       }
 
       if (toolCall.name === 'web_search') {
@@ -135,6 +153,7 @@ export const runDangerousLlmTurn = ({
 
       return executeSafeToolCall(toolCall);
     },
+    executionGuard: guard,
     failureMessage: error =>
       `LLM request failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
     maxToolRounds,
@@ -142,7 +161,7 @@ export const runDangerousLlmTurn = ({
     prepareTools: async () => {
       webMcpRoutes = new Map();
 
-      const discovery = await discoverWebMcpTools(selectedTabId);
+      const discovery = await discoverWebMcpTools(selectedTabId, guard);
 
       if (discovery === undefined || discovery.documentId === '') {
         return fixedTools;

--- a/apps/extension/entrypoints/sidepanel/agent-remote-mcp-tool-runtime.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-remote-mcp-tool-runtime.test.ts
@@ -1,23 +1,31 @@
+/* eslint-disable max-lines -- Exercise the real MCP client, transport, adapter, and runner in one focused suite. */
+import {
+  ErrorCode,
+  isJSONRPCRequest,
+  JSONRPCMessageSchema,
+  LATEST_PROTOCOL_VERSION,
+} from '@modelcontextprotocol/sdk/types.js';
+import type {
+  CallToolResult,
+  JSONRPCErrorResponse,
+  JSONRPCRequest,
+} from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it, vi } from 'vitest';
+import { createRemoteMcpToolCall, createUserMessage } from '@/src/shared/agent-conversation';
+import type { AgentConversationEvent } from '@/src/shared/agent-conversation';
+import { runLlmTurn } from '@/src/shared/agent-llm-turn-runner-core';
+import { ExecutionStoppedError } from '@/src/shared/agent-tool-results';
+import type { ExecutionGuard } from '@/src/shared/agent-tool-results';
 import type { RemoteMcpServer } from '@/src/shared/remote-mcp';
+import { buildRemoteMcpToolDefinitions } from '@/src/shared/remote-mcp-tools';
 import type { RemoteMcpToolRoute } from '@/src/shared/remote-mcp-tools';
 import type { KiloGatewayToolCallRequest } from '@/src/shared/kilo-api-client';
-
-const mocks = vi.hoisted(() => ({
-  callRemoteMcpTool: vi.fn<(args: unknown) => Promise<unknown>>(),
-}));
-
-// eslint-disable-next-line vitest/prefer-import-in-mock, jest/no-untyped-mock-factory
-vi.mock('./remote-mcp-client', () => ({ callRemoteMcpTool: mocks.callRemoteMcpTool }));
-
-// eslint-disable-next-line import/first
 import { executeRemoteMcpToolCall } from './agent-remote-mcp-tool-runtime';
-// eslint-disable-next-line import/first
 import { toRemoteMcpToolCallEvents } from './agent-tool-call-events';
-// eslint-disable-next-line import/first
-import { createRemoteMcpToolCall } from '@/src/shared/agent-conversation';
-// eslint-disable-next-line import/first
-import { buildRemoteMcpToolDefinitions } from '@/src/shared/remote-mcp-tools';
+
+// The OAuth provider imports browser; these unauthenticated fixtures never use it.
+// eslint-disable-next-line vitest/prefer-import-in-mock, jest/no-untyped-mock-factory
+vi.mock('#imports', () => ({ browser: {} }));
 
 const connectedServer = (overrides: Partial<RemoteMcpServer> = {}): RemoteMcpServer => ({
   allowInSafeMode: false,
@@ -35,8 +43,47 @@ const connectedServer = (overrides: Partial<RemoteMcpServer> = {}): RemoteMcpSer
 const routesFor = (servers: readonly RemoteMcpServer[]): ReadonlyMap<string, RemoteMcpToolRoute> =>
   buildRemoteMcpToolDefinitions({ mode: 'dangerous', servers }).routes;
 
-// eslint-disable-next-line promise/prefer-await-to-then, @typescript-eslint/no-unsafe-type-assertion
-const plainFetch = (() => Promise.resolve(new Response())) as unknown as typeof fetch;
+// Only the HTTP peer is controlled. The SDK and callRemoteMcpTool remain real.
+const createRemote = (rejection?: JSONRPCErrorResponse['error']) => {
+  const initialize = vi.fn<() => Promise<void>>().mockResolvedValue();
+  const callTool = vi
+    .fn<() => Promise<CallToolResult>>()
+    .mockResolvedValue({ content: [{ text: 'ok', type: 'text' }] });
+  const requests: Request[] = [];
+  const toolCalls: JSONRPCRequest[] = [];
+  const fetch: typeof globalThis.fetch = async (input, init) => {
+    const request = new Request(input, init);
+    requests.push(request);
+    if (request.method === 'GET') {
+      return new Response(null, { status: 405 });
+    }
+    const message = JSONRPCMessageSchema.parse(await request.json());
+    if (!isJSONRPCRequest(message)) {
+      return new Response(null, { status: 202 });
+    }
+    if (message.method === 'initialize') {
+      await initialize();
+      return Response.json({
+        id: message.id,
+        jsonrpc: '2.0',
+        result: {
+          capabilities: { tools: {} },
+          protocolVersion: LATEST_PROTOCOL_VERSION,
+          serverInfo: { name: 'fixture', version: '1.0.0' },
+        },
+      });
+    }
+    if (message.method === 'tools/call') {
+      toolCalls.push(message);
+      if (toolCalls.length === 1 && rejection !== undefined) {
+        return Response.json({ error: rejection, id: message.id, jsonrpc: '2.0' });
+      }
+      return Response.json({ id: message.id, jsonrpc: '2.0', result: await callTool() });
+    }
+    throw new Error(`Unexpected MCP method: ${message.method}`);
+  };
+  return { callTool, fetch, initialize, requests, toolCalls };
+};
 
 const searchEvent = (
   name: `mcp_${string}` = 'mcp_acme_search'
@@ -48,6 +95,76 @@ const searchEvent = (
     serverId: 'server-1',
     serverName: 'Acme',
   });
+
+const runRemoteTurn = async (
+  remote: ReturnType<typeof createRemote>,
+  options: { executionGuard?: ExecutionGuard; signal?: AbortSignal } = {}
+) => {
+  const server = connectedServer();
+  const { routes, tools } = buildRemoteMcpToolDefinitions({ mode: 'dangerous', servers: [server] });
+  const events: AgentConversationEvent[] = [];
+  const responses = [
+    {
+      choices: [
+        {
+          delta: {
+            tool_calls: ['first', 'second'].map((query, index) => ({
+              function: { arguments: JSON.stringify({ query }), name: 'mcp_acme_search' },
+              id: `call-${index}`,
+              index,
+              type: 'function',
+            })),
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+    },
+    { choices: [{ delta: { content: 'Done.' }, finish_reason: 'stop' }] },
+  ]
+    .map(
+      chunk =>
+        new Response(`data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`, {
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+    )
+    .values();
+  let modelRequests = 0;
+  const outcome = await runLlmTurn<ReturnType<typeof createRemoteMcpToolCall>>({
+    apiBaseUrl: 'https://app.kilo.ai',
+    appendEvents: appended => events.push(...appended),
+    conversationEvents: [createUserMessage('Run both searches.')],
+    executeToolCall: event =>
+      executeRemoteMcpToolCall({
+        event,
+        executionGuard: options.executionGuard,
+        fetch: remote.fetch,
+        routes,
+        servers: [server],
+        signal: options.signal,
+      }),
+    executionGuard: options.executionGuard,
+    failureMessage: String,
+    fetch: () => {
+      modelRequests += 1;
+      const response = responses.next().value;
+      if (response === undefined) {
+        throw new Error('Unexpected model retry.');
+      }
+      return response;
+    },
+    maxToolRounds: 3,
+    model: 'test-model',
+    noResponseMessage: 'No response.',
+    signal: options.signal,
+    toToolCallEvents: calls => toRemoteMcpToolCallEvents(calls, routes),
+    token: 'gateway-token',
+    tooManyToolRoundsMessage: 'Too many rounds.',
+    tools,
+    updateAssistantMessage: vi.fn(),
+    updateThinkingBlock: vi.fn(),
+  });
+  return { events, modelRequests, outcome };
+};
 
 describe('remote MCP tool-call event converter', () => {
   it('builds serverId/serverName/remoteToolName from the matching route', () => {
@@ -87,103 +204,293 @@ describe('remote MCP tool-call event converter', () => {
 });
 
 describe('remote MCP tool executor', () => {
+  it('stops later actions and prevents success after an issued transport fails', async () => {
+    const remote = createRemote();
+    remote.callTool.mockRejectedValueOnce(new Error('Connection lost.'));
+
+    const { events, modelRequests, outcome } = await runRemoteTurn(remote);
+
+    expect(outcome).toMatchObject({
+      effectsUncertain: true,
+      reason: 'effects_uncertain',
+      status: 'interrupted',
+      toolResults: [],
+    });
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        effectsUncertain: true,
+        error: 'Connection lost.',
+        ok: false,
+        type: 'tool-result',
+      })
+    );
+    expect(remote.toolCalls).toMatchObject([{ params: { arguments: { query: 'first' } } }]);
+    expect(modelRequests).toBe(1);
+  });
+
+  it('propagates AbortError through the SDK instead of returning a recoverable failure', async () => {
+    const error = new DOMException('Stopped.', 'AbortError');
+    const controller = new AbortController();
+    const remote = createRemote();
+    remote.callTool.mockImplementationOnce(async () => {
+      await Promise.resolve();
+      controller.abort(error);
+      return { content: [] };
+    });
+    const server = connectedServer();
+
+    await expect(
+      executeRemoteMcpToolCall({
+        event: searchEvent(),
+        fetch: remote.fetch,
+        routes: routesFor([server]),
+        servers: [server],
+        signal: controller.signal,
+      })
+    ).rejects.toBe(error);
+    expect(remote.toolCalls).toHaveLength(1);
+  });
+
+  it('retains a typed owner reason and uncertain effects after an issued call aborts', async () => {
+    const controller = new AbortController();
+    const remote = createRemote();
+    remote.callTool.mockImplementationOnce(async () => {
+      await Promise.resolve();
+      controller.abort(new ExecutionStoppedError('lease_lost'));
+      return { content: [] };
+    });
+
+    const { events, modelRequests, outcome } = await runRemoteTurn(remote, {
+      signal: controller.signal,
+    });
+
+    expect(outcome).toMatchObject({
+      effectsUncertain: true,
+      reason: 'lease_lost',
+      status: 'interrupted',
+      summary: 'Interrupted: lease_lost.',
+      toolResults: [],
+    });
+    expect(events.at(-1)).toMatchObject({ text: 'Interrupted: lease_lost.', type: 'message' });
+    expect(remote.toolCalls).toHaveLength(1);
+    expect(modelRequests).toBe(1);
+  });
+
+  it('rejects lost authority before calling the remote client', async () => {
+    const remote = createRemote();
+    const server = connectedServer();
+    await expect(
+      executeRemoteMcpToolCall({
+        event: searchEvent(),
+        executionGuard: () => {
+          throw new Error('lease_lost');
+        },
+        fetch: remote.fetch,
+        routes: routesFor([server]),
+        servers: [server],
+      })
+    ).rejects.toMatchObject({
+      effectsUncertain: false,
+      reason: 'lease_lost',
+      status: 'interrupted',
+    });
+    expect(remote.requests).toHaveLength(0);
+  });
+
+  it('prevents dispatch when the owner revokes authority during connection setup', async () => {
+    const remote = createRemote();
+    const connecting = Promise.withResolvers<void>();
+    const finishConnection = Promise.withResolvers<void>();
+    const executionGuard = vi.fn<ExecutionGuard>();
+    remote.initialize.mockImplementationOnce(() => {
+      connecting.resolve();
+      return finishConnection.promise;
+    });
+    const turn = runRemoteTurn(remote, { executionGuard });
+    await connecting.promise;
+    executionGuard.mockImplementation(() => {
+      throw new ExecutionStoppedError('lease_lost');
+    });
+    finishConnection.resolve();
+
+    const { modelRequests, outcome } = await turn;
+
+    expect(outcome).toMatchObject({
+      effectsUncertain: false,
+      reason: 'lease_lost',
+      status: 'interrupted',
+      toolResults: [],
+    });
+    expect(remote.toolCalls).toHaveLength(0);
+    expect(modelRequests).toBe(1);
+  });
+
+  it('keeps connection failure confirmed when no tool request was issued', async () => {
+    const remote = createRemote();
+    remote.initialize.mockRejectedValueOnce(new Error('connect failed'));
+    const server = connectedServer();
+
+    await expect(
+      executeRemoteMcpToolCall({
+        event: searchEvent(),
+        fetch: remote.fetch,
+        routes: routesFor([server]),
+        servers: [server],
+      })
+    ).resolves.toStrictEqual({ effectsUncertain: false, error: 'connect failed', ok: false });
+    expect(remote.toolCalls).toHaveLength(0);
+  });
+
   it('returns ok:true with a capped value on success', async () => {
-    mocks.callRemoteMcpTool.mockClear();
-    mocks.callRemoteMcpTool.mockResolvedValueOnce({ content: [{ text: 'ok', type: 'text' }] });
+    const remote = createRemote();
     const server = connectedServer();
 
     const result = await executeRemoteMcpToolCall({
       event: searchEvent(),
-      fetch: plainFetch,
+      fetch: remote.fetch,
       routes: routesFor([server]),
       servers: [server],
     });
 
-    expect(result).toStrictEqual({ ok: true, value: { content: [{ text: 'ok', type: 'text' }] } });
+    expect(result).toStrictEqual({
+      effectsUncertain: false,
+      ok: true,
+      value: { content: [{ text: 'ok', type: 'text' }] },
+    });
   });
 
   it('caps oversized results', async () => {
-    mocks.callRemoteMcpTool.mockClear();
-    mocks.callRemoteMcpTool.mockResolvedValueOnce({ big: 'x'.repeat(70 * 1024) });
+    const remote = createRemote();
+    remote.callTool.mockResolvedValueOnce({
+      content: [{ text: 'x'.repeat(70 * 1024), type: 'text' }],
+    });
     const server = connectedServer();
 
     const result = await executeRemoteMcpToolCall({
       event: searchEvent(),
-      fetch: plainFetch,
+      fetch: remote.fetch,
       routes: routesFor([server]),
       servers: [server],
     });
 
-    expect(result).toMatchObject({ ok: true, value: { truncated: true } });
+    expect(result).toMatchObject({ effectsUncertain: false, ok: true, value: { truncated: true } });
   });
 
-  it('passes the supplied fetch through to callRemoteMcpTool', async () => {
-    mocks.callRemoteMcpTool.mockClear();
-    mocks.callRemoteMcpTool.mockResolvedValueOnce({ content: [] });
+  it('uses the supplied fetch and preserves an empty confirmed result', async () => {
+    const remote = createRemote();
+    remote.callTool.mockResolvedValueOnce({ content: [] });
     const server = connectedServer();
 
-    await executeRemoteMcpToolCall({
+    const result = await executeRemoteMcpToolCall({
       event: searchEvent(),
-      fetch: plainFetch,
+      fetch: remote.fetch,
       routes: routesFor([server]),
       servers: [server],
     });
 
-    expect(mocks.callRemoteMcpTool).toHaveBeenCalledWith(
-      expect.objectContaining({ fetch: plainFetch })
+    expect(result).toStrictEqual({ effectsUncertain: false, ok: true, value: { content: [] } });
+    expect(new Set(remote.requests.map(request => request.url))).toStrictEqual(
+      new Set([server.url])
     );
   });
 
-  it('returns a tool error and never calls the client for an unresolved route', async () => {
-    mocks.callRemoteMcpTool.mockClear();
-
+  it('returns a confirmed tool error without a request for an unresolved route', async () => {
+    const remote = createRemote();
     const result = await executeRemoteMcpToolCall({
       event: searchEvent('mcp_gone_tool'),
-      fetch: plainFetch,
+      fetch: remote.fetch,
       routes: new Map(),
       servers: [],
     });
 
-    expect(result.ok).toBe(false);
-    expect(mocks.callRemoteMcpTool).not.toHaveBeenCalled();
+    expect(result).toStrictEqual({
+      effectsUncertain: false,
+      error: 'Remote MCP tool mcp_gone_tool is no longer available.',
+      ok: false,
+    });
+    expect(remote.requests).toHaveLength(0);
   });
 
-  it('returns a tool error and never calls the client for a disabled server', async () => {
-    mocks.callRemoteMcpTool.mockClear();
+  it('returns a confirmed tool error without a request for a disabled server', async () => {
+    const remote = createRemote();
     const server = connectedServer();
-
     const result = await executeRemoteMcpToolCall({
       event: searchEvent(),
-      fetch: plainFetch,
+      fetch: remote.fetch,
       routes: routesFor([server]),
       servers: [{ ...server, enabled: false }],
     });
 
-    expect(result.ok).toBe(false);
-    expect(mocks.callRemoteMcpTool).not.toHaveBeenCalled();
+    expect(result).toStrictEqual({
+      effectsUncertain: false,
+      error: 'Remote MCP tool mcp_acme_search is no longer available.',
+      ok: false,
+    });
+    expect(remote.requests).toHaveLength(0);
   });
 
-  it('maps an isError MCP result to a tool error', async () => {
-    mocks.callRemoteMcpTool.mockClear();
-    mocks.callRemoteMcpTool.mockResolvedValueOnce({
+  it('keeps a confirmed server tool error recoverable through the runner', async () => {
+    const remote = createRemote();
+    remote.callTool.mockResolvedValueOnce({
       content: [{ text: 'boom', type: 'text' }],
       isError: true,
     });
-    const server = connectedServer();
 
-    const result = await executeRemoteMcpToolCall({
-      event: searchEvent(),
-      fetch: plainFetch,
-      routes: routesFor([server]),
-      servers: [server],
+    const { modelRequests, outcome } = await runRemoteTurn(remote);
+
+    expect(outcome).toMatchObject({
+      effectsUncertain: false,
+      reason: 'completed',
+      status: 'succeeded',
+      summary: 'Done.',
+      toolResults: [
+        { effectsUncertain: false, error: 'boom', ok: false },
+        { effectsUncertain: false, ok: true, value: { content: [{ text: 'ok', type: 'text' }] } },
+      ],
     });
-
-    expect(result).toStrictEqual({ error: 'boom', ok: false });
+    expect(remote.toolCalls).toHaveLength(2);
+    expect(modelRequests).toBe(2);
   });
 
+  it.each([
+    {
+      code: ErrorCode.InvalidParams,
+      expectedError: 'MCP error -32602: Invalid query.',
+      message: 'Invalid query.',
+    },
+    {
+      code: ErrorCode.MethodNotFound,
+      expectedError: 'MCP error -32601: Method not found.',
+      message: 'Method not found.',
+    },
+  ])(
+    'keeps a received JSON-RPC rejection recoverable through the runner: $code',
+    async ({ code, expectedError, message }) => {
+      const remote = createRemote({ code, message });
+
+      const { modelRequests, outcome } = await runRemoteTurn(remote);
+
+      expect(outcome).toMatchObject({
+        effectsUncertain: false,
+        reason: 'completed',
+        status: 'succeeded',
+        summary: 'Done.',
+        toolResults: [
+          { effectsUncertain: false, error: expectedError, ok: false },
+          { effectsUncertain: false, ok: true, value: { content: [{ text: 'ok', type: 'text' }] } },
+        ],
+      });
+      expect(remote.toolCalls).toMatchObject([
+        { params: { arguments: { query: 'first' } } },
+        { params: { arguments: { query: 'second' } } },
+      ]);
+      expect(modelRequests).toBe(2);
+    }
+  );
+
   it('caps an oversized isError message', async () => {
-    mocks.callRemoteMcpTool.mockClear();
-    mocks.callRemoteMcpTool.mockResolvedValueOnce({
+    const remote = createRemote();
+    remote.callTool.mockResolvedValueOnce({
       content: [{ text: 'x'.repeat(70 * 1024), type: 'text' }],
       isError: true,
     });
@@ -191,11 +498,15 @@ describe('remote MCP tool executor', () => {
 
     const result = await executeRemoteMcpToolCall({
       event: searchEvent(),
-      fetch: plainFetch,
+      fetch: remote.fetch,
       routes: routesFor([server]),
       servers: [server],
     });
 
-    expect(result).toStrictEqual({ error: 'x'.repeat(64 * 1024), ok: false });
+    expect(result).toStrictEqual({
+      effectsUncertain: false,
+      error: 'x'.repeat(64 * 1024),
+      ok: false,
+    });
   });
 });

--- a/apps/extension/entrypoints/sidepanel/agent-remote-mcp-tool-runtime.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-remote-mcp-tool-runtime.ts
@@ -1,5 +1,7 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { RemoteMcpToolCallEvent } from '@/src/shared/agent-conversation';
+import { isExecutionStopped, normalizeExecutionGuard } from '@/src/shared/agent-tool-results';
+import type { ExecutionGuard } from '@/src/shared/agent-tool-results';
 import type { RemoteMcpServer } from '@/src/shared/remote-mcp';
 import type { RemoteMcpStorageArea } from '@/src/shared/remote-mcp-storage';
 import type { RemoteMcpToolRoute } from '@/src/shared/remote-mcp-tools';
@@ -8,7 +10,7 @@ import {
   MAX_REMOTE_MCP_RESULT_CHARS,
   resolveRemoteMcpToolRoute,
 } from '@/src/shared/remote-mcp-tools';
-import type { EvalTabResult } from '@/src/shared/tab-debugger';
+import type { NormalizedEvalTabResult } from '@/src/shared/tab-debugger';
 import { callRemoteMcpTool } from './remote-mcp-client';
 
 type FetchLike = typeof fetch;
@@ -29,6 +31,7 @@ const getMcpErrorText = (result: CallToolResult): string => {
  */
 export const executeRemoteMcpToolCall = async ({
   event,
+  executionGuard,
   fetch: fetchFn,
   routes,
   servers,
@@ -36,36 +39,60 @@ export const executeRemoteMcpToolCall = async ({
   storageArea,
 }: {
   readonly event: RemoteMcpToolCallEvent;
+  readonly executionGuard?: ExecutionGuard | undefined;
   readonly fetch: FetchLike;
   readonly routes: ReadonlyMap<string, RemoteMcpToolRoute>;
   readonly servers: readonly RemoteMcpServer[];
   readonly signal?: AbortSignal | undefined;
   readonly storageArea?: RemoteMcpStorageArea | undefined;
-}): Promise<EvalTabResult> => {
+}): Promise<NormalizedEvalTabResult> => {
+  const guard = normalizeExecutionGuard(executionGuard, signal);
+  guard();
   const resolution = resolveRemoteMcpToolRoute(routes, event.name);
 
   if (!resolution.ok) {
-    return { error: resolution.error, ok: false };
+    return { effectsUncertain: false, error: resolution.error, ok: false };
   }
 
   const server = servers.find(candidate => candidate.id === resolution.route.serverId);
 
   if (server === undefined || !server.enabled || server.status !== 'connected') {
-    return { error: `Remote MCP tool ${event.name} is no longer available.`, ok: false };
+    return {
+      effectsUncertain: false,
+      error: `Remote MCP tool ${event.name} is no longer available.`,
+      ok: false,
+    };
   }
 
-  const raw = await callRemoteMcpTool({
-    arguments: event.arguments,
-    fetch: fetchFn,
-    route: resolution.route,
-    server,
-    ...(signal === undefined ? {} : { signal }),
-    ...(storageArea === undefined ? {} : { storageArea }),
-  });
+  try {
+    guard();
+    const raw = await callRemoteMcpTool({
+      arguments: event.arguments,
+      executionGuard: guard,
+      fetch: fetchFn,
+      route: resolution.route,
+      server,
+      ...(signal === undefined ? {} : { signal }),
+      ...(storageArea === undefined ? {} : { storageArea }),
+    });
 
-  if (raw.isError === true) {
-    return { error: getMcpErrorText(raw).slice(0, MAX_REMOTE_MCP_RESULT_CHARS), ok: false };
+    if (raw.isError === true) {
+      return {
+        effectsUncertain: false,
+        error: getMcpErrorText(raw).slice(0, MAX_REMOTE_MCP_RESULT_CHARS),
+        ok: false,
+      };
+    }
+
+    return { effectsUncertain: false, ok: true, value: capRemoteMcpToolResult(raw) };
+  } catch (error) {
+    if (isExecutionStopped(error)) {
+      throw error;
+    }
+    return {
+      effectsUncertain: true,
+      error: error instanceof Error ? error.message : 'Remote MCP tool call failed.',
+      ok: false,
+    };
   }
-
-  return { ok: true, value: capRemoteMcpToolResult(raw) };
 };

--- a/apps/extension/entrypoints/sidepanel/agent-safe-llm-turn-runner.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-safe-llm-turn-runner.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable consistent-type-imports, no-unsafe-type-assertion, no-unsafe-call, no-unsafe-member-access, no-unsafe-assignment, no-unsafe-argument, id-length, prefer-destructuring, jest/no-untyped-mock-factory, no-useless-undefined, vitest/prefer-called-once, vitest/prefer-called-times, import/first -- test mock factories and fixture constraints */
+/* eslint-disable max-lines, jest/no-conditional-in-test, consistent-type-imports, no-unsafe-type-assertion, no-unsafe-call, no-unsafe-member-access, no-unsafe-assignment, no-unsafe-argument, id-length, prefer-destructuring, jest/no-untyped-mock-factory, no-useless-undefined, vitest/prefer-called-once, vitest/prefer-called-times, import/first -- test mock factories and fixture constraints */
 import { describe, expect, it, vi } from 'vitest';
 
 // eslint-disable-next-line vitest/prefer-import-in-mock, jest/no-untyped-mock-factory
@@ -15,7 +15,13 @@ vi.mock('#imports', () => ({
 
 // eslint-disable-next-line vitest/prefer-import-in-mock
 vi.mock('@/src/shared/agent-llm-turn-runner-core', () => ({
-  runLlmTurn: vi.fn().mockResolvedValue(undefined),
+  runLlmTurn: vi.fn().mockResolvedValue({
+    effectsUncertain: false,
+    reason: 'completed',
+    status: 'succeeded',
+    summary: 'Done.',
+    toolResults: [],
+  }),
 }));
 
 // eslint-disable-next-line vitest/prefer-import-in-mock
@@ -45,7 +51,34 @@ import { executeWorkflowToolCall } from './agent-workflow-tool-runtime';
 // eslint-disable-next-line import/first
 import { discoverWebMcpTools, executeWebMcpToolCall } from './agent-web-mcp-tool-runtime';
 // eslint-disable-next-line import/first
-import type { KiloGatewayToolDefinition, KiloGatewayToolName } from '@/src/shared/kilo-api-client';
+import type {
+  KiloGatewayChatCompletion,
+  KiloGatewayToolDefinition,
+  KiloGatewayToolName,
+} from '@/src/shared/kilo-api-client';
+import type { LlmTurnOutcome } from '@/src/shared/agent-llm-turn-runner-core';
+import { ExecutionStoppedError } from '@/src/shared/agent-tool-results';
+
+const gatewayResponse = (completion: KiloGatewayChatCompletion): Response =>
+  new Response(
+    `data: ${JSON.stringify({
+      choices: [
+        {
+          delta: {
+            content: completion.content,
+            reasoning: completion.reasoning,
+            tool_calls: completion.toolCalls.map((call, index) => ({
+              function: { arguments: JSON.stringify(call.arguments), name: call.name },
+              id: call.id,
+              index,
+            })),
+          },
+          finish_reason: completion.finishReason,
+        },
+      ],
+    })}\n\n`,
+    { headers: { 'Content-Type': 'text/event-stream' } }
+  );
 
 const makeToolDef = (name: string): KiloGatewayToolDefinition =>
   ({
@@ -85,6 +118,289 @@ describe('safe turn runner workflow wiring', () => {
       updateThinkingBlock: vi.fn() as never,
       ...overrides,
     }) as Parameters<typeof runSafeLlmTurn>[0];
+
+  const outcomeCases: {
+    completion?: KiloGatewayChatCompletion;
+    confirmed?: number;
+    error?: Error;
+    expected: Pick<LlmTurnOutcome, 'reason' | 'status'> & Partial<Pick<LlmTurnOutcome, 'summary'>>;
+    label: string;
+    nextCompletion?: KiloGatewayChatCompletion;
+    requests: number;
+    rounds?: number;
+    stop?: 'cancelled' | 'lease_lost';
+    uncertain?: boolean;
+  }[] = [
+    {
+      error: new ExecutionStoppedError('execution_timeout', 'interrupted', true),
+      expected: { reason: 'execution_timeout', status: 'interrupted' },
+      label: 'uncertain execution timeout',
+      requests: 1,
+      uncertain: true,
+    },
+    {
+      completion: { content: 'Final answer.', finishReason: 'stop', toolCalls: [] },
+      expected: { reason: 'completed', status: 'succeeded', summary: 'Final answer.' },
+      label: 'complete answer without evidence',
+      requests: 1,
+    },
+    {
+      completion: { finishReason: 'stop', toolCalls: [] },
+      expected: { reason: 'empty_response', status: 'failed' },
+      label: 'empty response',
+      requests: 1,
+    },
+    {
+      completion: { finishReason: 'model_context_window_exceeded', toolCalls: [] },
+      expected: {
+        reason: 'context_overflow',
+        status: 'failed',
+        summary: 'The model did not return a response.',
+      },
+      label: 'empty context overflow',
+      requests: 1,
+    },
+    {
+      completion: { finishReason: 'length', toolCalls: [] },
+      expected: {
+        reason: 'truncated_response',
+        status: 'failed',
+        summary: 'The model did not return a response.',
+      },
+      label: 'exhausted empty truncation',
+      requests: 3,
+    },
+    {
+      completion: { content: 'Partial answer.', finishReason: 'length', toolCalls: [] },
+      expected: { reason: 'truncated_response', status: 'failed', summary: 'Partial answer.' },
+      label: 'partial final output',
+      requests: 3,
+    },
+    {
+      completion: {
+        content: 'Partial answer.',
+        finishReason: 'model_context_window_exceeded',
+        toolCalls: [],
+      },
+      expected: { reason: 'context_overflow', status: 'failed', summary: 'Partial answer.' },
+      label: 'context overflow',
+      requests: 1,
+    },
+    {
+      expected: { reason: 'rounds_exhausted', status: 'failed' },
+      label: 'exhausted rounds',
+      requests: 0,
+      rounds: 0,
+    },
+    {
+      completion: {
+        finishReason: 'tool_calls',
+        toolCalls: [{ arguments: {}, id: 'read-1', name: 'get_page_snapshot' }],
+      },
+      confirmed: 1,
+      expected: { reason: 'rounds_exhausted', status: 'failed' },
+      label: 'confirmed action without final answer',
+      requests: 1,
+      rounds: 1,
+    },
+    {
+      completion: {
+        finishReason: 'tool_calls',
+        toolCalls: [
+          { arguments: {}, id: 'read-1', name: 'get_page_snapshot' },
+          { arguments: { code: 'document.title = "unsafe";' }, id: 'unsafe-1', name: 'eval' },
+        ],
+      },
+      expected: { reason: 'unsafe_tool_call', status: 'failed' },
+      label: 'unsafe call in a mixed batch',
+      nextCompletion: { content: 'False success.', finishReason: 'stop', toolCalls: [] },
+      requests: 1,
+    },
+    {
+      completion: {
+        toolCalls: [{ arguments: {}, id: 'unfinished-1', name: 'get_page_snapshot' }],
+      },
+      expected: { reason: 'truncated_response', status: 'failed' },
+      label: 'tool batch without finish metadata',
+      nextCompletion: { content: 'False success.', finishReason: 'stop', toolCalls: [] },
+      requests: 1,
+    },
+    {
+      error: new TypeError('Gateway stream tool call did not include a supported tool name.'),
+      expected: { reason: 'completed', status: 'succeeded', summary: 'Recovered.' },
+      label: 'transport TypeError with the same message as an unsupported tool',
+      nextCompletion: { content: 'Recovered.', finishReason: 'stop', toolCalls: [] },
+      requests: 2,
+    },
+    {
+      error: new Error('Model failed.'),
+      expected: { reason: 'model_failure', status: 'failed', summary: 'Model failed.' },
+      label: 'model failure',
+      requests: 1,
+    },
+    {
+      error: new TypeError('Network failed.'),
+      expected: { reason: 'retry_exhausted', status: 'failed' },
+      label: 'retry exhaustion',
+      requests: 3,
+    },
+    {
+      expected: { reason: 'cancelled', status: 'cancelled' },
+      label: 'Stop before a model round',
+      requests: 0,
+      stop: 'cancelled',
+    },
+    {
+      expected: { reason: 'lease_lost', status: 'interrupted' },
+      label: 'lost lease before a model round',
+      requests: 0,
+      stop: 'lease_lost',
+    },
+  ];
+
+  it.each(outcomeCases)('returns the real stream outcome for $label', async entry => {
+    const core = await vi.importActual<typeof import('@/src/shared/agent-llm-turn-runner-core')>(
+      '@/src/shared/agent-llm-turn-runner-core'
+    );
+    let requests = 0;
+    const actions: string[] = [];
+    const appended: Parameters<Parameters<typeof runSafeLlmTurn>[0]['appendEvents']>[0] = [];
+    vi.mocked(runLlmTurn).mockImplementationOnce(options =>
+      core.runLlmTurn({
+        ...options,
+        executeToolCall: toolCall => {
+          actions.push(toolCall.name);
+          return options.executeToolCall(toolCall);
+        },
+        maxToolRounds: entry.rounds ?? 5,
+      })
+    );
+    const controller = new AbortController();
+    if (entry.stop === 'cancelled') {
+      controller.abort();
+    }
+    vi.useFakeTimers();
+    try {
+      const pending = runSafeLlmTurn(
+        buildOptions({
+          appendEvents: events => appended.push(...events),
+          executionGuard: () => {
+            if (entry.stop === 'lease_lost') {
+              throw new ExecutionStoppedError('lease_lost');
+            }
+          },
+          fetch: () => {
+            requests += 1;
+            if (
+              entry.error !== undefined &&
+              (requests === 1 || entry.nextCompletion === undefined)
+            ) {
+              throw entry.error;
+            }
+            return gatewayResponse(
+              (requests > 1 ? entry.nextCompletion : undefined) ??
+                entry.completion ?? { content: 'Done.', finishReason: 'stop', toolCalls: [] }
+            );
+          },
+          signal: controller.signal,
+        })
+      );
+      await vi.runAllTimersAsync();
+      const result = await pending;
+      expect(result).toMatchObject({
+        ...entry.expected,
+        effectsUncertain: entry.uncertain ?? false,
+      });
+      expect(appended.filter(event => event.type === 'message')).toMatchObject([
+        { role: 'assistant', text: result.summary },
+      ]);
+      expect(result.toolResults).toHaveLength(entry.confirmed ?? 0);
+      expect(actions).toHaveLength(entry.confirmed ?? 0);
+      expect(requests).toBe(entry.requests);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { confirmed: false, reason: 'lease_lost', status: 'interrupted' as const },
+    { confirmed: false, reason: 'owner_cancelled', status: 'cancelled' as const },
+    { confirmed: true, reason: 'owner_cancelled', status: 'cancelled' as const },
+  ])(
+    'retains $reason after an issued search (confirmed=$confirmed)',
+    async ({ confirmed, reason, status }) => {
+      const core = await vi.importActual<typeof import('@/src/shared/agent-llm-turn-runner-core')>(
+        '@/src/shared/agent-llm-turn-runner-core'
+      );
+      const controller = new AbortController();
+      const request = Promise.withResolvers<Response>();
+      const issued = Promise.withResolvers<void>();
+      const requests: string[] = [];
+      const actions: string[] = [];
+      const searchResult = { results: [{ url: 'https://example.com/observed' }] };
+      vi.mocked(runLlmTurn).mockImplementationOnce(options =>
+        core.runLlmTurn({
+          ...options,
+          executeToolCall: toolCall => {
+            actions.push(toolCall.name);
+            return options.executeToolCall(toolCall);
+          },
+        })
+      );
+      const pending = runSafeLlmTurn(
+        buildOptions({
+          fetch: (input, init) => {
+            requests.push(String(input));
+            if (input === 'https://api.example.com/api/exa/search') {
+              init?.signal?.addEventListener(
+                'abort',
+                () => {
+                  request.reject(init.signal?.reason);
+                },
+                {
+                  once: true,
+                }
+              );
+              issued.resolve();
+              return request.promise;
+            }
+            return gatewayResponse(
+              requests.length === 1
+                ? {
+                    finishReason: 'tool_calls',
+                    toolCalls: [
+                      {
+                        arguments: { query: 'observed result' },
+                        id: 'search-1',
+                        name: 'web_search',
+                      },
+                      { arguments: {}, id: 'read-2', name: 'get_page_snapshot' },
+                    ],
+                  }
+                : { content: 'False success.', finishReason: 'stop', toolCalls: [] }
+            );
+          },
+          signal: controller.signal,
+        })
+      );
+      await issued.promise;
+      if (confirmed) {
+        request.resolve(Response.json(searchResult));
+      }
+      controller.abort(new ExecutionStoppedError(reason, status));
+      const result = await pending;
+
+      expect(result).toMatchObject({ effectsUncertain: !confirmed, reason, status });
+      expect(result.toolResults).toMatchObject(
+        confirmed ? [{ effectsUncertain: false, ok: true, value: searchResult }] : []
+      );
+      expect(actions).toStrictEqual(['web_search']);
+      expect(requests).toStrictEqual([
+        'https://api.example.com/api/gateway/v1/chat/completions',
+        'https://api.example.com/api/exa/search',
+      ]);
+    }
+  );
 
   it('routes workflow tool calls to executeWorkflowToolCall', async () => {
     vi.mocked(runLlmTurn).mockClear();
@@ -142,6 +458,13 @@ describe('safe turn runner workflow wiring', () => {
         type: 'tool-call' as const,
       };
       await options.executeToolCall(toolCall);
+      return {
+        effectsUncertain: false,
+        reason: 'completed',
+        status: 'succeeded',
+        summary: 'Done.',
+        toolResults: [],
+      };
     });
 
     const workflowToolContext = makeWorkflowCtx();
@@ -197,7 +520,7 @@ describe('safe turn runner workflow wiring', () => {
 
     const prepared = await prepareTools!();
 
-    expect(discoverWebMcpTools).toHaveBeenCalledWith(7);
+    expect(discoverWebMcpTools).toHaveBeenCalledWith(7, expect.any(Function));
     expect(prepared).toHaveLength(tools.length + 1);
     expect(prepared.at(-1)!.function.name).toBe('double');
   });
@@ -286,6 +609,13 @@ describe('safe turn runner workflow wiring', () => {
         webMcpOrigin: 'https://example.com',
       };
       await options.executeToolCall(toolCall);
+      return {
+        effectsUncertain: false,
+        reason: 'completed',
+        status: 'succeeded',
+        summary: 'Done.',
+        toolResults: [],
+      };
     });
 
     await runSafeLlmTurn(buildOptions({ workflowToolContext: makeWorkflowCtx() }));

--- a/apps/extension/entrypoints/sidepanel/agent-safe-llm-turn-runner.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-safe-llm-turn-runner.test.ts
@@ -120,16 +120,21 @@ describe('safe turn runner workflow wiring', () => {
     }) as Parameters<typeof runSafeLlmTurn>[0];
 
   const outcomeCases: {
+    assistantMessages?: string[];
     completion?: KiloGatewayChatCompletion;
     confirmed?: number;
     error?: Error;
-    expected: Pick<LlmTurnOutcome, 'reason' | 'status'> & Partial<Pick<LlmTurnOutcome, 'summary'>>;
+    expected: Pick<LlmTurnOutcome, 'reason' | 'status'> & {
+      summary?: string;
+      toolResults?: Partial<LlmTurnOutcome['toolResults'][number]>[];
+    };
     label: string;
     nextCompletion?: KiloGatewayChatCompletion;
     requests: number;
     rounds?: number;
     stop?: 'cancelled' | 'lease_lost';
     uncertain?: boolean;
+    workflowTools?: KiloGatewayToolDefinition[];
   }[] = [
     {
       error: new ExecutionStoppedError('execution_timeout', 'interrupted', true),
@@ -202,6 +207,59 @@ describe('safe turn runner workflow wiring', () => {
       label: 'confirmed action without final answer',
       requests: 1,
       rounds: 1,
+    },
+    {
+      assistantMessages: ['Creating the workflow now.', 'Creating the workflow now.'],
+      completion: {
+        finishReason: 'tool_calls',
+        toolCalls: [{ arguments: {}, id: 'read-1', name: 'get_page_snapshot' }],
+      },
+      confirmed: 1,
+      expected: {
+        reason: 'incomplete_response',
+        status: 'failed',
+        summary: 'Creating the workflow now.',
+        toolResults: [{ effectsUncertain: false, ok: true, value: 'safe' }],
+      },
+      label: 'unconfirmed announcement after continuation exhaustion',
+      nextCompletion: {
+        content: 'Creating the workflow now.',
+        finishReason: 'stop',
+        toolCalls: [],
+      },
+      requests: 3,
+    },
+    {
+      completion: {
+        finishReason: 'tool_calls',
+        toolCalls: [
+          { arguments: {}, id: 'read-1', name: 'get_page_snapshot' },
+          ...Array.from({ length: 25 }, (_value, index) => ({
+            arguments: { workflowId: `missing-${String(index)}` },
+            id: `failure-${String(index)}`,
+            name: 'get_workflow' as const,
+          })),
+          { arguments: { query: 'must not run' }, id: 'read-after-cap', name: 'find_in_page' },
+        ],
+      },
+      confirmed: 26,
+      expected: {
+        reason: 'tool_failure_limit',
+        status: 'failed',
+        toolResults: [
+          { effectsUncertain: false, ok: true, value: 'safe' },
+          ...Array.from({ length: 25 }, () => ({
+            effectsUncertain: false,
+            error: 'Workflow tool get_workflow is no longer available.',
+            ok: false as const,
+          })),
+        ],
+      },
+      label: 'tool failure cap with a pending read',
+      nextCompletion: { content: 'False success.', finishReason: 'stop', toolCalls: [] },
+      requests: 1,
+      // Missing workflow context exercises the wrapper's real confirmed failure path.
+      workflowTools: [makeToolDef('get_workflow')],
     },
     {
       completion: {
@@ -303,6 +361,7 @@ describe('safe turn runner workflow wiring', () => {
             );
           },
           signal: controller.signal,
+          workflowTools: entry.workflowTools,
         })
       );
       await vi.runAllTimersAsync();
@@ -311,12 +370,17 @@ describe('safe turn runner workflow wiring', () => {
         ...entry.expected,
         effectsUncertain: entry.uncertain ?? false,
       });
-      expect(appended.filter(event => event.type === 'message')).toMatchObject([
-        { role: 'assistant', text: result.summary },
-      ]);
+      expect(appended.filter(event => event.type === 'message')).toMatchObject(
+        (entry.assistantMessages ?? [result.summary]).map(text => ({ role: 'assistant', text }))
+      );
       expect(result.toolResults).toHaveLength(entry.confirmed ?? 0);
-      expect(actions).toHaveLength(entry.confirmed ?? 0);
-      expect(requests).toBe(entry.requests);
+      expect(result.toolResults).toStrictEqual(
+        appended.filter(event => event.type === 'tool-result')
+      );
+      expect({ actions: actions.length, requests }).toStrictEqual({
+        actions: entry.confirmed ?? 0,
+        requests: entry.requests,
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/apps/extension/entrypoints/sidepanel/agent-safe-llm-turn-runner.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-safe-llm-turn-runner.ts
@@ -7,7 +7,9 @@ import type {
 } from '@/src/shared/agent-conversation';
 import { createSafeToolDefinitions } from '@/src/shared/agent-llm-harness';
 import { runLlmTurn } from '@/src/shared/agent-llm-turn-runner-core';
-import type { OnTurnUsage } from '@/src/shared/agent-llm-turn-runner-core';
+import type { LlmTurnOutcome, OnTurnUsage } from '@/src/shared/agent-llm-turn-runner-core';
+import { normalizeExecutionGuard } from '@/src/shared/agent-tool-results';
+import type { ExecutionGuard } from '@/src/shared/agent-tool-results';
 import { maxAgentToolRounds } from '@/src/shared/agent-tool-round-limit';
 import type { FetchLike } from '@/src/shared/auth';
 import type {
@@ -38,12 +40,16 @@ interface RunSafeLlmTurnOptions {
   readonly apiBaseUrl: string;
   readonly appendEvents: (events: AgentConversationEvent[]) => void;
   readonly conversationEvents: AgentConversationEvent[];
+  readonly executionGuard?: ExecutionGuard | undefined;
   readonly fetch: FetchLike;
   readonly model: string;
   readonly organizationId?: string | undefined;
   readonly remoteMcpTools?: KiloGatewayToolDefinition[] | undefined;
   readonly executeRemoteMcpToolCall?:
-    | ((toolCall: RemoteMcpToolCallEvent) => Promise<EvalTabResult>)
+    | ((
+        toolCall: RemoteMcpToolCallEvent,
+        executionGuard?: ExecutionGuard
+      ) => Promise<EvalTabResult>)
     | undefined;
   readonly toRemoteMcpToolCallEvents?:
     | ((toolCalls: KiloGatewayToolCallRequest[]) => RemoteMcpToolCallEvent[])
@@ -77,12 +83,17 @@ export const runSafeLlmTurn = ({
   workflowToolContext,
   workflowTools = [],
   ...options
-}: RunSafeLlmTurnOptions): Promise<void> => {
+}: RunSafeLlmTurnOptions): Promise<LlmTurnOutcome> => {
+  const guard = normalizeExecutionGuard(
+    options.executionGuard ?? workflowToolContext?.executionGuard,
+    options.signal
+  );
   // One executor per turn: a fresh unchanged-snapshot memory, so a new conversation's first snapshot is served in full.
-  const executeSafeToolCall = createSafeToolExecutor();
+  const executeSafeToolCall = createSafeToolExecutor(guard);
   // One executor per turn: it carries the abort signal and caps the searches this turn may bill.
   const runWebSearch = createWebSearchExecutor({
     apiBaseUrl: options.apiBaseUrl,
+    executionGuard: guard,
     fetch: options.fetch,
     organizationId: options.organizationId,
     signal: options.signal,
@@ -102,24 +113,30 @@ export const runSafeLlmTurn = ({
     ...options,
     // eslint-disable-next-line require-await -- async normalizes the sync no-executor error branch into the Promise<EvalTabResult> the runner expects.
     executeToolCall: async (toolCall): Promise<EvalTabResult> => {
+      guard();
       if (isWebMcpToolCallEvent(toolCall)) {
-        return executeWebMcpToolCall(toolCall);
+        return executeWebMcpToolCall(toolCall, guard);
       }
 
       if (isWorkflowToolCallEvent(toolCall)) {
         if (workflowToolContext === undefined) {
           return {
+            effectsUncertain: false,
             error: `Workflow tool ${toolCall.name} is no longer available.`,
             ok: false,
           };
         }
-        return executeWorkflowToolCall(toolCall, workflowToolContext);
+        return executeWorkflowToolCall(toolCall, { ...workflowToolContext, executionGuard: guard });
       }
 
       if (isRemoteMcpToolCallEvent(toolCall)) {
         return executeRemoteMcpToolCall === undefined
-          ? { error: `Remote MCP tool ${toolCall.name} is no longer available.`, ok: false }
-          : executeRemoteMcpToolCall(toolCall);
+          ? {
+              effectsUncertain: false,
+              error: `Remote MCP tool ${toolCall.name} is no longer available.`,
+              ok: false,
+            }
+          : executeRemoteMcpToolCall(toolCall, guard);
       }
 
       if (toolCall.name === 'web_search') {
@@ -128,6 +145,7 @@ export const runSafeLlmTurn = ({
 
       return executeSafeToolCall(toolCall);
     },
+    executionGuard: guard,
     failureMessage: error => (error instanceof Error ? error.message : 'Failed to run safe mode.'),
     maxToolRounds: maxAgentToolRounds,
     noResponseMessage: 'The model did not return a response.',
@@ -138,7 +156,7 @@ export const runSafeLlmTurn = ({
         return fixedTools;
       }
 
-      const discovery = await discoverWebMcpTools(selectedTabId);
+      const discovery = await discoverWebMcpTools(selectedTabId, guard);
 
       if (discovery === undefined || discovery.documentId === '') {
         return fixedTools;

--- a/apps/extension/entrypoints/sidepanel/agent-safe-tool-runtime.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-safe-tool-runtime.test.ts
@@ -27,6 +27,38 @@ const snapshotResponse = (value: object) => ({
 const snapshotCall = (tabId: number) =>
   createSafeToolCall({ name: 'get_page_snapshot', providerToolCallId: 'call-1', tabId });
 
+describe('safe result certainty', () => {
+  it.each([
+    { label: 'legacy failure', result: { error: 'Lost result.', ok: false }, uncertain: true },
+    {
+      label: 'confirmed denial',
+      result: { effectsUncertain: false, error: 'Permission denied.', ok: false },
+      uncertain: false,
+    },
+    {
+      label: 'uncertain success',
+      result: { effectsUncertain: true, ok: true, value: snapshotValue },
+      uncertain: true,
+    },
+  ])('preserves $label through snapshot parsing', async ({ result, uncertain }) => {
+    sendMessage.mockResolvedValue({ ok: true, result, type: PAGE_SNAPSHOT_MESSAGE });
+    const value = await createSafeToolExecutor()(snapshotCall(994));
+    expect(value).toMatchObject({ effectsUncertain: uncertain, ok: false });
+  });
+
+  it('rejects a revoked guard before a snapshot dispatch', async () => {
+    sendMessage.mockClear();
+    const execute = createSafeToolExecutor(() => {
+      throw new Error('lease_lost');
+    });
+    await expect(execute(snapshotCall(995))).rejects.toMatchObject({
+      reason: 'lease_lost',
+      status: 'interrupted',
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
 describe('get_page_snapshot unchanged-page dedupe', () => {
   it('returns a compact unchanged marker for an identical consecutive snapshot', async () => {
     sendMessage.mockResolvedValue(snapshotResponse({ ...snapshotValue }));

--- a/apps/extension/entrypoints/sidepanel/agent-safe-tool-runtime.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-safe-tool-runtime.ts
@@ -9,8 +9,16 @@ import {
   PAGE_SNAPSHOT_MESSAGE,
   VIEWPORT_SCREENSHOT_MESSAGE,
   isTabDebuggerResponse,
+  normalizeEvalTabResult,
 } from '@/src/shared/tab-debugger';
-import type { EvalTabResult, PageSnapshot, PageSnapshotNode } from '@/src/shared/tab-debugger';
+import type {
+  EvalTabResult,
+  NormalizedEvalTabResult,
+  PageSnapshot,
+  PageSnapshotNode,
+} from '@/src/shared/tab-debugger';
+import { normalizeExecutionGuard } from '@/src/shared/agent-tool-results';
+import type { ExecutionGuard } from '@/src/shared/agent-tool-results';
 
 type SafeToolCall = Extract<AgentConversationEvent, { readonly name: SafeToolName }>;
 const pageSnapshotNodeSchema = z.object({
@@ -98,70 +106,78 @@ const toPageSnapshot = (snapshot: z.infer<typeof pageSnapshotSchema>): PageSnaps
 const readPageSnapshot = async (
   tabId: number,
   { query, textStart }: { readonly query?: string; readonly textStart?: number } = {}
-): Promise<EvalTabResult> => {
+): Promise<NormalizedEvalTabResult> => {
   const response: unknown = await browser.runtime.sendMessage({
     tabId,
     ...(query === undefined ? {} : { query }),
     ...(textStart === undefined ? {} : { textStart }),
     type: PAGE_SNAPSHOT_MESSAGE,
   });
-
   if (!isTabDebuggerResponse(response)) {
-    return { error: 'Extension background returned an invalid response.', ok: false };
+    return {
+      effectsUncertain: true,
+      error: 'Extension background returned an invalid response.',
+      ok: false,
+    };
   }
-
   if (!response.ok) {
-    return { error: response.error, ok: false };
+    return normalizeEvalTabResult(response);
   }
-
   if (response.type !== PAGE_SNAPSHOT_MESSAGE) {
-    return { error: 'Extension background returned the wrong response.', ok: false };
+    return {
+      effectsUncertain: true,
+      error: 'Extension background returned the wrong response.',
+      ok: false,
+    };
   }
-
-  return response.result;
+  return normalizeEvalTabResult(response.result);
 };
 
-const readViewportScreenshot = async (tabId: number): Promise<EvalTabResult> => {
+const readViewportScreenshot = async (tabId: number): Promise<NormalizedEvalTabResult> => {
   const response: unknown = await browser.runtime.sendMessage({
     tabId,
     type: VIEWPORT_SCREENSHOT_MESSAGE,
   });
-
   if (!isTabDebuggerResponse(response)) {
-    return { error: 'Extension background returned an invalid response.', ok: false };
+    return {
+      effectsUncertain: true,
+      error: 'Extension background returned an invalid response.',
+      ok: false,
+    };
   }
-
   if (!response.ok) {
-    return { error: response.error, ok: false };
+    return normalizeEvalTabResult(response);
   }
-
   if (response.type !== VIEWPORT_SCREENSHOT_MESSAGE) {
-    return { error: 'Extension background returned the wrong response.', ok: false };
+    return {
+      effectsUncertain: true,
+      error: 'Extension background returned the wrong response.',
+      ok: false,
+    };
   }
-
-  return response.result;
+  return normalizeEvalTabResult(response.result);
 };
 
 const getSnapshot = async (
   tabId: number,
   options: { readonly query?: string; readonly textStart?: number } = {}
-): Promise<{ error: string; ok: false } | { ok: true; value: PageSnapshot }> => {
+): Promise<
+  ({ error: string; ok: false } | { ok: true; value: PageSnapshot }) & { effectsUncertain: boolean }
+> => {
   const result = await readPageSnapshot(tabId, options);
-
   if (!result.ok) {
-    return { error: result.error, ok: false };
+    return result;
   }
-
+  if (result.effectsUncertain) {
+    return { effectsUncertain: true, error: 'Page snapshot completion is uncertain.', ok: false };
+  }
   const snapshot = pageSnapshotSchema.safeParse(result.value);
-
   if (!snapshot.success) {
-    return { error: 'Page snapshot was invalid.', ok: false };
+    return { effectsUncertain: false, error: 'Page snapshot was invalid.', ok: false };
   }
-
   const pageSnapshot = toPageSnapshot(snapshot.data);
   cacheSnapshot(tabId, pageSnapshot);
-
-  return { ok: true, value: pageSnapshot };
+  return { effectsUncertain: false, ok: true, value: pageSnapshot };
 };
 
 const searchableFields = ['text', 'label', 'href', 'role', 'tag'] as const;
@@ -283,7 +299,7 @@ const runSafeToolCall = async (
     );
 
     if (!snapshotResult.ok) {
-      return { error: snapshotResult.error, ok: false };
+      return snapshotResult;
     }
 
     const snapshot = snapshotResult.value;
@@ -331,16 +347,24 @@ const runSafeToolCall = async (
   const snapshotResult = await getSnapshot(toolCall.tabId, { query });
 
   if (!snapshotResult.ok) {
-    return { error: snapshotResult.error, ok: false };
+    return snapshotResult;
   }
 
   return { ok: true, value: getFindResults(snapshotResult.value, query) };
 };
 
 // One executor per turn: its unchanged-snapshot memory must not cross conversations (or a compaction), where the marker would reference a snapshot the model never saw.
-export const createSafeToolExecutor = (): ((toolCall: SafeToolCall) => Promise<EvalTabResult>) => {
+export const createSafeToolExecutor = (
+  executionGuard?: ExecutionGuard
+): ((toolCall: SafeToolCall) => Promise<NormalizedEvalTabResult>) => {
   const lastServedSnapshotByTab: ServedSnapshotsByTab = new Map();
-  return toolCall => runSafeToolCall(lastServedSnapshotByTab, toolCall);
+  const guard = normalizeExecutionGuard(executionGuard);
+  return async toolCall => {
+    guard();
+    const result = await runSafeToolCall(lastServedSnapshotByTab, toolCall);
+    // Local argument/cache denials are confirmed; browser responses carry their own metadata.
+    return { ...result, effectsUncertain: result.effectsUncertain ?? false };
+  };
 };
 
 export const executeSafeToolCall = createSafeToolExecutor();

--- a/apps/extension/entrypoints/sidepanel/agent-web-mcp-tool-runtime.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-web-mcp-tool-runtime.test.ts
@@ -38,6 +38,7 @@ describe('webmcp tool executor', () => {
     });
 
     await expect(executeWebMcpToolCall(createEvent())).resolves.toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: { doubled: 42 },
     });
@@ -52,6 +53,7 @@ describe('webmcp tool executor', () => {
     });
 
     await expect(executeWebMcpToolCall(createEvent())).resolves.toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: 'plain text result',
     });
@@ -66,6 +68,7 @@ describe('webmcp tool executor', () => {
     });
 
     await expect(executeWebMcpToolCall(createEvent())).resolves.toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: null,
     });
@@ -79,6 +82,7 @@ describe('webmcp tool executor', () => {
     });
 
     await expect(executeWebMcpToolCall(createEvent())).resolves.toStrictEqual({
+      effectsUncertain: true,
       error: 'tab closed',
       ok: false,
     });
@@ -89,6 +93,7 @@ describe('webmcp tool executor', () => {
     mocks.sendMessage.mockResolvedValueOnce({ unexpected: true });
 
     await expect(executeWebMcpToolCall(createEvent())).resolves.toStrictEqual({
+      effectsUncertain: true,
       error: 'Extension background returned an invalid response.',
       ok: false,
     });
@@ -99,6 +104,7 @@ describe('webmcp tool executor', () => {
     mocks.sendMessage.mockRejectedValueOnce(new Error('background disconnected'));
 
     await expect(executeWebMcpToolCall(createEvent())).resolves.toStrictEqual({
+      effectsUncertain: true,
       error: 'background disconnected',
       ok: false,
     });
@@ -114,6 +120,7 @@ describe('webmcp tool executor', () => {
     });
 
     await expect(executeWebMcpToolCall(createEvent())).resolves.toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         truncated: true,
@@ -169,14 +176,47 @@ describe('webmcp tool discovery', () => {
     expect(mocks.sendMessage).toHaveBeenCalledWith({ tabId: 7, type: WEB_MCP_DISCOVER_MESSAGE });
   });
 
-  it('returns undefined on a non-ok response', async () => {
+  it.each([
+    {
+      expected: undefined,
+      label: 'confirmed denial',
+      response: { effectsUncertain: false, error: 'Discovery denied.', ok: false },
+    },
+    {
+      expected: undefined,
+      label: 'confirmed inner failure',
+      response: {
+        ok: true,
+        result: { effectsUncertain: false, error: 'No tools.', ok: false },
+        type: WEB_MCP_DISCOVER_MESSAGE,
+      },
+    },
+    {
+      expected: { documentId: 'doc-1', tools: [] },
+      label: 'empty tool list',
+      response: {
+        ok: true,
+        result: { ok: true, value: { documentId: 'doc-1', tools: [] } },
+        type: WEB_MCP_DISCOVER_MESSAGE,
+      },
+    },
+  ])('keeps $label nonterminal', async ({ expected, response }) => {
+    mocks.sendMessage.mockReset().mockResolvedValueOnce(response);
+    await expect(discoverWebMcpTools(7)).resolves.toStrictEqual(expected);
+  });
+
+  it('interrupts on a legacy non-ok response', async () => {
     mocks.sendMessage.mockReset();
     mocks.sendMessage.mockResolvedValueOnce({ error: 'tab closed', ok: false });
 
-    await expect(discoverWebMcpTools(7)).resolves.toBeUndefined();
+    await expect(discoverWebMcpTools(7)).rejects.toMatchObject({
+      effectsUncertain: true,
+      reason: 'effects_uncertain',
+      status: 'interrupted',
+    });
   });
 
-  it('returns undefined on a wrong-typed response', async () => {
+  it('interrupts on a wrong-typed response', async () => {
     mocks.sendMessage.mockReset();
     mocks.sendMessage.mockResolvedValueOnce({
       ok: true,
@@ -184,10 +224,14 @@ describe('webmcp tool discovery', () => {
       type: WEB_MCP_EXECUTE_MESSAGE,
     });
 
-    await expect(discoverWebMcpTools(7)).resolves.toBeUndefined();
+    await expect(discoverWebMcpTools(7)).rejects.toMatchObject({
+      effectsUncertain: true,
+      reason: 'effects_uncertain',
+      status: 'interrupted',
+    });
   });
 
-  it('returns undefined on a non-ok inner result', async () => {
+  it('interrupts on a non-ok inner result', async () => {
     mocks.sendMessage.mockReset();
     mocks.sendMessage.mockResolvedValueOnce({
       ok: true,
@@ -195,20 +239,32 @@ describe('webmcp tool discovery', () => {
       type: WEB_MCP_DISCOVER_MESSAGE,
     });
 
-    await expect(discoverWebMcpTools(7)).resolves.toBeUndefined();
+    await expect(discoverWebMcpTools(7)).rejects.toMatchObject({
+      effectsUncertain: true,
+      reason: 'effects_uncertain',
+      status: 'interrupted',
+    });
   });
 
-  it('returns undefined on an invalid response', async () => {
+  it('interrupts on an invalid response', async () => {
     mocks.sendMessage.mockReset();
     mocks.sendMessage.mockResolvedValueOnce({ unexpected: true });
 
-    await expect(discoverWebMcpTools(7)).resolves.toBeUndefined();
+    await expect(discoverWebMcpTools(7)).rejects.toMatchObject({
+      effectsUncertain: true,
+      reason: 'effects_uncertain',
+      status: 'interrupted',
+    });
   });
 
-  it('returns undefined when sendMessage throws', async () => {
+  it('interrupts when sendMessage throws', async () => {
     mocks.sendMessage.mockReset();
     mocks.sendMessage.mockRejectedValueOnce(new Error('background disconnected'));
 
-    await expect(discoverWebMcpTools(7)).resolves.toBeUndefined();
+    await expect(discoverWebMcpTools(7)).rejects.toMatchObject({
+      effectsUncertain: true,
+      reason: 'effects_uncertain',
+      status: 'interrupted',
+    });
   });
 });

--- a/apps/extension/entrypoints/sidepanel/agent-web-mcp-tool-runtime.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-web-mcp-tool-runtime.ts
@@ -5,24 +5,25 @@ import {
   WEB_MCP_DISCOVER_MESSAGE,
   WEB_MCP_EXECUTE_MESSAGE,
   isTabDebuggerResponse,
+  normalizeEvalTabResult,
 } from '@/src/shared/tab-debugger';
-import type { EvalTabResult, WebMcpDiscoveryResult } from '@/src/shared/tab-debugger';
+import type { NormalizedEvalTabResult, WebMcpDiscoveryResult } from '@/src/shared/tab-debugger';
 import { capRemoteMcpToolResult } from '@/src/shared/remote-mcp-tools';
+import {
+  ExecutionStoppedError,
+  isExecutionStopped,
+  normalizeExecutionGuard,
+} from '@/src/shared/agent-tool-results';
+import type { ExecutionGuard } from '@/src/shared/agent-tool-results';
 
-/*
- * Chrome's eval returns a JSON string. Parse it into a structured value so the
- * result enters conversation state as an object, not a quoted string. A
- * non-JSON string and null pass through verbatim.
- */
+// Chrome returns JSON strings. Keep non-JSON strings and null unchanged.
 const stringSchema = z.string();
 const jsonRecordSchema = z.record(z.string(), z.unknown());
-
 const parseWebMcpResult = (value: unknown) => {
   const asString = stringSchema.safeParse(value);
   if (!asString.success) {
     return value;
   }
-
   try {
     const parsed: unknown = JSON.parse(asString.data);
     return parsed;
@@ -33,88 +34,89 @@ const parseWebMcpResult = (value: unknown) => {
 
 const isRecordObject = (value: unknown): value is Record<string, unknown> =>
   jsonRecordSchema.safeParse(value).success;
-
 const isWebMcpDiscoveryResult = (value: unknown): value is WebMcpDiscoveryResult =>
   isRecordObject(value) &&
   stringSchema.safeParse(value['documentId']).success &&
   Array.isArray(value['tools']);
 
-/*
- * Discover the WebMCP tools registered by the selected tab's page through the
- * background transport. Never throws: an invalid, non-ok, or wrong-typed
- * response, a non-ok inner result, or a thrown sendMessage rejection all
- * resolve to undefined so a discovery failure silently disables page tools for
- * the turn.
- */
+/** Confirmed discovery failures disable page tools; uncertain completion interrupts the turn. */
 export const discoverWebMcpTools = async (
-  tabId: number
+  tabId: number,
+  executionGuard?: ExecutionGuard
 ): Promise<WebMcpDiscoveryResult | undefined> => {
+  normalizeExecutionGuard(executionGuard)();
   try {
     const response: unknown = await browser.runtime.sendMessage({
       tabId,
       type: WEB_MCP_DISCOVER_MESSAGE,
     });
-
     if (!isTabDebuggerResponse(response)) {
+      throw new ExecutionStoppedError('effects_uncertain', 'interrupted', true);
+    }
+    if (response.ok && response.type !== WEB_MCP_DISCOVER_MESSAGE) {
+      throw new ExecutionStoppedError('effects_uncertain', 'interrupted', true);
+    }
+    const result = normalizeEvalTabResult(response.ok ? response.result : response);
+    if (result.effectsUncertain) {
+      throw new ExecutionStoppedError('effects_uncertain', 'interrupted', true);
+    }
+    if (!result.ok) {
       return undefined;
     }
-
-    if (!response.ok) {
-      return undefined;
+    return isWebMcpDiscoveryResult(result.value) ? result.value : undefined;
+  } catch (error) {
+    if (isExecutionStopped(error)) {
+      throw error;
     }
-
-    if (response.type !== WEB_MCP_DISCOVER_MESSAGE) {
-      return undefined;
-    }
-
-    if (!response.result.ok) {
-      return undefined;
-    }
-
-    const { value } = response.result;
-
-    return isWebMcpDiscoveryResult(value) ? value : undefined;
-  } catch {
-    return undefined;
+    throw new ExecutionStoppedError('effects_uncertain', 'interrupted', true);
   }
 };
 
-/*
- * Run a WebMCP tool call through the background transport. The background
- * re-checks the definition signature against the page's live registration, so
- * a stale call (the page re-registered the tool after the turn started) fails
- * with a stale-tool error instead of running against the wrong definition.
- */
-export const executeWebMcpToolCall = async (event: WebMcpToolCallEvent): Promise<EvalTabResult> => {
+/** The background checks the live document and definition before running a page tool. */
+export const executeWebMcpToolCall = async (
+  event: WebMcpToolCallEvent,
+  executionGuard?: ExecutionGuard
+): Promise<NormalizedEvalTabResult> => {
+  normalizeExecutionGuard(executionGuard)();
+  let dispatched = false;
   try {
-    const response: unknown = await browser.runtime.sendMessage({
+    const message = {
       arguments: JSON.stringify(event.arguments),
       definitionSignature: event.definitionSignature,
       documentId: event.documentId,
       tabId: event.tabId,
       toolName: event.name,
       type: WEB_MCP_EXECUTE_MESSAGE,
-    });
-
+    };
+    dispatched = true;
+    const response: unknown = await browser.runtime.sendMessage(message);
     if (!isTabDebuggerResponse(response)) {
-      return { error: 'Extension background returned an invalid response.', ok: false };
+      return {
+        effectsUncertain: true,
+        error: 'Extension background returned an invalid response.',
+        ok: false,
+      };
     }
-
     if (!response.ok) {
-      return { error: response.error, ok: false };
+      return normalizeEvalTabResult(response);
     }
-
     if (response.type !== WEB_MCP_EXECUTE_MESSAGE) {
-      return { error: 'Extension background returned the wrong response.', ok: false };
+      return {
+        effectsUncertain: true,
+        error: 'Extension background returned the wrong response.',
+        ok: false,
+      };
     }
-
-    if (!response.result.ok) {
-      return response.result;
-    }
-
-    return { ok: true, value: capRemoteMcpToolResult(parseWebMcpResult(response.result.value)) };
+    const result = normalizeEvalTabResult(response.result);
+    return result.ok
+      ? { ...result, value: capRemoteMcpToolResult(parseWebMcpResult(result.value)) }
+      : result;
   } catch (error) {
+    if (isExecutionStopped(error)) {
+      throw error;
+    }
     return {
+      effectsUncertain: dispatched,
       error: error instanceof Error ? error.message : 'Failed to run WebMCP tool.',
       ok: false,
     };

--- a/apps/extension/entrypoints/sidepanel/agent-web-search-tool-runtime.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-web-search-tool-runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { FetchLike } from '@/src/shared/auth';
+import { ExecutionStoppedError } from '@/src/shared/agent-tool-results';
 import {
   createWebSearchExecutor,
   executeWebSearchToolCall,
@@ -18,6 +19,100 @@ const context = (fetchMock: FetchLike) => ({
 });
 
 describe('web search tool runtime', () => {
+  it('propagates AbortError from an issued search', async () => {
+    const error = new DOMException('Stopped.', 'AbortError');
+    const fetchMock = vi.fn<FetchLike>().mockRejectedValue(error);
+    await expect(
+      executeWebSearchToolCall(webSearchCall('anything'), context(fetchMock))
+    ).rejects.toBe(error);
+  });
+
+  it.each([
+    { reason: 'lease_lost', status: 'interrupted' as const },
+    { reason: 'owner_cancelled', status: 'cancelled' as const },
+  ])('retains $reason and uncertainty when an issued search aborts', async ({ reason, status }) => {
+    const controller = new AbortController();
+    const request = Promise.withResolvers<Response>();
+    const fetchMock = vi.fn<FetchLike>((_input, init) => {
+      init?.signal?.addEventListener(
+        'abort',
+        () => {
+          request.reject(init.signal?.reason);
+        },
+        {
+          once: true,
+        }
+      );
+      return request.promise;
+    });
+    const pending = executeWebSearchToolCall(webSearchCall('anything'), {
+      ...context(fetchMock),
+      signal: controller.signal,
+    });
+    controller.abort(new ExecutionStoppedError(reason, status));
+
+    await expect(pending).rejects.toMatchObject({ effectsUncertain: true, reason, status });
+  });
+
+  it.each([
+    { effectsUncertain: true, status: 200 },
+    { effectsUncertain: false, status: 402 },
+  ])(
+    'retains typed cancellation while reading a $status response',
+    async ({ effectsUncertain, status }) => {
+      const controller = new AbortController();
+      const fetchMock = vi.fn<FetchLike>(
+        () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(body) {
+                controller.signal.addEventListener(
+                  'abort',
+                  () => {
+                    body.error(controller.signal.reason);
+                  },
+                  {
+                    once: true,
+                  }
+                );
+              },
+            }),
+            { headers: { 'Content-Type': 'application/json' }, status }
+          )
+      );
+      const pending = executeWebSearchToolCall(webSearchCall('anything'), {
+        ...context(fetchMock),
+        signal: controller.signal,
+      });
+      controller.abort(new ExecutionStoppedError('lease_lost'));
+
+      await expect(pending).rejects.toMatchObject({
+        effectsUncertain,
+        reason: 'lease_lost',
+        status: 'interrupted',
+      });
+    }
+  );
+
+  it.each([
+    { error: new Error('lease_lost'), label: 'legacy guard error' },
+    { error: new ExecutionStoppedError('lease_lost'), label: 'typed guard error' },
+  ])('keeps pre-dispatch rejection confirmed for a $label', async ({ error }) => {
+    const fetchMock = vi.fn<FetchLike>();
+    const runSearch = createWebSearchExecutor({
+      ...context(fetchMock),
+      executionGuard: () => {
+        throw error;
+      },
+    });
+    await expect(runSearch({ query: 'anything' })).rejects.toMatchObject({
+      effectsUncertain: false,
+      reason: 'lease_lost',
+      status: 'interrupted',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('posts the query to the Exa proxy and returns compact results', async () => {
     const fetchMock = vi.fn<FetchLike>().mockResolvedValue(
       jsonResponse(200, {
@@ -38,6 +133,7 @@ describe('web search tool runtime', () => {
     });
 
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         results: [
@@ -70,7 +166,11 @@ describe('web search tool runtime', () => {
     const result = await executeWebSearchToolCall(webSearchCall('  '), {
       ...context(fetchMock),
     });
-    expect(result).toStrictEqual({ error: 'Search query is required.', ok: false });
+    expect(result).toStrictEqual({
+      effectsUncertain: false,
+      error: 'Search query is required.',
+      ok: false,
+    });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -84,6 +184,7 @@ describe('web search tool runtime', () => {
       ...context(fetchMock),
     });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Web search failed with status 402. Exa free allowance exhausted and no credit balance available',
       ok: false,
@@ -96,6 +197,7 @@ describe('web search tool runtime', () => {
       ...context(fetchMock),
     });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: { message: 'No results found. Try a different query.', results: [] },
     });
@@ -106,7 +208,11 @@ describe('web search tool runtime', () => {
     const result = await executeWebSearchToolCall(webSearchCall('anything'), {
       ...context(fetchMock),
     });
-    expect(result).toStrictEqual({ error: 'Web search returned an invalid response.', ok: false });
+    expect(result).toStrictEqual({
+      effectsUncertain: true,
+      error: 'Web search returned an invalid response.',
+      ok: false,
+    });
   });
 
   it('returns a tool error on network failure', async () => {
@@ -114,7 +220,11 @@ describe('web search tool runtime', () => {
     const result = await executeWebSearchToolCall(webSearchCall('anything'), {
       ...context(fetchMock),
     });
-    expect(result).toStrictEqual({ error: 'Web search failed: offline', ok: false });
+    expect(result).toStrictEqual({
+      effectsUncertain: true,
+      error: 'Web search failed: offline',
+      ok: false,
+    });
   });
 });
 

--- a/apps/extension/entrypoints/sidepanel/agent-web-search-tool-runtime.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-web-search-tool-runtime.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import type { FetchLike } from '@/src/shared/auth';
-import type { EvalTabResult } from '@/src/shared/tab-debugger';
+import type { NormalizedEvalTabResult } from '@/src/shared/tab-debugger';
+import {
+  ExecutionStoppedError,
+  isExecutionStopped,
+  normalizeExecutionGuard,
+} from '@/src/shared/agent-tool-results';
+import type { ExecutionGuard } from '@/src/shared/agent-tool-results';
 
 interface WebSearchToolCall {
   readonly query?: string | undefined;
@@ -8,6 +14,7 @@ interface WebSearchToolCall {
 
 export interface WebSearchContext {
   readonly apiBaseUrl: string;
+  readonly executionGuard?: ExecutionGuard | undefined;
   readonly fetch: FetchLike;
   readonly organizationId?: string | undefined;
   readonly signal?: AbortSignal | undefined;
@@ -38,6 +45,7 @@ type FetchOutcome =
   | { readonly ok: false; readonly reason: string };
 
 const postSearch = async (query: string, context: WebSearchContext): Promise<FetchOutcome> => {
+  normalizeExecutionGuard(context.executionGuard, context.signal)();
   try {
     const response = await context.fetch(`${context.apiBaseUrl}/api/exa/search`, {
       body: JSON.stringify({
@@ -57,6 +65,13 @@ const postSearch = async (query: string, context: WebSearchContext): Promise<Fet
     });
     return { ok: true, response };
   } catch (error) {
+    if (error instanceof ExecutionStoppedError) {
+      // The request was issued; owner cancellation does not confirm its completion.
+      throw new ExecutionStoppedError(error.reason, error.status, true);
+    }
+    if (isExecutionStopped(error)) {
+      throw error;
+    }
     return { ok: false, reason: error instanceof Error ? error.message : 'network error' };
   }
 };
@@ -69,7 +84,14 @@ const readJson = async <Value>(
     const raw: unknown = await response.json();
     const parsed = schema.safeParse(raw);
     return parsed.success ? parsed.data : undefined;
-  } catch {
+  } catch (error) {
+    if (error instanceof ExecutionStoppedError && response.ok) {
+      // Successful headers alone do not confirm the search result; failed HTTP responses do.
+      throw new ExecutionStoppedError(error.reason, error.status, true);
+    }
+    if (isExecutionStopped(error)) {
+      throw error;
+    }
     return undefined;
   }
 };
@@ -83,49 +105,42 @@ const toResultEntry = (result: z.infer<typeof exaResponseSchema>['results'][numb
   url: result.url,
 });
 
-/**
- * Search the web through the Kilo Exa proxy (`/api/exa/search`). The backend
- * owns auth, the monthly free allowance, and per-request billing; the
- * extension only forwards the user's bearer token. Results come back as
- * compact title/url/snippet records — search results are untrusted data.
- */
+/** Search through the existing Kilo proxy. Results are untrusted data, not instructions. */
 export const executeWebSearchToolCall = async (
   toolCall: WebSearchToolCall,
   context: WebSearchContext
-): Promise<EvalTabResult> => {
+): Promise<NormalizedEvalTabResult> => {
+  normalizeExecutionGuard(context.executionGuard, context.signal)();
   const query = toolCall.query?.trim();
-
   if (query === undefined || query === '') {
-    return { error: QUERY_REQUIRED_ERROR, ok: false };
+    return { effectsUncertain: false, error: QUERY_REQUIRED_ERROR, ok: false };
   }
 
   const outcome = await postSearch(query, context);
-
   if (!outcome.ok) {
-    return { error: `Web search failed: ${outcome.reason}`, ok: false };
+    // The billable request was issued; a lost response does not confirm completion.
+    return { effectsUncertain: true, error: `Web search failed: ${outcome.reason}`, ok: false };
   }
 
   const { response } = outcome;
-
   if (!response.ok) {
-    // The proxy explains allowance and balance failures in its error body; pass that through so the model can tell the user why.
     const errorBody = await readJson(response, errorBodySchema);
     const detail = errorBody === undefined ? '' : ` ${errorBody.error}`;
     return {
+      effectsUncertain: false,
       error: `Web search failed with status ${String(response.status)}.${detail}`,
       ok: false,
     };
   }
 
   const parsed = await readJson(response, exaResponseSchema);
-
   if (parsed === undefined) {
-    return { error: 'Web search returned an invalid response.', ok: false };
+    return { effectsUncertain: true, error: 'Web search returned an invalid response.', ok: false };
   }
 
   const results = parsed.results.slice(0, MAX_RESULTS).map(result => toResultEntry(result));
-
   return {
+    effectsUncertain: false,
     ok: true,
     value:
       results.length === 0
@@ -134,25 +149,23 @@ export const executeWebSearchToolCall = async (
   };
 };
 
-/**
- * One executor per turn: it carries the turn's abort signal so a stopped turn
- * does not leave a billable search in flight, and it caps how many searches
- * one turn may spend from the account's allowance.
- */
+/** One executor per turn carries Stop and bounds billable searches; it cannot undo an issued request. */
 export const createWebSearchExecutor = (
   context: WebSearchContext
-): ((toolCall: WebSearchToolCall) => Promise<EvalTabResult>) => {
+): ((toolCall: WebSearchToolCall) => Promise<NormalizedEvalTabResult>) => {
   let searchCount = 0;
-
-  return async (toolCall: WebSearchToolCall): Promise<EvalTabResult> => {
+  const guard = normalizeExecutionGuard(context.executionGuard, context.signal);
+  return async toolCall => {
+    guard();
     if (searchCount >= MAX_SEARCHES_PER_TURN) {
       return {
+        effectsUncertain: false,
         error: `Web search limit reached for this turn (${String(MAX_SEARCHES_PER_TURN)} searches). Answer with what you have, or ask the user to continue.`,
         ok: false,
       };
     }
-    const result = await executeWebSearchToolCall(toolCall, context);
-    // A rejected argument never reaches the network and bills nothing, so it must not spend the budget.
+    const result = await executeWebSearchToolCall(toolCall, { ...context, executionGuard: guard });
+    // A rejected argument never reaches the network and bills nothing.
     if (result.ok || result.error !== QUERY_REQUIRED_ERROR) {
       searchCount += 1;
     }

--- a/apps/extension/entrypoints/sidepanel/agent-workflow-runtime.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-workflow-runtime.test.ts
@@ -60,7 +60,11 @@ describe('workflow eval', () => {
       type: EVAL_TAB_MESSAGE,
     });
 
-    await expect(evalInTab(7, 'return 42;')).resolves.toStrictEqual({ ok: true, value: 42 });
+    await expect(evalInTab(7, 'return 42;')).resolves.toStrictEqual({
+      effectsUncertain: false,
+      ok: true,
+      value: 42,
+    });
     expect(mocks.sendMessage).toHaveBeenCalledWith({
       code: 'return 42;',
       tabId: 7,
@@ -74,6 +78,7 @@ describe('workflow eval', () => {
     mocks.sendMessage.mockRejectedValueOnce(new Error('disconnected'));
 
     await expect(evalInTab(7, 'return 1;')).resolves.toStrictEqual({
+      effectsUncertain: true,
       error: 'disconnected',
       ok: false,
     });
@@ -84,6 +89,7 @@ describe('workflow eval', () => {
     mocks.sendMessage.mockResolvedValueOnce({ unexpected: true });
 
     await expect(evalInTab(7, 'return 1;')).resolves.toStrictEqual({
+      effectsUncertain: true,
       error: 'Extension background returned an invalid response.',
       ok: false,
     });
@@ -97,6 +103,7 @@ describe('workflow eval', () => {
     });
 
     await expect(evalInTab(7, 'return 1;')).resolves.toStrictEqual({
+      effectsUncertain: true,
       error: 'tab closed',
       ok: false,
     });
@@ -111,9 +118,48 @@ describe('workflow eval', () => {
     });
 
     await expect(evalInTab(7, 'return 42;')).resolves.toStrictEqual({
+      effectsUncertain: true,
       error: 'Extension background returned the wrong response.',
       ok: false,
     });
+  });
+});
+
+describe('workflow action boundaries', () => {
+  it.each([
+    { reason: 'cancelled', status: 'cancelled' },
+    { reason: 'lease_lost', status: 'interrupted' },
+  ])('blocks navigation when $reason arrives during the tab read', async ({ reason, status }) => {
+    const controller = new AbortController();
+    mocks.tabsUpdate.mockReset();
+    mocks.tabsGet.mockReset().mockImplementationOnce(() => {
+      controller.abort(reason === 'cancelled' ? undefined : new Error(reason));
+      return Promise.resolve({ id: 7, status: 'loading', url: 'https://example.com/old' });
+    });
+    await expect(
+      navigateTab(7, 'https://example.com/new', () => {
+        controller.signal.throwIfAborted();
+      })
+    ).rejects.toMatchObject({ effectsUncertain: false, reason, status });
+    expect(mocks.tabsUpdate).not.toHaveBeenCalled();
+    expect(mocks._onUpdatedListeners).toHaveLength(0);
+  });
+
+  it('propagates an issued eval AbortError without a fabricated failure result', async () => {
+    const stopped = new DOMException('Stopped.', 'AbortError');
+    mocks.sendMessage.mockReset().mockRejectedValueOnce(stopped);
+    await expect(evalInTab(7, 'return 1;')).rejects.toBe(stopped);
+  });
+
+  it.each([
+    { effectsUncertain: false, error: 'Permission denied.', ok: false },
+    { effectsUncertain: true, error: 'Unknown completion.', ok: false },
+    { effectsUncertain: true, ok: true, value: 'unconfirmed' },
+  ])('preserves explicit completion metadata through eval: %j', async raw => {
+    mocks.sendMessage
+      .mockReset()
+      .mockResolvedValueOnce({ ok: true, result: raw, type: EVAL_TAB_MESSAGE });
+    await expect(evalInTab(7, 'return 1;')).resolves.toStrictEqual(raw);
   });
 });
 

--- a/apps/extension/entrypoints/sidepanel/agent-workflow-runtime.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-workflow-runtime.ts
@@ -4,8 +4,18 @@ import {
   WORKFLOW_NAVIGATION_TIMEOUT_MS,
   WORKFLOW_PAGE_EVAL_TIMEOUT_MS,
 } from '@/src/shared/agent-workflows';
-import { EVAL_TAB_MESSAGE, isTabDebuggerResponse } from '@/src/shared/tab-debugger';
-import type { EvalTabResult } from '@/src/shared/tab-debugger';
+import {
+  EVAL_TAB_MESSAGE,
+  isTabDebuggerResponse,
+  normalizeEvalTabResult,
+} from '@/src/shared/tab-debugger';
+import type { NormalizedEvalTabResult } from '@/src/shared/tab-debugger';
+import {
+  ExecutionStoppedError,
+  isExecutionStopped,
+  normalizeExecutionGuard,
+} from '@/src/shared/agent-tool-results';
+import type { ExecutionGuard } from '@/src/shared/agent-tool-results';
 
 /**
  * Compare two URLs by origin, pathname, and search, ignoring hash.
@@ -26,35 +36,50 @@ const urlMatches = (left: string, right: string): boolean => {
   }
 };
 
-/**
- * Evaluate workflow page code in a tab through the background transport.
- * Always sends WORKFLOW_PAGE_EVAL_TIMEOUT_MS (30 s); the default 5 s
- * timeout is too short for multi-action page scripts.
- */
-export const evalInTab = async (tabId: number, code: string): Promise<EvalTabResult> => {
+/** Workflows need 30 seconds; ordinary eval retains the background's default timeout. */
+// eslint-disable-next-line max-params -- Both eval callers share response normalization while retaining their existing timeouts.
+export const evalInTab = async (
+  tabId: number,
+  code: string,
+  executionGuard?: ExecutionGuard,
+  timeoutMs = WORKFLOW_PAGE_EVAL_TIMEOUT_MS
+): Promise<NormalizedEvalTabResult> => {
+  normalizeExecutionGuard(executionGuard)();
   try {
     const response: unknown = await browser.runtime.sendMessage({
       code,
       tabId,
-      timeoutMs: WORKFLOW_PAGE_EVAL_TIMEOUT_MS,
+      timeoutMs,
       type: EVAL_TAB_MESSAGE,
     });
 
     if (!isTabDebuggerResponse(response)) {
-      return { error: 'Extension background returned an invalid response.', ok: false };
+      return {
+        effectsUncertain: true,
+        error: 'Extension background returned an invalid response.',
+        ok: false,
+      };
     }
 
     if (!response.ok) {
-      return { error: response.error, ok: false };
+      return normalizeEvalTabResult(response);
     }
 
     if (response.type !== EVAL_TAB_MESSAGE) {
-      return { error: 'Extension background returned the wrong response.', ok: false };
+      return {
+        effectsUncertain: true,
+        error: 'Extension background returned the wrong response.',
+        ok: false,
+      };
     }
 
-    return response.result;
+    return normalizeEvalTabResult(response.result);
   } catch (error) {
+    if (isExecutionStopped(error)) {
+      throw error;
+    }
     return {
+      effectsUncertain: true,
       error: error instanceof Error ? error.message : 'Failed to run eval.',
       ok: false,
     };
@@ -86,9 +111,16 @@ export const evalInTab = async (tabId: number, code: string): Promise<EvalTabRes
  *
  * The listener and timer are always removed in a finally block.
  */
-export const navigateTab = async (tabId: number, url: string): Promise<void> => {
+export const navigateTab = async (
+  tabId: number,
+  url: string,
+  executionGuard?: ExecutionGuard
+): Promise<void> => {
+  const guard = normalizeExecutionGuard(executionGuard);
+  guard();
   // Same-URL fast path.
   const tab = await browser.tabs.get(tabId);
+  guard();
   if (tab.status === 'complete' && tab.url !== undefined && urlMatches(tab.url, url)) {
     return;
   }
@@ -150,7 +182,13 @@ export const navigateTab = async (tabId: number, url: string): Promise<void> => 
 
       timeoutHandle = setTimeout(() => {
         onDone(() => {
-          reject(new Error(`Navigation to ${url} timed out: the page never finished loading.`));
+          reject(
+            new ExecutionStoppedError(
+              `Navigation to ${url} timed out: the page never finished loading.`,
+              'interrupted',
+              true
+            )
+          );
         });
       }, WORKFLOW_NAVIGATION_TIMEOUT_MS);
 
@@ -190,6 +228,7 @@ export const navigateTab = async (tabId: number, url: string): Promise<void> => 
       // Initiate navigation. After the update resolves, do a fresh tabs.get
       // Re-read so that a tab already complete at the matching URL resolves
       // Without waiting for a later onUpdated event.
+      guard();
       void browser.tabs.update(tabId, { url }).then(
         async () => {
           updateApplied = true;
@@ -214,6 +253,15 @@ export const navigateTab = async (tabId: number, url: string): Promise<void> => 
         }
       );
     });
+  } catch (error) {
+    if (isExecutionStopped(error)) {
+      throw error;
+    }
+    throw new ExecutionStoppedError(
+      error instanceof Error ? error.message : 'Navigation failed.',
+      'interrupted',
+      true
+    );
   } finally {
     cleanup();
   }

--- a/apps/extension/entrypoints/sidepanel/agent-workflow-tool-runtime.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-workflow-tool-runtime.test.ts
@@ -89,6 +89,7 @@ describe('search_workflows', () => {
 
     const result = await executeWorkflowToolCall(createToolCall('search_workflows'), ctx);
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: { message: 'No workflows saved yet. Use save_workflow to create one.', results: [] },
     });
@@ -181,6 +182,7 @@ describe('save_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         autoApproved: false,
@@ -207,28 +209,32 @@ describe('save_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: { reason: 'The user rejected the save.', saved: false },
     });
   });
 
-  it('aborted outcome returns error', async () => {
+  it('propagates an aborted approval instead of a recoverable tool error', async () => {
     const ctx = createBaseCtx({
       requestApproval: vi.fn().mockResolvedValue({ status: 'aborted' }),
     });
 
-    const result = await executeWorkflowToolCall(
-      createToolCall('save_workflow', {
-        description: 'desc',
-        name: 'My WF',
-        scopeOrigin: 'https://example.com',
-        script: 'return 1;',
-      }),
-      ctx
-    );
-    expect(result).toStrictEqual({
-      error: 'Run stopped before approval.',
-      ok: false,
+    await expect(
+      executeWorkflowToolCall(
+        createToolCall('save_workflow', {
+          description: 'desc',
+          name: 'My WF',
+          scopeOrigin: 'https://example.com',
+          script: 'return 1;',
+        }),
+        ctx
+      )
+    ).rejects.toMatchObject({
+      effectsUncertain: false,
+      name: 'AbortError',
+      reason: 'Run stopped before approval.',
+      status: 'cancelled',
     });
   });
 
@@ -249,6 +255,7 @@ describe('save_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: { reason: 'Some persist error', saved: false },
     });
@@ -279,6 +286,7 @@ describe('save_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         reason: 'Workflow store is full. Delete a workflow first.',
@@ -332,6 +340,7 @@ describe('save_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Workflow not found — the workflowId does not match any saved workflow. Use search_workflows to find it, or omit workflowId to create a new workflow.',
       ok: false,
@@ -397,6 +406,7 @@ describe('save_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error: 'startUrl must match the workflow scope (origin and pathPrefix, if set).',
       ok: false,
     });
@@ -415,6 +425,7 @@ describe('save_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error: 'startUrl must match the workflow scope (origin and pathPrefix, if set).',
       ok: false,
     });
@@ -433,6 +444,7 @@ describe('save_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error: `startUrl must be an absolute URL inside the scope, e.g. "https://example.com/path", or a path starting with "/". Received: not-a-valid-url`,
       ok: false,
     });
@@ -525,6 +537,7 @@ describe('save_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         autoApproved: false,
@@ -560,6 +573,7 @@ describe('save_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         autoApproved: false,
@@ -607,6 +621,7 @@ describe('save_workflow', () => {
 
     const result = await resultPromise;
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         autoApproved: false,
@@ -653,6 +668,7 @@ describe('save_workflow', () => {
 
     const result = await resultPromise;
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         autoApproved: false,
@@ -693,6 +709,7 @@ describe('save_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         autoApproved: false,
@@ -768,6 +785,7 @@ describe('save_workflow', () => {
 
     const result = await resultPromise;
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         autoApproved: false,
@@ -809,6 +827,7 @@ describe('save_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         autoApproved: true,
@@ -844,6 +863,7 @@ describe('run_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Workflow runs are disabled in safe mode. Ask the user to enable "Allow workflows in safe mode" in settings, or to switch this conversation to dangerous mode.',
       ok: false,
@@ -928,6 +948,7 @@ describe('run_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error: 'Workflow not found. Use search_workflows to list saved workflows and their ids.',
       ok: false,
     });
@@ -962,6 +983,7 @@ describe('delete_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: { deleted: true, name: 'My WF', workflowId: 'wf-1' },
     });
@@ -984,6 +1006,7 @@ describe('delete_workflow', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error: 'Workflow not found. Use search_workflows to list saved workflows and their ids.',
       ok: false,
     });
@@ -1038,6 +1061,7 @@ describe('save_memory', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: { memoryId: 'mem-1', saved: true },
     });
@@ -1053,23 +1077,24 @@ describe('save_memory', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: { reason: 'The user rejected the save.', saved: false },
     });
   });
 
-  it('aborted outcome returns error', async () => {
+  it('propagates an aborted approval instead of a recoverable tool error', async () => {
     const ctx = createBaseCtx({
       requestApproval: vi.fn().mockResolvedValue({ status: 'aborted' }),
     });
 
-    const result = await executeWorkflowToolCall(
-      createToolCall('save_memory', { text: 'Remember this' }),
-      ctx
-    );
-    expect(result).toStrictEqual({
-      error: 'Run stopped before approval.',
-      ok: false,
+    await expect(
+      executeWorkflowToolCall(createToolCall('save_memory', { text: 'Remember this' }), ctx)
+    ).rejects.toMatchObject({
+      effectsUncertain: false,
+      name: 'AbortError',
+      reason: 'Run stopped before approval.',
+      status: 'cancelled',
     });
   });
 
@@ -1085,6 +1110,7 @@ describe('save_memory', () => {
       ctx
     );
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: { reason: 'Memory store is full.', saved: false },
     });
@@ -1134,7 +1160,11 @@ describe('workflow params through tools', () => {
       ctx
     );
 
-    expect(result).toStrictEqual({ error: 'params must not contain duplicate names.', ok: false });
+    expect(result).toStrictEqual({
+      effectsUncertain: false,
+      error: 'params must not contain duplicate names.',
+      ok: false,
+    });
   });
 
   it('carries params into the approval draft on create', async () => {
@@ -1221,6 +1251,7 @@ describe('workflow params through tools', () => {
     const result = await executeWorkflowToolCall(createToolCall('search_workflows', {}), ctx);
 
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         results: [
@@ -1267,6 +1298,7 @@ describe('startUrl resolution', () => {
     );
 
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         autoApproved: false,
@@ -1305,7 +1337,12 @@ describe('run results name the workflow', () => {
     });
 
   it('includes the workflow name in a successful result', async () => {
-    vi.mocked(runWorkflow).mockResolvedValueOnce({ ok: true, pagesVisited: 1, result: 'done' });
+    vi.mocked(runWorkflow).mockResolvedValueOnce({
+      effectsUncertain: false,
+      ok: true,
+      pagesVisited: 1,
+      result: 'done',
+    });
 
     const result = await executeWorkflowToolCall(
       createToolCall('run_workflow', { workflowId: 'wf-1' }),
@@ -1313,13 +1350,18 @@ describe('run results name the workflow', () => {
     );
 
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: { pagesVisited: 1, result: 'done', workflowName: 'Flight price search' },
     });
   });
 
   it('names the workflow in a failure', async () => {
-    vi.mocked(runWorkflow).mockResolvedValueOnce({ error: 'Tab is at X.', ok: false });
+    vi.mocked(runWorkflow).mockResolvedValueOnce({
+      effectsUncertain: false,
+      error: 'Tab is at X.',
+      ok: false,
+    });
 
     const result = await executeWorkflowToolCall(
       createToolCall('run_workflow', { workflowId: 'wf-1' }),
@@ -1327,8 +1369,151 @@ describe('run results name the workflow', () => {
     );
 
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error: 'Workflow "Flight price search" failed: Tab is at X.',
       ok: false,
+    });
+  });
+});
+
+describe('workflow authority propagation', () => {
+  it('normalizes a legacy metadata-free workflow failure to uncertain completion', async () => {
+    // Old workflow producers omit metadata; the adapter must not treat that omission as confirmation.
+    const legacyRunner = runWorkflow as ReturnType<typeof vi.fn>;
+    legacyRunner.mockResolvedValueOnce({ error: 'Lost completion.', ok: false });
+    const ctx = createBaseCtx({
+      storage: {
+        getItem: () => [
+          {
+            createdAt: 1,
+            description: 'Test',
+            id: 'wf-1',
+            name: 'Test',
+            scopeOrigin: 'https://example.com',
+            script: 'return 1;',
+            updatedAt: 1,
+          },
+        ],
+        removeItem: () => {},
+        setItem: () => {},
+      },
+    });
+    const result = await executeWorkflowToolCall(
+      createToolCall('run_workflow', { workflowId: 'wf-1' }),
+      ctx
+    );
+    expect(result).toStrictEqual({
+      effectsUncertain: true,
+      error: 'Workflow "Test" failed: Lost completion.',
+      ok: false,
+    });
+  });
+
+  it('does not evaluate after lease loss during initial navigation', async () => {
+    const actual = await vi.importActual<typeof import('@/src/shared/agent-workflow-runner')>(
+      '@/src/shared/agent-workflow-runner'
+    );
+    const { hashWorkflowScript } = await import('@/src/shared/agent-workflows');
+    vi.mocked(runWorkflow).mockImplementationOnce(actual.runWorkflow);
+    const script = 'return { done: true, result: 1 };';
+    const workflow = {
+      approvedScriptHash: await hashWorkflowScript(script),
+      createdAt: 1,
+      description: 'Test',
+      id: 'wf-1',
+      name: 'Test',
+      scopeOrigin: 'https://example.com',
+      script,
+      startUrl: 'https://example.com/start',
+      updatedAt: 1,
+    };
+    const actions: string[] = [];
+    let active = true;
+    const ctx = createBaseCtx({
+      evalInTab: () => {
+        actions.push('eval');
+        return Promise.resolve({ ok: true, value: { ok: true, value: { done: true } } });
+      },
+      executionGuard: () => {
+        if (!active) {
+          throw new Error('lease_lost');
+        }
+      },
+      navigateTab: () => {
+        actions.push('navigate');
+        active = false;
+        return Promise.resolve();
+      },
+      storage: { getItem: () => [workflow], removeItem: () => {}, setItem: () => {} },
+    });
+
+    await expect(
+      executeWorkflowToolCall(createToolCall('run_workflow', { workflowId: 'wf-1' }), ctx)
+    ).rejects.toMatchObject({
+      effectsUncertain: false,
+      reason: 'lease_lost',
+      status: 'interrupted',
+    });
+    expect(actions).toStrictEqual(['navigate']);
+  });
+
+  it.each(['save_workflow', 'save_memory'])(
+    'preserves the owner interruption during %s approval',
+    async name => {
+      const controller = new AbortController();
+      const { ExecutionStoppedError } = await import('@/src/shared/agent-tool-results');
+      const ctx = createBaseCtx({
+        requestApproval: () => {
+          controller.abort(new ExecutionStoppedError('lease_lost'));
+          return Promise.resolve({ status: 'aborted' });
+        },
+        signal: controller.signal,
+      });
+      const tool = createToolCall(name, {
+        description: 'Test',
+        name: 'Test',
+        scopeOrigin: 'https://example.com',
+        script: 'return 1;',
+        text: 'Save this.',
+      });
+      await expect(executeWorkflowToolCall(tool, ctx)).rejects.toMatchObject({
+        effectsUncertain: false,
+        reason: 'lease_lost',
+        status: 'interrupted',
+      });
+    }
+  );
+
+  it.each([
+    { effectsUncertain: false, error: 'Confirmed failure.', ok: false as const },
+    { effectsUncertain: true, error: 'Uncertain failure.', ok: false as const },
+    { effectsUncertain: true, ok: true as const, pagesVisited: 1, result: 'unconfirmed' },
+  ])('preserves workflow certainty through result naming: %j', async workflowResult => {
+    vi.mocked(runWorkflow).mockResolvedValueOnce(workflowResult);
+    const ctx = createBaseCtx({
+      storage: {
+        getItem: () => [
+          {
+            createdAt: 1,
+            description: 'Test',
+            id: 'wf-1',
+            name: 'Test',
+            scopeOrigin: 'https://example.com',
+            script: 'return 1;',
+            updatedAt: 1,
+          },
+        ],
+        removeItem: () => {},
+        setItem: () => {},
+      },
+    });
+    const result = await executeWorkflowToolCall(
+      createToolCall('run_workflow', { workflowId: 'wf-1' }),
+      ctx
+    );
+    expect(result).toMatchObject({
+      effectsUncertain: workflowResult.effectsUncertain,
+      ok: workflowResult.ok,
     });
   });
 });

--- a/apps/extension/entrypoints/sidepanel/agent-workflow-tool-runtime.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-workflow-tool-runtime.ts
@@ -1,7 +1,10 @@
 /* eslint-disable max-lines */
 import { z } from 'zod';
 import type { WorkflowToolCallEvent } from '@/src/shared/agent-conversation';
-import type { EvalTabResult } from '@/src/shared/tab-debugger';
+import { normalizeEvalTabResult } from '@/src/shared/tab-debugger';
+import type { EvalTabResult, NormalizedEvalTabResult } from '@/src/shared/tab-debugger';
+import { ExecutionStoppedError, normalizeExecutionGuard } from '@/src/shared/agent-tool-results';
+import type { ExecutionGuard } from '@/src/shared/agent-tool-results';
 import {
   MAX_WORKFLOW_COUNT,
   MAX_WORKFLOW_NAME_LENGTH,
@@ -17,7 +20,7 @@ import {
   loadWorkflowSettings,
 } from '@/src/shared/agent-workflows-storage';
 import { runWorkflow } from '@/src/shared/agent-workflow-runner';
-import type { WorkflowRunResult } from '@/src/shared/agent-workflow-runner';
+import type { WorkflowRunResult, WorkflowRunnerDeps } from '@/src/shared/agent-workflow-runner';
 import type { ApprovalKind, ApprovalOutcome } from './pending-approval';
 
 // ---------- tool context ----------
@@ -40,9 +43,10 @@ export interface WorkflowToolContext {
     kind: ApprovalKind,
     draft: Record<string, unknown>
   ) => Promise<ApprovalOutcome>;
-  readonly evalInTab: (tabId: number, code: string) => Promise<EvalTabResult>;
-  readonly navigateTab: (tabId: number, url: string) => Promise<void>;
-  readonly getTabUrl: (tabId: number) => Promise<string>;
+  readonly executionGuard?: ExecutionGuard | undefined;
+  readonly evalInTab: WorkflowRunnerDeps['evalInTab'];
+  readonly navigateTab: WorkflowRunnerDeps['navigateTab'];
+  readonly getTabUrl: WorkflowRunnerDeps['getTabUrl'];
 }
 
 // ---------- zod schemas ----------
@@ -227,22 +231,21 @@ const approvalOutcomeToToolResult = (
     return { ok: true, value: { reason: 'The user rejected the save.', saved: false } };
   }
   if (outcome.status === 'aborted') {
-    return { error: 'Run stopped before approval.', ok: false };
+    throw new ExecutionStoppedError('Run stopped before approval.', 'cancelled');
   }
   // Failed to save — the draft stays in storage but the caller must know.
   return { ok: true, value: { reason: outcome.reason, saved: false } };
 };
 
-/**
- * Map a WorkflowRunResult to an EvalTabResult.
- * The workflow name rides along so the transcript and the model can say
- * which workflow produced the result or the failure.
- */
+/** Preserve action certainty while naming the workflow in its tool result. */
 const runResultToToolResult = (
   result: WorkflowRunResult,
   dryRun: boolean,
   workflowName: string
-): EvalTabResult => {
+): NormalizedEvalTabResult => {
+  // Old metadata-free workflow results use the same issued-failure fallback as eval results.
+  // Remove this normalization after all metadata-free workflow producers and stored results retire.
+  const { effectsUncertain } = normalizeEvalTabResult(result);
   if (result.ok) {
     const extra: Record<string, unknown> = {};
     if (dryRun) {
@@ -251,8 +254,8 @@ const runResultToToolResult = (
     } else if (result.dryRunActions !== undefined) {
       extra['dryRunActions'] = result.dryRunActions;
     }
-
     return {
+      effectsUncertain,
       ok: true,
       value: {
         pagesVisited: result.pagesVisited,
@@ -262,11 +265,10 @@ const runResultToToolResult = (
       },
     };
   }
-
   const withPage =
     result.pageUrl === undefined ? result.error : `${result.error} (page: ${result.pageUrl})`;
-
   return {
+    effectsUncertain,
     error: `Workflow "${workflowName}" failed: ${withPage}`,
     ok: false,
   };
@@ -284,6 +286,7 @@ const executeSearchWorkflows = async (
   }
 
   const workflows = await loadAgentWorkflows(ctx.storage);
+  ctx.executionGuard?.();
   const results = searchAgentWorkflows(workflows, ctx.selectedTabUrl, parsed.data.query);
 
   if (results.length === 0) {
@@ -323,6 +326,7 @@ const executeGetWorkflow = async (
   }
 
   const workflows = await loadAgentWorkflows(ctx.storage);
+  ctx.executionGuard?.();
   const workflow = workflows.find(item => item.id === parsed.data.workflowId);
 
   if (workflow === undefined) {
@@ -350,6 +354,7 @@ const executeSaveWorkflow = async (
   );
 
   const workflows = await loadAgentWorkflows(ctx.storage);
+  ctx.executionGuard?.();
   const existing =
     rawParsed.data.workflowId === undefined
       ? undefined
@@ -426,7 +431,11 @@ const executeSaveWorkflow = async (
   // The runs toggle is a permission the model reads through the save result's nextStep.
   // Request approval first, then read the setting when the save completes.
   // A change made while the card was pending is reflected in the guidance.
+  ctx.executionGuard?.();
   const outcome = await ctx.requestApproval('workflow', draft);
+  if (outcome.status === 'aborted') {
+    ctx.executionGuard?.();
+  }
 
   // A failed settings read still permits the save and falls back to the cautious ask-the-user guidance.
   let runsAutoApproved = false;
@@ -470,6 +479,7 @@ const executeRunWorkflow = async (
   const { workflowId, dryRun = false, input } = parsed.data;
 
   const workflows = await loadAgentWorkflows(ctx.storage);
+  ctx.executionGuard?.();
   const workflow = workflows.find(item => item.id === workflowId);
 
   if (workflow === undefined) {
@@ -480,16 +490,14 @@ const executeRunWorkflow = async (
   }
 
   const result = await runWorkflow(
-    // EvalInTab resolves to the same type structurally but a tsc project-reference edge case
-    // Sees two different EvalTabResult declarations. Cast through Parameters to reconcile.
-    // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- required for tsc project-reference type identity
     {
       evalInTab: ctx.evalInTab,
       getTabUrl: ctx.getTabUrl,
       navigateTab: ctx.navigateTab,
-    } as Parameters<typeof runWorkflow>[0],
+    },
     {
       dryRun,
+      executionGuard: ctx.executionGuard,
       input,
       signal: ctx.signal,
       tabId: ctx.selectedTabId,
@@ -518,6 +526,7 @@ const executeDeleteWorkflow = async (
   }
 
   const workflows = await loadAgentWorkflows(ctx.storage);
+  ctx.executionGuard?.();
   const workflow = workflows.find(item => item.id === parsed.data.workflowId);
 
   if (workflow === undefined) {
@@ -556,13 +565,28 @@ const executeSaveMemory = async (
     ...(note !== undefined && note.trim().length > 0 ? { note: note.trim() } : {}),
   };
 
+  ctx.executionGuard?.();
   const outcome = await ctx.requestApproval('memory', draft);
+  if (outcome.status === 'aborted') {
+    ctx.executionGuard?.();
+  }
   return approvalOutcomeToToolResult(outcome, 'memoryId');
 };
 
 // ---------- main executor ----------
 
-export const executeWorkflowToolCall = (
+export const executeWorkflowToolCall = async (
+  toolCall: WorkflowToolCallEvent,
+  ctx: WorkflowToolContext
+): Promise<NormalizedEvalTabResult> => {
+  const guard = normalizeExecutionGuard(ctx.executionGuard, ctx.signal);
+  guard();
+  const result = await dispatchWorkflowToolCall(toolCall, { ...ctx, executionGuard: guard });
+  // Local validation/approval results are confirmed. run_workflow normalizes its own raw result.
+  return { ...result, effectsUncertain: result.effectsUncertain ?? false };
+};
+
+const dispatchWorkflowToolCall = (
   toolCall: WorkflowToolCallEvent,
   ctx: WorkflowToolContext
 ): Promise<EvalTabResult> => {

--- a/apps/extension/entrypoints/sidepanel/remote-mcp-client-call.test.ts
+++ b/apps/extension/entrypoints/sidepanel/remote-mcp-client-call.test.ts
@@ -1,5 +1,7 @@
 /* eslint-disable max-classes-per-file */
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it, vi } from 'vitest';
+import { ExecutionStoppedError } from '../../src/shared/agent-tool-results';
 import type { RemoteMcpServer } from '../../src/shared/remote-mcp';
 import type { RemoteMcpToolRoute } from '../../src/shared/remote-mcp-tools';
 
@@ -112,20 +114,29 @@ describe('remote MCP tool call', () => {
     expect(lastCall?.[2]?.signal).toBeInstanceOf(AbortSignal);
   });
 
-  it('returns isError result on tool call failure', async () => {
+  it.each([
+    new Error('Connection lost.'),
+    new McpError(ErrorCode.ConnectionClosed, 'Connection closed.'),
+    new McpError(ErrorCode.RequestTimeout, 'Request timed out.'),
+  ])('does not turn an issued transport failure into a server tool error: %s', async failure => {
     mocks.connect.mockResolvedValueOnce();
-    mocks.callTool.mockRejectedValueOnce(new Error('tool exploded'));
+    mocks.callTool.mockRejectedValueOnce(failure);
     mocks.close.mockResolvedValueOnce();
 
-    const result = await callRemoteMcpTool({
-      arguments: {},
-      fetch: noopFetch,
-      route,
-      server,
-    });
+    await expect(
+      callRemoteMcpTool({ arguments: {}, fetch: noopFetch, route, server })
+    ).rejects.toBe(failure);
+  });
 
-    expect(result).toMatchObject({ isError: true });
-    expect(JSON.stringify(result)).toContain('tool exploded');
+  it('returns a confirmed server tool error without throwing', async () => {
+    const result = { content: [{ text: 'tool exploded', type: 'text' }], isError: true };
+    mocks.connect.mockResolvedValueOnce();
+    mocks.callTool.mockResolvedValueOnce(result);
+    mocks.close.mockResolvedValueOnce();
+
+    await expect(
+      callRemoteMcpTool({ arguments: {}, fetch: noopFetch, route, server })
+    ).resolves.toStrictEqual(result);
   });
 
   it('returns isError result when connect fails', async () => {
@@ -139,7 +150,10 @@ describe('remote MCP tool call', () => {
       server,
     });
 
-    expect(result).toMatchObject({ isError: true });
+    expect(result).toStrictEqual({
+      content: [{ text: 'connect failed', type: 'text' }],
+      isError: true,
+    });
   });
 
   it('closes the client in finally even on error', async () => {
@@ -171,39 +185,61 @@ describe('remote MCP tool call', () => {
     expect(mocks.callTool.mock.calls.at(-1)?.[2]?.signal).toBeInstanceOf(AbortSignal);
   });
 
-  it('returns tool-error object (does not throw) when callTool rejects with AbortError', async () => {
-    const abortErr = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+  it('propagates an issued AbortError instead of reporting a server tool error', async () => {
+    const error = new DOMException('The operation was aborted', 'AbortError');
     mocks.connect.mockResolvedValueOnce();
-    mocks.callTool.mockRejectedValueOnce(abortErr);
+    mocks.callTool.mockRejectedValueOnce(error);
     mocks.close.mockResolvedValueOnce();
 
-    const controller = new AbortController();
-    controller.abort();
-    const result = await callRemoteMcpTool({
-      arguments: {},
-      fetch: noopFetch,
-      route,
-      server,
-      signal: controller.signal,
-    });
-
-    expect(result).toMatchObject({ isError: true });
-    expect(JSON.stringify(result)).toContain('operation was aborted');
+    await expect(
+      callRemoteMcpTool({ arguments: {}, fetch: noopFetch, route, server })
+    ).rejects.toBe(error);
   });
 
-  it('returns tool-error object (does not throw) when connect rejects with AbortError (simulating timeout)', async () => {
-    const timeoutErr = Object.assign(new Error('signal timed out'), { name: 'AbortError' });
-    mocks.connect.mockRejectedValueOnce(timeoutErr);
+  it('marks a typed abort from an issued call uncertain without losing its owner reason', async () => {
+    mocks.connect.mockResolvedValueOnce();
+    mocks.callTool.mockRejectedValueOnce(new ExecutionStoppedError('lease_lost'));
     mocks.close.mockResolvedValueOnce();
 
-    const result = await callRemoteMcpTool({
-      arguments: {},
-      fetch: noopFetch,
-      route,
-      server,
+    await expect(
+      callRemoteMcpTool({ arguments: {}, fetch: noopFetch, route, server })
+    ).rejects.toMatchObject({
+      effectsUncertain: true,
+      reason: 'lease_lost',
+      status: 'interrupted',
     });
+  });
 
-    expect(result).toMatchObject({ isError: true });
-    expect(JSON.stringify(result)).toContain('signal timed out');
+  it('keeps a connection AbortError confirmed before tool dispatch', async () => {
+    mocks.callTool.mockClear();
+    mocks.connect.mockRejectedValueOnce(new DOMException('Stopped.', 'AbortError'));
+    mocks.close.mockResolvedValueOnce();
+
+    await expect(
+      callRemoteMcpTool({ arguments: {}, fetch: noopFetch, route, server })
+    ).rejects.toMatchObject({
+      effectsUncertain: false,
+      reason: 'cancelled',
+      status: 'cancelled',
+    });
+    expect(mocks.callTool).not.toHaveBeenCalled();
+  });
+
+  it('checks a direct caller guard before opening a connection', async () => {
+    mocks.connect.mockClear();
+    const error = new ExecutionStoppedError('lease_lost');
+
+    await expect(
+      callRemoteMcpTool({
+        arguments: {},
+        executionGuard: () => {
+          throw error;
+        },
+        fetch: noopFetch,
+        route,
+        server,
+      })
+    ).rejects.toBe(error);
+    expect(mocks.connect).not.toHaveBeenCalled();
   });
 });

--- a/apps/extension/entrypoints/sidepanel/remote-mcp-client.ts
+++ b/apps/extension/entrypoints/sidepanel/remote-mcp-client.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/max-dependencies -- Reuse the runner guard alongside the SDK transport, auth, and validation contracts. */
 import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import {
@@ -5,9 +6,15 @@ import {
   StreamableHTTPError,
 } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolResultSchema, ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { jsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/types.js';
+import {
+  ExecutionStoppedError,
+  isExecutionStopped,
+  normalizeExecutionGuard,
+} from '../../src/shared/agent-tool-results';
+import type { ExecutionGuard } from '../../src/shared/agent-tool-results';
 import type {
   RemoteMcpAuth,
   RemoteMcpCachedTool,
@@ -209,6 +216,7 @@ export const connectAndPersistRemoteMcpServer = async ({
 
 export const callRemoteMcpTool = async ({
   arguments: args,
+  executionGuard,
   fetch: fetchFn,
   route,
   server,
@@ -216,18 +224,25 @@ export const callRemoteMcpTool = async ({
   storageArea,
 }: {
   readonly arguments: Record<string, unknown>;
+  readonly executionGuard?: ExecutionGuard;
   readonly fetch: FetchLike;
   readonly route: RemoteMcpToolRoute;
   readonly server: RemoteMcpServer;
   readonly signal?: AbortSignal;
   readonly storageArea?: RemoteMcpStorageArea;
 }): Promise<CallToolResult> => {
+  const guard = normalizeExecutionGuard(executionGuard, signal);
+  guard();
   const combined = combineSignal(signal, CONNECT_TIMEOUT_MS);
   const client = makeClient();
   const transport = makeTransport(server, fetchFn, makeAuthProvider(server, storageArea));
+  let toolCallIssued = false;
 
   try {
     await client.connect(asTransport(transport), { signal: combined });
+    guard();
+    combined.throwIfAborted();
+    toolCallIssued = true;
     const result = await client.callTool(
       { arguments: args, name: route.remoteToolName },
       CallToolResultSchema,
@@ -240,7 +255,23 @@ export const callRemoteMcpTool = async ({
      */
     return CallToolResultSchema.parse(result);
   } catch (error) {
-    const text = error instanceof Error ? error.message : String(error);
+    // The SDK wraps in-flight aborts as request timeouts. Retain the owner's original reason.
+    const cause: unknown = signal?.aborted === true ? signal.reason : error;
+    if (cause instanceof ExecutionStoppedError) {
+      throw toolCallIssued ? new ExecutionStoppedError(cause.reason, cause.status, true) : cause;
+    }
+    // These protocol codes confirm rejection before execution; SDK timeouts still leave effects uncertain.
+    const confirmedRejection =
+      !combined.aborted &&
+      cause instanceof McpError &&
+      [ErrorCode.InvalidParams, ErrorCode.MethodNotFound].includes(cause.code);
+    if (toolCallIssued && !confirmedRejection) {
+      throw cause;
+    }
+    if (isExecutionStopped(cause)) {
+      throw new ExecutionStoppedError('cancelled', 'cancelled');
+    }
+    const text = cause instanceof Error ? cause.message : String(cause);
     return { content: [{ text, type: 'text' }], isError: true };
   } finally {
     await client.close();

--- a/apps/extension/src/shared/agent-llm-harness.test.ts
+++ b/apps/extension/src/shared/agent-llm-harness.test.ts
@@ -215,7 +215,20 @@ describe('agent LLM harness', () => {
       tabId: 7,
     });
 
-    expect(buildGatewayMessagesFromEvents([firstToolCall, secondToolCall])).toStrictEqual([
+    const firstResult = createToolResult({
+      ok: true,
+      toolCallId: firstToolCall.id,
+      value: 'Title',
+    });
+    const secondResult = createToolResult({
+      error: 'Unavailable.',
+      ok: false,
+      toolCallId: secondToolCall.id,
+    });
+
+    expect(
+      buildGatewayMessagesFromEvents([firstToolCall, secondToolCall, firstResult, secondResult])
+    ).toStrictEqual([
       { content: EXTENSION_AGENT_SYSTEM_PROMPT, role: 'system' },
       {
         content: null,
@@ -239,6 +252,8 @@ describe('agent LLM harness', () => {
           },
         ],
       },
+      { content: '{"ok":true,"value":"Title"}', role: 'tool', tool_call_id: 'call_eval_1' },
+      { content: '{"error":"Unavailable.","ok":false}', role: 'tool', tool_call_id: 'call_eval_2' },
     ]);
   });
 
@@ -254,8 +269,9 @@ describe('agent LLM harness', () => {
       }),
       reasoningDetails,
     };
+    const result = createToolResult({ ok: true, toolCallId: toolCall.id, value: 'Title' });
 
-    expect(buildGatewayMessagesFromEvents([toolCall])).toStrictEqual([
+    expect(buildGatewayMessagesFromEvents([toolCall, result])).toStrictEqual([
       { content: EXTENSION_AGENT_SYSTEM_PROMPT, role: 'system' },
       {
         content: null,
@@ -269,6 +285,139 @@ describe('agent LLM harness', () => {
           },
         ],
       },
+      { content: '{"ok":true,"value":"Title"}', role: 'tool', tool_call_id: 'call_eval_1' },
+    ]);
+  });
+
+  it('pairs an interrupted batch without adding synthetic results to the transcript', () => {
+    const confirmedCall = createEvalToolCall({
+      code: 'return document.title;',
+      providerToolCallId: 'confirmed',
+      tabId: 7,
+    });
+    const missingCall = createWorkflowToolCall({
+      arguments: { text: 'A memory' },
+      name: 'save_memory',
+      providerToolCallId: 'missing',
+      tabId: 7,
+    });
+    const confirmedResult = createToolResult({
+      ok: true,
+      toolCallId: confirmedCall.id,
+      value: 'Observed title',
+    });
+    const events = [
+      confirmedCall,
+      missingCall,
+      confirmedResult,
+      createAssistantMessage('Stopped.'),
+      createUserMessage('Summarize only the confirmed work.'),
+    ];
+    const originalEvents = structuredClone(events);
+    const expectedResults = [
+      { content: '{"ok":true,"value":"Observed title"}', role: 'tool', tool_call_id: 'confirmed' },
+      {
+        content: JSON.stringify({
+          effectsUncertain: true,
+          error:
+            'No result was recorded for this tool call. Execution and effects are unknown. Do not automatically retry it.',
+          ok: false,
+        }),
+        role: 'tool',
+        tool_call_id: 'missing',
+      },
+    ];
+
+    expect(buildGatewayMessagesFromEvents(events)).toMatchObject([
+      { role: 'system' },
+      { role: 'assistant', tool_calls: [{ id: 'confirmed' }, { id: 'missing' }] },
+      ...expectedResults,
+      { content: 'Stopped.', role: 'assistant' },
+      { content: 'Summarize only the confirmed work.', role: 'user' },
+    ]);
+    expect(
+      buildGatewayMessagesFromEvents([confirmedCall, missingCall, confirmedResult]).slice(-2)
+    ).toStrictEqual(expectedResults);
+    expect(events).toStrictEqual(originalEvents);
+  });
+
+  it.each([false, true])('withholds uncertain results and images when ok=%s', ok => {
+    const toolCall = createSafeToolCall({
+      name: 'get_viewport_screenshot',
+      providerToolCallId: 'uncertain',
+      tabId: 7,
+    });
+    const result = {
+      ...createToolResult({
+        error: 'Result timed out.',
+        ok,
+        toolCallId: toolCall.id,
+        value: { dataUrl: 'data:image/png;base64,c2NyZWVu', mediaType: 'image/png' },
+      }),
+      effectsUncertain: true,
+    };
+    const messages = buildGatewayMessagesFromEvents([toolCall, result], { supportsImages: true });
+
+    expect(messages).toMatchObject([
+      { role: 'system' },
+      { role: 'assistant', tool_calls: [{ id: 'uncertain' }] },
+      {
+        content: '{"effectsUncertain":true,"error":"Result timed out.","ok":false}',
+        role: 'tool',
+        tool_call_id: 'uncertain',
+      },
+    ]);
+  });
+
+  it('places screenshot images after every tool response in an interrupted batch', () => {
+    const screenshotCall = createSafeToolCall({
+      name: 'get_viewport_screenshot',
+      providerToolCallId: 'screenshot',
+      tabId: 7,
+    });
+    const skippedCall = createSafeToolCall({
+      name: 'get_page_snapshot',
+      providerToolCallId: 'skipped',
+      tabId: 7,
+    });
+    const screenshotResult = createToolResult({
+      ok: true,
+      toolCallId: screenshotCall.id,
+      value: { dataUrl: 'data:image/png;base64,c2NyZWVu', mediaType: 'image/png' },
+    });
+
+    expect(
+      buildGatewayMessagesFromEvents(
+        [screenshotCall, skippedCall, screenshotResult, createAssistantMessage('Stopped.')],
+        { supportsImages: true }
+      )
+    ).toMatchObject([
+      { role: 'system' },
+      { role: 'assistant', tool_calls: [{ id: 'screenshot' }, { id: 'skipped' }] },
+      {
+        content:
+          '{"ok":true,"value":{"mediaType":"image/png","note":"Viewport screenshot attached as an image input."}}',
+        role: 'tool',
+        tool_call_id: 'screenshot',
+      },
+      {
+        content: JSON.stringify({
+          effectsUncertain: true,
+          error:
+            'No result was recorded for this tool call. Execution and effects are unknown. Do not automatically retry it.',
+          ok: false,
+        }),
+        role: 'tool',
+        tool_call_id: 'skipped',
+      },
+      {
+        content: [
+          { text: 'Viewport screenshot from get_viewport_screenshot.', type: 'text' },
+          { image_url: { url: 'data:image/png;base64,c2NyZWVu' }, type: 'image_url' },
+        ],
+        role: 'user',
+      },
+      { content: 'Stopped.', role: 'assistant' },
     ]);
   });
 

--- a/apps/extension/src/shared/agent-llm-harness.ts
+++ b/apps/extension/src/shared/agent-llm-harness.ts
@@ -434,21 +434,43 @@ const getToolResultValue = (
 };
 
 const toToolResultContent = (
-  event: ToolResultEvent,
+  event: ToolResultEvent | undefined,
   toolCall: ToolCallEvent,
   supportsImages: boolean
-): string =>
-  JSON.stringify(
+): string => {
+  if (event === undefined) {
+    // Replay-only explanation: a missing result proves neither execution nor non-execution.
+    return JSON.stringify({
+      effectsUncertain: true,
+      error:
+        'No result was recorded for this tool call. Execution and effects are unknown. Do not automatically retry it.',
+      ok: false,
+    });
+  }
+  if ('effectsUncertain' in event && event.effectsUncertain === true) {
+    return JSON.stringify({
+      effectsUncertain: true,
+      error: event.error ?? 'Tool completion is uncertain.',
+      ok: false,
+    });
+  }
+  return JSON.stringify(
     event.ok
       ? { ok: true, value: getToolResultValue(event, toolCall, supportsImages) }
       : { error: event.error ?? 'Eval failed.', ok: false }
   );
+};
 
 const toScreenshotMessage = (
-  event: ToolResultEvent,
+  event: ToolResultEvent | undefined,
   toolCall: ToolCallEvent
 ): KiloGatewayChatMessage | undefined => {
-  if (!event.ok || toolCall.name !== 'get_viewport_screenshot') {
+  if (
+    event === undefined ||
+    !event.ok ||
+    ('effectsUncertain' in event && event.effectsUncertain === true) ||
+    toolCall.name !== 'get_viewport_screenshot'
+  ) {
     return undefined;
   }
 
@@ -467,11 +489,13 @@ const toScreenshotMessage = (
 
 const appendToolResultMessages = ({
   event,
+  imageMessages,
   messages,
   supportsImages,
   toolCall,
 }: {
-  readonly event: ToolResultEvent;
+  readonly event: ToolResultEvent | undefined;
+  readonly imageMessages: KiloGatewayChatMessage[];
   readonly messages: KiloGatewayChatMessage[];
   readonly supportsImages: boolean;
   readonly toolCall: ToolCallEvent;
@@ -485,7 +509,7 @@ const appendToolResultMessages = ({
   const screenshotMessage = toScreenshotMessage(event, toolCall);
 
   if (supportsImages && screenshotMessage !== undefined) {
-    messages.push(screenshotMessage);
+    imageMessages.push(screenshotMessage);
   }
 };
 
@@ -539,7 +563,11 @@ export const buildGatewayMessagesFromEvents = (
   events: AgentConversationEvent[],
   { supportsImages = false }: { readonly supportsImages?: boolean } = {}
 ): KiloGatewayChatMessage[] => {
-  const toolCallsById = new Map<string, ToolCallEvent>();
+  const toolResultsByCallId = new Map(
+    events.flatMap(event =>
+      event.type === 'tool-result' ? [[event.toolCallId, event] as const] : []
+    )
+  );
   const messages: KiloGatewayChatMessage[] = [
     { content: EXTENSION_AGENT_SYSTEM_PROMPT, role: 'system' },
   ];
@@ -553,7 +581,9 @@ export const buildGatewayMessagesFromEvents = (
           messages.push({ content: getGatewayMessageText(event), role: event.role });
           break;
         }
-        case 'thinking': {
+        case 'thinking':
+        case 'tool-result': {
+          // Results are emitted with their batch, before any normal message or image input.
           break;
         }
         case 'tool-call': {
@@ -563,39 +593,40 @@ export const buildGatewayMessagesFromEvents = (
           const toolCalls = consecutiveToolCalls.filter(
             (toolCall): toolCall is ExtensionToolCall => !('source' in toolCall)
           );
-          for (const toolCall of toolCalls) {
-            toolCallsById.set(toolCall.id, toolCall);
-          }
 
           index += consecutiveToolCalls.length - 1;
+          if (toolCalls.length === 0) {
+            break;
+          }
           const reasoningDetails = toolCalls.find(
             toolCall => toolCall.reasoningDetails !== undefined
           )?.reasoningDetails;
-          if (toolCalls.length > 0) {
-            messages.push({
-              content: null,
-              ...(reasoningDetails === undefined ? {} : { reasoning_details: reasoningDetails }),
-              role: 'assistant',
-              tool_calls: toolCalls.map(toolCall => ({
-                function: {
-                  arguments: getToolCallArguments(toolCall),
-                  // WebMCP names are stored as plain strings but are valid gateway tool names.
-                  // eslint-disable-next-line no-unsafe-type-assertion
-                  name: toolCall.name as KiloGatewayToolName,
-                },
-                id: getProviderToolCallId(toolCall),
-                type: 'function',
-              })),
+          messages.push({
+            content: null,
+            ...(reasoningDetails === undefined ? {} : { reasoning_details: reasoningDetails }),
+            role: 'assistant',
+            tool_calls: toolCalls.map(toolCall => ({
+              function: {
+                arguments: getToolCallArguments(toolCall),
+                // WebMCP names are stored as plain strings but are valid gateway tool names.
+                // eslint-disable-next-line no-unsafe-type-assertion
+                name: toolCall.name as KiloGatewayToolName,
+              },
+              id: getProviderToolCallId(toolCall),
+              type: 'function',
+            })),
+          });
+          const imageMessages: KiloGatewayChatMessage[] = [];
+          for (const toolCall of toolCalls) {
+            appendToolResultMessages({
+              event: toolResultsByCallId.get(toolCall.id),
+              imageMessages,
+              messages,
+              supportsImages,
+              toolCall,
             });
           }
-          break;
-        }
-        case 'tool-result': {
-          const toolCall = toolCallsById.get(event.toolCallId);
-
-          if (toolCall !== undefined) {
-            appendToolResultMessages({ event, messages, supportsImages, toolCall });
-          }
+          messages.push(...imageMessages);
           break;
         }
       }

--- a/apps/extension/src/shared/agent-llm-turn-runner-core.test.ts
+++ b/apps/extension/src/shared/agent-llm-turn-runner-core.test.ts
@@ -11,6 +11,9 @@ import type {
   KiloGatewayToolDefinition,
 } from './kilo-api-client';
 import { runLlmTurn } from './agent-llm-turn-runner-core';
+import type { LlmTurnOutcome } from './agent-llm-turn-runner-core';
+import { ExecutionStoppedError } from './agent-tool-results';
+import type { EvalTabResult } from './tab-debugger';
 
 const kiloApiClientMocks = vi.hoisted(() => ({
   fetchKiloGatewayChatCompletionStream: vi.fn(),
@@ -44,7 +47,7 @@ const getPageSnapshotTool: KiloGatewayToolDefinition = {
 function* createGatewayResponses(): Generator<Response, Response> {
   yield streamResponse([
     'data: {"choices":[{"delta":{"content":"Reading"}}]}\n\n',
-    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_snapshot","type":"function","function":{"name":"get_page_snapshot","arguments":"{}"}}]}}]}\n\n',
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_snapshot","type":"function","function":{"name":"get_page_snapshot","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}\n\n',
     'data: {"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":5,"total_tokens":105,"cost":0.0007}}\n\n',
     'data: [DONE]\n\n',
   ]);
@@ -59,7 +62,7 @@ function* createGatewayResponses(): Generator<Response, Response> {
 function* createToolOnlyGatewayResponses(rounds: number): Generator<Response, Response> {
   for (let index = 0; index < rounds; index += 1) {
     yield streamResponse([
-      `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_snapshot_${index}","type":"function","function":{"name":"get_page_snapshot","arguments":"{}"}}]}}]}\n\n`,
+      `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_snapshot_${index}","type":"function","function":{"name":"get_page_snapshot","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}\n\n`,
       'data: [DONE]\n\n',
     ]);
   }
@@ -814,7 +817,8 @@ describe('identical failing tool call guard', () => {
         appendedEvents.push(...events);
       },
       conversationEvents: [createUserMessage('Run the workflow')],
-      executeToolCall: () => Promise.resolve({ error: 'Workflow run failed', ok: false }),
+      executeToolCall: () =>
+        Promise.resolve({ effectsUncertain: false, error: 'Workflow run failed', ok: false }),
       failureMessage: String,
       fetch,
       maxToolRounds: 8,
@@ -872,7 +876,11 @@ describe('per-tool failure cap', () => {
         if (callIndex % 10 === 0) {
           return Promise.resolve({ ok: true, value: { text: 'ok' } });
         }
-        return Promise.resolve({ error: `failure ${String(callIndex)}`, ok: false });
+        return Promise.resolve({
+          effectsUncertain: false,
+          error: `failure ${String(callIndex)}`,
+          ok: false,
+        });
       },
       failureMessage: String,
       fetch,
@@ -902,6 +910,558 @@ describe('per-tool failure cap', () => {
     expect(JSON.stringify(lastEvent)).toContain(
       'Stopped: get_page_snapshot failed 25 times this turn'
     );
+  });
+});
+
+const completeAnswer: KiloGatewayChatCompletion = {
+  content: 'Final answer.',
+  finishReason: 'stop',
+  toolCalls: [],
+};
+const requestedTool: KiloGatewayChatCompletion = {
+  finishReason: 'tool_calls',
+  toolCalls: [{ arguments: {}, id: 'requested-1', name: 'get_page_snapshot' }],
+};
+const outcomeOptions = () => ({
+  apiBaseUrl: 'https://app.kilo.ai',
+  appendEvents: (_events: AgentConversationEvent[]) => {},
+  conversationEvents: [createUserMessage('Finish the requested work.')],
+  executeToolCall: () => Promise.resolve({ ok: true as const, value: 'Observed text.' }),
+  failureMessage: String,
+  fetch: () => new Response(),
+  maxToolRounds: 5,
+  model: 'test-model',
+  noResponseMessage: 'No response.',
+  token: 'test-token',
+  tools: [getPageSnapshotTool],
+  tooManyToolRoundsMessage: 'Round limit.',
+  toToolCallEvents: (calls: KiloGatewayToolCallRequest[]) =>
+    calls.flatMap(call =>
+      call.name === 'get_page_snapshot'
+        ? [createSafeToolCall({ name: 'get_page_snapshot', providerToolCallId: call.id, tabId: 1 })]
+        : []
+    ),
+  updateAssistantMessage: () => {},
+  updateThinkingBlock: () => {},
+});
+
+interface OutcomeCase {
+  label: string;
+  expected: Pick<LlmTurnOutcome, 'status' | 'reason'>;
+  completions?: KiloGatewayChatCompletion[];
+  error?: Error;
+  result?: EvalTabResult;
+  rounds?: number;
+  requests: number;
+  actions?: number;
+  confirmed?: number;
+  summary?: string;
+  uncertain?: boolean;
+}
+const outcomeCases: OutcomeCase[] = [
+  {
+    label: 'end_turn answer',
+    completions: [{ ...completeAnswer, finishReason: 'end_turn' }],
+    expected: { reason: 'completed', status: 'succeeded' },
+    requests: 1,
+    summary: 'Final answer.',
+  },
+  {
+    label: 'empty stream without a finish reason',
+    completions: [{ toolCalls: [] }],
+    expected: { reason: 'empty_response', status: 'failed' },
+    requests: 3,
+  },
+  {
+    label: 'truncated thinking cannot trigger the nudge',
+    completions: [{ reasoning: 'Partial thinking.', toolCalls: [] }],
+    expected: { reason: 'truncated_response', status: 'failed' },
+    requests: 3,
+  },
+  {
+    label: 'context overflow with tool calls',
+    completions: [{ ...requestedTool, finishReason: 'model_context_window_exceeded' }],
+    expected: { reason: 'context_overflow', status: 'failed' },
+    requests: 1,
+  },
+  {
+    label: 'complete answer without evidence',
+    completions: [completeAnswer],
+    expected: { status: 'succeeded', reason: 'completed' },
+    requests: 1,
+    summary: 'Final answer.',
+  },
+  {
+    label: 'empty completion',
+    completions: [{ finishReason: 'stop', toolCalls: [] }],
+    expected: { status: 'failed', reason: 'empty_response' },
+    requests: 1,
+  },
+  {
+    label: 'whitespace answer',
+    completions: [{ content: '   ', finishReason: 'stop', toolCalls: [] }],
+    expected: { status: 'failed', reason: 'empty_response' },
+    requests: 1,
+  },
+  {
+    label: 'thinking without a remaining round',
+    completions: [{ reasoning: 'Planning.', finishReason: 'stop', toolCalls: [] }],
+    rounds: 1,
+    expected: { status: 'failed', reason: 'empty_response' },
+    requests: 1,
+  },
+  {
+    label: 'thinking after the nudge',
+    completions: [{ reasoning: 'Planning.', finishReason: 'stop', toolCalls: [] }],
+    expected: { status: 'failed', reason: 'empty_response' },
+    requests: 2,
+  },
+  {
+    label: 'empty context overflow',
+    completions: [{ finishReason: 'model_context_window_exceeded', toolCalls: [] }],
+    expected: { status: 'failed', reason: 'context_overflow' },
+    requests: 1,
+    summary: 'No response.',
+  },
+  {
+    label: 'exhausted empty truncation',
+    completions: [{ finishReason: 'length', toolCalls: [] }],
+    expected: { status: 'failed', reason: 'truncated_response' },
+    requests: 3,
+    summary: 'No response.',
+  },
+  {
+    label: 'partial final output',
+    completions: [{ content: 'Partial answer.', finishReason: 'length', toolCalls: [] }],
+    expected: { status: 'failed', reason: 'truncated_response' },
+    requests: 3,
+    summary: 'Partial answer.',
+  },
+  {
+    label: 'missing finish reason',
+    completions: [{ content: 'Partial answer.', toolCalls: [] }],
+    expected: { status: 'failed', reason: 'truncated_response' },
+    requests: 3,
+    summary: 'Partial answer.',
+  },
+  {
+    label: 'non-final finish reason',
+    completions: [{ content: 'Partial answer.', finishReason: 'tool_calls', toolCalls: [] }],
+    expected: { status: 'failed', reason: 'truncated_response' },
+    requests: 1,
+  },
+  {
+    label: 'context overflow',
+    completions: [
+      { content: 'Partial answer.', finishReason: 'model_context_window_exceeded', toolCalls: [] },
+    ],
+    expected: { status: 'failed', reason: 'context_overflow' },
+    requests: 1,
+    summary: 'Partial answer.',
+  },
+  {
+    label: 'no available rounds',
+    rounds: 0,
+    expected: { status: 'failed', reason: 'rounds_exhausted' },
+    requests: 0,
+  },
+  {
+    label: 'round limit after confirmed work',
+    completions: [requestedTool],
+    rounds: 1,
+    expected: { status: 'failed', reason: 'rounds_exhausted' },
+    requests: 1,
+    actions: 1,
+    confirmed: 1,
+  },
+  {
+    label: 'discarded unsafe call in a mixed batch',
+    completions: [
+      {
+        finishReason: 'tool_calls',
+        toolCalls: [...requestedTool.toolCalls, { arguments: {}, id: 'unsafe', name: 'eval' }],
+      },
+    ],
+    expected: { status: 'failed', reason: 'unsafe_tool_call' },
+    requests: 1,
+  },
+  {
+    label: 'truncated tool batch',
+    completions: [{ ...requestedTool, finishReason: 'length' }],
+    expected: { status: 'failed', reason: 'truncated_response' },
+    requests: 1,
+  },
+  {
+    label: 'recoverable tool failure',
+    completions: [requestedTool, completeAnswer],
+    result: { effectsUncertain: false, error: 'Missing input.', ok: false },
+    expected: { status: 'succeeded', reason: 'completed' },
+    requests: 2,
+    actions: 1,
+    confirmed: 1,
+  },
+  {
+    label: 'uncertain failure',
+    completions: [requestedTool],
+    result: { effectsUncertain: true, error: 'Timeout.', ok: false },
+    expected: { status: 'interrupted', reason: 'effects_uncertain' },
+    requests: 1,
+    actions: 1,
+    uncertain: true,
+  },
+  {
+    label: 'legacy failure after dispatch',
+    completions: [requestedTool],
+    result: { error: 'Lost result.', ok: false },
+    expected: { status: 'interrupted', reason: 'effects_uncertain' },
+    requests: 1,
+    actions: 1,
+    uncertain: true,
+  },
+  {
+    label: 'uncertain success payload',
+    completions: [requestedTool],
+    result: { effectsUncertain: true, ok: true, value: 'Unconfirmed.' },
+    expected: { status: 'interrupted', reason: 'effects_uncertain' },
+    requests: 1,
+    actions: 1,
+    uncertain: true,
+  },
+  {
+    label: 'exhausted model retries',
+    error: new TypeError('Network failed.'),
+    expected: { status: 'failed', reason: 'retry_exhausted' },
+    requests: 3,
+  },
+  {
+    label: 'terminal model failure',
+    error: new Error('Model failed.'),
+    expected: { status: 'failed', reason: 'model_failure' },
+    requests: 1,
+  },
+  {
+    label: 'model AbortError',
+    error: new DOMException('Stopped.', 'AbortError'),
+    expected: { status: 'cancelled', reason: 'cancelled' },
+    requests: 1,
+  },
+  {
+    label: 'owner interruption',
+    error: new ExecutionStoppedError('lease_lost'),
+    expected: { status: 'interrupted', reason: 'lease_lost' },
+    requests: 1,
+  },
+  {
+    label: 'execution timeout',
+    error: new ExecutionStoppedError('execution_timeout', 'interrupted', true),
+    expected: { status: 'interrupted', reason: 'execution_timeout' },
+    requests: 1,
+    uncertain: true,
+  },
+  {
+    label: 'unconfirmed announcement after the nudge',
+    completions: [
+      requestedTool,
+      { content: 'Creating the workflow now.', finishReason: 'stop', toolCalls: [] },
+    ],
+    expected: { status: 'failed', reason: 'incomplete_response' },
+    requests: 3,
+    actions: 1,
+    confirmed: 1,
+  },
+  {
+    label: 'tool failure cap',
+    completions: [requestedTool],
+    rounds: 30,
+    result: { effectsUncertain: false, error: 'Still blocked.', ok: false },
+    expected: { status: 'failed', reason: 'tool_failure_limit' },
+    requests: 25,
+    actions: 25,
+    confirmed: 25,
+  },
+];
+
+describe('typed terminal outcomes', () => {
+  it.each([
+    { ending: '', label: 'end of stream' },
+    { ending: 'data: [DONE]\n\n', label: 'DONE without finish metadata' },
+  ])('rejects a complete tool call before dispatch at $label', async ({ ending }) => {
+    const appended: AgentConversationEvent[] = [];
+    const actions: string[] = [];
+    let requests = 0;
+    const result = await runLlmTurn({
+      ...outcomeOptions(),
+      appendEvents: events => appended.push(...events),
+      executeToolCall: call => {
+        actions.push(call.name);
+        return Promise.resolve({ ok: true, value: 'Unexpected action.' });
+      },
+      fetch: () => {
+        requests += 1;
+        return streamResponse(
+          requests === 1
+            ? [
+                'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"unfinished-1","function":{"name":"get_page_snapshot","arguments":"{}"}}]}}]}\n\n',
+                ending,
+              ]
+            : [
+                'data: {"choices":[{"delta":{"content":"False success."},"finish_reason":"stop"}]}\n\n',
+              ]
+        );
+      },
+    });
+
+    expect(result).toMatchObject({
+      effectsUncertain: false,
+      reason: 'truncated_response',
+      status: 'failed',
+      toolResults: [],
+    });
+    expect({ actions, requests }).toStrictEqual({ actions: [], requests: 1 });
+    expect(
+      appended.filter(event => event.type === 'tool-call' || event.type === 'tool-result')
+    ).toStrictEqual([]);
+  });
+
+  it('keeps a typed pre-dispatch rejection confirmed after executor setup', async () => {
+    kiloApiClientMocks.fetchKiloGatewayChatCompletionStream.mockResolvedValueOnce(requestedTool);
+    const actions: string[] = [];
+    let active = true;
+    const guard = () => {
+      if (!active) {
+        throw new ExecutionStoppedError('lease_lost');
+      }
+    };
+    const result = await runLlmTurn({
+      ...outcomeOptions(),
+      executeToolCall: async () => {
+        await Promise.resolve();
+        active = false;
+        guard();
+        actions.push('Unexpected action.');
+        return { ok: true, value: 'Unexpected result.' };
+      },
+      executionGuard: guard,
+    });
+
+    expect(result).toMatchObject({
+      effectsUncertain: false,
+      reason: 'lease_lost',
+      status: 'interrupted',
+      toolResults: [],
+    });
+    expect(actions).toStrictEqual([]);
+  });
+
+  it.each(outcomeCases)('returns a non-ambiguous result for $label', async entry => {
+    const actual = await vi.importActual<typeof import('./kilo-api-client')>('./kilo-api-client');
+    let requests = 0;
+    const actions: string[] = [];
+    const appended: AgentConversationEvent[] = [];
+    kiloApiClientMocks.fetchKiloGatewayChatCompletionStream.mockImplementation(() => {
+      requests += 1;
+      if (entry.error !== undefined) {
+        throw entry.error;
+      }
+      return entry.completions?.[requests - 1] ?? entry.completions?.at(-1) ?? completeAnswer;
+    });
+    vi.useFakeTimers();
+    try {
+      const pending = runLlmTurn({
+        ...outcomeOptions(),
+        appendEvents: events => appended.push(...events),
+        executeToolCall: call => {
+          actions.push(call.providerToolCallId ?? '');
+          return Promise.resolve(entry.result ?? { ok: true, value: 'Observed text.' });
+        },
+        maxToolRounds: entry.rounds ?? 5,
+      });
+      await vi.runAllTimersAsync();
+      const result = await pending;
+      expect(result).toMatchObject({
+        ...entry.expected,
+        effectsUncertain: entry.uncertain ?? false,
+        ...(entry.summary === undefined ? {} : { summary: entry.summary }),
+      });
+      const assistantMessages = appended.filter(event => event.type === 'message');
+      expect(assistantMessages.at(-1)).toMatchObject({ role: 'assistant', text: result.summary });
+      expect(result.toolResults).toHaveLength(entry.confirmed ?? 0);
+      expect(actions).toHaveLength(entry.actions ?? 0);
+      expect(requests).toBe(entry.requests);
+    } finally {
+      vi.useRealTimers();
+      kiloApiClientMocks.fetchKiloGatewayChatCompletionStream.mockImplementation(
+        actual.fetchKiloGatewayChatCompletionStream
+      );
+    }
+  });
+
+  it.each([
+    { label: 'Stop', reason: 'cancelled', status: 'cancelled' },
+    { label: 'lease loss', reason: 'lease_lost', status: 'interrupted' },
+  ])('prevents another tool or model round after $label', async ({ reason, status }) => {
+    const actual = await vi.importActual<typeof import('./kilo-api-client')>('./kilo-api-client');
+    const controller = new AbortController();
+    const actions: string[] = [];
+    let active = true;
+    let requests = 0;
+    kiloApiClientMocks.fetchKiloGatewayChatCompletionStream.mockImplementation(() => {
+      requests += 1;
+      return {
+        ...requestedTool,
+        toolCalls: [
+          ...requestedTool.toolCalls,
+          { arguments: {}, id: 'requested-2', name: 'get_page_snapshot' },
+        ],
+      };
+    });
+    try {
+      const result = await runLlmTurn({
+        ...outcomeOptions(),
+        executionGuard: () => {
+          if (!active) {
+            throw new Error('lease_lost');
+          }
+        },
+        executeToolCall: call => {
+          actions.push(call.providerToolCallId ?? '');
+          if (reason === 'cancelled') {
+            controller.abort();
+          } else {
+            active = false;
+          }
+          return Promise.resolve({ ok: true, value: 'Issued and confirmed.' });
+        },
+        signal: controller.signal,
+      });
+      expect(result).toMatchObject({ effectsUncertain: false, reason, status });
+      expect(result.toolResults).toMatchObject([{ ok: true, value: 'Issued and confirmed.' }]);
+      expect(actions).toStrictEqual(['requested-1']);
+      expect(requests).toBe(1);
+    } finally {
+      kiloApiClientMocks.fetchKiloGatewayChatCompletionStream.mockImplementation(
+        actual.fetchKiloGatewayChatCompletionStream
+      );
+    }
+  });
+
+  it('retains uncertainty when an issued executor aborts without a result', async () => {
+    const actual = await vi.importActual<typeof import('./kilo-api-client')>('./kilo-api-client');
+    kiloApiClientMocks.fetchKiloGatewayChatCompletionStream.mockResolvedValueOnce(requestedTool);
+    try {
+      const result = await runLlmTurn({
+        ...outcomeOptions(),
+        executeToolCall: () => Promise.reject(new DOMException('Transport aborted.', 'AbortError')),
+      });
+      expect(result).toMatchObject({
+        effectsUncertain: true,
+        status: 'cancelled',
+        toolResults: [],
+      });
+    } finally {
+      kiloApiClientMocks.fetchKiloGatewayChatCompletionStream.mockImplementation(
+        actual.fetchKiloGatewayChatCompletionStream
+      );
+    }
+  });
+});
+
+describe('authority across model awaits', () => {
+  it.each([
+    { reason: 'cancelled', status: 'cancelled' as const },
+    { reason: 'lease_lost', status: 'interrupted' as const },
+  ])('retains $reason while waiting to retry', async ({ reason, status }) => {
+    const actual = await vi.importActual<typeof import('./kilo-api-client')>('./kilo-api-client');
+    const controller = new AbortController();
+    let requests = 0;
+    kiloApiClientMocks.fetchKiloGatewayChatCompletionStream.mockImplementation(() => {
+      requests += 1;
+      setTimeout(() => {
+        controller.abort(new ExecutionStoppedError(reason, status));
+      }, 1);
+      throw new TypeError('Network failed.');
+    });
+    vi.useFakeTimers();
+    try {
+      const pending = runLlmTurn({ ...outcomeOptions(), signal: controller.signal });
+      await vi.runAllTimersAsync();
+      await expect(pending).resolves.toMatchObject({
+        effectsUncertain: false,
+        reason,
+        status,
+        toolResults: [],
+      });
+      expect(requests).toBe(1);
+    } finally {
+      vi.useRealTimers();
+      kiloApiClientMocks.fetchKiloGatewayChatCompletionStream.mockImplementation(
+        actual.fetchKiloGatewayChatCompletionStream
+      );
+    }
+  });
+
+  it('preserves the lease guard through the invisible continuation', async () => {
+    const actual = await vi.importActual<typeof import('./kilo-api-client')>('./kilo-api-client');
+    let active = true;
+    let requests = 0;
+    const actions: string[] = [];
+    const completions = [
+      requestedTool,
+      { content: 'Creating the workflow now.', finishReason: 'stop', toolCalls: [] },
+      requestedTool,
+    ];
+    kiloApiClientMocks.fetchKiloGatewayChatCompletionStream.mockImplementation(() => {
+      const completion = completions[requests];
+      requests += 1;
+      if (requests === 3) {
+        active = false;
+      }
+      return completion;
+    });
+    try {
+      const result = await runLlmTurn({
+        ...outcomeOptions(),
+        executeToolCall: () => {
+          actions.push('read');
+          return Promise.resolve({ ok: true, value: 'observed' });
+        },
+        executionGuard: () => {
+          if (!active) {
+            throw new ExecutionStoppedError('lease_lost');
+          }
+        },
+      });
+      expect(result).toMatchObject({
+        effectsUncertain: false,
+        reason: 'lease_lost',
+        status: 'interrupted',
+      });
+      expect(result.toolResults).toMatchObject([{ ok: true, value: 'observed' }]);
+      expect(actions).toStrictEqual(['read']);
+      expect(requests).toBe(3);
+    } finally {
+      kiloApiClientMocks.fetchKiloGatewayChatCompletionStream.mockImplementation(
+        actual.fetchKiloGatewayChatCompletionStream
+      );
+    }
+  });
+
+  it('retains discovery uncertainty even when Stop arrives at the same time', async () => {
+    const controller = new AbortController();
+    const result = await runLlmTurn({
+      ...outcomeOptions(),
+      prepareTools: () => {
+        controller.abort();
+        throw new ExecutionStoppedError('effects_uncertain', 'interrupted', true);
+      },
+      signal: controller.signal,
+    });
+    expect(result).toMatchObject({
+      effectsUncertain: true,
+      reason: 'effects_uncertain',
+      status: 'interrupted',
+      toolResults: [],
+    });
   });
 });
 

--- a/apps/extension/src/shared/agent-llm-turn-runner-core.test.ts
+++ b/apps/extension/src/shared/agent-llm-turn-runner-core.test.ts
@@ -1,8 +1,13 @@
 /* eslint-disable max-lines, sort-keys, no-promise-executor-return, promise/avoid-new, promise/prefer-await-to-then, jest/no-conditional-in-test, consistent-type-imports, jest/no-untyped-mock-factory, vitest/prefer-import-in-mock -- Retry fixtures need attempt-conditional fakes and raw promises; the typed stream-client mock needs importOriginal. */
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { createSafeToolCall, createUserMessage } from './agent-conversation';
+import {
+  createSafeToolCall,
+  createUserMessage,
+  createWorkflowToolCall,
+} from './agent-conversation';
 import type { AgentConversationEvent } from './agent-conversation';
+import { createWorkflowToolDefinitions } from './agent-llm-harness';
 import type { FetchLike } from './auth';
 import { maxAgentToolRounds } from './agent-tool-round-limit';
 import type {
@@ -943,6 +948,287 @@ const outcomeOptions = () => ({
     ),
   updateAssistantMessage: () => {},
   updateThinkingBlock: () => {},
+});
+
+const gatewayRequestSchema = z.object({ messages: z.array(z.unknown()) });
+
+const historyInterruptionCases = [
+  {
+    boundary: 'Stop between calls',
+    reason: 'cancelled',
+    status: 'cancelled',
+    confirmed: 1,
+    saved: false,
+  },
+  {
+    boundary: 'abort after streamed completion',
+    reason: 'cancelled',
+    status: 'cancelled',
+    confirmed: 0,
+    saved: false,
+  },
+  {
+    boundary: 'denied approval',
+    reason: 'permission_denied',
+    status: 'interrupted',
+    confirmed: 1,
+    saved: false,
+  },
+  {
+    boundary: 'uncertain failure',
+    reason: 'effects_uncertain',
+    status: 'interrupted',
+    confirmed: 1,
+    saved: true,
+  },
+  {
+    boundary: 'uncertain success',
+    reason: 'effects_uncertain',
+    status: 'interrupted',
+    confirmed: 1,
+    saved: true,
+  },
+  {
+    boundary: 'issued executor abort',
+    reason: 'cancelled',
+    status: 'cancelled',
+    confirmed: 1,
+    saved: true,
+  },
+] as const;
+
+describe('explicit continuation after interrupted tool batches', () => {
+  it.each(historyInterruptionCases)('continues without replay after $boundary', async entry => {
+    const controller = new AbortController();
+    const history: AgentConversationEvent[] = [createUserMessage('Finish the requested work.')];
+    const savedMemories: string[] = [];
+    const pageReads: string[] = [];
+    const reasoningDetails = [
+      { index: 0, signature: 'batch-signature', text: 'Read, then save.', type: 'reasoning.text' },
+    ];
+    const summary = entry.status === 'cancelled' ? 'Stopped.' : `Interrupted: ${entry.reason}.`;
+    const uncertainResult =
+      entry.boundary === 'uncertain failure' || entry.boundary === 'uncertain success';
+    const unknownResult = JSON.stringify({
+      effectsUncertain: true,
+      error:
+        'No result was recorded for this tool call. Execution and effects are unknown. Do not automatically retry it.',
+      ok: false,
+    });
+    const expectedHistory = [
+      { role: 'user', content: 'Finish the requested work.' },
+      { role: 'assistant', content: 'Starting the batch.' },
+      {
+        role: 'assistant',
+        reasoning_details: reasoningDetails,
+        tool_calls: [
+          { id: 'read-1', function: { name: 'get_page_snapshot', arguments: '{}' } },
+          { id: 'save-1', function: { name: 'save_memory', arguments: '{"text":"First memory"}' } },
+          {
+            id: 'save-2',
+            function: { name: 'save_memory', arguments: '{"text":"Skipped memory"}' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'read-1',
+        content: entry.confirmed === 0 ? unknownResult : '{"ok":true,"value":"Observed page."}',
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'save-1',
+        content: uncertainResult
+          ? JSON.stringify({
+              effectsUncertain: true,
+              error:
+                entry.boundary === 'uncertain failure'
+                  ? 'Result timed out.'
+                  : 'Tool completion is uncertain.',
+              ok: false,
+            })
+          : unknownResult,
+      },
+      { role: 'tool', tool_call_id: 'save-2', content: unknownResult },
+      { role: 'assistant', content: summary },
+      { role: 'user', content: 'Read the page once. Do not retry prior saves.' },
+    ];
+    let requests = 0;
+    const fetch: FetchLike = (_input, init) => {
+      requests += 1;
+      const request = gatewayRequestSchema.parse(JSON.parse(stringBodySchema.parse(init?.body)));
+      if (requests === 1) {
+        return streamResponse([
+          `data: ${JSON.stringify({
+            choices: [
+              {
+                delta: {
+                  content: 'Starting the batch.',
+                  reasoning_details: reasoningDetails,
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'read-1',
+                      type: 'function',
+                      function: { name: 'get_page_snapshot', arguments: '{}' },
+                    },
+                    {
+                      index: 1,
+                      id: 'save-1',
+                      type: 'function',
+                      function: { name: 'save_memory', arguments: '{"text":"First memory"}' },
+                    },
+                    {
+                      index: 2,
+                      id: 'save-2',
+                      type: 'function',
+                      function: { name: 'save_memory', arguments: '{"text":"Skipped memory"}' },
+                    },
+                  ],
+                },
+                finish_reason: 'tool_calls',
+              },
+            ],
+          })}\n\n`,
+          'data: [DONE]\n\n',
+        ]);
+      }
+      // Reject missing, reordered, or duplicate responses before accepting the follow-up.
+      expect(request.messages.slice(1)).toMatchObject(
+        requests === 2
+          ? expectedHistory
+          : [
+              ...expectedHistory,
+              {
+                role: 'assistant',
+                tool_calls: [
+                  { id: 'fresh-read', function: { name: 'get_page_snapshot', arguments: '{}' } },
+                ],
+              },
+              {
+                role: 'tool',
+                tool_call_id: 'fresh-read',
+                content: '{"ok":true,"value":"Observed page."}',
+              },
+            ]
+      );
+      return streamResponse(
+        requests === 2
+          ? [
+              'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"fresh-read","type":"function","function":{"name":"get_page_snapshot","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}\n\n',
+              'data: [DONE]\n\n',
+            ]
+          : [
+              'data: {"choices":[{"delta":{"content":"Read the page. No prior saves were retried."},"finish_reason":"stop"}]}\n\n',
+              'data: [DONE]\n\n',
+            ]
+      );
+    };
+    const options = {
+      ...outcomeOptions(),
+      appendEvents: (events: AgentConversationEvent[]) => history.push(...events),
+      conversationEvents: history,
+      fetch,
+      tools: [getPageSnapshotTool, ...createWorkflowToolDefinitions({ mode: 'safe' })],
+      toToolCallEvents: (calls: KiloGatewayToolCallRequest[]) =>
+        calls.map(call =>
+          call.name === 'save_memory'
+            ? createWorkflowToolCall({
+                arguments: call.arguments,
+                name: 'save_memory',
+                providerToolCallId: call.id,
+                tabId: 1,
+              })
+            : createSafeToolCall({
+                name: 'get_page_snapshot',
+                providerToolCallId: call.id,
+                tabId: 1,
+              })
+        ),
+      onAssistantStreaming: (eventId: string | undefined) => {
+        if (
+          eventId === undefined &&
+          requests === 1 &&
+          entry.boundary === 'abort after streamed completion'
+        ) {
+          controller.abort();
+        }
+      },
+    };
+    const executeToolCall = (
+      call: ReturnType<typeof options.toToolCallEvents>[number]
+    ): Promise<EvalTabResult> => {
+      if (call.name !== 'save_memory') {
+        pageReads.push(call.providerToolCallId ?? '');
+        if (call.providerToolCallId === 'read-1' && entry.boundary === 'Stop between calls') {
+          controller.abort();
+        }
+        return Promise.resolve({ ok: true, value: 'Observed page.' });
+      }
+      if (entry.boundary === 'denied approval') {
+        controller.abort(new ExecutionStoppedError('permission_denied'));
+        controller.signal.throwIfAborted();
+      }
+      savedMemories.push(String(call.arguments['text']));
+      if (entry.boundary === 'issued executor abort') {
+        return Promise.reject(new DOMException('Transport aborted.', 'AbortError'));
+      }
+      return Promise.resolve(
+        entry.boundary === 'uncertain success'
+          ? { effectsUncertain: true, ok: true, value: 'Unconfirmed save.' }
+          : { effectsUncertain: true, error: 'Result timed out.', ok: false }
+      );
+    };
+
+    const interrupted = await runLlmTurn({
+      ...options,
+      executeToolCall,
+      signal: controller.signal,
+    });
+    expect(interrupted).toMatchObject({
+      status: entry.status,
+      reason: entry.reason,
+      effectsUncertain: entry.saved,
+      summary,
+      toolResults:
+        entry.confirmed === 0
+          ? []
+          : [{ ok: true, value: 'Observed page.', effectsUncertain: false }],
+    });
+    expect({
+      recordedResults: history.filter(event => event.type === 'tool-result').length,
+      requests,
+    }).toStrictEqual({ recordedResults: entry.confirmed + (uncertainResult ? 1 : 0), requests: 1 });
+    const interruptedHistory = structuredClone(history);
+    history.push(createUserMessage('Read the page once. Do not retry prior saves.'));
+
+    const continued = await runLlmTurn({
+      ...options,
+      executeToolCall,
+      signal: new AbortController().signal,
+    });
+    expect({ outcome: continued, lastEvent: history.at(-1) }).toMatchObject({
+      outcome: {
+        status: 'succeeded',
+        reason: 'completed',
+        effectsUncertain: false,
+        summary: 'Read the page. No prior saves were retried.',
+        toolResults: [{ ok: true, value: 'Observed page.' }],
+      },
+      lastEvent: { role: 'assistant', text: 'Read the page. No prior saves were retried.' },
+    });
+    expect({
+      pageReads,
+      savedMemories,
+      previousEvents: history.slice(0, interruptedHistory.length),
+      requests,
+    }).toStrictEqual({
+      pageReads: entry.confirmed === 0 ? ['fresh-read'] : ['read-1', 'fresh-read'],
+      savedMemories: entry.saved ? ['First memory'] : [],
+      previousEvents: interruptedHistory,
+      requests: 3,
+    });
+  });
 });
 
 interface OutcomeCase {

--- a/apps/extension/src/shared/agent-llm-turn-runner-core.ts
+++ b/apps/extension/src/shared/agent-llm-turn-runner-core.ts
@@ -1,11 +1,19 @@
-/* eslint-disable max-lines, promise/avoid-new, promise/no-multiple-resolved -- Turn loop with a transparent stream-retry tier; the cancellable delay needs a raw, guard-settled promise. */
+/* eslint-disable max-lines, max-classes-per-file, promise/avoid-new, promise/no-multiple-resolved -- The turn loop uses distinct typed failures and a cancellable retry delay. */
 import {
   createAssistantMessage,
   createThinkingBlock,
   createUserMessage,
 } from './agent-conversation';
 import type { AgentConversationEvent } from './agent-conversation';
-import { runToolCalls } from './agent-tool-results';
+import {
+  ExecutionStoppedError,
+  isExecutionStopped,
+  normalizeExecutionGuard,
+  runToolCalls,
+} from './agent-tool-results';
+import type { ExecutionGuard, ToolResultEvent } from './agent-tool-results';
+import { normalizeEvalTabResult } from './tab-debugger';
+import type { EvalTabResult, NormalizedEvalTabResult } from './tab-debugger';
 import type { FetchLike } from './auth';
 import { buildGatewayMessagesFromEvents } from './agent-llm-harness';
 import type { KiloGatewayToolCallRequest, KiloGatewayToolDefinition } from './kilo-api-client';
@@ -13,8 +21,33 @@ import {
   fetchKiloGatewayChatCompletionStream,
   KiloGatewayHttpError,
   KiloGatewayStreamStalledError,
+  KiloGatewayUnsupportedToolError,
 } from './kilo-api-client';
-import type { EvalTabResult } from './tab-debugger';
+
+export type LlmTurnFailureReason =
+  | 'model_failure'
+  | 'retry_exhausted'
+  | 'context_overflow'
+  | 'rounds_exhausted'
+  | 'truncated_response'
+  | 'empty_response'
+  | 'incomplete_response'
+  | 'tool_failure_limit'
+  | 'unsafe_tool_call';
+
+type TurnTermination =
+  | { readonly status: 'succeeded'; readonly reason: 'completed' }
+  | { readonly status: 'failed'; readonly reason: LlmTurnFailureReason }
+  | { readonly status: 'cancelled' | 'interrupted'; readonly reason: string };
+
+export type LlmTurnOutcome = TurnTermination & {
+  readonly summary: string;
+  /** Only settled, confirmed results from this turn; never inferred evidence. */
+  readonly toolResults: ToolResultEvent[];
+  readonly effectsUncertain: boolean;
+};
+
+class ToolFailureLimitError extends Error {}
 
 type ToolCallEvent = Extract<AgentConversationEvent, { readonly type: 'tool-call' }>;
 
@@ -30,6 +63,7 @@ interface RunLlmTurnOptions<ToolCall extends ToolCallEvent> {
   readonly appendEvents: (events: AgentConversationEvent[]) => void;
   readonly conversationEvents: AgentConversationEvent[];
   readonly executeToolCall: (toolCall: ToolCall) => Promise<EvalTabResult>;
+  readonly executionGuard?: ExecutionGuard | undefined;
   readonly failureMessage: (error: unknown) => string;
   readonly fetch: FetchLike;
   readonly maxToolRounds: number;
@@ -65,13 +99,8 @@ const withReasoningDetails = <ToolCall extends ToolCallEvent>(
   return [{ ...first, reasoningDetails }, ...rest];
 };
 
-const isAbortError = (error: unknown): boolean =>
-  error instanceof Error && error.name === 'AbortError';
-
 const isHighEffort = (thinkingEffort: string | undefined): boolean =>
   thinkingEffort === 'high' || thinkingEffort === 'xhigh' || thinkingEffort === 'max';
-
-const isSignalAborted = (signal: AbortSignal | undefined): boolean => signal?.aborted === true;
 
 // One transparent retry tier for failures the user cannot act on: a stalled stream, a transient network failure, or a retriable gateway status.
 const MAX_STREAM_ATTEMPTS = 3;
@@ -154,6 +183,7 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
   appendEvents,
   conversationEvents,
   executeToolCall,
+  executionGuard,
   failureMessage,
   fetch,
   maxToolRounds,
@@ -172,15 +202,30 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
   updateAssistantMessage,
   updateThinkingBlock,
   onAssistantStreaming,
-}: RunLlmTurnOptions<ToolCall>): Promise<void> => {
+}: RunLlmTurnOptions<ToolCall>): Promise<LlmTurnOutcome> => {
+  const guard = normalizeExecutionGuard(executionGuard, signal);
+  const confirmedToolResults: ToolResultEvent[] = [];
+  let lastAssistantSummary = '';
+  let effectsUncertain = false;
+  let issuedActionPending = false;
+  let streamRetriesExhausted = false;
+  const outcome = (
+    termination: TurnTermination,
+    summary = lastAssistantSummary
+  ): LlmTurnOutcome => ({
+    ...termination,
+    effectsUncertain,
+    summary,
+    toolResults: [...confirmedToolResults],
+  });
   // A weak model can loop one byte-identical failing tool call for the whole turn (measured: 118 identical run_workflow calls). After the third identical failure the error tells it to stop; a success resets the count.
   const identicalFailureCounts = new Map<string, number>();
-  // Some models mutate the arguments slightly each round, so byte-identity never collides and the text escalation never lands; interleaved successes of other tools also defeat a consecutive counter (measured: 50 failing run_workflow calls between healthy snapshots). Count TOTAL failures per tool for the turn: across 812 benchmark attempts no passing attempt exceeded 19; runaway loops hit 118-119. At 25 the turn ends instead of burning billed rounds.
+  // Count total failures per tool, even across changed arguments and interleaved successes.
   const MAX_TOOL_FAILURES_PER_TURN = 25;
   const failureTotals = new Map<string, number>();
-  // Snapshot the message when the cap trips so later results cannot change it.
   let streakStopMessage: string | undefined = undefined;
-  const guardedExecuteToolCall = async (toolCall: ToolCall): Promise<EvalTabResult> => {
+  const guardedExecuteToolCall = async (toolCall: ToolCall): Promise<NormalizedEvalTabResult> => {
+    guard();
     // Key on the call content, not its per-call ids or attached reasoning: repeats must collide.
     const {
       id: _id,
@@ -192,7 +237,12 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
       readonly reasoningDetails?: readonly unknown[];
     };
     const key = JSON.stringify(callContent);
-    const result = await executeToolCall(toolCall);
+    issuedActionPending = true;
+    const result = normalizeEvalTabResult(await executeToolCall(toolCall));
+    issuedActionPending = false;
+    if (result.effectsUncertain) {
+      return result;
+    }
     if (result.ok) {
       identicalFailureCounts.delete(key);
       return result;
@@ -208,8 +258,8 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
       return result;
     }
     return {
+      ...result,
       error: `${result.error} — You have sent this exact ${toolCall.name} call ${count} times and it keeps failing. Do not send it again. Change the arguments or take a different approach.`,
-      ok: false,
     };
   };
   const getGatewayChatCompletion = async (
@@ -217,7 +267,9 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
     onContentDelta: (delta: string) => void,
     onReasoningDelta: (delta: string) => void
   ) => {
+    guard();
     const requestTools = prepareTools === undefined ? tools : await prepareTools();
+    guard();
 
     return fetchKiloGatewayChatCompletionStream({
       apiBaseUrl,
@@ -240,6 +292,7 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
     nextEvents: AgentConversationEvent[]
   ): Promise<{
     completionEvents: AgentConversationEvent[];
+    discardedToolCalls: boolean;
     finishReason: string | undefined;
     toolCallEvents: ToolCall[];
   }> => {
@@ -317,11 +370,16 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
           }
           return completion;
         } catch (error) {
-          if (
-            streamAttempt >= MAX_STREAM_ATTEMPTS ||
-            !isRetriableStreamError(error) ||
-            isSignalAborted(signal)
-          ) {
+          // Preserve producer uncertainty even when the owner revokes authority at the same time.
+          if (error instanceof ExecutionStoppedError) {
+            throw error;
+          }
+          guard();
+          if (isExecutionStopped(error)) {
+            throw error;
+          }
+          if (streamAttempt >= MAX_STREAM_ATTEMPTS || !isRetriableStreamError(error)) {
+            streamRetriesExhausted = isRetriableStreamError(error);
             // When every attempt came back truncated, degrade to the last partial text rather than replacing it with a failure message.
             if (
               error instanceof TruncatedCompletionError &&
@@ -334,11 +392,7 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
           resetStreamedTextOnNextDelta = true;
           resetThinkingTextOnNextDelta = true;
           await abortableDelay(STREAM_RETRY_DELAYS_MS[streamAttempt - 1] ?? 4000, signal);
-          if (isSignalAborted(signal)) {
-            const abortError = new Error('The user aborted a request.');
-            abortError.name = 'AbortError';
-            throw abortError;
-          }
+          guard();
           return streamWithRetries(streamAttempt + 1);
         }
       };
@@ -346,6 +400,11 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
 
       if (completion.usage !== undefined) {
         onUsage?.(completion.usage);
+      }
+
+      // An unfinished tool batch is terminal; do not retry it or expose unmatched calls in history.
+      if (completion.toolCalls.length > 0 && completion.finishReason === undefined) {
+        throw new TruncatedCompletionError('missing');
       }
 
       if (streamedThinkingEventId !== undefined) {
@@ -364,7 +423,8 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
       }
 
       if (streamedAssistantEventId !== undefined) {
-        const finalStreamedText = completion.content ?? streamedText;
+        const finalStreamedText =
+          completion.content ?? (resetStreamedTextOnNextDelta ? '' : streamedText);
         const streamedAssistantEventIndex = completionEvents.findIndex(
           event => event.id === streamedAssistantEventId
         );
@@ -388,10 +448,15 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
         completionEvents.push(createThinkingBlock(completion.reasoning));
       }
 
-      const toolCallEvents = withReasoningDetails(
-        toToolCallEvents(completion.toolCalls),
-        completion.reasoningDetails
-      );
+      const convertedToolCalls = toToolCallEvents(completion.toolCalls);
+      const discardedToolCalls = convertedToolCalls.length !== completion.toolCalls.length;
+      // A partially accepted response must not execute its remaining calls or leave unmatched calls in history.
+      const toolCallEvents =
+        discardedToolCalls ||
+        TRUNCATED_FINISH_REASONS.has(completion.finishReason ?? '') ||
+        completion.finishReason === 'model_context_window_exceeded'
+          ? []
+          : withReasoningDetails(convertedToolCalls, completion.reasoningDetails);
       completionEvents.push(...toolCallEvents);
 
       appendEvents(
@@ -400,7 +465,12 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
         )
       );
 
-      return { completionEvents, finishReason: completion.finishReason, toolCallEvents };
+      return {
+        completionEvents,
+        discardedToolCalls,
+        finishReason: completion.finishReason,
+        toolCallEvents,
+      };
     } finally {
       if (didStartAssistantStreaming) {
         // Explicit clear: callers key collapse chrome off this id being undefined.
@@ -416,79 +486,135 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
     const continueConversation = async (
       nextConversationEvents: AgentConversationEvent[],
       remainingRounds: number
-    ): Promise<void> => {
-      if (remainingRounds === 0) {
+    ): Promise<LlmTurnOutcome> => {
+      guard();
+      if (remainingRounds <= 0) {
         appendEvents([createAssistantMessage(tooManyToolRoundsMessage)]);
-        return;
+        return outcome({ reason: 'rounds_exhausted', status: 'failed' }, tooManyToolRoundsMessage);
       }
 
-      const { completionEvents, finishReason, toolCallEvents } =
+      const { completionEvents, discardedToolCalls, finishReason, toolCallEvents } =
         await appendCompletion(nextConversationEvents);
-
-      if (completionEvents.length === 0) {
-        appendEvents([createAssistantMessage(noResponseMessage)]);
-        return;
-      }
-
+      guard();
+      const lastAssistantText =
+        completionEvents
+          .toReversed()
+          .find(
+            (event): event is Extract<AgentConversationEvent, { type: 'message' }> =>
+              event.type === 'message' && event.role === 'assistant'
+          )?.text ?? '';
+      lastAssistantSummary = lastAssistantText;
       nextConversationEvents.push(...completionEvents);
 
+      if (discardedToolCalls) {
+        throw new KiloGatewayUnsupportedToolError();
+      }
+      if (
+        finishReason === 'model_context_window_exceeded' ||
+        TRUNCATED_FINISH_REASONS.has(finishReason ?? '') ||
+        (toolCallEvents.length === 0 &&
+          completionEvents.length > 0 &&
+          finishReason !== 'stop' &&
+          finishReason !== 'end_turn')
+      ) {
+        if (lastAssistantText.trim() === '') {
+          lastAssistantSummary = noResponseMessage;
+          appendEvents([createAssistantMessage(noResponseMessage)]);
+        }
+        return outcome({
+          reason:
+            finishReason === 'model_context_window_exceeded'
+              ? 'context_overflow'
+              : 'truncated_response',
+          status: 'failed',
+        });
+      }
+      if (completionEvents.length === 0) {
+        appendEvents([createAssistantMessage(noResponseMessage)]);
+        return outcome({ reason: 'empty_response', status: 'failed' }, noResponseMessage);
+      }
+
       if (toolCallEvents.length === 0) {
-        const lastAssistantText =
-          completionEvents
-            .toReversed()
-            .find(
-              (event): event is Extract<AgentConversationEvent, { type: 'message' }> =>
-                event.type === 'message' && event.role === 'assistant'
-            )?.text ?? '';
-        if (
-          !continueNudgeSent &&
-          // An overflowed prompt cannot fit again with a nudge appended; re-sending it would burn a second billed request on a guaranteed overflow.
-          finishReason !== 'model_context_window_exceeded' &&
-          remainingRounds > 1 &&
-          !isSignalAborted(signal) &&
-          (endedThinkingOnly(completionEvents, lastAssistantText) ||
-            (turnUsedTools && deservesContinueNudge(lastAssistantText)))
-        ) {
+        const needsContinuation =
+          endedThinkingOnly(completionEvents, lastAssistantText) ||
+          (turnUsedTools && deservesContinueNudge(lastAssistantText));
+        if (!continueNudgeSent && remainingRounds > 1 && needsContinuation) {
           continueNudgeSent = true;
           // Ephemeral: sent to the model, never appended to the stored conversation.
           nextConversationEvents.push(createUserMessage(CONTINUE_NUDGE_TEXT));
-          await continueConversation(nextConversationEvents, remainingRounds - 1);
+          return continueConversation(nextConversationEvents, remainingRounds - 1);
         }
-        return;
+        if (lastAssistantText.trim() === '') {
+          appendEvents([createAssistantMessage(noResponseMessage)]);
+          return outcome({ reason: 'empty_response', status: 'failed' }, noResponseMessage);
+        }
+        if (needsContinuation) {
+          return outcome({ reason: 'incomplete_response', status: 'failed' });
+        }
+        return outcome({ reason: 'completed', status: 'succeeded' });
       }
       turnUsedTools = true;
 
-      if (isSignalAborted(signal)) {
-        appendEvents([createAssistantMessage('Stopped.')]);
-        return;
+      await runToolCalls(toolCallEvents, guardedExecuteToolCall, signal, {
+        executionGuard: guard,
+        onResult: result => {
+          issuedActionPending = false;
+          effectsUncertain ||= result.effectsUncertain;
+          if (!result.effectsUncertain) {
+            confirmedToolResults.push(result);
+          }
+          // Keep confirmed events even if Stop or lease loss prevents the next call.
+          appendEvents([result]);
+          nextConversationEvents.push(result);
+          if (streakStopMessage !== undefined) {
+            throw new ToolFailureLimitError(streakStopMessage);
+          }
+        },
+      });
+      if (effectsUncertain) {
+        throw new ExecutionStoppedError('effects_uncertain', 'interrupted', true);
       }
-
-      const toolResultEvents: AgentConversationEvent[] = await runToolCalls(
-        toolCallEvents,
-        guardedExecuteToolCall,
-        signal
-      );
-
-      if (isSignalAborted(signal)) {
-        appendEvents([createAssistantMessage('Stopped.')]);
-        return;
-      }
-
-      appendEvents(toolResultEvents);
-      nextConversationEvents.push(...toolResultEvents);
-
-      if (streakStopMessage !== undefined) {
-        appendEvents([createAssistantMessage(streakStopMessage)]);
-        return;
-      }
-
-      await continueConversation(nextConversationEvents, remainingRounds - 1);
+      guard();
+      return continueConversation(nextConversationEvents, remainingRounds - 1);
     };
 
-    await continueConversation([...conversationEvents], maxToolRounds);
+    return await continueConversation([...conversationEvents], maxToolRounds);
   } catch (error) {
-    appendEvents([
-      createAssistantMessage(isAbortError(error) ? 'Stopped.' : failureMessage(error)),
-    ]);
+    if (error instanceof ExecutionStoppedError) {
+      effectsUncertain ||= error.effectsUncertain;
+      const summary = error.status === 'cancelled' ? 'Stopped.' : `Interrupted: ${error.reason}.`;
+      appendEvents([createAssistantMessage(summary)]);
+      return outcome({ reason: error.reason, status: error.status }, summary);
+    }
+    if (isExecutionStopped(error)) {
+      effectsUncertain ||= issuedActionPending;
+      appendEvents([createAssistantMessage('Stopped.')]);
+      return outcome({ reason: 'cancelled', status: 'cancelled' }, 'Stopped.');
+    }
+    if (error instanceof KiloGatewayUnsupportedToolError) {
+      const summary =
+        'The model requested an unavailable or unsafe tool. No calls from that response were executed.';
+      appendEvents([createAssistantMessage(summary)]);
+      return outcome({ reason: 'unsafe_tool_call', status: 'failed' }, summary);
+    }
+    const summary = error instanceof ToolFailureLimitError ? error.message : failureMessage(error);
+    appendEvents([createAssistantMessage(summary)]);
+    if (issuedActionPending) {
+      effectsUncertain = true;
+      return outcome({ reason: 'effects_uncertain', status: 'interrupted' }, summary);
+    }
+    if (error instanceof TruncatedCompletionError) {
+      return outcome({ reason: 'truncated_response', status: 'failed' }, summary);
+    }
+    if (error instanceof ToolFailureLimitError) {
+      return outcome({ reason: 'tool_failure_limit', status: 'failed' }, summary);
+    }
+    return outcome(
+      {
+        reason: streamRetriesExhausted ? 'retry_exhausted' : 'model_failure',
+        status: 'failed',
+      },
+      summary
+    );
   }
 };

--- a/apps/extension/src/shared/agent-safe-tool-runtime.test.ts
+++ b/apps/extension/src/shared/agent-safe-tool-runtime.test.ts
@@ -72,6 +72,7 @@ describe('safe tool runtime', () => {
         })
       )
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         limits: {
@@ -108,6 +109,7 @@ describe('safe tool runtime', () => {
         })
       )
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         id: 'node-1',
@@ -148,6 +150,7 @@ describe('safe tool runtime', () => {
         })
       )
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         limits: {
@@ -218,6 +221,7 @@ describe('safe tool runtime', () => {
         })
       )
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         matches: [
@@ -323,6 +327,7 @@ describe('safe tool runtime', () => {
         })
       )
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         limits: {
@@ -376,6 +381,7 @@ describe('safe tool runtime', () => {
         })
       )
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         results: [
@@ -408,6 +414,7 @@ describe('safe tool runtime', () => {
         })
       )
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: {
         message: 'No memories matched.',
@@ -430,6 +437,7 @@ describe('safe tool runtime', () => {
         })
       )
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       error: 'Search query is required.',
       ok: false,
     });
@@ -452,6 +460,7 @@ describe('safe tool runtime', () => {
         })
       )
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       ok: true,
       value: memory,
     });
@@ -472,6 +481,7 @@ describe('safe tool runtime', () => {
         })
       )
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       error: 'Memory not found.',
       ok: false,
     });
@@ -490,6 +500,7 @@ describe('safe tool runtime', () => {
         })
       )
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       error: 'Memory id is required.',
       ok: false,
     });

--- a/apps/extension/src/shared/agent-tool-results.test.ts
+++ b/apps/extension/src/shared/agent-tool-results.test.ts
@@ -1,33 +1,32 @@
+/* eslint-disable jest/no-conditional-in-test, promise/prefer-await-to-then -- Stateful guard fixtures distinguish synchronous throws from rejected promises. */
 import { describe, expect, it } from 'vitest';
 import { createEvalToolCall } from './agent-conversation';
-import { runToolCalls } from './agent-tool-results';
+import { ExecutionStoppedError, runToolCalls } from './agent-tool-results';
+import type { ToolResultEvent } from './agent-tool-results';
+import type { EvalTabResult } from './tab-debugger';
+
+const firstToolCall = createEvalToolCall({ code: 'first', tabId: 1 });
+const secondToolCall = createEvalToolCall({ code: 'second', tabId: 1 });
 
 describe('agent tool results', () => {
   it('runs eval tool calls sequentially', async () => {
     const events: string[] = [];
-    const firstToolCall = createEvalToolCall({ code: 'first', tabId: 1 });
-    const secondToolCall = createEvalToolCall({ code: 'second', tabId: 1 });
-
     const results = await runToolCalls([firstToolCall, secondToolCall], async toolCall => {
       events.push(`start:${toolCall.code}`);
       await Promise.resolve();
       events.push(`end:${toolCall.code}`);
       return { ok: true, value: toolCall.code };
     });
-
     expect(events).toStrictEqual(['start:first', 'end:first', 'start:second', 'end:second']);
-    expect(results.map(result => result.toolCallId)).toStrictEqual([
-      firstToolCall.id,
-      secondToolCall.id,
+    expect(results).toMatchObject([
+      { effectsUncertain: false, ok: true, toolCallId: firstToolCall.id, value: 'first' },
+      { effectsUncertain: false, ok: true, toolCallId: secondToolCall.id, value: 'second' },
     ]);
   });
 
-  it('stops before later tool calls once the signal is aborted', async () => {
+  it('preserves the issued result and stops later calls after Stop', async () => {
     const events: string[] = [];
     const controller = new AbortController();
-    const firstToolCall = createEvalToolCall({ code: 'first', tabId: 1 });
-    const secondToolCall = createEvalToolCall({ code: 'second', tabId: 1 });
-
     const results = await runToolCalls(
       [firstToolCall, secondToolCall],
       toolCall => {
@@ -37,8 +36,151 @@ describe('agent tool results', () => {
       },
       controller.signal
     );
-
     expect(events).toStrictEqual(['first']);
-    expect(results.map(result => result.toolCallId)).toStrictEqual([firstToolCall.id]);
+    expect(results).toMatchObject([
+      { effectsUncertain: false, ok: true, toolCallId: firstToolCall.id, value: 'first' },
+    ]);
+  });
+
+  it('performs no action when Stop precedes the batch', async () => {
+    const events: string[] = [];
+    const controller = new AbortController();
+    controller.abort();
+    const results = await runToolCalls(
+      [firstToolCall],
+      toolCall => {
+        events.push(toolCall.code);
+        return Promise.resolve({ ok: true });
+      },
+      controller.signal
+    );
+    expect({ events, results }).toStrictEqual({ events: [], results: [] });
+  });
+
+  const cases: {
+    actions: string[];
+    label: string;
+    ok: boolean;
+    result: EvalTabResult;
+    uncertain: boolean;
+  }[] = [
+    {
+      actions: ['first', 'second'],
+      label: 'confirmed failure',
+      ok: false,
+      result: { effectsUncertain: false, error: 'Missing input.', ok: false },
+      uncertain: false,
+    },
+    {
+      actions: ['first', 'second'],
+      label: 'legacy success',
+      ok: true,
+      result: { ok: true, value: 'observed' },
+      uncertain: false,
+    },
+    {
+      actions: ['first'],
+      label: 'legacy issued failure',
+      ok: false,
+      result: { error: 'Lost response.', ok: false },
+      uncertain: true,
+    },
+    {
+      actions: ['first'],
+      label: 'uncertain failure',
+      ok: false,
+      result: { effectsUncertain: true, error: 'Timed out.', ok: false },
+      uncertain: true,
+    },
+    {
+      actions: ['first'],
+      label: 'uncertain success payload',
+      ok: false,
+      result: { effectsUncertain: true, ok: true, value: 'unconfirmed' },
+      uncertain: true,
+    },
+  ];
+
+  it.each(cases)(
+    'preserves certainty for $label before another action',
+    async ({ actions, ok, result, uncertain }) => {
+      const events: string[] = [];
+      const results = await runToolCalls([firstToolCall, secondToolCall], toolCall => {
+        events.push(toolCall.code);
+        return Promise.resolve(result);
+      });
+      expect(events).toStrictEqual(actions);
+      expect(results[0]).toMatchObject({
+        effectsUncertain: uncertain,
+        ok,
+      });
+    }
+  );
+
+  it.each([
+    {
+      fail: (): Promise<EvalTabResult> => {
+        throw new Error('Transport lost.');
+      },
+      label: 'synchronous throw',
+    },
+    {
+      fail: (): Promise<EvalTabResult> => Promise.reject(new Error('Transport lost.')),
+      label: 'rejection',
+    },
+  ])('stops the batch after a dispatched $label', async ({ fail }) => {
+    const events: string[] = [];
+    const results = await runToolCalls([firstToolCall, secondToolCall], toolCall => {
+      events.push(toolCall.code);
+      return fail();
+    });
+    expect(events).toStrictEqual(['first']);
+    expect(results).toMatchObject([
+      { effectsUncertain: true, error: 'eval failed: Transport lost.', ok: false },
+    ]);
+  });
+
+  it('retains confirmed events when the lease ends between calls', async () => {
+    let active = true;
+    const actions: string[] = [];
+    const settled: ToolResultEvent[] = [];
+    const result = runToolCalls(
+      [firstToolCall, secondToolCall],
+      toolCall => {
+        actions.push(toolCall.code);
+        active = false;
+        return Promise.resolve({ ok: true, value: 'issued and confirmed' });
+      },
+      undefined,
+      {
+        executionGuard: () => {
+          if (!active) {
+            throw new Error('lease_lost');
+          }
+        },
+        onResult: event => settled.push(event),
+      }
+    );
+    await expect(result).rejects.toMatchObject({
+      effectsUncertain: false,
+      reason: 'lease_lost',
+      status: 'interrupted',
+    });
+    expect(actions).toStrictEqual(['first']);
+    expect(settled).toMatchObject([{ ok: true, value: 'issued and confirmed' }]);
+  });
+
+  it.each([
+    new DOMException('Stopped in flight.', 'AbortError'),
+    new ExecutionStoppedError('lease_lost'),
+    new ExecutionStoppedError('execution_timeout', 'interrupted', true),
+  ])('propagates a stopped executor without a fabricated result: %s', async stopped => {
+    const actions: string[] = [];
+    const result = runToolCalls([firstToolCall, secondToolCall], toolCall => {
+      actions.push(toolCall.code);
+      return Promise.reject(stopped);
+    });
+    await expect(result).rejects.toBe(stopped);
+    expect(actions).toStrictEqual(['first']);
   });
 });

--- a/apps/extension/src/shared/agent-tool-results.ts
+++ b/apps/extension/src/shared/agent-tool-results.ts
@@ -1,48 +1,116 @@
 import { createToolResult } from './agent-conversation';
 import type { AgentConversationEvent } from './agent-conversation';
-import type { EvalTabResult } from './tab-debugger';
+import { normalizeEvalTabResult } from './tab-debugger';
+import type { EvalTabResult, NormalizedEvalTabResult } from './tab-debugger';
 
 type ToolCallEvent = Extract<AgentConversationEvent, { readonly type: 'tool-call' }>;
-type ToolResultEvent = Extract<AgentConversationEvent, { readonly type: 'tool-result' }>;
+export type ToolResultEvent = Extract<AgentConversationEvent, { readonly type: 'tool-result' }> & {
+  readonly effectsUncertain: boolean;
+};
 
-const toToolResultEvent = (toolCall: ToolCallEvent, result: EvalTabResult): ToolResultEvent =>
-  result.ok
-    ? createToolResult({
-        ok: true,
-        toolCallId: toolCall.id,
-        value: result.value,
-      })
-    : createToolResult({
-        error: result.error,
-        ok: false,
-        toolCallId: toolCall.id,
-      });
+/** Synchronous authority check at an action boundary. Owners throw when their lease ends. */
+export type ExecutionGuard = () => void;
 
+export class ExecutionStoppedError extends Error {
+  readonly reason: string;
+  readonly status: 'cancelled' | 'interrupted';
+  readonly effectsUncertain: boolean;
+
+  constructor(
+    reason: string,
+    status: 'cancelled' | 'interrupted' = 'interrupted',
+    effectsUncertain = false
+  ) {
+    super(reason);
+    this.name = status === 'cancelled' ? 'AbortError' : 'ExecutionStoppedError';
+    this.reason = reason;
+    this.status = status;
+    this.effectsUncertain = effectsUncertain;
+  }
+}
+
+export const isExecutionStopped = (error: unknown): boolean =>
+  error instanceof ExecutionStoppedError || (error instanceof Error && error.name === 'AbortError');
+
+export const normalizeExecutionGuard =
+  (executionGuard: ExecutionGuard | undefined, signal?: AbortSignal): ExecutionGuard =>
+  () => {
+    try {
+      executionGuard?.();
+      // Old local callers supply only an AbortSignal, or neither input. An owner guard never replaces Stop.
+      // Remove this fallback after every guardless local caller retires.
+      signal?.throwIfAborted();
+    } catch (error) {
+      if (error instanceof ExecutionStoppedError) {
+        throw error;
+      }
+      if (isExecutionStopped(error)) {
+        throw new ExecutionStoppedError('cancelled', 'cancelled');
+      }
+      throw new ExecutionStoppedError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+const toToolResultEvent = (
+  toolCall: ToolCallEvent,
+  result: NormalizedEvalTabResult
+): ToolResultEvent => ({
+  ...createToolResult(
+    result.ok && !result.effectsUncertain
+      ? { ok: true, toolCallId: toolCall.id, value: result.value }
+      : {
+          error: result.ok ? 'Tool completion is uncertain.' : result.error,
+          ok: false,
+          toolCallId: toolCall.id,
+        }
+  ),
+  effectsUncertain: result.effectsUncertain,
+});
+
+interface ToolExecutionOptions {
+  readonly executionGuard?: ExecutionGuard | undefined;
+  readonly onResult?: (result: ToolResultEvent) => void;
+}
+
+// eslint-disable-next-line max-params -- Preserve the old signal argument; owners observe settled results before a later interruption.
 export const runToolCalls = <ToolCall extends ToolCallEvent>(
   toolCalls: ToolCall[],
   executeToolCall: (toolCall: ToolCall) => Promise<EvalTabResult>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  options: ToolExecutionOptions = {}
 ): Promise<ToolResultEvent[]> => {
+  const guard = normalizeExecutionGuard(options.executionGuard, signal);
   const runNext = async (index: number, results: ToolResultEvent[]): Promise<ToolResultEvent[]> => {
     const toolCall = toolCalls[index];
 
-    // Stop before each call so pressing Stop mid-batch doesn't run later (side-effecting) tools.
+    // Old signal-only callers receive settled results on Stop; guarded owners check termination after the batch.
+    // Remove this return form after those signal-only callers retire.
     if (toolCall === undefined || signal?.aborted === true) {
       return results;
     }
+    guard();
 
-    // A tool that throws must still produce an error tool-result: providers require a result for every call, and the model needs the failure text to react. Only an abort propagates.
-    const result: EvalTabResult = await executeToolCall(toolCall).catch((error: unknown) => {
-      if (error instanceof Error && error.name === 'AbortError') {
+    let result: NormalizedEvalTabResult | undefined = undefined;
+    try {
+      result = normalizeEvalTabResult(await executeToolCall(toolCall));
+    } catch (error) {
+      if (isExecutionStopped(error)) {
         throw error;
       }
-      return {
+      // The executor was dispatched. A lost result does not prove that its action stopped.
+      result = {
+        effectsUncertain: true,
         error: `${toolCall.name} failed: ${error instanceof Error ? error.message : String(error)}`,
-        ok: false as const,
+        ok: false,
       };
-    });
-
-    return runNext(index + 1, [...results, toToolResultEvent(toolCall, result)]);
+    }
+    const event = toToolResultEvent(toolCall, result);
+    options.onResult?.(event);
+    const nextResults = [...results, event];
+    if (result.effectsUncertain) {
+      return nextResults;
+    }
+    return runNext(index + 1, nextResults);
   };
 
   return runNext(0, []);

--- a/apps/extension/src/shared/agent-workflow-runner.test.ts
+++ b/apps/extension/src/shared/agent-workflow-runner.test.ts
@@ -1,18 +1,11 @@
-/* eslint-disable max-lines -- Comprehensive test suite covering all feature states of the workflow runner; splitting would obscure coverage relationships. */
+/* eslint-disable max-lines, jest/no-conditional-in-test -- Workflow state fixtures revoke authority at selected action boundaries. */
 import { describe, expect, it } from 'vitest';
 import { buildWorkflowPageCode, runWorkflow } from './agent-workflow-runner';
 import { hashWorkflowScript } from './agent-workflows';
 import type { AgentWorkflow } from './agent-workflows';
 
-interface EvalTabOkResult {
-  ok: true;
-  value: unknown;
-}
-interface EvalTabErrResult {
-  ok: false;
-  error: string;
-}
-type EvalTabResult = EvalTabOkResult | EvalTabErrResult;
+import type { EvalTabResult } from './tab-debugger';
+import { ExecutionStoppedError } from './agent-tool-results';
 
 const createDeps = (overrides?: {
   evalResponses?: EvalTabResult[];
@@ -105,7 +98,12 @@ describe('runWorkflow function', () => {
     });
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
-    expect(result).toStrictEqual({ ok: true, pagesVisited: 1, result: 42 });
+    expect(result).toStrictEqual({
+      effectsUncertain: false,
+      ok: true,
+      pagesVisited: 1,
+      result: 42,
+    });
   });
 
   it('returns success with pagesVisited for multi-page with state threading', async () => {
@@ -133,7 +131,12 @@ describe('runWorkflow function', () => {
     });
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
-    expect(result).toStrictEqual({ ok: true, pagesVisited: 2, result: 'done' });
+    expect(result).toStrictEqual({
+      effectsUncertain: false,
+      ok: true,
+      pagesVisited: 2,
+      result: 'done',
+    });
     expect(deps.navigateUrls).toStrictEqual(['https://shop.example.com/page2']);
   });
 
@@ -141,27 +144,41 @@ describe('runWorkflow function', () => {
     const workflow = await buildApprovedWorkflow();
     const deps = createDeps({
       evalResponses: [
-        { error: '{"code":-32000,"message":"Execution context was destroyed."}', ok: false },
+        {
+          effectsUncertain: false,
+          error: '{"code":-32000,"message":"Execution context was destroyed."}',
+          ok: false,
+        },
         { ok: true, value: { dryRunActions: [], ok: true, value: { done: true, result: 'ok' } } },
       ],
       tabUrls: ['https://shop.example.com/search', 'https://shop.example.com/results'],
     });
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
-    expect(result).toStrictEqual({ ok: true, pagesVisited: 1, result: 'ok' });
+    expect(result).toStrictEqual({
+      effectsUncertain: false,
+      ok: true,
+      pagesVisited: 1,
+      result: 'ok',
+    });
   }, 10_000);
 
   it('does not treat a destroyed context as navigation in a dry run', async () => {
     const workflow = await buildApprovedWorkflow();
     const deps = createDeps({
       evalResponses: [
-        { error: '{"code":-32000,"message":"Execution context was destroyed."}', ok: false },
+        {
+          effectsUncertain: false,
+          error: '{"code":-32000,"message":"Execution context was destroyed."}',
+          ok: false,
+        },
       ],
     });
 
     const result = await runWorkflow(deps, { dryRun: true, tabId: 1, workflow });
     expect(result).toStrictEqual({
       dryRunActions: [],
+      effectsUncertain: false,
       error: '{"code":-32000,"message":"Execution context was destroyed."}',
       ok: false,
       pageUrl: 'https://shop.example.com/page',
@@ -172,12 +189,21 @@ describe('runWorkflow function', () => {
     const workflow = await buildApprovedWorkflow();
     const deps = createDeps({
       evalResponses: [
-        { ok: true, value: { dryRunActions: [], error: 'Script exploded.', ok: false } },
+        {
+          ok: true,
+          value: {
+            dryRunActions: [],
+            effectsUncertain: false,
+            error: 'Script exploded.',
+            ok: false,
+          },
+        },
       ],
     });
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error: 'Script exploded.',
       ok: false,
       pageUrl: 'https://shop.example.com/page',
@@ -229,6 +255,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: true,
       error: 'Tab closed.',
       ok: false,
       pageUrl: 'https://shop.example.com/page',
@@ -252,6 +279,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Navigation target https://other.example.com/page is outside the workflow scope https://shop.example.com. Navigate only within the scope, or save the workflow with a wider scope.',
       ok: false,
@@ -269,6 +297,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Tab is at https://malicious.example.com/hijack, but this workflow only runs on https://shop.example.com. Navigate the tab there first, or save the workflow with a startUrl so runs navigate automatically.',
       ok: false,
@@ -282,6 +311,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Workflow script is not approved. Save it again with save_workflow (same workflowId) so the user can approve this version on the card.',
       ok: false,
@@ -297,6 +327,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Workflow script is not approved. Save it again with save_workflow (same workflowId) so the user can approve this version on the card.',
       ok: false,
@@ -324,6 +355,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Workflow exceeded the page limit (20 pages). The script returned { navigate } on every page. Branch on state so the results page returns { done: true, result } — e.g. first page returns { navigate: url, state: { searched: true } }, and when state.searched is true the script reads the results and finishes.',
       ok: false,
@@ -348,6 +380,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error: 'Workflow state exceeds the size limit.',
       ok: false,
       pageUrl: 'https://shop.example.com/page',
@@ -374,6 +407,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error: 'Workflow state is not serializable.',
       ok: false,
       pageUrl: 'https://shop.example.com/page',
@@ -404,6 +438,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Workflow startUrl https://other.example.com/evil is outside the workflow scope https://shop.example.com. Update the workflow so startUrl matches the scope.',
       ok: false,
@@ -455,12 +490,13 @@ describe('runWorkflow function', () => {
       return Promise.resolve();
     };
 
-    const result = await runWorkflow(deps, {
-      signal: controller.signal,
-      tabId: 1,
-      workflow,
-    });
-    expect(result).toStrictEqual({ error: 'Run stopped.', ok: false });
+    await expect(
+      runWorkflow(deps, {
+        signal: controller.signal,
+        tabId: 1,
+        workflow,
+      })
+    ).rejects.toMatchObject({ effectsUncertain: false, reason: 'cancelled', status: 'cancelled' });
   });
 
   it('dry run records click/fill actions across pages', async () => {
@@ -493,6 +529,7 @@ describe('runWorkflow function', () => {
         { action: 'click', selector: '.buy-button' },
         { action: 'fill', selector: '.qty' },
       ],
+      effectsUncertain: false,
       ok: true,
       pagesVisited: 1,
       result: 'checked',
@@ -512,6 +549,7 @@ describe('runWorkflow function', () => {
           ok: true,
           value: {
             dryRunActions: [{ action: 'click', selector: '.bad-selector' }],
+            effectsUncertain: false,
             error: 'No element matches selector: .bad-selector',
             ok: false,
           },
@@ -522,6 +560,7 @@ describe('runWorkflow function', () => {
     const result = await runWorkflow(deps, { dryRun: true, tabId: 1, workflow });
     expect(result).toStrictEqual({
       dryRunActions: [{ action: 'click', selector: '.bad-selector' }],
+      effectsUncertain: false,
       error: 'No element matches selector: .bad-selector',
       ok: false,
       pageUrl: 'https://shop.example.com/page',
@@ -535,6 +574,7 @@ describe('runWorkflow function', () => {
     const result = await runWorkflow(deps, { dryRun: true, tabId: 1, workflow });
     expect(result).toStrictEqual({
       dryRunActions: [],
+      effectsUncertain: false,
       error:
         'Workflow script is not approved. Save it again with save_workflow (same workflowId) so the user can approve this version on the card.',
       ok: false,
@@ -549,6 +589,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: true,
       error:
         'Workflow script returned an invalid value: "just a string". Return { done: true, result } to finish, or { navigate: "<url>", state: { … } } to continue on another page.',
       ok: false,
@@ -589,6 +630,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Workflow script returned { navigate } without a state object. Return { navigate: "<url>", state: { … } } — state must be a JSON object (use {} when nothing needs to carry over).',
       ok: false,
@@ -613,6 +655,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Workflow script returned { navigate } without a state object. Return { navigate: "<url>", state: { … } } — state must be a JSON object (use {} when nothing needs to carry over).',
       ok: false,
@@ -640,6 +683,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Workflow script returned { navigate } without a state object. Return { navigate: "<url>", state: { … } } — state must be a JSON object (use {} when nothing needs to carry over).',
       ok: false,
@@ -664,6 +708,7 @@ describe('runWorkflow function', () => {
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Workflow script returned { navigate } without a state object. Return { navigate: "<url>", state: { … } } — state must be a JSON object (use {} when nothing needs to carry over).',
       ok: false,
@@ -688,12 +733,13 @@ describe('runWorkflow function', () => {
       return Promise.resolve();
     };
 
-    const result = await runWorkflow(deps, {
-      signal: controller.signal,
-      tabId: 1,
-      workflow,
-    });
-    expect(result).toStrictEqual({ error: 'Run stopped.', ok: false });
+    await expect(
+      runWorkflow(deps, {
+        signal: controller.signal,
+        tabId: 1,
+        workflow,
+      })
+    ).rejects.toMatchObject({ effectsUncertain: false, reason: 'cancelled', status: 'cancelled' });
   });
 
   it('stops on abort after getTabUrl, before scope check', async () => {
@@ -711,12 +757,13 @@ describe('runWorkflow function', () => {
       return Promise.resolve(url);
     };
 
-    const result = await runWorkflow(deps, {
-      signal: controller.signal,
-      tabId: 1,
-      workflow,
-    });
-    expect(result).toStrictEqual({ error: 'Run stopped.', ok: false });
+    await expect(
+      runWorkflow(deps, {
+        signal: controller.signal,
+        tabId: 1,
+        workflow,
+      })
+    ).rejects.toMatchObject({ effectsUncertain: false, reason: 'cancelled', status: 'cancelled' });
   });
 
   it('stops on abort after evalInTab, before parsing envelope', async () => {
@@ -737,12 +784,13 @@ describe('runWorkflow function', () => {
       return Promise.resolve(result);
     };
 
-    const result = await runWorkflow(deps, {
-      signal: controller.signal,
-      tabId: 1,
-      workflow,
-    });
-    expect(result).toStrictEqual({ error: 'Run stopped.', ok: false });
+    await expect(
+      runWorkflow(deps, {
+        signal: controller.signal,
+        tabId: 1,
+        workflow,
+      })
+    ).rejects.toMatchObject({ effectsUncertain: false, reason: 'cancelled', status: 'cancelled' });
   });
 
   it('returns a clean failure for non-serializable initial input', async () => {
@@ -753,6 +801,7 @@ describe('runWorkflow function', () => {
     const deps = createDeps();
     const result = await runWorkflow(deps, { input: circular, tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error: 'run_workflow input is not JSON-serializable.',
       ok: false,
     });
@@ -793,6 +842,7 @@ describe('runWorkflow function', () => {
         { action: 'click', selector: '.next-btn' },
         { action: 'click', selector: '.submit-btn' },
       ],
+      effectsUncertain: false,
       ok: true,
       pagesVisited: 2,
       result: 'done',
@@ -839,6 +889,7 @@ describe('workflow params and input', () => {
     const result = await runWorkflow(deps, { input: { date: '2026-09-01' }, tabId: 1, workflow });
 
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Missing required input: "destination" — City or airport to fly to (e.g. "SFO"). ' +
         'Call run_workflow again with input: {"destination":"SFO"}.',
@@ -856,7 +907,12 @@ describe('workflow params and input', () => {
     });
 
     const result = await runWorkflow(deps, { tabId: 1, workflow });
-    expect(result).toStrictEqual({ ok: true, pagesVisited: 1, result: 'ok' });
+    expect(result).toStrictEqual({
+      effectsUncertain: false,
+      ok: true,
+      pagesVisited: 1,
+      result: 'ok',
+    });
   });
 
   it.each(['SFO', [['SFO']], 42])(
@@ -867,6 +923,7 @@ describe('workflow params and input', () => {
 
       const result = await runWorkflow(deps, { input: badInput, tabId: 1, workflow });
       expect(result).toStrictEqual({
+        effectsUncertain: false,
         error:
           'run_workflow input must be a JSON object mapping declared param names to values, e.g. {}. Declared params: none — omit input entirely.',
         ok: false,
@@ -896,7 +953,12 @@ describe('workflow params and input', () => {
 
     const result = await runWorkflow(capturingDeps, { input: stringInput, tabId: 1, workflow });
 
-    expect(result).toStrictEqual({ ok: true, pagesVisited: 1, result: 'ok' });
+    expect(result).toStrictEqual({
+      effectsUncertain: false,
+      ok: true,
+      pagesVisited: 1,
+      result: 'ok',
+    });
     expect(evalCodes[0]).toContain('input: {"destination":"SFO"}');
   });
 
@@ -910,6 +972,7 @@ describe('workflow params and input', () => {
 
     // No input at all on a required-param workflow: the missing-params error, not the shape error.
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'Missing required input: "destination" — Destination city. Call run_workflow again with input: {"destination":"<value>"}.',
       ok: false,
@@ -927,6 +990,7 @@ describe('workflow params and input', () => {
 
     const result = await runWorkflow(deps, { input: 'SFO', tabId: 1, workflow });
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'run_workflow input must be a JSON object mapping declared param names to values, e.g. {"destination": "<value>"}. Declared params: cabin, destination.',
       ok: false,
@@ -963,7 +1027,12 @@ describe('workflow params and input', () => {
       workflow,
     });
 
-    expect(result).toStrictEqual({ ok: true, pagesVisited: 2, result: 'end' });
+    expect(result).toStrictEqual({
+      effectsUncertain: false,
+      ok: true,
+      pagesVisited: 2,
+      result: 'end',
+    });
     expect({
       count: evalCodes.length,
       firstInput: evalCodes[0]?.includes('input: {"destination":"SFO"}'),
@@ -997,6 +1066,7 @@ describe('dry-run selector verification', () => {
           value: {
             dryRunActions: [{ action: 'click', selector: '#search' }],
             dryRunUnverified: true,
+            effectsUncertain: false,
             error: 'Selector not reachable in a dry run: .result',
             ok: false,
           },
@@ -1063,6 +1133,165 @@ describe('dry-run selector verification', () => {
   });
 });
 
+/* eslint-disable jest/no-conditional-in-test, promise/prefer-await-to-then -- These fakes revoke authority at selected asynchronous boundaries. */
+describe('workflow action authority', () => {
+  const boundaries = [
+    { actions: [], phase: 'before start' },
+    { actions: [], phase: 'navigation dispatch' },
+    { actions: ['navigate'], phase: 'after start navigation' },
+    { actions: ['navigate'], phase: 'evaluation dispatch' },
+    { actions: ['navigate', 'eval'], phase: 'after evaluation' },
+    { actions: ['navigate', 'eval', 'navigate'], phase: 'between pages' },
+  ];
+
+  describe.each([
+    { reason: 'cancelled', status: 'cancelled' as const },
+    { reason: 'lease_lost', status: 'interrupted' as const },
+  ])('$reason', ({ reason, status }) => {
+    it.each(boundaries)(
+      'blocks the next action at $phase',
+      async ({ actions: expectedActions, phase }) => {
+        const workflow = await buildApprovedWorkflow({
+          startUrl: 'https://shop.example.com/start',
+        });
+        const controller = new AbortController();
+        const actions: string[] = [];
+        let active = true;
+        const revokeAt = (boundary: string): void => {
+          if (phase === boundary) {
+            active = false;
+            if (status === 'cancelled') {
+              controller.abort();
+            }
+          }
+        };
+        const executionGuard = (): void => {
+          if (!active && status === 'interrupted') {
+            throw new ExecutionStoppedError(reason);
+          }
+        };
+        revokeAt('before start');
+        const result = runWorkflow(
+          {
+            evalInTab: async (_tabId, _code, guard) => {
+              await Promise.resolve();
+              revokeAt('evaluation dispatch');
+              guard?.();
+              actions.push('eval');
+              revokeAt('after evaluation');
+              return {
+                ok: true,
+                value: {
+                  ok: true,
+                  value: { navigate: 'https://shop.example.com/next', state: {} },
+                },
+              };
+            },
+            getTabUrl: () => Promise.resolve('https://shop.example.com/start'),
+            navigateTab: async (_tabId, _url, guard) => {
+              await Promise.resolve();
+              revokeAt('navigation dispatch');
+              guard?.();
+              actions.push('navigate');
+              revokeAt(actions.length === 1 ? 'after start navigation' : 'between pages');
+            },
+          },
+          { executionGuard, signal: controller.signal, tabId: 1, workflow }
+        );
+
+        await expect(result).rejects.toMatchObject({ effectsUncertain: false, reason, status });
+        expect(actions).toStrictEqual(expectedActions);
+      }
+    );
+  });
+
+  it.each([
+    {
+      label: 'legacy destroyed context',
+      result: { error: 'Execution context was destroyed', ok: false },
+    },
+    { label: 'producer timeout', result: { effectsUncertain: true, error: 'Timeout.', ok: false } },
+    {
+      label: 'uncertain outer success',
+      result: {
+        effectsUncertain: true,
+        ok: true,
+        value: { ok: true, value: { done: true, result: 'unconfirmed' } },
+      },
+    },
+    {
+      label: 'uncertain navigation envelope',
+      result: {
+        ok: true,
+        value: {
+          effectsUncertain: true,
+          ok: true,
+          value: { navigate: 'https://shop.example.com/next', state: {} },
+        },
+      },
+    },
+    {
+      label: 'legacy failed envelope',
+      result: { ok: true, value: { error: 'Lost completion.', ok: false } },
+    },
+    { label: 'invalid envelope', result: { ok: true, value: 'invalid' } },
+  ] satisfies { label: string; result: EvalTabResult }[])(
+    'never retries or navigates after $label',
+    async ({ result }) => {
+      const workflow = await buildApprovedWorkflow();
+      const actions: string[] = [];
+      const outcome = await runWorkflow(
+        {
+          evalInTab: () => {
+            actions.push('eval');
+            return Promise.resolve(result);
+          },
+          getTabUrl: () => Promise.resolve('https://shop.example.com/start'),
+          navigateTab: () => {
+            actions.push('navigate');
+            return Promise.resolve();
+          },
+        },
+        { tabId: 1, workflow }
+      );
+
+      expect(outcome).toMatchObject({ effectsUncertain: true, ok: false });
+      expect(actions).toStrictEqual(['eval']);
+    }
+  );
+
+  it('preserves envelope uncertainty when Stop arrives with the result', async () => {
+    const workflow = await buildApprovedWorkflow();
+    const controller = new AbortController();
+    const actions: string[] = [];
+    const result = await runWorkflow(
+      {
+        evalInTab: () => {
+          actions.push('eval');
+          controller.abort();
+          return Promise.resolve({
+            ok: true,
+            value: {
+              effectsUncertain: true,
+              ok: true,
+              value: { done: true, result: 'unconfirmed' },
+            },
+          });
+        },
+        getTabUrl: () => Promise.resolve('https://shop.example.com/start'),
+        navigateTab: () => {
+          actions.push('navigate');
+          return Promise.resolve();
+        },
+      },
+      { signal: controller.signal, tabId: 1, workflow }
+    );
+
+    expect(result).toMatchObject({ effectsUncertain: true, ok: false });
+    expect(actions).toStrictEqual(['eval']);
+  });
+});
+
 describe('run input bound', () => {
   it('rejects an oversized input before touching the page', async () => {
     const workflow = await buildApprovedWorkflow({ startUrl: 'https://shop.example.com/start' });
@@ -1075,6 +1304,7 @@ describe('run input bound', () => {
     });
 
     expect(result).toStrictEqual({
+      effectsUncertain: false,
       error:
         'run_workflow input exceeds the size limit (16000 characters). Pass only the values the workflow declares as params.',
       ok: false,

--- a/apps/extension/src/shared/agent-workflow-runner.ts
+++ b/apps/extension/src/shared/agent-workflow-runner.ts
@@ -9,8 +9,14 @@ import {
   matchesWorkflowScope,
 } from './agent-workflows';
 import type { AgentWorkflow } from './agent-workflows';
+import { isExecutionStopped, normalizeExecutionGuard } from './agent-tool-results';
+import type { ExecutionGuard } from './agent-tool-results';
+import { normalizeEvalTabResult } from './tab-debugger';
+import type { EvalTabResult } from './tab-debugger';
 
-export type WorkflowRunResult =
+// Old producers and stored workflow results omit effectsUncertain; runWorkflow returns the normalized contract.
+// Remove this raw compatibility form after those producers and records retire.
+export type WorkflowRunResult = { readonly effectsUncertain?: boolean } & (
   | {
       ok: true;
       pagesVisited: number;
@@ -22,7 +28,12 @@ export type WorkflowRunResult =
       error: string;
       pageUrl?: string | undefined;
       dryRunActions?: { action: string; selector: string }[] | undefined;
-    };
+    }
+);
+
+export type NormalizedWorkflowRunResult = WorkflowRunResult & {
+  readonly effectsUncertain: boolean;
+};
 
 // The value a workflow script carries across navigations via { navigate, state }.
 interface WorkflowScriptState {
@@ -30,20 +41,10 @@ interface WorkflowScriptState {
   readonly [key: string]: unknown;
 }
 
-interface EvalTabOkResult {
-  ok: true;
-  value: unknown;
-}
-interface EvalTabErrResult {
-  ok: false;
-  error: string;
-}
-type EvalTabResult = EvalTabOkResult | EvalTabErrResult;
-
-interface WorkflowRunnerDeps {
-  evalInTab(tabId: number, code: string): Promise<EvalTabResult>;
+export interface WorkflowRunnerDeps {
+  evalInTab(tabId: number, code: string, executionGuard?: ExecutionGuard): Promise<EvalTabResult>;
   getTabUrl(tabId: number): Promise<string>;
-  navigateTab(tabId: number, url: string): Promise<void>;
+  navigateTab(tabId: number, url: string, executionGuard?: ExecutionGuard): Promise<void>;
 }
 
 // CDP surfaces a mid-eval page navigation as one of these context errors.
@@ -105,6 +106,7 @@ const scriptEnvelopeSchema = z.object({
     .optional()
     .default([]),
   dryRunUnverified: z.boolean().optional(),
+  effectsUncertain: z.boolean().optional(),
   error: z.string().optional(),
   ok: z.boolean(),
   value: z.unknown().optional(),
@@ -339,10 +341,11 @@ export const buildWorkflowPageCode = (
   '  try {\n' +
   '    candidate = compiledExpression();\n' +
   '  } catch (error) {\n' +
-  "    return { ok: false, error: 'Workflow script threw while evaluating: ' + String(error && error.message ? error.message : error) + '. Pass an async ({ page, state, input }) => { … } function (or a bare function body); do not invoke it yourself.', dryRunActions };\n" +
+  "    return { effectsUncertain: false, ok: false, error: 'Workflow script threw while evaluating: ' + String(error && error.message ? error.message : error) + '. Pass an async ({ page, state, input }) => { … } function (or a bare function body); do not invoke it yourself.', dryRunActions };\n" +
   '  }\n' +
   "  if (typeof candidate === 'function') { workflow = candidate; }\n" +
-  "  else { return { ok: false, error: 'Workflow script must be a function, but evaluated to a non-function value. Pass an async ({ page, state, input }) => { … } function (or a bare function body); do not invoke it yourself.', dryRunActions }; }\n" +
+  // An invoked async expression can keep acting after this shape rejection.
+  "  else { return { effectsUncertain: true, ok: false, error: 'Workflow script must be a function, but evaluated to a non-function value. Pass an async ({ page, state, input }) => { … } function (or a bare function body); do not invoke it yourself.', dryRunActions }; }\n" +
   '}\n' +
   'if (workflow === undefined) {\n' +
   "  workflow = new AsyncFunctionCtor('{ page, state, input }', scriptText);\n" +
@@ -356,6 +359,7 @@ export const buildWorkflowPageCode = (
   '  return { ok: true, value, dryRunActions };\n' +
   '} catch (error) {\n' +
   '  return {\n' +
+  '    effectsUncertain: false,\n' +
   '    ok: false,\n' +
   '    error: error instanceof Error ? error.message : String(error),\n' +
   '    dryRunActions,\n' +
@@ -366,6 +370,7 @@ export const buildWorkflowPageCode = (
 
 interface RunWorkflowOptions {
   dryRun?: boolean;
+  executionGuard?: ExecutionGuard | undefined;
   input?: unknown;
   signal?: AbortSignal;
   tabId: number;
@@ -380,14 +385,12 @@ const resultWithActions = (
   base: WorkflowRunResult,
   dryRun: boolean,
   actions: { action: string; selector: string }[]
-): WorkflowRunResult => {
-  if (dryRun) {
-    return { ...base, dryRunActions: actions };
-  }
-  return base;
-};
-
-const isRunStopped = (signal: AbortSignal | undefined): boolean => signal?.aborted === true;
+): NormalizedWorkflowRunResult => ({
+  ...base,
+  // These local validation results are confirmed; issued-action failures pass their metadata explicitly.
+  effectsUncertain: base.effectsUncertain ?? false,
+  ...(dryRun ? { dryRunActions: actions } : {}),
+});
 
 const formatWorkflowScopeText = (
   workflow: Pick<AgentWorkflow, 'scopeOrigin' | 'pathPrefix'>
@@ -502,8 +505,10 @@ const validateNavigationState = (
 export const runWorkflow = async (
   deps: WorkflowRunnerDeps,
   options: RunWorkflowOptions
-): Promise<WorkflowRunResult> => {
-  const { workflow, tabId, input, dryRun = false, signal } = options;
+): Promise<NormalizedWorkflowRunResult> => {
+  const { workflow, tabId, input, dryRun = false, signal, executionGuard } = options;
+  const guard = normalizeExecutionGuard(executionGuard, signal);
+  guard();
 
   // 1. Approval gate — also applies to dry runs.
   if (!(await isWorkflowApproved(workflow))) {
@@ -573,7 +578,8 @@ export const runWorkflow = async (
     );
   }
 
-  // 2. Optional startUrl navigation.
+  // 2. Optional startUrl navigation. Approval and input reads never grant authority to act.
+  guard();
   if (workflow.startUrl !== undefined && workflow.startUrl !== '') {
     if (!matchesWorkflowScope(workflow, workflow.startUrl)) {
       return resultWithActions(
@@ -586,10 +592,15 @@ export const runWorkflow = async (
       );
     }
     try {
-      await deps.navigateTab(tabId, workflow.startUrl);
+      guard();
+      await deps.navigateTab(tabId, workflow.startUrl, guard);
     } catch (error) {
+      if (isExecutionStopped(error)) {
+        throw error;
+      }
       return resultWithActions(
         {
+          effectsUncertain: true,
           error: `Navigation to the startUrl failed: ${error instanceof Error ? error.message : String(error)}`,
           ok: false,
         },
@@ -597,31 +608,25 @@ export const runWorkflow = async (
         []
       );
     }
-    if (isRunStopped(signal)) {
-      return resultWithActions({ error: 'Run stopped.', ok: false }, dryRun, []);
-    }
+    guard();
   }
 
-  // 3. Initialize before the loop. `state.input` mirrors `input` on the first
-  // Page for scripts written against the old contract.
+  // 3. `state.input` mirrors input on the first page for older scripts.
   let state: WorkflowScriptState = { input: normalizedInput };
   let pagesVisited = 0;
   let navigationRecoveries = 0;
   const dryRunActions: { action: string; selector: string }[] = [];
 
-  // 4. Loop, at most MAX_WORKFLOW_PAGES_PER_RUN iterations.
   for (let pageIndex = 0; pageIndex < MAX_WORKFLOW_PAGES_PER_RUN; pageIndex++) {
-    // A. Abort check.
-    if (isRunStopped(signal)) {
-      return resultWithActions({ error: 'Run stopped.', ok: false }, dryRun, dryRunActions);
-    }
-
-    // B. Scope check on current tab URL.
+    guard();
     let url = '';
     try {
       // eslint-disable-next-line no-await-in-loop -- Sequential workflow execution by design.
       url = await deps.getTabUrl(tabId);
     } catch (error) {
+      if (isExecutionStopped(error)) {
+        throw error;
+      }
       return resultWithActions(
         {
           error: `Could not read the tab URL: ${error instanceof Error ? error.message : String(error)}`,
@@ -631,9 +636,7 @@ export const runWorkflow = async (
         dryRunActions
       );
     }
-    if (isRunStopped(signal)) {
-      return resultWithActions({ error: 'Run stopped.', ok: false }, dryRun, dryRunActions);
-    }
+    guard();
     if (!matchesWorkflowScope(workflow, url)) {
       return resultWithActions(
         {
@@ -646,24 +649,46 @@ export const runWorkflow = async (
       );
     }
 
-    // C. Build the injected code.
     const code = buildWorkflowPageCode(workflow.script, state, dryRun, normalizedInput);
-
-    // D. Eval in the tab.
-    // eslint-disable-next-line no-await-in-loop — Sequential workflow execution by design.
-    const evalResult = await deps.evalInTab(tabId, code);
-    if (isRunStopped(signal)) {
-      return resultWithActions({ error: 'Run stopped.', ok: false }, dryRun, dryRunActions);
+    let rawResult: EvalTabResult | undefined = undefined;
+    try {
+      guard();
+      // eslint-disable-next-line no-await-in-loop -- Sequential workflow execution by design.
+      rawResult = await deps.evalInTab(tabId, code, guard);
+    } catch (error) {
+      if (isExecutionStopped(error)) {
+        throw error;
+      }
+      rawResult = {
+        effectsUncertain: true,
+        error: error instanceof Error ? error.message : String(error),
+        ok: false,
+      };
+    }
+    const evalResult = normalizeEvalTabResult(rawResult);
+    // Check uncertainty before Stop, navigation recovery, or success. An issued action can outlive its result.
+    if (evalResult.effectsUncertain) {
+      return resultWithActions(
+        {
+          effectsUncertain: true,
+          error: evalResult.ok ? 'Workflow action completion is uncertain.' : evalResult.error,
+          ok: false,
+          pageUrl: url,
+        },
+        dryRun,
+        dryRunActions
+      );
     }
     if (!evalResult.ok) {
-      // A real click can navigate the page mid-eval; the destroyed execution context IS the navigation the script wanted. Re-run the script on the landed page with the same state, exactly like the { navigate } path. Fixed 1.5 s settle and a 3-recovery cap; add a load-complete dep if flaky pages surface.
+      guard();
+      // Recover only when the producer confirms completion. A metadata-free destroyed context is not proof of quiescence.
       if (!dryRun && isNavigationDestroyedEval(evalResult.error) && navigationRecoveries < 3) {
         navigationRecoveries += 1;
-        // eslint-disable-next-line no-await-in-loop, promise/avoid-new -- Sequential workflow execution by design; a plain settle delay has no promise-returning primitive to defer to.
+        // eslint-disable-next-line no-await-in-loop, promise/avoid-new -- Sequential workflow recovery needs a settle delay.
         await new Promise<void>(resolve => {
           setTimeout(resolve, 1500);
         });
-        // eslint-disable-next-line no-continue -- Mirrors the { navigate } path: same state, next page iteration.
+        // eslint-disable-next-line no-continue -- The next iteration checks authority before another action.
         continue;
       }
       return resultWithActions(
@@ -673,25 +698,39 @@ export const runWorkflow = async (
       );
     }
 
-    // E. Increment pagesVisited and parse layer-2 envelope.
     pagesVisited++;
-
     const envelope = scriptEnvelopeSchema.safeParse(evalResult.value);
     if (!envelope.success) {
       return resultWithActions(
-        { error: invalidValueError(evalResult.value, dryRun), ok: false, pageUrl: url },
+        {
+          effectsUncertain: true,
+          error: invalidValueError(evalResult.value, dryRun),
+          ok: false,
+          pageUrl: url,
+        },
         dryRun,
         dryRunActions
       );
     }
 
-    // Accumulate dryRunActions.
-    const pageActions = envelope.data.dryRunActions;
-    dryRunActions.push(...pageActions);
+    dryRunActions.push(...envelope.data.dryRunActions);
+    // Old metadata-free script envelopes cannot confirm a failed issued action.
+    // Remove this fallback after those injected scripts and stored results retire.
+    if (envelope.data.effectsUncertain ?? !envelope.data.ok) {
+      return resultWithActions(
+        {
+          effectsUncertain: true,
+          error: envelope.data.error ?? 'Workflow action completion is uncertain.',
+          ok: false,
+          pageUrl: url,
+        },
+        dryRun,
+        dryRunActions
+      );
+    }
 
-    /* A dry run cannot reach content its own skipped clicks would have produced.
-       Selectors up to the first recorded action are verified, so this reports
-       success with the recorded actions instead of failing a correct script. */
+    guard();
+    // A dry run cannot reach content its skipped clicks would have produced.
     if (dryRun && envelope.data.dryRunUnverified === true) {
       return resultWithActions(
         {
@@ -707,7 +746,6 @@ export const runWorkflow = async (
       );
     }
 
-    // Script threw an error.
     if (!envelope.data.ok) {
       return resultWithActions(
         { error: envelope.data.error ?? 'Unknown script error.', ok: false, pageUrl: url },
@@ -717,8 +755,6 @@ export const runWorkflow = async (
     }
 
     if (!jsonRecordSchema.safeParse(envelope.data.value).success) {
-      /* Same reasoning as above: a dry-run script that falls through without a
-         return value usually read post-action content that never rendered. */
       if (dryRun && dryRunActions.length > 0) {
         return resultWithActions(
           {
@@ -733,7 +769,6 @@ export const runWorkflow = async (
           dryRunActions
         );
       }
-
       return resultWithActions(
         { error: invalidValueError(envelope.data.value, dryRun), ok: false, pageUrl: url },
         dryRun,
@@ -741,10 +776,8 @@ export const runWorkflow = async (
       );
     }
 
-    // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- Preceding jsonRecordSchema check guarantees a plain object.
+    // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- The schema check guarantees a plain object.
     const innerValue = envelope.data.value as Record<string, unknown>;
-
-    // Success: { done: true, result: <unknown> }
     if (innerValue['done'] === true) {
       return resultWithActions(
         { ok: true, pagesVisited, result: innerValue['result'] },
@@ -753,22 +786,24 @@ export const runWorkflow = async (
       );
     }
 
-    // Navigation: { navigate: string, state: object }
     const navigateValue = stringSchema.safeParse(innerValue['navigate']);
     if (navigateValue.success && navigateValue.data.length > 0) {
       const validationResult = validateNavigationState(workflow, innerValue, url);
-
       if (validationResult.kind === 'error') {
         return resultWithActions(validationResult.errorResult, dryRun, dryRunActions);
       }
-
       state = validationResult.nextState;
       try {
+        guard();
         // eslint-disable-next-line no-await-in-loop -- Sequential workflow execution by design.
-        await deps.navigateTab(tabId, validationResult.navigateUrl);
+        await deps.navigateTab(tabId, validationResult.navigateUrl, guard);
       } catch (error) {
+        if (isExecutionStopped(error)) {
+          throw error;
+        }
         return resultWithActions(
           {
+            effectsUncertain: true,
             error: `Navigation to ${validationResult.navigateUrl} failed: ${error instanceof Error ? error.message : String(error)}`,
             ok: false,
             pageUrl: url,
@@ -777,11 +812,11 @@ export const runWorkflow = async (
           dryRunActions
         );
       }
+      guard();
       // eslint-disable-next-line no-continue -- Clearer than deep nesting for this state machine.
       continue;
     }
 
-    // Anything else is invalid.
     return resultWithActions(
       { error: invalidValueError(innerValue, dryRun), ok: false, pageUrl: url },
       dryRun,

--- a/apps/extension/src/shared/kilo-api-client.ts
+++ b/apps/extension/src/shared/kilo-api-client.ts
@@ -4,6 +4,7 @@ export {
   fetchKiloGatewayChatCompletionStream,
   KiloGatewayHttpError,
   KiloGatewayStreamStalledError,
+  KiloGatewayUnsupportedToolError,
   parseKiloGatewayChatCompletionStream,
 } from './kilo-gateway-chat-stream-client';
 export type {

--- a/apps/extension/src/shared/kilo-gateway-chat-stream-client.test.ts
+++ b/apps/extension/src/shared/kilo-gateway-chat-stream-client.test.ts
@@ -5,6 +5,7 @@ import {
   fetchKiloGatewayChatCompletionStream,
   KiloGatewayHttpError,
   KiloGatewayStreamStalledError,
+  KiloGatewayUnsupportedToolError,
   parseKiloGatewayChatCompletionStream,
 } from './kilo-api-client';
 import type { KiloGatewayToolDefinition, KiloGatewayToolName } from './kilo-api-client';
@@ -222,7 +223,7 @@ describe('kilo gateway chat stream client', () => {
         token: 'token-1',
         tools: searchPageTools,
       })
-    ).rejects.toThrow('Gateway stream tool call did not include a supported tool name.');
+    ).rejects.toBeInstanceOf(KiloGatewayUnsupportedToolError);
   });
 
   it('concatenates a fragmented offered page name across tool call deltas', async () => {

--- a/apps/extension/src/shared/kilo-gateway-chat-stream-client.ts
+++ b/apps/extension/src/shared/kilo-gateway-chat-stream-client.ts
@@ -45,6 +45,14 @@ export class KiloGatewayHttpError extends Error {
   }
 }
 
+/** A call outside the offered tool set is terminal, not a transport failure. */
+export class KiloGatewayUnsupportedToolError extends Error {
+  constructor() {
+    super('Gateway stream tool call did not include a supported tool name.');
+    this.name = 'KiloGatewayUnsupportedToolError';
+  }
+}
+
 const DEFAULT_STALL_TIMEOUT_MS = 45_000;
 const DEFAULT_COMPLETION_TIMEOUT_MS = 90_000;
 
@@ -198,7 +206,7 @@ const parseToolCallBuffer = (
       : [...allowedToolNames].find(allowed => allowed === value.name);
 
   if (name === undefined) {
-    throw new TypeError('Gateway stream tool call did not include a supported tool name.');
+    throw new KiloGatewayUnsupportedToolError();
   }
 
   const parsedArguments = (() => {

--- a/apps/extension/src/shared/tab-debugger.test.ts
+++ b/apps/extension/src/shared/tab-debugger.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-/* eslint-disable max-lines */
+/* eslint-disable max-lines, jest/no-conditional-in-test -- Producer fixtures fail before or after dispatch to verify action certainty. */
 import { describe, expect, it } from 'vitest';
 import {
   WEB_MCP_DISCOVER_MESSAGE,
@@ -160,6 +160,39 @@ describe('tab debugger helpers', () => {
     ]);
   });
 
+  it.each([
+    { effectsUncertain: false, phase: 'attach' },
+    { effectsUncertain: true, phase: 'evaluate' },
+  ])('distinguishes a failure during $phase', async ({ effectsUncertain, phase }) => {
+    const commands: string[] = [];
+    const debuggerApi: ChromeDebuggerApi = {
+      ...createDebuggerApi(),
+      attach: () => {
+        if (phase === 'attach') {
+          throw new Error('Denied.');
+        }
+      },
+      sendCommand: () => {
+        commands.push('evaluate');
+        throw new Error('Response lost.');
+      },
+    };
+    const result = await evalInTab({ code: 'return 1;', debuggerApi, tabId: 7 });
+    expect(result).toMatchObject({ effectsUncertain, ok: false });
+    expect(commands).toStrictEqual(phase === 'attach' ? [] : ['evaluate']);
+  });
+
+  it.each([
+    { effectsUncertain: 'false', error: 'Denied.', ok: false },
+    {
+      ok: true,
+      result: { effectsUncertain: 'true', error: 'Lost result.', ok: false },
+      type: WEB_MCP_EXECUTE_MESSAGE,
+    },
+  ])('rejects malformed uncertainty metadata: %j', response => {
+    expect(isTabDebuggerResponse(response)).toBe(false);
+  });
+
   it('returns eval errors and still detaches', async () => {
     const debuggerApi = createDebuggerApi({
       sendCommand: () => ({
@@ -175,6 +208,7 @@ describe('tab debugger helpers', () => {
         tabId: 7,
       })
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       error: 'Page evaluation failed: ReferenceError: missingValue is not defined',
       ok: false,
     });
@@ -284,7 +318,11 @@ describe('tab debugger helpers', () => {
         tabId: 7,
         timeoutMs: 1,
       })
-    ).resolves.toStrictEqual({ error: 'Page evaluation timed out.', ok: false });
+    ).resolves.toStrictEqual({
+      effectsUncertain: true,
+      error: 'Page evaluation timed out.',
+      ok: false,
+    });
   });
 
   it('reports Firefox scripting eval errors instead of a phantom success', async () => {
@@ -299,6 +337,7 @@ describe('tab debugger helpers', () => {
         tabId: 7,
       })
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       error: 'Page evaluation failed: missingValue is not defined',
       ok: false,
     });
@@ -312,6 +351,7 @@ describe('tab debugger helpers', () => {
     await expect(
       getPageSnapshotInTabWithScripting({ scriptingApi, tabId: 7 })
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       error: 'Failed to read page snapshot: Page snapshot timed out.',
       ok: false,
     });
@@ -334,6 +374,7 @@ describe('tab debugger helpers', () => {
         tabId: 7,
       })
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       error: 'Eval result was not JSON-serializable.',
       ok: false,
     });
@@ -408,7 +449,11 @@ describe('tab debugger helpers', () => {
         tabId: 7,
         timeoutMs: 1,
       })
-    ).resolves.toStrictEqual({ error: 'Page evaluation timed out.', ok: false });
+    ).resolves.toStrictEqual({
+      effectsUncertain: true,
+      error: 'Page evaluation timed out.',
+      ok: false,
+    });
   });
 
   it('captures a viewport screenshot for the selected tab and restores the active tab', async () => {
@@ -466,6 +511,7 @@ describe('tab debugger helpers', () => {
     };
 
     await expect(getViewportScreenshotWithTabsApi({ tabId: 7, tabsApi })).resolves.toStrictEqual({
+      effectsUncertain: false,
       error: 'The selected tab was not active at capture time.',
       ok: false,
     });
@@ -689,7 +735,7 @@ describe('tab debugger helpers', () => {
         tabId: 7,
         toolName: 'double',
       })
-    ).resolves.toStrictEqual({ ok: true, value: '{"doubled":42}' });
+    ).resolves.toStrictEqual({ effectsUncertain: false, ok: true, value: '{"doubled":42}' });
   });
 
   it('executes a tool in the MAIN world targeting the reported document', async () => {
@@ -729,7 +775,7 @@ describe('tab debugger helpers', () => {
         tabId: 7,
         toolName: 'double',
       })
-    ).resolves.toStrictEqual({ ok: true, value: '{"ok":true}' });
+    ).resolves.toStrictEqual({ effectsUncertain: false, ok: true, value: '{"ok":true}' });
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.world).toBe('MAIN');
@@ -766,7 +812,7 @@ describe('tab debugger helpers', () => {
         tabId: 7,
         toolName: 'navigate',
       })
-    ).resolves.toStrictEqual({ ok: true, value: null });
+    ).resolves.toStrictEqual({ effectsUncertain: false, ok: true, value: null });
   });
 
   it('returns a browser rejection as an error result', async () => {
@@ -783,7 +829,11 @@ describe('tab debugger helpers', () => {
         tabId: 7,
         toolName: 'missing',
       })
-    ).resolves.toStrictEqual({ error: 'WebMCP tool execution failed: Tool not found', ok: false });
+    ).resolves.toStrictEqual({
+      effectsUncertain: true,
+      error: 'WebMCP tool execution failed: Tool not found',
+      ok: false,
+    });
   });
 
   it('accepts the WebMCP discover and execute request shapes', () => {
@@ -855,7 +905,7 @@ describe('tab debugger helpers', () => {
         tabId: 7,
         toolName: 'double',
       })
-    ).resolves.toStrictEqual({ ok: true, value: '{"ok":true}' });
+    ).resolves.toStrictEqual({ effectsUncertain: false, ok: true, value: '{"ok":true}' });
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.args).toStrictEqual(['double', '{}', signature]);
@@ -891,7 +941,7 @@ describe('tab debugger helpers', () => {
         tabId: 7,
         toolName: 'double',
       })
-    ).resolves.toStrictEqual({ ok: true, value: '{"doubled":42}' });
+    ).resolves.toStrictEqual({ effectsUncertain: false, ok: true, value: '{"doubled":42}' });
   });
 
   it('returns a stale-tool error when the definition signature changed', async () => {
@@ -928,6 +978,7 @@ describe('tab debugger helpers', () => {
         toolName: 'double',
       })
     ).resolves.toStrictEqual({
+      effectsUncertain: false,
       error: 'WebMCP tool execution failed: WebMCP tool "double" changed; refresh the page tools.',
       ok: false,
     });

--- a/apps/extension/src/shared/tab-debugger.ts
+++ b/apps/extension/src/shared/tab-debugger.ts
@@ -158,16 +158,26 @@ export interface WebMcpDiscoveryResult {
   readonly tools: WebMcpToolDescriptor[];
 }
 
-export type EvalTabResult =
+export type EvalTabResult = (
   | {
-      readonly description?: string;
+      readonly description?: string | undefined;
       readonly ok: true;
       readonly value?: unknown;
     }
   | {
       readonly error: string;
       readonly ok: false;
-    };
+    }
+) & { readonly effectsUncertain?: boolean | undefined };
+
+export type NormalizedEvalTabResult = EvalTabResult & { readonly effectsUncertain: boolean };
+
+export const normalizeEvalTabResult = (result: EvalTabResult): NormalizedEvalTabResult => ({
+  ...result,
+  // Old metadata-free producers cannot confirm completion after an issued failure.
+  // Remove this fallback after all metadata-free producers and clients retire.
+  effectsUncertain: result.effectsUncertain ?? !result.ok,
+});
 
 export type TabDebuggerRequest =
   | {
@@ -235,6 +245,7 @@ export type TabDebuggerResponse =
       readonly type: typeof WEB_MCP_EXECUTE_MESSAGE;
     }
   | {
+      readonly effectsUncertain?: boolean | undefined;
       readonly error: string;
       readonly ok: false;
     };
@@ -247,10 +258,12 @@ const inspectableTabSchema = z.object({
 const evalTabResultSchema = z.union([
   z.object({
     description: z.string().optional(),
+    effectsUncertain: z.boolean().optional(),
     ok: z.literal(true),
     value: z.unknown().optional(),
   }),
   z.object({
+    effectsUncertain: z.boolean().optional(),
     error: z.string(),
     ok: z.literal(false),
   }),
@@ -321,6 +334,7 @@ const tabDebuggerResponseSchema = z.union([
     type: z.literal(WEB_MCP_EXECUTE_MESSAGE),
   }),
   z.object({
+    effectsUncertain: z.boolean().optional(),
     error: z.string(),
     ok: z.literal(false),
   }),
@@ -427,7 +441,11 @@ export const getViewportScreenshotWithTabsApi = ({
   const queryTabs = tabsApi.query.bind(tabsApi);
 
   if (captureVisibleTab === undefined || getTab === undefined || updateTab === undefined) {
-    return Promise.resolve({ error: 'Viewport screenshot API is unavailable.', ok: false });
+    return Promise.resolve({
+      effectsUncertain: false,
+      error: 'Viewport screenshot API is unavailable.',
+      ok: false,
+    });
   }
 
   return runScreenshotCaptureExclusively(async () => {
@@ -443,7 +461,11 @@ export const getViewportScreenshotWithTabsApi = ({
 
       // A manual tab switch can land between activation and capture; refuse rather than capture and upload a different tab's contents.
       if (getTabId(activeTab) !== tabId) {
-        return { error: 'The selected tab was not active at capture time.', ok: false };
+        return {
+          effectsUncertain: false,
+          error: 'The selected tab was not active at capture time.',
+          ok: false,
+        };
       }
 
       const dataUrl = await captureVisibleTab(windowId, { format: 'png' });
@@ -506,7 +528,7 @@ const toSerializableEvalResult = (value: unknown): EvalTabResult => {
   try {
     JSON.stringify(value);
   } catch {
-    return { error: 'Eval result was not JSON-serializable.', ok: false };
+    return { effectsUncertain: false, error: 'Eval result was not JSON-serializable.', ok: false };
   }
 
   const stringValue = evalStringValueSchema.safeParse(value);
@@ -901,8 +923,7 @@ const runInjectedWebMcpExecute = async (
   toolNameText: string,
   argumentsText: string,
   definitionSignatureText: string
-  // oxlint-disable-next-line anti-slop/no-unknown-returns -- injected function; the third-party tool result shape is arbitrary and cannot be parsed without importing a schema.
-): Promise<unknown> => {
+): Promise<NormalizedEvalTabResult> => {
   const { modelContext } = document as Document & {
     modelContext?: {
       getTools?: () => Promise<unknown[]>;
@@ -919,7 +940,7 @@ const runInjectedWebMcpExecute = async (
     typeof value === 'string';
   const asString = (value: unknown): string => (isString(value) ? value : '');
   const isPlainObject = (value: unknown): value is Record<string, unknown> =>
-    // oxlint-disable-next-line anti-slop/no-runtime-typeof -- injected function distinguishing a plain-object schema from a primitive/array in arbitrary third-party tool data; cannot import a schema to parse it.
+    // oxlint-disable-next-line anti-slop/no-runtime-typeof -- injected function distinguishing a plain-object schema from a primitive/array in arbitrary third-party tool data; cannot import a schema to parse them.
     typeof value === 'object' && value !== null && !Array.isArray(value);
 
   if (
@@ -927,12 +948,16 @@ const runInjectedWebMcpExecute = async (
     modelContext.getTools === undefined ||
     modelContext.executeTool === undefined
   ) {
-    throw new Error('WebMCP is not available in this document.');
+    return {
+      effectsUncertain: false,
+      error: 'WebMCP is not available in this document.',
+      ok: false,
+    };
   }
 
   const tools = await modelContext.getTools();
   if (!isArray(tools)) {
-    throw new TypeError('WebMCP returned no tools.');
+    return { effectsUncertain: false, error: 'WebMCP returned no tools.', ok: false };
   }
 
   let tool: unknown = undefined;
@@ -943,12 +968,15 @@ const runInjectedWebMcpExecute = async (
       break;
     }
   }
-
   if (tool === undefined) {
-    throw new Error(`WebMCP tool "${toolNameText}" is not available.`);
+    return {
+      effectsUncertain: false,
+      error: `WebMCP tool "${toolNameText}" is not available.`,
+      ok: false,
+    };
   }
 
-  // Rebuild the ordered definition signature identically to web-mcp-tools.ts and reject a changed registration as a stale tool.
+  // Rebuild the ordered signature before dispatching the page tool.
   const record = isToolRecord(tool) ? tool : {};
   const name = asString(record['name']);
   const title = asString(record['title']);
@@ -964,14 +992,24 @@ const runInjectedWebMcpExecute = async (
   }
   const normalizedSchema = isPlainObject(schema) ? schema : undefined;
   const definitionSignature = JSON.stringify([name, title, description, origin, normalizedSchema]);
-
   if (definitionSignature !== definitionSignatureText) {
-    throw new Error(`WebMCP tool "${toolNameText}" changed; refresh the page tools.`);
+    return {
+      effectsUncertain: false,
+      error: `WebMCP tool "${toolNameText}" changed; refresh the page tools.`,
+      ok: false,
+    };
   }
 
-  const result = await modelContext.executeTool(tool, argumentsText);
-
-  return result;
+  try {
+    const value = await modelContext.executeTool(tool, argumentsText);
+    return { effectsUncertain: false, ok: true, value };
+  } catch (error) {
+    return {
+      effectsUncertain: true,
+      error: error instanceof Error ? error.message : String(error),
+      ok: false,
+    };
+  }
 };
 /* eslint-enable unicorn/consistent-function-scoping */
 
@@ -1011,43 +1049,46 @@ export const evalInTab = async ({
 }): Promise<EvalTabResult> => {
   const target = { tabId };
   let attached = false;
-
+  let dispatched = false;
   try {
     await debuggerApi.attach(target, DEBUGGER_PROTOCOL_VERSION);
     attached = true;
-
+    dispatched = true;
     const response = await debuggerApi.sendCommand(target, 'Runtime.evaluate', {
       awaitPromise: true,
       expression: getEvalExpression(code),
       returnByValue: true,
       timeout: timeoutMs,
     });
-
     const parsed = chromeEvalResponseSchema.safeParse(response);
-
     if (!parsed.success) {
-      return { error: 'Debugger returned an invalid eval response.', ok: false };
+      return {
+        effectsUncertain: true,
+        error: 'Debugger returned an invalid eval response.',
+        ok: false,
+      };
     }
-
     const { exceptionDetails, result } = parsed.data;
-
     if (exceptionDetails !== undefined) {
-      return { error: getExceptionMessage(exceptionDetails), ok: false };
+      return { effectsUncertain: false, error: getExceptionMessage(exceptionDetails), ok: false };
     }
-
     if (result === undefined) {
-      return { error: 'Debugger returned an invalid eval result.', ok: false };
+      return {
+        effectsUncertain: true,
+        error: 'Debugger returned an invalid eval result.',
+        ok: false,
+      };
     }
-
     const normalizedResult = Object.hasOwn(result, 'value')
       ? toSerializableEvalResult(result.value)
       : ({ ok: true } satisfies EvalTabResult);
-
     return normalizedResult.ok && result.description !== undefined
       ? { ...normalizedResult, description: result.description }
       : normalizedResult;
   } catch (error) {
     return {
+      // Attach denial issued no page code. A timeout or lost eval response cannot prove completion.
+      effectsUncertain: dispatched,
       error: error instanceof Error ? error.message : 'Page evaluation failed.',
       ok: false,
     };
@@ -1074,12 +1115,7 @@ export const evalInTabWithScripting = async ({
   readonly timeoutMs?: number;
 }): Promise<EvalTabResult> => {
   try {
-    /*
-     * Soft timeout only. withTimeout rejects this promise, but a runaway model-authored snippet
-     * keeps running in the page's MAIN world after we report a timeout — scripting has no
-     * cancellation primitive. The Chrome/CDP path passes a real timeout to Runtime.evaluate; this
-     * one can't. Revisit if scripting ever gains enforced cancellation.
-     */
+    // This soft timeout cannot stop MAIN-world code. Every timeout or lost result below is uncertain.
     const [response] = await withTimeout(
       Promise.resolve(
         scriptingApi.executeScript({
@@ -1091,20 +1127,22 @@ export const evalInTabWithScripting = async ({
       ),
       timeoutMs
     );
-
-    if (response?.error !== undefined) {
+    if (response === undefined) {
+      return { effectsUncertain: true, error: 'Page evaluation returned no result.', ok: false };
+    }
+    if (response.error !== undefined) {
       const detail = extractInjectionErrorText(response.error);
-
       return {
+        effectsUncertain: false,
         error:
           detail === undefined ? 'Page evaluation failed.' : `Page evaluation failed: ${detail}`,
         ok: false,
       };
     }
-
-    return toSerializableEvalResult(response?.result);
+    return toSerializableEvalResult(response.result);
   } catch (error) {
     return {
+      effectsUncertain: true,
       error: error instanceof Error ? error.message : 'Page evaluation failed.',
       ok: false,
     };
@@ -1136,11 +1174,13 @@ export const getPageSnapshotInTabWithScripting = async ({
       ),
       timeoutMs
     );
-
-    if (response?.error !== undefined) {
+    if (response === undefined) {
+      return { effectsUncertain: true, error: 'Page snapshot returned no result.', ok: false };
+    }
+    if (response.error !== undefined) {
       const detail = extractInjectionErrorText(response.error);
-
       return {
+        effectsUncertain: false,
         error:
           detail === undefined
             ? 'Failed to read page snapshot.'
@@ -1148,10 +1188,10 @@ export const getPageSnapshotInTabWithScripting = async ({
         ok: false,
       };
     }
-
-    return { ok: true, value: response?.result };
+    return { ok: true, value: response.result };
   } catch (error) {
     return {
+      effectsUncertain: true,
       error: error instanceof Error ? error.message : 'Failed to read page snapshot.',
       ok: false,
     };
@@ -1180,11 +1220,13 @@ export const discoverWebMcpToolsInTab = async ({
       ),
       DEFAULT_EVAL_TIMEOUT_MS
     );
-
-    if (response?.error !== undefined) {
+    if (response === undefined) {
+      return { effectsUncertain: true, error: 'WebMCP discovery returned no result.', ok: false };
+    }
+    if (response.error !== undefined) {
       const detail = extractInjectionErrorText(response.error);
-
       return {
+        effectsUncertain: false,
         error:
           detail === undefined
             ? 'Failed to discover WebMCP tools.'
@@ -1192,18 +1234,16 @@ export const discoverWebMcpToolsInTab = async ({
         ok: false,
       };
     }
-
-    const documentId = response?.documentId ?? '';
-    const tools = isWebMcpToolDescriptorArray(response?.result) ? response.result : [];
-
-    // The browser must report the target document; without it the tools cannot be bound to a page.
-    if (documentId === '') {
-      return { ok: true, value: { documentId: '', tools: [] } satisfies WebMcpDiscoveryResult };
-    }
-
-    return { ok: true, value: { documentId, tools } satisfies WebMcpDiscoveryResult };
+    const documentId = response.documentId ?? '';
+    const tools = isWebMcpToolDescriptorArray(response.result) ? response.result : [];
+    // Without a document ID, the tools cannot be bound to a page.
+    return {
+      ok: true,
+      value: { documentId, tools: documentId === '' ? [] : tools } satisfies WebMcpDiscoveryResult,
+    };
   } catch (error) {
     return {
+      effectsUncertain: true,
       error: error instanceof Error ? error.message : 'Failed to discover WebMCP tools.',
       ok: false,
     };
@@ -1237,11 +1277,10 @@ export const executeWebMcpToolInTab = async ({
       ),
       DEFAULT_EVAL_TIMEOUT_MS
     );
-
     if (response?.error !== undefined) {
       const detail = extractInjectionErrorText(response.error);
-
       return {
+        effectsUncertain: true,
         error:
           detail === undefined
             ? 'WebMCP tool execution failed.'
@@ -1249,10 +1288,21 @@ export const executeWebMcpToolInTab = async ({
         ok: false,
       };
     }
-
-    return { ok: true, value: response?.result };
+    const parsed = evalTabResultSchema.safeParse(response?.result);
+    if (!parsed.success) {
+      return {
+        effectsUncertain: true,
+        error: 'WebMCP execution returned an invalid result.',
+        ok: false,
+      };
+    }
+    const result = normalizeEvalTabResult(parsed.data);
+    return result.ok
+      ? result
+      : { ...result, error: `WebMCP tool execution failed: ${result.error}` };
   } catch (error) {
     return {
+      effectsUncertain: true,
       error: error instanceof Error ? error.message : 'WebMCP tool execution failed.',
       ok: false,
     };


### PR DESCRIPTION
- Empty replies now show an explanation when a response stops early or the conversation is too long.
- Kilo does not run actions from unfinished replies. If a reply requests an unavailable or unsafe action, Kilo explains the failure and runs none of that reply’s actions.
- Stop now prevents Kilo from starting another workflow step, including its first page change. It does not undo an action already in progress.
- The chat keeps completed action results if you stop a request before its next action.
- If Kilo cannot confirm an action finished, it stops the request instead of retrying or starting another action. This includes page actions, workflows, searches, and connected tools.

---

## Summary

`LlmTurnOutcome` replaces `Promise<void>` with four statuses: `succeeded`, `failed`, `cancelled`, and `interrupted`, plus a reason, summary, confirmed `toolResults`, and `effectsUncertain`. `LlmTurnFailureReason` distinguishes model failure, retry exhaustion, context overflow, exhausted rounds, truncation, empty or incomplete answers, failure caps, and unsafe calls. `succeeded` means a complete answer, not verified page changes; confirmed tool errors remain recoverable, and existing callers keep transcript updates.

<details>
<summary>Files</summary>

- `apps/extension/src/shared/agent-llm-turn-runner-core.ts` — Source, modified, 298 changed lines. Classifies terminal paths, explains empty failures, preserves partial replies, excludes stale retry summaries, and stops batches at the 25-failure cap. Checks authority before model requests, retries, tool calls, and automatic continuation, including after asynchronous tool preparation.
- `apps/extension/src/shared/agent-llm-turn-runner-core.test.ts` — Test, modified, 568 changed lines. Updates coverage for terminal outcomes, guards, unsafe calls, and recovery.

</details>

`ExecutionGuard` and `ExecutionStoppedError` combine owner checks with `AbortSignal`, preserving cancellation and interruption reasons without claiming to undo issued actions. `ToolExecutionOptions.onResult` reports settled `ToolResultEvent` values immediately; required `effectsUncertain` turns uncertain successes into failed events and stops later calls. Existing signal-only callers still receive settled results on Stop; the documented compatibility path remains until all guardless callers retire.

<details>
<summary>Files</summary>

- `apps/extension/src/shared/agent-tool-results.ts` — Source, modified, 116 changed lines. Adds guard normalization, typed stops, immediate callbacks, and uncertain-error events while preserving the existing signal argument.
- `apps/extension/src/shared/agent-tool-results.test.ts` — Test, modified, 170 changed lines. Updates batch-stop, uncertainty, and settled-result assertions.

</details>

`EvalTabResult` and `TabDebuggerResponse` add optional `effectsUncertain`, while `NormalizedEvalTabResult` requires it. `normalizeEvalTabResult` treats older successes as confirmed and failures without metadata as uncertain; `evalTabResultSchema` and `tabDebuggerResponseSchema` preserve explicit metadata. Browser producers mark timeouts and lost results as uncertain, distinguish confirmed rejection or script errors, and never equate a scripting timeout with cancellation.

<details>
<summary>Files</summary>

- `apps/extension/src/shared/tab-debugger.ts` — Source, modified, 178 changed lines. Adds producer metadata and structured page-tool replies across evaluation, snapshots, screenshots, and discovery; distinguishes denied or settled failures from missing replies.
- `apps/extension/src/shared/tab-debugger.test.ts` — Test, modified, 69 changed lines. Updates browser-result and uncertainty assertions.

</details>

`KiloGatewayUnsupportedToolError` separates missing or unoffered tool names from retryable transport errors. The runner rejects unsafe, truncated, or unfinished call batches before dispatch, including partially accepted replies. A bad call invalidates the entire batch, so accepted calls cannot execute beside discarded calls or leave unmatched history events.

<details>
<summary>Files</summary>

- `apps/extension/src/shared/kilo-gateway-chat-stream-client.ts` — Source, modified, 10 changed lines. Throws the terminal error from the real stream parser instead of a retryable `TypeError`.
- `apps/extension/src/shared/kilo-api-client.ts` — Source, modified, 1 changed line. Re-exports the typed unsupported-tool error for runner consumers.
- `apps/extension/src/shared/kilo-gateway-chat-stream-client.test.ts` — Test, modified, 3 changed lines. Updates the unsupported-tool parser assertion.

</details>

`WorkflowRunnerDeps`, `WorkflowToolContext`, and `RunWorkflowOptions` carry `executionGuard` through approval, `startUrl` navigation, page evaluation, and later navigation. `WorkflowRunResult`, `NormalizedWorkflowRunResult`, and `scriptEnvelopeSchema` preserve `effectsUncertain`; old failed results without metadata now interrupt instead of triggering recovery. `requestApproval` still uses existing permissions; aborted approvals cancel, uncertain envelopes stop before another action, and only confirmed evaluation failures permit navigation recovery.

<details>
<summary>Files</summary>

- `apps/extension/src/shared/agent-workflow-runner.ts` — Source, modified, 185 changed lines. Reuses `EvalTabResult`, guards each step, and preserves uncertainty through envelopes and dry-run results. Marks invoked non-function scripts uncertain and limits navigation recovery to confirmed failures.
- `apps/extension/entrypoints/sidepanel/agent-workflow-runtime.ts` — Source, modified, 78 changed lines. Guards navigation and evaluation; maps lost responses and navigation timeouts to uncertainty while retaining existing timeout budgets.
- `apps/extension/entrypoints/sidepanel/agent-workflow-tool-runtime.ts` — Source, modified, 64 changed lines. Uses shared dependency types without a cast, guards storage and approval boundaries, and preserves metadata during result conversion.
- `apps/extension/src/shared/agent-workflow-runner.test.ts` — Test, modified, 316 changed lines. Updates workflow guard, navigation, envelope, and uncertainty coverage.
- `apps/extension/entrypoints/sidepanel/agent-workflow-runtime.test.ts` — Test, modified, 48 changed lines. Updates browser navigation and evaluation assertions.
- `apps/extension/entrypoints/sidepanel/agent-workflow-tool-runtime.test.ts` — Test, modified, 233 changed lines. Updates workflow adapter, approval, guard, and result assertions.

</details>

`RunLlmTurnOptions`, `RunSafeLlmTurnOptions`, and `RunDangerousLlmTurnOptions` accept `executionGuard`; both wrappers return `LlmTurnOutcome` and forward the guard to every tool family. Safe and Dangerous tool selection, workflow permissions, remote filtering, and streaming callbacks stay unchanged. Dangerous `eval` uses the guarded transport with the existing five-second timeout; workflow evaluation retains thirty seconds.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/agent-llm-turn-runner.ts` — Source, modified, 41 changed lines. Returns the outcome, accepts a remote executor guard argument, falls back to the workflow guard, and shares guarded evaluation.
- `apps/extension/entrypoints/sidepanel/agent-safe-llm-turn-runner.ts` — Source, modified, 36 changed lines. Returns the outcome and forwards the normalized guard through discovery, workflows, remote tools, and search; retains optional page-tool discovery.
- `apps/extension/entrypoints/sidepanel/agent-llm-turn-runner.test.ts` — Test, modified, 503 changed lines. Updates Dangerous-mode outcome, guard, and real-parser regression coverage.
- `apps/extension/entrypoints/sidepanel/agent-safe-llm-turn-runner.test.ts` — Test, modified, 338 changed lines. Updates Safe-mode outcome, guard, and real-parser regression coverage.

</details>

`createSafeToolExecutor` accepts an optional `ExecutionGuard` and returns `NormalizedEvalTabResult` without changing snapshot caching or memory reads. Page snapshots and screenshots retain producer uncertainty, and uncertain snapshots never enter the cache. Local argument, cache, and parsed-snapshot errors remain confirmed failures, so the runner can recover from them.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/agent-safe-tool-runtime.ts` — Source, modified, 88 changed lines. Normalizes browser replies, rejects uncertain snapshots, and adds guarded execution while preserving memory and cache behavior.
- `apps/extension/entrypoints/sidepanel/agent-safe-tool-runtime.test.ts` — Test, modified, 32 changed lines. Updates safe-tool guard and result assertions.
- `apps/extension/src/shared/agent-safe-tool-runtime.test.ts` — Test, modified, 11 changed lines. Updates the shared safe-tool assertions.

</details>

`discoverWebMcpTools` and `executeWebMcpToolCall` accept `ExecutionGuard`; confirmed discovery failures still disable page tools, but uncertain discovery now interrupts. Execution preserves `effectsUncertain` through result parsing and size limits, distinguishes pre-dispatch serialization failures, and propagates typed stops. Existing document and definition checks still gate page tools; the change adds no new permission.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/agent-web-mcp-tool-runtime.ts` — Source, modified, 114 changed lines. Preserves certainty through discovery, execution, JavaScript Object Notation (JSON) parsing, and output limits; guards both entrypoints.
- `apps/extension/entrypoints/sidepanel/agent-web-mcp-tool-runtime.test.ts` — Test, modified, 76 changed lines. Updates page-tool discovery and execution tests.

</details>

Remote Model Context Protocol (MCP) calls now carry `ExecutionGuard` through `callRemoteMcpTool` and `executeRemoteMcpToolCall`, preserving interruption reasons and post-dispatch uncertainty. `CallToolResult.isError` and `McpError` codes `InvalidParams` or `MethodNotFound` remain recoverable; lost results, transport failures, and request timeouts stay uncertain. Remote calls still use plain fetch, existing route/server filtering, and capped results, so Kilo credentials stay separate from third-party authentication.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/agent-remote-mcp-tool-runtime.ts` — Source, modified, 59 changed lines. Forwards the guard to the real client and distinguishes confirmed tool errors from uncertain transport failures without changing filtering or result limits.
- `apps/extension/entrypoints/sidepanel/remote-mcp-client.ts` — Source, modified, 35 changed lines. Rechecks authority after connection setup, tracks dispatch, preserves owner cancellation reasons, and distinguishes protocol rejections from uncertain failures.
- `apps/extension/entrypoints/sidepanel/agent-remote-mcp-tool-runtime.test.ts` — Test, modified, 427 changed lines. Updates real-client interruption, lease-loss, and protocol-rejection coverage.
- `apps/extension/entrypoints/sidepanel/remote-mcp-client-call.test.ts` — Test, modified, 108 changed lines. Updates client cancellation, error, and dispatch assertions.

</details>

`WebSearchContext.executionGuard` now gates the existing search request; `executeWebSearchToolCall` and `createWebSearchExecutor` return `NormalizedEvalTabResult`. Lost replies, invalid successful replies, and cancellation while reading a successful reply preserve uncertainty; confirmed server errors remain recoverable. Query and budget denials remain confirmed; the five-search budget and result limits stay unchanged, and Stop cannot undo an issued request.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/agent-web-search-tool-runtime.ts` — Source, modified, 69 changed lines. Guards billable requests, preserves cancellation during fetch and body reads, and separates uncertainty from confirmed search errors.
- `apps/extension/entrypoints/sidepanel/agent-web-search-tool-runtime.test.ts` — Test, modified, 116 changed lines. Updates search guard, parsing, and cancellation tests.

</details>

Tests: 15 unit test files modified, with 3,018 changed lines.
Generated: 0 files changed.

---

## Verification

Manual verification: not run. Runtime verification remains pending on the stack tips.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Human steps

- **before merge:** After all section pull requests receive human-ready, merge each repository's levels from bottom to top.
- **after merge:** No additional manual setup is required. This change adds no environment values, secrets, migrations, or flags.

### Recorded check evidence

- The cumulative review passed all 15 changed test files, scoped formatting, type-aware lint, and whitespace checks.
- A later clean recheck passed 121 targeted tests and five checks.
- This description round did not rerun product checks. The recorded results do not establish continuous integration (CI), native browser, or live-model verification.

### Stack and review scope

- Base cloud pull request: https://github.com/Kilo-Org/cloud/pull/5653
- Matching command-line interface (CLI) integration is already published: https://github.com/Kilo-Org/kilocode/pull/13567
- Review range: `browser-task-0787-s4...browser-task-0787-s7`, with head `f1a542f21`.
- Scope: 30 modified files, with 3,740 insertions and 650 deletions. Each listed file size counts added and removed lines.
- Cloud worktree: `/Users/igor/Projects/.worktrees/browser-task-0787`, branch `browser-task-0787-s7`; this level is the review scope.
- CLI worktree: `/Users/igor/Projects/.worktrees/browser-task-0787-kilocode`, branch `browser-task-0787-s6`; the published integration is dependency context only.

### Notes

Runtime verification remains pending on the stack tips. Profile locks, provider integration, consent controls, and native browser proof follow in later levels.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `browser-task-0787` — #5638
2. `browser-task-0787-s2` — #5644
3. `browser-task-0787-s3` — #5648
4. `browser-task-0787-s4` — #5653
7. `browser-task-0787-s7` — #5681 ← this PR
8. `browser-task-0787-s8` — #5694
9. `browser-task-0787-s9` — #5698
10. `browser-task-0787-s10` — #5702
11. `browser-task-0787-s11` — #5716
12. `browser-task-0787-s12` — #5734
13. `browser-task-0787-s13` — #5742 (tip)

