### PR TITLE
feat(pr-review): complete labels and requested people

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-people.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-people.test.ts
@@ -1,0 +1,398 @@
+import type { Octokit } from '@octokit/rest';
+import {
+  createContextReadBudget,
+  readPullRequestContext,
+  PR_CONTEXT_REVISION_QUERY,
+} from './context-reader';
+import { PR_CONTEXT_PEOPLE_QUERIES } from './context-people';
+import { GitHubPrReviewContextSchema } from './context-dtos';
+import type { PullRequestRestData } from './mappers';
+
+const fields = ['labels', 'assignees', 'reviewRequests'] as const;
+type Field = (typeof fields)[number];
+const revision = {
+  prNodeId: 'PR_1',
+  number: 1,
+  headSha: 'head',
+  baseRepoFullName: 'o/r',
+  baseRef: 'main',
+  baseSha: 'base',
+};
+const pr: PullRequestRestData = {
+  node_id: 'PR_1',
+  number: 1,
+  title: 'PR',
+  body: null,
+  user: null,
+  state: 'open',
+  head: { ref: 'feature', sha: 'head' },
+  base: { ref: 'main', sha: 'base', repo: { full_name: 'o/r' } },
+  commits: 1,
+  changed_files: 1,
+  additions: 1,
+  deletions: 0,
+  mergeable: null,
+};
+const person = (id: string) => ({
+  __typename: 'User',
+  id,
+  login: 'login',
+  name: null,
+  avatarUrl: null,
+  url: null,
+});
+const node = (field: Field, index: number) =>
+  field === 'labels'
+    ? { id: `labels-${index}`, name: 'same name', color: null }
+    : field === 'assignees'
+      ? person(`assignees-${index}`)
+      : { id: `request-${index}`, requestedReviewer: person(`reviewer-${index}`) };
+const rest = {
+  labels: [
+    { node_id: 'labels-0', name: 'old name', color: 'ffffff' },
+    { id: 7, name: 'same name' },
+  ],
+  assignees: [
+    { node_id: 'assignees-0', login: 'login', name: 'Known name' },
+    { id: 7, login: 'login' },
+  ],
+  requested_reviewers: [
+    { node_id: 'reviewer-0', login: 'login', name: 'Known name' },
+    { id: 7, login: 'login' },
+  ],
+};
+function page(
+  field: Field,
+  nodes: unknown[],
+  totalCount = nodes.length,
+  next: string | null = null,
+  errors?: unknown[]
+) {
+  return {
+    data: {
+      data: {
+        repository: {
+          pullRequest: {
+            [field]: {
+              nodes,
+              totalCount,
+              pageInfo: { hasNextPage: next !== null, endCursor: next },
+            },
+          },
+        },
+      },
+      errors,
+    },
+  };
+}
+let budget: ReturnType<typeof createContextReadBudget>;
+beforeEach(() => {
+  jest.useFakeTimers();
+  budget = createContextReadBudget();
+});
+afterEach(() => {
+  budget.close();
+  jest.useRealTimers();
+});
+async function run(
+  serve: (field: Field, after: string | null, signal: AbortSignal) => unknown,
+  fallback: Partial<PullRequestRestData> = rest,
+  requests: string[] = []
+) {
+  const octokit = {
+    pulls: { get: async () => ({ data: { ...pr, ...fallback } }) },
+    request: async (
+      _route: string,
+      body: { query: string; variables: { after: string | null }; request: { signal: AbortSignal } }
+    ) => {
+      requests.push(body.query);
+      if (body.query === PR_CONTEXT_REVISION_QUERY)
+        return {
+          data: {
+            data: {
+              repository: {
+                pullRequest: {
+                  id: 'PR_1',
+                  number: 1,
+                  headRefOid: 'head',
+                  baseRefName: 'main',
+                  baseRefOid: 'base',
+                  baseRepository: { nameWithOwner: 'o/r' },
+                },
+              },
+            },
+          },
+        };
+      const field = fields.find(field => PR_CONTEXT_PEOPLE_QUERIES[field] === body.query);
+      if (!field) throw new Error('Unexpected per-person request');
+      return serve(field, body.variables.after, body.request.signal);
+    },
+  } as unknown as Octokit;
+  return GitHubPrReviewContextSchema.parse(
+    await readPullRequestContext(
+      octokit,
+      { owner: 'o', repo: 'r', number: 1, expectedRevision: revision },
+      budget
+    )
+  );
+}
+
+it('traverses more than 100 entries independently without per-person requests', async () => {
+  const counts = { labels: 101, assignees: 102, reviewRequests: 103 };
+  const requests: string[] = [];
+  const result = await run(
+    (field, after) => {
+      if (after !== null && after !== `${field}-next`) throw new Error('Wrong cursor');
+      return page(
+        field,
+        Array.from({ length: after ? counts[field] - 100 : 100 }, (_, i) =>
+          node(field, i + (after ? 100 : 0))
+        ),
+        counts[field],
+        after ? null : `${field}-next`
+      );
+    },
+    rest,
+    requests
+  );
+  for (const field of fields) {
+    expect(result[field]).toMatchObject({
+      knownCount: counts[field],
+      totalCount: counts[field],
+      completeness: 'complete',
+      hasNextPage: false,
+      source: { availability: 'available' },
+    });
+    expect(result[field].items).toHaveLength(counts[field]);
+  }
+  // Two pages per collection and the final revision read, without identity lookups.
+  expect(requests).toHaveLength(7);
+});
+
+describe.each(fields)('%s completeness', field => {
+  it('replaces fallback membership after a successful empty traversal', async () => {
+    expect((await run(other => page(other, [])))[field]).toMatchObject({
+      items: [],
+      knownCount: 0,
+      totalCount: 0,
+      completeness: 'complete',
+      source: { availability: 'available', retryable: false },
+    });
+  });
+
+  it.each([
+    'repeat',
+    'null-node',
+    'invalid-node',
+    'partial-error',
+    'denied-error',
+    'pathless-error',
+    'count-mismatch',
+    'changed-count',
+    'missing-page-info',
+    'null-source',
+    'null-ancestor',
+  ])('retains known entries and explicit uncertainty for %s', async defect => {
+    let pages = 0;
+    const result = await run((other, after) => {
+      if (other !== field) return page(other, []);
+      if (++pages > 2) throw new Error('Repeated cursor was not stopped');
+      if (defect === 'null-source' || defect === 'null-ancestor')
+        return {
+          data: {
+            data: {
+              repository: { pullRequest: defect === 'null-source' ? { [field]: null } : null },
+            },
+          },
+        };
+      if (defect === 'partial-error' || defect === 'changed-count')
+        return page(
+          field,
+          [node(field, after ? 1 : 0)],
+          !after && defect === 'changed-count' ? 3 : 2,
+          after ? null : 'next',
+          !after && defect === 'partial-error'
+            ? [{ type: 'INTERNAL', path: ['repository', 'pullRequest', field, 'nodes', 0] }]
+            : undefined
+        );
+      const response = page(
+        field,
+        [
+          node(field, 0),
+          node(field, 1),
+          ...(defect === 'null-node' ? [null] : defect === 'invalid-node' ? [{}] : []),
+        ],
+        ['null-node', 'invalid-node', 'count-mismatch'].includes(defect) ? 3 : 2,
+        defect === 'repeat' ? 'same-cursor' : null,
+        defect.endsWith('error')
+          ? [
+              {
+                type: defect === 'denied-error' ? 'FORBIDDEN' : 'INTERNAL',
+                path:
+                  defect === 'pathless-error'
+                    ? undefined
+                    : ['repository', 'pullRequest', field, 'nodes', 0],
+              },
+            ]
+          : undefined
+      );
+      if (defect === 'missing-page-info')
+        Reflect.deleteProperty(response.data.data.repository.pullRequest[field], 'pageInfo');
+      if (after && defect !== 'repeat') throw new Error('Unexpected page');
+      return response;
+    });
+    const reason =
+      defect === 'denied-error'
+        ? 'graphql-denied'
+        : ['partial-error', 'pathless-error', 'null-source', 'null-ancestor'].includes(defect)
+          ? 'graphql-incomplete'
+          : 'pagination-incomplete';
+    expect(result[field]).toMatchObject({
+      completeness: 'partial',
+      source: { availability: 'partial', retryable: defect !== 'denied-error', reason },
+    });
+    expect(result[field].items).toHaveLength(
+      defect.startsWith('null-') && defect !== 'null-node' ? 2 : 3
+    );
+    for (const other of fields.filter(other => other !== field))
+      expect(result[other].completeness).toBe('complete');
+    if (!defect.startsWith('null-') || defect === 'null-node') {
+      if (field === 'labels')
+        expect(result.labels.items).toEqual([
+          { id: 'labels-0', name: 'same name', color: 'ffffff' },
+          { id: 'labels-1', name: 'same name', color: null },
+          { id: '7', name: 'same name', color: null },
+        ]);
+      if (field === 'assignees')
+        expect(result.assignees.items).toMatchObject([
+          { id: 'assignees-0', name: 'Known name' },
+          { id: 'assignees-1' },
+          { id: '7' },
+        ]);
+      if (field === 'reviewRequests')
+        expect(result.reviewRequests.items).toMatchObject([
+          { id: 'request-0', reviewer: { id: 'reviewer-0', name: 'Known name' } },
+          { id: 'request-1' },
+          { id: null, reviewer: { id: '7' } },
+        ]);
+    }
+  });
+
+  it.each([401, 403, 503])(
+    'preserves fallback with the correct retry policy after HTTP %s',
+    async status => {
+      const result = await run(other => {
+        if (other === field) throw { status };
+        return page(other, []);
+      });
+      expect(result[field]).toMatchObject({
+        knownCount: 2,
+        completeness: 'partial',
+        source: { availability: 'partial', retryable: status === 503 },
+      });
+      const empty = await run(other => {
+        if (other === field) throw { status };
+        return page(other, []);
+      }, {});
+      expect(empty[field]).toMatchObject({
+        items: [],
+        completeness: 'unknown',
+        source: {
+          availability: status === 503 ? 'unavailable' : 'denied',
+          retryable: status === 503,
+        },
+      });
+    }
+  );
+
+  it('retains completed pages when the shared deadline aborts a later page', async () => {
+    let aborted = false;
+    const pending = run((other, after, signal) => {
+      if (other !== field) return page(other, []);
+      if (!after) return page(field, [node(field, 0)], 2, 'next');
+      return new Promise(resolve =>
+        signal.addEventListener(
+          'abort',
+          () => {
+            aborted = true;
+            resolve(page(field, [node(field, 1)], 2));
+          },
+          { once: true }
+        )
+      );
+    }, {});
+    await jest.advanceTimersByTimeAsync(10_000);
+    expect((await pending)[field]).toMatchObject({
+      knownCount: 1,
+      totalCount: 2,
+      hasNextPage: true,
+      endCursor: 'next',
+      completeness: 'partial',
+      source: { availability: 'partial', retryable: true, reason: 'deadline' },
+    });
+    expect(aborted).toBe(true);
+  });
+});
+
+it.each([null, 'https://avatars.example/supplied.png'])(
+  'preserves full text, typed identities, stable fallbacks, and supplied avatar %s',
+  async avatarUrl => {
+    const long = 'Full display name'.repeat(30);
+    const result = await run(field =>
+      page(
+        field,
+        field === 'labels'
+          ? [{ id: 'L', name: long }]
+          : field === 'assignees'
+            ? [
+                { ...person('U'), name: long, avatarUrl, url: 'https://github.com/octocat' },
+                { ...person('missing-avatar'), avatarUrl: 'invalid' },
+              ]
+            : [
+                ...['User', 'Bot', 'Mannequin'].map((kind, i) => ({
+                  id: `R${i}`,
+                  requestedReviewer: { ...person(`P${i}`), __typename: kind },
+                })),
+                {
+                  id: 'team',
+                  requestedReviewer: {
+                    __typename: 'Team',
+                    id: 'T',
+                    teamName: long,
+                    slug: 'core',
+                    teamAvatarUrl: avatarUrl,
+                    url: 'https://github.com/orgs/o/teams/core',
+                  },
+                },
+                { id: 'missing-1', requestedReviewer: null },
+                { id: 'missing-2', requestedReviewer: null },
+              ]
+      )
+    );
+    expect(result.labels.items).toEqual([{ id: 'L', name: long, color: null }]);
+    expect(result.assignees.items).toMatchObject([
+      { id: 'U', name: long, avatarUrl, url: 'https://github.com/octocat' },
+      { id: 'missing-avatar', name: null, login: 'login', avatarUrl: null },
+    ]);
+    expect(result.reviewRequests.items).toMatchObject([
+      { id: 'R0', reviewer: { kind: 'User', login: 'login', name: null } },
+      { id: 'R1', reviewer: { kind: 'Bot', login: 'login' } },
+      { id: 'R2', reviewer: { kind: 'Mannequin', login: 'login' } },
+      {
+        id: 'team',
+        reviewer: {
+          kind: 'Team',
+          login: null,
+          name: long,
+          teamSlug: 'core',
+          avatarUrl,
+          url: 'https://github.com/orgs/o/teams/core',
+        },
+      },
+      { id: 'missing-1', reviewer: { kind: 'Unavailable', id: null } },
+      { id: 'missing-2', reviewer: { kind: 'Unavailable', id: null } },
+    ]);
+    expect(result.reviewDecisions.items).toEqual([]);
+    expect(result.reviewRequests.completeness).toBe('complete');
+  }
+);

