### PR TITLE
feat(pr-review): define source-backed context contracts

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-dtos.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-dtos.test.ts
@@ -1,0 +1,110 @@
+import {
+  GitHubPrReviewApplicationBindingSchema,
+  GitHubPrReviewContextSchema,
+} from './context-dtos';
+
+const revision = {
+  prNodeId: 'PR_12',
+  number: 12,
+  headSha: 'head',
+  baseRepoFullName: 'kilo/flux',
+  baseRef: 'main',
+  baseSha: 'base',
+};
+const observedAt = '2026-08-28T12:00:00+02:00';
+const source = {
+  availability: 'available',
+  retryable: false,
+  provenance: ['graphql'],
+  reason: null,
+  observedAt,
+};
+const complete = <T>(items: T[]) => ({
+  source,
+  items,
+  completeness: 'complete',
+  knownCount: items.length,
+  totalCount: items.length,
+  hasNextPage: false,
+  endCursor: null,
+});
+
+test('normalizes omitted sources without claiming complete empty collections', () => {
+  const context = GitHubPrReviewContextSchema.parse({ revision });
+  for (const collection of [
+    context.labels,
+    context.assignees,
+    context.reviewRequests,
+    context.reviewDecisions,
+    context.reviewActivity,
+    context.issues,
+    context.requirements,
+    context.checks,
+  ]) {
+    expect(collection).toMatchObject({
+      source: { availability: 'unavailable', reason: 'not-requested', retryable: false },
+      items: [],
+      completeness: 'unknown',
+      knownCount: 0,
+      totalCount: null,
+      hasNextPage: null,
+      endCursor: null,
+    });
+  }
+  expect(context).toMatchObject({
+    revision,
+    observedAt: null,
+    evaluatedShas: [],
+    lifecycle: { openedAt: null, updatedAt: null, closedAt: null, mergedAt: null },
+    merger: { identity: null },
+    queue: { membership: { state: 'unknown' }, position: { value: null } },
+  });
+});
+
+test('preserves successful siblings, exact lifecycle times, and confirmed emptiness', () => {
+  const labels = complete([{ id: 'L_1', name: 'bug', color: null }]);
+  const lifecycle = {
+    source,
+    openedAt: observedAt,
+    updatedAt: observedAt,
+    closedAt: null,
+    mergedAt: null,
+  };
+  const input = { revision, labels, lifecycle, assignees: complete([]) };
+  expect(GitHubPrReviewContextSchema.parse(input)).toMatchObject(input);
+});
+
+test.each([
+  ['partial', true],
+  ['stale', true],
+  ['unavailable', true],
+  ['denied', false],
+])('preserves queued membership when position is %s', (availability, retryable) => {
+  const queue = {
+    membership: { source, state: 'queued', entryId: 'Q_1' },
+    position: {
+      source: { ...source, availability, retryable, reason: 'source-failure' },
+      entryId: 'Q_1',
+      prNodeId: 'PR_12',
+      value: null,
+      state: null,
+      enqueuedAt: null,
+    },
+  };
+  const context = GitHubPrReviewContextSchema.parse({ revision, queue, labels: complete([]) });
+  expect(context.queue).toEqual(queue);
+  expect(context.labels).toEqual(complete([]));
+});
+
+test.each([{ kind: 'app', appId: 1 }, { kind: 'any' }, { kind: 'unknown' }])(
+  'preserves the explicit application binding %j',
+  binding => {
+    expect(GitHubPrReviewApplicationBindingSchema.parse(binding)).toEqual(binding);
+  }
+);
+
+test.each([null, undefined, 0])('rejects an invalid bound application ID: %s', appId => {
+  expect(GitHubPrReviewApplicationBindingSchema.safeParse({ kind: 'app', appId }).success).toBe(
+    false
+  );
+});

