### PR TITLE
feat(pr-review): isolate optional context reads

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-reader.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-reader.test.ts
@@ -1,0 +1,388 @@
+import { z } from 'zod';
+import type { Octokit } from '@octokit/rest';
+import {
+  createContextReadBudget,
+  createContextSourceReader,
+  decodeContextGraphQlSource,
+  type ContextReadResult,
+} from './context-reader';
+
+const input = { owner: 'octocat', repo: 'hello', number: 1 };
+const pageSchema = z.object({ nodes: z.array(z.object({ name: z.string() }).nullable()) });
+const labelsPath = ['repository', 'pullRequest', 'labels'];
+function envelope(data: unknown, errors?: unknown): ContextReadResult<unknown> {
+  return {
+    data: { data, errors },
+    source: {
+      availability: 'available',
+      retryable: false,
+      reason: null,
+      provenance: ['graphql.test'],
+      observedAt: '2026-08-29T00:00:00Z',
+    },
+  };
+}
+let budget: ReturnType<typeof createContextReadBudget>;
+beforeEach(() => {
+  jest.useFakeTimers();
+  budget = createContextReadBudget();
+});
+afterEach(() => {
+  budget.close();
+  jest.useRealTimers();
+});
+function reader(probe = jest.fn()) {
+  return createContextSourceReader({ pulls: { get: probe } } as unknown as Octokit, input, budget);
+}
+
+describe('optional GraphQL source decoding', () => {
+  it.each([
+    {
+      path: [...labelsPath, 'nodes', 1, 'name'],
+      type: 'FORBIDDEN',
+      sibling: 'available',
+      retryable: false,
+    },
+    { path: undefined, type: 'INTERNAL', sibling: 'partial', retryable: true },
+    { path: ['repository'], type: 'FORBIDDEN', sibling: 'partial', retryable: false },
+  ])('retains data with $type at $path', ({ path, type, sibling, retryable }) => {
+    const result = envelope(
+      {
+        repository: {
+          pullRequest: {
+            labels: { nodes: [{ name: 'known' }, null] },
+            assignees: { nodes: [] },
+          },
+        },
+      },
+      [{ type, path, message: 'must not leave the provider boundary' }]
+    );
+    const labels = decodeContextGraphQlSource(result, labelsPath, pageSchema);
+    expect(labels.data?.nodes).toEqual([{ name: 'known' }, null]);
+    expect(labels.source).toMatchObject({ availability: 'partial', retryable });
+    expect(JSON.stringify(labels)).not.toContain('must not leave');
+    const assignees = decodeContextGraphQlSource(
+      result,
+      ['repository', 'pullRequest', 'assignees'],
+      pageSchema
+    );
+    expect(assignees.data?.nodes).toEqual([]);
+    expect(assignees.source.availability).toBe(sibling);
+  });
+
+  it('checks all errors rather than only the first error', () => {
+    const result = envelope({ repository: { pullRequest: { labels: { nodes: [] } } } }, [
+      { type: 'FORBIDDEN', path: ['viewer'] },
+      { type: 'INTERNAL', path: labelsPath },
+    ]);
+    expect(decodeContextGraphQlSource(result, labelsPath, pageSchema)).toMatchObject({
+      data: { nodes: [] },
+      source: { availability: 'partial', retryable: true },
+    });
+  });
+
+  it.each([null, {}, { labels: null }])(
+    'does not call a null or omitted source empty: %p',
+    pullRequest => {
+      const result = envelope({ repository: { pullRequest }, viewer: { login: 'known' } }, [
+        { type: 'FORBIDDEN', path: ['repository', 'pullRequest', 'queue', 'position'] },
+      ]);
+      expect(decodeContextGraphQlSource(result, labelsPath, pageSchema)).toMatchObject({
+        data: null,
+        source: { availability: 'unavailable' },
+      });
+      expect(
+        decodeContextGraphQlSource(result, ['viewer'], z.object({ login: z.string() }))
+      ).toMatchObject({
+        data: { login: 'known' },
+        source: { availability: 'available' },
+      });
+    }
+  );
+
+  it.each([[], undefined, [{ path: ['viewer'], type: 'FORBIDDEN' }]])(
+    'accepts an error-free empty sibling: %p',
+    errors => {
+      expect(
+        decodeContextGraphQlSource(
+          envelope({ repository: { pullRequest: { labels: { nodes: [] } } } }, errors),
+          labelsPath,
+          pageSchema
+        )
+      ).toMatchObject({
+        data: { nodes: [] },
+        source: { availability: 'available', retryable: false },
+      });
+    }
+  );
+
+  it.each([null, 'invalid', [{ path: [false], type: 'FORBIDDEN' }]])(
+    'treats malformed errors as pathless uncertainty: %p',
+    errors => {
+      expect(
+        decodeContextGraphQlSource(
+          envelope({ repository: { pullRequest: { labels: { nodes: [] } } } }, errors),
+          labelsPath,
+          pageSchema
+        )
+      ).toMatchObject({
+        data: { nodes: [] },
+        source: { availability: 'partial', retryable: true },
+      });
+    }
+  );
+
+  it.each(['FORBIDDEN', 'NOT_FOUND'])(
+    'isolates a null source denied through extensions: %s',
+    code => {
+      const result = envelope(
+        {
+          repository: {
+            pullRequest: {
+              labels: null,
+              assignees: { nodes: [{ name: 'known' }] },
+            },
+          },
+        },
+        [{ extensions: { code }, path: labelsPath }]
+      );
+      expect(decodeContextGraphQlSource(result, labelsPath, pageSchema)).toMatchObject({
+        data: null,
+        source: { availability: 'denied', retryable: false },
+      });
+      expect(
+        decodeContextGraphQlSource(result, ['repository', 'pullRequest', 'assignees'], pageSchema)
+      ).toMatchObject({
+        data: { nodes: [{ name: 'known' }] },
+        source: { availability: 'available' },
+      });
+    }
+  );
+
+  it('keeps numeric sibling paths independent', () => {
+    const result = envelope(
+      {
+        repository: {
+          pullRequest: {
+            labels: {
+              nodes: [{ name: 'known' }, null],
+            },
+          },
+        },
+      },
+      [{ type: 'FORBIDDEN', path: [...labelsPath, 'nodes', 1, 'name'] }]
+    );
+    expect(
+      decodeContextGraphQlSource(
+        result,
+        [...labelsPath, 'nodes', 0],
+        z.object({ name: z.string() })
+      )
+    ).toMatchObject({
+      data: { name: 'known' },
+      source: { availability: 'available' },
+    });
+    expect(
+      decodeContextGraphQlSource(
+        result,
+        [...labelsPath, 'nodes', 1],
+        z.object({ name: z.string() }).nullable()
+      )
+    ).toMatchObject({
+      data: null,
+      source: { availability: 'denied', retryable: false },
+    });
+  });
+
+  it.each([null, { nodes: 'invalid' }, { nodes: [] }])(
+    'does not let a default schema prove an omitted source empty: %p',
+    labels => {
+      const result = envelope({ repository: { pullRequest: { labels } } });
+      const decoded = decodeContextGraphQlSource(
+        result,
+        [...labelsPath, 'missing'],
+        pageSchema.default({ nodes: [] })
+      );
+      expect(decoded).toMatchObject({
+        data: null,
+        source: { availability: 'unavailable', retryable: true },
+      });
+    }
+  );
+});
+
+describe('optional HTTP failures', () => {
+  it.each([
+    { status: 403, probeStatus: 200, availability: 'denied', retryable: false },
+    { status: 503, probeStatus: 200, availability: 'unavailable', retryable: true },
+    { status: 429, probeStatus: 200, availability: 'unavailable', retryable: true },
+    { status: 401, probeStatus: 200, availability: 'denied', retryable: false },
+    { status: 401, probeStatus: 503, availability: 'unavailable', retryable: true },
+    { status: 401, probeStatus: 404, availability: 'unavailable', retryable: true },
+  ])(
+    'isolates $status with probe $probeStatus',
+    async ({ status, probeStatus, availability, retryable }) => {
+      const probe = jest.fn(async () => {
+        if (probeStatus !== 200) throw { status: probeStatus };
+        return { data: {} };
+      });
+      await expect(
+        reader(probe)('rules', async () => {
+          throw { status };
+        })
+      ).resolves.toMatchObject({
+        data: null,
+        source: { availability, retryable },
+      });
+    }
+  );
+
+  it('passes only a confirmed core 401 to credential rotation', async () => {
+    const read = reader(jest.fn().mockRejectedValue({ status: 401 }));
+    await expect(
+      read('rules', async () => {
+        throw { status: 401 };
+      })
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it.each([200, 401, 503])(
+    'shares one probe with status %s within four active requests',
+    async status => {
+      let active = 0,
+        peak = 0,
+        probes = 0;
+      async function network<T>(work: () => Promise<T>) {
+        active++;
+        peak = Math.max(peak, active);
+        try {
+          return await work();
+        } finally {
+          active--;
+        }
+      }
+      const held = Promise.withResolvers<string>();
+      const probe = Promise.withResolvers<unknown>();
+      const read = reader(
+        jest.fn(() =>
+          network(() => {
+            probes++;
+            return probe.promise;
+          })
+        )
+      );
+      const pending = Promise.allSettled([
+        ...Array.from({ length: 3 }, () => read('sibling', () => network(() => held.promise))),
+        ...Array.from({ length: 6 }, () =>
+          read('denied', () =>
+            network(async () => {
+              await new Promise(resolve => setTimeout(resolve, 5));
+              throw { status: 401 };
+            })
+          )
+        ),
+      ]);
+      await jest.advanceTimersByTimeAsync(50);
+      if (status === 200) probe.resolve({ data: {} });
+      else probe.reject({ status });
+      held.resolve('known');
+      const results = await pending;
+      for (const result of results.slice(0, 3)) {
+        expect(result).toMatchObject({ status: 'fulfilled', value: { data: 'known' } });
+      }
+      for (const result of results.slice(3)) {
+        if (status === 401)
+          expect(result).toMatchObject({ status: 'rejected', reason: { status: 401 } });
+        else
+          expect(result).toMatchObject({
+            status: 'fulfilled',
+            value: {
+              data: null,
+              source: {
+                availability: status === 200 ? 'denied' : 'unavailable',
+                retryable: status !== 200,
+              },
+            },
+          });
+      }
+      expect(probes).toBe(1);
+      expect(peak).toBe(4);
+    }
+  );
+});
+
+it('retains a completed page, aborts pending pages, and never starts queued or late requests', async () => {
+  const read = reader();
+  const completed = await read('pages', async () => ({ nodes: ['known'], hasNextPage: true }));
+  let started = 0;
+  let aborted = 0;
+  const pending = Promise.all(
+    Array.from({ length: 5 }, () =>
+      read('pages', signal => {
+        started++;
+        return new Promise(resolve =>
+          signal.addEventListener(
+            'abort',
+            () => {
+              aborted++;
+              resolve('late page');
+            },
+            { once: true }
+          )
+        );
+      })
+    )
+  );
+  await jest.advanceTimersByTimeAsync(10_000);
+  expect(completed).toMatchObject({
+    data: { nodes: ['known'], hasNextPage: true },
+    source: { availability: 'available' },
+  });
+  expect((await pending).map(result => result.source.reason)).toEqual(Array(5).fill('deadline'));
+  expect(aborted).toBe(4);
+  const late = await read('pages', async () => {
+    started++;
+    return 'late request';
+  });
+  expect(late).toMatchObject({
+    data: null,
+    source: { availability: 'unavailable', retryable: true, reason: 'deadline' },
+  });
+  expect(started).toBe(4);
+});
+
+it.each(['success', '401'])(
+  'rejects late %s before an overdue deadline timer runs',
+  async outcome => {
+    const started = Promise.withResolvers<void>();
+    const response = Promise.withResolvers<string>();
+    const pending = reader()('pages', () => {
+      started.resolve();
+      return response.promise;
+    });
+    await started.promise;
+    jest.setSystemTime(Date.now() + 10_000);
+    if (outcome === 'success') response.resolve('late page');
+    else response.reject({ status: 401 });
+    await expect(pending).resolves.toMatchObject({
+      data: null,
+      source: { availability: 'unavailable', retryable: true, reason: 'deadline' },
+    });
+  }
+);
+
+it('leaves an expired credential probe inconclusive', async () => {
+  const read = reader(jest.fn(() => new Promise(() => undefined)));
+  const pending = read('rules', async () => {
+    throw { status: 401 };
+  });
+  await jest.advanceTimersByTimeAsync(10_000);
+  await expect(pending).resolves.toMatchObject({
+    data: null,
+    source: {
+      availability: 'unavailable',
+      retryable: true,
+      reason: 'credential-probe-inconclusive',
+    },
+  });
+});

--- a/apps/web/src/lib/github-pr-review/context-reader.ts
+++ b/apps/web/src/lib/github-pr-review/context-reader.ts
@@ -1,0 +1,309 @@
+import 'server-only';
+
+import pLimit from 'p-limit';
+import { z } from 'zod';
+import type { Octokit } from '@octokit/rest';
+import {
+  GitHubPrReviewContextSchema,
+  type GitHubPrReviewContext,
+  type GitHubPrReviewRevision,
+  type GitHubPrReviewSource,
+} from './context-dtos';
+import { classifyGitHubHttpError } from './errors';
+import { buildOverviewDto } from './mappers';
+
+const deadlineError = new Error('PR context deadline');
+type PrInput = { owner: string; repo: string; number: number };
+export type ContextReadResult<T> = { data: T | null; source: GitHubPrReviewSource };
+
+export function createContextReadBudget() {
+  const deadline = Date.now() + 10_000;
+  const limit = pLimit({ concurrency: 4, rejectOnClear: true });
+  const controller = new AbortController();
+  const expired = new Promise<never>((_resolve, reject) => {
+    controller.signal.addEventListener('abort', () => reject(deadlineError), { once: true });
+  });
+  // Authentication can still be pending when the deadline expires.
+  void expired.catch(() => undefined);
+  const close = () => {
+    controller.abort();
+    limit.clearQueue();
+  };
+  const timer = setTimeout(close, 10_000);
+  return {
+    async run<T>(request: (signal: AbortSignal) => Promise<T>): Promise<T> {
+      if (Date.now() >= deadline) close();
+      if (controller.signal.aborted) throw deadlineError;
+      const result = await Promise.race([
+        limit(() => {
+          if (controller.signal.aborted || Date.now() >= deadline) throw deadlineError;
+          return request(controller.signal);
+        }),
+        expired,
+      ]).catch((error: unknown) => {
+        if (Date.now() >= deadline) close();
+        throw controller.signal.aborted ? deadlineError : error;
+      });
+      // A response can settle before an overdue timer gets its turn.
+      if (Date.now() >= deadline) close();
+      if (controller.signal.aborted) throw deadlineError;
+      return result;
+    },
+    close() {
+      clearTimeout(timer);
+      close();
+    },
+  };
+}
+
+type ContextReadBudget = ReturnType<typeof createContextReadBudget>;
+const isHttp401 = (error: unknown) =>
+  typeof error === 'object' && error !== null && 'status' in error && error.status === 401;
+const observation = (provenance: string): GitHubPrReviewSource => ({
+  availability: 'available',
+  retryable: false,
+  provenance: [provenance],
+  reason: null,
+  observedAt: new Date().toISOString(),
+});
+
+function failedSource(error: unknown, provenance: string): GitHubPrReviewSource {
+  const { code } = classifyGitHubHttpError(error);
+  return {
+    ...observation(provenance),
+    availability: code === 'FORBIDDEN' ? 'denied' : 'unavailable',
+    retryable: ['BAD_GATEWAY', 'TOO_MANY_REQUESTS', 'CONFLICT'].includes(code),
+    reason: error === deadlineError ? 'deadline' : code.toLowerCase(),
+  };
+}
+
+export function createContextSourceReader(
+  octokit: Octokit,
+  input: PrInput,
+  budget: ContextReadBudget
+) {
+  let probe: Promise<boolean> | undefined;
+  return async function read<T>(
+    provenance: string,
+    request: (signal: AbortSignal) => Promise<T>
+  ): Promise<ContextReadResult<T>> {
+    try {
+      return { data: await budget.run(request), source: observation(provenance) };
+    } catch (error) {
+      if (!isHttp401(error)) return { data: null, source: failedSource(error, provenance) };
+      // Release the optional request's slot before sharing a same-credential core probe.
+      probe ??= budget
+        .run(signal =>
+          octokit.pulls.get({
+            owner: input.owner,
+            repo: input.repo,
+            pull_number: input.number,
+            request: { signal },
+          })
+        )
+        .then(
+          () => true,
+          error => {
+            if (isHttp401(error)) throw error;
+            return false;
+          }
+        );
+      const valid = await probe;
+      return {
+        data: null,
+        source: {
+          ...observation(provenance),
+          availability: valid ? 'denied' : 'unavailable',
+          retryable: !valid,
+          reason: valid ? 'optional-permission-denied' : 'credential-probe-inconclusive',
+        },
+      };
+    }
+  };
+}
+
+const graphQlErrorSchema = z
+  .object({
+    type: z.string().optional(),
+    path: z.array(z.union([z.string(), z.number().int().nonnegative()])).nullish(),
+    extensions: z.object({ code: z.string().optional() }).optional(),
+  })
+  .catch({});
+const envelopeSchema = z.object({
+  data: z.unknown(),
+  errors: z.array(graphQlErrorSchema).optional().catch([{}]),
+});
+
+// Optional reads alone decode partial envelopes; mutation guards stay fail-closed.
+export function decodeContextGraphQlSource<T extends z.ZodTypeAny>(
+  result: ContextReadResult<unknown>,
+  path: ReadonlyArray<string | number>,
+  schema: T
+): ContextReadResult<z.output<T>> {
+  if (result.source.availability !== 'available') return { data: null, source: result.source };
+  const envelope = envelopeSchema.safeParse(result.data);
+  const errors = envelope.success ? (envelope.data.errors ?? []) : [{}];
+  const related = errors.filter(
+    error =>
+      !error.path?.length ||
+      error.path
+        .slice(0, Math.min(path.length, error.path.length))
+        .every((part, i) => part === path[i])
+  );
+  let value: unknown = envelope.success ? envelope.data.data : undefined;
+  let missing = false;
+  for (const part of path) {
+    if (typeof value !== 'object' || value === null || !Object.hasOwn(value, part)) {
+      missing = true;
+      break;
+    }
+    value = Reflect.get(value, part);
+  }
+  const parsed = schema.safeParse(value);
+  const complete = !missing && parsed.success && related.length === 0;
+  const denied = (error: z.output<typeof graphQlErrorSchema>) =>
+    ['FORBIDDEN', 'NOT_FOUND'].includes(error.type ?? error.extensions?.code ?? '');
+  return {
+    data: !missing && parsed.success ? parsed.data : null,
+    source: {
+      ...result.source,
+      availability: complete
+        ? 'available'
+        : !missing && parsed.success && parsed.data !== null
+          ? 'partial'
+          : related.some(denied)
+            ? 'denied'
+            : 'unavailable',
+      retryable: !complete && (related.length === 0 || related.some(error => !denied(error))),
+      reason: complete ? null : related.some(denied) ? 'graphql-denied' : 'graphql-incomplete',
+    },
+  };
+}
+
+export const PR_CONTEXT_REVISION_QUERY = /* GraphQL */ `
+  query PrReviewContextRevision($owner: String!, $name: String!, $number: Int!) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        id
+        number
+        headRefOid
+        baseRefName
+        baseRefOid
+        baseRepository { nameWithOwner }
+      }
+    }
+  }
+`;
+const graphQlRevisionSchema = z
+  .object({
+    id: z.string().min(1),
+    number: z.number().int().positive(),
+    headRefOid: z.string().min(1),
+    baseRefName: z.string(),
+    baseRefOid: z.string().min(1).nullable(),
+    baseRepository: z.object({ nameWithOwner: z.string().min(1) }).nullable(),
+  })
+  .transform(
+    (pr): GitHubPrReviewRevision => ({
+      prNodeId: pr.id,
+      number: pr.number,
+      headSha: pr.headRefOid,
+      baseRef: pr.baseRefName,
+      baseSha: pr.baseRefOid,
+      baseRepoFullName: pr.baseRepository?.nameWithOwner ?? null,
+    })
+  );
+
+function invalidateRevision(context: GitHubPrReviewContext, source: GitHubPrReviewSource) {
+  for (const collection of [context.requirements, context.checks]) {
+    collection.source = source;
+    collection.completeness = 'unknown';
+  }
+  context.queue.membership.source = source;
+  context.queue.position.source = source;
+  return context;
+}
+
+export async function readPullRequestContext(
+  octokit: Octokit,
+  input: PrInput & { expectedRevision: GitHubPrReviewRevision },
+  budget: ContextReadBudget
+): Promise<GitHubPrReviewContext> {
+  let context = GitHubPrReviewContextSchema.parse({ revision: input.expectedRevision });
+  try {
+    const initial = await budget.run(signal =>
+      octokit.pulls.get({
+        owner: input.owner,
+        repo: input.repo,
+        pull_number: input.number,
+        request: { signal },
+      })
+    );
+    context = buildOverviewDto({ pr: initial.data, repo: {}, graphQl: null, viewer: null }).context;
+  } catch (error) {
+    // This is a core REST read, so its 401 already confirms credential rejection.
+    if (isHttp401(error)) throw error;
+    return invalidateRevision(context, failedSource(error, 'rest.pullRequest'));
+  }
+  const read = createContextSourceReader(octokit, input, budget);
+  // Later source readers use this same reader and budget before the final revision fence.
+  const final = decodeContextGraphQlSource(
+    await read('graphql.revision', async (signal): Promise<unknown> => {
+      const response = await octokit.request('POST /graphql', {
+        query: PR_CONTEXT_REVISION_QUERY,
+        variables: { owner: input.owner, name: input.repo, number: input.number },
+        request: { signal },
+      });
+      return response.data;
+    }),
+    ['repository', 'pullRequest'],
+    graphQlRevisionSchema
+  );
+  const observations = [input.expectedRevision, context.revision, final.data];
+  const fields = [
+    'prNodeId',
+    'number',
+    'headSha',
+    'baseRepoFullName',
+    'baseRef',
+    'baseSha',
+  ] as const;
+  const mismatch =
+    input.number !== input.expectedRevision.number ||
+    fields.some(
+      field =>
+        new Set(
+          observations
+            .map(revision => revision?.[field])
+            .filter(value => value != null && value !== '')
+        ).size > 1
+    );
+  if (mismatch) {
+    // Only normalized revision identities enter diagnostics, never provider envelopes or errors.
+    console.info('github-pr-review.context-revision-mismatch', {
+      expected: input.expectedRevision,
+      initial: context.revision,
+      final: final.data,
+    });
+    return invalidateRevision(context, {
+      ...observation('revision-fence'),
+      availability: 'stale',
+      retryable: true,
+      reason: 'revision-mismatch',
+    });
+  }
+  if (
+    final.source.availability !== 'available' ||
+    observations.some(
+      revision => !revision || !revision.baseRepoFullName || !revision.baseSha || !revision.baseRef
+    )
+  ) {
+    return invalidateRevision(context, {
+      ...final.source,
+      availability: final.source.availability === 'denied' ? 'denied' : 'unavailable',
+      retryable: final.source.availability === 'available' || final.source.retryable,
+      reason: final.source.reason ?? 'revision-unavailable',
+    });
+  }
+  return context;
+}

--- a/apps/web/src/routers/github-pr-review-graphql-schema.test.ts
+++ b/apps/web/src/routers/github-pr-review-graphql-schema.test.ts
@@ -11,8 +11,19 @@ import { join } from 'node:path';
 import { buildClientSchema, parse, validate } from 'graphql';
 
 import { describe, test, expect } from '@jest/globals';
+import type * as TrpcServer from '@trpc/server';
 
 import { PR_REVIEW_GRAPHQL_DOCUMENTS } from '@/routers/github-pr-review-router';
+
+// Document validation needs router registration, not authentication or database services.
+jest.mock('@/lib/trpc/init', () => {
+  const { initTRPC } = jest.requireActual<typeof TrpcServer>('@trpc/server');
+  const t = initTRPC.create();
+  return { baseProcedure: t.procedure, createTRPCRouter: t.router };
+});
+jest.mock('@/lib/drizzle', () => ({}));
+jest.mock('@kilocode/db/operation-ledger', () => ({}));
+jest.mock('@/lib/integrations/platforms/github/user-token-client', () => ({}));
 
 // `@octokit/graphql-schema` is published as an ESM-only package (`"type":
 // "module"`), which Jest's CJS test runner cannot `import` directly without
@@ -31,8 +42,8 @@ const introspection = JSON.parse(readFileSync(introspectionPath, 'utf8'));
 const githubSchema = buildClientSchema(introspection);
 
 describe('github-pr-review-router GraphQL documents', () => {
-  test('exports exactly 11 documents (sanity guard for the export record)', () => {
-    expect(Object.keys(PR_REVIEW_GRAPHQL_DOCUMENTS)).toHaveLength(11);
+  test('exports exactly 12 documents (sanity guard for the export record)', () => {
+    expect(Object.keys(PR_REVIEW_GRAPHQL_DOCUMENTS)).toHaveLength(12);
   });
 
   test.each(Object.entries(PR_REVIEW_GRAPHQL_DOCUMENTS))(

--- a/apps/web/src/routers/github-pr-review-router.test.ts
+++ b/apps/web/src/routers/github-pr-review-router.test.ts
@@ -4,7 +4,16 @@
 import { TRPCError } from '@trpc/server';
 import { createCallerFactory } from '@/lib/trpc/init';
 import type { User } from '@kilocode/db/schema';
-import { INBOX_SEARCH_QUERY, prLedgerResourceKey } from './github-pr-review-router';
+import {
+  INBOX_SEARCH_QUERY,
+  type githubPrReviewRouter,
+  prLedgerResourceKey,
+} from './github-pr-review-router';
+import type { GitHubPrReviewRevision } from '@/lib/github-pr-review/context-dtos';
+
+// Callers supply the authenticated context; these unused HTTP-auth imports need no test services.
+jest.mock('@/lib/user/server', () => ({}));
+jest.mock('@/lib/admin/admin-access-log', () => ({}));
 
 const getGitHubUserAccessToken = jest.fn();
 
@@ -1056,6 +1065,7 @@ describe('githubPrReviewRouter.listInbox', () => {
           number: 1,
           title: 'Fix the thing',
           author: { login: 'octocat', avatarUrl: 'https://avatars.example/octocat.png' },
+          authorDisplayName: null,
           isDraft: false,
           updatedAt: '2026-01-01T00:00:00Z',
         },
@@ -1247,6 +1257,367 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
       }
     }
   }
+
+  describe('getPullRequestContext isolation', () => {
+    const revision: GitHubPrReviewRevision = {
+      prNodeId: 'PR_1',
+      number: 1,
+      headSha: 'a'.repeat(40),
+      baseRepoFullName: 'octocat/hello',
+      baseRef: 'main',
+      baseSha: 'b'.repeat(40),
+    };
+    const prInput = { owner: 'octocat', repo: 'hello', number: 1 };
+    const contextInput = { ...prInput, expectedRevision: revision };
+    let caller: ReturnType<typeof githubPrReviewRouter.createCaller>;
+
+    function contextPr(identity = revision) {
+      return {
+        ...overviewPrData,
+        number: identity.number,
+        node_id: identity.prNodeId,
+        head: { ...overviewPrData.head, sha: identity.headSha },
+        base: {
+          ref: identity.baseRef,
+          sha: identity.baseSha ?? undefined,
+          repo: identity.baseRepoFullName ? { full_name: identity.baseRepoFullName } : null,
+        },
+        labels: [{ name: 'known', node_id: 'LABEL_1', color: 'ffffff' }],
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-08-28T12:00:00Z',
+        closed_at: null,
+        merged_at: null,
+        merged_by: null,
+        privatePayload: 'provider-only',
+      };
+    }
+    function contextEnvelope(identity = revision) {
+      return {
+        data: {
+          data: {
+            repository: {
+              pullRequest: {
+                id: identity.prNodeId,
+                number: identity.number,
+                headRefOid: identity.headSha,
+                baseRefName: identity.baseRef,
+                baseRefOid: identity.baseSha,
+                baseRepository: identity.baseRepoFullName
+                  ? { nameWithOwner: identity.baseRepoFullName }
+                  : null,
+                privatePayload: 'provider-only',
+              },
+            },
+          },
+        },
+      };
+    }
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.spyOn(console, 'info').mockImplementation(() => undefined);
+      getGitHubUserAccessToken.mockResolvedValue(connected('t1', 'auth_1', 1));
+      caller = createCaller({ user: { id: 'user-1' } as User });
+      const octokit = buildOctokit('t1');
+      octokit.pulls.get.mockResolvedValue({ data: contextPr() });
+      octokit.repos.get.mockResolvedValue({ data: overviewRepoData });
+      octokit.request.mockResolvedValue(contextEnvelope());
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    it('returns REST context without claiming that unattached readers are empty', async () => {
+      const result = await caller.getPullRequestContext(contextInput);
+      expect(result.revision).toEqual(revision);
+      expect(result.labels).toMatchObject({
+        items: [{ name: 'known' }],
+        completeness: 'unknown',
+        source: { availability: 'partial' },
+      });
+      expect(result.lifecycle).toMatchObject({
+        source: { availability: 'available' },
+        openedAt: '2026-01-01T00:00:00Z',
+        closedAt: null,
+      });
+      for (const collection of [
+        result.reviewDecisions,
+        result.reviewActivity,
+        result.issues,
+        result.requirements,
+        result.checks,
+      ]) {
+        expect(collection).toMatchObject({
+          items: [],
+          completeness: 'unknown',
+          totalCount: null,
+          hasNextPage: null,
+          source: { availability: 'unavailable', reason: 'not-requested' },
+        });
+      }
+      expect(result.queue).toMatchObject({
+        membership: { state: 'unknown', source: { availability: 'unavailable' } },
+        position: { value: null, source: { availability: 'unavailable' } },
+      });
+    });
+
+    it('accepts old PR payloads without inventing missing context or base identity', async () => {
+      buildOctokit('t1').pulls.get.mockResolvedValue({ data: overviewPrData });
+      const result = await caller.getPullRequestContext({
+        ...contextInput,
+        expectedRevision: { ...revision, baseSha: null },
+      });
+      expect(result.revision.baseSha).toBeNull();
+      expect(result.labels).toMatchObject({
+        completeness: 'unknown',
+        source: { availability: 'unavailable', reason: 'not-requested' },
+      });
+      expect(result.lifecycle.openedAt).toBeNull();
+      expect(result.requirements.source).toMatchObject({
+        availability: 'unavailable',
+        retryable: true,
+        reason: 'revision-unavailable',
+      });
+    });
+
+    it('returns core and Files before the ten-second optional deadline', async () => {
+      const started = Promise.withResolvers<void>();
+      const held = Promise.withResolvers<ReturnType<typeof contextEnvelope>>();
+      const octokit = buildOctokit('t1');
+      octokit.request.mockImplementation((_path: string, body: { query: string }) => {
+        if (body.query.includes('PrReviewContextRevision')) {
+          started.resolve();
+          return held.promise;
+        }
+        return Promise.resolve({ data: { data: overviewGraphQlData } });
+      });
+      octokit.pulls.listFiles.mockResolvedValue({ data: [] });
+      let settled = false;
+      const pending = caller.getPullRequestContext(contextInput).then(result => {
+        settled = true;
+        return result;
+      });
+      await started.promise;
+      const core = await caller.getPullRequest(prInput);
+      expect(core).toMatchObject({
+        title: 'Fix the thing',
+        headSha: revision.headSha,
+        counts: { changedFiles: 2 },
+        reviewDecision: 'APPROVED',
+      });
+      await expect(caller.listFiles(prInput)).resolves.toMatchObject({
+        files: [],
+        nextCursor: null,
+      });
+      expect(settled).toBe(false);
+      await jest.advanceTimersByTimeAsync(9999);
+      expect(settled).toBe(false);
+      await jest.advanceTimersByTimeAsync(1);
+      const context = await pending;
+      expect(context.labels.items).toEqual([{ id: 'LABEL_1', name: 'known', color: 'ffffff' }]);
+      expect(context.requirements.source).toMatchObject({
+        availability: 'unavailable',
+        retryable: true,
+        reason: 'deadline',
+      });
+      held.resolve(contextEnvelope());
+    });
+
+    describe.each(['expected', 'initial', 'final'] as const)('%s revision fence', phase => {
+      it.each([
+        { prNodeId: 'PR_other' },
+        { number: 2 },
+        { headSha: 'c'.repeat(40) },
+        { baseRepoFullName: 'other/hello' },
+        { baseRef: 'release' },
+        { baseSha: 'c'.repeat(40) },
+      ])('marks conflicting identity stale: %p', async patch => {
+        const changed = { ...revision, ...patch };
+        const expected = phase === 'expected' ? changed : revision;
+        const initial = phase === 'initial' ? changed : revision;
+        const final = phase === 'final' ? changed : revision;
+        const octokit = buildOctokit('t1');
+        octokit.pulls.get.mockResolvedValue({ data: contextPr(initial) });
+        octokit.request.mockResolvedValue(contextEnvelope(final));
+        const result = await caller.getPullRequestContext({
+          ...contextInput,
+          expectedRevision: expected,
+        });
+        expect(result.revision).toEqual(initial);
+        for (const source of [
+          result.requirements.source,
+          result.checks.source,
+          result.queue.membership.source,
+          result.queue.position.source,
+        ]) {
+          expect(source).toMatchObject({
+            availability: 'stale',
+            retryable: true,
+            reason: 'revision-mismatch',
+          });
+        }
+        expect(result.labels.items[0]?.name).toBe('known');
+        expect(console.info).toHaveBeenCalledWith('github-pr-review.context-revision-mismatch', {
+          expected,
+          initial,
+          final,
+        });
+      });
+    });
+
+    it('rejects a revision for a different requested PR number as stale', async () => {
+      await expect(
+        caller.getPullRequestContext({ ...contextInput, number: 2 })
+      ).resolves.toMatchObject({
+        requirements: { source: { availability: 'stale', reason: 'revision-mismatch' } },
+        queue: { membership: { source: { availability: 'stale' } } },
+      });
+    });
+
+    it.each([null, { headRefOid: revision.headSha }])(
+      'keeps missing final identity unavailable: %p',
+      pullRequest => {
+        buildOctokit('t1').request.mockResolvedValue({
+          data: { data: { repository: { pullRequest } } },
+        });
+        return expect(caller.getPullRequestContext(contextInput)).resolves.toMatchObject({
+          labels: { items: [{ name: 'known' }] },
+          requirements: { source: { availability: 'unavailable', retryable: true } },
+        });
+      }
+    );
+
+    it.each([200, 403, 404, 503])(
+      'does not reconnect on optional 401 with probe status %s',
+      async status => {
+        const octokit = buildOctokit('t1');
+        octokit.request.mockRejectedValue({ status: 401, message: 'provider-only' });
+        if (status !== 200)
+          octokit.pulls.get
+            .mockResolvedValueOnce({ data: contextPr() })
+            .mockRejectedValueOnce({ status });
+        const result = await caller.getPullRequestContext(contextInput);
+        expect(result.labels.items[0]?.name).toBe('known');
+        expect(result.requirements.source).toMatchObject({
+          availability: status === 200 ? 'denied' : 'unavailable',
+          retryable: status !== 200,
+          reason: status === 200 ? 'optional-permission-denied' : 'credential-probe-inconclusive',
+        });
+        expect(getGitHubUserAccessToken.mock.calls).toEqual([['user-1', { op: 'fetch' }]]);
+      }
+    );
+
+    it.each(['initial', 'optional'])(
+      'rotates after confirmed %s credential rejection',
+      async phase => {
+        getGitHubUserAccessToken
+          .mockResolvedValueOnce(connected('t1', 'auth_1', 1))
+          .mockResolvedValueOnce(connected('t2', 'auth_1', 2));
+        const first = buildOctokit('t1');
+        first.pulls.get.mockRejectedValue({ status: 401 });
+        if (phase === 'optional') first.pulls.get.mockResolvedValueOnce({ data: contextPr() });
+        first.request.mockRejectedValue({ status: 401 });
+        const second = buildOctokit('t2');
+        second.pulls.get.mockResolvedValue({
+          data: { ...contextPr(), labels: [{ name: 'rotated' }] },
+        });
+        second.request.mockResolvedValue(contextEnvelope());
+        const result = await caller.getPullRequestContext(contextInput);
+        expect(result.labels.items[0]?.name).toBe('rotated');
+        expect(result.requirements.source.reason).toBe('not-requested');
+        expect(getGitHubUserAccessToken).toHaveBeenNthCalledWith(2, 'user-1', {
+          op: 'rotate',
+          staleAuthorizationId: 'auth_1',
+          staleCredentialVersion: 1,
+        });
+      }
+    );
+
+    it('shares the original deadline through credential rotation', async () => {
+      getGitHubUserAccessToken
+        .mockResolvedValueOnce(connected('t1', 'auth_1', 1))
+        .mockResolvedValueOnce(connected('t2', 'auth_1', 2));
+      buildOctokit('t1').pulls.get.mockImplementation(async () => {
+        await new Promise(resolve => setTimeout(resolve, 6000));
+        throw { status: 401 };
+      });
+      const second = buildOctokit('t2');
+      second.pulls.get.mockResolvedValue({ data: contextPr() });
+      second.request.mockImplementation(async () => {
+        await new Promise(resolve => setTimeout(resolve, 6000));
+        return contextEnvelope();
+      });
+      let settled = false;
+      const pending = caller.getPullRequestContext(contextInput).then(result => {
+        settled = true;
+        return result;
+      });
+      await jest.advanceTimersByTimeAsync(9999);
+      expect(settled).toBe(false);
+      await jest.advanceTimersByTimeAsync(1);
+      expect(settled).toBe(true);
+      await expect(pending).resolves.toMatchObject({
+        labels: { items: [{ name: 'known' }] },
+        requirements: {
+          source: { availability: 'unavailable', retryable: true, reason: 'deadline' },
+        },
+      });
+    });
+
+    it.each(['core', 'mutation', 'context'])(
+      'keeps terminal credential rejection for %s',
+      async operation => {
+        getGitHubUserAccessToken
+          .mockResolvedValueOnce(connected('t1', 'auth_1', 1))
+          .mockResolvedValueOnce(connected('t2', 'auth_1', 2))
+          .mockResolvedValueOnce({ status: 'disconnected', reason: 'revoked' });
+        for (const token of ['t1', 't2']) {
+          const octokit = buildOctokit(token);
+          octokit.pulls.get
+            .mockResolvedValueOnce({ data: contextPr() })
+            .mockRejectedValue({ status: 401 });
+          octokit.repos.get.mockResolvedValue({ data: overviewRepoData });
+          octokit.request.mockRejectedValue({ status: 401 });
+        }
+        const pending =
+          operation === 'core'
+            ? caller.getPullRequest(prInput)
+            : operation === 'mutation'
+              ? caller.resolveThread({ threadId: 'THREAD_1' })
+              : caller.getPullRequestContext(contextInput);
+        await expect(pending).rejects.toMatchObject({
+          code: 'PRECONDITION_FAILED',
+          message: 'GitHub connection is no longer valid — reconnect',
+        });
+        expect(getGitHubUserAccessToken).toHaveBeenNthCalledWith(3, 'user-1', {
+          op: 'reportRejected',
+          authorizationId: 'auth_1',
+          credentialVersion: 2,
+        });
+      }
+    );
+
+    it('requires the authenticated user’s GitHub connection', async () => {
+      getGitHubUserAccessToken.mockResolvedValue({
+        status: 'disconnected',
+        reason: 'not_connected',
+      });
+      await expect(caller.getPullRequestContext(contextInput)).rejects.toMatchObject({
+        code: 'PRECONDITION_FAILED',
+      });
+    });
+
+    it.each([
+      prInput,
+      { ...contextInput, owner: 'invalid/owner' },
+      { ...contextInput, number: 0 },
+      { ...contextInput, expectedRevision: { ...revision, extra: true } },
+    ])('rejects invalid context input: %p', async input => {
+      await expect(caller.getPullRequestContext(input as never)).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+      });
+    });
+  });
 
   it('getPullRequest starts repos.get and the GraphQL leg before pulls.get resolves', async () => {
     getGitHubUserAccessToken.mockResolvedValueOnce(connected('t1', 'auth_1', 1));

--- a/apps/web/src/routers/github-pr-review-router.ts
+++ b/apps/web/src/routers/github-pr-review-router.ts
@@ -38,6 +38,15 @@ import {
   REVIEW_THREADS_PAGE_SIZE,
 } from '@/lib/github-pr-review/dtos';
 import { throwTrpcFromGraphQlErrors, withGitHubUserTokenRetry } from '@/lib/github-pr-review/retry';
+import {
+  GitHubPrReviewContextSchema,
+  GitHubPrReviewRevisionSchema,
+} from '@/lib/github-pr-review/context-dtos';
+import {
+  createContextReadBudget,
+  readPullRequestContext,
+  PR_CONTEXT_REVISION_QUERY,
+} from '@/lib/github-pr-review/context-reader';
 import { getGitHubUserAccessToken } from '@/lib/integrations/platforms/github/user-token-client';
 import {
   AutoMergeMethodSchema,
@@ -78,6 +87,9 @@ const operationKeySchema = z.string().min(1).max(128).optional();
 const prNumberSchema = z.number().int().positive();
 
 const GetPullRequestInput = ownerRepoSchema.extend({ number: prNumberSchema }).strict();
+const GetPullRequestContextInput = GetPullRequestInput.extend({
+  expectedRevision: GitHubPrReviewRevisionSchema,
+}).strict();
 
 const ListChecksInput = ownerRepoSchema.extend({ ref: z.string().min(1).max(255) }).strict();
 
@@ -522,12 +534,13 @@ function normalizeComment(node: GraphQlCommentNode) {
 export const REVIEW_THREAD_COMMENTS_FOLLOWUP_QUERY_FOR_TEST = REVIEW_THREAD_COMMENTS_FOLLOWUP_QUERY;
 export const CONVERSATION_COMMENTS_QUERY_FOR_TEST = CONVERSATION_COMMENTS_QUERY;
 
-// All raw PR-Review GraphQL documents defined in this router, collected as a
+// All raw PR-Review GraphQL documents used by this router, collected as a
 // single exported record so the schema-validity test enumerates docs from
 // module exports (newly added docs are auto-covered). Keys are the
 // operation name / mutation tag; values are the unchanged document strings.
 export const PR_REVIEW_GRAPHQL_DOCUMENTS = {
   PULL_REQUEST_FRAGMENT_QUERY,
+  PR_CONTEXT_REVISION_QUERY,
   REVIEW_THREADS_QUERY,
   REVIEW_THREAD_COMMENTS_FOLLOWUP_QUERY,
   CONVERSATION_COMMENTS_QUERY,
@@ -1516,6 +1529,22 @@ export const githubPrReviewRouter = createTRPCRouter({
     });
     return overview;
   }),
+
+  // Keep optional reads separate so they cannot delay core data or Files inputs.
+  getPullRequestContext: baseProcedure
+    .input(GetPullRequestContextInput)
+    .output(GitHubPrReviewContextSchema)
+    .query(async ({ ctx, input }) => {
+      const budget = createContextReadBudget();
+      try {
+        return await withGitHubUserTokenRetry({
+          kiloUserId: ctx.user.id,
+          call: octokit => readPullRequestContext(octokit, input, budget),
+        });
+      } finally {
+        budget.close();
+      }
+    }),
 
   listChecks: baseProcedure.input(ListChecksInput).query(async ({ ctx, input }) => {
     return withGitHubUserTokenRetry({


### PR DESCRIPTION
No new behavior — this change prepares optional review details without changing the product screens.

---

## Summary

`getPullRequestContext` adds an authenticated, read-only query with strict `GetPullRequestContextInput`, requiring `owner`, `repo`, `number`, and an `expectedRevision` matching `GitHubPrReviewRevisionSchema`.
`GitHubPrReviewContextSchema` validates the response while `getPullRequest` and Files queries remain independent of optional reads.
Older callers retain their existing inputs, outputs, mutation guards, and credential rejection behavior.

<details>
<summary>Files</summary>

- `apps/web/src/routers/github-pr-review-router.ts` — Modified source (31 changed lines). Adds the independent query and registers the revision document. Retains owner/repository validation and positive pull request numbers. Creates the shared budget before retrieving the user's GitHub credential, reuses `withGitHubUserTokenRetry`, and closes the budget on every exit.

</details>

`readPullRequestContext` preserves initial metadata and unavailable placeholders, using `PR_CONTEXT_REVISION_QUERY` and `graphQlRevisionSchema` to compare expected, initial, and final revisions.
`github-pr-review.context-revision-mismatch` logs normalized identities; conflicts mark requirements, checks, and queue data stale and retryable without discarding unrelated context.
Missing or denied revision evidence keeps those sources unavailable or denied; older payloads never prove that optional collections are empty or complete.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-reader.ts` — Added source (309 changed lines). Adds the shared budget, source reader, partial decoder, revision document, and context orchestration. Compares the request number, pull request node, head commit, base repository, base branch, and base commit across revision observations. Keeps initial metadata and marks requirements/checks completeness unknown when revision validation fails. Applies the failure source to queue membership and position without replacing sibling data. Leaves unrequested review decisions, review activity, linked issues, requirements, checks, and queue data unavailable or unknown. Records source availability, retryability, provenance, reason, and observation time. Classifies denied permissions separately from retryable server, rate-limit, conflict, and deadline failures. Returns normalized data and limits mismatch diagnostics to normalized identities, without provider envelopes or error text.

</details>

`ContextReadBudget` enforces four concurrent requests and one ten-second deadline across rotation; expiration aborts active work, rejects queued or late results, and preserves completed data.
`createContextSourceReader` exposes `ContextReadResult` metadata and shares one core probe, using the same credential after optional 401 responses.
A successful probe yields denied access; an inconclusive probe stays retryable, while a probe 401 invokes existing credential rotation and terminal rejection.

<details>
<summary>Files</summary>

- `apps/web/src/routers/github-pr-review-router.test.ts` — Modified test (373 changed lines). Covers strict input, normalized output, old payloads, revision conflicts and missing identities, retained siblings, independent core/Files calls, and unchanged terminal credential errors. Checks shared deadlines during rotation and requires the authenticated user's GitHub connection. Mocks unused authentication services and adds the existing `authorDisplayName: null` Inbox expectation.

</details>

`decodeContextGraphQlSource` uses `envelopeSchema` and `graphQlErrorSchema` to retain validated partial data while isolating unrelated GraphQL errors, including numeric paths.
Pathless or malformed errors affect every source, and absent ancestors never become empty results through defaults.
Denial codes `FORBIDDEN` and `NOT_FOUND` stop retries unless uncertainty remains; mutation guards stay unchanged.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-reader.test.ts` — Added test (388 changed lines). Covers partial data, numeric siblings, ancestor errors, pathless errors, malformed errors, extension denial codes, and valid empty results. Checks that schema defaults cannot turn missing data into empty results and provider messages never enter output. Tests optional failure classification, shared probes, four active requests, deadline cancellation, expired probes, and rejection of overdue successes or errors. Confirms completed data survives while queued requests never start.

</details>

`PR_REVIEW_GRAPHQL_DOCUMENTS` now registers `PrReviewContextRevision` through `PR_CONTEXT_REVISION_QUERY`, increasing the validation set from 11 documents to 12.
Service mocks keep the schema check independent of authentication and database services, so document validation needs no live backend.

<details>
<summary>Files</summary>

- `apps/web/src/routers/github-pr-review-graphql-schema.test.ts` — Modified test (15 changed lines). Adds mocks for router, database, operation ledger, and credential services. Raises the document count from 11 to 12 and validates the registered revision query against the GitHub schema.

</details>

Tests: 3 changed files — `context-reader.test.ts` added; `github-pr-review-router.test.ts` and `github-pr-review-graphql-schema.test.ts` modified; 776 changed lines.
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual tests: not run; this level adds independent optional reads without mobile integration. Live backend and iOS verification waits for the completed stack tip.

## Reviewer Notes

### Human steps

No human steps before merge or after merge.

### Scope and automated checks

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- Review range: `mobile-pr-review-context-5458-s4...mobile-pr-review-context-5458-s5` only.
- Supplied evidence reports three passing focused suites with 157 tests.
- The supplied review reports zero lint warnings or errors, no formatting differences, and no whitespace errors across the five changed files.
- Those suites mock service dependencies and disable database setup; they do not establish live authentication, provider permissions, or mobile transport behavior.

### Notes

This level isolates optional context reads from core PR data. Live backend and iOS verification will run on the completed stack tip.









<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690 ← this PR
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