--- a/apps/web/src/lib/github-pr-review/context-people.ts
+++ b/apps/web/src/lib/github-pr-review/context-people.ts
@@ -1,0 +1,118 @@
+import 'server-only';
+
+import { z } from 'zod';
+import type { GitHubPrReviewIdentity } from './context-dtos';
+
+function peopleQuery(field: 'labels' | 'assignees' | 'reviewRequests', selection: string) {
+  return /* GraphQL */ `
+    query PrReviewContext_${field}($owner: String!, $name: String!, $number: Int!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          ${field}(first: 100, after: $after) {
+            totalCount
+            pageInfo { hasNextPage endCursor }
+            nodes { ${selection} }
+          }
+        }
+      }
+    }
+  `;
+}
+
+export const PR_CONTEXT_PEOPLE_QUERIES = {
+  labels: peopleQuery('labels', 'id name color'),
+  assignees: peopleQuery('assignees', '__typename id login name avatarUrl url'),
+  reviewRequests: peopleQuery(
+    'reviewRequests',
+    `
+    id
+    requestedReviewer {
+      __typename
+      ... on User { id login name avatarUrl url }
+      ... on Team { id teamName: name slug teamAvatarUrl: avatarUrl url }
+      ... on Bot { id login avatarUrl url }
+      ... on Mannequin { id login avatarUrl url }
+    }
+  `
+  ),
+};
+
+export const contextLabelSchema = z.object({
+  id: z.string().min(1),
+  name: z.string(),
+  color: z
+    .string()
+    .nullish()
+    .transform(value => value ?? null),
+});
+const identityFields = z.object({
+  id: z.string().min(1),
+  avatarUrl: z.string().url().nullable().catch(null),
+  url: z.string().url().nullable().catch(null),
+});
+export const contextIdentitySchema = z
+  .union([
+    identityFields.extend({
+      __typename: z.literal('User'),
+      login: z.string(),
+      name: z.string().nullable(),
+    }),
+    identityFields.extend({ __typename: z.enum(['Bot', 'Mannequin']), login: z.string() }),
+    // Team field nullability differs from User, so the query uses distinct aliases.
+    identityFields.extend({
+      __typename: z.literal('Team'),
+      teamName: z.string(),
+      slug: z.string(),
+      teamAvatarUrl: identityFields.shape.avatarUrl,
+    }),
+  ])
+  .transform(
+    (actor): GitHubPrReviewIdentity => ({
+      id: actor.id,
+      kind: actor.__typename,
+      login: 'login' in actor ? actor.login : null,
+      name:
+        actor.__typename === 'Team'
+          ? actor.teamName.trim() || null
+          : 'name' in actor
+            ? actor.name?.trim() || null
+            : null,
+      avatarUrl: actor.__typename === 'Team' ? actor.teamAvatarUrl : actor.avatarUrl,
+      url: actor.url,
+      teamSlug: 'slug' in actor ? actor.slug : null,
+    })
+  );
+const unavailableIdentity: GitHubPrReviewIdentity = {
+  id: null,
+  kind: 'Unavailable',
+  login: null,
+  name: null,
+  avatarUrl: null,
+  url: null,
+  teamSlug: null,
+};
+export const contextReviewRequestSchema = z
+  .object({
+    id: z.string().min(1),
+    requestedReviewer: contextIdentitySchema.nullable().catch(null),
+  })
+  .transform(request => ({
+    id: request.id,
+    reviewer: request.requestedReviewer ?? unavailableIdentity,
+  }));
+
+export function mergeKnownContextIdentity(
+  known: GitHubPrReviewIdentity | null,
+  current: GitHubPrReviewIdentity | null
+): GitHubPrReviewIdentity | null {
+  if (!current || current.kind === 'Unavailable') return known ?? current;
+  if (!known || known.id !== current.id || known.kind !== current.kind) return current;
+  return {
+    ...current,
+    login: current.login ?? known.login,
+    name: current.name ?? known.name,
+    avatarUrl: current.avatarUrl ?? known.avatarUrl,
+    url: current.url ?? known.url,
+    teamSlug: current.teamSlug ?? known.teamSlug,
+  };
+}