--- a/apps/web/src/lib/github-pr-review/context-dtos.ts
+++ b/apps/web/src/lib/github-pr-review/context-dtos.ts
@@ -1,0 +1,279 @@
+import 'server-only';
+
+import { z } from 'zod';
+
+export const GitHubPrReviewTimestampSchema = z.string().datetime({ offset: true });
+const nullableTimestamp = GitHubPrReviewTimestampSchema.nullable();
+const nullableId = z.string().min(1).nullable();
+
+export const GitHubPrReviewSourceSchema = z
+  .object({
+    availability: z.enum(['available', 'partial', 'denied', 'unavailable', 'stale']),
+    retryable: z.boolean(),
+    provenance: z.array(z.string().min(1)),
+    reason: z.string().nullable(),
+    observedAt: nullableTimestamp,
+  })
+  .strict();
+export type GitHubPrReviewSource = z.infer<typeof GitHubPrReviewSourceSchema>;
+
+export const unavailablePrReviewSource = (): GitHubPrReviewSource => ({
+  availability: 'unavailable',
+  retryable: false,
+  provenance: [],
+  reason: 'not-requested',
+  observedAt: null,
+});
+
+export function githubPrReviewCollectionSchema<T extends z.ZodTypeAny>(item: T) {
+  return z
+    .object({
+      source: GitHubPrReviewSourceSchema,
+      items: z.array(item),
+      completeness: z.enum(['complete', 'partial', 'unknown']),
+      knownCount: z.number().int().nonnegative(),
+      totalCount: z.number().int().nonnegative().nullable(),
+      hasNextPage: z.boolean().nullable(),
+      endCursor: z.string().nullable(),
+    })
+    .strict()
+    .default(() => ({
+      source: unavailablePrReviewSource(),
+      items: [],
+      completeness: 'unknown' as const,
+      knownCount: 0,
+      totalCount: null,
+      hasNextPage: null,
+      endCursor: null,
+    }));
+}
+
+export const GitHubPrReviewRevisionSchema = z
+  .object({
+    prNodeId: z.string().min(1),
+    number: z.number().int().positive(),
+    headSha: z.string().min(1),
+    baseRepoFullName: nullableId,
+    baseRef: z.string(),
+    baseSha: nullableId,
+  })
+  .strict();
+export type GitHubPrReviewRevision = z.infer<typeof GitHubPrReviewRevisionSchema>;
+
+export const GitHubPrReviewIdentitySchema = z
+  .object({
+    id: nullableId,
+    kind: z.enum(['User', 'Team', 'Bot', 'Mannequin', 'Unavailable']),
+    login: z.string().nullable(),
+    name: z.string().nullable(),
+    avatarUrl: z.string().url().nullable(),
+    url: z.string().url().nullable(),
+    teamSlug: z.string().nullable(),
+  })
+  .strict();
+export type GitHubPrReviewIdentity = z.infer<typeof GitHubPrReviewIdentitySchema>;
+
+export const GitHubPrReviewLabelSchema = z
+  .object({
+    id: nullableId,
+    name: z.string(),
+    color: z.string().nullable(),
+  })
+  .strict();
+
+export const GitHubPrReviewSubmissionSchema = z
+  .object({
+    id: z.string().min(1),
+    actor: GitHubPrReviewIdentitySchema.nullable(),
+    state: z.enum([
+      'APPROVED',
+      'CHANGES_REQUESTED',
+      'COMMENTED',
+      'DISMISSED',
+      'PENDING',
+      'UNKNOWN',
+    ]),
+    submittedAt: nullableTimestamp,
+    commitSha: nullableId,
+    onBehalfOf: githubPrReviewCollectionSchema(GitHubPrReviewIdentitySchema.nullable()),
+  })
+  .strict();
+
+export const GitHubPrReviewIssueSchema = z
+  .object({
+    id: z.string().min(1),
+    number: z.number().int().positive(),
+    title: z.string(),
+    state: z.enum(['OPEN', 'CLOSED']),
+    repository: z.string().min(1),
+    url: z.string().url().nullable(),
+    relationships: z.array(
+      z
+        .object({
+          category: z.enum(['closing', 'connected', 'referenced', 'duplicate']),
+          membership: z.enum(['current', 'historical']),
+          evidenceId: z.string().min(1),
+          sourceId: z.string().min(1),
+          targetId: z.string().min(1),
+        })
+        .strict()
+    ),
+  })
+  .strict();
+
+export const GitHubPrReviewEvidenceSchema = z
+  .object({
+    source: z.string().min(1),
+    policyId: nullableId,
+    observation: z.string().min(1),
+    headSha: nullableId,
+    baseSha: nullableId,
+    evaluatedSha: nullableId,
+    observedAt: nullableTimestamp,
+  })
+  .strict();
+
+const checkKind = z.enum(['check-run', 'status', 'unknown']);
+export const GitHubPrReviewApplicationBindingSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('app'), appId: z.number().int().positive() }).strict(),
+  z.object({ kind: z.literal('any') }).strict(),
+  z.object({ kind: z.literal('unknown') }).strict(),
+]);
+
+export const GitHubPrReviewRequirementSchema = z
+  .object({
+    id: z.string().min(1),
+    kind: z.string().min(1),
+    title: z.string(),
+    state: z.enum(['met', 'unmet', 'unavailable']),
+    policy: z
+      .object({
+        id: z.string().min(1),
+        source: z.enum(['classic', 'ruleset', 'github']),
+        enforcement: z.enum(['active', 'evaluate', 'disabled', 'unknown']),
+      })
+      .strict()
+      .nullable(),
+    check: z
+      .object({
+        name: z.string().min(1),
+        kind: checkKind,
+        application: GitHubPrReviewApplicationBindingSchema,
+      })
+      .strict()
+      .nullable(),
+    evidence: z.array(GitHubPrReviewEvidenceSchema),
+  })
+  .strict();
+
+export const GitHubPrReviewContextCheckSchema = z
+  .object({
+    id: nullableId,
+    name: z.string().min(1),
+    kind: checkKind,
+    application: z
+      .object({
+        id: z.number().int().positive().nullable(),
+        nodeId: nullableId,
+        slug: z.string().nullable(),
+        name: z.string().nullable(),
+      })
+      .strict()
+      .nullable(),
+    outcome: z.enum(['success', 'failure', 'pending', 'skipped', 'unknown']),
+    status: z.string().nullable(),
+    conclusion: z.string().nullable(),
+    requiredness: z.enum(['required', 'optional', 'unknown']),
+    observation: z.enum(['observed', 'missing', 'unknown']),
+    evaluatedSha: nullableId,
+    detailsUrl: z.string().url().nullable(),
+    evidence: z.array(GitHubPrReviewEvidenceSchema),
+  })
+  .strict();
+
+export const GitHubPrReviewLifecycleSchema = z
+  .object({
+    source: GitHubPrReviewSourceSchema,
+    openedAt: nullableTimestamp,
+    updatedAt: nullableTimestamp,
+    closedAt: nullableTimestamp,
+    mergedAt: nullableTimestamp,
+  })
+  .strict();
+
+export const GitHubPrReviewQueueSchema = z
+  .object({
+    membership: z
+      .object({
+        source: GitHubPrReviewSourceSchema,
+        state: z.enum(['queued', 'not-queued', 'unknown']),
+        entryId: nullableId,
+      })
+      .strict(),
+    position: z
+      .object({
+        source: GitHubPrReviewSourceSchema,
+        entryId: nullableId,
+        prNodeId: nullableId,
+        value: z.number().int().nonnegative().nullable(),
+        state: z
+          .enum(['AWAITING_CHECKS', 'LOCKED', 'MERGEABLE', 'QUEUED', 'UNMERGEABLE'])
+          .nullable(),
+        enqueuedAt: nullableTimestamp,
+      })
+      .strict(),
+  })
+  .strict();
+
+// Old context payloads omit sources. Retain defaults until all old clients, servers, and records are gone.
+// Missing sources never establish an empty collection.
+export const GitHubPrReviewContextSchema = z
+  .object({
+    revision: GitHubPrReviewRevisionSchema,
+    observedAt: nullableTimestamp.default(null),
+    evaluatedShas: z.array(z.string().min(1)).default(() => []),
+    labels: githubPrReviewCollectionSchema(GitHubPrReviewLabelSchema),
+    assignees: githubPrReviewCollectionSchema(GitHubPrReviewIdentitySchema.nullable()),
+    reviewRequests: githubPrReviewCollectionSchema(
+      z
+        .object({
+          id: nullableId,
+          reviewer: GitHubPrReviewIdentitySchema.nullable(),
+        })
+        .strict()
+    ),
+    reviewDecisions: githubPrReviewCollectionSchema(GitHubPrReviewSubmissionSchema),
+    reviewActivity: githubPrReviewCollectionSchema(GitHubPrReviewSubmissionSchema),
+    lifecycle: GitHubPrReviewLifecycleSchema.default(() => ({
+      source: unavailablePrReviewSource(),
+      openedAt: null,
+      updatedAt: null,
+      closedAt: null,
+      mergedAt: null,
+    })),
+    merger: z
+      .object({
+        source: GitHubPrReviewSourceSchema,
+        identity: GitHubPrReviewIdentitySchema.nullable(),
+      })
+      .strict()
+      .default(() => ({ source: unavailablePrReviewSource(), identity: null })),
+    issues: githubPrReviewCollectionSchema(GitHubPrReviewIssueSchema),
+    // Completeness covers supported PR-side sources, not every outgoing or inaccessible link.
+    issueCoverage: z.literal('supported-pr-sources').default('supported-pr-sources'),
+    requirements: githubPrReviewCollectionSchema(GitHubPrReviewRequirementSchema),
+    checks: githubPrReviewCollectionSchema(GitHubPrReviewContextCheckSchema),
+    queue: GitHubPrReviewQueueSchema.default(() => ({
+      membership: { source: unavailablePrReviewSource(), state: 'unknown' as const, entryId: null },
+      position: {
+        source: unavailablePrReviewSource(),
+        entryId: null,
+        prNodeId: null,
+        value: null,
+        state: null,
+        enqueuedAt: null,
+      },
+    })),
+  })
+  .strict();
+export type GitHubPrReviewContext = z.infer<typeof GitHubPrReviewContextSchema>;


