### PR TITLE
feat(pr-review): normalize optional context payloads

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-dtos.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-dtos.test.ts
@@ -2,7 +2,57 @@ import {
   GitHubPrReviewApplicationBindingSchema,
   GitHubPrReviewContextSchema,
 } from './context-dtos';
+import {
+  GitHubPrReviewChecksResultSchema,
+  GitHubPrReviewInboxItemSchema,
+  GitHubPrReviewInboxResultSchema,
+  GitHubPrReviewOverviewSchema,
+  GitHubPrReviewReviewCommentSchema,
+  NormalizedGitHubPrReviewInboxItemSchema,
+  NormalizedGitHubPrReviewInboxResultSchema,
+  NormalizedGitHubPrReviewOverviewSchema,
+} from './dtos';
 
+const author = { login: 'octocat', avatarUrl: null };
+const oldOverview = {
+  number: 12,
+  title: 'Fix',
+  bodyMarkdown: null,
+  author,
+  state: 'open',
+  draft: false,
+  baseRef: 'main',
+  headRef: 'fix',
+  isCrossRepo: false,
+  headRepoFullName: null,
+  headSha: 'head',
+  prNodeId: 'PR_12',
+  counts: { commits: 1, changedFiles: 1, additions: 2, deletions: 0 },
+  mergeable: null,
+  mergeableState: null,
+  autoMerge: null,
+  reviewDecision: null,
+  repo: {
+    allowMergeCommit: false,
+    allowSquashMerge: false,
+    allowRebaseMerge: false,
+    allowAutoMerge: false,
+    deleteBranchOnMerge: false,
+    allowUpdateBranch: false,
+    viewerCanPush: false,
+    viewerCanAdmin: false,
+    viewerLogin: null,
+  },
+};
+const oldInbox = {
+  owner: 'kilo',
+  repo: 'flux',
+  number: 12,
+  title: 'Fix',
+  author,
+  isDraft: false,
+  updatedAt: '',
+};
 const revision = {
   prNodeId: 'PR_12',
   number: 12,
@@ -28,6 +78,147 @@ const complete = <T>(items: T[]) => ({
   hasNextPage: false,
   endCursor: null,
 });
+
+const identity = {
+  id: 'U_1',
+  kind: 'User',
+  login: 'octocat',
+  name: 'Octo Cat',
+  avatarUrl: null,
+  url: null,
+  teamSlug: null,
+};
+const evidence = [
+  {
+    source: 'graphql.checks',
+    policyId: 'rule-1',
+    observation: 'failure',
+    headSha: 'head',
+    baseSha: 'base',
+    evaluatedSha: 'head',
+    observedAt,
+  },
+];
+const fullContext = {
+  revision,
+  observedAt,
+  evaluatedShas: ['head'],
+  labels: complete([{ id: 'L_1', name: 'bug', color: null }]),
+  assignees: complete([identity]),
+  reviewRequests: complete([
+    {
+      id: 'RR_1',
+      reviewer: {
+        ...identity,
+        id: 'T_1',
+        kind: 'Team',
+        login: null,
+        name: 'Core',
+        teamSlug: 'core',
+      },
+    },
+  ]),
+  reviewDecisions: complete([
+    {
+      id: 'R_1',
+      actor: identity,
+      state: 'APPROVED',
+      submittedAt: observedAt,
+      commitSha: 'head',
+      onBehalfOf: complete([]),
+    },
+  ]),
+  reviewActivity: complete([
+    {
+      id: 'R_2',
+      actor: null,
+      state: 'COMMENTED',
+      submittedAt: null,
+      commitSha: null,
+      onBehalfOf: complete([]),
+    },
+  ]),
+  lifecycle: {
+    source,
+    openedAt: '2026-01-01T12:00:00+01:00',
+    updatedAt: observedAt,
+    closedAt: null,
+    mergedAt: null,
+  },
+  merger: { source, identity: null },
+  issues: complete([
+    {
+      id: 'I_1',
+      number: 7,
+      title: 'Issue',
+      state: 'OPEN',
+      repository: 'other/flux',
+      url: 'https://github.com/other/flux/issues/7',
+      relationships: [
+        {
+          category: 'connected',
+          membership: 'current',
+          evidenceId: 'E_1',
+          sourceId: 'PR_12',
+          targetId: 'I_1',
+        },
+      ],
+    },
+  ]),
+  issueCoverage: 'supported-pr-sources',
+  requirements: complete([
+    {
+      id: 'rule-1',
+      kind: 'status-check',
+      title: 'CI',
+      state: 'unmet',
+      policy: { id: 'rule-1', source: 'classic', enforcement: 'active' },
+      check: { name: 'ci', kind: 'check-run', application: { kind: 'app', appId: 1 } },
+      evidence,
+    },
+  ]),
+  checks: complete([
+    {
+      id: 'C_1',
+      name: 'ci',
+      kind: 'check-run',
+      application: { id: 1, nodeId: 'APP_1', slug: 'ci', name: 'CI' },
+      outcome: 'failure',
+      status: 'completed',
+      conclusion: 'failure',
+      requiredness: 'required',
+      observation: 'observed',
+      evaluatedSha: 'head',
+      detailsUrl: null,
+      evidence,
+    },
+    {
+      id: null,
+      name: 'ci',
+      kind: 'status',
+      application: null,
+      outcome: 'unknown',
+      status: null,
+      conclusion: null,
+      requiredness: 'required',
+      observation: 'missing',
+      evaluatedSha: 'head',
+      detailsUrl: null,
+      evidence,
+    },
+  ]),
+  queue: {
+    membership: { source, state: 'queued', entryId: 'Q_1' },
+    position: {
+      source,
+      entryId: 'Q_1',
+      prNodeId: 'PR_12',
+      value: 3,
+      state: 'QUEUED',
+      enqueuedAt: observedAt,
+    },
+  },
+};
 
 test('normalizes omitted sources without claiming complete empty collections', () => {
   const context = GitHubPrReviewContextSchema.parse({ revision });
@@ -94,6 +285,21 @@ test.each([
   const context = GitHubPrReviewContextSchema.parse({ revision, queue, labels: complete([]) });
   expect(context.queue).toEqual(queue);
   expect(context.labels).toEqual(complete([]));
+
+  const input = {
+    ...fullContext,
+    queue: {
+      ...fullContext.queue,
+      position: {
+        ...fullContext.queue.position,
+        source: queue.position.source,
+        value: null,
+      },
+    },
+  };
+  expect(
+    NormalizedGitHubPrReviewOverviewSchema.parse({ ...oldOverview, context: input }).context
+  ).toStrictEqual(input);
 });
 
 test.each([{ kind: 'app', appId: 1 }, { kind: 'any' }, { kind: 'unknown' }])(
@@ -107,4 +313,146 @@ test.each([null, undefined, 0])('rejects an invalid bound application ID: %s', a
   expect(GitHubPrReviewApplicationBindingSchema.safeParse({ kind: 'app', appId }).success).toBe(
     false
   );
+});
+
+test('accepts old overview and Inbox payloads without altering legacy fields', () => {
+  expect(GitHubPrReviewOverviewSchema.parse(oldOverview)).toStrictEqual(oldOverview);
+  expect(GitHubPrReviewInboxItemSchema.parse(oldInbox)).toStrictEqual(oldInbox);
+  const { context, ...legacy } = NormalizedGitHubPrReviewOverviewSchema.parse(oldOverview);
+  expect(legacy).toStrictEqual(oldOverview);
+  expect(context.revision).toStrictEqual({ ...revision, baseSha: null, baseRepoFullName: null });
+  for (const collection of [
+    context.labels,
+    context.assignees,
+    context.reviewRequests,
+    context.reviewDecisions,
+    context.reviewActivity,
+    context.issues,
+    context.requirements,
+    context.checks,
+  ]) {
+    expect(collection).toMatchObject({
+      source: { availability: 'unavailable', reason: 'not-requested', retryable: false },
+      items: [],
+      completeness: 'unknown',
+      knownCount: 0,
+      totalCount: null,
+      hasNextPage: null,
+      endCursor: null,
+    });
+  }
+  for (const missingSource of [
+    context.lifecycle.source,
+    context.merger.source,
+    context.queue.membership.source,
+    context.queue.position.source,
+  ]) {
+    expect(missingSource).toStrictEqual({
+      availability: 'unavailable',
+      reason: 'not-requested',
+      retryable: false,
+      provenance: [],
+      observedAt: null,
+    });
+  }
+  expect(context).toMatchObject({
+    observedAt: null,
+    evaluatedShas: [],
+    issueCoverage: 'supported-pr-sources',
+    lifecycle: { openedAt: null, updatedAt: null, closedAt: null, mergedAt: null },
+    merger: { identity: null },
+    queue: {
+      membership: { state: 'unknown', entryId: null },
+      position: { entryId: null, prNodeId: null, value: null, state: null, enqueuedAt: null },
+    },
+  });
+  expect(NormalizedGitHubPrReviewInboxItemSchema.parse(oldInbox)).toStrictEqual({
+    ...oldInbox,
+    authorDisplayName: null,
+  });
+});
+
+test('retains full context, source evidence, distinct check identities, and Inbox names', () => {
+  const overview = { ...oldOverview, autoMerge: { method: 'squash' }, context: fullContext };
+  expect(GitHubPrReviewOverviewSchema.parse(overview)).toStrictEqual(overview);
+  expect(NormalizedGitHubPrReviewOverviewSchema.parse(overview)).toStrictEqual(overview);
+  expect(
+    NormalizedGitHubPrReviewInboxItemSchema.parse({ ...oldInbox, authorDisplayName: 'Octo Cat' })
+  ).toStrictEqual({ ...oldInbox, authorDisplayName: 'Octo Cat' });
+});
+
+test('normalizes missing source additions without changing a confirmed empty sibling', () => {
+  const { context } = NormalizedGitHubPrReviewOverviewSchema.parse({
+    ...oldOverview,
+    context: { revision, labels: complete([]) },
+  });
+  expect(context.labels).toStrictEqual(complete([]));
+  expect(context.assignees).toMatchObject({
+    source: { availability: 'unavailable' },
+    completeness: 'unknown',
+    totalCount: null,
+  });
+  expect(context.queue.position).toMatchObject({
+    source: { availability: 'unavailable' },
+    value: null,
+  });
+});
+
+test.each([null, undefined])(
+  'normalizes an unavailable Inbox name (%s) without inventing an author',
+  authorDisplayName => {
+    const input = { ...oldInbox, author: null, authorDisplayName };
+    expect(GitHubPrReviewInboxItemSchema.parse(input)).toStrictEqual(input);
+    expect(NormalizedGitHubPrReviewInboxItemSchema.parse(input)).toStrictEqual({
+      ...input,
+      authorDisplayName: null,
+    });
+  }
+);
+
+test('normalizes mixed Inbox items without changing names or pagination', () => {
+  const named = { ...oldInbox, number: 13, authorDisplayName: 'Octo Cat' };
+  const deleted = { ...oldInbox, number: 14, author: null, authorDisplayName: null };
+  const page = { items: [oldInbox, named, deleted], nextCursor: 'next-page' };
+  expect(GitHubPrReviewInboxResultSchema.parse(page)).toStrictEqual(page);
+  expect(NormalizedGitHubPrReviewInboxResultSchema.parse(page)).toStrictEqual({
+    items: [{ ...oldInbox, authorDisplayName: null }, named, deleted],
+    nextCursor: 'next-page',
+  });
+});
+
+test('preserves an empty Inbox without inventing an author row', () => {
+  const empty = { items: [], nextCursor: null };
+  expect(NormalizedGitHubPrReviewInboxResultSchema.parse(empty)).toStrictEqual(empty);
+});
+
+test('preserves strict comment-author and legacy aggregate checks contracts', () => {
+  const comment = {
+    commentId: 1,
+    nodeId: 'C_1',
+    author,
+    bodyMarkdown: 'Review',
+    createdAt: observedAt,
+    reactions: [],
+  };
+  const checks = {
+    checkRuns: [
+      { name: 'ci', status: 'completed', conclusion: 'failure', detailsUrl: null, appName: 'CI' },
+    ],
+    rollup: { total: 1, success: 0, failure: 1, pending: 0, skipped: 0 },
+  };
+  expect(GitHubPrReviewReviewCommentSchema.parse(comment)).toStrictEqual(comment);
+  expect(GitHubPrReviewChecksResultSchema.parse(checks)).toStrictEqual(checks);
+  expect(
+    GitHubPrReviewReviewCommentSchema.safeParse({
+      ...comment,
+      author: { ...author, name: 'Octo Cat' },
+    }).success
+  ).toBe(false);
+  expect(
+    GitHubPrReviewChecksResultSchema.safeParse({
+      ...checks,
+      checkRuns: [{ ...checks.checkRuns[0], requiredness: 'required' }],
+    }).success
+  ).toBe(false);
 });

--- a/apps/web/src/lib/github-pr-review/dtos.ts
+++ b/apps/web/src/lib/github-pr-review/dtos.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { z } from 'zod';
+import { GitHubPrReviewContextSchema } from './context-dtos';
 
 export const GitHubPrReviewAuthorSchema = z
   .object({
@@ -52,9 +53,32 @@ export const GitHubPrReviewOverviewSchema = z
         viewerLogin: z.string().nullable(),
       })
       .strict(),
+    // Old overview payloads omit context. Retain until all old clients, servers, and records are gone.
+    context: GitHubPrReviewContextSchema.optional(),
   })
   .strict();
 export type GitHubPrReviewOverview = z.infer<typeof GitHubPrReviewOverviewSchema>;
+
+export const NormalizedGitHubPrReviewOverviewSchema = GitHubPrReviewOverviewSchema.transform(
+  overview => ({
+    ...overview,
+    context:
+      overview.context ??
+      GitHubPrReviewContextSchema.parse({
+        revision: {
+          prNodeId: overview.prNodeId,
+          number: overview.number,
+          headSha: overview.headSha,
+          baseRepoFullName: null,
+          baseRef: overview.baseRef,
+          baseSha: null,
+        },
+      }),
+  })
+);
+export type NormalizedGitHubPrReviewOverview = z.infer<
+  typeof NormalizedGitHubPrReviewOverviewSchema
+>;
 
 export const GitHubPrReviewCheckRunSchema = z
   .object({
@@ -167,11 +191,20 @@ export const GitHubPrReviewInboxItemSchema = z
     number: z.number().int().positive(),
     title: z.string(),
     author: GitHubPrReviewAuthorSchema.nullable(),
+    // Old Inbox payloads omit names. Retain until all old clients, servers, and records are gone.
+    authorDisplayName: z.string().nullable().optional(),
     isDraft: z.boolean(),
     updatedAt: z.string(),
   })
   .strict();
 export type GitHubPrReviewInboxItem = z.infer<typeof GitHubPrReviewInboxItemSchema>;
+
+export const NormalizedGitHubPrReviewInboxItemSchema = GitHubPrReviewInboxItemSchema.extend({
+  authorDisplayName: z.string().nullable().default(null),
+});
+export type NormalizedGitHubPrReviewInboxItem = z.infer<
+  typeof NormalizedGitHubPrReviewInboxItemSchema
+>;
 
 export const GitHubPrReviewInboxResultSchema = z
   .object({
@@ -180,6 +213,10 @@ export const GitHubPrReviewInboxResultSchema = z
   })
   .strict();
 export type GitHubPrReviewInboxResult = z.infer<typeof GitHubPrReviewInboxResultSchema>;
+
+export const NormalizedGitHubPrReviewInboxResultSchema = GitHubPrReviewInboxResultSchema.extend({
+  items: z.array(NormalizedGitHubPrReviewInboxItemSchema),
+});
 
 export const INBOX_PAGE_SIZE = 25;
 


### PR DESCRIPTION
No new behavior — this change only handles review information internally.

---

## Summary

Old payloads remain valid: `GitHubPrReviewOverviewSchema`/`GitHubPrReviewOverview` accept optional `context`; `GitHubPrReviewInboxItemSchema`/`GitHubPrReviewInboxItem` and `GitHubPrReviewInboxResultSchema`/`GitHubPrReviewInboxResult` accept optional, nullable `authorDisplayName` on items.
`NormalizedGitHubPrReviewOverviewSchema` and `NormalizedGitHubPrReviewOverview` require context in parsed output, preserving supplied context or deriving unavailable defaults from the overview revision.
`NormalizedGitHubPrReviewInboxItemSchema`, `NormalizedGitHubPrReviewInboxItem`, and `NormalizedGitHubPrReviewInboxResultSchema` require `authorDisplayName` in parsed output, defaulting omissions to `null` without changing pagination, shared authors, or legacy checks.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/dtos.ts` — modified (+37 lines, no deletions). Adds optional wire fields, normalized schemas, and inferred types. Builds fallback context from `prNodeId`, `number`, `headSha`, and `baseRef`, with `baseRepoFullName` and `baseSha` set to `null`. Reuses `GitHubPrReviewContextSchema` defaults: omitted sources remain unavailable, collection completeness stays unknown, and queue membership stays unknown rather than absent. Preserves supplied context and legacy fields; Inbox normalization retains names, null authors, pagination, and empty results. Keeps the wire additions optional until old clients, servers, and records retire.

</details>

Tests: 1 modified test file, `apps/web/src/lib/github-pr-review/context-dtos.test.ts` (+348 lines, no deletions). Adds legacy and full-context fixtures, checking fallback revisions, unavailable defaults, preserved evidence, distinct checks, and unchanged legacy fields. Covers confirmed empty data, queued membership despite position failures, null authors and names, mixed Inbox pages, empty results, and pagination. Confirms that shared comment-author and legacy aggregate checks contracts still reject extra fields.
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual tests: not run. This level only adds wire normalization; live backend and iOS verification waits for the completed stack tip.

## Reviewer Notes

### Human steps

None. This change needs no human action before or after merge.

### Notes

This level adds compatible wire normalization. Live backend and iOS verification will run on the completed stack tip.

- The handoff reports all 20 scoped tests passed.
- The handoff reports changed-file lint, format, and whitespace checks passed.










<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684 ← this PR
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