--- a/apps/web/src/lib/github-pr-review/context-reader.ts
+++ b/apps/web/src/lib/github-pr-review/context-reader.ts
@@ -11,6 +11,13 @@ import {
 } from './context-dtos';
 import { classifyGitHubHttpError } from './errors';
 import { buildOverviewDto } from './mappers';
+import {
+  PR_CONTEXT_PEOPLE_QUERIES,
+  contextLabelSchema,
+  contextIdentitySchema,
+  contextReviewRequestSchema,
+  mergeKnownContextIdentity,
+} from './context-people';
 
 const deadlineError = new Error('PR context deadline');
 type PrInput = { owner: string; repo: string; number: number };
@@ -246,7 +253,144 @@ export async function readPullRequestContext(
     return invalidateRevision(context, failedSource(error, 'rest.pullRequest'));
   }
   const read = createContextSourceReader(octokit, input, budget);
-  // Later source readers use this same reader and budget before the final revision fence.
+  type Collection<T> = Omit<GitHubPrReviewContext['labels'], 'items'> & { items: T[] };
+  async function collect<T extends { id: string | null } | null>(
+    field: keyof typeof PR_CONTEXT_PEOPLE_QUERIES,
+    node: z.ZodType<T>,
+    fallback: Collection<T>,
+    merge: (known: T, current: T) => T,
+    matches = (known: T, current: T) => known?.id != null && known.id === current?.id
+  ): Promise<Collection<T>> {
+    const schema = z.object({
+      nodes: z.array(node.nullable().catch(null)).nullish().catch(null),
+      totalCount: z.number().int().nonnegative().nullish().catch(null),
+      pageInfo: z
+        .object({ hasNextPage: z.boolean(), endCursor: z.string().nullable() })
+        .nullish()
+        .catch(null),
+    });
+    const collection: Collection<T> = {
+      ...fallback,
+      items: [],
+      totalCount: null,
+      hasNextPage: null,
+      endCursor: null,
+    };
+    const entries = new Map<string, T>();
+    const cursors = new Set<string>();
+    let incomplete: GitHubPrReviewSource | undefined;
+    const markIncomplete = (): GitHubPrReviewSource => ({
+      ...collection.source,
+      reason: incomplete?.reason ?? collection.source.reason ?? 'pagination-incomplete',
+      retryable: Boolean(
+        incomplete?.retryable ||
+        collection.source.retryable ||
+        collection.source.availability === 'available'
+      ),
+    });
+    for (;;) {
+      const page = decodeContextGraphQlSource(
+        await read(`graphql.${field}`, async (signal): Promise<unknown> => {
+          const response = await octokit.request('POST /graphql', {
+            query: PR_CONTEXT_PEOPLE_QUERIES[field],
+            variables: {
+              owner: input.owner,
+              name: input.repo,
+              number: input.number,
+              after: collection.endCursor,
+            },
+            request: { signal },
+          });
+          return response.data;
+        }),
+        ['repository', 'pullRequest', field],
+        schema
+      );
+      collection.source = page.source;
+      if (page.source.availability !== 'available') incomplete = markIncomplete();
+      if (!page.data) break;
+      const { nodes, totalCount, pageInfo } = page.data;
+      if (
+        !nodes ||
+        totalCount == null ||
+        !pageInfo ||
+        (collection.totalCount != null && totalCount !== collection.totalCount)
+      ) {
+        incomplete = markIncomplete();
+      }
+      collection.totalCount = totalCount ?? collection.totalCount;
+      collection.hasNextPage = pageInfo?.hasNextPage ?? null;
+      collection.endCursor = pageInfo?.endCursor ?? null;
+      for (const item of nodes ?? []) {
+        if (item?.id) entries.set(item.id, item);
+        else incomplete = markIncomplete();
+      }
+      if (!pageInfo?.hasNextPage) break;
+      if (!pageInfo.endCursor || cursors.has(pageInfo.endCursor)) {
+        incomplete = markIncomplete();
+        break;
+      }
+      cursors.add(pageInfo.endCursor);
+    }
+    if (
+      !incomplete &&
+      (collection.hasNextPage !== false || entries.size !== collection.totalCount)
+    ) {
+      incomplete = markIncomplete();
+    }
+    collection.items = [...entries.values()];
+    if (incomplete) {
+      collection.items = collection.items.map(current => {
+        const known = fallback.items.find(item => matches(item, current));
+        return known === undefined ? current : merge(known, current);
+      });
+      collection.items.push(
+        ...fallback.items.filter(
+          known => !collection.items.some(current => matches(known, current))
+        )
+      );
+      collection.source = {
+        ...incomplete,
+        availability:
+          collection.items.length || incomplete.availability === 'available'
+            ? 'partial'
+            : incomplete.availability,
+        provenance: [...new Set([...fallback.source.provenance, ...incomplete.provenance])],
+      };
+    }
+    collection.knownCount = collection.items.length;
+    collection.completeness = incomplete
+      ? collection.knownCount
+        ? 'partial'
+        : 'unknown'
+      : 'complete';
+    return collection;
+  }
+  [context.labels, context.assignees, context.reviewRequests] = await Promise.all([
+    collect('labels', contextLabelSchema, context.labels, (known, current) => ({
+      ...current,
+      color: current.color ?? known.color,
+    })),
+    collect(
+      'assignees',
+      contextIdentitySchema.nullable(),
+      context.assignees,
+      mergeKnownContextIdentity
+    ),
+    collect(
+      'reviewRequests',
+      contextReviewRequestSchema,
+      context.reviewRequests,
+      (known, current) => ({
+        ...current,
+        reviewer: mergeKnownContextIdentity(known.reviewer, current.reviewer),
+      }),
+      (known, current) =>
+        known.id != null
+          ? known.id === current.id
+          : known.reviewer?.id != null && known.reviewer.id === current.reviewer?.id
+    ),
+  ]);
   const final = decodeContextGraphQlSource(
     await read('graphql.revision', async (signal): Promise<unknown> => {
       const response = await octokit.request('POST /graphql', {

--- a/apps/web/src/routers/github-pr-review-graphql-schema.test.ts
+++ b/apps/web/src/routers/github-pr-review-graphql-schema.test.ts
@@ -42,8 +42,8 @@ const introspection = JSON.parse(readFileSync(introspectionPath, 'utf8'));
 const githubSchema = buildClientSchema(introspection);
 
 describe('github-pr-review-router GraphQL documents', () => {
-  test('exports exactly 12 documents (sanity guard for the export record)', () => {
-    expect(Object.keys(PR_REVIEW_GRAPHQL_DOCUMENTS)).toHaveLength(12);
+  test('exports exactly 15 documents (sanity guard for the export record)', () => {
+    expect(Object.keys(PR_REVIEW_GRAPHQL_DOCUMENTS)).toHaveLength(15);
   });
 
   test.each(Object.entries(PR_REVIEW_GRAPHQL_DOCUMENTS))(

--- a/apps/web/src/routers/github-pr-review-router.test.ts
+++ b/apps/web/src/routers/github-pr-review-router.test.ts
@@ -1291,7 +1291,8 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
         privatePayload: 'provider-only',
       };
     }
-    function contextEnvelope(identity = revision) {
+    function contextEnvelope(identity = revision, labelName = 'known') {
+      const empty = { nodes: [], totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null } };
       return {
         data: {
           data: {
@@ -1305,6 +1306,13 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
                 baseRepository: identity.baseRepoFullName
                   ? { nameWithOwner: identity.baseRepoFullName }
                   : null,
+                labels: {
+                  ...empty,
+                  nodes: [{ id: 'LABEL_1', name: labelName, color: 'ffffff' }],
+                  totalCount: 1,
+                },
+                assignees: empty,
+                reviewRequests: empty,
                 privatePayload: 'provider-only',
               },
             },
@@ -1327,14 +1335,16 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
       jest.restoreAllMocks();
     });
 
-    it('returns REST context without claiming that unattached readers are empty', async () => {
+    it('enriches people and labels without claiming that unattached readers are empty', async () => {
       const result = await caller.getPullRequestContext(contextInput);
       expect(result.revision).toEqual(revision);
       expect(result.labels).toMatchObject({
         items: [{ name: 'known' }],
-        completeness: 'unknown',
-        source: { availability: 'partial' },
+        completeness: 'complete',
+        source: { availability: 'available', provenance: ['graphql.labels'] },
       });
+      expect(result.assignees).toMatchObject({ items: [], completeness: 'complete' });
+      expect(result.reviewRequests).toMatchObject({ items: [], completeness: 'complete' });
       expect(result.lifecycle).toMatchObject({
         source: { availability: 'available' },
         openedAt: '2026-01-01T00:00:00Z',
@@ -1369,8 +1379,9 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
       });
       expect(result.revision.baseSha).toBeNull();
       expect(result.labels).toMatchObject({
-        completeness: 'unknown',
-        source: { availability: 'unavailable', reason: 'not-requested' },
+        items: [{ name: 'known' }],
+        completeness: 'complete',
+        source: { availability: 'available' },
       });
       expect(result.lifecycle.openedAt).toBeNull();
       expect(result.requirements.source).toMatchObject({
@@ -1521,7 +1532,7 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
         second.pulls.get.mockResolvedValue({
           data: { ...contextPr(), labels: [{ name: 'rotated' }] },
         });
-        second.request.mockResolvedValue(contextEnvelope());
+        second.request.mockResolvedValue(contextEnvelope(revision, 'rotated'));
         const result = await caller.getPullRequestContext(contextInput);
         expect(result.labels.items[0]?.name).toBe('rotated');
         expect(result.requirements.source.reason).toBe('not-requested');

--- a/apps/web/src/routers/github-pr-review-router.ts
+++ b/apps/web/src/routers/github-pr-review-router.ts
@@ -47,6 +47,7 @@ import {
   readPullRequestContext,
   PR_CONTEXT_REVISION_QUERY,
 } from '@/lib/github-pr-review/context-reader';
+import { PR_CONTEXT_PEOPLE_QUERIES } from '@/lib/github-pr-review/context-people';
 import { getGitHubUserAccessToken } from '@/lib/integrations/platforms/github/user-token-client';
 import {
   AutoMergeMethodSchema,
@@ -541,6 +542,7 @@ export const CONVERSATION_COMMENTS_QUERY_FOR_TEST = CONVERSATION_COMMENTS_QUERY;
 export const PR_REVIEW_GRAPHQL_DOCUMENTS = {
   PULL_REQUEST_FRAGMENT_QUERY,
   PR_CONTEXT_REVISION_QUERY,
+  ...PR_CONTEXT_PEOPLE_QUERIES,
   REVIEW_THREADS_QUERY,
   REVIEW_THREAD_COMMENTS_FOLLOWUP_QUERY,
   CONVERSATION_COMMENTS_QUERY,


### PR DESCRIPTION
No new behavior — the pull request screens do not use these additional label and people details yet.

---

## Summary

`getPullRequestContext` now pages `labels`, `assignees`, and `reviewRequests` independently within the existing ten-second budget and four-request limit.
Complete collections replace fallback membership, including empty lists; incomplete collections retain known members with explicit counts, cursors, completeness, provenance, and retryability.
`GitHubPrReviewContext` keeps its existing shape, and callers retain their inputs; optional failures stay isolated before the final revision check.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-reader.ts` — Modified source (146 changed lines). Adds concurrent collection reads and deduplicates provider identifiers; malformed nodes, changing totals, invalid cursor progress, and count mismatches prevent completion. Partial reads retain prior pages, merge known label colors and identity details, and preserve unmatched fallback members. Review requests match by request identifier, or by reviewer identifier when the fallback lacks a request identifier. Complete results require a terminal page and matching unique counts; source metadata preserves availability, retryability, reason, observation time, and provenance.

</details>

`PR_CONTEXT_PEOPLE_QUERIES` fetches 100 records per page and selects identity details directly, avoiding per-person requests.
`contextLabelSchema`, `contextIdentitySchema`, and `contextReviewRequestSchema` normalize labels and `User`, `Team`, `Bot`, and `Mannequin` identities; unreadable reviewers become `Unavailable`.
During incomplete reads, `mergeKnownContextIdentity` fills missing details for matching identifiers and kinds, or keeps the known identity when the new identity is unavailable.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-people.ts` — Added source (118 changed lines). Adds server-only queries and schemas, aliases team fields, trims display names, and normalizes missing colors or invalid avatar/profile links to null. Preserves logins, provider identifiers, and team slugs for available identities. Keeps each review-request identifier when its reviewer is unavailable.

</details>

`PR_REVIEW_GRAPHQL_DOCUMENTS` includes the three collection queries, so schema validation covers the provider selections used by the reader.
This extends the existing validation contract without introducing another route or changing stored data.

<details>
<summary>Files</summary>

- `apps/web/src/routers/github-pr-review-router.ts` — Modified source (2 changed lines). Imports the people queries and includes them in the exported GraphQL document registry for automatic schema validation.

</details>

Tests: 3 files changed — `apps/web/src/lib/github-pr-review/context-people.test.ts` added (398 changed lines), `apps/web/src/routers/github-pr-review-graphql-schema.test.ts` modified (4 changed lines), and `apps/web/src/routers/github-pr-review-router.test.ts` modified (25 changed lines).
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual tests: not run for this backend-only level; live backend and iOS verification will run on the completed stack tip.

## Reviewer Notes

### Human steps

No human steps before merge or after merge.

### Scope and automated checks

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- Review range: `mobile-pr-review-context-5458-s5...mobile-pr-review-context-5458-s6` only.
- The supplied verification record reports 3 passing suites and 178 passing tests.
- Scoped lint reports no warnings or errors; scoped format and whitespace checks passed.
- The suites use the existing web configuration with database setup disabled and a temporary cache outside the repository.
- Package-wide type checks, builds, and repository-wide checks did not run.

### Notes

This level completes available label and people context with explicit pagination coverage. Live backend and iOS verification will run on the completed stack tip.









<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691 ← this PR
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