### PR DESCRIPTION
No new behavior — this change adds data definitions without connecting them to the product.

---

## Summary

`GitHubPrReviewContextSchema` adds strict, server-only context without production consumers; `GitHubPrReviewRevisionSchema`, `GitHubPrReviewIdentitySchema`, `GitHubPrReviewLabelSchema`, `GitHubPrReviewSubmissionSchema`, `GitHubPrReviewIssueSchema`, `GitHubPrReviewLifecycleSchema`, and `GitHubPrReviewTimestampSchema` preserve metadata, with inferred `GitHubPrReviewContext`, `GitHubPrReviewRevision`, and `GitHubPrReviewIdentity` types.
`GitHubPrReviewRequirementSchema`, `GitHubPrReviewContextCheckSchema`, `GitHubPrReviewEvidenceSchema`, and `GitHubPrReviewApplicationBindingSchema` retain policy and check evidence; `GitHubPrReviewQueueSchema` keeps membership and position sources independent.
`GitHubPrReviewSourceSchema`, `GitHubPrReviewSource`, `githubPrReviewCollectionSchema`, and `unavailablePrReviewSource` define defaults for omitted legacy fields; these defaults never establish complete emptiness or queue absence.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-dtos.ts` — added, 279 lines. Adds Zod validation and inferred types for revisions, labels, nullable identities, review requests, decisions, activity, lifecycle times, and merger identity. Requires revision identity; base repository and base commit data can be null. Sources retain availability, retryability, provenance, reasons, and observation times; collections retain completeness, counts, and pagination. Timestamps accept offsets; identities include users, teams, bots, mannequins, and unavailable actors with nullable profile and team fields. Reviews retain actors, states, submission times, commit identifiers, and delegated identities. Issue relationships retain categories, current or historical membership, and evidence identifiers; completeness covers only supported pull request sources. Requirements retain states, policy source, enforcement, check kinds, app bindings, and commit-linked evidence. Checks retain kinds, outcomes, raw status, conclusions, requiredness, observations, application identity, evaluated commits, and details links. App bindings distinguish a positive integer app identifier, any app, and unknown. Queue data retains independent sources, entry identifiers, pull request identity, position, state, and enqueue time. Missing collections default to unavailable, non-retryable sources, a `not-requested` reason, unknown completeness, empty items, zero known counts, and null totals and pagination. Missing times, merger identity, and queue position default to null; evaluated commits default to an empty list, and queue membership remains unknown.

</details>

Tests: 1 file added, `apps/web/src/lib/github-pr-review/context-dtos.test.ts` (+110 lines). Covers defaults, preserved data and timestamps, confirmed emptiness, independent queue sources, explicit app bindings, and invalid app identifiers.
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual verification: not run. This level adds context schemas and schema-only tests, without production consumers.

## Reviewer Notes

### Human steps

None. This level requires no setup, migration, or deployment step before or after merge.

### Notes

This level defines context contracts without production consumers. Live backend and iOS verification will run on the completed stack tip.

- The handoff reports 12 passing scoped tests and successful scoped lint, format, and whitespace checks.
- Actual stack-base continuous integration (CI) evidence remains pending until this pull request runs its checks.










<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682 ← this PR
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
