### PR TITLE
feat(extension): coordinate browser execution across panels

### DIFF
--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.test.ts
@@ -1253,8 +1253,44 @@ describe('local admission and shared run context', () => {
     });
   });
 
+  it.each(['chat', 'Settings workflow'] as const)(
+    'rejects %s execution when durable protection cannot be written',
+    async site => {
+      const view = renderApp(true);
+      try {
+        await waitFor(() => {
+          expect(view.getByLabelText('Run workflow "Read order"')).toHaveProperty(
+            'disabled',
+            false
+          );
+        });
+        fixture.failSafetyWrite = true;
+        if (site === 'chat') {
+          await send(view, 'do not dispatch without protection');
+        } else {
+          fireEvent.click(view.getByLabelText('Run workflow "Read order"'));
+        }
+        await waitFor(() => {
+          expect(coordinator().getSnapshot().blockedReason).toContain('Restore storage access');
+          expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+        });
+        expect({ actions, requests }).toStrictEqual({ actions: [], requests: [] });
+        expect(view.getAllByRole('status').map(status => status.textContent)).toStrictEqual(
+          expect.arrayContaining([expect.stringContaining('Restore storage access')])
+        );
+      } finally {
+        fixture.failSafetyWrite = false;
+        await act(async () => {
+          await coordinator().recover(async () => []);
+        });
+      }
+    }
+  );
+
   it('quarantines a Settings workflow timeout before any model continuation or later admission', async () => {
+    const protectionAtDispatch: unknown[] = [];
     fixture.dispatch = async request => {
+      protectionAtDispatch.push(structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)));
       actions.push({ code: request.code, tabId: request.tabId });
       return {
         ok: true,
@@ -1276,6 +1312,7 @@ describe('local admission and shared run context', () => {
       ).toBe(false);
     });
     expect(storedEvents().some(event => event.type === 'tool-result' && !event.ok)).toBe(true);
+    expect(protectionAtDispatch).toMatchObject([{ localRuns: [{ tabId: 7 }], tabIds: [] }]);
     await send(view, 'blocked local action');
     const owner = hold(await coordinator().acquireProviderOwner());
     const delegated = await coordinator().acquireDelegated(
@@ -1302,6 +1339,8 @@ describe('local admission and shared run context', () => {
   it('recovers a failed safety write after the panel drops its completed workflow run', async () => {
     fixture.dispatch = async request => {
       actions.push({ code: request.code, tabId: request.tabId });
+      // Registration must succeed before this issued action loses its completion proof.
+      fixture.failSafetyWrite = true;
       return {
         ok: true,
         result: { effectsUncertain: true, error: 'Script timed out.', ok: false },
@@ -1313,7 +1352,6 @@ describe('local admission and shared run context', () => {
       await waitFor(() => {
         expect(view.getByLabelText('Run workflow "Read order"')).toHaveProperty('disabled', false);
       });
-      fixture.failSafetyWrite = true;
       fireEvent.click(view.getByLabelText('Run workflow "Read order"'));
       await waitFor(() => {
         expect(actions).toHaveLength(1);
@@ -1329,7 +1367,7 @@ describe('local admission and shared run context', () => {
         requests,
       }).toMatchObject({
         held: [{ mode: 'shared' }],
-        persisted: false,
+        persisted: true,
         request: undefined,
         requests: [],
       });
@@ -1360,7 +1398,10 @@ describe('local admission and shared run context', () => {
       expect({
         local: (await coordinator().acquireLocal()).admitted,
         safety: fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY),
-      }).toStrictEqual({ local: false, safety: { tabIds: [7], version: 1 } });
+      }).toMatchObject({
+        local: false,
+        safety: { localRuns: [{ tabId: 7 }], tabIds: [7], version: 1 },
+      });
       fixture.tabs = [];
       await act(async () => {
         await expect(
@@ -1428,6 +1469,16 @@ describe('local admission and shared run context', () => {
         await finalResponse.promise;
         return response();
       };
+      const { dispatch } = fixture;
+      const protectionAtDispatch: unknown[] = [];
+      fixture.dispatch = async request => {
+        if (request.type === EVAL_TAB_MESSAGE) {
+          protectionAtDispatch.push(
+            structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY))
+          );
+        }
+        return dispatch(request);
+      };
       const context = runContext(local, mode);
       const running = runBrowserTurn(context, []);
       fixture.activeTabId = 8;
@@ -1443,7 +1494,10 @@ describe('local admission and shared run context', () => {
       await waitFor(async () => {
         expect((await nativeLocks.query()).pending).toHaveLength(1);
       });
-      expect(actions.map(action => action.tabId)).toStrictEqual([7]);
+      expect({ protectionAtDispatch, tabs: actions.map(action => action.tabId) }).toMatchObject({
+        protectionAtDispatch: [{ localRuns: [{ tabId: 7 }], tabIds: [] }],
+        tabs: [7],
+      });
       expect(requests[2]).toContain('Continue: finish the request now');
       expect(events.some(event => event.type === 'message' && event.role === 'user')).toBe(false);
       finalResponse.resolve();
@@ -1452,6 +1506,10 @@ describe('local admission and shared run context', () => {
         status: 'succeeded',
         summary: 'Answer done.',
         toolResults: [expect.objectContaining({ ok: true })],
+      });
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+        tabIds: [],
+        version: 1,
       });
       await local.release();
       hold(await waiting);
@@ -1472,8 +1530,11 @@ describe('local admission and shared run context', () => {
     fixture.tabs = [{ id: 8, title: 'Other tab', url: 'https://example.com/other' }];
     fixture.activeTabId = 8;
     await expect(runBrowserTurn(runContext(local), [])).rejects.toThrow('tab_lost');
-    expect(requests).toStrictEqual([]);
-    expect(actions).toStrictEqual([]);
+    expect({
+      actions,
+      requests,
+      safety: fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY),
+    }).toStrictEqual({ actions: [], requests: [], safety: { tabIds: [], version: 1 } });
   });
 
   it('aborts the bound tab without releasing its lease before the runner unwinds', async () => {

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.test.ts
@@ -82,7 +82,6 @@ vi.mock('./use-agent-workflows', () => ({
 vi.mock('./model-picker', () => ({ ModelPicker: () => null }));
 vi.mock('./context-donut', () => ({ ContextDonut: () => null }));
 vi.mock('./conversation-history-button', () => ({ ConversationHistoryButton: () => null }));
-vi.mock('./conversation-list', () => ({ ConversationList: () => null }));
 
 import {
   AgentChatPanel,
@@ -1502,6 +1501,24 @@ describe('local admission and shared run context', () => {
     });
     expect(store.get(workflowRunRequestAtom)).toBe(request);
     expect({ actions, requests }).toStrictEqual({ actions: [], requests: [] });
+  });
+
+  it('keeps admission feedback and the composer outside the clipped conversation', async () => {
+    const provider = hold(await coordinator().acquireProviderOwner());
+    hold(
+      await coordinator().acquireDelegated(provider, 'layout-owner', new AbortController().signal)
+    );
+    const view = renderApp();
+    await waitFor(() => {
+      expect(view.getByRole('status').textContent).toContain('layout-owner');
+    });
+    const conversation = view.getByRole('region', { name: 'Agent conversation' });
+    const viewport = conversation.parentElement;
+    const status = view.getByRole('status');
+    const textbox = view.getByRole('textbox', { name: 'Message agent' });
+    expect(conversation.closest('.overflow-hidden')).toBe(viewport);
+    expect(viewport?.nextElementSibling).toBe(status);
+    expect(viewport?.contains(textbox)).toBe(false);
   });
 
   it('retains a blocked draft and requires a new Send after delegated control returns', async () => {

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.test.ts
@@ -1,24 +1,119 @@
-import { describe, expect, it, vi } from 'vitest';
+/* eslint-disable import/first, import/no-nodejs-modules, jest/no-hooks, jest/no-untyped-mock-factory, jest/no-conditional-in-test, vitest/prefer-import-in-mock, max-lines, import/max-dependencies, require-await, typescript/require-await, typescript/no-unsafe-assignment, unicorn/no-await-expression-member -- Node and DOM fixtures exercise real adapters; asynchronous fakes and asymmetric matchers preserve their contracts. */
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { locks as nativeLocks } from 'node:worker_threads';
+import { createHash, webcrypto } from 'node:crypto';
+import { createElement } from 'react';
+import { Provider, createStore } from 'jotai';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import type { AgentWorkflow } from '@/src/shared/agent-workflows';
 
-// Agent-chat-panel transitively imports the WXT '#imports' virtual module; stub it so the graph loads under vitest.
-// eslint-disable-next-line vitest/prefer-import-in-mock, jest/no-untyped-mock-factory
+const fixture = vi.hoisted(() => ({
+  activeTabId: 7,
+  dispatch: async (_request: {
+    type: string;
+    tabId?: number;
+    code?: string;
+  }): Promise<unknown> => ({ ok: false }),
+  failSafetyWrite: false,
+  removed: new Set<(tabId: number) => void>(),
+  tabs: [{ id: 7, title: 'Approved tab', url: 'https://example.com/' }],
+  values: new Map<string, unknown>(),
+  workflows: [] as AgentWorkflow[],
+}));
 vi.mock('#imports', () => ({
-  browser: { runtime: { sendMessage: vi.fn() }, tabs: { query: vi.fn() } },
+  browser: {
+    runtime: {
+      sendMessage: (request: { type: string; tabId?: number; code?: string }) =>
+        fixture.dispatch(request),
+    },
+    tabs: {
+      get: async (id: number) => {
+        const tab = fixture.tabs.find(item => item.id === id);
+        if (tab === undefined) {
+          throw new Error('Tab closed');
+        }
+        return { ...tab, status: 'complete' };
+      },
+      onRemoved: {
+        addListener: (listener: (id: number) => void) => {
+          fixture.removed.add(listener);
+        },
+        removeListener: (listener: (id: number) => void) => {
+          fixture.removed.delete(listener);
+        },
+      },
+      query: async () => [{ id: fixture.activeTabId }],
+    },
+  },
   storage: {
-    getItem: vi.fn(),
-    setItem: vi.fn(),
-    watch: vi.fn(() => () => {
-      /* No-op unwatch */
-    }),
+    getItem: (key: string) => fixture.values.get(key),
+    removeItem: (key: string) => {
+      fixture.values.delete(key);
+    },
+    setItem: (key: string, value: unknown) => {
+      if (fixture.failSafetyWrite && key === 'local:kiloBrowserExecutionSafety') {
+        throw new Error('Safety storage unavailable');
+      }
+      fixture.values.set(key, structuredClone(value));
+    },
+    watch: () => () => {},
   },
 }));
+vi.mock('./use-tab-debugger', () => ({
+  getActiveTabId: async () => fixture.activeTabId,
+  useTabDebugger: () => ({
+    activeTabId: fixture.activeTabId,
+    inspectableTabs: fixture.tabs,
+    isLoadingTabs: false,
+  }),
+}));
+vi.mock('./use-gateway-models', () => ({
+  useGatewayModels: () => ({
+    modelOptions: [{ id: 'test-model', supportsImages: false, variants: [] }],
+    refetchModels: async () => {},
+  }),
+}));
+vi.mock('./use-agent-memories', () => ({ useAgentMemories: () => ({ memories: [] }) }));
+vi.mock('./use-agent-workflows', () => ({
+  useAgentWorkflows: () => ({ isLoaded: true, loadError: false, workflows: fixture.workflows }),
+}));
+vi.mock('./model-picker', () => ({ ModelPicker: () => null }));
+vi.mock('./context-donut', () => ({ ContextDonut: () => null }));
+vi.mock('./conversation-history-button', () => ({ ConversationHistoryButton: () => null }));
+vi.mock('./conversation-list', () => ({ ConversationList: () => null }));
 
-// eslint-disable-next-line import/first
 import {
+  AgentChatPanel,
   formatSelectedTabSystemEnvironment,
   formatSystemEnvironment,
   getSelectedInspectableTabId,
 } from './agent-chat-panel';
+import {
+  draftAtomFamily,
+  queuedMessageAtomFamily,
+  runningConversationIdsAtom,
+} from './agent-chat-atoms';
+import {
+  normalizeStoredConversationStore,
+  updateStoredConversationEvents,
+} from './agent-conversation-storage';
+import {
+  BROWSER_EXECUTION_LOCK,
+  BROWSER_EXECUTION_SAFETY_KEY,
+  getBrowserExecutionCoordinator,
+} from './browser-execution-lock';
+import type { BrowserExecutionLease, BrowserAdmission } from './browser-execution-lock';
+import { reserveWorkflowLease, runBrowserTurn, takeWorkflowLease } from './browser-run-context';
+import type { BrowserRunContext } from './browser-run-context';
+import { WorkflowSettings } from './workflow-settings';
+import { workflowRunRequestAtom } from './workflow-settings-state';
+import { activeConversationIdAtom } from './settings-dialog-state';
+import { EVAL_TAB_MESSAGE } from '@/src/shared/tab-debugger';
+import { DEFAULT_WORKFLOW_SETTINGS } from '@/src/shared/agent-workflows';
+import type { AgentConversationEvent } from '@/src/shared/agent-conversation';
+import { storage } from '#imports';
 
 describe('selected tab context formatting', () => {
   it('redacts URL query and hash data and escapes page-controlled title text', () => {
@@ -237,5 +332,1172 @@ describe('system environment builder', () => {
     expect(context).toContain('<memories count="1">');
     expect(context).toContain('<workflows count="1">');
     expect(context).toContain('</system_environment>');
+  });
+});
+
+const response = (delta?: Record<string, unknown>, finish = 'stop'): Response =>
+  new Response(
+    `data: ${JSON.stringify({ choices: [{ delta: delta ?? { content: 'Answer done.' }, finish_reason: finish }] })}\n\n`,
+    { headers: { 'Content-Type': 'text/event-stream' } }
+  );
+const held = new Set<BrowserExecutionLease>();
+const hold = (admission: BrowserAdmission): BrowserExecutionLease => {
+  if (!admission.admitted) {
+    throw new Error(admission.reason);
+  }
+  held.add(admission.lease);
+  return admission.lease;
+};
+
+describe('local admission and shared run context', () => {
+  let store = createStore();
+  let client = new QueryClient();
+  let gateway: () => Promise<Response> = async () => response();
+  const requests: string[] = [];
+  const actions: { tabId: number | undefined; code: string | undefined }[] = [];
+  const events: AgentConversationEvent[] = [];
+  const coordinator = () => getBrowserExecutionCoordinator();
+  const storedEvents = () =>
+    normalizeStoredConversationStore(
+      fixture.values.get('local:kiloAgentConversations')
+    )?.conversations.find(conversation => conversation.id === 'conversation-1')?.events ?? [];
+  const seedHistory = (): AgentConversationEvent[] => {
+    const history: AgentConversationEvent[] = [
+      { id: 'prior-user', role: 'user', text: 'Prior question', type: 'message' },
+      { id: 'prior-answer', role: 'assistant', text: 'Prior answer', type: 'message' },
+    ];
+    const previous = normalizeStoredConversationStore(
+      fixture.values.get('local:kiloAgentConversations')
+    );
+    if (previous === undefined) {
+      throw new Error('Missing conversation fixture');
+    }
+    fixture.values.set(
+      'local:kiloAgentConversations',
+      updateStoredConversationEvents(previous, 'conversation-1', () => history)
+    );
+    return history;
+  };
+  const runContext = (
+    lease: BrowserExecutionLease,
+    mode: 'safe' | 'dangerous' = 'safe'
+  ): BrowserRunContext => ({
+    abort: new AbortController(),
+    allowTabFallback: false,
+    allowWebMcpInSafeMode: false,
+    apiBaseUrl: 'https://api.example.com',
+    appendEvents: next => {
+      events.push(...next);
+    },
+    executionGuard: lease.guard,
+    fetch: (url, init) => fetch(url, init),
+    lease,
+    mode,
+    model: 'test-model',
+    onRemoteMcpWarning: () => {},
+    remoteFetch: globalThis.fetch,
+    remoteMcpServers: [],
+    requestApproval: async () => ({ status: 'rejected' }),
+    selectedTab: { id: 7, title: 'Approved tab', url: 'https://example.com/' },
+    settings: { ...DEFAULT_WORKFLOW_SETTINGS, allowWorkflowsInSafeMode: true },
+    storage,
+    token: 'test-token',
+    updateAssistantMessage: (id, text) => {
+      const index = events.findIndex(candidate => candidate.id === id);
+      const event = events[index];
+      if (event?.type === 'message') {
+        events[index] = { ...event, text };
+      }
+    },
+    updateThinkingBlock: () => {},
+  });
+  const app = (settings = false) =>
+    createElement(
+      QueryClientProvider,
+      { client },
+      createElement(
+        Provider,
+        { store },
+        createElement(
+          'div',
+          null,
+          createElement(AgentChatPanel, {
+            auth: { token: 'test-token', userEmail: 'test@example.com' },
+            organizationId: undefined,
+          }),
+          settings ? createElement(WorkflowSettings) : null
+        )
+      )
+    );
+  const renderApp = (settings = false) => render(app(settings));
+  const send = async (view: ReturnType<typeof renderApp>, text: string): Promise<void> => {
+    fireEvent.change(view.getByRole('textbox', { name: 'Message agent' }), {
+      target: { value: text },
+    });
+    await waitFor(() => {
+      expect(view.getByRole('textbox', { name: 'Message agent' })).toBeDefined();
+    });
+    fireEvent.keyDown(view.getByRole('textbox', { name: 'Message agent' }), { key: 'Enter' });
+  };
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: nativeLocks });
+    vi.stubGlobal('crypto', webcrypto);
+    fixture.values.clear();
+    fixture.tabs = [{ id: 7, title: 'Approved tab', url: 'https://example.com/' }];
+    fixture.activeTabId = 7;
+    requests.length = 0;
+    actions.length = 0;
+    events.length = 0;
+    store = createStore();
+    client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    gateway = async () => response();
+    vi.stubGlobal('fetch', async (_url: string, init?: RequestInit) => {
+      if (typeof init?.body !== 'string') {
+        throw new TypeError('Missing gateway body');
+      }
+      requests.push(init.body);
+      return gateway();
+    });
+    const script = 'return { done: true, result: input };';
+    fixture.workflows = [
+      {
+        approvedScriptHash: createHash('sha256').update(script).digest('hex'),
+        createdAt: 1,
+        description: 'Read the order',
+        id: 'wf-1',
+        name: 'Read order',
+        scopeOrigin: 'https://example.com',
+        script,
+        updatedAt: 1,
+      },
+    ];
+    fixture.values.set('local:kiloAgentWorkflows', fixture.workflows);
+    fixture.values.set('local:kiloWorkflowSettings', {
+      ...DEFAULT_WORKFLOW_SETTINGS,
+      allowWorkflowsInSafeMode: true,
+    });
+    fixture.values.set('local:kiloRemoteMcpServers', { servers: [] });
+    fixture.values.set('local:kiloAgentConversations', {
+      activeConversationId: 'conversation-1',
+      conversations: [
+        {
+          events: [],
+          id: 'conversation-1',
+          mode: 'safe',
+          model: 'test-model',
+          selectedTabId: 7,
+          title: '',
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+      openConversationIds: ['conversation-1'],
+    });
+    fixture.dispatch = async request => {
+      if (request.type !== EVAL_TAB_MESSAGE) {
+        return {
+          ok: true,
+          result: { ok: true, value: { documentId: 'document-7', tools: [] } },
+          type: request.type,
+        };
+      }
+      actions.push({ code: request.code, tabId: request.tabId });
+      return {
+        ok: true,
+        result: {
+          effectsUncertain: false,
+          ok: true,
+          value: {
+            dryRunActions: [],
+            effectsUncertain: false,
+            ok: true,
+            value: { done: true, result: 'observed order' },
+          },
+        },
+        type: request.type,
+      };
+    };
+  });
+  afterEach(async () => {
+    cleanup();
+    const request = store.get(workflowRunRequestAtom);
+    if (request !== undefined) {
+      const reservation = takeWorkflowLease(request);
+      if (reservation !== undefined) {
+        await reservation.lease.release();
+      }
+    }
+    await Promise.all([...held].map(lease => lease.release()));
+    held.clear();
+    client.clear();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  const workflowResponse = (): Response =>
+    response(
+      {
+        tool_calls: [
+          {
+            function: {
+              arguments: JSON.stringify({ workflowId: 'wf-1' }),
+              name: 'run_workflow',
+            },
+            id: 'workflow-call',
+            index: 0,
+          },
+        ],
+      },
+      'tool_calls'
+    );
+
+  it.each(['selection change', 'tab removal', 'unrefreshed tab removal'] as const)(
+    'retains a submitted draft after %s during delayed admission',
+    async change => {
+      const history = seedHistory();
+      fixture.tabs.push({ id: 8, title: 'Replacement tab', url: 'https://example.com/other' });
+      const admission = await coordinator().acquireLocal();
+      hold(admission);
+      const pending = Promise.withResolvers<BrowserAdmission>();
+      const entered = Promise.withResolvers<void>();
+      vi.spyOn(coordinator(), 'acquireLocal').mockImplementationOnce(() => {
+        entered.resolve();
+        return pending.promise;
+      });
+      gateway = async () => (requests.length === 1 ? workflowResponse() : response());
+      const view = renderApp();
+      try {
+        await waitFor(() => {
+          expect(view.getByRole('button', { name: 'Close Prior question' })).toBeDefined();
+        });
+        await send(view, '  submitted for approved tab  ');
+        await entered.promise;
+        expect(view.getByRole('combobox', { name: 'Target tab' })).toHaveProperty(
+          'disabled',
+          false
+        );
+        if (change === 'selection change') {
+          fireEvent.change(view.getByRole('combobox', { name: 'Target tab' }), {
+            target: { value: '8' },
+          });
+        } else {
+          fixture.tabs = fixture.tabs.filter(tab => tab.id !== 7);
+          fixture.activeTabId = 8;
+          if (change === 'tab removal') {
+            view.rerender(app());
+          }
+        }
+        await act(async () => {
+          pending.resolve(admission);
+        });
+        await waitFor(() => {
+          expect(view.getByRole('status').textContent).toContain('target tab');
+        });
+        await waitFor(async () => {
+          expect(
+            (await nativeLocks.query()).held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
+          ).toBe(false);
+        });
+        expect({
+          actions,
+          draft: store.get(draftAtomFamily('conversation-1')),
+          events: storedEvents(),
+          requests,
+          running: store.get(runningConversationIdsAtom),
+        }).toStrictEqual({
+          actions: [],
+          draft: '  submitted for approved tab  ',
+          events: history,
+          requests: [],
+          running: [],
+        });
+        view.rerender(app());
+        await act(async () => {
+          await coordinator().refresh();
+        });
+        expect(view.getByRole('combobox', { name: 'Target tab' })).toHaveProperty('value', '8');
+        expect({ actions, requests }).toStrictEqual({ actions: [], requests: [] });
+        fireEvent.click(view.getByRole('button', { name: 'Send message' }));
+        await waitFor(() => {
+          expect(
+            storedEvents().some(event => event.type === 'message' && event.text === 'Answer done.')
+          ).toBe(true);
+          expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+        });
+        expect({
+          actions,
+          draft: store.get(draftAtomFamily('conversation-1')),
+          requests,
+        }).toStrictEqual({
+          actions: [{ code: expect.any(String), tabId: 8 }],
+          draft: '',
+          requests: [
+            expect.stringContaining('Selected tab URL: https://example.com/other'),
+            expect.any(String),
+          ],
+        });
+      } finally {
+        view.unmount();
+        pending.resolve(admission);
+      }
+    }
+  );
+
+  it('keeps the submitted target when only the active browser tab changes during admission', async () => {
+    seedHistory();
+    fixture.tabs.push({ id: 8, title: 'Other tab', url: 'https://example.com/other' });
+    const admission = await coordinator().acquireLocal();
+    hold(admission);
+    const pending = Promise.withResolvers<BrowserAdmission>();
+    vi.spyOn(coordinator(), 'acquireLocal').mockReturnValueOnce(pending.promise);
+    const finish = Promise.withResolvers<void>();
+    gateway = async () => {
+      if (requests.length === 1) {
+        return workflowResponse();
+      }
+      await finish.promise;
+      return response();
+    };
+    const view = renderApp();
+    try {
+      await waitFor(() => {
+        expect(view.getByRole('button', { name: 'Close Prior question' })).toBeDefined();
+      });
+      await send(view, 'use the submitted target');
+      fixture.activeTabId = 8;
+      view.rerender(app());
+      await act(async () => {
+        pending.resolve(admission);
+      });
+      await waitFor(() => {
+        expect(requests).toHaveLength(2);
+      });
+      expect(actions).toStrictEqual([{ code: expect.any(String), tabId: 7 }]);
+      expect(requests[0]).toContain('Selected tab title: Approved tab');
+      expect(view.getByRole('combobox', { name: 'Target tab' })).toHaveProperty('value', '7');
+      expect(view.getByRole('button', { name: 'Stop' })).toBeDefined();
+      expect(store.get(draftAtomFamily('conversation-1'))).toBe('');
+      await act(async () => {
+        finish.resolve();
+      });
+      await waitFor(() => {
+        expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+      });
+    } finally {
+      view.unmount();
+      pending.resolve(admission);
+      finish.resolve();
+    }
+  });
+
+  it.each([
+    { change: 'selection change', site: 'queue' },
+    { change: 'tab removal', site: 'queue' },
+    { change: 'selection change', site: 'workflow' },
+    { change: 'tab removal', site: 'workflow' },
+  ] as const)(
+    'pauses $site input after $change during delayed admission until explicit Resume',
+    async ({ change, site }) => {
+      const history = seedHistory();
+      fixture.tabs.push({ id: 8, title: 'Replacement tab', url: 'https://example.com/other' });
+      const admission = await coordinator().acquireLocal();
+      hold(admission);
+      const pending = Promise.withResolvers<BrowserAdmission>();
+      const entered = Promise.withResolvers<void>();
+      vi.spyOn(coordinator(), 'acquireLocal').mockImplementationOnce(() => {
+        entered.resolve();
+        return pending.promise;
+      });
+      const request = { input: { order: 'order-42' }, workflowId: 'wf-1' };
+      const queued = 'queued for approved tab';
+      if (site === 'queue') {
+        store.set(queuedMessageAtomFamily('conversation-1'), queued);
+        gateway = async () => (requests.length === 1 ? workflowResponse() : response());
+      }
+      const view = renderApp();
+      try {
+        await waitFor(() => {
+          expect(view.getByRole('button', { name: 'Close Prior question' })).toBeDefined();
+        });
+        if (site === 'workflow') {
+          await act(async () => {
+            store.set(workflowRunRequestAtom, request);
+          });
+        }
+        await entered.promise;
+        if (change === 'selection change') {
+          fireEvent.change(view.getByRole('combobox', { name: 'Target tab' }), {
+            target: { value: '8' },
+          });
+        } else {
+          fixture.tabs = fixture.tabs.filter(tab => tab.id !== 7);
+          fixture.activeTabId = 8;
+          view.rerender(app());
+        }
+        await act(async () => {
+          pending.resolve(admission);
+        });
+        const resumeLabel = site === 'queue' ? 'Resume queued message' : 'Resume workflow';
+        await waitFor(() => {
+          expect(view.getByRole('button', { name: resumeLabel })).toBeDefined();
+        });
+        await waitFor(async () => {
+          expect(
+            (await nativeLocks.query()).held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
+          ).toBe(false);
+        });
+        expect({ actions, events: storedEvents(), requests }).toStrictEqual({
+          actions: [],
+          events: history,
+          requests: [],
+        });
+        expect(
+          site === 'queue'
+            ? store.get(queuedMessageAtomFamily('conversation-1'))
+            : store.get(workflowRunRequestAtom)
+        ).toStrictEqual(site === 'queue' ? queued : request);
+        view.rerender(app());
+        await act(async () => {
+          await coordinator().refresh();
+        });
+        expect({ actions, requests }).toStrictEqual({ actions: [], requests: [] });
+        fireEvent.click(view.getByRole('button', { name: resumeLabel }));
+        await waitFor(() => {
+          expect(
+            storedEvents().some(event => event.type === 'message' && event.text === 'Answer done.')
+          ).toBe(true);
+          expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+        });
+        expect({
+          actions,
+          queued: store.get(queuedMessageAtomFamily('conversation-1')),
+          request: store.get(workflowRunRequestAtom),
+          requests: requests.length,
+        }).toStrictEqual({
+          actions: [{ code: expect.any(String), tabId: 8 }],
+          queued: undefined,
+          request: undefined,
+          requests: site === 'queue' ? 2 : 1,
+        });
+      } finally {
+        view.unmount();
+        pending.resolve(admission);
+      }
+    }
+  );
+
+  /* eslint-disable jest/no-conditional-expect -- Each admission fixture checks its distinct retained input. */
+  it.each(['draft', 'queue', 'workflow'] as const)(
+    'retains %s input after an admission exception until explicit submission',
+    async site => {
+      const request = { input: { order: 'order-42' }, workflowId: 'wf-1' };
+      vi.spyOn(coordinator(), 'acquireLocal').mockRejectedValueOnce(
+        new Error('Browser admission is unavailable. Submit again.')
+      );
+      if (site === 'queue') {
+        store.set(queuedMessageAtomFamily('conversation-1'), 'retained queue');
+      }
+      const view = renderApp();
+      await waitFor(() => {
+        expect(store.get(activeConversationIdAtom)).toBe('conversation-1');
+      });
+      if (site === 'draft') {
+        await send(view, '  retained draft  ');
+      } else if (site === 'workflow') {
+        fireEvent.change(view.getByRole('textbox', { name: 'Message agent' }), {
+          target: { value: 'retained workflow draft' },
+        });
+        await waitFor(() => {
+          expect(view.getByRole('button', { name: 'Send message' })).toHaveProperty(
+            'disabled',
+            false
+          );
+        });
+        await act(async () => {
+          store.set(workflowRunRequestAtom, request);
+        });
+      }
+      await waitFor(() => {
+        expect(view.getByRole('status').textContent).toContain('Browser admission is unavailable');
+      });
+      const provider = hold(await coordinator().acquireProviderOwner());
+      const delegated = hold(
+        await coordinator().acquireDelegated(
+          provider,
+          'temporary-owner',
+          new AbortController().signal
+        )
+      );
+      await act(async () => {
+        await delegated.release();
+        await coordinator().refresh();
+      });
+      expect(view.getByRole('status').textContent).toContain('Browser admission is unavailable');
+      expect({ actions, requests }).toStrictEqual({ actions: [], requests: [] });
+      if (site === 'draft') {
+        expect(store.get(draftAtomFamily('conversation-1'))).toBe('  retained draft  ');
+        await send(view, '  retained draft  ');
+      } else if (site === 'queue') {
+        expect(view.getByText('Queued: retained queue')).toBeDefined();
+        fireEvent.click(view.getByRole('button', { name: 'Resume queued message' }));
+      } else {
+        expect(store.get(workflowRunRequestAtom)).toBe(request);
+        fireEvent.click(view.getByRole('button', { name: 'Resume workflow' }));
+      }
+      await waitFor(() => {
+        expect(requests).toHaveLength(1);
+      });
+    }
+  );
+  /* eslint-enable jest/no-conditional-expect */
+
+  /* eslint-disable jest/no-conditional-expect -- Each admission order and cancellation site has a distinct retained input. */
+  it.each(['chat', 'workflow'] as const)(
+    'keeps one live run and intact history when %s admission resolves first',
+    async first => {
+      const history = seedHistory();
+      const workflowAdmission = await coordinator().acquireLocal();
+      const chatAdmission = await coordinator().acquireLocal();
+      hold(workflowAdmission);
+      hold(chatAdmission);
+      const workflowPending = Promise.withResolvers<BrowserAdmission>();
+      const chatPending = Promise.withResolvers<BrowserAdmission>();
+      vi.spyOn(coordinator(), 'acquireLocal')
+        .mockReturnValueOnce(workflowPending.promise)
+        .mockReturnValueOnce(chatPending.promise);
+      const finishFirst = Promise.withResolvers<void>();
+      gateway = async () => {
+        await finishFirst.promise;
+        return response();
+      };
+      const request = { input: { order: 'order-42' }, workflowId: 'wf-1' };
+      const view = renderApp();
+      try {
+        await waitFor(() => {
+          expect(view.getByRole('button', { name: 'Close Prior question' })).toBeDefined();
+        });
+        await act(async () => {
+          store.set(workflowRunRequestAtom, request);
+        });
+        await send(view, 'competing draft');
+        await act(async () => {
+          if (first === 'chat') {
+            chatPending.resolve(chatAdmission);
+          } else {
+            workflowPending.resolve(workflowAdmission);
+          }
+        });
+        await waitFor(() => {
+          expect(requests).toHaveLength(1);
+        });
+        await act(async () => {
+          if (first === 'chat') {
+            workflowPending.resolve(workflowAdmission);
+          } else {
+            chatPending.resolve(chatAdmission);
+          }
+        });
+        await waitFor(async () => {
+          expect(
+            (await nativeLocks.query()).held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)
+          ).toHaveLength(1);
+        });
+        expect({
+          events: storedEvents(),
+          requests,
+          running: store.get(runningConversationIdsAtom),
+          stop: view.getByRole('button', { name: 'Stop' }).textContent,
+        }).toStrictEqual({
+          events: expect.arrayContaining(history),
+          requests: [expect.stringContaining('Prior answer')],
+          running: ['conversation-1'],
+          stop: 'Stop',
+        });
+        if (first === 'chat') {
+          expect(actions).toStrictEqual([]);
+          expect(store.get(workflowRunRequestAtom)).toBe(request);
+          expect(view.getByRole('button', { name: 'Resume workflow' })).toBeDefined();
+        } else {
+          expect(actions).toHaveLength(1);
+          expect(store.get(queuedMessageAtomFamily('conversation-1'))).toBe('competing draft');
+          expect(view.getByText('Queued: competing draft')).toBeDefined();
+        }
+        await act(async () => {
+          finishFirst.resolve();
+        });
+        if (first === 'chat') {
+          await waitFor(() => {
+            expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+          });
+          expect(requests).toHaveLength(1);
+          expect(actions).toStrictEqual([]);
+          expect(store.get(workflowRunRequestAtom)).toBe(request);
+          fireEvent.click(view.getByRole('button', { name: 'Resume workflow' }));
+        }
+        await waitFor(() => {
+          expect(requests).toHaveLength(2);
+          expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+        });
+        expect(requests[1]).toContain('Prior answer');
+        expect(requests[1]).toContain('Answer done.');
+        expect(requests[1]).toContain('competing draft');
+        expect({
+          actions,
+          events: storedEvents(),
+          queued: store.get(queuedMessageAtomFamily('conversation-1')),
+          request: store.get(workflowRunRequestAtom),
+          requests: requests.length,
+        }).toStrictEqual({
+          actions: [{ code: expect.stringContaining('order-42'), tabId: 7 }],
+          events: expect.arrayContaining(history),
+          queued: undefined,
+          request: undefined,
+          requests: 2,
+        });
+      } finally {
+        view.unmount();
+        workflowPending.resolve(workflowAdmission);
+        chatPending.resolve(chatAdmission);
+        finishFirst.resolve();
+      }
+    }
+  );
+
+  it.each([
+    { cancellation: 'close', site: 'draft' },
+    { cancellation: 'close', site: 'queue' },
+    { cancellation: 'close', site: 'workflow' },
+    { cancellation: 'unmount', site: 'draft' },
+    { cancellation: 'unmount', site: 'queue' },
+    { cancellation: 'unmount', site: 'workflow' },
+  ] as const)(
+    'prevents late $site execution after conversation $cancellation',
+    async ({ site, cancellation }) => {
+      const history = seedHistory();
+      const admission = await coordinator().acquireLocal();
+      hold(admission);
+      const pending = Promise.withResolvers<BrowserAdmission>();
+      const entered = Promise.withResolvers<void>();
+      vi.spyOn(coordinator(), 'acquireLocal').mockImplementationOnce(() => {
+        entered.resolve();
+        return pending.promise;
+      });
+      if (site === 'queue') {
+        store.set(queuedMessageAtomFamily('conversation-1'), 'cancelled queue');
+      }
+      const view = renderApp();
+      await waitFor(() => {
+        expect(view.getByRole('button', { name: 'Close Prior question' })).toBeDefined();
+      });
+      if (site === 'draft') {
+        await send(view, 'retained cancelled draft');
+      } else if (site === 'workflow') {
+        await act(async () => {
+          store.set(workflowRunRequestAtom, { input: { order: 'cancelled' }, workflowId: 'wf-1' });
+        });
+      }
+      await entered.promise;
+      if (cancellation === 'close') {
+        fireEvent.click(view.getByRole('button', { name: 'Close Prior question' }));
+      } else {
+        view.unmount();
+      }
+      await act(async () => {
+        pending.resolve(admission);
+      });
+      await waitFor(async () => {
+        expect(
+          (await nativeLocks.query()).held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
+        ).toBe(false);
+      });
+      expect({ actions, requests }).toStrictEqual({ actions: [], requests: [] });
+      expect(storedEvents()).toStrictEqual(history);
+      expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+      expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+      if (site === 'draft') {
+        expect(store.get(draftAtomFamily('conversation-1'))).toBe('retained cancelled draft');
+      }
+    }
+  );
+  /* eslint-enable jest/no-conditional-expect */
+
+  it('invalidates pending draft admission when Stop cancels the active run', async () => {
+    const finish = Promise.withResolvers<void>();
+    gateway = async () => {
+      await finish.promise;
+      return response();
+    };
+    const view = renderApp();
+    const pending = Promise.withResolvers<BrowserAdmission>();
+    const admission = await coordinator().acquireLocal();
+    hold(admission);
+    try {
+      await send(view, 'active turn');
+      await waitFor(() => {
+        expect(requests).toHaveLength(1);
+      });
+      vi.spyOn(coordinator(), 'acquireLocal').mockReturnValueOnce(pending.promise);
+      await send(view, 'retain this cancelled admission');
+      fireEvent.click(view.getByRole('button', { name: 'Stop' }));
+      await act(async () => {
+        pending.resolve(admission);
+        finish.resolve();
+      });
+      await waitFor(async () => {
+        expect(
+          (await nativeLocks.query()).held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
+        ).toBe(false);
+      });
+      expect(store.get(draftAtomFamily('conversation-1'))).toBe('retain this cancelled admission');
+      expect(store.get(queuedMessageAtomFamily('conversation-1'))).toBeUndefined();
+      expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+      expect(requests).toHaveLength(1);
+      expect(actions).toStrictEqual([]);
+    } finally {
+      view.unmount();
+      pending.resolve(admission);
+      finish.resolve();
+    }
+  });
+
+  it('releases a reserved workflow lease when the conversation cannot start', async () => {
+    const lease = hold(await coordinator().acquireLocal());
+    const request = { input: { order: 'order-42' }, workflowId: 'wf-1' };
+    reserveWorkflowLease(request, lease, 'conversation-1');
+    store.set(runningConversationIdsAtom, ['conversation-1']);
+    const view = renderApp();
+    await act(async () => {
+      store.set(workflowRunRequestAtom, request);
+    });
+    await waitFor(() => {
+      expect(view.getByRole('button', { name: 'Resume workflow' })).toBeDefined();
+    });
+    await waitFor(async () => {
+      expect(
+        (await nativeLocks.query()).held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
+      ).toBe(false);
+    });
+    expect(store.get(workflowRunRequestAtom)).toBe(request);
+    expect({ actions, requests }).toStrictEqual({ actions: [], requests: [] });
+  });
+
+  it('retains a blocked draft and requires a new Send after delegated control returns', async () => {
+    const provider = hold(await coordinator().acquireProviderOwner());
+    const delegated = hold(
+      await coordinator().acquireDelegated(provider, 'parent-chat', new AbortController().signal)
+    );
+    const view = renderApp();
+    await send(view, '  keep my draft  ');
+    await waitFor(() => {
+      expect(view.getByRole('status').textContent).toContain('parent-chat');
+    });
+    expect(store.get(draftAtomFamily('conversation-1'))).toBe('  keep my draft  ');
+    expect(storedEvents()).toStrictEqual([]);
+    await act(async () => {
+      await delegated.release();
+      await coordinator().refresh();
+    });
+    expect({
+      draft: store.get(draftAtomFamily('conversation-1')),
+      events: storedEvents(),
+      requests,
+      status: view.getByRole('status').textContent,
+    }).toStrictEqual({
+      draft: '  keep my draft  ',
+      events: [],
+      requests: [],
+      status: expect.stringMatching(/^Your message is retained\. Submit it again/u),
+    });
+    await send(view, '  keep my draft  ');
+    await waitFor(() => {
+      expect(
+        storedEvents().some(event => event.type === 'message' && event.text === 'Answer done.')
+      ).toBe(true);
+    });
+    expect(store.get(draftAtomFamily('conversation-1'))).toBe('');
+    expect(requests).toHaveLength(1);
+  });
+
+  it('returns to idle after delegation releases without inventing retained input', async () => {
+    const provider = hold(await coordinator().acquireProviderOwner());
+    const delegated = hold(
+      await coordinator().acquireDelegated(provider, 'idle-owner', new AbortController().signal)
+    );
+    const view = renderApp();
+    await waitFor(() => {
+      expect(view.getByRole('status').textContent).toContain('idle-owner');
+    });
+    await act(async () => {
+      await delegated.release();
+      await coordinator().refresh();
+    });
+    expect(view.queryByRole('status')).toBeNull();
+    expect(view.queryByRole('button', { name: /Resume/u })).toBeNull();
+    expect({ actions, requests }).toStrictEqual({ actions: [], requests: [] });
+    await send(view, 'ordinary local send');
+    await waitFor(() => {
+      expect(
+        storedEvents().some(event => event.type === 'message' && event.text === 'Answer done.')
+      ).toBe(true);
+    });
+    expect(requests).toHaveLength(1);
+  });
+
+  it('retains a blocked queue and pauses automatic draining until explicit Resume', async () => {
+    const firstResponse = Promise.withResolvers<void>();
+    gateway = async () => {
+      await firstResponse.promise;
+      return response();
+    };
+    const view = renderApp();
+    const provider = hold(await coordinator().acquireProviderOwner());
+    await send(view, 'first turn');
+    await waitFor(() => {
+      expect(requests).toHaveLength(1);
+    });
+    await send(view, 'queued follow-up');
+    await waitFor(() => {
+      expect(store.get(queuedMessageAtomFamily('conversation-1'))).toBe('queued follow-up');
+    });
+    const waiting = coordinator().acquireDelegated(
+      provider,
+      'parent-queue',
+      new AbortController().signal
+    );
+    await waitFor(async () => {
+      expect((await nativeLocks.query()).pending).toHaveLength(1);
+    });
+    firstResponse.resolve();
+    const delegated = hold(await waiting);
+    await waitFor(() => {
+      expect(view.getByRole('button', { name: 'Resume queued message' })).toBeDefined();
+    });
+    expect(view.getByText('Queued: queued follow-up')).toBeDefined();
+    await act(async () => {
+      await delegated.release();
+      await coordinator().refresh();
+    });
+    expect(requests).toHaveLength(1);
+    expect(store.get(queuedMessageAtomFamily('conversation-1'))).toBe('queued follow-up');
+    fireEvent.click(view.getByRole('button', { name: 'Resume queued message' }));
+    await waitFor(() => {
+      expect(requests).toHaveLength(2);
+    });
+    expect(requests[1]).toContain('Answer done.');
+    expect(store.get(queuedMessageAtomFamily('conversation-1'))).toBeUndefined();
+  });
+
+  it('preserves a new draft instead of queueing it behind a waiting delegation', async () => {
+    const firstResponse = Promise.withResolvers<void>();
+    gateway = async () => {
+      await firstResponse.promise;
+      return response();
+    };
+    const view = renderApp();
+    const provider = hold(await coordinator().acquireProviderOwner());
+    await send(view, 'first turn');
+    await waitFor(() => {
+      expect(requests).toHaveLength(1);
+    });
+    const waiting = coordinator().acquireDelegated(
+      provider,
+      'parent-wait',
+      new AbortController().signal
+    );
+    await waitFor(async () => {
+      expect((await nativeLocks.query()).pending).toHaveLength(1);
+    });
+    await send(view, 'do not queue this');
+    await waitFor(() => {
+      expect(view.getByRole('status').textContent).toContain('parent-wait');
+    });
+    expect(store.get(draftAtomFamily('conversation-1'))).toBe('do not queue this');
+    expect(store.get(queuedMessageAtomFamily('conversation-1'))).toBeUndefined();
+    firstResponse.resolve();
+    hold(await waiting);
+  });
+
+  it('retains a blocked legacy workflow request and its parameters until explicit Resume', async () => {
+    const provider = hold(await coordinator().acquireProviderOwner());
+    const delegated = hold(
+      await coordinator().acquireDelegated(
+        provider,
+        'parent-workflow',
+        new AbortController().signal
+      )
+    );
+    const view = renderApp();
+    await send(view, 'retained draft');
+    const request = { input: { order: 'order-42' }, workflowId: 'wf-1' };
+    await act(async () => {
+      store.set(workflowRunRequestAtom, request);
+    });
+    await waitFor(() => {
+      expect(view.getByRole('button', { name: 'Resume workflow' })).toBeDefined();
+    });
+    expect(store.get(workflowRunRequestAtom)).toBe(request);
+    await act(async () => {
+      await delegated.release();
+      await coordinator().refresh();
+    });
+    expect(actions).toStrictEqual([]);
+    expect(requests).toStrictEqual([]);
+    fireEvent.click(view.getByRole('button', { name: 'Resume workflow' }));
+    await waitFor(() => {
+      expect(actions).toHaveLength(1);
+    });
+    expect(actions[0]?.code).toContain('order-42');
+    expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+    await waitFor(() => {
+      expect(requests).toHaveLength(1);
+    });
+  });
+
+  it('quarantines a Settings workflow timeout before any model continuation or later admission', async () => {
+    fixture.dispatch = async request => {
+      actions.push({ code: request.code, tabId: request.tabId });
+      return {
+        ok: true,
+        result: { effectsUncertain: true, error: 'Script timed out.', ok: false },
+        type: request.type,
+      };
+    };
+    const view = renderApp(true);
+    await waitFor(() => {
+      expect(view.getByLabelText('Run workflow "Read order"')).toHaveProperty('disabled', false);
+    });
+    fireEvent.click(view.getByLabelText('Run workflow "Read order"'));
+    await waitFor(() => {
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+    });
+    await waitFor(async () => {
+      expect(
+        (await nativeLocks.query()).held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
+      ).toBe(false);
+    });
+    expect(storedEvents().some(event => event.type === 'tool-result' && !event.ok)).toBe(true);
+    await send(view, 'blocked local action');
+    const owner = hold(await coordinator().acquireProviderOwner());
+    const delegated = await coordinator().acquireDelegated(
+      owner,
+      'parent-after-timeout',
+      new AbortController().signal
+    );
+    const local = await coordinator().acquireLocal();
+    expect({
+      actions: actions.length,
+      delegated: delegated.admitted,
+      draft: store.get(draftAtomFamily('conversation-1')),
+      local: local.admitted,
+      requests,
+    }).toStrictEqual({
+      actions: 1,
+      delegated: false,
+      draft: 'blocked local action',
+      local: false,
+      requests: [],
+    });
+  });
+
+  it('recovers a failed safety write after the panel drops its completed workflow run', async () => {
+    fixture.dispatch = async request => {
+      actions.push({ code: request.code, tabId: request.tabId });
+      return {
+        ok: true,
+        result: { effectsUncertain: true, error: 'Script timed out.', ok: false },
+        type: request.type,
+      };
+    };
+    const view = renderApp(true);
+    try {
+      await waitFor(() => {
+        expect(view.getByLabelText('Run workflow "Read order"')).toHaveProperty('disabled', false);
+      });
+      fixture.failSafetyWrite = true;
+      fireEvent.click(view.getByLabelText('Run workflow "Read order"'));
+      await waitFor(() => {
+        expect(actions).toHaveLength(1);
+        expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+        expect(coordinator().getSnapshot().blockedReason).toContain('safety state is unavailable');
+      });
+      expect({
+        held: (await nativeLocks.query()).held?.filter(
+          lock => lock.name === BROWSER_EXECUTION_LOCK
+        ),
+        persisted: fixture.values.has(BROWSER_EXECUTION_SAFETY_KEY),
+        request: store.get(workflowRunRequestAtom),
+        requests,
+      }).toMatchObject({
+        held: [{ mode: 'shared' }],
+        persisted: false,
+        request: undefined,
+        requests: [],
+      });
+      await send(view, 'retained after safety failure');
+      const provider = hold(await coordinator().acquireProviderOwner());
+      expect({
+        delegated: (
+          await coordinator().acquireDelegated(
+            provider,
+            'after-failed-write',
+            new AbortController().signal
+          )
+        ).admitted,
+        local: (await coordinator().acquireLocal()).admitted,
+        recovery: await coordinator().recover(async () => [7]),
+      }).toMatchObject({ delegated: false, local: false, recovery: { recovered: false } });
+      fixture.failSafetyWrite = false;
+      await act(async () => {
+        await coordinator().refresh();
+        expect(
+          (await nativeLocks.query()).held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)
+        ).toMatchObject([{ mode: 'shared' }]);
+        await expect(coordinator().recover(async () => [7])).resolves.toStrictEqual({
+          reason: 'Close all affected tabs before recovery.',
+          recovered: false,
+        });
+      });
+      expect({
+        local: (await coordinator().acquireLocal()).admitted,
+        safety: fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY),
+      }).toStrictEqual({ local: false, safety: { tabIds: [7], version: 1 } });
+      fixture.tabs = [];
+      await act(async () => {
+        await expect(
+          coordinator().recover(async () => fixture.tabs.map(tab => tab.id))
+        ).resolves.toMatchObject({ recovered: true });
+      });
+      const nativeState = await nativeLocks.query();
+      expect({
+        actions: actions.length,
+        draft: store.get(draftAtomFamily('conversation-1')),
+        held: nativeState.held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK),
+        pending: nativeState.pending?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK),
+        requests,
+        safety: fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY),
+        status: view.getByRole('status').textContent,
+      }).toStrictEqual({
+        actions: 1,
+        draft: 'retained after safety failure',
+        held: [],
+        pending: [],
+        requests: [],
+        safety: { tabIds: [], version: 1 },
+        status: expect.stringMatching(/^Your message is retained\. Submit it again/u),
+      });
+      const local = hold(await coordinator().acquireLocal());
+      await local.release();
+      const delegated = hold(
+        await coordinator().acquireDelegated(provider, 'new-work', new AbortController().signal)
+      );
+      await delegated.release();
+      expect({ actions: actions.length, requests }).toStrictEqual({ actions: 1, requests: [] });
+    } finally {
+      fixture.failSafetyWrite = false;
+      await coordinator().recover(async () => []);
+    }
+  });
+
+  it.each(['safe', 'dangerous'] as const)(
+    'keeps one %s lease and tab through workflows and invisible continuation',
+    async mode => {
+      const local = hold(await coordinator().acquireLocal());
+      const provider = hold(await coordinator().acquireProviderOwner());
+      const finalResponse = Promise.withResolvers<void>();
+      gateway = async () => {
+        if (requests.length === 1) {
+          return response(
+            {
+              tool_calls: [
+                {
+                  function: {
+                    arguments: JSON.stringify({ workflowId: 'wf-1' }),
+                    name: 'run_workflow',
+                  },
+                  id: 'workflow-call',
+                  index: 0,
+                },
+              ],
+            },
+            'tool_calls'
+          );
+        }
+        if (requests.length === 2) {
+          return response({ content: "I'll finish the workflow now." });
+        }
+        await finalResponse.promise;
+        return response();
+      };
+      const context = runContext(local, mode);
+      const running = runBrowserTurn(context, []);
+      fixture.activeTabId = 8;
+      fixture.tabs.push({ id: 8, title: 'Other tab', url: 'https://example.com/other' });
+      await waitFor(() => {
+        expect(requests).toHaveLength(3);
+      });
+      const waiting = coordinator().acquireDelegated(
+        provider,
+        'parent-next',
+        new AbortController().signal
+      );
+      await waitFor(async () => {
+        expect((await nativeLocks.query()).pending).toHaveLength(1);
+      });
+      expect(actions.map(action => action.tabId)).toStrictEqual([7]);
+      expect(requests[2]).toContain('Continue: finish the request now');
+      expect(events.some(event => event.type === 'message' && event.role === 'user')).toBe(false);
+      finalResponse.resolve();
+      await expect(running).resolves.toMatchObject({
+        effectsUncertain: false,
+        status: 'succeeded',
+        summary: 'Answer done.',
+        toolResults: [expect.objectContaining({ ok: true })],
+      });
+      await local.release();
+      hold(await waiting);
+    }
+  );
+
+  it('rejects a provider-owner lease at the public execution API', async () => {
+    const provider = hold(await coordinator().acquireProviderOwner());
+    await expect(runBrowserTurn(runContext(provider), [])).rejects.toThrow(
+      'execution_lease_required'
+    );
+    expect(requests).toStrictEqual([]);
+    expect(actions).toStrictEqual([]);
+  });
+
+  it('never falls back to another tab when the supplied approved tab is absent', async () => {
+    const local = hold(await coordinator().acquireLocal());
+    fixture.tabs = [{ id: 8, title: 'Other tab', url: 'https://example.com/other' }];
+    fixture.activeTabId = 8;
+    await expect(runBrowserTurn(runContext(local), [])).rejects.toThrow('tab_lost');
+    expect(requests).toStrictEqual([]);
+    expect(actions).toStrictEqual([]);
+  });
+
+  it('aborts the bound tab without releasing its lease before the runner unwinds', async () => {
+    const local = hold(await coordinator().acquireLocal());
+    const context = runContext(local);
+    const pendingResponse = Promise.withResolvers<void>();
+    gateway = async () => {
+      await pendingResponse.promise;
+      return response();
+    };
+    const running = runBrowserTurn(context, []);
+    await waitFor(() => {
+      expect(requests).toHaveLength(1);
+    });
+    for (const listener of fixture.removed) {
+      listener(7);
+    }
+    expect(context.abort.signal.aborted).toBe(true);
+    expect(
+      (await nativeLocks.query()).held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
+    ).toBe(true);
+    pendingResponse.resolve();
+    await expect(running).resolves.toMatchObject({ reason: 'tab_lost', status: 'interrupted' });
+    expect(actions).toStrictEqual([]);
+    expect(fixture.removed.size).toBe(0);
   });
 });

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.test.ts
@@ -551,6 +551,269 @@ describe('local admission and shared run context', () => {
       'tool_calls'
     );
 
+  /* eslint-disable jest/no-conditional-expect -- Each deferred outcome checks its retained input and explicit retry control. */
+  it.each(['success', 'rejection', 'error'] as const)(
+    'announces delayed Send admission through %s without consuming or duplicating a draft',
+    async outcome => {
+      const history = seedHistory();
+      const admission = await coordinator().acquireLocal();
+      hold(admission);
+      const pending = Promise.withResolvers<BrowserAdmission>();
+      vi.spyOn(coordinator(), 'acquireLocal').mockReturnValueOnce(pending.promise);
+      const finish = Promise.withResolvers<void>();
+      gateway = async () => {
+        await finish.promise;
+        return response();
+      };
+      const view = renderApp();
+      try {
+        await waitFor(() => {
+          expect(view.getByRole('button', { name: 'Close Prior question' })).toBeDefined();
+        });
+        const textbox = view.getByRole('textbox', { name: 'Message agent' });
+        const sendButton = view.getByRole('button', { name: 'Send message' });
+        const status = view.getByRole('status');
+        fireEvent.keyDown(textbox, { key: 'Enter' });
+        expect({ className: status.className, text: status.textContent }).toStrictEqual({
+          className: 'sr-only',
+          text: '',
+        });
+        fireEvent.change(textbox, { target: { value: '  submitted draft  ' } });
+        fireEvent.click(sendButton);
+        expect({
+          disabled: sendButton.hasAttribute('disabled'),
+          draft: store.get(draftAtomFamily('conversation-1')),
+          sameButton: view.getByRole('button', { name: 'Send message' }) === sendButton,
+          sameStatus: view.getByRole('status') === status,
+          screenReaderOnly: status.classList.contains('sr-only'),
+          status: status.textContent,
+        }).toStrictEqual({
+          disabled: true,
+          draft: '  submitted draft  ',
+          sameButton: true,
+          sameStatus: true,
+          screenReaderOnly: false,
+          status: expect.stringContaining('Checking browser control'),
+        });
+        fireEvent.change(textbox, { target: { value: 'updated while waiting' } });
+        fireEvent.click(sendButton);
+        fireEvent.keyDown(textbox, { key: 'Enter' });
+        fireEvent.keyDown(textbox, { key: 'Enter' });
+        expect({
+          actions,
+          draft: store.get(draftAtomFamily('conversation-1')),
+          events: storedEvents(),
+          requests,
+        }).toStrictEqual({
+          actions: [],
+          draft: 'updated while waiting',
+          events: history,
+          requests: [],
+        });
+        await act(async () => {
+          if (outcome === 'error') {
+            pending.reject(new Error('Admission unavailable.'));
+          } else {
+            pending.resolve(
+              outcome === 'success' ? admission : { admitted: false, reason: 'Busy' }
+            );
+          }
+        });
+        if (outcome !== 'success') {
+          view.rerender(app());
+          expect({
+            actions,
+            disabled: sendButton.hasAttribute('disabled'),
+            events: storedEvents(),
+            pending: view.queryByText(/Checking browser control/u),
+            requests,
+            status: view.getByRole('status').textContent,
+          }).toStrictEqual({
+            actions: [],
+            disabled: false,
+            events: history,
+            pending: null,
+            requests: [],
+            status: expect.stringContaining('retained'),
+          });
+          fireEvent.click(sendButton);
+        }
+        await waitFor(() => {
+          expect(requests).toHaveLength(1);
+          expect(view.queryByText(/Checking browser control/u)).toBeNull();
+        });
+        expect({
+          disabled: sendButton.hasAttribute('disabled'),
+          draft: store.get(draftAtomFamily('conversation-1')),
+          queued: store.get(queuedMessageAtomFamily('conversation-1')),
+          requests,
+          sameButton: view.getByRole('button', { name: 'Stop' }) === sendButton,
+        }).toStrictEqual({
+          disabled: false,
+          draft: outcome === 'success' ? 'updated while waiting' : '',
+          queued: undefined,
+          requests: [
+            expect.stringContaining(
+              outcome === 'success' ? 'submitted draft' : 'updated while waiting'
+            ),
+          ],
+          sameButton: true,
+        });
+        await act(async () => {
+          finish.resolve();
+        });
+        await waitFor(() => {
+          expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+          expect(requests).toHaveLength(1);
+        });
+      } finally {
+        view.unmount();
+        pending.resolve(admission);
+        finish.resolve();
+      }
+    }
+  );
+
+  it.each([
+    { outcome: 'success', site: 'queue' },
+    { outcome: 'success', site: 'workflow' },
+    { outcome: 'rejection', site: 'queue' },
+    { outcome: 'rejection', site: 'workflow' },
+    { outcome: 'error', site: 'queue' },
+    { outcome: 'error', site: 'workflow' },
+  ] as const)(
+    'announces delayed $site Resume through $outcome without consuming or duplicating input',
+    async ({ site, outcome }) => {
+      const history = seedHistory();
+      const admission = await coordinator().acquireLocal();
+      hold(admission);
+      const pending = Promise.withResolvers<BrowserAdmission>();
+      vi.spyOn(coordinator(), 'acquireLocal')
+        .mockResolvedValueOnce({ admitted: false, reason: 'Busy' })
+        .mockReturnValueOnce(pending.promise);
+      const request = { input: { order: 'order-42' }, workflowId: 'wf-1' };
+      const queued = 'retained queue';
+      if (site === 'queue') {
+        store.set(queuedMessageAtomFamily('conversation-1'), queued);
+      }
+      const finish = Promise.withResolvers<void>();
+      gateway = async () => {
+        await finish.promise;
+        return response();
+      };
+      const view = renderApp();
+      try {
+        await waitFor(() => {
+          expect(view.getByRole('button', { name: 'Close Prior question' })).toBeDefined();
+        });
+        if (site === 'workflow') {
+          await act(async () => {
+            store.set(workflowRunRequestAtom, request);
+          });
+        }
+        const label = site === 'queue' ? 'Resume queued message' : 'Resume workflow';
+        await waitFor(() => {
+          expect(view.getByRole('button', { name: label })).toHaveProperty('disabled', false);
+        });
+        const resume = view.getByRole('button', { name: label });
+        const status = view.getByRole('status');
+        expect(status.textContent).toContain('retained');
+        fireEvent.change(view.getByRole('textbox', { name: 'Message agent' }), {
+          target: { value: 'retain composer draft' },
+        });
+        fireEvent.click(resume);
+        expect({
+          disabled: resume.hasAttribute('disabled'),
+          sameButton: view.getByRole('button', { name: label }) === resume,
+          sameStatus: view.getByRole('status') === status,
+          screenReaderOnly: status.classList.contains('sr-only'),
+          status: status.textContent,
+        }).toStrictEqual({
+          disabled: true,
+          sameButton: true,
+          sameStatus: true,
+          screenReaderOnly: false,
+          status: expect.stringContaining('Checking browser control'),
+        });
+        fireEvent.click(resume);
+        fireEvent.click(resume);
+        expect({
+          actions,
+          events: storedEvents(),
+          input:
+            site === 'queue'
+              ? store.get(queuedMessageAtomFamily('conversation-1'))
+              : store.get(workflowRunRequestAtom),
+          requests,
+        }).toStrictEqual({
+          actions: [],
+          events: history,
+          input: site === 'queue' ? queued : request,
+          requests: [],
+        });
+        await act(async () => {
+          if (outcome === 'error') {
+            pending.reject(new Error('Admission unavailable. Resume explicitly.'));
+          } else {
+            pending.resolve(
+              outcome === 'success' ? admission : { admitted: false, reason: 'Busy' }
+            );
+          }
+        });
+        if (outcome !== 'success') {
+          view.rerender(app());
+          expect({
+            actions,
+            disabled: resume.hasAttribute('disabled'),
+            events: storedEvents(),
+            input:
+              site === 'queue'
+                ? store.get(queuedMessageAtomFamily('conversation-1'))
+                : store.get(workflowRunRequestAtom),
+            pending: view.queryByText(/Checking browser control/u),
+            requests,
+          }).toStrictEqual({
+            actions: [],
+            disabled: false,
+            events: history,
+            input: site === 'queue' ? queued : request,
+            pending: null,
+            requests: [],
+          });
+          fireEvent.click(resume);
+        }
+        await waitFor(() => {
+          expect(requests).toHaveLength(1);
+          expect(view.queryByText(/Checking browser control/u)).toBeNull();
+          expect(view.queryByRole('button', { name: label })).toBeNull();
+        });
+        expect({
+          actions: actions.length,
+          draft: store.get(draftAtomFamily('conversation-1')),
+          queued: store.get(queuedMessageAtomFamily('conversation-1')),
+          request: store.get(workflowRunRequestAtom),
+        }).toStrictEqual({
+          actions: site === 'queue' ? 0 : 1,
+          draft: 'retain composer draft',
+          queued: undefined,
+          request: undefined,
+        });
+        await act(async () => {
+          finish.resolve();
+        });
+        await waitFor(() => {
+          expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+          expect(requests).toHaveLength(1);
+        });
+      } finally {
+        view.unmount();
+        pending.resolve(admission);
+        finish.resolve();
+      }
+    }
+  );
+  /* eslint-enable jest/no-conditional-expect */
+
   it.each(['selection change', 'tab removal', 'unrefreshed tab removal'] as const)(
     'retains a submitted draft after %s during delayed admission',
     async change => {
@@ -642,6 +905,132 @@ describe('local admission and shared run context', () => {
       }
     }
   );
+
+  it('clears cancelled queue feedback without clearing a newer draft admission', async () => {
+    seedHistory();
+    const oldAdmission = await coordinator().acquireLocal();
+    const newAdmission = await coordinator().acquireLocal();
+    hold(oldAdmission);
+    hold(newAdmission);
+    const oldPending = Promise.withResolvers<BrowserAdmission>();
+    const newPending = Promise.withResolvers<BrowserAdmission>();
+    vi.spyOn(coordinator(), 'acquireLocal')
+      .mockReturnValueOnce(oldPending.promise)
+      .mockReturnValueOnce(newPending.promise);
+    store.set(queuedMessageAtomFamily('conversation-1'), 'cancel this queue');
+    store.set(draftAtomFamily('conversation-1'), 'keep this draft');
+    const view = renderApp();
+    try {
+      await waitFor(() => {
+        expect(view.getByRole('status').textContent).toContain('Checking browser control');
+      });
+      fireEvent.click(view.getByRole('button', { name: 'Cancel queued message' }));
+      const sendButton = view.getByRole('button', { name: 'Send message' });
+      expect({
+        disabled: sendButton.hasAttribute('disabled'),
+        pending: view.queryByText(/Checking browser control/u),
+      }).toStrictEqual({ disabled: false, pending: null });
+      fireEvent.click(sendButton);
+      expect(view.getByRole('status').textContent).toContain('Checking browser control');
+      await act(async () => {
+        oldPending.resolve(oldAdmission);
+      });
+      await waitFor(async () => {
+        expect(
+          (await nativeLocks.query()).held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)
+        ).toHaveLength(1);
+      });
+      expect({
+        actions,
+        disabled: sendButton.hasAttribute('disabled'),
+        draft: store.get(draftAtomFamily('conversation-1')),
+        queued: store.get(queuedMessageAtomFamily('conversation-1')),
+        requests,
+        status: view.getByRole('status').textContent,
+      }).toStrictEqual({
+        actions: [],
+        disabled: true,
+        draft: 'keep this draft',
+        queued: undefined,
+        requests: [],
+        status: expect.stringContaining('Checking browser control'),
+      });
+      fireEvent.keyDown(view.getByRole('textbox', { name: 'Message agent' }), { key: 'Enter' });
+      await act(async () => {
+        newPending.resolve(newAdmission);
+      });
+      await waitFor(() => {
+        expect(
+          storedEvents().some(event => event.type === 'message' && event.text === 'Answer done.')
+        ).toBe(true);
+        expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+      });
+      expect({ pending: view.queryByText(/Checking browser control/u), requests }).toStrictEqual({
+        pending: null,
+        requests: [expect.stringContaining('keep this draft')],
+      });
+      expect(requests[0]).not.toContain('cancel this queue');
+    } finally {
+      view.unmount();
+      oldPending.resolve(oldAdmission);
+      newPending.resolve(newAdmission);
+    }
+  });
+
+  it('keeps pending feedback and Send availability isolated between conversations', async () => {
+    seedHistory();
+    const admission = await coordinator().acquireLocal();
+    hold(admission);
+    const pending = Promise.withResolvers<BrowserAdmission>();
+    vi.spyOn(coordinator(), 'acquireLocal').mockReturnValueOnce(pending.promise);
+    const view = renderApp();
+    try {
+      await waitFor(() => {
+        expect(view.getByRole('tab', { name: 'Prior question' })).toBeDefined();
+      });
+      await send(view, 'first conversation draft');
+      expect(view.getByRole('status').textContent).toContain('Checking browser control');
+      fireEvent.click(view.getByRole('button', { name: 'New conversation' }));
+      fireEvent.change(view.getByRole('textbox', { name: 'Message agent' }), {
+        target: { value: 'second conversation draft' },
+      });
+      expect({
+        disabled: view.getByRole('button', { name: 'Send message' }).hasAttribute('disabled'),
+        status: view.getByRole('status').textContent,
+      }).toStrictEqual({ disabled: false, status: '' });
+      fireEvent.click(view.getByRole('button', { name: 'Send message' }));
+      await waitFor(() => {
+        expect(requests).toHaveLength(1);
+        expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+      });
+      expect({ draft: store.get(draftAtomFamily('conversation-1')), requests }).toStrictEqual({
+        draft: 'first conversation draft',
+        requests: [expect.stringContaining('second conversation draft')],
+      });
+      fireEvent.click(view.getByRole('tab', { name: 'Prior question' }));
+      expect({
+        disabled: view.getByRole('button', { name: 'Send message' }).hasAttribute('disabled'),
+        status: view.getByRole('status').textContent,
+      }).toStrictEqual({
+        disabled: true,
+        status: expect.stringContaining('Checking browser control'),
+      });
+      await act(async () => {
+        pending.resolve(admission);
+      });
+      await waitFor(() => {
+        expect(requests).toHaveLength(2);
+        expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
+      });
+      expect({ request: requests[1], status: view.getByRole('status').textContent }).toStrictEqual({
+        request: expect.stringContaining('first conversation draft'),
+        status: '',
+      });
+    } finally {
+      view.unmount();
+      pending.resolve(admission);
+    }
+  });
 
   it('keeps the submitted target when only the active browser tab changes during admission', async () => {
     seedHistory();
@@ -997,11 +1386,15 @@ describe('local admission and shared run context', () => {
         });
       }
       await entered.promise;
+      await waitFor(() => {
+        expect(view.getByRole('status').textContent).toContain('Checking browser control');
+      });
       if (cancellation === 'close') {
         fireEvent.click(view.getByRole('button', { name: 'Close Prior question' }));
       } else {
         view.unmount();
       }
+      expect(view.queryByText(/Checking browser control/u)).toBeNull();
       await act(async () => {
         pending.resolve(admission);
       });
@@ -1010,10 +1403,21 @@ describe('local admission and shared run context', () => {
           (await nativeLocks.query()).held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
         ).toBe(false);
       });
-      expect({ actions, requests }).toStrictEqual({ actions: [], requests: [] });
-      expect(storedEvents()).toStrictEqual(history);
-      expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
-      expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+      expect({
+        actions,
+        events: storedEvents(),
+        pending: view.queryByText(/Checking browser control/u),
+        request: store.get(workflowRunRequestAtom),
+        requests,
+        running: store.get(runningConversationIdsAtom),
+      }).toStrictEqual({
+        actions: [],
+        events: history,
+        pending: null,
+        request: undefined,
+        requests: [],
+        running: [],
+      });
       if (site === 'draft') {
         expect(store.get(draftAtomFamily('conversation-1'))).toBe('retained cancelled draft');
       }
@@ -1038,7 +1442,18 @@ describe('local admission and shared run context', () => {
       });
       vi.spyOn(coordinator(), 'acquireLocal').mockReturnValueOnce(pending.promise);
       await send(view, 'retain this cancelled admission');
+      expect({
+        disabled: view.getByRole('button', { name: 'Stop' }).hasAttribute('disabled'),
+        status: view.getByRole('status').textContent,
+      }).toStrictEqual({
+        disabled: false,
+        status: expect.stringContaining('Checking browser control'),
+      });
       fireEvent.click(view.getByRole('button', { name: 'Stop' }));
+      expect({
+        draft: store.get(draftAtomFamily('conversation-1')),
+        pending: view.queryByText(/Checking browser control/u),
+      }).toStrictEqual({ draft: 'retain this cancelled admission', pending: null });
       await act(async () => {
         pending.resolve(admission);
         finish.resolve();
@@ -1048,11 +1463,19 @@ describe('local admission and shared run context', () => {
           (await nativeLocks.query()).held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
         ).toBe(false);
       });
-      expect(store.get(draftAtomFamily('conversation-1'))).toBe('retain this cancelled admission');
-      expect(store.get(queuedMessageAtomFamily('conversation-1'))).toBeUndefined();
-      expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
-      expect(requests).toHaveLength(1);
-      expect(actions).toStrictEqual([]);
+      expect({
+        actions,
+        draft: store.get(draftAtomFamily('conversation-1')),
+        queued: store.get(queuedMessageAtomFamily('conversation-1')),
+        requests: requests.length,
+        running: store.get(runningConversationIdsAtom),
+      }).toStrictEqual({
+        actions: [],
+        draft: 'retain this cancelled admission',
+        queued: undefined,
+        requests: 1,
+        running: [],
+      });
     } finally {
       view.unmount();
       pending.resolve(admission);
@@ -1131,7 +1554,8 @@ describe('local admission and shared run context', () => {
       await delegated.release();
       await coordinator().refresh();
     });
-    expect(view.queryByRole('status')).toBeNull();
+    expect(view.getByRole('status').textContent).toBe('');
+    expect(view.getByRole('status').className).toBe('sr-only');
     expect(view.queryByRole('button', { name: /Resume/u })).toBeNull();
     expect({ actions, requests }).toStrictEqual({ actions: [], requests: [] });
     await send(view, 'ordinary local send');
@@ -1416,7 +1840,7 @@ describe('local admission and shared run context', () => {
         pending: nativeState.pending?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK),
         requests,
         safety: fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY),
-        status: view.getByRole('status').textContent,
+        statuses: view.getAllByRole('status').map(status => status.textContent),
       }).toStrictEqual({
         actions: 1,
         draft: 'retained after safety failure',
@@ -1424,7 +1848,7 @@ describe('local admission and shared run context', () => {
         pending: [],
         requests: [],
         safety: { tabIds: [], version: 1 },
-        status: expect.stringMatching(/^Your message is retained\. Submit it again/u),
+        statuses: [expect.stringMatching(/^Your message is retained\. Submit it again/u), ''],
       });
       const local = hold(await coordinator().acquireLocal());
       await local.release();

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -104,6 +104,11 @@ interface ConversationRunState {
   readonly token: number;
 }
 
+interface PendingAdmission {
+  readonly signal: AbortSignal;
+  readonly queued?: string;
+}
+
 export const getSelectedInspectableTabId = ({
   activeTabId,
   inspectableTabs,
@@ -188,7 +193,13 @@ export const AgentChatPanel = ({
   const execution = useBrowserExecutionSnapshot();
   const [admissionBlocker, setAdmissionBlocker] = useState<string>();
   const mountedRef = useRef(true);
-  const pendingAdmissionsRef = useRef(new Set<string>());
+  const pendingAdmissionsRef = useRef(new Map<string, PendingAdmission>());
+  const [pendingAdmissionIds, setPendingAdmissionIds] = useState<string[]>([]);
+  const [pendingWorkflowAdmission, setPendingWorkflowAdmission] = useState<{
+    request: WorkflowRunRequest;
+    conversationId: string;
+    isResuming: boolean;
+  }>();
   const admissionControllersRef = useRef(new Map<string, AbortController>());
   const pausedQueuesRef = useRef(new Set<string>());
   const [pausedQueueIds, setPausedQueueIds] = useState<string[]>([]);
@@ -371,12 +382,14 @@ export const AgentChatPanel = ({
     mountedRef.current = true;
     const runs = runStatesRef.current;
     const admissions = admissionControllersRef.current;
+    const pendingAdmissions = pendingAdmissionsRef.current;
     return () => {
       mountedRef.current = false;
       for (const controller of admissions.values()) {
         controller.abort();
       }
       admissions.clear();
+      pendingAdmissions.clear();
       for (const runState of runs.values()) {
         runState.abort.abort();
       }
@@ -845,17 +858,39 @@ export const AgentChatPanel = ({
     mountedRef.current &&
     !signal.aborted &&
     isStoredConversationOpen(conversationStoreRef.current, conversationId);
+  const finishAdmission = useCallback((conversationId: string, pending: PendingAdmission): void => {
+    if (pendingAdmissionsRef.current.get(conversationId) === pending) {
+      pendingAdmissionsRef.current.delete(conversationId);
+      if (mountedRef.current) {
+        setPendingAdmissionIds([...pendingAdmissionsRef.current.keys()]);
+      }
+    }
+  }, []);
   const cancelConversationAdmissions = useCallback(
     (conversationId: string): void => {
       admissionControllersRef.current.get(conversationId)?.abort();
       admissionControllersRef.current.delete(conversationId);
+      const pending = pendingAdmissionsRef.current.get(conversationId);
+      if (pending !== undefined) {
+        finishAdmission(conversationId, pending);
+      }
+      setPendingWorkflowAdmission(current =>
+        current?.conversationId === conversationId ? undefined : current
+      );
       const request = store.get(workflowRunRequestAtom);
       if (request !== undefined && processingWorkflowsRef.current.get(request) === conversationId) {
         store.set(workflowRunRequestAtom, undefined);
       }
     },
-    [store]
+    [finishAdmission, store]
   );
+
+  useEffect(() => {
+    const pending = pendingAdmissionsRef.current.get(activeConversationId);
+    if (pending?.queued !== undefined && pending.queued !== activeQueuedMessage) {
+      finishAdmission(activeConversationId, pending);
+    }
+  }, [activeConversationId, activeQueuedMessage, finishAdmission]);
 
   const submitDraft = async (): Promise<void> => {
     const conversationId = conversationStoreRef.current.activeConversationId;
@@ -866,14 +901,19 @@ export const AgentChatPanel = ({
     }
     const submittedTabId = getConversationSelectedTabId(conversationId);
     const signal = getAdmissionSignal(conversationId);
-    pendingAdmissionsRef.current.add(conversationId);
+    const pending = { signal };
+    pendingAdmissionsRef.current.set(conversationId, pending);
+    setPendingAdmissionIds([...pendingAdmissionsRef.current.keys()]);
     let lease: BrowserExecutionLease | undefined = undefined;
     let handedOff = false;
     try {
       const admission = await getBrowserExecutionCoordinator().acquireLocal();
       lease = admission.admitted ? admission.lease : undefined;
       const targetExists = lease !== undefined && (await isTabOpen(submittedTabId));
-      if (!isAdmissionCurrent(conversationId, signal)) {
+      if (
+        !isAdmissionCurrent(conversationId, signal) ||
+        pendingAdmissionsRef.current.get(conversationId) !== pending
+      ) {
         return;
       }
       if (
@@ -921,13 +961,18 @@ export const AgentChatPanel = ({
         store.set(draftAtomFamily(conversationId), '');
       }
     } catch (error) {
-      if (isAdmissionCurrent(conversationId, signal)) {
+      if (
+        isAdmissionCurrent(conversationId, signal) &&
+        pendingAdmissionsRef.current.get(conversationId) === pending
+      ) {
         setAdmissionBlocker(
-          error instanceof Error ? error.message : 'Browser admission stopped. Submit again.'
+          error instanceof Error
+            ? `${error.message} Your message is retained. Submit again explicitly.`
+            : 'Browser admission stopped. Submit again.'
         );
       }
     } finally {
-      pendingAdmissionsRef.current.delete(conversationId);
+      finishAdmission(conversationId, pending);
       if (lease !== undefined && !handedOff) {
         await lease.release();
       }
@@ -944,7 +989,9 @@ export const AgentChatPanel = ({
     }
     const submittedTabId = getConversationSelectedTabId(conversationId);
     const signal = getAdmissionSignal(conversationId);
-    pendingAdmissionsRef.current.add(conversationId);
+    const pending = { queued, signal };
+    pendingAdmissionsRef.current.set(conversationId, pending);
+    setPendingAdmissionIds([...pendingAdmissionsRef.current.keys()]);
     let lease: BrowserExecutionLease | undefined = undefined;
     let handedOff = false;
     try {
@@ -953,6 +1000,7 @@ export const AgentChatPanel = ({
       const targetExists = lease !== undefined && (await isTabOpen(submittedTabId));
       if (
         !isAdmissionCurrent(conversationId, signal) ||
+        pendingAdmissionsRef.current.get(conversationId) !== pending ||
         store.get(queuedMessageAtomFamily(conversationId)) !== queued
       ) {
         return;
@@ -979,15 +1027,20 @@ export const AgentChatPanel = ({
         setAdmissionBlocker(undefined);
       }
     } catch (error) {
-      if (isAdmissionCurrent(conversationId, signal)) {
+      if (
+        isAdmissionCurrent(conversationId, signal) &&
+        pendingAdmissionsRef.current.get(conversationId) === pending
+      ) {
         pausedQueuesRef.current.add(conversationId);
         setPausedQueueIds([...pausedQueuesRef.current]);
         setAdmissionBlocker(
-          error instanceof Error ? error.message : 'Browser admission stopped. Resume explicitly.'
+          error instanceof Error
+            ? `${error.message} Your queued message is retained. Resume explicitly.`
+            : 'Browser admission stopped. Resume explicitly.'
         );
       }
     } finally {
-      pendingAdmissionsRef.current.delete(conversationId);
+      finishAdmission(conversationId, pending);
       if (lease !== undefined && !handedOff) {
         await lease.release();
       }
@@ -1002,8 +1055,11 @@ export const AgentChatPanel = ({
   const workflowRunRequest = useAtomValue(workflowRunRequestAtom);
 
   useEffect(() => {
+    if (workflowRunRequest === undefined) {
+      setPendingWorkflowAdmission(undefined);
+      return;
+    }
     if (
-      workflowRunRequest === undefined ||
       blockedWorkflowRef.current === workflowRunRequest ||
       processingWorkflowsRef.current.has(workflowRunRequest)
     ) {
@@ -1015,6 +1071,11 @@ export const AgentChatPanel = ({
     const runSelectedTabId = getConversationSelectedTabId(conversationId);
     const signal = getAdmissionSignal(conversationId);
     processingWorkflowsRef.current.set(request, conversationId);
+    setPendingWorkflowAdmission(current => ({
+      conversationId,
+      isResuming: current?.request === request && current.isResuming,
+      request,
+    }));
     void (async (): Promise<void> => {
       let lease = reservation?.lease;
       let runState: RunState | undefined = undefined;
@@ -1065,6 +1126,9 @@ export const AgentChatPanel = ({
         // Consume only after admission; keep the same lease through workflow and model continuation.
         store.set(workflowRunRequestAtom, undefined);
         setAdmissionBlocker(undefined);
+        setPendingWorkflowAdmission(current =>
+          current?.request === request ? undefined : current
+        );
         runState = createRunState(conversationId, runSelectedTabId, lease);
         const selectedTab = inspectableTabsRef.current.find(tab => tab.id === runSelectedTabId);
         const workflowName =
@@ -1126,6 +1190,11 @@ export const AgentChatPanel = ({
         );
       } finally {
         processingWorkflowsRef.current.delete(request);
+        if (mountedRef.current) {
+          setPendingWorkflowAdmission(current =>
+            current?.request === request ? undefined : current
+          );
+        }
         if (runState !== undefined) {
           await finishRun(conversationId, runState);
         } else if (lease !== undefined) {
@@ -1397,6 +1466,14 @@ export const AgentChatPanel = ({
     return null;
   }
 
+  const messageAdmissionPending = pendingAdmissionIds.includes(activeConversationId);
+  const workflowAdmissionPending =
+    pendingWorkflowAdmission?.conversationId === activeConversationId;
+  const admissionStatus =
+    messageAdmissionPending || workflowAdmissionPending
+      ? 'Checking browser control… Your input is retained.'
+      : (execution.blockedReason ?? admissionBlocker);
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <ConversationTabs
@@ -1416,14 +1493,16 @@ export const AgentChatPanel = ({
         </p>
       )}
 
-      {execution.blockedReason === undefined && admissionBlocker === undefined ? null : (
-        <p
-          className="type-body border-t border-border px-4 py-2 text-status-yellow-400"
-          role="status"
-        >
-          {execution.blockedReason ?? admissionBlocker}
-        </p>
-      )}
+      <p
+        className={
+          admissionStatus === undefined
+            ? 'sr-only'
+            : 'type-body border-t border-border px-4 py-2 text-status-yellow-400'
+        }
+        role="status"
+      >
+        {admissionStatus}
+      </p>
       {execution.delegationUnavailableReason === undefined ? null : (
         <p className="type-label px-4 py-2 text-foreground-muted">
           {execution.delegationUnavailableReason}
@@ -1431,7 +1510,9 @@ export const AgentChatPanel = ({
       )}
       {pausedQueueIds.includes(activeConversationId) && activeQueuedMessage !== undefined ? (
         <button
-          className="type-label mx-4 my-2 rounded-md border border-border bg-surface-overlay p-2 text-foreground-on-secondary"
+          aria-busy={messageAdmissionPending}
+          className="type-label mx-4 my-2 rounded-md border border-border bg-surface-overlay p-2 text-foreground-on-secondary disabled:cursor-wait disabled:opacity-50"
+          disabled={messageAdmissionPending}
           onClick={() => {
             void submitQueuedMessage(activeConversationId);
           }}
@@ -1440,10 +1521,23 @@ export const AgentChatPanel = ({
           Resume queued message
         </button>
       ) : null}
-      {workflowRunRequest !== undefined && blockedWorkflowRef.current === workflowRunRequest ? (
+      {workflowRunRequest !== undefined &&
+      (blockedWorkflowRef.current === workflowRunRequest ||
+        (pendingWorkflowAdmission?.request === workflowRunRequest &&
+          pendingWorkflowAdmission.isResuming)) ? (
         <button
-          className="type-label mx-4 my-2 rounded-md border border-border bg-surface-overlay p-2 text-foreground-on-secondary"
+          aria-busy={pendingWorkflowAdmission?.request === workflowRunRequest}
+          className="type-label mx-4 my-2 rounded-md border border-border bg-surface-overlay p-2 text-foreground-on-secondary disabled:cursor-wait disabled:opacity-50"
+          disabled={pendingWorkflowAdmission?.request === workflowRunRequest}
           onClick={() => {
+            if (processingWorkflowsRef.current.has(workflowRunRequest)) {
+              return;
+            }
+            setPendingWorkflowAdmission({
+              conversationId: activeConversationId,
+              isResuming: true,
+              request: workflowRunRequest,
+            });
             blockedWorkflowRef.current = undefined;
             setWorkflowResume(current => current + 1);
           }}
@@ -1454,7 +1548,7 @@ export const AgentChatPanel = ({
       ) : null}
       <MessageComposer
         activeConversationId={activeConversationId}
-        canSend={canSend}
+        canSend={canSend && !messageAdmissionPending}
         isRunning={isRunning}
         onStop={stopRun}
         onSubmit={() => {

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -2,7 +2,7 @@
 import { browser, storage } from '#imports';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { JSX, ReactNode } from 'react';
-import { getDefaultStore, useAtomValue, useSetAtom, useStore } from 'jotai';
+import { useAtomValue, useSetAtom, useStore } from 'jotai';
 import { AlertTriangle } from 'lucide-react';
 import {
   compactingConversationIdsAtom,
@@ -22,7 +22,6 @@ import {
 } from './agent-message-queue';
 import {
   createAssistantMessage,
-  createToolResult,
   createUserMessage,
   createWorkflowToolCall,
   groupConversationEvents,
@@ -60,14 +59,20 @@ import {
 } from './agent-conversation-storage';
 import { AgentFooterControls } from './agent-footer-controls';
 import { ContextDonut } from './context-donut';
-import { runDangerousLlmTurn, runSafeLlmTurn } from './agent-turn-runners';
-import { createWorkflowToolDefinitions } from '@/src/shared/agent-llm-harness';
+import {
+  getBrowserExecutionCoordinator,
+  QUARANTINE_MESSAGE,
+  useBrowserExecutionSnapshot,
+} from './browser-execution-lock';
+import type { BrowserExecutionLease } from './browser-execution-lock';
+import { runBrowserTurn, runBrowserWorkflow, takeWorkflowLease } from './browser-run-context';
+import type { BrowserRunContext } from './browser-run-context';
+import { ExecutionStoppedError } from '@/src/shared/agent-tool-results';
+import type { WorkflowRunRequest } from './workflow-settings-state';
 import { formatAgentWorkflowIndex } from '@/src/shared/agent-workflows';
 import type { AgentWorkflow } from '@/src/shared/agent-workflows';
 import { loadWorkflowSettings } from '@/src/shared/agent-workflows-storage';
 import { loadWebMcpSettings } from '@/src/shared/web-mcp-settings';
-import { executeWorkflowToolCall } from './agent-workflow-tool-runtime';
-import { evalInTab, getTabUrl, navigateTab } from './agent-workflow-runtime';
 import { AUTO_COMPACT_RATIO, getContextRatio } from '@/src/shared/context-usage';
 import { addSessionCost } from '@/src/shared/session-cost';
 import { getActiveTabId, useTabDebugger } from './use-tab-debugger';
@@ -77,10 +82,7 @@ import { MessageComposer } from './message-composer';
 import { ConversationHistoryButton } from './conversation-history-button';
 import { useGatewayModels } from './use-gateway-models';
 import { loadRemoteMcpStore } from '@/src/shared/remote-mcp-storage';
-import { buildRemoteMcpToolDefinitions } from '@/src/shared/remote-mcp-tools';
 import { connectAndPersistRemoteMcpServer } from './remote-mcp-client';
-import { toRemoteMcpToolCallEvents } from './agent-tool-call-events';
-import { executeRemoteMcpToolCall } from './agent-remote-mcp-tool-runtime';
 import { useAgentMemories } from './use-agent-memories';
 import { useAgentWorkflows } from './use-agent-workflows';
 import type { AgentMemory } from '@/src/shared/agent-memories';
@@ -89,12 +91,12 @@ import { requestApproval } from './pending-approval';
 import { workflowRunRequestAtom } from './workflow-settings-state';
 import { activeConversationIdAtom, conversationModeAtom } from './settings-dialog-state';
 import { sanitizeTabContextText, sanitizeTabContextUrl } from '@/src/shared/tab-context-sanitize';
-import { maxAgentToolRounds } from '@/src/shared/agent-tool-round-limit';
 
 const apiBaseUrl = getKiloApiBaseUrl();
 const fetchFromWindow = (input: string, init?: RequestInit): Promise<Response> =>
   fetch(input, init);
 const emptyDefaultConversationEvents = (): AgentConversationEvent[] => [];
+const recoveryGuidance = 'Browser execution stopped. Submit new work explicitly after recovery.';
 
 interface ConversationRunState {
   readonly abort: AbortController;
@@ -183,6 +185,17 @@ export const AgentChatPanel = ({
   const workflowsRef = useRef(workflows);
   const runStatesRef = useRef(new Map<string, ConversationRunState>());
   const runTokenRef = useRef(0);
+  const execution = useBrowserExecutionSnapshot();
+  const [admissionBlocker, setAdmissionBlocker] = useState<string>();
+  const mountedRef = useRef(true);
+  const pendingAdmissionsRef = useRef(new Set<string>());
+  const admissionControllersRef = useRef(new Map<string, AbortController>());
+  const pausedQueuesRef = useRef(new Set<string>());
+  const [pausedQueueIds, setPausedQueueIds] = useState<string[]>([]);
+  // eslint-disable-next-line unicorn/no-useless-undefined -- React 19 requires an initial ref value.
+  const blockedWorkflowRef = useRef<WorkflowRunRequest | undefined>(undefined);
+  const processingWorkflowsRef = useRef(new Map<WorkflowRunRequest, string>());
+  const [workflowResume, setWorkflowResume] = useState(0);
   const [remoteMcpToolWarning, setRemoteMcpToolWarning] = useState<string>();
   const [pendingCreateDefaultConversationId, setPendingCreateDefaultConversationId] = useState<
     string | undefined
@@ -227,6 +240,7 @@ export const AgentChatPanel = ({
   const activePromptTokens = activeUsage?.promptTokens ?? 0;
   const activeSessionCostUsd = useAtomValue(sessionCostAtomFamily(activeConversationId));
   const streamingMessageId = useAtomValue(streamingMessageIdAtomFamily(activeConversationId));
+  const activeQueuedMessage = useAtomValue(queuedMessageAtomFamily(activeConversationId));
   const contextLength = selectedModel?.contextLength;
 
   // Wire the settings-dialog outreach atoms so WorkflowSettings can read the
@@ -353,14 +367,29 @@ export const AgentChatPanel = ({
   memoriesRef.current = memories;
   workflowsRef.current = workflows;
 
-  useEffect(
-    () => () => {
-      for (const runState of runStatesRef.current.values()) {
+  useEffect(() => {
+    mountedRef.current = true;
+    const runs = runStatesRef.current;
+    const admissions = admissionControllersRef.current;
+    return () => {
+      mountedRef.current = false;
+      for (const controller of admissions.values()) {
+        controller.abort();
+      }
+      admissions.clear();
+      for (const runState of runs.values()) {
         runState.abort.abort();
       }
-    },
-    []
-  );
+      const request = store.get(workflowRunRequestAtom);
+      if (request !== undefined) {
+        store.set(workflowRunRequestAtom, undefined);
+        const reservation = takeWorkflowLease(request);
+        if (reservation !== undefined) {
+          void reservation.lease.release();
+        }
+      }
+    };
+  }, [store]);
 
   useEffect(() => {
     let cancelled = false;
@@ -542,6 +571,8 @@ export const AgentChatPanel = ({
 
   interface RunState {
     readonly abort: AbortController;
+    readonly lease: BrowserExecutionLease;
+    readonly selectedTabId: number;
     readonly runToken: number;
     readonly isCurrentRun: () => boolean;
     readonly appendRunEvents: (events: AgentConversationEvent[]) => void;
@@ -551,7 +582,12 @@ export const AgentChatPanel = ({
     readonly currentRunHasUsage: () => boolean;
   }
 
-  const createRunState = (conversationId: string, runSelectedTabId: number): RunState => {
+  const createRunState = (
+    conversationId: string,
+    runSelectedTabId: number,
+    lease: BrowserExecutionLease
+  ): RunState => {
+    lease.guard();
     const abort = new AbortController();
     const runToken = (runTokenRef.current += 1);
     const isCurrentRun = (): boolean =>
@@ -599,406 +635,513 @@ export const AgentChatPanel = ({
       appendRunEvents,
       currentRunHasUsage,
       isCurrentRun,
+      lease,
       runToken,
+      selectedTabId: runSelectedTabId,
       updateRunAssistantMessage,
       updateRunThinkingBlock,
       updateRunUsage,
     };
   };
 
-  const startTurn = async (
-    conversationId: string,
-    conversationEventsForGateway: AgentConversationEvent[],
-    runState: RunState
-  ): Promise<void> => {
-    const cleanupRun = (): void => {
-      if (!runState.isCurrentRun()) {
-        return;
-      }
-
-      store.set(streamingMessageIdAtomFamily(conversationId), undefined);
-      runStatesRef.current.delete(conversationId);
-      setRunningConversationIds(currentIds =>
-        currentIds.filter(currentId => currentId !== conversationId)
-      );
-    };
-
-    const conversation = conversationStoreRef.current.conversations.find(
-      candidate => candidate.id === conversationId
-    );
-    if (conversation === undefined) {
-      cleanupRun();
-      return;
-    }
-
-    const runMode = conversation.mode ?? defaultMode;
-    const runModel = conversation.model ?? '';
-    const runSelectedModel = modelOptions.find(option => option.id === runModel);
-    const runThinkingOptions = runSelectedModel?.variants ?? [];
-    const runThinkingEffort = conversation.thinkingEffort ?? runThinkingOptions[0] ?? '';
-    const runStateEntry = runStatesRef.current.get(conversationId);
-    if (runStateEntry === undefined) {
-      cleanupRun();
-      return;
-    }
-    const runSelectedTabId = runStateEntry.selectedTabId;
-    const selectedTab = inspectableTabs.find(tab => tab.id === runSelectedTabId);
-
+  const finishRun = async (conversationId: string, runState: RunState): Promise<void> => {
     try {
-      const remoteMcpServers = store.get(remoteMcpStoreAtom).servers;
-      const {
-        routes: remoteMcpRoutes,
-        tools: remoteMcpTools,
-        warning: remoteMcpWarning,
-      } = buildRemoteMcpToolDefinitions({ mode: runMode, servers: remoteMcpServers });
-      setRemoteMcpToolWarning(remoteMcpWarning);
-
-      const settings = await loadWorkflowSettings(storage);
-      if (!runState.isCurrentRun() || runState.abort.signal.aborted) {
-        return;
-      }
-
-      let allowWebMcpInSafeMode = false;
-      try {
-        ({ allowWebMcpInSafeMode } = await loadWebMcpSettings(storage));
-      } catch {
-        allowWebMcpInSafeMode = false;
-      }
-
-      const { allowWorkflowsInSafeMode } = settings;
-      const workflowTools = createWorkflowToolDefinitions({
-        allowWorkflows: allowWorkflowsInSafeMode,
-        mode: runMode,
-      });
-      const runTurn = runMode === 'dangerous' ? runDangerousLlmTurn : runSafeLlmTurn;
-
-      captureEvent(MESSAGE_SENT_EVENT, { mode: runMode });
-      await runTurn({
-        allowWebMcpInSafeMode,
-        apiBaseUrl,
-        appendEvents: runState.appendRunEvents,
-        conversationEvents: conversationEventsForGateway,
-        executeRemoteMcpToolCall: event =>
-          executeRemoteMcpToolCall({
-            event,
-            fetch: globalThis.fetch,
-            routes: remoteMcpRoutes,
-            servers: remoteMcpServers,
-            signal: runState.abort.signal,
-            storageArea: storage,
-          }),
-        fetch: fetchFromWindow,
-        maxToolRounds: maxAgentToolRounds,
-        model: runModel,
-        onAssistantStreaming: eventId => {
-          if (runState.isCurrentRun()) {
-            store.set(streamingMessageIdAtomFamily(conversationId), eventId);
-          }
-        },
-        onUsage: runState.updateRunUsage,
-        organizationId,
-        remoteMcpTools,
-        selectedTabId: runSelectedTabId,
-        signal: runState.abort.signal,
-        supportsImages: runSelectedModel?.supportsImages === true,
-        thinkingEffort: runThinkingEffort,
-        toRemoteMcpToolCallEvents: toolCalls =>
-          toRemoteMcpToolCallEvents(toolCalls, remoteMcpRoutes),
-        token: auth.token,
-        updateAssistantMessage: runState.updateRunAssistantMessage,
-        updateThinkingBlock: runState.updateRunThinkingBlock,
-        workflowToolContext: {
-          allowWorkflowsInSafeMode,
-          evalInTab,
-          getTabUrl,
-          mode: runMode,
-          navigateTab,
-          requestApproval: (kind, draft) =>
-            requestApproval(storage, kind, draft, runState.abort.signal),
-          selectedTabId: runSelectedTabId,
-          selectedTabTitle: selectedTab?.title ?? '',
-          selectedTabUrl: selectedTab?.url ?? '',
-          signal: runState.abort.signal,
-          storage,
-        },
-        workflowTools,
-      });
-    } finally {
-      if (runState.isCurrentRun()) {
-        const latest = store.get(contextUsageAtomFamily(conversationId))?.promptTokens ?? 0;
-        const runContextLength = modelOptions.find(option => option.id === runModel)?.contextLength;
-        const ratio = getContextRatio(latest, runContextLength);
-
-        // Clean up the run state first so compactConversation's running-conversation check passes.
-        cleanupRun();
-
-        // A stopped or aborted run drops its pending message. A clean end leaves it for the
-        // Drain effect, which runs after this run's last events are committed to the store.
-        if (
-          !shouldSendQueuedMessage({
-            aborted: runState.abort.signal.aborted,
-            queued: store.get(queuedMessageAtomFamily(conversationId)),
-          })
-        ) {
-          store.set(queuedMessageAtomFamily(conversationId), undefined);
-        }
-
-        if (runState.currentRunHasUsage() && ratio !== undefined && ratio >= AUTO_COMPACT_RATIO) {
-          void compactConversation(conversationId);
-        }
-      }
+      await runState.lease.release();
+    } catch {
+      setAdmissionBlocker(recoveryGuidance);
+    }
+    if (!runState.isCurrentRun()) {
+      return;
+    }
+    const conversation = conversationStoreRef.current.conversations.find(
+      item => item.id === conversationId
+    );
+    const latest = store.get(contextUsageAtomFamily(conversationId))?.promptTokens ?? 0;
+    const ratio = getContextRatio(
+      latest,
+      modelOptions.find(option => option.id === conversation?.model)?.contextLength
+    );
+    store.set(streamingMessageIdAtomFamily(conversationId), undefined);
+    runStatesRef.current.delete(conversationId);
+    setRunningConversationIds(current => current.filter(id => id !== conversationId));
+    if (
+      !shouldSendQueuedMessage({
+        aborted: runState.abort.signal.aborted,
+        queued: store.get(queuedMessageAtomFamily(conversationId)),
+      })
+    ) {
+      store.set(queuedMessageAtomFamily(conversationId), undefined);
+    }
+    if (runState.currentRunHasUsage() && ratio !== undefined && ratio >= AUTO_COMPACT_RATIO) {
+      void compactConversation(conversationId);
     }
   };
 
-  const submitMessage = (conversationId: string, text: string): void => {
+  const setupRunContext = async (
+    conversationId: string,
+    runState: RunState
+  ): Promise<BrowserRunContext> => {
+    const conversation = conversationStoreRef.current.conversations.find(
+      item => item.id === conversationId
+    );
+    const selectedTab = inspectableTabsRef.current.find(tab => tab.id === runState.selectedTabId);
+    if (conversation === undefined || selectedTab === undefined) {
+      throw new ExecutionStoppedError('tab_lost');
+    }
+    const runModel = conversation.model ?? '';
+    const runSelectedModel = modelOptions.find(option => option.id === runModel);
+    const remoteMcpServers = store.get(remoteMcpStoreAtom).servers;
+    const settings = await loadWorkflowSettings(storage);
+    let allowWebMcpInSafeMode = false;
+    try {
+      ({ allowWebMcpInSafeMode } = await loadWebMcpSettings(storage));
+    } catch {
+      allowWebMcpInSafeMode = false;
+    }
+    return {
+      abort: runState.abort,
+      allowTabFallback: false,
+      allowWebMcpInSafeMode,
+      apiBaseUrl,
+      appendEvents: runState.appendRunEvents,
+      executionGuard: () => {
+        if (!runState.isCurrentRun()) {
+          throw new ExecutionStoppedError('run_replaced');
+        }
+        if (!inspectableTabsRef.current.some(tab => tab.id === runState.selectedTabId)) {
+          throw new ExecutionStoppedError('tab_lost');
+        }
+      },
+      fetch: fetchFromWindow,
+      lease: runState.lease,
+      mode: conversation.mode ?? defaultMode,
+      model: runModel,
+      onAssistantStreaming: eventId => {
+        if (runState.isCurrentRun()) {
+          store.set(streamingMessageIdAtomFamily(conversationId), eventId);
+        }
+      },
+      onRemoteMcpWarning: setRemoteMcpToolWarning,
+      onUsage: runState.updateRunUsage,
+      organizationId,
+      remoteFetch: globalThis.fetch,
+      remoteMcpServers,
+      requestApproval: (kind, draft) =>
+        requestApproval(storage, kind, draft, runState.abort.signal),
+      selectedTab,
+      settings,
+      storage,
+      supportsImages: runSelectedModel?.supportsImages === true,
+      thinkingEffort: conversation.thinkingEffort ?? runSelectedModel?.variants[0] ?? '',
+      token: auth.token,
+      updateAssistantMessage: runState.updateRunAssistantMessage,
+      updateThinkingBlock: runState.updateRunThinkingBlock,
+    };
+  };
+
+  // eslint-disable-next-line max-params -- Workflow continuation reuses the prepared context and existing run state.
+  const startTurn = async (
+    conversationId: string,
+    conversationEvents: AgentConversationEvent[],
+    runState: RunState,
+    preparedContext?: BrowserRunContext
+  ): Promise<void> => {
+    try {
+      const context = preparedContext ?? (await setupRunContext(conversationId, runState));
+      captureEvent(MESSAGE_SENT_EVENT, { mode: context.mode });
+      const outcome = await runBrowserTurn(context, conversationEvents);
+      if (outcome.effectsUncertain) {
+        setAdmissionBlocker(recoveryGuidance);
+      }
+    } catch (error) {
+      runState.appendRunEvents([
+        createAssistantMessage(
+          error instanceof Error
+            ? `Interrupted: ${error.message}`
+            : 'Browser execution was interrupted.'
+        ),
+      ]);
+    } finally {
+      await finishRun(conversationId, runState);
+    }
+  };
+
+  const getConversationSelectedTabId = (conversationId: string): number | undefined => {
     const conversation = conversationStoreRef.current.conversations.find(
       candidate => candidate.id === conversationId
     );
+    return conversation === undefined
+      ? undefined
+      : getSelectedInspectableTabId({
+          activeTabId,
+          inspectableTabs: inspectableTabsRef.current,
+          selectedTabId: conversation.selectedTabId,
+        });
+  };
 
-    if (conversation === undefined) {
-      return;
+  const isTabOpen = async (tabId: number | undefined): Promise<boolean> => {
+    if (tabId === undefined) {
+      return false;
     }
+    try {
+      // The tab list can lag behind a closure while admission is pending.
+      await browser.tabs.get(tabId);
+      return true;
+    } catch {
+      return false;
+    }
+  };
 
-    const conversationEvents = conversation.events;
+  const submitMessage = (
+    conversationId: string,
+    text: string,
+    lease: BrowserExecutionLease
+  ): boolean => {
+    lease.guard();
+    const conversation = conversationStoreRef.current.conversations.find(
+      candidate => candidate.id === conversationId
+    );
+    if (
+      conversation === undefined ||
+      store.get(runningConversationIdsAtom).includes(conversationId) ||
+      store.get(compactingConversationIdsAtom).includes(conversationId) ||
+      !isModelInCatalog(conversation.model ?? '')
+    ) {
+      return false;
+    }
     const runSelectedTabId = getSelectedInspectableTabId({
       activeTabId,
-      inspectableTabs,
+      inspectableTabs: inspectableTabsRef.current,
       selectedTabId: conversation.selectedTabId,
     });
-    const selectedTab = inspectableTabs.find(tab => tab.id === runSelectedTabId);
+    if (runSelectedTabId === undefined) {
+      setAdmissionBlocker('Pick a target tab first. Your message has not been sent.');
+      return false;
+    }
+    const selectedTab = inspectableTabsRef.current.find(tab => tab.id === runSelectedTabId);
     const userEvent = createUserMessage(
       text,
       formatSystemEnvironment({
         memories: memoriesRef.current,
-        selectedTab:
-          selectedTab === undefined
-            ? undefined
-            : { title: selectedTab.title, url: selectedTab.url },
+        selectedTab,
         workflows: workflowsRef.current,
       })
     );
-    const conversationWithUserMessage = [...conversationEvents, userEvent];
-
+    const runState = createRunState(conversationId, runSelectedTabId, lease);
     appendEvents(conversationId, [userEvent]);
-
-    if (runSelectedTabId === undefined) {
-      appendEvents(conversationId, [createAssistantMessage('Pick a target tab first.')]);
-      return;
-    }
-
-    const runState = createRunState(conversationId, runSelectedTabId);
-
-    void startTurn(conversationId, conversationWithUserMessage, runState);
+    void startTurn(conversationId, [...conversation.events, userEvent], runState);
+    return true;
   };
 
-  const submitDraft = (): void => {
-    const text = store.get(draftAtomFamily(activeConversationId)).trim();
-    const conversation = getActiveStoredConversation(conversationStoreRef.current);
-    const action = resolveSendAction({
-      hasModel: isModelInCatalog(conversation.model ?? ''),
-      hasTargetTab:
-        getSelectedInspectableTabId({
-          activeTabId,
-          inspectableTabs,
-          selectedTabId: conversation.selectedTabId,
-        }) !== undefined,
-      isCompacting: store.get(compactingConversationIdsAtom).includes(conversation.id),
-      isRunning: store.get(runningConversationIdsAtom).includes(conversation.id),
-      isStoreLoaded: isConversationStoreLoaded,
-      text,
-    });
+  const getAdmissionSignal = (conversationId: string): AbortSignal => {
+    let controller = admissionControllersRef.current.get(conversationId);
+    if (controller === undefined) {
+      controller = new AbortController();
+      admissionControllersRef.current.set(conversationId, controller);
+    }
+    return controller.signal;
+  };
+  const isAdmissionCurrent = (conversationId: string, signal: AbortSignal): boolean =>
+    mountedRef.current &&
+    !signal.aborted &&
+    isStoredConversationOpen(conversationStoreRef.current, conversationId);
+  const cancelConversationAdmissions = useCallback(
+    (conversationId: string): void => {
+      admissionControllersRef.current.get(conversationId)?.abort();
+      admissionControllersRef.current.delete(conversationId);
+      const request = store.get(workflowRunRequestAtom);
+      if (request !== undefined && processingWorkflowsRef.current.get(request) === conversationId) {
+        store.set(workflowRunRequestAtom, undefined);
+      }
+    },
+    [store]
+  );
 
-    if (action === 'ignore') {
+  const submitDraft = async (): Promise<void> => {
+    const conversationId = conversationStoreRef.current.activeConversationId;
+    const rawDraft = store.get(draftAtomFamily(conversationId));
+    const text = rawDraft.trim();
+    if (text === '' || pendingAdmissionsRef.current.has(conversationId)) {
       return;
     }
-
-    store.set(draftAtomFamily(activeConversationId), '');
-
-    // A send during a run queues one pending message for the next turn.
-    if (action === 'queue') {
-      store.set(queuedMessageAtomFamily(conversation.id), current =>
-        appendQueuedMessage(current, text)
+    const submittedTabId = getConversationSelectedTabId(conversationId);
+    const signal = getAdmissionSignal(conversationId);
+    pendingAdmissionsRef.current.add(conversationId);
+    let lease: BrowserExecutionLease | undefined = undefined;
+    let handedOff = false;
+    try {
+      const admission = await getBrowserExecutionCoordinator().acquireLocal();
+      lease = admission.admitted ? admission.lease : undefined;
+      const targetExists = lease !== undefined && (await isTabOpen(submittedTabId));
+      if (!isAdmissionCurrent(conversationId, signal)) {
+        return;
+      }
+      if (
+        lease === undefined ||
+        !targetExists ||
+        getConversationSelectedTabId(conversationId) !== submittedTabId
+      ) {
+        setAdmissionBlocker(
+          lease === undefined
+            ? 'Your message is retained. Submit it again when browser control is available.'
+            : 'The target tab changed or closed. Your message is retained. Select a target tab and submit again.'
+        );
+        return;
+      }
+      lease.guard();
+      const conversation = conversationStoreRef.current.conversations.find(
+        candidate => candidate.id === conversationId
       );
+      if (conversation === undefined) {
+        return;
+      }
+      const action = resolveSendAction({
+        hasModel: isModelInCatalog(conversation.model ?? ''),
+        hasTargetTab: submittedTabId !== undefined,
+        isCompacting: store.get(compactingConversationIdsAtom).includes(conversationId),
+        isRunning: store.get(runningConversationIdsAtom).includes(conversationId),
+        isStoreLoaded: isConversationStoreLoaded,
+        text,
+      });
+      if (action === 'ignore') {
+        return;
+      }
+      if (action === 'queue') {
+        store.set(queuedMessageAtomFamily(conversationId), current =>
+          appendQueuedMessage(current, text)
+        );
+      } else {
+        handedOff = submitMessage(conversationId, text, lease);
+        if (!handedOff) {
+          return;
+        }
+      }
+      setAdmissionBlocker(undefined);
+      if (store.get(draftAtomFamily(conversationId)) === rawDraft) {
+        store.set(draftAtomFamily(conversationId), '');
+      }
+    } catch (error) {
+      if (isAdmissionCurrent(conversationId, signal)) {
+        setAdmissionBlocker(
+          error instanceof Error ? error.message : 'Browser admission stopped. Submit again.'
+        );
+      }
+    } finally {
+      pendingAdmissionsRef.current.delete(conversationId);
+      if (lease !== undefined && !handedOff) {
+        await lease.release();
+      }
+    }
+  };
+
+  const submitQueuedMessage = async (conversationId: string): Promise<void> => {
+    if (pendingAdmissionsRef.current.has(conversationId)) {
       return;
     }
-
-    submitMessage(conversation.id, text);
+    const queued = store.get(queuedMessageAtomFamily(conversationId));
+    if (queued === undefined) {
+      return;
+    }
+    const submittedTabId = getConversationSelectedTabId(conversationId);
+    const signal = getAdmissionSignal(conversationId);
+    pendingAdmissionsRef.current.add(conversationId);
+    let lease: BrowserExecutionLease | undefined = undefined;
+    let handedOff = false;
+    try {
+      const admission = await getBrowserExecutionCoordinator().acquireLocal();
+      lease = admission.admitted ? admission.lease : undefined;
+      const targetExists = lease !== undefined && (await isTabOpen(submittedTabId));
+      if (
+        !isAdmissionCurrent(conversationId, signal) ||
+        store.get(queuedMessageAtomFamily(conversationId)) !== queued
+      ) {
+        return;
+      }
+      if (
+        lease === undefined ||
+        !targetExists ||
+        getConversationSelectedTabId(conversationId) !== submittedTabId
+      ) {
+        pausedQueuesRef.current.add(conversationId);
+        setPausedQueueIds([...pausedQueuesRef.current]);
+        setAdmissionBlocker(
+          lease === undefined
+            ? 'Your queued message is retained. Use Resume queued message when browser control is available.'
+            : 'The target tab changed or closed. Your queued message is retained. Select a target tab and use Resume queued message.'
+        );
+        return;
+      }
+      handedOff = submitMessage(conversationId, queued, lease);
+      if (handedOff) {
+        store.set(queuedMessageAtomFamily(conversationId), undefined);
+        pausedQueuesRef.current.delete(conversationId);
+        setPausedQueueIds([...pausedQueuesRef.current]);
+        setAdmissionBlocker(undefined);
+      }
+    } catch (error) {
+      if (isAdmissionCurrent(conversationId, signal)) {
+        pausedQueuesRef.current.add(conversationId);
+        setPausedQueueIds([...pausedQueuesRef.current]);
+        setAdmissionBlocker(
+          error instanceof Error ? error.message : 'Browser admission stopped. Resume explicitly.'
+        );
+      }
+    } finally {
+      pendingAdmissionsRef.current.delete(conversationId);
+      if (lease !== undefined && !handedOff) {
+        await lease.release();
+      }
+    }
   };
 
   const stopRun = (): void => {
+    cancelConversationAdmissions(activeConversationId);
     runStatesRef.current.get(activeConversationId)?.abort.abort();
   };
 
   const workflowRunRequest = useAtomValue(workflowRunRequestAtom);
 
   useEffect(() => {
-    if (workflowRunRequest === undefined) {
+    if (
+      workflowRunRequest === undefined ||
+      blockedWorkflowRef.current === workflowRunRequest ||
+      processingWorkflowsRef.current.has(workflowRunRequest)
+    ) {
       return;
     }
     const request = workflowRunRequest;
-
+    const reservation = takeWorkflowLease(request);
+    const conversationId = reservation?.conversationId ?? activeConversationId;
+    const runSelectedTabId = getConversationSelectedTabId(conversationId);
+    const signal = getAdmissionSignal(conversationId);
+    processingWorkflowsRef.current.set(request, conversationId);
     void (async (): Promise<void> => {
-      // Clear the request first so a re-render cannot double-fire.
-      getDefaultStore().set(workflowRunRequestAtom, undefined);
-
-      const conversation = conversationStoreRef.current.conversations.find(
-        candidate => candidate.id === activeConversationId
-      );
-      if (conversation === undefined) {
-        return;
-      }
-      const conversationId = conversation.id;
-      const runModel = conversation.model ?? '';
-      const runSelectedTabId = getSelectedInspectableTabId({
-        activeTabId,
-        inspectableTabs,
-        selectedTabId: conversation.selectedTabId,
-      });
-
-      // Preflight gates match run button disabled states — fail silently.
-      const isCompactingNow = store.get(compactingConversationIdsAtom).includes(conversationId);
-      const isRunningNow = store.get(runningConversationIdsAtom).includes(conversationId);
-
-      if (
-        !isConversationStoreLoaded ||
-        !isModelInCatalog(runModel) ||
-        isCompactingNow ||
-        isRunningNow
-      ) {
-        return;
-      }
-
-      if (runSelectedTabId === undefined) {
-        appendEvents(conversationId, [createAssistantMessage('Pick a target tab first.')]);
-        return;
-      }
-
-      const runState = createRunState(conversationId, runSelectedTabId);
-
-      // Clean up the run state whenever the runner exits before calling startTurn.
-      const cleanupUnstartedRun = (): void => {
-        if (!runState.isCurrentRun()) {
+      let lease = reservation?.lease;
+      let runState: RunState | undefined = undefined;
+      try {
+        if (lease === undefined) {
+          // Old UI callers publish only workflowId/input. Remove this admission fallback after all request writers reserve a lease.
+          const admission = await getBrowserExecutionCoordinator().acquireLocal();
+          lease = admission.admitted ? admission.lease : undefined;
+        }
+        const targetExists = lease !== undefined && (await isTabOpen(runSelectedTabId));
+        if (!isAdmissionCurrent(conversationId, signal)) {
+          if (store.get(workflowRunRequestAtom) === request) {
+            store.set(workflowRunRequestAtom, undefined);
+          }
           return;
         }
-
-        runStatesRef.current.delete(conversationId);
-        setRunningConversationIds(currentIds =>
-          currentIds.filter(currentId => currentId !== conversationId)
+        if (store.get(workflowRunRequestAtom) !== request) {
+          return;
+        }
+        if (lease === undefined) {
+          blockedWorkflowRef.current = request;
+          setAdmissionBlocker(
+            'Workflow input is retained. Use Resume workflow when browser control is available.'
+          );
+          return;
+        }
+        lease.guard();
+        // Admission can finish after a competing send or compaction. Recheck before consuming input.
+        const conversation = conversationStoreRef.current.conversations.find(
+          candidate => candidate.id === conversationId
         );
-        store.set(streamingMessageIdAtomFamily(conversationId), undefined);
-
-        // Same rule as startTurn's finally: an aborted run drops its pending message.
         if (
-          !shouldSendQueuedMessage({
-            aborted: runState.abort.signal.aborted,
-            queued: store.get(queuedMessageAtomFamily(conversationId)),
-          })
+          conversation === undefined ||
+          !isConversationStoreLoaded ||
+          !isModelInCatalog(conversation.model ?? '') ||
+          runSelectedTabId === undefined ||
+          !targetExists ||
+          getConversationSelectedTabId(conversationId) !== runSelectedTabId ||
+          store.get(compactingConversationIdsAtom).includes(conversationId) ||
+          store.get(runningConversationIdsAtom).includes(conversationId)
         ) {
-          store.set(queuedMessageAtomFamily(conversationId), undefined);
+          blockedWorkflowRef.current = request;
+          setAdmissionBlocker(
+            'Workflow input is retained. Select an available conversation, model, and target tab, then resume the workflow.'
+          );
+          return;
         }
-      };
-
-      // Build user message with system environment including workflows index.
-      const selectedTab = inspectableTabs.find(tab => tab.id === runSelectedTabId);
-      const workflow = workflows.find(wf => wf.id === request.workflowId);
-      const workflowName = workflow?.name ?? 'workflow';
-      const userEvent = createUserMessage(
-        `Run the workflow "${workflowName}".`,
-        formatSystemEnvironment({
-          memories: memoriesRef.current,
-          selectedTab:
-            selectedTab === undefined
-              ? undefined
-              : { title: selectedTab.title, url: selectedTab.url },
-          workflows: workflows,
-        })
-      );
-      appendEvents(conversationId, [userEvent]);
-
-      if (runState.abort.signal.aborted) {
-        cleanupUnstartedRun();
-        return;
-      }
-
-      // Execute the workflow as a tool call and append the result.
-      const toolCall = createWorkflowToolCall({
-        arguments: {
-          workflowId: request.workflowId,
-          ...(request.input === undefined ? {} : { input: request.input }),
-        },
-        name: 'run_workflow',
-        tabId: runSelectedTabId,
-      });
-
-      // eslint-disable-next-line init-declarations -- assigned in try block before any use; catch path returns.
-      let result: Awaited<ReturnType<typeof executeWorkflowToolCall>>;
-      try {
-        const settings = await loadWorkflowSettings(storage);
-        const runMode = conversation.mode ?? defaultMode;
-        result = await executeWorkflowToolCall(toolCall, {
-          allowWorkflowsInSafeMode: settings.allowWorkflowsInSafeMode,
-          evalInTab: (tabId, code) => evalInTab(tabId, code),
-          getTabUrl: tabId => getTabUrl(tabId),
-          mode: runMode,
-          navigateTab: (tabId, url) => navigateTab(tabId, url),
-          requestApproval: (kind, draft) =>
-            requestApproval(storage, kind, draft, runState.abort.signal),
-          selectedTabId: runSelectedTabId,
-          selectedTabTitle: selectedTab?.title ?? '',
-          selectedTabUrl: selectedTab?.url ?? '',
-          signal: runState.abort.signal,
-          storage,
+        // Consume only after admission; keep the same lease through workflow and model continuation.
+        store.set(workflowRunRequestAtom, undefined);
+        setAdmissionBlocker(undefined);
+        runState = createRunState(conversationId, runSelectedTabId, lease);
+        const selectedTab = inspectableTabsRef.current.find(tab => tab.id === runSelectedTabId);
+        const workflowName =
+          workflowsRef.current.find(workflow => workflow.id === request.workflowId)?.name ??
+          'workflow';
+        const userEvent = createUserMessage(
+          `Run the workflow "${workflowName}".`,
+          formatSystemEnvironment({
+            memories: memoriesRef.current,
+            selectedTab,
+            workflows: workflowsRef.current,
+          })
+        );
+        appendEvents(conversationId, [userEvent]);
+        const context = await setupRunContext(conversationId, runState);
+        const toolCall = createWorkflowToolCall({
+          arguments: {
+            workflowId: request.workflowId,
+            ...(request.input === undefined ? {} : { input: request.input }),
+          },
+          name: 'run_workflow',
+          tabId: runSelectedTabId,
         });
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        if (runState.isCurrentRun()) {
-          appendEvents(conversationId, [
-            toolCall,
-            createToolResult({
-              error: errorMessage,
-              ok: false,
-              toolCallId: toolCall.id,
-            }),
-          ]);
+        const outcome = await runBrowserWorkflow(context, toolCall);
+        runState.appendRunEvents(outcome.events);
+        if (outcome.effectsUncertain) {
+          setAdmissionBlocker(recoveryGuidance);
+          runState.appendRunEvents([createAssistantMessage(QUARANTINE_MESSAGE)]);
+          return;
         }
-        cleanupUnstartedRun();
-        return;
+        if (
+          outcome.status === 'interrupted' ||
+          outcome.status === 'cancelled' ||
+          runState.abort.signal.aborted ||
+          !runState.isCurrentRun()
+        ) {
+          return;
+        }
+        await startTurn(
+          conversationId,
+          [...conversation.events, userEvent, ...outcome.events],
+          runState,
+          context
+        );
+      } catch (error) {
+        if (
+          !isAdmissionCurrent(conversationId, signal) ||
+          (runState === undefined && store.get(workflowRunRequestAtom) !== request)
+        ) {
+          return;
+        }
+        if (store.get(workflowRunRequestAtom) === request) {
+          blockedWorkflowRef.current = request;
+        }
+        setAdmissionBlocker(
+          error instanceof Error
+            ? `Interrupted: ${error.message}`
+            : 'Workflow execution was interrupted.'
+        );
+      } finally {
+        processingWorkflowsRef.current.delete(request);
+        if (runState !== undefined) {
+          await finishRun(conversationId, runState);
+        } else if (lease !== undefined) {
+          await lease.release();
+        }
       }
-
-      if (!runState.isCurrentRun()) {
-        return;
-      }
-
-      const resultEvent = createToolResult({
-        ok: result.ok,
-        toolCallId: toolCall.id,
-        ...(result.ok ? { value: result.value } : { error: result.error }),
-      });
-      appendEvents(conversationId, [toolCall, resultEvent]);
-
-      if (runState.abort.signal.aborted || !runState.isCurrentRun()) {
-        cleanupUnstartedRun();
-        return;
-      }
-
-      const conversationEventsWithToolExchange = [
-        ...conversation.events,
-        userEvent,
-        toolCall,
-        resultEvent,
-      ];
-      void startTurn(conversationId, conversationEventsWithToolExchange, runState);
     })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps — createRunState/startTurn/appendEvents are intentionally defined at component scope and use Refs for latest values; adding them as deps would cause an infinite render loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Execution helpers read current refs. A blocked request resumes only through its explicit button.
   }, [
     workflowRunRequest,
+    workflowResume,
     activeConversationId,
     activeTabId,
-    inspectableTabs,
     isConversationStoreLoaded,
     modelOptions,
     store,
-    workflows,
   ]);
 
   /*
@@ -1024,11 +1167,10 @@ export const AgentChatPanel = ({
         queued !== undefined &&
         !runningIds.includes(conversation.id) &&
         !compactingIds.includes(conversation.id) &&
+        !pausedQueuesRef.current.has(conversation.id) &&
         isModelInCatalog(conversation.model ?? '')
       ) {
-        // Clear before sending so a failing send cannot re-queue itself.
-        store.set(queuedMessageAtomFamily(conversation.id), undefined);
-        submitMessage(conversation.id, queued);
+        void submitQueuedMessage(conversation.id);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- submitMessage and isModelInCatalog are component-scope helpers reading refs for latest values; listing them would loop every render. The listed deps are the only triggers: a run or compaction ending, a catalog change, or a stored conversation update such as the model repair.
@@ -1109,6 +1251,7 @@ export const AgentChatPanel = ({
 
   const abortConversationRun = useCallback(
     (conversationId: string): void => {
+      cancelConversationAdmissions(conversationId);
       runStatesRef.current.get(conversationId)?.abort.abort();
       runStatesRef.current.delete(conversationId);
       // Required: deleting run-state makes the run's later finally see isCurrentRun() === false
@@ -1120,7 +1263,7 @@ export const AgentChatPanel = ({
         currentIds.filter(currentId => currentId !== conversationId)
       );
     },
-    [setRunningConversationIds, store]
+    [cancelConversationAdmissions, setRunningConversationIds, store]
   );
 
   const closeConversation = useCallback(
@@ -1202,16 +1345,17 @@ export const AgentChatPanel = ({
           isStoredConversationEmpty(getActiveStoredConversation(currentStore)),
         store: currentStore,
       });
-      // Opening history can drop the active empty conversation; free its atoms.
+      // Opening history can drop the active empty conversation; cancel admission and free its atoms.
       for (const conversation of currentStore.conversations) {
         if (!nextStore.conversations.some(next => next.id === conversation.id)) {
+          cancelConversationAdmissions(conversation.id);
           evictConversationAtoms(conversation.id);
         }
       }
       conversationStoreRef.current = nextStore;
       setConversationStore(nextStore);
     },
-    [isConversationStoreLoaded, setConversationStore, store]
+    [cancelConversationAdmissions, isConversationStoreLoaded, setConversationStore, store]
   );
 
   useEffect(() => {
@@ -1272,12 +1416,50 @@ export const AgentChatPanel = ({
         </p>
       )}
 
+      {execution.blockedReason === undefined && admissionBlocker === undefined ? null : (
+        <p
+          className="type-body border-t border-border px-4 py-2 text-status-yellow-400"
+          role="status"
+        >
+          {execution.blockedReason ?? admissionBlocker}
+        </p>
+      )}
+      {execution.delegationUnavailableReason === undefined ? null : (
+        <p className="type-label px-4 py-2 text-foreground-muted">
+          {execution.delegationUnavailableReason}
+        </p>
+      )}
+      {pausedQueueIds.includes(activeConversationId) && activeQueuedMessage !== undefined ? (
+        <button
+          className="type-label mx-4 my-2 rounded-md border border-border bg-surface-overlay p-2 text-foreground-on-secondary"
+          onClick={() => {
+            void submitQueuedMessage(activeConversationId);
+          }}
+          type="button"
+        >
+          Resume queued message
+        </button>
+      ) : null}
+      {workflowRunRequest !== undefined && blockedWorkflowRef.current === workflowRunRequest ? (
+        <button
+          className="type-label mx-4 my-2 rounded-md border border-border bg-surface-overlay p-2 text-foreground-on-secondary"
+          onClick={() => {
+            blockedWorkflowRef.current = undefined;
+            setWorkflowResume(current => current + 1);
+          }}
+          type="button"
+        >
+          Resume workflow
+        </button>
+      ) : null}
       <MessageComposer
         activeConversationId={activeConversationId}
         canSend={canSend}
         isRunning={isRunning}
         onStop={stopRun}
-        onSubmit={submitDraft}
+        onSubmit={() => {
+          void submitDraft();
+        }}
       />
 
       <footer className="border-t border-border bg-surface-raised px-4 py-2">

--- a/apps/extension/entrypoints/sidepanel/browser-action-boundary.test.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-action-boundary.test.ts
@@ -1,0 +1,504 @@
+/* eslint-disable max-lines, max-depth, import/no-nodejs-modules, jest/no-conditional-in-test, prefer-destructuring -- This Node-only inventory walks syntax, including alias and mutation fixtures. */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const root = fileURLToPath(new URL('../../', import.meta.url));
+const panel = 'entrypoints/sidepanel/';
+const shared = 'src/shared/';
+const sources = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return sources(path);
+    }
+    return /\.tsx?$/u.test(path) && !/\.test\./u.test(path) ? [path] : [];
+  });
+const sourceFiles = [...sources(join(root, 'entrypoints')), ...sources(join(root, shared))];
+const parse = (path: string, text: string): ts.SourceFile =>
+  ts.createSourceFile(
+    path,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    path.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+const member = (node: ts.Node): string | undefined => {
+  if (ts.isIdentifier(node) || ts.isStringLiteralLike(node)) {
+    return node.text;
+  }
+  return undefined;
+};
+const enclosing = (node: ts.Node): string => {
+  for (
+    let parent: ts.Node | undefined = node.parent;
+    parent !== undefined;
+    parent = parent.parent
+  ) {
+    if (ts.isFunctionDeclaration(parent) && parent.name !== undefined) {
+      return parent.name.text;
+    }
+    if (ts.isArrowFunction(parent) || ts.isFunctionExpression(parent)) {
+      if (ts.isVariableDeclaration(parent.parent)) {
+        return member(parent.parent.name) ?? '<anonymous>';
+      }
+      if (ts.isPropertyAssignment(parent.parent)) {
+        return member(parent.parent.name) ?? '<anonymous>';
+      }
+    }
+    if (ts.isMethodDeclaration(parent)) {
+      return member(parent.name) ?? '<anonymous>';
+    }
+  }
+  return '<module>';
+};
+const runnerNames = new Set([
+  'runSafeLlmTurn',
+  'runDangerousLlmTurn',
+  'runLlmTurn',
+  'runWorkflow',
+  'runToolCalls',
+  'executeWorkflowToolCall',
+  'executeEvalToolCall',
+]);
+const nativeActions = new Set([
+  'getViewportScreenshotWithTabsApi',
+  'getViewportScreenshot',
+  'getPageSnapshotInTab',
+  'getPageSnapshotInTabWithScripting',
+  'discoverWebMcpToolsInTab',
+  'executeWebMcpToolInTab',
+  'evalInTabWithScripting',
+]);
+const adapterImports = new Set([
+  ...runnerNames,
+  ...nativeActions,
+  'evalInTab',
+  'navigateTab',
+  'executeSafeToolCall',
+  'createSafeToolExecutor',
+  'discoverWebMcpTools',
+  'executeWebMcpToolCall',
+  'executeRemoteMcpToolCall',
+  'executeWebSearchToolCall',
+  'createWebSearchExecutor',
+  'callRemoteMcpTool',
+]);
+const allowedImports = new Set([
+  ...[
+    'agent-turn-runners.ts',
+    'browser-run-context.ts',
+    'agent-llm-turn-runner.ts',
+    'agent-safe-llm-turn-runner.ts',
+    'agent-workflow-tool-runtime.ts',
+    'agent-remote-mcp-tool-runtime.ts',
+    'agent-web-search-tool-runtime.ts',
+  ].map(path => `${panel}${path}`),
+  `${shared}agent-llm-turn-runner-core.ts`,
+  `${shared}agent-workflow-runner.ts`,
+  'entrypoints/background.ts',
+]);
+const runnerSites = new Map<string, readonly string[]>([
+  [`${panel}browser-run-context.ts:runBrowserTurn`, ['runSafeLlmTurn', 'runDangerousLlmTurn']],
+  [`${panel}browser-run-context.ts:runBrowserWorkflow`, ['executeWorkflowToolCall']],
+  [`${panel}agent-llm-turn-runner.ts:runDangerousLlmTurn`, ['runLlmTurn']],
+  [`${panel}agent-safe-llm-turn-runner.ts:runSafeLlmTurn`, ['runLlmTurn']],
+  [`${panel}agent-llm-turn-runner.ts:executeToolCall`, ['executeWorkflowToolCall']],
+  [`${panel}agent-safe-llm-turn-runner.ts:executeToolCall`, ['executeWorkflowToolCall']],
+  [`${panel}agent-workflow-tool-runtime.ts:executeRunWorkflow`, ['runWorkflow']],
+  [`${shared}agent-llm-turn-runner-core.ts:continueConversation`, ['runToolCalls']],
+]);
+// These native adapters receive calls from the guarded wrappers above, not model-selected dispatch functions.
+const guardedAdapters = new Set([
+  `${panel}agent-workflow-runtime.ts:evalInTab`,
+  `${panel}agent-workflow-runtime.ts:navigateTab`,
+  `${panel}agent-safe-tool-runtime.ts:readPageSnapshot`,
+  `${panel}agent-safe-tool-runtime.ts:readViewportScreenshot`,
+  `${panel}agent-web-mcp-tool-runtime.ts:discoverWebMcpTools`,
+  `${panel}agent-web-mcp-tool-runtime.ts:executeWebMcpToolCall`,
+  `${panel}agent-remote-mcp-tool-runtime.ts:executeRemoteMcpToolCall`,
+  `${panel}remote-mcp-client.ts:callRemoteMcpTool`,
+  `${panel}agent-web-search-tool-runtime.ts:postSearch`,
+  `${shared}agent-workflow-runner.ts:runWorkflow`,
+  'entrypoints/background.ts:handleTabDebuggerRequest',
+  ...[
+    'getViewportScreenshotWithTabsApi',
+    'evalInTab',
+    'evalInTabWithScripting',
+    'getPageSnapshotInTabWithScripting',
+    'discoverWebMcpToolsInTab',
+    'executeWebMcpToolInTab',
+    'runInjectedEval',
+    'runInjectedWebMcpExecute',
+  ].map(name => `${shared}tab-debugger.ts:${name}`),
+]);
+const legacyAdapters = new Set([
+  // Old executeEvalToolCall(event) remains a compatibility adapter. Remove this exception when guardless local callers retire.
+  `${panel}agent-eval-runtime.ts:executeEvalToolCall`,
+  // The old tab-list request helper is read-only. Remove this exception when it becomes a list-only API.
+  `${panel}use-tab-debugger.ts:sendTabDebuggerRequest`,
+]);
+const leaf = (name: string): string => name.split('.').at(-1) ?? name;
+const rawSink = (name: string): boolean =>
+  /(?:^|\.)(?:sendMessage|executeScript|captureVisibleTab|callTool|executeTool)$/u.test(name) ||
+  /(?:^|\.)(?:tabs|tabsApi)\.update$/u.test(name) ||
+  /(?:^|\.)(?:debugger|debuggerApi)\.sendCommand$/u.test(name) ||
+  /(?:^|\.)(?:runtime|scripting|tabs)\.\*$/u.test(name) ||
+  name === 'context.fetch';
+
+const inspect = (path: string, text: string): string[] => {
+  const source = parse(path, text);
+  const aliases = new Map<string, ts.Expression | string>();
+  const failures: string[] = [];
+  const names = (expression: ts.Expression, seen = new Set<string>()): string[] => {
+    if (ts.isIdentifier(expression)) {
+      if (seen.has(expression.text)) {
+        return [expression.text];
+      }
+      const target = aliases.get(expression.text);
+      if (target === undefined) {
+        return [expression.text];
+      }
+      if (typeof target === 'string') {
+        return [target];
+      }
+      return names(target, new Set([...seen, expression.text]));
+    }
+    if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+      const key = ts.isPropertyAccessExpression(expression)
+        ? expression.name
+        : expression.argumentExpression;
+      const constant = ts.isIdentifier(key) ? aliases.get(key.text) : undefined;
+      const constantProperty =
+        constant !== undefined && typeof constant !== 'string' && ts.isStringLiteralLike(constant)
+          ? constant.text
+          : '*';
+      const property =
+        ts.isPropertyAccessExpression(expression) || ts.isStringLiteralLike(key)
+          ? member(key)
+          : constantProperty;
+      const base = expression.expression;
+      if (ts.isIdentifier(base)) {
+        const target = aliases.get(base.text);
+        if (
+          target !== undefined &&
+          typeof target !== 'string' &&
+          ts.isObjectLiteralExpression(target)
+        ) {
+          const value = target.properties.find(
+            entry => entry.name !== undefined && member(entry.name) === property
+          );
+          if (value !== undefined && ts.isPropertyAssignment(value)) {
+            return names(value.initializer, seen);
+          }
+          if (value !== undefined && ts.isShorthandPropertyAssignment(value)) {
+            return names(value.name, seen);
+          }
+        }
+      }
+      return names(base, seen).map(name =>
+        name === '<namespace>' ? (property ?? '*') : `${name}.${property ?? '*'}`
+      );
+    }
+    if (ts.isConditionalExpression(expression)) {
+      return [...names(expression.whenTrue, seen), ...names(expression.whenFalse, seen)];
+    }
+    if (
+      ts.isParenthesizedExpression(expression) ||
+      ts.isAsExpression(expression) ||
+      ts.isNonNullExpression(expression)
+    ) {
+      return names(expression.expression, seen);
+    }
+    if (
+      ts.isCallExpression(expression) &&
+      ts.isPropertyAccessExpression(expression.expression) &&
+      expression.expression.name.text === 'bind'
+    ) {
+      return names(expression.expression.expression, seen);
+    }
+    return [];
+  };
+  const collect = (node: ts.Node): void => {
+    // TypeScript 5.9 still exposes isTypeOnly; newer compiler declarations deprecate it without changing this syntax contract.
+    // eslint-disable-next-line typescript/no-deprecated
+    if (ts.isImportDeclaration(node) && node.importClause?.isTypeOnly !== true) {
+      const bindings = node.importClause?.namedBindings;
+      if (bindings !== undefined && ts.isNamedImports(bindings)) {
+        for (const binding of bindings.elements.filter(element => !element.isTypeOnly)) {
+          const original = binding.propertyName?.text ?? binding.name.text;
+          aliases.set(binding.name.text, original);
+          if (adapterImports.has(original) && !allowedImports.has(path)) {
+            failures.push(`unguarded import ${original}`);
+          }
+        }
+      } else if (bindings !== undefined && ts.isNamespaceImport(bindings)) {
+        aliases.set(bindings.name.text, '<namespace>');
+      }
+    }
+    if (ts.isVariableDeclaration(node) && node.initializer !== undefined) {
+      if (ts.isIdentifier(node.name)) {
+        aliases.set(node.name.text, node.initializer);
+      }
+      if (ts.isObjectBindingPattern(node.name)) {
+        for (const element of node.name.elements) {
+          if (ts.isIdentifier(element.name)) {
+            const property = member(element.propertyName ?? element.name);
+            const [base] = names(node.initializer);
+            if (base !== undefined && property !== undefined) {
+              aliases.set(element.name.text, `${base}.${property}`);
+            }
+          }
+        }
+      }
+    }
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left)
+    ) {
+      aliases.set(node.left.text, node.right);
+    }
+    ts.forEachChild(node, collect);
+  };
+  collect(source);
+  const hasGuard = (node: ts.CallExpression | ts.NewExpression): boolean =>
+    (node.arguments ?? []).some(argument => {
+      if (ts.isObjectLiteralExpression(argument)) {
+        return argument.properties.some(
+          property =>
+            ts.isPropertyAssignment(property) &&
+            member(property.name) === 'executionGuard' &&
+            property.initializer.getText(source) !== 'undefined'
+        );
+      }
+      if (
+        ts.isCallExpression(argument) &&
+        ts.isIdentifier(argument.expression) &&
+        argument.expression.text === 'workflowContext'
+      ) {
+        return argument.arguments.length === 2;
+      }
+      return (
+        ts.isIdentifier(argument) &&
+        (argument.text === 'guard' || argument.text === 'executionGuard')
+      );
+    });
+  const check = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) || ts.isNewExpression(node)) {
+      const called = names(node.expression).map(name => name.replace(/\.(?:call|apply)$/u, ''));
+      const site = `${path}:${enclosing(node)}`;
+      for (const name of called) {
+        const target = leaf(name);
+        if (
+          runnerNames.has(target) &&
+          (!(runnerSites.get(site)?.includes(target) ?? false) || !hasGuard(node))
+        ) {
+          failures.push(`${site}: unguarded ${target}`);
+        }
+        if (
+          adapterImports.has(target) &&
+          !runnerNames.has(target) &&
+          !guardedAdapters.has(site) &&
+          (!allowedImports.has(path) || !hasGuard(node))
+        ) {
+          failures.push(`${site}: unguarded adapter ${target}`);
+        }
+        if (
+          (rawSink(name) || (ts.isNewExpression(node) && name === 'Function')) &&
+          !guardedAdapters.has(site) &&
+          !legacyAdapters.has(site)
+        ) {
+          failures.push(`${site}: direct ${name}`);
+        }
+      }
+    }
+    if (ts.isNoSubstitutionTemplateLiteral(node) && !path.includes('#')) {
+      // Only this fixed helper is an admitted injected adapter. Dynamic model code still requires runtime guards.
+      const container = ts.isVariableDeclaration(node.parent)
+        ? member(node.parent.name)
+        : undefined;
+      if (!(path === `${shared}agent-workflow-runner.ts` && container === 'PAGE_HELPERS_CODE')) {
+        failures.push(...inspect(`${path}#${container ?? 'literal'}`, node.text));
+      }
+    }
+    ts.forEachChild(node, check);
+  };
+  check(source);
+  return [...new Set(failures)];
+};
+const functionBody = (source: ts.SourceFile, name: string): ts.Node => {
+  let found: ts.Node | undefined = undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name &&
+      node.initializer !== undefined
+    ) {
+      found = node.initializer;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  if (found === undefined) {
+    throw new Error(`Missing execution entry ${name}`);
+  }
+  return found;
+};
+const callPositions = (node: ts.Node, name: string): number[] => {
+  const found: number[] = [];
+  const visit = (child: ts.Node): void => {
+    if (ts.isCallExpression(child)) {
+      const { expression } = child;
+      if (
+        (ts.isIdentifier(expression) && expression.text === name) ||
+        (ts.isPropertyAccessExpression(expression) && expression.name.text === name)
+      ) {
+        found.push(child.pos);
+      }
+    }
+    ts.forEachChild(child, visit);
+  };
+  visit(node);
+  return found;
+};
+
+describe('browser action boundary inventory', () => {
+  it('permits only the inventoried guarded runners and browser adapters', () => {
+    expect(
+      sourceFiles.flatMap(path => inspect(relative(root, path), readFileSync(path, 'utf8')))
+    ).toStrictEqual([]);
+  });
+
+  it.each([
+    [
+      'chat alias',
+      "import { runSafeLlmTurn as start } from './agent-turn-runners'; start(options);",
+    ],
+    [
+      'workflow namespace element',
+      "import * as tools from './agent-workflow-tool-runtime'; tools['executeWorkflowToolCall'](event, options);",
+    ],
+    [
+      'adapter namespace element',
+      "import * as tools from './agent-workflow-runtime'; tools['evalInTab'](7, code);",
+    ],
+    [
+      'direct dispatch alias',
+      "const send = browser['runtime']['sendMessage']; send({type: 'eval'});",
+    ],
+    [
+      'bound dispatch',
+      'const send = browser.runtime.sendMessage.bind(browser.runtime); send(message);',
+    ],
+    ['destructured dispatch', 'const { sendMessage: send } = browser.runtime; send(message);'],
+    [
+      'object alias',
+      "const actions = { send: browser.runtime.sendMessage }; actions['send'](message);",
+    ],
+    [
+      'assigned dispatch',
+      'let send; send = browser.runtime.sendMessage; send.call(browser.runtime, message);',
+    ],
+    ['direct script', "browser['scripting']['executeScript'](script);"],
+    ['constant element', "const method = 'sendMessage'; browser.runtime[method](message);"],
+    ['unknown element', 'browser.runtime[method](message);'],
+    ['static injected bypass', 'const script = `browser.runtime.sendMessage(message)`;'],
+    [
+      'import without call',
+      "import { evalInTab as evaluate } from './agent-workflow-runtime'; export { evaluate };",
+    ],
+  ])('rejects a new %s bypass', (_label, text) => {
+    expect(inspect(`${panel}new-entry.ts`, text).length).toBeGreaterThan(0);
+  });
+
+  it('rejects a missing guard at the existing chat adapter', () => {
+    const path = `${panel}browser-run-context.ts`;
+    const text = readFileSync(join(root, path), 'utf8');
+    const broken = text.replace(
+      'executionGuard: guard,\n      fetch:',
+      'executionGuard: undefined,\n      fetch:'
+    );
+    expect(broken).not.toBe(text);
+    expect(inspect(path, broken)).toContain(`${path}:runBrowserTurn: unguarded runSafeLlmTurn`);
+  });
+
+  it('permits a11 to use only the guarded public context API', () => {
+    expect(
+      inspect(
+        `${panel}browser-task-runner.ts`,
+        "import { runBrowserTurn } from './browser-run-context'; export const run = (context: BrowserRunContext, events: AgentConversationEvent[]) => runBrowserTurn(context, events);"
+      )
+    ).toStrictEqual([]);
+  });
+
+  it.each([
+    {
+      action: 'set',
+      entry: 'submitDraft',
+      file: 'agent-chat-panel.tsx',
+      guard: 'acquireLocal',
+      label: 'chat draft',
+    },
+    {
+      action: 'submitMessage',
+      entry: 'submitQueuedMessage',
+      file: 'agent-chat-panel.tsx',
+      guard: 'acquireLocal',
+      label: 'queued drain',
+    },
+    {
+      action: 'setRunRequest',
+      entry: 'handleRun',
+      file: 'workflow-settings.tsx',
+      guard: 'acquireLocal',
+      label: 'Settings and parameter prompt',
+    },
+    {
+      action: 'runBrowserTurn',
+      entry: 'startTurn',
+      file: 'agent-chat-panel.tsx',
+      guard: 'setupRunContext',
+      label: 'chat continuation',
+    },
+    {
+      action: 'continueConversation',
+      entry: 'continueConversation',
+      file: '../../src/shared/agent-llm-turn-runner-core.ts',
+      guard: 'guard',
+      label: 'recursive continuation',
+    },
+  ])('keeps admission before execution for $label', ({ file, entry, guard, action }) => {
+    const path = join(root, panel, file);
+    const body = functionBody(parse(path, readFileSync(path, 'utf8')), entry);
+    const gates = callPositions(body, guard);
+    const actions = callPositions(body, action);
+    expect(gates.length).toBeGreaterThan(0);
+    expect(actions.length).toBeGreaterThan(0);
+    expect(gates[0]).toBeLessThan(actions[0] ?? -1);
+  });
+
+  it('keeps the workflow effect on the admitted shared context path', () => {
+    const path = join(root, panel, 'agent-chat-panel.tsx');
+    const source = parse(path, readFileSync(path, 'utf8'));
+    const reservation = callPositions(source, 'takeWorkflowLease');
+    const workflow = callPositions(source, 'runBrowserWorkflow');
+    expect(reservation.length).toBeGreaterThan(0);
+    expect(workflow).toHaveLength(1);
+    expect(reservation.at(-1)).toBeLessThan(workflow[0] ?? -1);
+  });
+
+  it('inventories static injected helpers without pretending to prove model JavaScript', () => {
+    const path = join(root, shared, 'agent-workflow-runner.ts');
+    const helpers = functionBody(parse(path, readFileSync(path, 'utf8')), 'PAGE_HELPERS_CODE');
+    if (!ts.isNoSubstitutionTemplateLiteral(helpers)) {
+      throw new Error('Review the changed injected helper format');
+    }
+    const injected = parse('workflow-page-helpers.ts', helpers.text);
+    expect(callPositions(injected, 'click').length).toBeGreaterThan(0);
+    expect(callPositions(injected, 'dispatchEvent').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/browser-action-boundary.test.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-action-boundary.test.ts
@@ -355,15 +355,18 @@ const functionBody = (source: ts.SourceFile, name: string): ts.Node => {
   }
   return found;
 };
-const callPositions = (node: ts.Node, name: string): number[] => {
+type CallMatcher = string | ((call: ts.CallExpression) => boolean);
+const callPositions = (node: ts.Node, match: CallMatcher): number[] => {
   const found: number[] = [];
   const visit = (child: ts.Node): void => {
     if (ts.isCallExpression(child)) {
       const { expression } = child;
-      if (
-        (ts.isIdentifier(expression) && expression.text === name) ||
-        (ts.isPropertyAccessExpression(expression) && expression.name.text === name)
-      ) {
+      const matches =
+        typeof match === 'function'
+          ? match(child)
+          : (ts.isIdentifier(expression) && expression.text === match) ||
+            (ts.isPropertyAccessExpression(expression) && expression.name.text === match);
+      if (matches) {
         found.push(child.pos);
       }
     }
@@ -371,6 +374,20 @@ const callPositions = (node: ts.Node, name: string): number[] => {
   };
   visit(node);
   return found;
+};
+const isChatInputWrite = (call: ts.CallExpression): boolean => {
+  const { expression } = call;
+  // Exclude only the known pending-map write; other set calls can consume aliased input.
+  return (
+    expression.getText() !== 'pendingAdmissionsRef.current.set' &&
+    ((ts.isIdentifier(expression) && expression.text === 'set') ||
+      (ts.isPropertyAccessExpression(expression) && expression.name.text === 'set'))
+  );
+};
+const admissionPrecedesAction = (node: ts.Node, guard: string, action: CallMatcher): boolean => {
+  const [gate] = callPositions(node, guard);
+  const [firstAction] = callPositions(node, action);
+  return gate !== undefined && firstAction !== undefined && gate < firstAction;
 };
 
 describe('browser action boundary inventory', () => {
@@ -460,7 +477,7 @@ describe('browser action boundary inventory', () => {
 
   it.each([
     {
-      action: 'set',
+      action: isChatInputWrite,
       entry: 'submitDraft',
       file: 'agent-chat-panel.tsx',
       guard: 'acquireLocal',
@@ -472,6 +489,13 @@ describe('browser action boundary inventory', () => {
       file: 'agent-chat-panel.tsx',
       guard: 'acquireLocal',
       label: 'queued drain',
+    },
+    {
+      action: isChatInputWrite,
+      entry: 'submitQueuedMessage',
+      file: 'agent-chat-panel.tsx',
+      guard: 'acquireLocal',
+      label: 'queued input consumption',
     },
     {
       action: 'setRunRequest',
@@ -497,11 +521,50 @@ describe('browser action boundary inventory', () => {
   ])('keeps admission before execution for $label', ({ file, entry, guard, action }) => {
     const path = join(root, panel, file);
     const body = functionBody(parse(path, readFileSync(path, 'utf8')), entry);
-    const gates = callPositions(body, guard);
-    const actions = callPositions(body, action);
-    expect(gates.length).toBeGreaterThan(0);
-    expect(actions.length).toBeGreaterThan(0);
-    expect(gates[0]).toBeLessThan(actions[0] ?? -1);
+    expect(admissionPrecedesAction(body, guard, action)).toBe(true);
+  });
+
+  it.each([
+    ['draft clearing', 'submitDraft', "store.set(draftAtomFamily(conversationId), '');"],
+    [
+      'draft queueing',
+      'submitDraft',
+      'store.set(queuedMessageAtomFamily(conversationId), current => appendQueuedMessage(current, text));',
+    ],
+    [
+      'queue consumption',
+      'submitQueuedMessage',
+      'store.set(queuedMessageAtomFamily(conversationId), undefined);',
+    ],
+    [
+      'aliased draft clearing',
+      'submitDraft',
+      "const inputStore = store; inputStore.set(draftAtomFamily(conversationId), '');",
+    ],
+    [
+      'aliased queue consumption',
+      'submitQueuedMessage',
+      'const inputStore = store; inputStore.set(queuedMessageAtomFamily(conversationId), undefined);',
+    ],
+    [
+      'draft atom alias clearing',
+      'submitDraft',
+      "const draft = draftAtomFamily(conversationId); store.set(draft, '');",
+    ],
+    [
+      'queued atom alias consumption',
+      'submitQueuedMessage',
+      'const queuedAtom = queuedMessageAtomFamily(conversationId); store.set(queuedAtom, undefined);',
+    ],
+  ])('rejects %s before admission', (_label, entry, mutation) => {
+    const path = join(root, panel, 'agent-chat-panel.tsx');
+    const source = parse(path, readFileSync(path, 'utf8'));
+    const original = functionBody(source, entry).getText(source);
+    const gate = 'const admission = await getBrowserExecutionCoordinator().acquireLocal();';
+    const broken = original.replace(gate, `${mutation}\n${gate}`);
+    expect(broken).not.toBe(original);
+    const body = functionBody(parse(path, `const ${entry} = ${broken};`), entry);
+    expect(admissionPrecedesAction(body, 'acquireLocal', isChatInputWrite)).toBe(false);
   });
 
   it('keeps the workflow effect on the admitted shared context path', () => {

--- a/apps/extension/entrypoints/sidepanel/browser-action-boundary.test.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-action-boundary.test.ts
@@ -293,6 +293,13 @@ const inspect = (path: string, text: string): string[] => {
       for (const name of called) {
         const target = leaf(name);
         if (
+          site === `${panel}browser-run-context.ts:withBoundTab` &&
+          name === 'context.lease.run' &&
+          node.arguments?.[1]?.getText(source) !== 'context.selectedTab.id'
+        ) {
+          failures.push(`${site}: missing bound local protection`);
+        }
+        if (
           runnerNames.has(target) &&
           (!(runnerSites.get(site)?.includes(target) ?? false) || !hasGuard(node))
         ) {
@@ -425,6 +432,22 @@ describe('browser action boundary inventory', () => {
     expect(broken).not.toBe(text);
     expect(inspect(path, broken)).toContain(`${path}:runBrowserTurn: unguarded runSafeLlmTurn`);
   });
+
+  it.each(['undefined', '8'])(
+    'rejects shared run setup that replaces the bound protection tab with %s',
+    replacement => {
+      const path = `${panel}browser-run-context.ts`;
+      const text = readFileSync(join(root, path), 'utf8');
+      const broken = text.replace(
+        /,\s*context\.selectedTab\.id(?=\s*,?\s*\))/u,
+        `, ${replacement}`
+      );
+      expect(broken).not.toBe(text);
+      expect(inspect(path, broken)).toContain(
+        `${path}:withBoundTab: missing bound local protection`
+      );
+    }
+  );
 
   it('permits a11 to use only the guarded public context API', () => {
     expect(

--- a/apps/extension/entrypoints/sidepanel/browser-execution-lock.test.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-execution-lock.test.ts
@@ -40,10 +40,49 @@ const profile = (supportsLocks = true) => {
     },
   };
   return {
-    panel: () =>
-      createBrowserExecutionCoordinator({ locks: supportsLocks ? locks : undefined, storageArea }),
+    panel: (panelLocks = locks) =>
+      createBrowserExecutionCoordinator({
+        locks: supportsLocks ? panelLocks : undefined,
+        storageArea,
+      }),
     storageArea,
     values,
+  };
+};
+
+// Model context destruction by releasing its native requests, not by settling the issued page work.
+// Actual Chrome/Firefox panel destruction remains a13 verification.
+const nativeContext = () => {
+  const destroyed = Promise.withResolvers<void>();
+  const requests: Promise<unknown>[] = [];
+  const callbacks: unknown[] = [];
+  type Work = (lock: Lock | null) => unknown;
+  const request = (name: string, options: LockOptions | Work, callback?: Work) => {
+    const work = typeof options === 'function' ? options : callback;
+    if (work === undefined) {
+      throw new Error('Missing native lock callback');
+    }
+    const running = locks.request(name, typeof options === 'function' ? {} : options, lock => {
+      const pending = work(lock);
+      callbacks.push(pending);
+      return Promise.race([pending, destroyed.promise]);
+    });
+    requests.push(running);
+    return running;
+  };
+  return {
+    destroy: async () => {
+      destroyed.resolve();
+      await Promise.all(requests);
+    },
+    drain: async () => {
+      // Late callbacks can append a final safety mutation while earlier callbacks drain.
+      for (const callback of callbacks) {
+        // eslint-disable-next-line no-await-in-loop -- Include callbacks appended by each awaited completion.
+        await callback;
+      }
+    },
+    locks: { query: () => locks.query(), request } as LockManager,
   };
 };
 
@@ -51,6 +90,417 @@ describe('profile browser execution locks', () => {
   afterEach(async () => {
     await Promise.all([...leases].map(lease => lease.release()));
     leases.clear();
+  });
+
+  it('records bound tabs before dispatch and removes only each completed shared run', async () => {
+    const state = profile();
+    const first = state.panel();
+    const second = state.panel();
+    const one = admitted(await first.acquireLocal());
+    const startedOne = Promise.withResolvers<void>();
+    const startedTwo = Promise.withResolvers<void>();
+    const finishOne = Promise.withResolvers<void>();
+    const finishTwo = Promise.withResolvers<void>();
+    const issued: unknown[] = [];
+    const workOne = one.run(async () => {
+      issued.push(structuredClone(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)));
+      startedOne.resolve();
+      await finishOne.promise;
+      return 'first tab completed';
+    }, 0);
+    await startedOne.promise;
+    const two = admitted(await second.acquireLocal());
+    const workTwo = two.run(async () => {
+      issued.push(structuredClone(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)));
+      startedTwo.resolve();
+      await finishTwo.promise;
+      return 'second tab completed';
+    }, 8);
+    try {
+      await startedTwo.promise;
+      expect(issued).toMatchObject([
+        { localRuns: [{ tabId: 0 }], tabIds: [] },
+        { localRuns: [{ tabId: 0 }, { tabId: 8 }], tabIds: [] },
+      ]);
+      finishOne.resolve();
+      await expect(workOne).resolves.toBe('first tab completed');
+      await one.release();
+      expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({
+        localRuns: [{ tabId: 8 }],
+        tabIds: [],
+      });
+      const joining = admitted(await state.panel().acquireLocal());
+      await joining.release();
+      await second.refresh();
+      expect(second.getSnapshot()).toMatchObject({ blockedReason: undefined, localRuns: 1 });
+    } finally {
+      finishOne.resolve();
+      finishTwo.resolve();
+      await Promise.all([workOne, workTwo]);
+      await Promise.all([one.release(), two.release()]);
+    }
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      tabIds: [],
+      version: 1,
+    });
+    const reloaded = state.panel();
+    const provider = admitted(await reloaded.acquireProviderOwner());
+    const delegated = admitted(
+      await reloaded.acquireDelegated(provider, 'after-completion', new AbortController().signal)
+    );
+    await expect(delegated.run(async () => 'next work')).resolves.toBe('next work');
+  });
+
+  it('keeps guarded shared work running when a populated refresh crosses normal completion', async () => {
+    const state = profile();
+    const first = state.panel();
+    const second = state.panel();
+    const one = admitted(await first.acquireLocal());
+    const two = admitted(await second.acquireLocal());
+    const startedOne = Promise.withResolvers<void>();
+    const startedTwo = Promise.withResolvers<void>();
+    const finishOne = Promise.withResolvers<void>();
+    const finishTwo = Promise.withResolvers<void>();
+    const workOne = one.run(async () => {
+      startedOne.resolve();
+      await finishOne.promise;
+      return 'first tab completed';
+    }, 7);
+    const workTwo = two.run(async guard => {
+      startedTwo.resolve();
+      await finishTwo.promise;
+      guard();
+      return 'second tab completed';
+    }, 8);
+    await Promise.all([startedOne.promise, startedTwo.promise]);
+    const read = state.storageArea.getItem;
+    const captured = Promise.withResolvers<void>();
+    const stale = Promise.withResolvers<void>();
+    let delayed = false;
+    state.storageArea.getItem = async key => {
+      const value = read(key);
+      if (key === BROWSER_EXECUTION_SAFETY_KEY && !delayed) {
+        delayed = true;
+        captured.resolve();
+        await stale.promise;
+      }
+      return value;
+    };
+    const refreshing = second.refresh();
+    try {
+      await captured.promise;
+      finishOne.resolve();
+      await expect(workOne).resolves.toBe('first tab completed');
+      await one.release();
+      expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({
+        localRuns: [{ tabId: 8 }],
+        tabIds: [],
+      });
+      stale.resolve();
+      await refreshing;
+      finishTwo.resolve();
+      await expect(workTwo).resolves.toBe('second tab completed');
+      expect(second.getSnapshot()).toMatchObject({
+        blockedReason: undefined,
+        quarantinedTabIds: [],
+      });
+    } finally {
+      stale.resolve();
+      finishOne.resolve();
+      finishTwo.resolve();
+      state.storageArea.getItem = read;
+      await Promise.allSettled([refreshing, workOne, workTwo]);
+      await Promise.all([one.release(), two.release()]);
+    }
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      tabIds: [],
+      version: 1,
+    });
+  });
+
+  it('serializes simultaneous completions from separate coordinators', async () => {
+    const state = profile();
+    const one = admitted(await state.panel().acquireLocal());
+    const two = admitted(await state.panel().acquireLocal());
+    const finish = Promise.withResolvers<void>();
+    let issued = 0;
+    const execute = async () => {
+      issued += 1;
+      await finish.promise;
+    };
+    const workOne = one.run(execute, 7);
+    const workTwo = two.run(execute, 8);
+    try {
+      await vi.waitFor(() => {
+        expect(issued).toBe(2);
+      });
+    } finally {
+      finish.resolve();
+      await Promise.all([workOne, workTwo]);
+      await Promise.all([one.release(), two.release()]);
+    }
+    const next = admitted(await state.panel().acquireLocal());
+    await expect(next.run(async () => 'both runs drained', 0)).resolves.toBe('both runs drained');
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      tabIds: [],
+      version: 1,
+    });
+  });
+
+  it.each([0, 7])('retains tab %s protection after native owner loss and reload', async tabId => {
+    const state = profile();
+    const context = nativeContext();
+    const owner = state.panel(context.locks);
+    const observer = state.panel();
+    const local = admitted(await owner.acquireLocal());
+    const issued = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    const effects: string[] = [];
+    const running = local.run(async () => {
+      issued.resolve();
+      await finish.promise;
+      effects.push('page work settled');
+    }, tabId);
+    try {
+      await issued.promise;
+      await observer.refresh();
+      expect(observer.getSnapshot().blockedReason).toBeUndefined();
+      await context.destroy();
+      await local.release();
+      const reloaded = state.panel();
+      const provider = admitted(await reloaded.acquireProviderOwner());
+      expect({
+        delegated: (
+          await reloaded.acquireDelegated(provider, 'after-loss', new AbortController().signal)
+        ).admitted,
+        effects,
+        existingPanel: await observer.acquireLocal(),
+        reloadedPanel: await reloaded.acquireLocal(),
+      }).toMatchObject({
+        delegated: false,
+        effects: [],
+        existingPanel: {
+          admitted: false,
+          reason: expect.stringContaining('Close the affected tabs'),
+        },
+        reloadedPanel: {
+          admitted: false,
+          reason: expect.stringContaining('Close the affected tabs'),
+        },
+      });
+      expect(reloaded.getSnapshot().quarantinedTabIds).toStrictEqual([tabId]);
+    } finally {
+      finish.resolve();
+      await running;
+      await local.release();
+      await context.drain();
+    }
+    // A late result cannot prove completion on behalf of a destroyed native owner.
+    expect({
+      admission: await observer.acquireLocal(),
+      effects,
+      openReadiness: await observer.prepareRecovery(async () => [tabId]),
+      readiness: await observer.prepareRecovery(async () => []),
+      rechecked: await observer.recover(async () => [tabId]),
+      recovery: await observer.recover(async () => []),
+    }).toMatchObject({
+      admission: { admitted: false },
+      effects: ['page work settled'],
+      openReadiness: { ready: false },
+      readiness: { ready: true },
+      rechecked: { recovered: false },
+      recovery: { recovered: true },
+    });
+    const next = admitted(await observer.acquireLocal());
+    await expect(next.run(async () => 'explicit new work', 8)).resolves.toBe('explicit new work');
+  });
+
+  it('rechecks durable protection before dispatch despite another panel returning a stale empty read', async () => {
+    const state = profile();
+    const context = nativeContext();
+    const owner = state.panel(context.locks);
+    const observer = state.panel();
+    const existing = admitted(await observer.acquireLocal());
+    const local = admitted(await owner.acquireLocal());
+    const read = state.storageArea.getItem;
+    const captured = Promise.withResolvers<void>();
+    const stale = Promise.withResolvers<void>();
+    let delayed = false;
+    state.storageArea.getItem = async key => {
+      const value = read(key);
+      if (key === BROWSER_EXECUTION_SAFETY_KEY && !delayed) {
+        delayed = true;
+        captured.resolve();
+        await stale.promise;
+      }
+      return value;
+    };
+    const refreshing = observer.refresh();
+    await captured.promise;
+    const issued = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    const running = local.run(async () => {
+      issued.resolve();
+      await finish.promise;
+    }, 7);
+    const effects: string[] = [];
+    try {
+      await issued.promise;
+      await context.destroy();
+      await local.release();
+      stale.resolve();
+      await refreshing;
+      await expect(
+        existing.run(async () => {
+          effects.push('unsafe dispatch');
+        }, 8)
+      ).rejects.toThrow('profile_quarantined');
+      expect(effects).toStrictEqual([]);
+      await expect(observer.acquireLocal()).resolves.toMatchObject({ admitted: false });
+      await expect(state.panel().acquireLocal()).resolves.toMatchObject({ admitted: false });
+    } finally {
+      stale.resolve();
+      state.storageArea.getItem = read;
+      finish.resolve();
+      await Promise.all([refreshing, running]);
+      await local.release();
+      await context.drain();
+    }
+  });
+
+  it('does not let a stale completion erase a new run or quarantine after recovery', async () => {
+    const state = profile();
+    const context = nativeContext();
+    const lost = admitted(await state.panel(context.locks).acquireLocal());
+    const issued = Promise.withResolvers<void>();
+    const finishLost = Promise.withResolvers<void>();
+    const oldWork = lost.run(async () => {
+      issued.resolve();
+      await finishLost.promise;
+    }, 7);
+    await issued.promise;
+    await context.destroy();
+    await lost.release();
+    const nextPanel = state.panel();
+    await expect(nextPanel.recover(async () => [])).resolves.toMatchObject({ recovered: true });
+    const next = admitted(await nextPanel.acquireLocal());
+    const nextIssued = Promise.withResolvers<void>();
+    const finishNext = Promise.withResolvers<void>();
+    const nextWork = next.run(async () => {
+      nextIssued.resolve();
+      await finishNext.promise;
+    }, 8);
+    try {
+      await nextIssued.promise;
+      const uncertain = admitted(await state.panel().acquireLocal());
+      await uncertain.quarantine(9);
+      await uncertain.release();
+      const protectedState = structuredClone(state.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+      finishLost.resolve();
+      await oldWork;
+      await context.drain();
+      expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(protectedState);
+      expect(protectedState).toMatchObject({ localRuns: [{ tabId: 8 }], tabIds: [9] });
+    } finally {
+      finishLost.resolve();
+      finishNext.resolve();
+      await Promise.all([oldWork, nextWork]);
+      await Promise.all([lost.release(), next.release()]);
+      await context.drain();
+    }
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      tabIds: [9],
+      version: 1,
+    });
+    await expect(state.panel().acquireLocal()).resolves.toMatchObject({ admitted: false });
+  });
+
+  it.each([false, true])(
+    'rejects dispatch when the protection write fails (persisted=%s)',
+    async persisted => {
+      const state = profile();
+      const panel = state.panel();
+      const local = admitted(await panel.acquireLocal());
+      const write = state.storageArea.setItem;
+      const effects: string[] = [];
+      state.storageArea.setItem = async (key, value) => {
+        if (persisted) {
+          await write(key, value);
+        }
+        throw new Error('storage unavailable');
+      };
+      try {
+        await expect(
+          local.run(async () => {
+            effects.push('unsafe dispatch');
+          }, 7)
+        ).rejects.toThrow('storage unavailable');
+        await local.release();
+        expect({
+          admission: await panel.acquireLocal(),
+          effects,
+          persisted: state.values.has(BROWSER_EXECUTION_SAFETY_KEY),
+        }).toMatchObject({
+          admission: { admitted: false, reason: expect.stringContaining('Restore storage access') },
+          effects: [],
+          persisted,
+        });
+      } finally {
+        state.storageArea.setItem = write;
+      }
+      await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: true });
+      const next = admitted(await state.panel().acquireLocal());
+      await expect(next.run(async () => 'explicit retry', 8)).resolves.toBe('explicit retry');
+    }
+  );
+
+  it('retains durable protection when completion cannot be persisted', async () => {
+    const state = profile();
+    const panel = state.panel();
+    const local = admitted(await panel.acquireLocal());
+    const issued = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    const running = local.run(async () => {
+      issued.resolve();
+      await finish.promise;
+    }, 7);
+    await issued.promise;
+    const write = state.storageArea.setItem;
+    state.storageArea.setItem = () => {
+      throw new Error('storage unavailable');
+    };
+    try {
+      finish.resolve();
+      await expect(running).rejects.toThrow('storage unavailable');
+      await local.release();
+    } finally {
+      state.storageArea.setItem = write;
+    }
+    const reloaded = state.panel();
+    await expect(reloaded.acquireLocal()).resolves.toMatchObject({ admitted: false });
+    await expect(reloaded.recover(async () => [7])).resolves.toMatchObject({ recovered: false });
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({
+      localRuns: [{ tabId: 7 }],
+    });
+    await expect(reloaded.recover(async () => [])).resolves.toMatchObject({ recovered: true });
+    admitted(await reloaded.acquireLocal());
+  });
+
+  it('retains protection for an unexpected result loss without misreporting a storage error', async () => {
+    const state = profile();
+    const local = admitted(await state.panel().acquireLocal());
+    await expect(
+      local.run(async () => {
+        throw new Error('page result lost');
+      }, 7)
+    ).rejects.toThrow('page result lost');
+    await local.release();
+    const reloaded = state.panel();
+    await expect(reloaded.acquireLocal()).resolves.toMatchObject({
+      admitted: false,
+      reason: expect.stringContaining('Close the affected tabs'),
+    });
+    await expect(reloaded.recover(async () => [7])).resolves.toMatchObject({ recovered: false });
   });
 
   it('admits shared local runs in separate panels without sharing provider ownership', async () => {
@@ -657,6 +1107,24 @@ describe('profile browser execution locks', () => {
     await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: true });
   });
 
+  it.each([
+    {
+      failure: 'negative tab',
+      localRuns: [{ lockName: `${BROWSER_EXECUTION_LOCK}:local:lost`, tabId: -1 }],
+    },
+    { failure: 'foreign lock', localRuns: [{ lockName: BROWSER_EXECUTION_LOCK, tabId: 7 }] },
+    { failure: 'invalid list', localRuns: 'invalid' },
+  ])('fails closed on $failure protection data', async ({ localRuns }) => {
+    const state = profile();
+    const record = { localRuns, tabIds: [], version: 1 };
+    state.values.set(BROWSER_EXECUTION_SAFETY_KEY, record);
+    await expect(state.panel().acquireLocal()).resolves.toMatchObject({
+      admitted: false,
+      reason: expect.stringContaining('safety state is unavailable'),
+    });
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(record);
+  });
+
   it('fails closed on corrupt safety data rather than discarding the fence', async () => {
     const state = profile();
     state.values.set(BROWSER_EXECUTION_SAFETY_KEY, { tabIds: ['7'], version: 1 });
@@ -673,7 +1141,7 @@ describe('profile browser execution locks', () => {
       storageArea: state.storageArea,
     });
     const local = admitted(await panel.acquireLocal());
-    await expect(local.run(async () => 'local result')).resolves.toBe('local result');
+    await expect(local.run(async () => 'local result', 0)).resolves.toBe('local result');
     await expect(panel.acquireProviderOwner()).resolves.toMatchObject({
       admitted: false,
       reason: expect.stringContaining('does not support Web Locks'),

--- a/apps/extension/entrypoints/sidepanel/browser-execution-lock.test.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-execution-lock.test.ts
@@ -1,0 +1,701 @@
+/* eslint-disable import/no-nodejs-modules, jest/no-hooks, jest/no-conditional-in-test, max-lines, require-await, typescript/require-await, typescript/no-unsafe-assignment, unicorn/no-await-expression-member, promise/prefer-await-to-callbacks -- Native scheduling fixtures implement asynchronous APIs and storage subscriptions; matchers describe observable state. */
+import { locks as nativeLocks } from 'node:worker_threads';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  BROWSER_EXECUTION_LOCK,
+  BROWSER_EXECUTION_SAFETY_KEY,
+  createBrowserExecutionCoordinator,
+} from './browser-execution-lock';
+import type {
+  BrowserAdmission,
+  BrowserExecutionLease,
+  BrowserLockStorage,
+} from './browser-execution-lock';
+
+const locks = nativeLocks as LockManager;
+const leases = new Set<BrowserExecutionLease>();
+const admitted = (admission: BrowserAdmission): BrowserExecutionLease => {
+  if (!admission.admitted) {
+    throw new Error(admission.reason);
+  }
+  leases.add(admission.lease);
+  return admission.lease;
+};
+const profile = (supportsLocks = true) => {
+  const values = new Map<string, unknown>();
+  const watchers = new Set<() => void>();
+  const storageArea: BrowserLockStorage = {
+    getItem: key => values.get(key),
+    setItem: (key, value) => {
+      values.set(key, structuredClone(value));
+      for (const watcher of watchers) {
+        watcher();
+      }
+    },
+    watch: (_key, callback) => {
+      watchers.add(callback);
+      return () => {
+        watchers.delete(callback);
+      };
+    },
+  };
+  return {
+    panel: () =>
+      createBrowserExecutionCoordinator({ locks: supportsLocks ? locks : undefined, storageArea }),
+    storageArea,
+    values,
+  };
+};
+
+describe('profile browser execution locks', () => {
+  afterEach(async () => {
+    await Promise.all([...leases].map(lease => lease.release()));
+    leases.clear();
+  });
+
+  it('admits shared local runs in separate panels without sharing provider ownership', async () => {
+    const state = profile();
+    const first = state.panel();
+    const second = state.panel();
+    const owner = admitted(await first.acquireProviderOwner());
+    expect((await second.acquireProviderOwner()).admitted).toBe(false);
+    const one = admitted(await first.acquireLocal());
+    const two = admitted(await second.acquireLocal());
+    const values = await Promise.all([
+      one.run(async () => 'first tab'),
+      two.run(async () => 'second tab'),
+    ]);
+    expect(values).toStrictEqual(['first tab', 'second tab']);
+    await first.refresh();
+    expect(first.getSnapshot()).toMatchObject({
+      delegated: 'idle',
+      localRuns: 2,
+      providerOwned: true,
+    });
+    await owner.release();
+    admitted(await second.acquireProviderOwner());
+  });
+
+  it('rejects new local work while delegation waits and while it runs', async () => {
+    const state = profile();
+    const localPanel = state.panel();
+    const providerPanel = state.panel();
+    const local = admitted(await localPanel.acquireLocal());
+    const provider = admitted(await providerPanel.acquireProviderOwner());
+    const pending = providerPanel.acquireDelegated(
+      provider,
+      'parent-a',
+      new AbortController().signal
+    );
+    await vi.waitFor(async () => {
+      expect(
+        (await locks.query()).pending?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
+      ).toBe(true);
+    });
+    const blocked = await localPanel.acquireLocal();
+    expect(blocked).toMatchObject({
+      admitted: false,
+      reason: expect.stringContaining('CLI session parent-a'),
+    });
+    await local.release();
+    const delegated = admitted(await pending);
+    expect((await localPanel.acquireLocal()).admitted).toBe(false);
+    await delegated.release();
+    admitted(await localPanel.acquireLocal());
+  });
+
+  it('holds the execution lock until an issued action unwinds after release is requested', async () => {
+    const panel = profile().panel();
+    const local = admitted(await panel.acquireLocal());
+    const provider = admitted(await panel.acquireProviderOwner());
+    const action = Promise.withResolvers<void>();
+    const events: string[] = [];
+    const work = local.run(async guard => {
+      guard();
+      events.push('issued');
+      await action.promise;
+      events.push('unwound');
+    });
+    const releasing = local.release();
+    const pending = panel.acquireDelegated(provider, 'parent-a', new AbortController().signal);
+    try {
+      await vi.waitFor(async () => {
+        expect(
+          (await locks.query()).pending?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
+        ).toBe(true);
+      });
+      expect(events).toStrictEqual(['issued']);
+      expect(() => {
+        local.guard();
+      }).toThrow('execution_lease_lost');
+    } finally {
+      action.resolve();
+    }
+    await Promise.all([work, releasing]);
+    const delegated = admitted(await pending);
+    await delegated.run(async () => {
+      events.push('delegated');
+    });
+    expect(events).toStrictEqual(['issued', 'unwound', 'delegated']);
+  });
+
+  it('rejects a cancelled waiter and admits explicit local work after native drainage', async () => {
+    const panel = profile().panel();
+    const local = admitted(await panel.acquireLocal());
+    const provider = admitted(await panel.acquireProviderOwner());
+    const abort = new AbortController();
+    const waiting = panel.acquireDelegated(provider, 'parent-a', abort.signal);
+    await vi.waitFor(async () => {
+      expect((await locks.query()).pending).toHaveLength(1);
+    });
+    abort.abort();
+    expect((await waiting).admitted).toBe(false);
+    await expect(local.run(async () => 'existing local work')).resolves.toBe('existing local work');
+    // Node 24 retains the cancelled native waiter until shared work drains and its scheduler advances.
+    // Never hide a native pending exclusive lock in product code; browser cancellation proof belongs to a13.
+    await local.release();
+    await vi.waitFor(async () => {
+      expect((await locks.query()).pending).toHaveLength(0);
+    });
+    const next = admitted(await panel.acquireLocal());
+    await expect(next.run(async () => 'explicit submission')).resolves.toBe('explicit submission');
+  });
+
+  it('persists quarantine before release and blocks fresh panels until closed-tab recovery', async () => {
+    const state = profile();
+    const panel = state.panel();
+    const local = admitted(await panel.acquireLocal());
+    await local.quarantine(7);
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      tabIds: [7],
+      version: 1,
+    });
+    await local.release();
+    const reloaded = state.panel();
+    const provider = admitted(await reloaded.acquireProviderOwner());
+    expect({
+      delegated: (
+        await reloaded.acquireDelegated(provider, 'parent-b', new AbortController().signal)
+      ).admitted,
+      local: (await reloaded.acquireLocal()).admitted,
+    }).toStrictEqual({ delegated: false, local: false });
+    await expect(reloaded.recover(async () => [7, 8])).resolves.toMatchObject({ recovered: false });
+    await expect(reloaded.recover(async () => [8])).resolves.toMatchObject({ recovered: true });
+    const resumed = admitted(await panel.acquireLocal());
+    await expect(resumed.run(async () => 'explicit new work')).resolves.toBe('explicit new work');
+  });
+
+  it('requires every shared action to drain before recovery', async () => {
+    const state = profile();
+    const first = state.panel();
+    const second = state.panel();
+    const one = admitted(await first.acquireLocal());
+    const two = admitted(await second.acquireLocal());
+    await one.quarantine(7);
+    await one.release();
+    await expect(first.recover(async () => [])).resolves.toMatchObject({
+      reason: expect.stringContaining('unwinding'),
+      recovered: false,
+    });
+    await two.release();
+    await expect(first.recover(async () => [])).resolves.toMatchObject({ recovered: true });
+  });
+
+  it('does not release while the quarantine write is pending', async () => {
+    const state = profile();
+    const write = state.storageArea.setItem;
+    const persist = Promise.withResolvers<void>();
+    state.storageArea.setItem = async (key, value) => {
+      if (key === BROWSER_EXECUTION_SAFETY_KEY) {
+        await persist.promise;
+      }
+      await write(key, value);
+    };
+    const panel = state.panel();
+    const local = admitted(await panel.acquireLocal());
+    const quarantine = local.quarantine(7);
+    const releasing = local.release();
+    try {
+      await vi.waitFor(async () => {
+        expect((await locks.query()).held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)).toBe(
+          true
+        );
+      });
+      await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: false });
+      expect((await state.panel().acquireLocal()).admitted).toBe(false);
+    } finally {
+      persist.resolve();
+    }
+    await Promise.all([quarantine, releasing]);
+    expect((await state.panel().acquireLocal()).admitted).toBe(false);
+  });
+
+  it('merges uncertain tabs from concurrent local panels', async () => {
+    const state = profile();
+    const one = admitted(await state.panel().acquireLocal());
+    const two = admitted(await state.panel().acquireLocal());
+    await Promise.all([one.quarantine(7), two.quarantine(8)]);
+    await Promise.all([one.release(), two.release()]);
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({
+      tabIds: expect.arrayContaining([7, 8]),
+    });
+    await expect(state.panel().recover(async () => [8])).resolves.toMatchObject({
+      recovered: false,
+    });
+  });
+
+  it('keeps the lock after a failed fence write instead of granting delegation', async () => {
+    const state = profile();
+    const panel = state.panel();
+    const local = admitted(await panel.acquireLocal());
+    const write = state.storageArea.setItem;
+    state.storageArea.setItem = () => {
+      throw new Error('storage unavailable');
+    };
+    try {
+      await expect(local.quarantine(7)).rejects.toThrow('storage unavailable');
+      await expect(local.release()).rejects.toThrow('storage unavailable');
+      await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: false });
+    } finally {
+      state.storageArea.setItem = write;
+      await local.quarantine(7);
+      await local.release();
+    }
+  });
+
+  it('recovers a discarded failed lease only after a durable fence and affected-tab closure', async () => {
+    const state = profile();
+    const panel = state.panel();
+    const write = state.storageArea.setItem;
+    state.storageArea.setItem = () => {
+      throw new Error('storage unavailable');
+    };
+    {
+      const local = admitted(await panel.acquireLocal());
+      await expect(local.quarantine(7)).rejects.toThrow('storage unavailable');
+      await expect(local.release()).rejects.toThrow('storage unavailable');
+      leases.delete(local);
+    }
+    const persist = Promise.withResolvers<void>();
+    let writing = false;
+    state.storageArea.setItem = async (key, value) => {
+      writing = true;
+      await persist.promise;
+      await write(key, value);
+    };
+    const recovering = panel.recover(async () => [7, 8]);
+    try {
+      await vi.waitFor(() => {
+        expect(writing).toBe(true);
+      });
+      expect(state.values.has(BROWSER_EXECUTION_SAFETY_KEY)).toBe(false);
+      expect(
+        (await locks.query()).held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)
+      ).toMatchObject([{ mode: 'shared' }]);
+      expect((await state.panel().acquireLocal()).admitted).toBe(false);
+      await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: false });
+    } finally {
+      persist.resolve();
+      state.storageArea.setItem = write;
+    }
+    await expect(recovering).resolves.toStrictEqual({
+      reason: 'Close all affected tabs before recovery.',
+      recovered: false,
+    });
+    expect({
+      admitted: (await state.panel().acquireLocal()).admitted,
+      safety: state.values.get(BROWSER_EXECUTION_SAFETY_KEY),
+    }).toMatchObject({ admitted: false, safety: { tabIds: [7] } });
+    await expect(panel.recover(async () => [8])).resolves.toStrictEqual({
+      reason: 'Browser control recovered. Submit new work explicitly.',
+      recovered: true,
+    });
+    expect(
+      (await locks.query()).held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)
+    ).toHaveLength(0);
+    const next = admitted(await panel.acquireLocal());
+    await expect(next.run(async () => 'explicit new work')).resolves.toBe('explicit new work');
+  });
+
+  it('keeps discarded leases fenced across repeated recovery write failures', async () => {
+    const state = profile();
+    const panel = state.panel();
+    const otherPanel = state.panel();
+    const provider = admitted(await otherPanel.acquireProviderOwner());
+    const write = state.storageArea.setItem;
+    state.storageArea.setItem = () => {
+      throw new Error('storage unavailable');
+    };
+    {
+      const local = admitted(await panel.acquireLocal());
+      await expect(local.quarantine(7)).rejects.toThrow('storage unavailable');
+      await expect(local.release()).rejects.toThrow('storage unavailable');
+      leases.delete(local);
+    }
+    try {
+      await expect(panel.recover(async () => [])).resolves.toMatchObject({
+        reason: expect.stringContaining('safety state is unavailable'),
+        recovered: false,
+      });
+      expect(state.values.has(BROWSER_EXECUTION_SAFETY_KEY)).toBe(false);
+      expect(
+        (await locks.query()).held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)
+      ).toMatchObject([{ mode: 'shared' }]);
+      expect({
+        delegated: (
+          await otherPanel.acquireDelegated(provider, 'parent-b', new AbortController().signal)
+        ).admitted,
+        local: (await panel.acquireLocal()).admitted,
+        otherLocal: (await otherPanel.acquireLocal()).admitted,
+      }).toStrictEqual({ delegated: false, local: false, otherLocal: false });
+      await expect(otherPanel.recover(async () => [])).resolves.toMatchObject({ recovered: false });
+    } finally {
+      state.storageArea.setItem = write;
+      await panel.recover(async () => []);
+    }
+    const next = admitted(await otherPanel.acquireLocal());
+    await expect(next.run(async () => 'explicit new work')).resolves.toBe('explicit new work');
+  });
+
+  it('waits for an issued action before retrying a discarded lease fence', async () => {
+    const state = profile();
+    const panel = state.panel();
+    const write = state.storageArea.setItem;
+    const action = Promise.withResolvers<void>();
+    const events: string[] = [];
+    const work = (async () => {
+      const local = admitted(await panel.acquireLocal());
+      const running = local.run(async guard => {
+        guard();
+        events.push('issued');
+        await action.promise;
+        events.push('unwound');
+      });
+      state.storageArea.setItem = () => {
+        throw new Error('storage unavailable');
+      };
+      await expect(local.quarantine(7)).rejects.toThrow('storage unavailable');
+      await expect(local.release()).rejects.toThrow('storage unavailable');
+      leases.delete(local);
+      state.storageArea.setItem = write;
+      return running;
+    })();
+    try {
+      await vi.waitFor(() => {
+        expect(leases.size).toBe(0);
+        expect(events).toStrictEqual(['issued']);
+      });
+      await expect(panel.recover(async () => [])).resolves.toMatchObject({
+        reason: expect.stringContaining('unwinding'),
+        recovered: false,
+      });
+      expect(state.values.has(BROWSER_EXECUTION_SAFETY_KEY)).toBe(false);
+      expect((await state.panel().acquireLocal()).admitted).toBe(false);
+    } finally {
+      action.resolve();
+      await work;
+      state.storageArea.setItem = write;
+    }
+    expect(events).toStrictEqual(['issued', 'unwound']);
+    await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: true });
+  });
+
+  it('drains other panels before clearing a recovered discarded lease fence', async () => {
+    const state = profile();
+    const panel = state.panel();
+    const otherPanel = state.panel();
+    const otherLocal = admitted(await otherPanel.acquireLocal());
+    const write = state.storageArea.setItem;
+    state.storageArea.setItem = () => {
+      throw new Error('storage unavailable');
+    };
+    {
+      const local = admitted(await panel.acquireLocal());
+      await expect(local.quarantine(7)).rejects.toThrow('storage unavailable');
+      await expect(local.release()).rejects.toThrow('storage unavailable');
+      leases.delete(local);
+    }
+    state.storageArea.setItem = write;
+    await expect(otherPanel.recover(async () => [])).resolves.toMatchObject({ recovered: false });
+    await expect(panel.recover(async () => [])).resolves.toMatchObject({
+      reason: expect.stringContaining('unwinding'),
+      recovered: false,
+    });
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+    expect((await state.panel().acquireLocal()).admitted).toBe(false);
+    await otherLocal.release();
+    await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: true });
+  });
+
+  it('fails closed on corrupt safety data rather than discarding the fence', async () => {
+    const state = profile();
+    state.values.set(BROWSER_EXECUTION_SAFETY_KEY, { tabIds: ['7'], version: 1 });
+    await expect(state.panel().acquireLocal()).resolves.toMatchObject({
+      admitted: false,
+      reason: expect.stringContaining('safety state is unavailable'),
+    });
+  });
+
+  it('preserves local operation but denies delegation when Web Locks are absent', async () => {
+    const state = profile();
+    const panel = createBrowserExecutionCoordinator({
+      locks: undefined,
+      storageArea: state.storageArea,
+    });
+    const local = admitted(await panel.acquireLocal());
+    await expect(local.run(async () => 'local result')).resolves.toBe('local result');
+    await expect(panel.acquireProviderOwner()).resolves.toMatchObject({
+      admitted: false,
+      reason: expect.stringContaining('does not support Web Locks'),
+    });
+    expect(
+      (await panel.acquireDelegated(local, 'parent-a', new AbortController().signal)).admitted
+    ).toBe(false);
+    expect(panel.getSnapshot().delegationUnavailableReason).toContain(
+      'Local browser work remains available'
+    );
+  });
+
+  it('retains fallback quarantine across panels instead of claiming global drainage', async () => {
+    const state = profile(false);
+    const panel = state.panel();
+    const otherPanel = state.panel();
+    const local = admitted(await panel.acquireLocal());
+    const otherLocal = admitted(await otherPanel.acquireLocal());
+    const action = Promise.withResolvers<void>();
+    const work = otherLocal.run(async () => action.promise);
+    await local.quarantine(7);
+    await local.release();
+    try {
+      const recoveries = await Promise.all([
+        panel.recover(async () => []),
+        state.panel().recover(async () => []),
+      ]);
+      expect(recoveries).toStrictEqual([
+        { reason: expect.stringContaining('Recovery requires Web Locks'), recovered: false },
+        { reason: expect.stringContaining('Recovery requires Web Locks'), recovered: false },
+      ]);
+      expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+      expect((await state.panel().acquireLocal()).admitted).toBe(false);
+    } finally {
+      action.resolve();
+      await work;
+      await otherLocal.release();
+    }
+    await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: false });
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+  });
+
+  it('persists a failed fallback fence without clearing it during unsupported recovery', async () => {
+    const state = profile(false);
+    const panel = state.panel();
+    const write = state.storageArea.setItem;
+    state.storageArea.setItem = () => {
+      throw new Error('storage unavailable');
+    };
+    {
+      const local = admitted(await panel.acquireLocal());
+      await expect(local.quarantine(7)).rejects.toThrow('storage unavailable');
+      await expect(local.release()).rejects.toThrow('storage unavailable');
+      leases.delete(local);
+    }
+    state.storageArea.setItem = write;
+    await panel.refresh();
+    const { blockedReason } = panel.getSnapshot();
+    await expect(panel.recover(async () => [])).resolves.toMatchObject({
+      reason: expect.stringContaining('Recovery requires Web Locks'),
+      recovered: false,
+    });
+    expect({
+      admitted: (await state.panel().acquireLocal()).admitted,
+      blockedReason,
+      safety: state.values.get(BROWSER_EXECUTION_SAFETY_KEY),
+    }).toStrictEqual({
+      admitted: false,
+      blockedReason: expect.stringContaining('Close all target tabs'),
+      safety: { allTabs: true, tabIds: [7], version: 1 },
+    });
+    const reloaded = createBrowserExecutionCoordinator({ locks, storageArea: state.storageArea });
+    const blocked = await reloaded.recover(async () => [42]);
+    const recovered = await reloaded.recover(async () => []);
+    expect({ blocked, recovered }).toMatchObject({
+      blocked: { recovered: false },
+      recovered: { recovered: true },
+    });
+  });
+
+  it('requires all target tabs to close after competing fallback writes lose an affected tab', async () => {
+    const state = profile(false);
+    const first = state.panel();
+    const second = state.panel();
+    const one = admitted(await first.acquireLocal());
+    const two = admitted(await second.acquireLocal());
+    const read = state.storageArea.getItem;
+    const firstRead = Promise.withResolvers<void>();
+    const secondRead = Promise.withResolvers<void>();
+    let reads = 0;
+    state.storageArea.getItem = async key => {
+      const value = read(key);
+      if (key === BROWSER_EXECUTION_SAFETY_KEY) {
+        reads += 1;
+        await (reads === 1 ? firstRead.promise : secondRead.promise);
+      }
+      return value;
+    };
+    // Both panels capture the empty record before either write can finish.
+    const firstQuarantine = one.quarantine(7);
+    const secondQuarantine = two.quarantine(8);
+    const records: unknown[] = [];
+    try {
+      firstRead.resolve();
+      await firstQuarantine;
+      records.push(state.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+      secondRead.resolve();
+      await secondQuarantine;
+      records.push(state.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+    } finally {
+      firstRead.resolve();
+      secondRead.resolve();
+      state.storageArea.getItem = read;
+      await Promise.all([firstQuarantine, secondQuarantine]);
+    }
+    await Promise.all([one.release(), two.release()]);
+
+    const reloaded = createBrowserExecutionCoordinator({ locks, storageArea: state.storageArea });
+    await reloaded.refresh();
+    await expect(reloaded.recover(async () => [7])).resolves.toMatchObject({
+      reason: expect.stringContaining('Close all target tabs'),
+      recovered: false,
+    });
+    expect({ reads, records }).toStrictEqual({
+      reads: 2,
+      records: [
+        { allTabs: true, tabIds: [7], version: 1 },
+        { allTabs: true, tabIds: [8], version: 1 },
+      ],
+    });
+    expect({
+      admitted: (await reloaded.acquireLocal()).admitted,
+      blockedReason: reloaded.getSnapshot().blockedReason,
+    }).toStrictEqual({
+      admitted: false,
+      blockedReason: expect.stringContaining('Close all target tabs'),
+    });
+    await expect(reloaded.recover(async () => [])).resolves.toMatchObject({ recovered: true });
+    const resumed = admitted(await first.acquireLocal());
+    expect({
+      result: await resumed.run(async () => 'explicit new work'),
+      safety: state.values.get(BROWSER_EXECUTION_SAFETY_KEY),
+    }).toStrictEqual({
+      result: 'explicit new work',
+      safety: { tabIds: [], version: 1 },
+    });
+  });
+
+  it('preserves the all-tabs flag in native writes until explicit recovery clears it', async () => {
+    const state = profile();
+    const panel = state.panel();
+    const native = admitted(await panel.acquireLocal());
+    const fallback = createBrowserExecutionCoordinator({
+      locks: undefined,
+      storageArea: state.storageArea,
+    });
+    const local = admitted(await fallback.acquireLocal());
+    await local.quarantine(7);
+    await local.release();
+    await native.quarantine(8);
+    await native.release();
+    const reloaded = state.panel();
+    await expect(reloaded.recover(async () => [42])).resolves.toMatchObject({
+      reason: expect.stringContaining('Close all target tabs'),
+      recovered: false,
+    });
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      allTabs: true,
+      tabIds: [7, 8],
+      version: 1,
+    });
+    await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: true });
+    const next = admitted(await panel.acquireLocal());
+    await next.quarantine(9);
+    await next.release();
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      tabIds: [9],
+      version: 1,
+    });
+  });
+
+  it('preserves the all-tabs flag through failed native writes, refreshes, and discarded-lease retries', async () => {
+    const state = profile();
+    const panel = state.panel();
+    const native = admitted(await panel.acquireLocal());
+    const fallback = createBrowserExecutionCoordinator({
+      locks: undefined,
+      storageArea: state.storageArea,
+    });
+    const local = admitted(await fallback.acquireLocal());
+    await local.quarantine(7);
+    await local.release();
+    await panel.refresh();
+    const write = state.storageArea.setItem;
+    state.storageArea.setItem = () => {
+      throw new Error('storage unavailable');
+    };
+    try {
+      await expect(native.quarantine(8)).rejects.toThrow('storage unavailable');
+      await expect(native.release()).rejects.toThrow('storage unavailable');
+      leases.delete(native);
+      await panel.refresh();
+      expect(panel.getSnapshot().blockedReason).toContain('Close all target tabs');
+    } finally {
+      state.storageArea.setItem = write;
+      // Recovery must retry the discarded lease before it can release the native lock.
+      await panel.recover(async () => [42]);
+    }
+    const reloaded = state.panel();
+    await expect(reloaded.recover(async () => [42])).resolves.toMatchObject({
+      reason: expect.stringContaining('Close all target tabs'),
+      recovered: false,
+    });
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      allTabs: true,
+      tabIds: [7, 8],
+      version: 1,
+    });
+    await panel.recover(async () => []);
+  });
+
+  it('blocks an incomplete inventory even without stored tab IDs', async () => {
+    const state = profile();
+    state.values.set(BROWSER_EXECUTION_SAFETY_KEY, { allTabs: true, tabIds: [], version: 1 });
+    const panel = state.panel();
+    await panel.refresh();
+    expect(panel.getSnapshot().blockedReason).toContain('Close all target tabs');
+    await expect(panel.acquireLocal()).resolves.toMatchObject({
+      admitted: false,
+      reason: expect.stringContaining('Close all target tabs'),
+    });
+    await expect(panel.recover(async () => [7])).resolves.toMatchObject({ recovered: false });
+    await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: true });
+    const next = admitted(await panel.acquireLocal());
+    await expect(next.run(async () => 'explicit submission')).resolves.toBe('explicit submission');
+  });
+
+  it('clears the displayed owner at idle and never exposes unsafe label text', async () => {
+    const panel = profile().panel();
+    const provider = admitted(await panel.acquireProviderOwner());
+    const delegated = admitted(
+      await panel.acquireDelegated(provider, '<parent>\n\u202E-a', new AbortController().signal)
+    );
+    await panel.refresh();
+    expect(panel.getSnapshot().owner).toBe('CLI session parent-a');
+    await delegated.release();
+    await panel.refresh();
+    expect(panel.getSnapshot()).toMatchObject({
+      blockedReason: undefined,
+      delegated: 'idle',
+      localRuns: 0,
+      owner: undefined,
+    });
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/browser-execution-lock.test.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-execution-lock.test.ts
@@ -221,6 +221,10 @@ describe('profile browser execution locks', () => {
           true
         );
       });
+      await expect(panel.prepareRecovery(async () => [])).resolves.toMatchObject({
+        ready: false,
+        reason: expect.stringContaining('unwinding'),
+      });
       await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: false });
       expect((await state.panel().acquireLocal()).admitted).toBe(false);
     } finally {
@@ -263,59 +267,276 @@ describe('profile browser execution locks', () => {
     }
   });
 
-  it('recovers a discarded failed lease only after a durable fence and affected-tab closure', async () => {
+  it('prepares a discarded failed lease without clearing quarantine or admitting work', async () => {
     const state = profile();
     const panel = state.panel();
+    const otherPanel = state.panel();
+    const provider = admitted(await otherPanel.acquireProviderOwner());
     const write = state.storageArea.setItem;
-    state.storageArea.setItem = () => {
-      throw new Error('storage unavailable');
-    };
     {
       const local = admitted(await panel.acquireLocal());
+      state.storageArea.setItem = () => {
+        throw new Error('storage unavailable');
+      };
       await expect(local.quarantine(7)).rejects.toThrow('storage unavailable');
       await expect(local.release()).rejects.toThrow('storage unavailable');
       leases.delete(local);
     }
-    const persist = Promise.withResolvers<void>();
-    let writing = false;
-    state.storageArea.setItem = async (key, value) => {
-      writing = true;
-      await persist.promise;
-      await write(key, value);
-    };
-    const recovering = panel.recover(async () => [7, 8]);
     try {
-      await vi.waitFor(() => {
-        expect(writing).toBe(true);
+      const unavailable = await panel.prepareRecovery(async () => []);
+      state.storageArea.setItem = write;
+      // A display-only refresh leaves the failed-release lock held after storage returns.
+      await panel.refresh();
+      expect({
+        admitted: (await otherPanel.acquireLocal()).admitted,
+        localRuns: panel.getSnapshot().localRuns,
+        persisted: state.values.has(BROWSER_EXECUTION_SAFETY_KEY),
+        unavailable,
+      }).toStrictEqual({
+        admitted: false,
+        localRuns: 1,
+        persisted: false,
+        unavailable: { ready: false, reason: expect.stringContaining('Restore storage access') },
+      });
+
+      const readiness = await panel.prepareRecovery(async () => []);
+      expect({
+        delegated: (
+          await otherPanel.acquireDelegated(provider, 'parent-b', new AbortController().signal)
+        ).admitted,
+        local: (await otherPanel.acquireLocal()).admitted,
+        localRuns: panel.getSnapshot().localRuns,
+        readiness,
+        safety: state.values.get(BROWSER_EXECUTION_SAFETY_KEY),
+      }).toStrictEqual({
+        delegated: false,
+        local: false,
+        localRuns: 0,
+        readiness: { ready: true, reason: expect.stringContaining('Recover explicitly') },
+        safety: { tabIds: [7], version: 1 },
+      });
+    } finally {
+      state.storageArea.setItem = write;
+      await panel.recover(async () => []);
+    }
+  });
+
+  it('does not prepare a failed lease until its caller requests release', async () => {
+    const state = profile();
+    const panel = state.panel();
+    const local = admitted(await panel.acquireLocal());
+    const write = state.storageArea.setItem;
+    state.storageArea.setItem = () => {
+      throw new Error('storage unavailable');
+    };
+    await expect(local.quarantine(7)).rejects.toThrow('storage unavailable');
+    state.storageArea.setItem = write;
+    try {
+      await expect(panel.prepareRecovery(async () => [])).resolves.toMatchObject({
+        ready: false,
+        reason: expect.stringContaining('unwinding'),
       });
       expect(state.values.has(BROWSER_EXECUTION_SAFETY_KEY)).toBe(false);
-      expect(
-        (await locks.query()).held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)
-      ).toMatchObject([{ mode: 'shared' }]);
-      expect((await state.panel().acquireLocal()).admitted).toBe(false);
-      await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: false });
+      expect(panel.getSnapshot().localRuns).toBe(1);
     } finally {
-      persist.resolve();
-      state.storageArea.setItem = write;
+      await local.quarantine(7);
+      await local.release();
     }
-    await expect(recovering).resolves.toStrictEqual({
+  });
+
+  it('rejects queued delegation when preparation drains a failed release', async () => {
+    const state = profile();
+    const panel = state.panel();
+    const otherPanel = state.panel();
+    const local = admitted(await panel.acquireLocal());
+    const provider = admitted(await otherPanel.acquireProviderOwner());
+    const waiting = otherPanel.acquireDelegated(provider, 'parent-b', new AbortController().signal);
+    await vi.waitFor(async () => {
+      expect((await locks.query()).pending).toHaveLength(1);
+    });
+    const write = state.storageArea.setItem;
+    state.storageArea.setItem = () => {
+      throw new Error('storage unavailable');
+    };
+    await expect(local.quarantine(7)).rejects.toThrow('storage unavailable');
+    await expect(local.release()).rejects.toThrow('storage unavailable');
+    state.storageArea.setItem = write;
+    try {
+      // The rejected waiter can still be unwinding during the first native readiness check.
+      await panel.prepareRecovery(async () => []);
+      const admission = await waiting;
+      if (admission.admitted) {
+        admitted(admission);
+      }
+      expect(admission).toMatchObject({
+        admitted: false,
+        reason: expect.stringContaining('Close the affected tabs'),
+      });
+      await expect(panel.prepareRecovery(async () => [])).resolves.toMatchObject({ ready: true });
+      expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+        tabIds: [7],
+        version: 1,
+      });
+    } finally {
+      await panel.recover(async () => []);
+    }
+  });
+
+  it.each(['shared', 'exclusive'] as const)(
+    'rechecks native %s locks after earlier readiness without waiting or stealing',
+    async mode => {
+      const state = profile();
+      const record = { tabIds: [7], version: 1 };
+      state.values.set(BROWSER_EXECUTION_SAFETY_KEY, record);
+      const panel = state.panel();
+      await expect(panel.prepareRecovery(async () => [])).resolves.toMatchObject({ ready: true });
+      const entered = Promise.withResolvers<void>();
+      const drain = Promise.withResolvers<void>();
+      const holding = locks.request(BROWSER_EXECUTION_LOCK, { mode }, () => {
+        entered.resolve();
+        return drain.promise;
+      });
+      await entered.promise;
+      try {
+        await expect(state.panel().prepareRecovery(async () => [])).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('unwinding'),
+        });
+        await expect(panel.recover(async () => [])).resolves.toMatchObject({
+          reason: expect.stringContaining('unwinding'),
+          recovered: false,
+        });
+        expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(record);
+        expect(
+          (await locks.query()).held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)
+        ).toMatchObject([{ mode }]);
+      } finally {
+        drain.resolve();
+        await holding;
+      }
+    }
+  );
+
+  it.each(['unavailable', 'corrupt'] as const)(
+    'fails preparation closed on %s storage and rechecks it during recovery',
+    async failure => {
+      const state = profile();
+      const record = { tabIds: [7], version: 1 };
+      state.values.set(BROWSER_EXECUTION_SAFETY_KEY, record);
+      const panel = state.panel();
+      await expect(panel.prepareRecovery(async () => [])).resolves.toMatchObject({ ready: true });
+      const read = state.storageArea.getItem;
+      state.storageArea.getItem = key => {
+        if (key === BROWSER_EXECUTION_SAFETY_KEY) {
+          if (failure === 'unavailable') {
+            throw new Error('storage unavailable');
+          }
+          return { tabIds: ['7'], version: 1 };
+        }
+        return read(key);
+      };
+      try {
+        await expect(panel.prepareRecovery(async () => [])).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('Restore storage'),
+        });
+        await expect(panel.recover(async () => [])).rejects.toThrow(
+          failure === 'unavailable' ? 'storage unavailable' : 'expected number'
+        );
+        expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(record);
+        expect((await panel.acquireLocal()).admitted).toBe(false);
+      } finally {
+        state.storageArea.getItem = read;
+      }
+      await expect(panel.prepareRecovery(async () => [])).resolves.toMatchObject({ ready: true });
+      expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(record);
+    }
+  );
+
+  it('rechecks newly persisted affected tabs and all-tabs closure after empty-profile readiness', async () => {
+    const state = profile();
+    const panel = state.panel();
+    await expect(panel.prepareRecovery(async () => [])).resolves.toMatchObject({ ready: true });
+    expect(state.values.size).toBe(0);
+    state.values.set(BROWSER_EXECUTION_SAFETY_KEY, { tabIds: [7], version: 1 });
+    await expect(panel.recover(async () => [7])).resolves.toStrictEqual({
       reason: 'Close all affected tabs before recovery.',
       recovered: false,
     });
-    expect({
-      admitted: (await state.panel().acquireLocal()).admitted,
-      safety: state.values.get(BROWSER_EXECUTION_SAFETY_KEY),
-    }).toMatchObject({ admitted: false, safety: { tabIds: [7] } });
-    await expect(panel.recover(async () => [8])).resolves.toStrictEqual({
-      reason: 'Browser control recovered. Submit new work explicitly.',
-      recovered: true,
+    state.values.set(BROWSER_EXECUTION_SAFETY_KEY, { allTabs: true, tabIds: [], version: 1 });
+    await expect(panel.recover(async () => [42])).resolves.toMatchObject({
+      reason: expect.stringContaining('Close all target tabs'),
+      recovered: false,
     });
-    expect(
-      (await locks.query()).held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)
-    ).toHaveLength(0);
-    const next = admitted(await panel.acquireLocal());
-    await expect(next.run(async () => 'explicit new work')).resolves.toBe('explicit new work');
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      allTabs: true,
+      tabIds: [],
+      version: 1,
+    });
   });
+
+  it.each(['recover', 'prepareRecovery'] as const)(
+    'retains a failed fence during a pending retry write (%s)',
+    async operation => {
+      const state = profile();
+      const panel = state.panel();
+      const write = state.storageArea.setItem;
+      state.storageArea.setItem = () => {
+        throw new Error('storage unavailable');
+      };
+      {
+        const local = admitted(await panel.acquireLocal());
+        await expect(local.quarantine(7)).rejects.toThrow('storage unavailable');
+        await expect(local.release()).rejects.toThrow('storage unavailable');
+        leases.delete(local);
+      }
+      const persist = Promise.withResolvers<void>();
+      let writing = false;
+      state.storageArea.setItem = async (key, value) => {
+        writing = true;
+        await persist.promise;
+        await write(key, value);
+      };
+      const checking = panel[operation](async () => [7, 8]);
+      try {
+        await vi.waitFor(() => {
+          expect(writing).toBe(true);
+        });
+        expect(state.values.has(BROWSER_EXECUTION_SAFETY_KEY)).toBe(false);
+        expect(
+          (await locks.query()).held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)
+        ).toMatchObject([{ mode: 'shared' }]);
+        expect((await state.panel().acquireLocal()).admitted).toBe(false);
+        await expect(panel.prepareRecovery(async () => [])).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('unwinding'),
+        });
+        await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: false });
+      } finally {
+        persist.resolve();
+        state.storageArea.setItem = write;
+      }
+      await expect(checking).resolves.toStrictEqual({
+        ...(operation === 'recover' ? { recovered: false } : { ready: false }),
+        reason: 'Close all affected tabs before recovery.',
+      });
+      const readiness = await panel.prepareRecovery(async () => [8]);
+      expect({
+        admitted: (await state.panel().acquireLocal()).admitted,
+        readiness,
+        safety: state.values.get(BROWSER_EXECUTION_SAFETY_KEY),
+      }).toMatchObject({ admitted: false, readiness: { ready: true }, safety: { tabIds: [7] } });
+      await expect(panel.recover(async () => [8])).resolves.toStrictEqual({
+        reason: 'Browser control recovered. Submit new work explicitly.',
+        recovered: true,
+      });
+      expect(
+        (await locks.query()).held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)
+      ).toHaveLength(0);
+      const next = admitted(await panel.acquireLocal());
+      await expect(next.run(async () => 'explicit new work')).resolves.toBe('explicit new work');
+    }
+  );
 
   it('keeps discarded leases fenced across repeated recovery write failures', async () => {
     const state = profile();
@@ -385,6 +606,10 @@ describe('profile browser execution locks', () => {
         expect(leases.size).toBe(0);
         expect(events).toStrictEqual(['issued']);
       });
+      await expect(panel.prepareRecovery(async () => [])).resolves.toMatchObject({
+        ready: false,
+        reason: expect.stringContaining('unwinding'),
+      });
       await expect(panel.recover(async () => [])).resolves.toMatchObject({
         reason: expect.stringContaining('unwinding'),
         recovered: false,
@@ -397,6 +622,11 @@ describe('profile browser execution locks', () => {
       state.storageArea.setItem = write;
     }
     expect(events).toStrictEqual(['issued', 'unwound']);
+    await expect(panel.prepareRecovery(async () => [])).resolves.toMatchObject({ ready: true });
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      tabIds: [7],
+      version: 1,
+    });
     await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: true });
   });
 
@@ -502,6 +732,10 @@ describe('profile browser execution locks', () => {
     state.storageArea.setItem = write;
     await panel.refresh();
     const { blockedReason } = panel.getSnapshot();
+    await expect(panel.prepareRecovery(async () => [])).resolves.toMatchObject({
+      ready: false,
+      reason: expect.stringContaining('Restore browser Web Locks support'),
+    });
     await expect(panel.recover(async () => [])).resolves.toMatchObject({
       reason: expect.stringContaining('Recovery requires Web Locks'),
       recovered: false,
@@ -670,12 +904,35 @@ describe('profile browser execution locks', () => {
     state.values.set(BROWSER_EXECUTION_SAFETY_KEY, { allTabs: true, tabIds: [], version: 1 });
     const panel = state.panel();
     await panel.refresh();
-    expect(panel.getSnapshot().blockedReason).toContain('Close all target tabs');
-    await expect(panel.acquireLocal()).resolves.toMatchObject({
-      admitted: false,
-      reason: expect.stringContaining('Close all target tabs'),
+    expect({
+      admission: await panel.acquireLocal(),
+      blockedReason: panel.getSnapshot().blockedReason,
+      preparation: await panel.prepareRecovery(async () => [7]),
+      recovery: await panel.recover(async () => [7]),
+    }).toMatchObject({
+      admission: { admitted: false, reason: expect.stringContaining('Close all target tabs') },
+      blockedReason: expect.stringContaining('Close all target tabs'),
+      preparation: { ready: false, reason: expect.stringContaining('Close all target tabs') },
+      recovery: { recovered: false },
     });
-    await expect(panel.recover(async () => [7])).resolves.toMatchObject({ recovered: false });
+    await expect(
+      panel.prepareRecovery(async () => {
+        throw new Error('tab enumeration failed');
+      })
+    ).resolves.toMatchObject({
+      ready: false,
+      reason: expect.stringContaining('Restore storage and browser access'),
+    });
+    const readiness = await panel.prepareRecovery(async () => []);
+    expect({
+      admitted: (await panel.acquireLocal()).admitted,
+      readiness,
+      safety: state.values.get(BROWSER_EXECUTION_SAFETY_KEY),
+    }).toStrictEqual({
+      admitted: false,
+      readiness: { ready: true, reason: expect.stringContaining('Recover explicitly') },
+      safety: { allTabs: true, tabIds: [], version: 1 },
+    });
     await expect(panel.recover(async () => [])).resolves.toMatchObject({ recovered: true });
     const next = admitted(await panel.acquireLocal());
     await expect(next.run(async () => 'explicit submission')).resolves.toBe('explicit submission');

--- a/apps/extension/entrypoints/sidepanel/browser-execution-lock.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-execution-lock.ts
@@ -56,6 +56,10 @@ export interface BrowserRecovery {
   readonly recovered: boolean;
   readonly reason: string;
 }
+export interface BrowserRecoveryReadiness {
+  readonly ready: boolean;
+  readonly reason: string;
+}
 
 /** Native locks grant authority; the observable record supplies display information only. */
 export const createBrowserExecutionCoordinator = ({
@@ -320,7 +324,7 @@ export const createBrowserExecutionCoordinator = ({
             }
           },
         };
-        // Recovery owns this retry even when the caller discards a failed lease.
+        // The coordinator owns this retry even when the caller discards a failed lease.
         const retryRelease = async (): Promise<void> => {
           if (!closing || users !== 0 || fencePending) {
             return;
@@ -369,6 +373,49 @@ export const createBrowserExecutionCoordinator = ({
         }
       })();
     });
+  };
+  const withRecoveryLock = async (
+    getOpenTabIds: () => Promise<readonly number[]>,
+    onReady: () => string | Promise<string>
+  ): Promise<BrowserRecoveryReadiness> => {
+    try {
+      await Promise.all([...failedReleases].map(retry => retry()));
+    } catch {
+      await refresh();
+      return { ready: false, reason: safetyReason() ?? QUARANTINE_MESSAGE };
+    }
+    if (locks === undefined) {
+      // A panel-local counter cannot prove that another panel's issued actions have drained.
+      return {
+        ready: false,
+        reason: `Recovery requires Web Locks. Restore browser Web Locks support before recovering. ${ALL_TABS_RECOVERY_MESSAGE} Browser control remains blocked.`,
+      };
+    }
+    // Recovery never waits behind, steals, or cancels an execution lock.
+    const result = await locks.request(
+      BROWSER_EXECUTION_LOCK,
+      { ifAvailable: true, mode: 'exclusive' },
+      async lock => {
+        if (lock === null) {
+          return {
+            ready: false,
+            reason: 'Browser actions are still unwinding. Wait before recovery.',
+          };
+        }
+        const record = await readSafety();
+        const affected = new Set([...safety.tabIds, ...record.tabIds]);
+        const open = await getOpenTabIds();
+        if ((record.allTabs === true || safety.allTabs === true) && open.length > 0) {
+          return { ready: false, reason: ALL_TABS_RECOVERY_MESSAGE };
+        }
+        if (open.some(tabId => affected.has(tabId))) {
+          return { ready: false, reason: 'Close all affected tabs before recovery.' };
+        }
+        return { ready: true, reason: await onReady() };
+      }
+    );
+    await refresh();
+    return result;
   };
   return {
     /** SessionId must come from the authenticated provider job, never the model's tool arguments. */
@@ -424,53 +471,35 @@ export const createBrowserExecutionCoordinator = ({
       return admission;
     },
     getSnapshot: (): BrowserExecutionSnapshot => snapshot,
-    recover: async (getOpenTabIds: () => Promise<readonly number[]>): Promise<BrowserRecovery> => {
+    /** Readiness grants no authority; explicit recovery must repeat these checks. */
+    prepareRecovery: async (
+      getOpenTabIds: () => Promise<readonly number[]>
+    ): Promise<BrowserRecoveryReadiness> => {
       try {
-        await Promise.all([...failedReleases].map(retry => retry()));
+        return await withRecoveryLock(
+          getOpenTabIds,
+          () =>
+            'Browser control is ready for recovery. Recover explicitly before submitting new work.'
+        );
       } catch {
         await refresh();
-        return { reason: safetyReason() ?? QUARANTINE_MESSAGE, recovered: false };
-      }
-      if (locks === undefined) {
-        // A panel-local counter cannot prove that another panel's issued actions have drained.
         return {
-          reason: `Recovery requires Web Locks. Restore browser Web Locks support before recovering. ${ALL_TABS_RECOVERY_MESSAGE} Browser control remains blocked.`,
-          recovered: false,
+          ready: false,
+          reason:
+            'Recovery readiness could not be checked. Restore storage and browser access before trying again.',
         };
       }
-      // Recovery never waits behind, steals, or cancels an execution lock.
-      const result = await locks.request(
-        BROWSER_EXECUTION_LOCK,
-        { ifAvailable: true, mode: 'exclusive' },
-        async lock => {
-          if (lock === null) {
-            return {
-              reason: 'Browser actions are still unwinding. Wait before recovery.',
-              recovered: false,
-            };
-          }
-          const record = await readSafety();
-          const affected = new Set([...safety.tabIds, ...record.tabIds]);
-          const open = await getOpenTabIds();
-          if ((record.allTabs === true || safety.allTabs === true) && open.length > 0) {
-            return { reason: ALL_TABS_RECOVERY_MESSAGE, recovered: false };
-          }
-          if (open.some(tabId => affected.has(tabId))) {
-            return { reason: 'Close all affected tabs before recovery.', recovered: false };
-          }
-          await storageArea.setItem(BROWSER_EXECUTION_SAFETY_KEY, { tabIds: [], version: 1 });
-          safetyRevision += 1;
-          safety = { tabIds: [], version: 1 };
-          safetyError = false;
-          // A11 must register a fresh generation before delegated execution.
-          return {
-            reason: 'Browser control recovered. Submit new work explicitly.',
-            recovered: true,
-          };
-        }
-      );
-      await refresh();
-      return result;
+    },
+    recover: async (getOpenTabIds: () => Promise<readonly number[]>): Promise<BrowserRecovery> => {
+      const { ready, reason } = await withRecoveryLock(getOpenTabIds, async () => {
+        await storageArea.setItem(BROWSER_EXECUTION_SAFETY_KEY, { tabIds: [], version: 1 });
+        safetyRevision += 1;
+        safety = { tabIds: [], version: 1 };
+        safetyError = false;
+        // A11 must register a fresh generation before delegated execution.
+        return 'Browser control recovered. Submit new work explicitly.';
+      });
+      return { reason, recovered: ready };
     },
     refresh,
     subscribe: (listener: () => void): (() => void) => {

--- a/apps/extension/entrypoints/sidepanel/browser-execution-lock.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-execution-lock.ts
@@ -18,14 +18,23 @@ export const QUARANTINE_MESSAGE =
 const ALL_TABS_RECOVERY_MESSAGE =
   'Close all target tabs before recovery. The affected-tab list is not known to be complete.';
 
+const localRunSchema = z.object({
+  lockName: z.string().startsWith(`${BROWSER_EXECUTION_LOCK}:local:`),
+  tabId: z.number().int().nonnegative(),
+});
 const safetySchema = z.object({
   // Without Web Locks, competing writers can lose tab IDs.
   allTabs: z.literal(true).optional(),
+  localRuns: z.array(localRunSchema).optional(),
   tabIds: z.array(z.number().int().nonnegative()),
   version: z.literal(1),
 });
 const ownerSchema = z.object({ sessionId: z.string().max(80) });
 type SafetyRecord = z.infer<typeof safetySchema>;
+const orphanedTabs = (record: SafetyRecord, held: readonly LockInfo[]): number[] =>
+  (record.localRuns ?? [])
+    .filter(run => !held.some(lock => lock.name === run.lockName))
+    .map(run => run.tabId);
 type StorageKey = typeof BROWSER_EXECUTION_SAFETY_KEY | typeof OWNER_KEY;
 export interface BrowserLockStorage {
   // eslint-disable-next-line anti-slop/no-unknown-returns -- Raw storage is untrusted; readSafety and ownerSchema validate it at this boundary.
@@ -45,7 +54,11 @@ export interface BrowserExecutionSnapshot {
 export interface BrowserExecutionLease {
   readonly kind: 'local' | 'delegated' | 'provider';
   readonly guard: ExecutionGuard;
-  readonly run: <Result>(work: (guard: ExecutionGuard) => Promise<Result>) => Promise<Result>;
+  /** Bound local work must supply its tab and quarantine uncertain effects before returning. */
+  readonly run: <Result>(
+    work: (guard: ExecutionGuard) => Promise<Result>,
+    tabId?: number
+  ) => Promise<Result>;
   readonly quarantine: (tabId: number) => Promise<void>;
   readonly release: () => Promise<void>;
 }
@@ -61,7 +74,7 @@ export interface BrowserRecoveryReadiness {
   readonly reason: string;
 }
 
-/** Native locks grant authority; the observable record supplies display information only. */
+/** Native locks grant authority; durable safety records retain exclusion after owner loss. */
 export const createBrowserExecutionCoordinator = ({
   locks,
   storageArea,
@@ -74,6 +87,7 @@ export const createBrowserExecutionCoordinator = ({
   const pendingSafetyTabs = new Set<number>();
   const failedReleases = new Set<() => Promise<void>>();
   let safety: SafetyRecord = { tabIds: [], version: 1 };
+  let lostLocalTabs: number[] = [];
   let safetyRevision = 0;
   let safetyError = false;
   let fallbackLocalRuns = 0;
@@ -109,17 +123,27 @@ export const createBrowserExecutionCoordinator = ({
     if (safety.allTabs === true) {
       return `Browser control is blocked because an action may still be running. ${ALL_TABS_RECOVERY_MESSAGE} Issued actions cannot be undone.`;
     }
-    return safety.tabIds.length > 0 ? QUARANTINE_MESSAGE : undefined;
+    return safety.tabIds.length > 0 || lostLocalTabs.length > 0 ? QUARANTINE_MESSAGE : undefined;
   };
   const refresh = (): Promise<void> => {
     refreshInFlight ??= (async () => {
       const revision = safetyRevision;
       try {
-        const [record, nativeState, ownerValue] = await Promise.all([
+        const [initialRecord, ownerValue] = await Promise.all([
           readSafety(),
-          locks?.query(),
           storageArea.getItem(OWNER_KEY),
         ]);
+        let record = initialRecord;
+        // Read owners after the record: a newly recorded owner already holds its native lock.
+        let nativeState = await locks?.query();
+        if (locks !== undefined && orphanedTabs(record, nativeState?.held ?? []).length > 0) {
+          // Confirm owner loss under the mutation lock: normal completion can invalidate the first record.
+          await locks.request(SAFETY_WRITE_LOCK, async () => {
+            record = await readSafety();
+            nativeState = await locks.query();
+          });
+        }
+        const held = nativeState?.held ?? [];
         // A stale read cannot erase a fence while this panel writes it.
         if (revision === safetyRevision) {
           safety = {
@@ -127,8 +151,8 @@ export const createBrowserExecutionCoordinator = ({
             ...(safety.allTabs === true && pendingSafetyTabs.size > 0 ? { allTabs: true } : {}),
             tabIds: [...new Set([...record.tabIds, ...pendingSafetyTabs])],
           };
+          lostLocalTabs = orphanedTabs(safety, held);
         }
-        const held = nativeState?.held ?? [];
         const pending = nativeState?.pending ?? [];
         const running = held.some(
           lock => lock.name === BROWSER_EXECUTION_LOCK && lock.mode === 'exclusive'
@@ -158,7 +182,7 @@ export const createBrowserExecutionCoordinator = ({
                   .length,
           owner,
           providerOwned: held.some(lock => lock.name === PROVIDER_OWNER_LOCK),
-          quarantinedTabIds: safety.tabIds,
+          quarantinedTabIds: [...new Set([...safety.tabIds, ...lostLocalTabs])],
         };
         if (JSON.stringify(next) !== JSON.stringify(snapshot)) {
           snapshot = next;
@@ -173,6 +197,78 @@ export const createBrowserExecutionCoordinator = ({
       }
     })();
     return refreshInFlight;
+  };
+  // Call only while holding SAFETY_WRITE_LOCK. Never build a write from a display snapshot.
+  const writeLocalSafety = async (record: SafetyRecord): Promise<void> => {
+    safetyRevision += 1;
+    try {
+      await storageArea.setItem(BROWSER_EXECUTION_SAFETY_KEY, record);
+    } catch (error) {
+      safetyError = true;
+      throw error;
+    }
+    safety = { ...record, tabIds: [...new Set([...record.tabIds, ...pendingSafetyTabs])] };
+    safetyRevision += 1;
+  };
+  const withLocalProtection = <Result>(
+    tabId: number,
+    guard: ExecutionGuard,
+    work: (guard: ExecutionGuard) => Promise<Result>
+  ): Promise<Result> => {
+    if (locks === undefined) {
+      return work(guard);
+    }
+    const lockName = `${BROWSER_EXECUTION_LOCK}:local:${crypto.randomUUID()}`;
+    return locks.request(lockName, async () => {
+      await locks.request(SAFETY_WRITE_LOCK, async () => {
+        const record = await readSafety();
+        const { held = [] } = await locks.query();
+        if (
+          record.allTabs === true ||
+          record.tabIds.length > 0 ||
+          orphanedTabs(record, held).length > 0
+        ) {
+          throw new ExecutionStoppedError('profile_quarantined');
+        }
+        guard();
+        await writeLocalSafety({
+          ...record,
+          localRuns: [...(record.localRuns ?? []), { lockName, tabId }],
+        });
+      });
+      let completed = false;
+      try {
+        guard();
+        const result = await work(guard);
+        completed = true;
+        return result;
+      } catch (error) {
+        completed = error instanceof ExecutionStoppedError && !error.effectsUncertain;
+        throw error;
+      } finally {
+        if (completed) {
+          await locks.request(SAFETY_WRITE_LOCK, async () => {
+            const record = await readSafety();
+            const { held = [] } = await locks.query();
+            if (
+              !held.some(lock => lock.name === lockName) ||
+              record.allTabs === true ||
+              record.tabIds.includes(tabId) ||
+              pendingSafetyTabs.has(tabId) ||
+              record.localRuns?.some(run => run.lockName === lockName) !== true
+            ) {
+              return;
+            }
+            const remaining = record.localRuns.filter(run => run.lockName !== lockName);
+            const next: SafetyRecord = { ...record, localRuns: remaining };
+            if (remaining.length === 0) {
+              delete next.localRuns;
+            }
+            await writeLocalSafety(next);
+          });
+        }
+      }
+    });
   };
   const quarantineBarriers = new Set<() => void>();
   const persistQuarantine = async (tabId: number): Promise<void> => {
@@ -201,6 +297,7 @@ export const createBrowserExecutionCoordinator = ({
     const write = async (): Promise<void> => {
       const persisted = await readSafety();
       safety = {
+        ...persisted,
         ...(locks === undefined || persisted.allTabs === true || safety.allTabs === true
           ? { allTabs: true }
           : {}),
@@ -310,14 +407,16 @@ export const createBrowserExecutionCoordinator = ({
             await released;
             failedReleases.delete(retryRelease);
           },
-          run: async work => {
+          run: async (work, tabId) => {
             if (kind === 'provider') {
               throw new ExecutionStoppedError('execution_lease_required');
             }
             guard();
             users += 1;
             try {
-              return await work(guard);
+              return await (kind === 'local' && tabId !== undefined
+                ? withLocalProtection(tabId, guard, work)
+                : work(guard));
             } finally {
               users -= 1;
               drain();
@@ -395,23 +494,29 @@ export const createBrowserExecutionCoordinator = ({
     const result = await locks.request(
       BROWSER_EXECUTION_LOCK,
       { ifAvailable: true, mode: 'exclusive' },
-      async lock => {
+      lock => {
         if (lock === null) {
           return {
             ready: false,
             reason: 'Browser actions are still unwinding. Wait before recovery.',
           };
         }
-        const record = await readSafety();
-        const affected = new Set([...safety.tabIds, ...record.tabIds]);
-        const open = await getOpenTabIds();
-        if ((record.allTabs === true || safety.allTabs === true) && open.length > 0) {
-          return { ready: false, reason: ALL_TABS_RECOVERY_MESSAGE };
-        }
-        if (open.some(tabId => affected.has(tabId))) {
-          return { ready: false, reason: 'Close all affected tabs before recovery.' };
-        }
-        return { ready: true, reason: await onReady() };
+        return locks.request(SAFETY_WRITE_LOCK, async () => {
+          const record = await readSafety();
+          const affected = new Set([
+            ...safety.tabIds,
+            ...record.tabIds,
+            ...(record.localRuns ?? []).map(run => run.tabId),
+          ]);
+          const open = await getOpenTabIds();
+          if ((record.allTabs === true || safety.allTabs === true) && open.length > 0) {
+            return { ready: false, reason: ALL_TABS_RECOVERY_MESSAGE };
+          }
+          if (open.some(tabId => affected.has(tabId))) {
+            return { ready: false, reason: 'Close all affected tabs before recovery.' };
+          }
+          return { ready: true, reason: await onReady() };
+        });
       }
     );
     await refresh();
@@ -495,6 +600,7 @@ export const createBrowserExecutionCoordinator = ({
         await storageArea.setItem(BROWSER_EXECUTION_SAFETY_KEY, { tabIds: [], version: 1 });
         safetyRevision += 1;
         safety = { tabIds: [], version: 1 };
+        lostLocalTabs = [];
         safetyError = false;
         // A11 must register a fresh generation before delegated execution.
         return 'Browser control recovered. Submit new work explicitly.';

--- a/apps/extension/entrypoints/sidepanel/browser-execution-lock.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-execution-lock.ts
@@ -1,0 +1,509 @@
+/* eslint-disable max-lines, promise/avoid-new -- Native lock callbacks hold a lease until its awaited work drains. */
+import { storage } from '#imports';
+import { useSyncExternalStore } from 'react';
+import { z } from 'zod';
+import { ExecutionStoppedError } from '@/src/shared/agent-tool-results';
+import type { ExecutionGuard } from '@/src/shared/agent-tool-results';
+
+export const PROVIDER_OWNER_LOCK = 'kilo:browser-provider-owner';
+export const BROWSER_EXECUTION_LOCK = 'kilo:browser-execution';
+// Account-independent safety data. Auth cleanup must preserve this key (slice a10).
+export const BROWSER_EXECUTION_SAFETY_KEY = 'local:kiloBrowserExecutionSafety';
+const OWNER_KEY = 'local:kiloBrowserExecutionOwner';
+const SAFETY_WRITE_LOCK = 'kilo:browser-execution-safety-write';
+const LOCKS_UNAVAILABLE =
+  'CLI delegation is unavailable because this browser does not support Web Locks. Local browser work remains available.';
+export const QUARANTINE_MESSAGE =
+  'Browser control is blocked because an action may still be running. Close the affected tabs, then explicitly recover browser control. Issued actions cannot be undone.';
+const ALL_TABS_RECOVERY_MESSAGE =
+  'Close all target tabs before recovery. The affected-tab list is not known to be complete.';
+
+const safetySchema = z.object({
+  // Without Web Locks, competing writers can lose tab IDs.
+  allTabs: z.literal(true).optional(),
+  tabIds: z.array(z.number().int().nonnegative()),
+  version: z.literal(1),
+});
+const ownerSchema = z.object({ sessionId: z.string().max(80) });
+type SafetyRecord = z.infer<typeof safetySchema>;
+type StorageKey = typeof BROWSER_EXECUTION_SAFETY_KEY | typeof OWNER_KEY;
+export interface BrowserLockStorage {
+  // eslint-disable-next-line anti-slop/no-unknown-returns -- Raw storage is untrusted; readSafety and ownerSchema validate it at this boundary.
+  getItem: (key: StorageKey) => unknown;
+  setItem: (key: StorageKey, value: unknown) => void | Promise<void>;
+  watch: (key: StorageKey, callback: () => void) => () => void;
+}
+export interface BrowserExecutionSnapshot {
+  readonly localRuns: number;
+  readonly providerOwned: boolean;
+  readonly delegated: 'idle' | 'waiting' | 'running';
+  readonly owner: string | undefined;
+  readonly blockedReason: string | undefined;
+  readonly delegationUnavailableReason: string | undefined;
+  readonly quarantinedTabIds: readonly number[];
+}
+export interface BrowserExecutionLease {
+  readonly kind: 'local' | 'delegated' | 'provider';
+  readonly guard: ExecutionGuard;
+  readonly run: <Result>(work: (guard: ExecutionGuard) => Promise<Result>) => Promise<Result>;
+  readonly quarantine: (tabId: number) => Promise<void>;
+  readonly release: () => Promise<void>;
+}
+export type BrowserAdmission =
+  | { readonly admitted: true; readonly lease: BrowserExecutionLease }
+  | { readonly admitted: false; readonly reason: string };
+export interface BrowserRecovery {
+  readonly recovered: boolean;
+  readonly reason: string;
+}
+
+/** Native locks grant authority; the observable record supplies display information only. */
+export const createBrowserExecutionCoordinator = ({
+  locks,
+  storageArea,
+}: {
+  locks: LockManager | undefined;
+  storageArea: BrowserLockStorage;
+}) => {
+  const listeners = new Set<() => void>();
+  const providerLeases = new WeakSet<BrowserExecutionLease>();
+  const pendingSafetyTabs = new Set<number>();
+  const failedReleases = new Set<() => Promise<void>>();
+  let safety: SafetyRecord = { tabIds: [], version: 1 };
+  let safetyRevision = 0;
+  let safetyError = false;
+  let fallbackLocalRuns = 0;
+  let delegationPending = false;
+  let snapshot: BrowserExecutionSnapshot = {
+    blockedReason: undefined,
+    delegated: 'idle',
+    delegationUnavailableReason: locks === undefined ? LOCKS_UNAVAILABLE : undefined,
+    localRuns: 0,
+    owner: undefined,
+    providerOwned: false,
+    quarantinedTabIds: [],
+  };
+  // eslint-disable-next-line init-declarations -- The first refresh supplies this deferred promise.
+  let refreshInFlight: Promise<void> | undefined;
+  const readSafety = async (): Promise<SafetyRecord> => {
+    const value = await storageArea.getItem(BROWSER_EXECUTION_SAFETY_KEY);
+    // Old profiles have no execution safety record. Remove this empty-record fallback after those profiles migrate.
+    return value === null || value === undefined
+      ? { tabIds: [], version: 1 }
+      : safetySchema.parse(value);
+  };
+  const notify = (): void => {
+    for (const listener of listeners) {
+      listener();
+    }
+  };
+  const safetyReason = (): string | undefined => {
+    if (safetyError) {
+      const recovery = safety.allTabs === true ? ` ${ALL_TABS_RECOVERY_MESSAGE}` : '';
+      return `Browser safety state is unavailable. No browser work can start. Restore storage access before recovery.${recovery}`;
+    }
+    if (safety.allTabs === true) {
+      return `Browser control is blocked because an action may still be running. ${ALL_TABS_RECOVERY_MESSAGE} Issued actions cannot be undone.`;
+    }
+    return safety.tabIds.length > 0 ? QUARANTINE_MESSAGE : undefined;
+  };
+  const refresh = (): Promise<void> => {
+    refreshInFlight ??= (async () => {
+      const revision = safetyRevision;
+      try {
+        const [record, nativeState, ownerValue] = await Promise.all([
+          readSafety(),
+          locks?.query(),
+          storageArea.getItem(OWNER_KEY),
+        ]);
+        // A stale read cannot erase a fence while this panel writes it.
+        if (revision === safetyRevision) {
+          safety = {
+            ...record,
+            ...(safety.allTabs === true && pendingSafetyTabs.size > 0 ? { allTabs: true } : {}),
+            tabIds: [...new Set([...record.tabIds, ...pendingSafetyTabs])],
+          };
+        }
+        const held = nativeState?.held ?? [];
+        const pending = nativeState?.pending ?? [];
+        const running = held.some(
+          lock => lock.name === BROWSER_EXECUTION_LOCK && lock.mode === 'exclusive'
+        );
+        const waiting = pending.some(
+          lock => lock.name === BROWSER_EXECUTION_LOCK && lock.mode === 'exclusive'
+        );
+        const queued = waiting || delegationPending ? 'waiting' : 'idle';
+        const delegated = running ? 'running' : queued;
+        const parsedOwner = ownerSchema.safeParse(ownerValue);
+        const ownerLabel = parsedOwner.success
+          ? `CLI session ${parsedOwner.data.sessionId.replaceAll(/[^a-zA-Z0-9_-]/gu, '').slice(0, 12) || 'unknown'}`
+          : 'A CLI session';
+        const owner = delegated === 'idle' ? undefined : ownerLabel;
+        const next: BrowserExecutionSnapshot = {
+          blockedReason:
+            safetyReason() ??
+            (delegated === 'idle'
+              ? undefined
+              : `${owner} ${running ? 'owns' : 'is waiting for'} browser control. Use Stop or wait for it to finish, then submit again.`),
+          delegated,
+          delegationUnavailableReason: locks === undefined ? LOCKS_UNAVAILABLE : undefined,
+          localRuns:
+            locks === undefined
+              ? fallbackLocalRuns
+              : held.filter(lock => lock.name === BROWSER_EXECUTION_LOCK && lock.mode === 'shared')
+                  .length,
+          owner,
+          providerOwned: held.some(lock => lock.name === PROVIDER_OWNER_LOCK),
+          quarantinedTabIds: safety.tabIds,
+        };
+        if (JSON.stringify(next) !== JSON.stringify(snapshot)) {
+          snapshot = next;
+          notify();
+        }
+      } catch {
+        safetyError = true;
+        snapshot = { ...snapshot, blockedReason: safetyReason() };
+        notify();
+      } finally {
+        refreshInFlight = undefined;
+      }
+    })();
+    return refreshInFlight;
+  };
+  const quarantineBarriers = new Set<() => void>();
+  const persistQuarantine = async (tabId: number): Promise<void> => {
+    pendingSafetyTabs.add(tabId);
+    safetyRevision += 1;
+    safety = {
+      ...safety,
+      ...(locks === undefined ? { allTabs: true } : {}),
+      tabIds: [...new Set([...safety.tabIds, tabId])],
+    };
+    snapshot = { ...snapshot, blockedReason: safetyReason(), quarantinedTabIds: safety.tabIds };
+    notify();
+    if (locks !== undefined) {
+      // Queue a native barrier immediately, so another panel cannot join a shared run before the fence write finishes.
+      const durable = new Promise<void>(resolve => {
+        quarantineBarriers.add(resolve);
+      });
+      void (async () => {
+        try {
+          await locks.request(BROWSER_EXECUTION_LOCK, () => durable);
+        } catch {
+          safetyError = true;
+        }
+      })();
+    }
+    const write = async (): Promise<void> => {
+      const persisted = await readSafety();
+      safety = {
+        ...(locks === undefined || persisted.allTabs === true || safety.allTabs === true
+          ? { allTabs: true }
+          : {}),
+        tabIds: [...new Set([...persisted.tabIds, ...safety.tabIds, ...pendingSafetyTabs])],
+        version: 1,
+      };
+      await storageArea.setItem(BROWSER_EXECUTION_SAFETY_KEY, safety);
+      pendingSafetyTabs.delete(tabId);
+      safetyRevision += 1;
+      if (pendingSafetyTabs.size === 0) {
+        for (const resume of quarantineBarriers) {
+          resume();
+        }
+        quarantineBarriers.clear();
+      }
+    };
+    try {
+      await (locks === undefined ? write() : locks.request(SAFETY_WRITE_LOCK, write));
+    } catch (error) {
+      safetyError = true;
+      throw error;
+    }
+  };
+  const acquire = (
+    kind: BrowserExecutionLease['kind'],
+    signal?: AbortSignal,
+    authority?: ExecutionGuard
+  ): Promise<BrowserAdmission> => {
+    const name = kind === 'provider' ? PROVIDER_OWNER_LOCK : BROWSER_EXECUTION_LOCK;
+    // eslint-disable-next-line promise/param-names -- Admission and native lock release settle different promises.
+    return new Promise(resolveAdmission => {
+      // eslint-disable-next-line init-declarations -- The native lease assigns its release callback below.
+      let unlock: (() => void) | undefined;
+      const held = new Promise<void>(resolve => {
+        unlock = resolve;
+      });
+      let active = true;
+      let users = 0;
+      let closing = false;
+      let releaseReady = false;
+      let fencePending = false;
+      let fenceFailed = false;
+      // eslint-disable-next-line init-declarations -- A normal lease has no quarantine write to await.
+      let quarantineWrite: Promise<void> | undefined;
+      const guard = (): void => {
+        if (!active || closing) {
+          throw new ExecutionStoppedError('execution_lease_lost');
+        }
+        authority?.();
+        signal?.throwIfAborted();
+        if (kind !== 'provider' && safetyReason() !== undefined) {
+          throw new ExecutionStoppedError('profile_quarantined');
+        }
+      };
+      const drain = (): void => {
+        if (releaseReady && users === 0 && !fencePending && !fenceFailed) {
+          unlock?.();
+        }
+      };
+      const entered = async (lock: Lock | null): Promise<void> => {
+        if (lock === null) {
+          await refresh();
+          resolveAdmission({
+            admitted: false,
+            reason:
+              snapshot.blockedReason ??
+              'Browser control is busy. Submit again after control returns.',
+          });
+          return;
+        }
+        await refreshInFlight;
+        await refresh();
+        if (kind !== 'provider' && safetyReason() !== undefined) {
+          resolveAdmission({ admitted: false, reason: safetyReason() ?? QUARANTINE_MESSAGE });
+          return;
+        }
+        guard();
+        const failedQuarantineTabs = new Set<number>();
+        const lease: BrowserExecutionLease = {
+          guard,
+          kind,
+          quarantine: tabId => {
+            fencePending = true;
+            quarantineWrite = (async () => {
+              try {
+                await persistQuarantine(tabId);
+                failedQuarantineTabs.delete(tabId);
+                fenceFailed = failedQuarantineTabs.size > 0;
+              } catch (error) {
+                fenceFailed = true;
+                failedQuarantineTabs.add(tabId);
+                failedReleases.add(retryRelease);
+                throw error;
+              } finally {
+                fencePending = false;
+                drain();
+              }
+            })();
+            return quarantineWrite;
+          },
+          release: async () => {
+            closing = true;
+            // A failed fence write deliberately keeps the native lock held, even after early release.
+            await quarantineWrite;
+            releaseReady = true;
+            drain();
+            await released;
+            failedReleases.delete(retryRelease);
+          },
+          run: async work => {
+            if (kind === 'provider') {
+              throw new ExecutionStoppedError('execution_lease_required');
+            }
+            guard();
+            users += 1;
+            try {
+              return await work(guard);
+            } finally {
+              users -= 1;
+              drain();
+            }
+          },
+        };
+        // Recovery owns this retry even when the caller discards a failed lease.
+        const retryRelease = async (): Promise<void> => {
+          if (!closing || users !== 0 || fencePending) {
+            return;
+          }
+          for (const tabId of failedQuarantineTabs) {
+            // eslint-disable-next-line no-await-in-loop -- A lease serializes its fence writes before releasing its native lock.
+            await lease.quarantine(tabId);
+          }
+          await lease.release();
+        };
+        if (kind === 'provider') {
+          providerLeases.add(lease);
+        }
+        resolveAdmission({ admitted: true, lease });
+        await held;
+      };
+      if (locks === undefined) {
+        fallbackLocalRuns += 1;
+      }
+      const request =
+        locks === undefined
+          ? entered({ mode: 'shared', name })
+          : locks.request(
+              name,
+              {
+                ifAvailable: kind !== 'delegated',
+                mode: kind === 'local' ? 'shared' : 'exclusive',
+                ...(kind === 'delegated' && signal !== undefined ? { signal } : {}),
+              },
+              entered
+            );
+      const released = (async () => {
+        try {
+          await request;
+        } catch {
+          resolveAdmission({
+            admitted: false,
+            reason: 'Browser admission stopped. Submit again explicitly.',
+          });
+        } finally {
+          active = false;
+          if (locks === undefined) {
+            fallbackLocalRuns -= 1;
+          }
+          await refresh();
+        }
+      })();
+    });
+  };
+  return {
+    /** SessionId must come from the authenticated provider job, never the model's tool arguments. */
+    acquireDelegated: async (
+      provider: BrowserExecutionLease,
+      sessionId: string,
+      signal: AbortSignal
+    ): Promise<BrowserAdmission> => {
+      if (locks === undefined) {
+        return { admitted: false, reason: LOCKS_UNAVAILABLE };
+      }
+      provider.guard();
+      if (!providerLeases.has(provider)) {
+        return { admitted: false, reason: 'This panel does not own the provider.' };
+      }
+      await refresh();
+      if (delegationPending || snapshot.delegated !== 'idle') {
+        return { admitted: false, reason: 'The provider already has delegated work.' };
+      }
+      if (safetyReason() !== undefined) {
+        return { admitted: false, reason: safetyReason() ?? QUARANTINE_MESSAGE };
+      }
+      delegationPending = true;
+      try {
+        await storageArea.setItem(OWNER_KEY, {
+          sessionId: sessionId.replaceAll(/[^a-zA-Z0-9_-]/gu, '').slice(0, 80),
+        });
+        provider.guard();
+        signal.throwIfAborted();
+        const admission = acquire('delegated', signal, provider.guard);
+        void refresh();
+        return await admission;
+      } finally {
+        delegationPending = false;
+        await refreshInFlight;
+        await refresh();
+      }
+    },
+    acquireLocal: async (): Promise<BrowserAdmission> => {
+      // Admission must not reuse a query started before a waiter was cancelled.
+      await refreshInFlight;
+      await refresh();
+      if (snapshot.blockedReason !== undefined) {
+        return { admitted: false, reason: snapshot.blockedReason };
+      }
+      return acquire('local');
+    },
+    acquireProviderOwner: async (): Promise<BrowserAdmission> => {
+      const admission: BrowserAdmission =
+        locks === undefined
+          ? { admitted: false, reason: LOCKS_UNAVAILABLE }
+          : await acquire('provider');
+      return admission;
+    },
+    getSnapshot: (): BrowserExecutionSnapshot => snapshot,
+    recover: async (getOpenTabIds: () => Promise<readonly number[]>): Promise<BrowserRecovery> => {
+      try {
+        await Promise.all([...failedReleases].map(retry => retry()));
+      } catch {
+        await refresh();
+        return { reason: safetyReason() ?? QUARANTINE_MESSAGE, recovered: false };
+      }
+      if (locks === undefined) {
+        // A panel-local counter cannot prove that another panel's issued actions have drained.
+        return {
+          reason: `Recovery requires Web Locks. Restore browser Web Locks support before recovering. ${ALL_TABS_RECOVERY_MESSAGE} Browser control remains blocked.`,
+          recovered: false,
+        };
+      }
+      // Recovery never waits behind, steals, or cancels an execution lock.
+      const result = await locks.request(
+        BROWSER_EXECUTION_LOCK,
+        { ifAvailable: true, mode: 'exclusive' },
+        async lock => {
+          if (lock === null) {
+            return {
+              reason: 'Browser actions are still unwinding. Wait before recovery.',
+              recovered: false,
+            };
+          }
+          const record = await readSafety();
+          const affected = new Set([...safety.tabIds, ...record.tabIds]);
+          const open = await getOpenTabIds();
+          if ((record.allTabs === true || safety.allTabs === true) && open.length > 0) {
+            return { reason: ALL_TABS_RECOVERY_MESSAGE, recovered: false };
+          }
+          if (open.some(tabId => affected.has(tabId))) {
+            return { reason: 'Close all affected tabs before recovery.', recovered: false };
+          }
+          await storageArea.setItem(BROWSER_EXECUTION_SAFETY_KEY, { tabIds: [], version: 1 });
+          safetyRevision += 1;
+          safety = { tabIds: [], version: 1 };
+          safetyError = false;
+          // A11 must register a fresh generation before delegated execution.
+          return {
+            reason: 'Browser control recovered. Submit new work explicitly.',
+            recovered: true,
+          };
+        }
+      );
+      await refresh();
+      return result;
+    },
+    refresh,
+    subscribe: (listener: () => void): (() => void) => {
+      listeners.add(listener);
+      const onChange = (): void => {
+        void refresh();
+      };
+      const unwatchSafety = storageArea.watch(BROWSER_EXECUTION_SAFETY_KEY, onChange);
+      const unwatchOwner = storageArea.watch(OWNER_KEY, onChange);
+      // Native locks have no change event. Query also notices a panel disappearing without cleanup.
+      const timer = setInterval(onChange, 500);
+      onChange();
+      return () => {
+        clearInterval(timer);
+        unwatchSafety();
+        unwatchOwner();
+        listeners.delete(listener);
+      };
+    },
+  };
+};
+
+export type BrowserExecutionCoordinator = ReturnType<typeof createBrowserExecutionCoordinator>;
+// eslint-disable-next-line init-declarations -- The first panel creates the shared coordinator.
+let coordinator: BrowserExecutionCoordinator | undefined;
+export const getBrowserExecutionCoordinator = (): BrowserExecutionCoordinator => {
+  coordinator ??= createBrowserExecutionCoordinator({
+    locks: globalThis.navigator?.locks,
+    storageArea: storage,
+  });
+  return coordinator;
+};
+export const useBrowserExecutionSnapshot = (): BrowserExecutionSnapshot => {
+  const current = getBrowserExecutionCoordinator();
+  return useSyncExternalStore(current.subscribe, current.getSnapshot);
+};

--- a/apps/extension/entrypoints/sidepanel/browser-run-context.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-run-context.ts
@@ -103,7 +103,7 @@ const withBoundTab = <Result>(
     } finally {
       browser.tabs.onRemoved.removeListener(onRemoved);
     }
-  });
+  }, context.selectedTab.id);
 
 export const runBrowserTurn = (
   context: BrowserRunContext,

--- a/apps/extension/entrypoints/sidepanel/browser-run-context.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-run-context.ts
@@ -1,0 +1,234 @@
+/* eslint-disable import/max-dependencies -- Shared setup wires the existing tool families without another runner. */
+import { browser } from '#imports';
+import { createToolResult } from '@/src/shared/agent-conversation';
+import type {
+  AgentConversationEvent,
+  WorkflowToolCallEvent,
+} from '@/src/shared/agent-conversation';
+import { createWorkflowToolDefinitions } from '@/src/shared/agent-llm-harness';
+import type { LlmTurnOutcome } from '@/src/shared/agent-llm-turn-runner-core';
+import { ExecutionStoppedError, normalizeExecutionGuard } from '@/src/shared/agent-tool-results';
+import type { ExecutionGuard } from '@/src/shared/agent-tool-results';
+import { maxAgentToolRounds } from '@/src/shared/agent-tool-round-limit';
+import type { AgentWorkflowSettings } from '@/src/shared/agent-workflows';
+import type { RemoteMcpServer } from '@/src/shared/remote-mcp';
+import type { RemoteMcpStorageArea } from '@/src/shared/remote-mcp-storage';
+import { buildRemoteMcpToolDefinitions } from '@/src/shared/remote-mcp-tools';
+import { normalizeEvalTabResult } from '@/src/shared/tab-debugger';
+import type { NormalizedEvalTabResult } from '@/src/shared/tab-debugger';
+import { executeRemoteMcpToolCall } from './agent-remote-mcp-tool-runtime';
+import { runDangerousLlmTurn, runSafeLlmTurn } from './agent-turn-runners';
+import { toRemoteMcpToolCallEvents } from './agent-tool-call-events';
+import { evalInTab, getTabUrl, navigateTab } from './agent-workflow-runtime';
+import { executeWorkflowToolCall } from './agent-workflow-tool-runtime';
+import type { WorkflowToolContext } from './agent-workflow-tool-runtime';
+import type { BrowserExecutionLease } from './browser-execution-lock';
+import type { WorkflowRunRequest } from './workflow-settings-state';
+
+type TurnOptions = Parameters<typeof runSafeLlmTurn>[0];
+export type BrowserRunContext = Pick<
+  TurnOptions,
+  | 'apiBaseUrl'
+  | 'appendEvents'
+  | 'fetch'
+  | 'model'
+  | 'onAssistantStreaming'
+  | 'onUsage'
+  | 'organizationId'
+  | 'supportsImages'
+  | 'thinkingEffort'
+  | 'token'
+  | 'updateAssistantMessage'
+  | 'updateThinkingBlock'
+> & {
+  readonly abort: AbortController;
+  readonly executionGuard: ExecutionGuard;
+  readonly lease: BrowserExecutionLease;
+  readonly mode: 'safe' | 'dangerous';
+  /** Local callers resolve their existing fallback before setup. Delegated callers must supply the approved tab. */
+  readonly selectedTab: { readonly id: number; readonly title: string; readonly url: string };
+  readonly allowTabFallback: false;
+  readonly settings: AgentWorkflowSettings;
+  readonly allowWebMcpInSafeMode: boolean;
+  readonly remoteMcpServers: readonly RemoteMcpServer[];
+  readonly remoteFetch: typeof fetch;
+  readonly storage: WorkflowToolContext['storage'] & RemoteMcpStorageArea;
+  readonly requestApproval: WorkflowToolContext['requestApproval'];
+  readonly onRemoteMcpWarning: (warning: string | undefined) => void;
+};
+
+const workflowContext = (
+  context: BrowserRunContext,
+  guard: ExecutionGuard
+): WorkflowToolContext => ({
+  allowWorkflowsInSafeMode: context.settings.allowWorkflowsInSafeMode,
+  evalInTab,
+  executionGuard: guard,
+  getTabUrl,
+  mode: context.mode,
+  navigateTab,
+  requestApproval: context.requestApproval,
+  selectedTabId: context.selectedTab.id,
+  selectedTabTitle: context.selectedTab.title,
+  selectedTabUrl: context.selectedTab.url,
+  signal: context.abort.signal,
+  storage: context.storage,
+});
+
+/** The lease covers the complete awaited call, including recursive model continuations and issued actions. */
+const withBoundTab = <Result>(
+  context: BrowserRunContext,
+  work: (guard: ExecutionGuard) => Promise<Result>
+): Promise<Result> =>
+  context.lease.run(async leaseGuard => {
+    const guard = normalizeExecutionGuard(() => {
+      leaseGuard();
+      context.executionGuard();
+    }, context.abort.signal);
+    const onRemoved = (tabId: number): void => {
+      if (tabId === context.selectedTab.id) {
+        context.abort.abort(new ExecutionStoppedError('tab_lost'));
+      }
+    };
+    guard();
+    browser.tabs.onRemoved.addListener(onRemoved);
+    try {
+      try {
+        await browser.tabs.get(context.selectedTab.id);
+      } catch {
+        context.abort.abort(new ExecutionStoppedError('tab_lost'));
+      }
+      guard();
+      return await work(guard);
+    } finally {
+      browser.tabs.onRemoved.removeListener(onRemoved);
+    }
+  });
+
+export const runBrowserTurn = (
+  context: BrowserRunContext,
+  conversationEvents: AgentConversationEvent[]
+): Promise<LlmTurnOutcome> =>
+  withBoundTab(context, async guard => {
+    const { routes, tools, warning } = buildRemoteMcpToolDefinitions({
+      mode: context.mode,
+      servers: context.remoteMcpServers,
+    });
+    context.onRemoteMcpWarning(warning);
+    const runTurn = context.mode === 'dangerous' ? runDangerousLlmTurn : runSafeLlmTurn;
+    const outcome = await runTurn({
+      allowWebMcpInSafeMode: context.allowWebMcpInSafeMode,
+      apiBaseUrl: context.apiBaseUrl,
+      appendEvents: context.appendEvents,
+      conversationEvents,
+      executeRemoteMcpToolCall: (event, executionGuard) =>
+        executeRemoteMcpToolCall({
+          event,
+          executionGuard: executionGuard ?? guard,
+          fetch: context.remoteFetch,
+          routes,
+          servers: context.remoteMcpServers,
+          signal: context.abort.signal,
+          storageArea: context.storage,
+        }),
+      executionGuard: guard,
+      fetch: context.fetch,
+      maxToolRounds: maxAgentToolRounds,
+      model: context.model,
+      onAssistantStreaming: context.onAssistantStreaming,
+      onUsage: context.onUsage,
+      organizationId: context.organizationId,
+      remoteMcpTools: tools,
+      selectedTabId: context.selectedTab.id,
+      signal: context.abort.signal,
+      supportsImages: context.supportsImages === true,
+      thinkingEffort: context.thinkingEffort,
+      toRemoteMcpToolCallEvents: toolCalls => toRemoteMcpToolCallEvents(toolCalls, routes),
+      token: context.token,
+      updateAssistantMessage: context.updateAssistantMessage,
+      updateThinkingBlock: context.updateThinkingBlock,
+      workflowToolContext: workflowContext(context, guard),
+      workflowTools: createWorkflowToolDefinitions({
+        allowWorkflows: context.settings.allowWorkflowsInSafeMode,
+        mode: context.mode,
+      }),
+    });
+    if (outcome.effectsUncertain) {
+      await context.lease.quarantine(context.selectedTab.id);
+    }
+    return outcome;
+  });
+
+export type BrowserWorkflowOutcome = LlmTurnOutcome & { readonly events: AgentConversationEvent[] };
+export const runBrowserWorkflow = (
+  context: BrowserRunContext,
+  toolCall: WorkflowToolCallEvent
+): Promise<BrowserWorkflowOutcome> =>
+  withBoundTab(context, async guard => {
+    let result: NormalizedEvalTabResult = {
+      effectsUncertain: false,
+      error: 'Workflow did not start.',
+      ok: false,
+    };
+    // eslint-disable-next-line init-declarations -- Only an interrupted workflow supplies this reason.
+    let stopped: ExecutionStoppedError | undefined;
+    try {
+      result = normalizeEvalTabResult(
+        await executeWorkflowToolCall(toolCall, workflowContext(context, guard))
+      );
+    } catch (error) {
+      stopped = error instanceof ExecutionStoppedError ? error : undefined;
+      result = {
+        effectsUncertain: stopped?.effectsUncertain ?? true,
+        error: error instanceof Error ? error.message : 'Workflow execution was interrupted.',
+        ok: false,
+      };
+    }
+    // Consume uncertainty before converting events or permitting the next model turn.
+    if (result.effectsUncertain) {
+      await context.lease.quarantine(context.selectedTab.id);
+    }
+    const event = {
+      ...createToolResult({
+        ok: result.ok && !result.effectsUncertain,
+        toolCallId: toolCall.id,
+        ...(result.ok && !result.effectsUncertain
+          ? { value: result.value }
+          : { error: result.ok ? 'Workflow completion is uncertain.' : result.error }),
+      }),
+      effectsUncertain: result.effectsUncertain,
+    };
+    const details = {
+      effectsUncertain: result.effectsUncertain,
+      events: [toolCall, event],
+      summary: result.ok ? 'Workflow completed.' : result.error,
+      toolResults: result.effectsUncertain ? [] : [event],
+    };
+    if (result.effectsUncertain) {
+      return { ...details, reason: 'effects_uncertain', status: 'interrupted' };
+    }
+    if (stopped !== undefined) {
+      return { ...details, reason: stopped.reason, status: stopped.status };
+    }
+    return result.ok
+      ? { ...details, reason: 'completed', status: 'succeeded' }
+      : { ...details, reason: 'model_failure', status: 'failed' };
+  });
+
+// Preserve the old request atom shape. The UI-only reservation is not model input or persisted state.
+const workflowReservations = new WeakMap<
+  WorkflowRunRequest,
+  { lease: BrowserExecutionLease; conversationId: string | undefined }
+>();
+export const reserveWorkflowLease = (
+  request: WorkflowRunRequest,
+  lease: BrowserExecutionLease,
+  conversationId: string | undefined
+): void => {
+  workflowReservations.set(request, { conversationId, lease });
+};
+export const takeWorkflowLease = (request: WorkflowRunRequest) => {
+  const reserved = workflowReservations.get(request);
+  workflowReservations.delete(request);
+  return reserved;
+};

--- a/apps/extension/entrypoints/sidepanel/conversation-list.test.ts
+++ b/apps/extension/entrypoints/sidepanel/conversation-list.test.ts
@@ -1,19 +1,34 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it } from 'vitest';
+import { createElement } from 'react';
+import { render } from '@testing-library/react';
+import { LEGACY_CONVERSATION_GREETING } from '@/src/shared/agent-conversation-tabs';
 import {
+  ConversationList,
   decideConversationScroll,
   isAtConversationBottom,
   isDifferentConversation,
 } from './conversation-list';
 
 /*
- * The virtualizer renders no rows under jsdom (see agents-session-view.test.ts),
- * so these tests cover the scroll decision itself, not the DOM scroll.
+ * The virtualizer renders no rows under jsdom (see agents-session-view.test.ts).
+ * These tests cover scroll decisions and DOM boundaries, not browser geometry.
  */
 
 const atBottom = { clientHeight: 400, scrollHeight: 2000, scrollTop: 1600 };
 const scrolledUp = { clientHeight: 400, scrollHeight: 2000, scrollTop: 400 };
+
+describe('conversation viewport boundary', () => {
+  it('keeps the empty greeting inside a clipped, internally scrolling viewport', () => {
+    const view = render(createElement(ConversationList, { items: [] }));
+    const conversation = view.getByRole('region', { name: 'Agent conversation' });
+
+    expect(conversation.closest('.min-h-0.overflow-hidden')).toBe(view.container.firstElementChild);
+    expect(conversation.classList.contains('overflow-y-auto')).toBe(true);
+    expect(view.getByText(LEGACY_CONVERSATION_GREETING).parentElement).toBe(conversation);
+  });
+});
 
 describe('isAtConversationBottom()', () => {
   it('accepts the exact bottom', () => {

--- a/apps/extension/entrypoints/sidepanel/conversation-list.tsx
+++ b/apps/extension/entrypoints/sidepanel/conversation-list.tsx
@@ -371,7 +371,7 @@ export const ConversationList = ({
   const virtualItems = virtualizer.getVirtualItems();
 
   return (
-    <div className="relative min-h-0 flex-1">
+    <div className="relative min-h-0 flex-1 overflow-hidden">
       <section
         aria-label="Agent conversation"
         className="agent-conversation-scrollbar h-full overflow-y-auto px-4 py-4"

--- a/apps/extension/entrypoints/sidepanel/workflow-row.tsx
+++ b/apps/extension/entrypoints/sidepanel/workflow-row.tsx
@@ -1,6 +1,6 @@
 import { Play, Trash2 } from 'lucide-react';
 import type { JSX } from 'react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { WorkflowRunPrompt } from './workflow-run-prompt';
 import { deriveWorkflowRunDisabledReason } from './workflow-settings-state';
 import type { WorkflowSettingsListItem } from './workflow-settings-state';
@@ -25,6 +25,7 @@ export const WorkflowRow = ({
   activeConversationRunning,
   allowWorkflowsInSafeMode,
   autoApproveChanges,
+  blocker,
   isDangerousMode,
   item,
   onDelete,
@@ -33,10 +34,15 @@ export const WorkflowRow = ({
   activeConversationRunning: boolean;
   allowWorkflowsInSafeMode: boolean;
   autoApproveChanges: boolean;
+  blocker: string | undefined;
   isDangerousMode: boolean;
   item: WorkflowSettingsListItem;
   onDelete: (id: string) => void;
-  onRun: (id: string, input?: Record<string, string>) => void;
+  onRun: (
+    id: string,
+    input: Record<string, string> | undefined,
+    signal: AbortSignal
+  ) => Promise<boolean>;
 }): JSX.Element => {
   const disabledReason = deriveWorkflowRunDisabledReason({
     activeConversationRunning,
@@ -46,13 +52,37 @@ export const WorkflowRow = ({
   });
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [collectingInput, setCollectingInput] = useState(false);
+  // eslint-disable-next-line unicorn/no-useless-undefined -- React 19 requires an initial ref value.
+  const pendingRunRef = useRef<AbortController | undefined>(undefined);
+  useEffect(
+    () => () => {
+      pendingRunRef.current?.abort();
+    },
+    []
+  );
 
+  const submitRun = async (input?: Record<string, string>): Promise<void> => {
+    if (pendingRunRef.current !== undefined) {
+      return;
+    }
+    const controller = new AbortController();
+    pendingRunRef.current = controller;
+    try {
+      if ((await onRun(item.id, input, controller.signal)) && !controller.signal.aborted) {
+        setCollectingInput(false);
+      }
+    } finally {
+      if (pendingRunRef.current === controller) {
+        pendingRunRef.current = undefined;
+      }
+    }
+  };
   const startRun = (): void => {
     if (item.params.length > 0) {
       setCollectingInput(true);
       return;
     }
-    onRun(item.id);
+    void submitRun();
   };
 
   return (
@@ -108,17 +138,28 @@ export const WorkflowRow = ({
       </div>
 
       {collectingInput && (
-        <WorkflowRunPrompt
-          name={item.name}
-          onCancel={() => {
-            setCollectingInput(false);
-          }}
-          onRun={input => {
-            setCollectingInput(false);
-            onRun(item.id, input);
-          }}
-          params={item.params}
-        />
+        <>
+          <WorkflowRunPrompt
+            name={item.name}
+            onCancel={() => {
+              pendingRunRef.current?.abort();
+              pendingRunRef.current = undefined;
+              setCollectingInput(false);
+            }}
+            onRun={input => {
+              void submitRun(input);
+            }}
+            params={item.params}
+          />
+          {blocker === undefined ? null : (
+            <p
+              className="type-body fixed inset-x-4 top-4 z-[31] rounded-md border border-status-yellow-500/30 bg-surface-raised p-3 text-status-yellow-400"
+              role="alert"
+            >
+              {blocker}
+            </p>
+          )}
+        </>
       )}
     </li>
   );

--- a/apps/extension/entrypoints/sidepanel/workflow-row.tsx
+++ b/apps/extension/entrypoints/sidepanel/workflow-row.tsx
@@ -23,6 +23,7 @@ const confirmDeleteButtonClass =
  */
 export const WorkflowRow = ({
   activeConversationRunning,
+  admissionPending,
   allowWorkflowsInSafeMode,
   autoApproveChanges,
   blocker,
@@ -32,6 +33,7 @@ export const WorkflowRow = ({
   onRun,
 }: {
   activeConversationRunning: boolean;
+  admissionPending: boolean;
   allowWorkflowsInSafeMode: boolean;
   autoApproveChanges: boolean;
   blocker: string | undefined;
@@ -108,9 +110,10 @@ export const WorkflowRow = ({
       </div>
       <div className="flex shrink-0 items-center gap-1">
         <button
+          aria-busy={admissionPending}
           aria-label={`Run workflow "${item.name}"`}
           className={runButtonClass}
-          disabled={disabledReason !== undefined}
+          disabled={admissionPending || disabledReason !== undefined}
           onClick={startRun}
           title={disabledReason?.label}
           type="button"
@@ -138,28 +141,20 @@ export const WorkflowRow = ({
       </div>
 
       {collectingInput && (
-        <>
-          <WorkflowRunPrompt
-            name={item.name}
-            onCancel={() => {
-              pendingRunRef.current?.abort();
-              pendingRunRef.current = undefined;
-              setCollectingInput(false);
-            }}
-            onRun={input => {
-              void submitRun(input);
-            }}
-            params={item.params}
-          />
-          {blocker === undefined ? null : (
-            <p
-              className="type-body fixed inset-x-4 top-4 z-[31] rounded-md border border-status-yellow-500/30 bg-surface-raised p-3 text-status-yellow-400"
-              role="alert"
-            >
-              {blocker}
-            </p>
-          )}
-        </>
+        <WorkflowRunPrompt
+          admissionPending={admissionPending}
+          blocker={blocker}
+          name={item.name}
+          onCancel={() => {
+            pendingRunRef.current?.abort();
+            pendingRunRef.current = undefined;
+            setCollectingInput(false);
+          }}
+          onRun={input => {
+            void submitRun(input);
+          }}
+          params={item.params}
+        />
       )}
     </li>
   );

--- a/apps/extension/entrypoints/sidepanel/workflow-run-prompt.tsx
+++ b/apps/extension/entrypoints/sidepanel/workflow-run-prompt.tsx
@@ -14,11 +14,15 @@ const primaryButtonClass =
  * from the input so the script sees undefined rather than an empty string.
  */
 export const WorkflowRunPrompt = ({
+  admissionPending,
+  blocker,
   name,
   onCancel,
   onRun,
   params,
 }: {
+  admissionPending: boolean;
+  blocker: string | undefined;
   name: string;
   onCancel: () => void;
   onRun: (input: Record<string, string>) => void;
@@ -66,13 +70,25 @@ export const WorkflowRunPrompt = ({
             />
           </label>
         ))}
+        <p
+          className={admissionPending ? 'type-body text-status-yellow-400' : 'sr-only'}
+          role="status"
+        >
+          {admissionPending ? blocker : undefined}
+        </p>
+        {!admissionPending && blocker !== undefined ? (
+          <p className="type-body text-status-yellow-400" role="alert">
+            {blocker}
+          </p>
+        ) : null}
         <div className="flex justify-end gap-2">
           <button className={secondaryButtonClass} onClick={onCancel} type="button">
             Cancel
           </button>
           <button
+            aria-busy={admissionPending}
             className={primaryButtonClass}
-            disabled={missingRequired}
+            disabled={missingRequired || admissionPending}
             onClick={submit}
             type="button"
           >

--- a/apps/extension/entrypoints/sidepanel/workflow-run-prompt.tsx
+++ b/apps/extension/entrypoints/sidepanel/workflow-run-prompt.tsx
@@ -66,6 +66,7 @@ export const WorkflowRunPrompt = ({
                 setValues(current => ({ ...current, [param.name]: value }));
               }}
               placeholder={param.example ?? ''}
+              readOnly={admissionPending}
               value={values[param.name] ?? ''}
             />
           </label>

--- a/apps/extension/entrypoints/sidepanel/workflow-settings.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/workflow-settings.test.tsx
@@ -329,9 +329,13 @@ describe('workflow settings', () => {
           text: '',
         });
         if (parameters) {
+          expect(controls.getByRole('textbox')).toHaveProperty('readOnly', false);
           fireEvent.change(controls.getByRole('textbox'), { target: { value: 'large' } });
         }
         fireEvent.click(runButton);
+        if (parameters) {
+          expect(controls.getByRole('textbox')).toHaveProperty('readOnly', true);
+        }
         expect({
           busy: runButton.getAttribute('aria-busy'),
           cancelDisabled: parameters
@@ -398,12 +402,16 @@ describe('workflow settings', () => {
             sameStatus: true,
             settingsOpen: true,
           });
+          if (parameters) {
+            expect(controls.getByRole('textbox')).toHaveProperty('readOnly', false);
+            fireEvent.change(controls.getByRole('textbox'), { target: { value: 'medium' } });
+          }
           fireEvent.click(runButton);
         }
         await waitFor(() => {
           expect(store.get(workflowRunRequestAtom)).toStrictEqual({
             workflowId: 'wf-1',
-            ...(parameters ? { input: { size: 'large' } } : {}),
+            ...(parameters ? { input: { size: outcome === 'success' ? 'large' : 'medium' } } : {}),
           });
           expect(store.get(settingsDialogOpenAtom)).toBe(false);
           expect(view.queryByRole('dialog')).toBeNull();

--- a/apps/extension/entrypoints/sidepanel/workflow-settings.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/workflow-settings.test.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { Provider, createStore } from 'jotai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { runningConversationIdsAtom } from './agent-chat-atoms';
 import {
   activeConversationIdAtom,
@@ -28,9 +28,22 @@ vi.mock('@/src/shared/agent-workflows-storage', () => ({
   saveWorkflowSettings: vi.fn(),
 }));
 
+const lockStorage = vi.hoisted(() => new Map<string, unknown>());
 vi.mock('#imports', () => ({
-  storage: {},
+  storage: {
+    getItem: (key: string) => lockStorage.get(key),
+    setItem: (key: string, value: unknown) => {
+      lockStorage.set(key, value);
+    },
+    watch: () => () => {},
+  },
 }));
+// eslint-disable-next-line import/no-nodejs-modules -- These fixtures exercise native locks under Node.
+import { locks as nativeLocks } from 'node:worker_threads';
+import { BROWSER_EXECUTION_LOCK, getBrowserExecutionCoordinator } from './browser-execution-lock';
+import type { BrowserAdmission, BrowserExecutionLease } from './browser-execution-lock';
+import { reserveWorkflowLease, takeWorkflowLease } from './browser-run-context';
+const heldLeases = new Set<BrowserExecutionLease>();
 
 import { useAgentWorkflows } from './use-agent-workflows';
 import { DEFAULT_WORKFLOW_SETTINGS } from '@/src/shared/agent-workflows';
@@ -72,12 +85,24 @@ describe('workflow settings', () => {
   let store: ReturnType<typeof createStore>;
 
   beforeEach(() => {
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: nativeLocks });
+    lockStorage.clear();
     store = createStore();
     store.set(runningConversationIdsAtom, []);
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    const request = store.get(workflowRunRequestAtom);
+    if (request !== undefined) {
+      const reservation = takeWorkflowLease(request);
+      if (reservation !== undefined) {
+        await reservation.lease.release();
+      }
+    }
+    await Promise.all([...heldLeases].map(lease => lease.release()));
+    heldLeases.clear();
+    vi.restoreAllMocks();
     vi.resetAllMocks();
   });
 
@@ -128,12 +153,13 @@ describe('workflow settings', () => {
       allowWorkflowsInSafeMode: false,
     });
 
-    const { getByText } = render(createElement(WorkflowSettings), {
+    const { getByText, queryByRole } = render(createElement(WorkflowSettings), {
       wrapper: createWrapper(store),
     });
 
     await waitFor(() => {
       expect(getByText(/No workflows yet. Ask Kilo to save one/u)).toBeDefined();
+      expect(queryByRole('status')).toBeNull();
     });
   });
 
@@ -243,9 +269,335 @@ describe('workflow settings', () => {
       runButton.click();
     }
 
-    expect(store.get(workflowRunRequestAtom)).toStrictEqual({ workflowId: 'wf-1' });
-    expect(store.get(settingsDialogOpenAtom)).toBe(false);
+    await waitFor(() => {
+      expect(store.get(workflowRunRequestAtom)).toStrictEqual({ workflowId: 'wf-1' });
+      expect(store.get(settingsDialogOpenAtom)).toBe(false);
+    });
   });
+
+  it.each([
+    { failure: 'request', parameters: false },
+    { failure: 'request', parameters: true },
+    { failure: 'lease', parameters: false },
+    { failure: 'lease', parameters: true },
+  ])(
+    'retains input after a $failure exception (parameters=$parameters)',
+    async ({ failure, parameters }) => {
+      mockUseAgentWorkflows.mockReturnValue({
+        ...emptyResult,
+        workflows: [
+          {
+            ...approvedWorkflow,
+            ...(parameters
+              ? { params: [{ name: 'size', description: 'Pizza size', required: true }] }
+              : {}),
+          },
+        ],
+      });
+      mockLoadWorkflowSettings.mockResolvedValue({
+        ...DEFAULT_WORKFLOW_SETTINGS,
+        allowWorkflowsInSafeMode: true,
+      });
+      store.set(settingsDialogOpenAtom, true);
+      const coordinator = getBrowserExecutionCoordinator();
+      if (failure === 'request') {
+        vi.spyOn(coordinator, 'acquireLocal').mockRejectedValueOnce(
+          new Error('Admission unavailable. Submit again.')
+        );
+      } else {
+        const admission = await coordinator.acquireLocal();
+        if (!admission.admitted) {
+          throw new Error(admission.reason);
+        }
+        await admission.lease.release();
+        vi.spyOn(coordinator, 'acquireLocal').mockResolvedValueOnce(admission);
+      }
+      const view = render(createElement(WorkflowSettings), { wrapper: createWrapper(store) });
+      await waitFor(() => {
+        expect(view.getByLabelText('Run workflow "Order pizza"')).toHaveProperty('disabled', false);
+      });
+      fireEvent.click(view.getByLabelText('Run workflow "Order pizza"'));
+      if (parameters) {
+        fireEvent.change(view.getByRole('textbox'), { target: { value: 'large' } });
+        fireEvent.click(view.getByRole('button', { name: 'Run' }));
+      }
+      await waitFor(() => {
+        expect(view.getByRole(parameters ? 'alert' : 'status').textContent).toContain(
+          failure === 'request' ? 'Admission unavailable' : 'execution_lease_lost'
+        );
+      });
+      expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+      expect(store.get(settingsDialogOpenAtom)).toBe(true);
+      if (parameters) {
+        expect(view.getByDisplayValue('large')).toBeDefined();
+      }
+      const owner = await coordinator.acquireProviderOwner();
+      if (!owner.admitted) {
+        throw new Error(owner.reason);
+      }
+      heldLeases.add(owner.lease);
+      const delegated = await coordinator.acquireDelegated(
+        owner.lease,
+        'temporary-owner',
+        new AbortController().signal
+      );
+      if (!delegated.admitted) {
+        throw new Error(delegated.reason);
+      }
+      heldLeases.add(delegated.lease);
+      await act(async () => {
+        await delegated.lease.release();
+        await coordinator.refresh();
+      });
+      expect(view.getByRole(parameters ? 'alert' : 'status').textContent).toContain(
+        failure === 'request' ? 'Admission unavailable' : 'execution_lease_lost'
+      );
+      expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+      fireEvent.click(
+        parameters
+          ? view.getByRole('button', { name: 'Run' })
+          : view.getByLabelText('Run workflow "Order pizza"')
+      );
+      await waitFor(() => {
+        expect(store.get(workflowRunRequestAtom)).toStrictEqual({
+          workflowId: 'wf-1',
+          ...(parameters ? { input: { size: 'large' } } : {}),
+        });
+        expect(store.get(settingsDialogOpenAtom)).toBe(false);
+        expect(view.queryByRole('dialog')).toBeNull();
+      });
+    }
+  );
+
+  it.each(['cancel', 'row unmount', 'Settings unmount'] as const)(
+    'discards pending parameter admission after %s',
+    async cancellation => {
+      mockUseAgentWorkflows.mockReturnValue({
+        ...emptyResult,
+        workflows: [
+          {
+            ...approvedWorkflow,
+            params: [{ name: 'size', description: 'Pizza size', required: true }],
+          },
+        ],
+      });
+      mockLoadWorkflowSettings.mockResolvedValue({
+        ...DEFAULT_WORKFLOW_SETTINGS,
+        allowWorkflowsInSafeMode: true,
+      });
+      store.set(settingsDialogOpenAtom, true);
+      const coordinator = getBrowserExecutionCoordinator();
+      const admission = await coordinator.acquireLocal();
+      if (!admission.admitted) {
+        throw new Error(admission.reason);
+      }
+      heldLeases.add(admission.lease);
+      const pending = Promise.withResolvers<BrowserAdmission>();
+      vi.spyOn(coordinator, 'acquireLocal').mockReturnValueOnce(pending.promise);
+      const view = render(createElement(WorkflowSettings), { wrapper: createWrapper(store) });
+      await waitFor(() => {
+        expect(view.getByLabelText('Run workflow "Order pizza"')).toHaveProperty('disabled', false);
+      });
+      fireEvent.click(view.getByLabelText('Run workflow "Order pizza"'));
+      fireEvent.change(view.getByRole('textbox'), { target: { value: 'large' } });
+      fireEvent.click(view.getByRole('button', { name: 'Run' }));
+      expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+      if (cancellation === 'cancel') {
+        fireEvent.click(view.getByRole('button', { name: 'Cancel' }));
+      } else if (cancellation === 'row unmount') {
+        mockUseAgentWorkflows.mockReturnValue(emptyResult);
+        view.rerender(createElement(WorkflowSettings));
+      } else {
+        view.unmount();
+      }
+      await act(async () => {
+        pending.resolve(admission);
+        await pending.promise;
+      });
+      expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+      expect(store.get(settingsDialogOpenAtom)).toBe(true);
+      expect(view.queryByRole('dialog')).toBeNull();
+      await waitFor(async () => {
+        const state = await nativeLocks.query();
+        expect(state.held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)).toBe(false);
+      });
+    }
+  );
+
+  it('releases admission acquired after Settings unmounts', async () => {
+    mockUseAgentWorkflows.mockReturnValue({ ...emptyResult, workflows: [approvedWorkflow] });
+    mockLoadWorkflowSettings.mockResolvedValue({
+      ...DEFAULT_WORKFLOW_SETTINGS,
+      allowWorkflowsInSafeMode: true,
+    });
+    store.set(settingsDialogOpenAtom, true);
+    const coordinator = getBrowserExecutionCoordinator();
+    const admission = await coordinator.acquireLocal();
+    if (!admission.admitted) {
+      throw new Error(admission.reason);
+    }
+    heldLeases.add(admission.lease);
+    const pending = Promise.withResolvers<BrowserAdmission>();
+    vi.spyOn(coordinator, 'acquireLocal').mockReturnValueOnce(pending.promise);
+    const view = render(createElement(WorkflowSettings), { wrapper: createWrapper(store) });
+    await waitFor(() => {
+      expect(view.getByLabelText('Run workflow "Order pizza"')).toHaveProperty('disabled', false);
+    });
+    fireEvent.click(view.getByLabelText('Run workflow "Order pizza"'));
+    view.unmount();
+    pending.resolve(admission);
+    await waitFor(async () => {
+      const state = await nativeLocks.query();
+      expect(state.held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)).toBe(false);
+    });
+    expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+    expect(store.get(settingsDialogOpenAtom)).toBe(true);
+  });
+
+  it('preserves an existing workflow reservation instead of replacing it and leaking its lease', async () => {
+    mockUseAgentWorkflows.mockReturnValue({ ...emptyResult, workflows: [approvedWorkflow] });
+    mockLoadWorkflowSettings.mockResolvedValue({
+      ...DEFAULT_WORKFLOW_SETTINGS,
+      allowWorkflowsInSafeMode: true,
+    });
+    const admission = await getBrowserExecutionCoordinator().acquireLocal();
+    if (!admission.admitted) {
+      throw new Error(admission.reason);
+    }
+    heldLeases.add(admission.lease);
+    const request = { input: { size: 'small' }, workflowId: 'wf-1' };
+    reserveWorkflowLease(request, admission.lease, 'conversation-1');
+    store.set(workflowRunRequestAtom, request);
+    store.set(settingsDialogOpenAtom, true);
+    const view = render(createElement(WorkflowSettings), { wrapper: createWrapper(store) });
+    await waitFor(() => {
+      expect(view.getByLabelText('Run workflow "Order pizza"')).toHaveProperty('disabled', false);
+    });
+    fireEvent.click(view.getByLabelText('Run workflow "Order pizza"'));
+    await waitFor(() => {
+      expect(view.getByRole('status').textContent).toContain('workflow request');
+    });
+    expect(store.get(workflowRunRequestAtom)).toBe(request);
+    expect(store.get(settingsDialogOpenAtom)).toBe(true);
+    const reservation = takeWorkflowLease(request);
+    await reservation?.lease.release();
+    await waitFor(async () => {
+      const state = await nativeLocks.query();
+      expect(state.held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)).toBe(false);
+    });
+  });
+
+  it.each([
+    { parameters: false, phase: 'waiting' },
+    { parameters: false, phase: 'running' },
+    { parameters: true, phase: 'waiting' },
+    { parameters: true, phase: 'running' },
+  ])(
+    'retains Settings input when delegation is $phase (parameters=$parameters)',
+    async ({ parameters, phase }) => {
+      mockUseAgentWorkflows.mockReturnValue({
+        ...emptyResult,
+        workflows: [
+          {
+            ...approvedWorkflow,
+            ...(parameters
+              ? { params: [{ name: 'size', description: 'Pizza size', required: true }] }
+              : {}),
+          },
+        ],
+      });
+      mockLoadWorkflowSettings.mockResolvedValue({
+        ...DEFAULT_WORKFLOW_SETTINGS,
+        allowWorkflowsInSafeMode: true,
+      });
+      store.set(settingsDialogOpenAtom, true);
+      const coordinator = getBrowserExecutionCoordinator();
+      const ownerAdmission = await coordinator.acquireProviderOwner();
+      if (!ownerAdmission.admitted) {
+        throw new Error(ownerAdmission.reason);
+      }
+      heldLeases.add(ownerAdmission.lease);
+      const localAdmission = phase === 'waiting' ? await coordinator.acquireLocal() : undefined;
+      if (localAdmission?.admitted === true) {
+        heldLeases.add(localAdmission.lease);
+      }
+      const delegatedPromise = coordinator.acquireDelegated(
+        ownerAdmission.lease,
+        'parent-order',
+        new AbortController().signal
+      );
+      let delegated: BrowserExecutionLease | undefined;
+      if (phase === 'running') {
+        const admission = await delegatedPromise;
+        if (!admission.admitted) {
+          throw new Error(admission.reason);
+        }
+        delegated = admission.lease;
+        heldLeases.add(delegated);
+      } else {
+        await waitFor(async () => {
+          const state = await nativeLocks.query();
+          expect(state.pending).toHaveLength(1);
+        });
+      }
+      const view = render(createElement(WorkflowSettings), { wrapper: createWrapper(store) });
+      await waitFor(() => {
+        expect(view.getByLabelText('Run workflow "Order pizza"')).toHaveProperty('disabled', false);
+      });
+      fireEvent.click(view.getByLabelText('Run workflow "Order pizza"'));
+      if (parameters) {
+        fireEvent.change(view.getByRole('textbox'), { target: { value: 'large' } });
+        fireEvent.click(view.getByRole('button', { name: 'Run' }));
+        await waitFor(() => {
+          expect(view.getByRole('alert').textContent).toContain('parent-order');
+        });
+        expect(view.getByDisplayValue('large')).toBeDefined();
+        expect(view.getByRole('dialog')).toBeDefined();
+      } else {
+        await waitFor(() => {
+          expect(view.getByRole('status').textContent).toContain('parent-order');
+        });
+      }
+      expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+      expect(store.get(settingsDialogOpenAtom)).toBe(true);
+      if (localAdmission?.admitted === true) {
+        await localAdmission.lease.release();
+      }
+      if (delegated === undefined) {
+        const admission = await delegatedPromise;
+        if (!admission.admitted) {
+          throw new Error(admission.reason);
+        }
+        delegated = admission.lease;
+        heldLeases.add(delegated);
+      }
+      const delegatedLease = delegated;
+      await act(async () => {
+        await delegatedLease.release();
+        await coordinator.refresh();
+      });
+      expect(view.getByRole('status').textContent).not.toContain('parent-order');
+      expect(view.getByRole('status').textContent).toMatch(/input is retained.*Run it again/u);
+      if (parameters) {
+        expect(view.getByRole('alert').textContent).not.toContain('parent-order');
+        expect(view.getByDisplayValue('large')).toBeDefined();
+      }
+      expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+      fireEvent.click(
+        parameters
+          ? view.getByRole('button', { name: 'Run' })
+          : view.getByLabelText('Run workflow "Order pizza"')
+      );
+      await waitFor(() => {
+        expect(store.get(workflowRunRequestAtom)).toStrictEqual({
+          workflowId: 'wf-1',
+          ...(parameters ? { input: { size: 'large' } } : {}),
+        });
+        expect(store.get(settingsDialogOpenAtom)).toBe(false);
+        expect(view.queryByRole('dialog')).toBeNull();
+      });
+    }
+  );
 
   it('sets the toggle on click and persists the change', async () => {
     mockUseAgentWorkflows.mockReturnValue(emptyResult);

--- a/apps/extension/entrypoints/sidepanel/workflow-settings.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/workflow-settings.test.tsx
@@ -487,6 +487,84 @@ describe('workflow settings', () => {
     });
   });
 
+  it.each([false, true])(
+    'retains Settings input after a local owner disappears (parameters=%s)',
+    async parameters => {
+      const { storage } = await import('#imports');
+      const { BROWSER_EXECUTION_SAFETY_KEY, createBrowserExecutionCoordinator } =
+        await import('./browser-execution-lock');
+      lockStorage.set(BROWSER_EXECUTION_SAFETY_KEY, {
+        localRuns: [{ lockName: `${BROWSER_EXECUTION_LOCK}:local:closed-panel`, tabId: 0 }],
+        tabIds: [],
+        version: 1,
+      });
+      mockUseAgentWorkflows.mockReturnValue({
+        ...emptyResult,
+        workflows: [
+          {
+            ...approvedWorkflow,
+            ...(parameters
+              ? { params: [{ name: 'size', description: 'Pizza size', required: true }] }
+              : {}),
+          },
+        ],
+      });
+      mockLoadWorkflowSettings.mockResolvedValue({
+        ...DEFAULT_WORKFLOW_SETTINGS,
+        allowWorkflowsInSafeMode: true,
+      });
+      store.set(settingsDialogOpenAtom, true);
+      const view = render(createElement(WorkflowSettings), { wrapper: createWrapper(store) });
+      await waitFor(() => {
+        expect(view.getByLabelText('Run workflow "Order pizza"')).toHaveProperty('disabled', false);
+      });
+      fireEvent.click(view.getByLabelText('Run workflow "Order pizza"'));
+      if (parameters) {
+        fireEvent.change(view.getByRole('textbox'), { target: { value: 'large' } });
+        fireEvent.click(view.getByRole('button', { name: 'Run' }));
+      }
+      await waitFor(() => {
+        expect(view.getByRole(parameters ? 'alert' : 'status').textContent).toContain(
+          'Close the affected tabs'
+        );
+      });
+      expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+      expect(store.get(settingsDialogOpenAtom)).toBe(true);
+      const otherPanel = createBrowserExecutionCoordinator({
+        locks: nativeLocks as LockManager,
+        storageArea: storage,
+      });
+      await expect(otherPanel.recover(() => Promise.resolve([0]))).resolves.toMatchObject({
+        recovered: false,
+      });
+      await act(async () => {
+        await expect(otherPanel.recover(() => Promise.resolve([]))).resolves.toMatchObject({
+          recovered: true,
+        });
+        await getBrowserExecutionCoordinator().refresh();
+      });
+      expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+      expect(view.getByRole(parameters ? 'alert' : 'status').textContent).toContain(
+        'input is retained'
+      );
+      if (parameters) {
+        expect(view.getByDisplayValue('large')).toBeDefined();
+      }
+      fireEvent.click(
+        parameters
+          ? view.getByRole('button', { name: 'Run' })
+          : view.getByLabelText('Run workflow "Order pizza"')
+      );
+      await waitFor(() => {
+        expect(store.get(workflowRunRequestAtom)).toStrictEqual({
+          workflowId: 'wf-1',
+          ...(parameters ? { input: { size: 'large' } } : {}),
+        });
+        expect(store.get(settingsDialogOpenAtom)).toBe(false);
+      });
+    }
+  );
+
   it.each([
     { parameters: false, phase: 'waiting' },
     { parameters: false, phase: 'running' },

--- a/apps/extension/entrypoints/sidepanel/workflow-settings.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/workflow-settings.test.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { Provider, createStore } from 'jotai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react';
 import { runningConversationIdsAtom } from './agent-chat-atoms';
 import {
   activeConversationIdAtom,
@@ -153,13 +153,14 @@ describe('workflow settings', () => {
       allowWorkflowsInSafeMode: false,
     });
 
-    const { getByText, queryByRole } = render(createElement(WorkflowSettings), {
+    const { getByText, getByRole } = render(createElement(WorkflowSettings), {
       wrapper: createWrapper(store),
     });
 
     await waitFor(() => {
       expect(getByText(/No workflows yet. Ask Kilo to save one/u)).toBeDefined();
-      expect(queryByRole('status')).toBeNull();
+      expect(getByRole('status').textContent).toBe('');
+      expect(getByRole('status').className).toBe('sr-only');
     });
   });
 
@@ -273,6 +274,256 @@ describe('workflow settings', () => {
       expect(store.get(workflowRunRequestAtom)).toStrictEqual({ workflowId: 'wf-1' });
       expect(store.get(settingsDialogOpenAtom)).toBe(false);
     });
+  });
+
+  it.each([
+    { outcome: 'success', parameters: false },
+    { outcome: 'success', parameters: true },
+    { outcome: 'rejection', parameters: false },
+    { outcome: 'rejection', parameters: true },
+    { outcome: 'error', parameters: false },
+    { outcome: 'error', parameters: true },
+  ])(
+    'announces delayed Run admission through $outcome (parameters=$parameters)',
+    async ({ outcome, parameters }) => {
+      mockUseAgentWorkflows.mockReturnValue({
+        ...emptyResult,
+        workflows: [
+          {
+            ...approvedWorkflow,
+            ...(parameters
+              ? { params: [{ name: 'size', description: 'Pizza size', required: true }] }
+              : {}),
+          },
+        ],
+      });
+      mockLoadWorkflowSettings.mockResolvedValue({
+        ...DEFAULT_WORKFLOW_SETTINGS,
+        allowWorkflowsInSafeMode: true,
+      });
+      store.set(settingsDialogOpenAtom, true);
+      const coordinator = getBrowserExecutionCoordinator();
+      const admission = await coordinator.acquireLocal();
+      if (!admission.admitted) {
+        throw new Error(admission.reason);
+      }
+      heldLeases.add(admission.lease);
+      const pending = Promise.withResolvers<BrowserAdmission>();
+      vi.spyOn(coordinator, 'acquireLocal').mockReturnValueOnce(pending.promise);
+      const view = render(createElement(WorkflowSettings), { wrapper: createWrapper(store) });
+      try {
+        const rowRun = view.getByRole('button', { name: 'Run workflow "Order pizza"' });
+        await waitFor(() => {
+          expect(rowRun).toHaveProperty('disabled', false);
+        });
+        const settingsStatus = view.getByRole('status');
+        if (parameters) {
+          fireEvent.click(rowRun);
+        }
+        const controls = parameters ? within(view.getByRole('dialog')) : view;
+        const runName = parameters ? 'Run' : 'Run workflow "Order pizza"';
+        const runButton = controls.getByRole('button', { name: runName });
+        const status = controls.getByRole('status');
+        expect({ className: status.className, text: status.textContent }).toStrictEqual({
+          className: 'sr-only',
+          text: '',
+        });
+        if (parameters) {
+          fireEvent.change(controls.getByRole('textbox'), { target: { value: 'large' } });
+        }
+        fireEvent.click(runButton);
+        expect({
+          busy: runButton.getAttribute('aria-busy'),
+          cancelDisabled: parameters
+            ? controls.getByRole('button', { name: 'Cancel' }).hasAttribute('disabled')
+            : false,
+          disabled: runButton.hasAttribute('disabled'),
+          sameButton: controls.getByRole('button', { name: runName }) === runButton,
+          sameStatus: controls.getByRole('status') === status,
+          screenReaderOnly: status.classList.contains('sr-only'),
+          pending: status.textContent?.includes('Checking browser control'),
+        }).toStrictEqual({
+          busy: 'true',
+          cancelDisabled: false,
+          disabled: true,
+          sameButton: true,
+          sameStatus: true,
+          screenReaderOnly: false,
+          pending: true,
+        });
+        fireEvent.click(rowRun);
+        fireEvent.click(runButton);
+        fireEvent.click(runButton);
+        expect({
+          input: parameters ? controls.queryByDisplayValue('large') !== null : undefined,
+          request: store.get(workflowRunRequestAtom),
+          settingsOpen: store.get(settingsDialogOpenAtom),
+        }).toStrictEqual({
+          input: parameters ? true : undefined,
+          request: undefined,
+          settingsOpen: true,
+        });
+        await act(async () => {
+          if (outcome === 'error') {
+            pending.reject(new Error('Admission unavailable.'));
+          } else {
+            pending.resolve(
+              outcome === 'success' ? admission : { admitted: false, reason: 'Busy' }
+            );
+          }
+          await pending.promise.catch(() => {});
+        });
+        expect({
+          busy: rowRun.getAttribute('aria-busy'),
+          pending: view.queryByText(/Checking browser control/u),
+        }).toStrictEqual({ busy: 'false', pending: null });
+        if (outcome !== 'success') {
+          view.rerender(createElement(WorkflowSettings));
+          expect({
+            busy: runButton.getAttribute('aria-busy'),
+            disabled: runButton.hasAttribute('disabled'),
+            input: parameters ? controls.queryByDisplayValue('large') !== null : undefined,
+            request: store.get(workflowRunRequestAtom),
+            retryGuidance: controls
+              .getByRole(parameters ? 'alert' : 'status')
+              .textContent?.includes('Run it again'),
+            sameStatus: controls.getByRole('status') === status,
+            settingsOpen: store.get(settingsDialogOpenAtom),
+          }).toStrictEqual({
+            busy: 'false',
+            disabled: false,
+            input: parameters ? true : undefined,
+            request: undefined,
+            retryGuidance: true,
+            sameStatus: true,
+            settingsOpen: true,
+          });
+          fireEvent.click(runButton);
+        }
+        await waitFor(() => {
+          expect(store.get(workflowRunRequestAtom)).toStrictEqual({
+            workflowId: 'wf-1',
+            ...(parameters ? { input: { size: 'large' } } : {}),
+          });
+          expect(store.get(settingsDialogOpenAtom)).toBe(false);
+          expect(view.queryByRole('dialog')).toBeNull();
+          expect({
+            className: settingsStatus.className,
+            sameStatus: view.getByRole('status') === settingsStatus,
+            text: settingsStatus.textContent,
+          }).toStrictEqual({ className: 'sr-only', sameStatus: true, text: '' });
+        });
+      } finally {
+        view.unmount();
+        pending.resolve(admission);
+      }
+    }
+  );
+
+  it('keeps a newer Run pending when cancelled admission finishes late', async () => {
+    mockUseAgentWorkflows.mockReturnValue({
+      ...emptyResult,
+      workflows: [
+        {
+          ...approvedWorkflow,
+          params: [{ name: 'size', description: 'Pizza size', required: true }],
+        },
+      ],
+    });
+    mockLoadWorkflowSettings.mockResolvedValue({
+      ...DEFAULT_WORKFLOW_SETTINGS,
+      allowWorkflowsInSafeMode: true,
+    });
+    store.set(settingsDialogOpenAtom, true);
+    const coordinator = getBrowserExecutionCoordinator();
+    const oldAdmission = await coordinator.acquireLocal();
+    const newAdmission = await coordinator.acquireLocal();
+    if (!oldAdmission.admitted || !newAdmission.admitted) {
+      throw new Error('Expected local admission');
+    }
+    heldLeases.add(oldAdmission.lease);
+    heldLeases.add(newAdmission.lease);
+    const oldPending = Promise.withResolvers<BrowserAdmission>();
+    const newPending = Promise.withResolvers<BrowserAdmission>();
+    vi.spyOn(coordinator, 'acquireLocal')
+      .mockReturnValueOnce(oldPending.promise)
+      .mockReturnValueOnce(newPending.promise);
+    const view = render(createElement(WorkflowSettings), { wrapper: createWrapper(store) });
+    try {
+      const rowRun = view.getByRole('button', { name: 'Run workflow "Order pizza"' });
+      await waitFor(() => {
+        expect(rowRun).toHaveProperty('disabled', false);
+      });
+      fireEvent.click(rowRun);
+      const oldDialog = within(view.getByRole('dialog'));
+      const oldStatus = oldDialog.getByRole('status');
+      expect(oldStatus.textContent).toBe('');
+      fireEvent.change(oldDialog.getByRole('textbox'), { target: { value: 'large' } });
+      fireEvent.click(oldDialog.getByRole('button', { name: 'Run' }));
+      expect({
+        pending: oldStatus.textContent?.includes('Checking browser control'),
+        sameStatus: oldDialog.getByRole('status') === oldStatus,
+      }).toStrictEqual({ pending: true, sameStatus: true });
+      fireEvent.click(oldDialog.getByRole('button', { name: 'Cancel' }));
+      expect({
+        dialog: view.queryByRole('dialog'),
+        disabled: rowRun.hasAttribute('disabled'),
+        pending: view.queryByText(/Checking browser control/u),
+      }).toStrictEqual({ dialog: null, disabled: false, pending: null });
+      fireEvent.click(rowRun);
+      const dialog = within(view.getByRole('dialog'));
+      const status = dialog.getByRole('status');
+      const runButton = dialog.getByRole('button', { name: 'Run' });
+      expect(status.textContent).toBe('');
+      fireEvent.change(dialog.getByRole('textbox'), { target: { value: 'medium' } });
+      fireEvent.click(runButton);
+      await act(async () => {
+        oldPending.resolve(oldAdmission);
+        await oldPending.promise;
+      });
+      await waitFor(async () => {
+        const nativeState = await nativeLocks.query();
+        expect(nativeState.held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)).toHaveLength(
+          1
+        );
+      });
+      expect({
+        busy: runButton.getAttribute('aria-busy'),
+        cancelDisabled: dialog.getByRole('button', { name: 'Cancel' }).hasAttribute('disabled'),
+        disabled: runButton.hasAttribute('disabled'),
+        input: dialog.queryByDisplayValue('medium') !== null,
+        request: store.get(workflowRunRequestAtom),
+        sameStatus: dialog.getByRole('status') === status,
+        settingsOpen: store.get(settingsDialogOpenAtom),
+        pending: status.textContent?.includes('Checking browser control'),
+      }).toStrictEqual({
+        busy: 'true',
+        cancelDisabled: false,
+        disabled: true,
+        input: true,
+        request: undefined,
+        sameStatus: true,
+        settingsOpen: true,
+        pending: true,
+      });
+      await act(async () => {
+        newPending.resolve(newAdmission);
+        await newPending.promise;
+      });
+      await waitFor(() => {
+        expect(store.get(workflowRunRequestAtom)).toStrictEqual({
+          workflowId: 'wf-1',
+          input: { size: 'medium' },
+        });
+        expect(store.get(settingsDialogOpenAtom)).toBe(false);
+        expect(view.queryByRole('dialog')).toBeNull();
+        expect(view.queryByText(/Checking browser control/u)).toBeNull();
+      });
+    } finally {
+      view.unmount();
+      oldPending.resolve(oldAdmission);
+      newPending.resolve(newAdmission);
+    }
   });
 
   it.each([
@@ -399,24 +650,46 @@ describe('workflow settings', () => {
         expect(view.getByLabelText('Run workflow "Order pizza"')).toHaveProperty('disabled', false);
       });
       fireEvent.click(view.getByLabelText('Run workflow "Order pizza"'));
-      fireEvent.change(view.getByRole('textbox'), { target: { value: 'large' } });
-      fireEvent.click(view.getByRole('button', { name: 'Run' }));
-      expect(store.get(workflowRunRequestAtom)).toBeUndefined();
+      const dialog = within(view.getByRole('dialog'));
+      const status = dialog.getByRole('status');
+      const runButton = dialog.getByRole('button', { name: 'Run' });
+      expect(status.textContent).toBe('');
+      fireEvent.change(dialog.getByRole('textbox'), { target: { value: 'large' } });
+      fireEvent.click(runButton);
+      expect({
+        busy: runButton.getAttribute('aria-busy'),
+        cancelDisabled: dialog.getByRole('button', { name: 'Cancel' }).hasAttribute('disabled'),
+        disabled: runButton.hasAttribute('disabled'),
+        request: store.get(workflowRunRequestAtom),
+        sameStatus: dialog.getByRole('status') === status,
+        pending: status.textContent?.includes('Checking browser control'),
+      }).toStrictEqual({
+        busy: 'true',
+        cancelDisabled: false,
+        disabled: true,
+        request: undefined,
+        sameStatus: true,
+        pending: true,
+      });
       if (cancellation === 'cancel') {
-        fireEvent.click(view.getByRole('button', { name: 'Cancel' }));
+        fireEvent.click(dialog.getByRole('button', { name: 'Cancel' }));
       } else if (cancellation === 'row unmount') {
         mockUseAgentWorkflows.mockReturnValue(emptyResult);
         view.rerender(createElement(WorkflowSettings));
       } else {
         view.unmount();
       }
+      expect(view.queryByText(/Checking browser control/u)).toBeNull();
       await act(async () => {
         pending.resolve(admission);
         await pending.promise;
       });
-      expect(store.get(workflowRunRequestAtom)).toBeUndefined();
-      expect(store.get(settingsDialogOpenAtom)).toBe(true);
-      expect(view.queryByRole('dialog')).toBeNull();
+      expect({
+        dialog: view.queryByRole('dialog'),
+        pending: view.queryByText(/Checking browser control/u),
+        request: store.get(workflowRunRequestAtom),
+        settingsOpen: store.get(settingsDialogOpenAtom),
+      }).toStrictEqual({ dialog: null, pending: null, request: undefined, settingsOpen: true });
       await waitFor(async () => {
         const state = await nativeLocks.query();
         expect(state.held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)).toBe(false);
@@ -444,7 +717,9 @@ describe('workflow settings', () => {
       expect(view.getByLabelText('Run workflow "Order pizza"')).toHaveProperty('disabled', false);
     });
     fireEvent.click(view.getByLabelText('Run workflow "Order pizza"'));
+    expect(view.getByRole('status').textContent).toContain('Checking browser control');
     view.unmount();
+    expect(view.queryByText(/Checking browser control/u)).toBeNull();
     pending.resolve(admission);
     await waitFor(async () => {
       const state = await nativeLocks.query();
@@ -654,10 +929,12 @@ describe('workflow settings', () => {
         await delegatedLease.release();
         await coordinator.refresh();
       });
-      expect(view.getByRole('status').textContent).not.toContain('parent-order');
-      expect(view.getByRole('status').textContent).toMatch(/input is retained.*Run it again/u);
+      const feedback = parameters
+        ? within(view.getByRole('dialog')).getByRole('alert')
+        : view.getByRole('status');
+      expect(feedback.textContent).not.toContain('parent-order');
+      expect(feedback.textContent).toMatch(/input is retained.*Run it again/u);
       if (parameters) {
-        expect(view.getByRole('alert').textContent).not.toContain('parent-order');
         expect(view.getByDisplayValue('large')).toBeDefined();
       }
       expect(store.get(workflowRunRequestAtom)).toBeUndefined();

--- a/apps/extension/entrypoints/sidepanel/workflow-settings.tsx
+++ b/apps/extension/entrypoints/sidepanel/workflow-settings.tsx
@@ -1,7 +1,14 @@
+/* eslint-disable import/max-dependencies -- Settings admission uses the shared execution lease and existing workflow controls. */
 import { storage } from '#imports';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom, useStore } from 'jotai';
 import type { JSX } from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  getBrowserExecutionCoordinator,
+  useBrowserExecutionSnapshot,
+} from './browser-execution-lock';
+import type { BrowserExecutionLease } from './browser-execution-lock';
+import { reserveWorkflowLease } from './browser-run-context';
 import { runningConversationIdsAtom } from './agent-chat-atoms';
 import {
   deleteAgentWorkflow,
@@ -97,6 +104,7 @@ export const SettingsToggle = ({
 );
 
 export const WorkflowSettings = (): JSX.Element => {
+  const store = useStore();
   const { isLoaded, loadError, reload, workflows } = useAgentWorkflows();
   const view = deriveWorkflowSettingsView({ isLoaded, loadError, workflows });
   const runningConversationIds = useAtomValue(runningConversationIdsAtom);
@@ -199,13 +207,73 @@ export const WorkflowSettings = (): JSX.Element => {
     })();
   }, []);
 
+  const execution = useBrowserExecutionSnapshot();
+  const [admissionBlocker, setAdmissionBlocker] = useState<string>();
+  const admittingRef = useRef(false);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
   const handleRun = useCallback(
-    (id: string, input?: Record<string, string>) => {
-      setRunRequest({ workflowId: id, ...(input === undefined ? {} : { input }) });
-      setIsSettingsOpen(false);
+    async (
+      id: string,
+      input: Record<string, string> | undefined,
+      signal: AbortSignal
+    ): Promise<boolean> => {
+      if (admittingRef.current) {
+        return false;
+      }
+      admittingRef.current = true;
+      let lease: BrowserExecutionLease | undefined = undefined;
+      let handedOff = false;
+      try {
+        const admission = await getBrowserExecutionCoordinator().acquireLocal();
+        lease = admission.admitted ? admission.lease : undefined;
+        if (!mountedRef.current || signal.aborted) {
+          return false;
+        }
+        if (lease === undefined) {
+          setAdmissionBlocker(
+            'Workflow input is retained. Run it again when browser control is available.'
+          );
+          return false;
+        }
+        lease.guard();
+        if (store.get(workflowRunRequestAtom) !== undefined) {
+          setAdmissionBlocker(
+            'A workflow request is already pending. Finish or resume it in Browser chat before submitting another workflow.'
+          );
+          return false;
+        }
+        const request = { workflowId: id, ...(input === undefined ? {} : { input }) };
+        reserveWorkflowLease(request, lease, activeConversationId);
+        setRunRequest(request);
+        handedOff = true;
+        setAdmissionBlocker(undefined);
+        setIsSettingsOpen(false);
+        return true;
+      } catch (error) {
+        if (mountedRef.current && !signal.aborted) {
+          setAdmissionBlocker(
+            error instanceof Error
+              ? error.message
+              : 'Browser admission stopped. Submit again explicitly.'
+          );
+        }
+        return false;
+      } finally {
+        admittingRef.current = false;
+        if (lease !== undefined && !handedOff) {
+          await lease.release();
+        }
+      }
     },
-    [setRunRequest, setIsSettingsOpen]
+    [activeConversationId, setRunRequest, setIsSettingsOpen, store]
   );
+  const blocker = execution.blockedReason ?? admissionBlocker;
 
   return (
     <section
@@ -261,6 +329,16 @@ export const WorkflowSettings = (): JSX.Element => {
         )}
       </div>
 
+      {blocker === undefined ? null : (
+        <p className="type-body mt-2 text-status-yellow-400" role="status">
+          {blocker}
+        </p>
+      )}
+      {execution.delegationUnavailableReason === undefined ? null : (
+        <p className="type-body mt-2 text-foreground-muted">
+          {execution.delegationUnavailableReason}
+        </p>
+      )}
       <h2 className="type-label mt-3 text-foreground-muted">Saved workflows</h2>
 
       {view.kind === 'loading' ? (
@@ -293,6 +371,7 @@ export const WorkflowSettings = (): JSX.Element => {
                 activeConversationRunning={activeConversationRunning}
                 allowWorkflowsInSafeMode={settings.allowWorkflowsInSafeMode}
                 autoApproveChanges={settings.autoApproveWorkflowChanges}
+                blocker={blocker}
                 isDangerousMode={isDangerousMode}
                 item={item}
                 key={item.id}

--- a/apps/extension/entrypoints/sidepanel/workflow-settings.tsx
+++ b/apps/extension/entrypoints/sidepanel/workflow-settings.tsx
@@ -209,7 +209,9 @@ export const WorkflowSettings = (): JSX.Element => {
 
   const execution = useBrowserExecutionSnapshot();
   const [admissionBlocker, setAdmissionBlocker] = useState<string>();
-  const admittingRef = useRef(false);
+  const [admitting, setAdmitting] = useState(false);
+  // eslint-disable-next-line unicorn/no-useless-undefined -- React 19 requires an initial ref value.
+  const admittingRef = useRef<AbortSignal | undefined>(undefined);
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
@@ -223,10 +225,20 @@ export const WorkflowSettings = (): JSX.Element => {
       input: Record<string, string> | undefined,
       signal: AbortSignal
     ): Promise<boolean> => {
-      if (admittingRef.current) {
+      if (admittingRef.current !== undefined || signal.aborted) {
         return false;
       }
-      admittingRef.current = true;
+      admittingRef.current = signal;
+      setAdmitting(true);
+      const finishAdmission = (): void => {
+        if (admittingRef.current === signal) {
+          admittingRef.current = undefined;
+          if (mountedRef.current) {
+            setAdmitting(false);
+          }
+        }
+      };
+      signal.addEventListener('abort', finishAdmission, { once: true });
       let lease: BrowserExecutionLease | undefined = undefined;
       let handedOff = false;
       try {
@@ -259,13 +271,14 @@ export const WorkflowSettings = (): JSX.Element => {
         if (mountedRef.current && !signal.aborted) {
           setAdmissionBlocker(
             error instanceof Error
-              ? error.message
+              ? `${error.message} Workflow input is retained. Run it again explicitly.`
               : 'Browser admission stopped. Submit again explicitly.'
           );
         }
         return false;
       } finally {
-        admittingRef.current = false;
+        signal.removeEventListener('abort', finishAdmission);
+        finishAdmission();
         if (lease !== undefined && !handedOff) {
           await lease.release();
         }
@@ -273,7 +286,9 @@ export const WorkflowSettings = (): JSX.Element => {
     },
     [activeConversationId, setRunRequest, setIsSettingsOpen, store]
   );
-  const blocker = execution.blockedReason ?? admissionBlocker;
+  const blocker = admitting
+    ? 'Checking browser control… Your workflow has not started.'
+    : (execution.blockedReason ?? admissionBlocker);
 
   return (
     <section
@@ -329,11 +344,12 @@ export const WorkflowSettings = (): JSX.Element => {
         )}
       </div>
 
-      {blocker === undefined ? null : (
-        <p className="type-body mt-2 text-status-yellow-400" role="status">
-          {blocker}
-        </p>
-      )}
+      <p
+        className={blocker === undefined ? 'sr-only' : 'type-body mt-2 text-status-yellow-400'}
+        role="status"
+      >
+        {blocker}
+      </p>
       {execution.delegationUnavailableReason === undefined ? null : (
         <p className="type-body mt-2 text-foreground-muted">
           {execution.delegationUnavailableReason}
@@ -369,6 +385,7 @@ export const WorkflowSettings = (): JSX.Element => {
             {view.items.map(item => (
               <WorkflowRow
                 activeConversationRunning={activeConversationRunning}
+                admissionPending={admitting}
                 allowWorkflowsInSafeMode={settings.allowWorkflowsInSafeMode}
                 autoApproveChanges={settings.autoApproveWorkflowChanges}
                 blocker={blocker}


### PR DESCRIPTION
- Chat and workflow settings explain when browser control is blocked and show the controlling session when available.
- Blocked messages stay in the draft. Blocked queued messages wait for “Resume queued message” instead of restarting automatically.
- Blocked workflows keep entered values and leave the parameter form open. “Resume workflow” lets you retry a retained request from chat.
- Cancelling a workflow form or closing its settings prevents a delayed run. Closing a conversation also cancels submissions that have not started.
- Changing or closing a target tab while submission waits preserves the input instead of silently choosing another tab. Started runs keep their target and stop if it closes.
- If the browser cannot confirm an action’s result, it blocks further browser work and shows recovery instructions. These require closing affected tabs, or every target tab when the affected set is unknown.
- Unsupported browsers explain why command-line browser work is unavailable and keep ordinary local work available until recovery is required.

---

## Summary

`BrowserExecutionCoordinator` separates `PROVIDER_OWNER_LOCK` from `BROWSER_EXECUTION_LOCK`; `BrowserAdmission` grants shared local or exclusive delegated `BrowserExecutionLease` values, rejecting local requests behind delegated owners or waiters. `BrowserLockStorage` stores `safetySchema` under `BROWSER_EXECUTION_SAFETY_KEY` and `ownerSchema` under `OWNER_KEY`; missing safety records default empty, uncertainty or storage errors block execution, and `BrowserExecutionSnapshot` reports display-only ownership. `BrowserRecovery` needs Web Locks, drained actions, and closed affected tabs; unsupported browsers permit local work but persist uncertainty as `allTabs`, requiring all target tabs closed.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/browser-execution-lock.ts` — Source, added, 509 changed lines. Adds origin-scoped coordination, authenticated-session ownership labels, cancellable delegated admission, and lease release after runners and awaited actions finish. Storage watchers and 500 ms polling report native occupancy; sanitized owner records never authorize work. Serializes native quarantine writes, retains failed leases for coordinator-owned recovery retries, and preserves `allTabs` through reloads and restored support. Recovery never steals an active execution lock or waits behind one.
- `apps/extension/entrypoints/sidepanel/browser-execution-lock.test.ts` — Test, added, 701 changed lines. Adds coordinator regression coverage for shared local execution, exclusive delegation, waiter cancellation, quarantine persistence, unsupported contexts, and explicit recovery.

</details>

`BrowserRunContext` carries credentials, settings, approvals, and callbacks; callers must supply `ExecutionGuard`, a lease, and a fixed tab with `allowTabFallback: false`. `runBrowserTurn` and `runBrowserWorkflow` reuse existing runners and return `LlmTurnOutcome` or `BrowserWorkflowOutcome`; local callers resolve fallback first, while delegated callers supply approved tabs. `effectsUncertain` persists quarantine before result conversion or another model turn; `toolResults` excludes unconfirmed actions, and target-tab closure aborts execution.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/browser-run-context.ts` — Source, added, 234 changed lines. Extracts existing safe and dangerous runner setup and workflow and remote Model Context Protocol (MCP) adapters without adding another agent. Keeps gateway credentials separate from remote fetch and shares one lease across workflows, actions, and recursive continuation. A transient WeakMap transfers workflow reservations without changing the existing request shape or persisting a lease.

</details>

`AgentChatPanel` acquires `BrowserAdmission` before clearing drafts, draining queued messages, or consuming workflows, then rechecks conversation activity and model availability. Blocked input requires explicit resubmission or resume; a changed or closed target cannot redirect a pending submission. Stop, conversation closure or deletion, history replacement, and unmount cancel pending admission; workflow execution and model continuation retain one lease until awaited work ends.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx` — Source, modified, 894 changed lines. Routes chat and direct workflows through the guarded context, snapshots targets before admission, checks actual tab existence, and preserves edits made during admission. Adds current blocker feedback, explicit queue and workflow resume controls, and reservation cleanup; uncertain workflow results stop before any model continuation. Workflow requests now use the panel’s Jotai store consistently; legacy requests without a reserved lease acquire admission before execution.
- `apps/extension/entrypoints/sidepanel/agent-chat-panel.test.ts` — Test, modified, 1,282 changed lines. Expands regression coverage for admission races, retained input, fixed tabs, cancellation, local concurrency, workflow uncertainty, and release after awaited work ends.

</details>

`WorkflowRow.onRun` now accepts an `AbortSignal` and returns `Promise<boolean>`; the new `blocker` prop keeps rejection feedback above the parameter form. Settings uses `reserveWorkflowLease` and chat uses `takeWorkflowLease` to share admission without changing `WorkflowRunRequest` or `workflowRunRequestAtom`. Cancelled or unmounted forms cannot publish delayed requests; failed admission retains parameters, and pending workflows reject duplicate submissions.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/workflow-settings.tsx` — Source, modified, 91 changed lines. Acquires admission before publishing a request or closing Settings, preserves the initiating conversation, rejects replacement of pending requests, and releases unused leases. Displays current ownership, quarantine, and unsupported-browser messages instead of retaining an old owner claim.
- `apps/extension/entrypoints/sidepanel/workflow-row.tsx` — Source, modified, 69 changed lines. Awaits admission before dismissing the parameter form, prevents duplicate submissions, and aborts pending submissions on Cancel or unmount. Shows blocker feedback above the open form.
- `apps/extension/entrypoints/sidepanel/workflow-settings.test.tsx` — Test, modified, 364 changed lines. Expands Settings and parameter-form coverage for retained values, cancellation, lease transfer, pending requests, and ownership feedback.

</details>

An abstract syntax tree (AST) inventory rejects unguarded runner imports, calls, aliases, element access, and direct browser dispatch outside approved adapters. New callers use `runBrowserTurn` or `runBrowserWorkflow`; only `executeEvalToolCall(event)` and the read-only `sendTabDebuggerRequest` retain named legacy exceptions with removal conditions. Admission-order checks and mutation fixtures protect the boundary; runtime guards and native browser verification remain necessary for model-authored JavaScript and scheduling.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/browser-action-boundary.test.ts` — Test, added, 504 changed lines. Adds table-driven chat, queue, Settings, workflow, and continuation checks, plus alias, direct-dispatch, and static injected-code mutation fixtures. Inventories fixed injected helpers and permits later provider callers through the guarded public run interface without expanding the adapter exceptions.

</details>

Tests: 4 files changed—`agent-chat-panel.test.ts`, `browser-action-boundary.test.ts`, `browser-execution-lock.test.ts`, and `workflow-settings.test.tsx`—with 2,851 changed lines. The handoff records 4/4 passing checks: focused Vitest, formatting, type-aware lint/type checking, and `git diff --check`.
Generated: 0 files changed.

---

## Verification

Manual browser and visual verification did not run. This slice limits local verification to changed-file checks and unit tests; native multi-panel proof remains assigned to level 13.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

This level adds coordination infrastructure only; it does not enable the complete browser provider. Approvals, persistence integration, provider execution, and supervision controls are outside this level.

- Cloud level 8 builds on [Cloud level 7](https://github.com/Kilo-Org/cloud/pull/5681), which supplies guarded execution contracts.
- The corresponding [command-line interface (CLI) tip](https://github.com/Kilo-Org/kilocode/pull/13567) supplies owned browser-job support.

### Human steps

- **before merge:** Complete the section’s gates, including native Chrome, Firefox, real CLI, and local relay verification.
- **before merge:** Merge lower stack levels before this level.
- **after merge:** Merge higher stack levels in order.
- **after merge, if recovery is required:** Close affected target tabs before requesting explicit recovery.
- **after merge, if `allTabs` is set:** Close every target tab before requesting explicit recovery.
- **after merge, if Web Locks are unavailable:** Restore native Web Locks support before recovery. Restart the browser context after restoring support.
- **after merge, if safety storage fails:** Restore storage access before requesting recovery.

This level requires no new environment values, secrets, database migrations, or manual data conversion.

### Notes

Live browser verification is pending. Native Chrome and Firefox behavior, the real CLI, and the local relay remain required before human-ready.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `browser-task-0787` — #5638
2. `browser-task-0787-s2` — #5644
3. `browser-task-0787-s3` — #5648
4. `browser-task-0787-s4` — #5653
7. `browser-task-0787-s7` — #5681
8. `browser-task-0787-s8` — #5694 ← this PR
9. `browser-task-0787-s9` — #5698
10. `browser-task-0787-s10` — #5702
11. `browser-task-0787-s11` — #5716
12. `browser-task-0787-s12` — #5734
13. `browser-task-0787-s13` — #5742 (tip)

