### PR TITLE
feat(pr-review): map available REST context metadata

### DIFF
--- a/apps/web/src/lib/github-pr-review/mappers.test.ts
+++ b/apps/web/src/lib/github-pr-review/mappers.test.ts
@@ -1,11 +1,17 @@
 import {
   buildChecksResult,
   buildFilesPage,
+  buildInboxResult,
   buildOverviewDto,
   buildReviewThreadsResult,
   sliceFileLines,
+  type PullRequestRestData,
 } from './mappers';
-import { FILES_MAX_PAGES } from './dtos';
+import {
+  FILES_MAX_PAGES,
+  type NormalizedGitHubPrReviewInboxItem,
+  type NormalizedGitHubPrReviewOverview,
+} from './dtos';
 
 describe('buildOverviewDto', () => {
   const basePr = {
@@ -91,6 +97,256 @@ describe('buildOverviewDto', () => {
     expect(dto.author).toBeNull();
     expect(dto.reviewDecision).toBeNull();
     expect(dto.repo.viewerLogin).toBeNull();
+    expect(dto.repo).toEqual({
+      allowMergeCommit: false,
+      allowSquashMerge: false,
+      allowRebaseMerge: false,
+      allowAutoMerge: false,
+      deleteBranchOnMerge: false,
+      allowUpdateBranch: false,
+      viewerCanPush: false,
+      viewerCanAdmin: false,
+      viewerLogin: null,
+    });
+  });
+
+  function contextFor(changes: Partial<PullRequestRestData> = {}) {
+    const dto: NormalizedGitHubPrReviewOverview = buildOverviewDto({
+      pr: { ...basePr, ...changes },
+      repo: {},
+      graphQl: null,
+      viewer: null,
+    });
+    return { dto, context: dto.context };
+  }
+
+  it('retains the known revision and unavailable additions for old REST payloads', () => {
+    const { dto, context } = contextFor({
+      draft: undefined,
+      mergeable_state: undefined,
+      auto_merge: undefined,
+      body: null,
+    });
+    expect(dto).toMatchObject({
+      draft: false,
+      mergeableState: null,
+      autoMerge: null,
+      bodyMarkdown: null,
+    });
+    expect(context.revision).toEqual({
+      prNodeId: 'PR_node',
+      number: 12,
+      headSha: 'abc123',
+      baseRepoFullName: 'kilo/flux',
+      baseRef: 'main',
+      baseSha: null,
+    });
+    expect(context.lifecycle.source).toMatchObject({
+      availability: 'unavailable',
+      reason: 'not-requested',
+    });
+    expect(context.merger.identity).toBeNull();
+    expect(context.queue.membership.state).toBe('unknown');
+    expect(context.checks.source.availability).toBe('unavailable');
+  });
+
+  it('maps REST dates, merger, labels, assignees, requested users, and teams without extra reads', () => {
+    const person = {
+      node_id: 'U_1',
+      login: 'octocat',
+      name: null,
+      avatar_url: 'invalid',
+      type: 'Bot',
+    };
+    const { dto, context } = contextFor({
+      state: 'closed',
+      merged: true,
+      base: { ...basePr.base, sha: 'base123' },
+      created_at: '2026-03-08T01:30:00-05:00',
+      updated_at: '2026-03-08T03:30:00-04:00',
+      closed_at: '2026-03-09T00:00:00Z',
+      merged_at: '2026-03-09T00:01:00Z',
+      merged_by: { ...person, name: 'Octo Cat' },
+      labels: [{ node_id: 'L_1', name: 'long label', color: null }],
+      assignees: [person, null],
+      requested_reviewers: [person, null],
+      requested_teams: [{ node_id: 'T_1', name: 'Core team', slug: 'core' }],
+    });
+    expect(dto.state).toBe('merged');
+    expect(dto.autoMerge).toEqual({ method: 'squash' });
+    expect(context.revision.baseSha).toBe('base123');
+    expect(context.lifecycle).toMatchObject({
+      source: { availability: 'available' },
+      openedAt: '2026-03-08T01:30:00-05:00',
+      updatedAt: '2026-03-08T03:30:00-04:00',
+      closedAt: '2026-03-09T00:00:00Z',
+      mergedAt: '2026-03-09T00:01:00Z',
+    });
+    expect(context.merger.identity).toMatchObject({
+      id: 'U_1',
+      login: 'octocat',
+      name: 'Octo Cat',
+      avatarUrl: null,
+    });
+    expect(context.labels.items).toEqual([{ id: 'L_1', name: 'long label', color: null }]);
+    expect(context.assignees.items).toEqual([
+      {
+        id: 'U_1',
+        kind: 'Bot',
+        login: 'octocat',
+        name: null,
+        avatarUrl: null,
+        url: null,
+        teamSlug: null,
+      },
+      null,
+    ]);
+    expect(context.reviewRequests.items).toEqual([
+      { id: null, reviewer: context.assignees.items[0] },
+      { id: null, reviewer: null },
+      {
+        id: null,
+        reviewer: {
+          id: 'T_1',
+          kind: 'Team',
+          login: null,
+          name: 'Core team',
+          avatarUrl: null,
+          url: null,
+          teamSlug: 'core',
+        },
+      },
+    ]);
+    expect(context.reviewRequests).toMatchObject({
+      knownCount: 3,
+      completeness: 'unknown',
+      totalCount: null,
+      source: { availability: 'partial', provenance: ['rest.pullRequest'] },
+    });
+    expect(context.queue.membership.state).toBe('unknown');
+  });
+
+  it.each([
+    { value: undefined, availability: 'unavailable' },
+    { value: null, availability: 'unavailable' },
+    { value: [], availability: 'partial' },
+  ])(
+    'never calls embedded or missing REST collections complete: $availability/$value',
+    ({ value, availability }) => {
+      const { context } = contextFor({
+        labels: value,
+        assignees: value,
+        requested_reviewers: value,
+        requested_teams: value,
+      });
+      for (const collection of [context.labels, context.assignees, context.reviewRequests]) {
+        expect(collection).toMatchObject({
+          items: [],
+          knownCount: 0,
+          completeness: 'unknown',
+          totalCount: null,
+          hasNextPage: null,
+          source: { availability },
+        });
+      }
+    }
+  );
+
+  // A reopened REST PR also has state=open and closed_at=null.
+  it.each(['open', 'closed'] as const)(
+    'preserves nullable lifecycle events for an unmerged %s PR',
+    state => {
+      const closedAt = state === 'closed' ? '2026-03-09T00:00:00Z' : null;
+      const { dto, context } = contextFor({
+        state,
+        merged: false,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-03-09T00:00:00Z',
+        closed_at: closedAt,
+        merged_at: null,
+        merged_by: null,
+      });
+      expect(dto.state).toBe(state);
+      expect(context.lifecycle).toMatchObject({
+        source: { availability: 'available' },
+        closedAt,
+        mergedAt: null,
+      });
+      expect(context.merger).toMatchObject({
+        source: { availability: 'available' },
+        identity: null,
+      });
+    }
+  );
+
+  it.each([undefined, null, 'invalid', '2026-02-30T00:00:00Z'])(
+    'never substitutes another event time for %s',
+    invalid => {
+      const { context } = contextFor({
+        state: 'closed',
+        merged: true,
+        created_at: invalid,
+        closed_at: invalid,
+        updated_at: '2026-03-09T00:00:00Z',
+        merged_at: '2026-03-09T00:01:00Z',
+      });
+      expect(context.lifecycle).toMatchObject({
+        source: { availability: 'partial', retryable: true },
+        openedAt: null,
+        closedAt: null,
+        updatedAt: '2026-03-09T00:00:00Z',
+        mergedAt: '2026-03-09T00:01:00Z',
+      });
+    }
+  );
+
+  it('preserves merged state when the merger and merge time are unavailable', () => {
+    const { dto, context } = contextFor({
+      state: 'closed',
+      merged: true,
+      merged_by: null,
+      merged_at: 'invalid',
+      closed_at: '2026-03-09T00:00:00Z',
+    });
+    expect(dto.state).toBe('merged');
+    expect(context.lifecycle).toMatchObject({ mergedAt: null, closedAt: '2026-03-09T00:00:00Z' });
+    expect(context.merger).toMatchObject({
+      source: { availability: 'unavailable', retryable: false },
+      identity: null,
+    });
+  });
+});
+
+describe('buildInboxResult', () => {
+  it('normalizes missing display names while retaining author identity and pagination', () => {
+    const result = buildInboxResult({
+      nodes: [
+        {
+          number: 12,
+          title: 'Fix',
+          isDraft: true,
+          updatedAt: '2026-03-09T00:00:00Z',
+          author: { login: 'octocat', avatarUrl: null },
+          repository: { name: 'flux', owner: { login: 'kilo' } },
+        },
+      ],
+      pageInfo: { hasNextPage: true, endCursor: 'next' },
+    }) satisfies { items: NormalizedGitHubPrReviewInboxItem[] };
+    expect(result).toEqual({
+      items: [
+        {
+          owner: 'kilo',
+          repo: 'flux',
+          number: 12,
+          title: 'Fix',
+          isDraft: true,
+          updatedAt: '2026-03-09T00:00:00Z',
+          author: { login: 'octocat', avatarUrl: null },
+          authorDisplayName: null,
+        },
+      ],
+      nextCursor: 'next',
+    });
   });
 });
 

--- a/apps/web/src/lib/github-pr-review/mappers.ts
+++ b/apps/web/src/lib/github-pr-review/mappers.ts
@@ -9,19 +9,36 @@ import {
   type GitHubPrReviewFile,
   type GitHubPrReviewFilesResult,
   type GitHubPrReviewInboxItem,
-  type GitHubPrReviewInboxResult,
   type GitHubPrReviewReviewComment,
   type GitHubPrReviewReviewThread,
   type GitHubPrReviewReviewThreadsResult,
   GitHubPrReviewFilesResultSchema,
-  GitHubPrReviewInboxResultSchema,
+  NormalizedGitHubPrReviewInboxResultSchema,
   GitHubPrReviewReviewThreadsResultSchema,
 } from './dtos';
 import {
   GitHubPrReviewAuthorSchema,
-  GitHubPrReviewOverviewSchema,
+  NormalizedGitHubPrReviewOverviewSchema,
   type GitHubPrReviewOverview,
 } from './dtos';
+import {
+  GitHubPrReviewContextSchema,
+  GitHubPrReviewTimestampSchema,
+  unavailablePrReviewSource,
+  type GitHubPrReviewIdentity,
+  type GitHubPrReviewSource,
+} from './context-dtos';
+
+type RestContextIdentity = {
+  id?: number;
+  node_id?: string;
+  login?: string | null;
+  name?: string | null;
+  avatar_url?: string | null;
+  html_url?: string | null;
+  type?: string;
+  slug?: string;
+};
 
 export type PullRequestRestData = {
   number: number;
@@ -31,7 +48,7 @@ export type PullRequestRestData = {
   state: 'open' | 'closed';
   draft?: boolean;
   merged?: boolean;
-  base: { ref: string; repo?: { full_name: string } | null };
+  base: { ref: string; sha?: string; repo?: { full_name: string } | null };
   head: { ref: string; sha: string; repo?: { full_name: string } | null };
   node_id: string;
   commits: number;
@@ -41,6 +58,16 @@ export type PullRequestRestData = {
   mergeable: boolean | null;
   mergeable_state?: string | null;
   auto_merge?: { merge_method?: string | null } | null;
+  // Older producers omit metadata. Retain until all old clients, servers, and records are gone.
+  created_at?: string | null;
+  updated_at?: string | null;
+  closed_at?: string | null;
+  merged_at?: string | null;
+  merged_by?: RestContextIdentity | null;
+  labels?: Array<{ id?: number; node_id?: string; name: string; color?: string | null }> | null;
+  assignees?: Array<RestContextIdentity | null> | null;
+  requested_reviewers?: Array<RestContextIdentity | null> | null;
+  requested_teams?: Array<RestContextIdentity | null> | null;
 };
 
 export type RepoRestData = {
@@ -78,12 +105,145 @@ const GitHubRestUserSchema = z
   })
   .strict();
 
+const contextUrl = z.string().url().nullable().catch(null);
+const contextTimestamp = GitHubPrReviewTimestampSchema.nullable().catch(null);
+
+function mapRestContextIdentity(
+  actor: RestContextIdentity | null,
+  team = false
+): GitHubPrReviewIdentity | null {
+  if (!actor) return null;
+  return {
+    id: actor.node_id ?? actor.id?.toString() ?? null,
+    kind: team
+      ? 'Team'
+      : actor.type === 'Bot'
+        ? 'Bot'
+        : actor.type === 'Mannequin'
+          ? 'Mannequin'
+          : 'User',
+    login: team ? null : (actor.login ?? null),
+    name: actor.name?.trim() || null,
+    avatarUrl: team ? null : contextUrl.parse(actor.avatar_url),
+    url: contextUrl.parse(actor.html_url),
+    teamSlug: team ? (actor.slug ?? null) : null,
+  };
+}
+
+function buildRestContext(pr: PullRequestRestData) {
+  const observedAt = new Date().toISOString();
+  const source: GitHubPrReviewSource = {
+    availability: 'available',
+    retryable: false,
+    provenance: ['rest.pullRequest'],
+    reason: null,
+    observedAt,
+  };
+  function collection<T>(items: T[] | undefined) {
+    return {
+      items: items ?? [],
+      knownCount: items?.length ?? 0,
+      totalCount: null,
+      completeness: 'unknown',
+      hasNextPage: null,
+      endCursor: null,
+      source:
+        items === undefined
+          ? unavailablePrReviewSource()
+          : {
+              ...source,
+              availability: 'partial',
+              retryable: true,
+              reason: 'unproved-completeness',
+            },
+    };
+  }
+  const dates = {
+    openedAt: contextTimestamp.parse(pr.created_at),
+    updatedAt: contextTimestamp.parse(pr.updated_at),
+    closedAt: contextTimestamp.parse(pr.closed_at),
+    mergedAt: contextTimestamp.parse(pr.merged_at),
+  };
+  const rawDates = [pr.created_at, pr.updated_at, pr.closed_at, pr.merged_at];
+  const requiredDates = [
+    dates.openedAt,
+    dates.updatedAt,
+    ...(pr.state === 'closed' || pr.merged ? [dates.closedAt] : []),
+    ...(pr.merged ? [dates.mergedAt] : []),
+  ];
+  const incompleteDates =
+    requiredDates.includes(null) ||
+    rawDates.some(
+      value => value != null && !GitHubPrReviewTimestampSchema.safeParse(value).success
+    );
+  const requests =
+    pr.requested_reviewers != null || pr.requested_teams != null
+      ? [
+          ...(pr.requested_reviewers ?? []).map(actor => ({
+            id: null,
+            reviewer: mapRestContextIdentity(actor),
+          })),
+          ...(pr.requested_teams ?? []).map(actor => ({
+            id: null,
+            reviewer: mapRestContextIdentity(actor, true),
+          })),
+        ]
+      : undefined;
+  return GitHubPrReviewContextSchema.parse({
+    revision: {
+      prNodeId: pr.node_id,
+      number: pr.number,
+      headSha: pr.head.sha,
+      baseRepoFullName: pr.base.repo?.full_name ?? null,
+      baseRef: pr.base.ref,
+      baseSha: pr.base.sha ?? null,
+    },
+    observedAt,
+    labels: collection(
+      pr.labels?.map(label => ({
+        id: label.node_id ?? label.id?.toString() ?? null,
+        name: label.name,
+        color: label.color ?? null,
+      }))
+    ),
+    assignees: collection(pr.assignees?.map(actor => mapRestContextIdentity(actor))),
+    reviewRequests: collection(requests),
+    lifecycle: rawDates.some(value => value !== undefined)
+      ? {
+          ...dates,
+          source: incompleteDates
+            ? {
+                ...source,
+                availability: 'partial',
+                retryable: true,
+                reason: 'invalid-or-missing-date',
+              }
+            : source,
+        }
+      : undefined,
+    merger:
+      pr.merged_by === undefined
+        ? undefined
+        : {
+            identity: mapRestContextIdentity(pr.merged_by),
+            source:
+              pr.merged && pr.merged_by === null
+                ? {
+                    ...source,
+                    availability: 'unavailable',
+                    reason: 'identity-unavailable',
+                  }
+                : source,
+          },
+  });
+}
+
 export function buildOverviewDto(args: {
   pr: PullRequestRestData;
   repo: RepoRestData;
   graphQl: OverviewGraphQlData;
   viewer: ViewerInfo;
-}): GitHubPrReviewOverview {
+}) {
   const { pr, repo, graphQl, viewer } = args;
   const state: GitHubPrReviewOverview['state'] = pr.merged
     ? 'merged'
@@ -116,6 +276,7 @@ export function buildOverviewDto(args: {
     headRepoFullName,
     headSha: pr.head.sha,
     prNodeId: pr.node_id,
+    context: buildRestContext(pr),
     counts: {
       commits: pr.commits,
       changedFiles: pr.changed_files,
@@ -140,7 +301,7 @@ export function buildOverviewDto(args: {
       viewerLogin: viewer?.login ?? null,
     },
   };
-  return GitHubPrReviewOverviewSchema.parse(overview);
+  return NormalizedGitHubPrReviewOverviewSchema.parse(overview);
 }
 
 const GitHubCheckRunRestSchema = z
@@ -369,7 +530,7 @@ export type GraphQlInboxNode = {
 export function buildInboxResult(args: {
   nodes: (GraphQlInboxNode | null)[];
   pageInfo: { hasNextPage: boolean; endCursor: string | null } | null;
-}): GitHubPrReviewInboxResult {
+}) {
   const { nodes, pageInfo } = args;
   const items: GitHubPrReviewInboxItem[] = [];
   for (const node of nodes) {
@@ -391,7 +552,7 @@ export function buildInboxResult(args: {
     });
   }
   const nextCursor = pageInfo?.hasNextPage ? pageInfo.endCursor : null;
-  return GitHubPrReviewInboxResultSchema.parse({ items, nextCursor });
+  return NormalizedGitHubPrReviewInboxResultSchema.parse({ items, nextCursor });
 }
 
 export { GitHubRestUserSchema };

--- a/apps/web/src/routers/github-pr-review-router.test.ts
+++ b/apps/web/src/routers/github-pr-review-router.test.ts
@@ -1056,6 +1056,7 @@ describe('githubPrReviewRouter.listInbox', () => {
           number: 1,
           title: 'Fix the thing',
           author: { login: 'octocat', avatarUrl: 'https://avatars.example/octocat.png' },
+          authorDisplayName: null,
           isDraft: false,
           updatedAt: '2026-01-01T00:00:00Z',
         },


### PR DESCRIPTION
The backend now returns source-backed REST metadata with explicit availability; the mobile screens remain unchanged.

---

## Summary

`PullRequestRestData` and `RestContextIdentity` now map GitHub Representational State Transfer (REST) metadata into `GitHubPrReviewContextSchema`, without extra requests. `NormalizedGitHubPrReviewOverviewSchema` guarantees context tied to the revision; older payloads retain existing overview defaults and explicit unavailable values. Collections never claim completeness; valid event dates retain their offsets, missing dates stay null, and identities remain independent of display names.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/mappers.ts` — Source; modified (`M`); +169/-8 lines. Records revision identity, optional `base.sha`, observation time, and `rest.pullRequest` provenance. Maps lifecycle dates, merger identity, labels, assignees, and combined user/team review requests. Prefers node identifiers, stringifies numeric identifiers, distinguishes users/bots/mannequins/teams, trims names, clears invalid links, preserves null actors, and retains team slugs. Supplied lists, including empty lists, remain retryable and partial; known counts include all received entries, while totals and pagination stay unknown. Missing lists remain unavailable, and no list proves completeness. Validates each event date independently; missing required dates or invalid dates produce retryable partial context without substituting another event. Distinguishes an unavailable merger on a merged request from a known null merger on an unmerged request. Leaves unfetched checks and queue status unavailable or unknown. Infers both builder return types from normalized output schemas.
- `apps/web/src/lib/github-pr-review/mappers.test.ts` — Test; modified (`M`); +257/-1 lines. Adds normalized-return assertions for legacy defaults, revision metadata, nullable identities, combined user/team requests, and missing or empty collections. Covers timezone offsets, impossible dates, state-specific date requirements, merged state without merger details, and Inbox identity and pagination.

</details>

`NormalizedGitHubPrReviewInboxResultSchema` now returns `authorDisplayName: null` when a display name is absent. Author identity and pagination stay unchanged; the exact `listInbox` response assertion now includes this default, without another runtime change.

<details>
<summary>Files</summary>

- `apps/web/src/routers/github-pr-review-router.test.ts` — Test; modified (`M`); +1/-0 lines. Adds `authorDisplayName: null` to the Inbox equality expectation; this assertion correction changes no runtime code.

</details>

Tests: 2 files changed — `mappers.test.ts` (+257/-1 lines) and `github-pr-review-router.test.ts` (+1/-0 lines).
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual tests: not run. This level maps existing metadata only; live backend and iOS verification waits for the completed stack tip.

## Reviewer Notes

### Human steps

None before merge or after merge.

### Scope and automated checks

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- Review range: `mobile-pr-review-context-5458-s3...mobile-pr-review-context-5458-s4` only.
- Review head: `f4f283b79b60d2b6c0f624efb8298089605c38e0`; all changed source and test files were read at this commit.
- The owning level and cumulative snapshots passed the complete router suite, scoped Oxlint, and Oxfmt comparison.
- The fresh Jest runs passed with a no-service configuration that mocks unused authentication imports; they do not establish live backend or iOS behavior.
- Continuous integration (CI), `kilo-app CI`, and `Secret Scanning` passed on the review head.
- Successful run identifiers: CI `33365546328`; `kilo-app CI` `33365546346`; `Secret Scanning` `33365546318`.

### Notes

This level maps available REST metadata without waiting for optional enrichment. Live backend and iOS verification will run on the completed stack tip.

No manual runtime verification ran. Backend and iOS verification remain required before complete-stack readiness.

Owner-descoped visual checks: large text/font scaling, theme variants, contrast rendering, scaled-text layout, and screen-reader presentation. Functional accessibility labels, roles, identifiers, selectors, default-size behavior, and all non-visual criteria remain required.

Higher-level publication remains parked by owner direction. No partial human-ready label or product PR merge is authorized.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687 ← this PR
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
