### PR TITLE
feat(pr-review): define review source documents and normalization

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-reviews-schema.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-reviews-schema.test.ts
@@ -1,0 +1,185 @@
+import { contextReviewSchema } from './context-reviews';
+
+const submittedAt = '2026-08-25T12:00:00+02:00';
+const later = '2026-08-26T10:00:00Z';
+const actor = {
+  __typename: 'User',
+  id: 'U',
+  login: 'same-login',
+  name: ' Person ',
+  avatarUrl: 'https://github.com/avatar.png',
+  url: 'https://github.com/person',
+};
+const team = {
+  __typename: 'Team',
+  id: 'T',
+  teamName: 'Review team',
+  slug: 'team',
+  teamAvatarUrl: null,
+  url: null,
+};
+const connection = (nodes: unknown[], totalCount = nodes.length, next: string | null = null) => ({
+  nodes,
+  totalCount,
+  pageInfo: { hasNextPage: next !== null, endCursor: next },
+});
+const review = (patch: Record<string, unknown> = {}) => ({
+  id: 'decision',
+  state: 'APPROVED',
+  author: actor,
+  submittedAt,
+  commit: { oid: 'reviewed-commit' },
+  onBehalfOf: connection([]),
+  createdAt: later,
+  updatedAt: later,
+  ...patch,
+});
+
+it.each(['APPROVED', 'CHANGES_REQUESTED', 'COMMENTED', 'DISMISSED'])(
+  'preserves the submitted %s review and its own clock',
+  state => {
+    expect(contextReviewSchema.parse(review({ state }))).toMatchObject({
+      id: 'decision',
+      state,
+      submittedAt: '2026-08-25T12:00:00+02:00',
+      commitSha: 'reviewed-commit',
+      actor: { id: 'U', kind: 'User' },
+    });
+  }
+);
+
+it.each([null, undefined, 'invalid'])(
+  'does not substitute another clock for submission time %p',
+  time => {
+    const result = contextReviewSchema.parse(review({ submittedAt: time }));
+    expect(result.submittedAt).toBeNull();
+    expect(result).not.toHaveProperty('createdAt');
+    expect(result).not.toHaveProperty('updatedAt');
+  }
+);
+
+it('keeps a pending review unsubmitted even when the response contains a time', () => {
+  expect(contextReviewSchema.parse(review({ state: 'PENDING' }))).toMatchObject({
+    id: 'decision',
+    state: 'PENDING',
+    submittedAt: null,
+  });
+});
+
+it.each(['FUTURE_STATE', null, undefined])('keeps unsupported state %p unknown', state => {
+  expect(contextReviewSchema.parse(review({ state }))).toMatchObject({
+    id: 'decision',
+    state: 'UNKNOWN',
+    submittedAt: '2026-08-25T12:00:00+02:00',
+  });
+});
+
+it.each([
+  ['User', 'Person'],
+  ['Bot', null],
+  ['Mannequin', null],
+])('normalizes the %s actor without using its login as an ID', (kind, name) => {
+  expect(
+    contextReviewSchema.parse(review({ author: { ...actor, __typename: kind } })).actor
+  ).toEqual({
+    id: 'U',
+    kind,
+    login: 'same-login',
+    name,
+    avatarUrl: 'https://github.com/avatar.png',
+    url: 'https://github.com/person',
+    teamSlug: null,
+  });
+});
+
+it.each([null, undefined, {}, team])(
+  'retains a review with unavailable individual actor %p',
+  author => {
+    expect(contextReviewSchema.parse(review({ author }))).toMatchObject({
+      id: 'decision',
+      actor: null,
+      state: 'APPROVED',
+    });
+  }
+);
+
+it.each([null, undefined, {}, { oid: '' }])('keeps unavailable commit %p null', commit => {
+  expect(contextReviewSchema.parse(review({ commit }))).toMatchObject({
+    id: 'decision',
+    commitSha: null,
+    submittedAt: '2026-08-25T12:00:00+02:00',
+  });
+});
+
+it.each([null, undefined, ''])('rejects missing review identity %p', id => {
+  expect(() => contextReviewSchema.parse(review({ id }))).toThrow();
+});
+
+it('keeps complete empty attribution distinct from missing attribution', () => {
+  expect(contextReviewSchema.parse(review()).onBehalfOf).toMatchObject({
+    items: [],
+    knownCount: 0,
+    totalCount: 0,
+    completeness: 'complete',
+    hasNextPage: false,
+    endCursor: null,
+    source: { availability: 'available', retryable: false, reason: null },
+  });
+});
+
+it.each([null, undefined, {}])('keeps unavailable attribution %p unknown', onBehalfOf => {
+  expect(contextReviewSchema.parse(review({ onBehalfOf })).onBehalfOf).toMatchObject({
+    items: [],
+    knownCount: 0,
+    totalCount: null,
+    completeness: 'unknown',
+    hasNextPage: null,
+    endCursor: null,
+    source: { availability: 'unavailable', retryable: true, reason: 'attribution-incomplete' },
+  });
+});
+
+it('keeps complete team attribution separate from the individual review', () => {
+  const result = contextReviewSchema.parse(review({ onBehalfOf: connection([team]) }));
+  expect(result).toMatchObject({
+    id: 'decision',
+    actor: { id: 'U', kind: 'User' },
+    state: 'APPROVED',
+  });
+  expect(result.onBehalfOf).toMatchObject({
+    items: [{ id: 'T', kind: 'Team', name: 'Review team', teamSlug: 'team', login: null }],
+    knownCount: 1,
+    totalCount: 1,
+    completeness: 'complete',
+    source: { availability: 'available', retryable: false },
+  });
+});
+
+it('retains a team page without claiming complete attribution', () => {
+  const result = contextReviewSchema.parse(
+    review({ onBehalfOf: connection([team], 101, 'team-next') })
+  );
+  expect(result.onBehalfOf).toMatchObject({
+    items: [{ id: 'T', kind: 'Team' }],
+    knownCount: 1,
+    totalCount: 101,
+    completeness: 'partial',
+    hasNextPage: true,
+    endCursor: 'team-next',
+    source: { availability: 'partial', retryable: true, reason: 'attribution-incomplete' },
+  });
+});
+
+it.each([
+  { name: 'duplicate', nodes: [team, team] },
+  { name: 'invalid', nodes: [team, null, {}, actor] },
+])('retains known teams without claiming complete $name attribution', ({ nodes }) => {
+  const result = contextReviewSchema.parse(review({ onBehalfOf: connection(nodes) }));
+  expect(result.onBehalfOf).toMatchObject({
+    items: [{ id: 'T', kind: 'Team' }],
+    knownCount: 1,
+    completeness: 'partial',
+    source: { availability: 'partial', retryable: true },
+  });
+  expect(result.onBehalfOf.items).toHaveLength(1);
+});

--- a/apps/web/src/lib/github-pr-review/context-reviews.ts
+++ b/apps/web/src/lib/github-pr-review/context-reviews.ts
@@ -1,0 +1,111 @@
+import 'server-only';
+
+import { z } from 'zod';
+import { GitHubPrReviewTimestampSchema, type GitHubPrReviewContext } from './context-dtos';
+import { contextIdentitySchema } from './context-people';
+
+type Reviews = GitHubPrReviewContext['reviewDecisions'];
+type Review = Reviews['items'][number];
+
+function reviewQuery(field: 'latestOpinionatedReviews' | 'latestReviews') {
+  return /* GraphQL */ `
+    query PrReviewContext_${field}($owner: String!, $name: String!, $number: Int!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          ${field}(first: 100, after: $after${field === 'latestOpinionatedReviews' ? ', writersOnly: false' : ''}) {
+            totalCount
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id state submittedAt
+              commit { oid }
+              author {
+                __typename
+                ... on User { id login name avatarUrl url }
+                ... on Bot { id login avatarUrl url }
+                ... on Mannequin { id login avatarUrl url }
+              }
+              onBehalfOf(first: 100) {
+                totalCount
+                pageInfo { hasNextPage endCursor }
+                nodes { __typename id teamName: name slug teamAvatarUrl: avatarUrl url }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+}
+
+export const PR_CONTEXT_REVIEW_QUERIES = {
+  latestOpinionatedReviews: reviewQuery('latestOpinionatedReviews'),
+  latestReviews: reviewQuery('latestReviews'),
+};
+
+const attributionSchema = z
+  .object({
+    nodes: z.array(contextIdentitySchema.nullable().catch(null)).nullish().catch(null),
+    totalCount: z.number().int().nonnegative().nullish().catch(null),
+    pageInfo: z
+      .object({ hasNextPage: z.boolean(), endCursor: z.string().nullable() })
+      .nullish()
+      .catch(null),
+  })
+  .nullable()
+  .catch(null);
+
+export const contextReviewSchema = z
+  .object({
+    id: z.string().min(1),
+    author: contextIdentitySchema
+      .refine(actor => actor.kind !== 'Team')
+      .nullable()
+      .catch(null),
+    state: z
+      .enum(['APPROVED', 'CHANGES_REQUESTED', 'COMMENTED', 'DISMISSED', 'PENDING', 'UNKNOWN'])
+      .catch('UNKNOWN'),
+    submittedAt: GitHubPrReviewTimestampSchema.nullable().catch(null),
+    commit: z
+      .object({ oid: z.string().min(1) })
+      .nullable()
+      .catch(null),
+    onBehalfOf: attributionSchema,
+  })
+  .transform((review): Review => {
+    const teams = review.onBehalfOf;
+    const items = [
+      ...new Map(
+        (teams?.nodes ?? []).flatMap(team =>
+          team?.id && team.kind === 'Team' ? [[team.id, team] as const] : []
+        )
+      ).values(),
+    ];
+    const complete =
+      teams?.nodes != null &&
+      teams.pageInfo?.hasNextPage === false &&
+      items.length === teams.nodes.length &&
+      items.length === teams.totalCount;
+    return {
+      id: review.id,
+      actor: review.author,
+      state: review.state,
+      submittedAt: review.state === 'PENDING' ? null : review.submittedAt,
+      commitSha: review.commit?.oid ?? null,
+      // Attribution is not team approval. An unfinished nested page never proves full attribution.
+      onBehalfOf: {
+        items,
+        knownCount: items.length,
+        totalCount: teams?.totalCount ?? null,
+        hasNextPage: teams?.pageInfo?.hasNextPage ?? null,
+        endCursor: teams?.pageInfo?.endCursor ?? null,
+        completeness: complete ? 'complete' : items.length ? 'partial' : 'unknown',
+        source: {
+          availability: complete ? 'available' : items.length ? 'partial' : 'unavailable',
+          retryable: !complete,
+          reason: complete ? null : 'attribution-incomplete',
+          provenance: ['graphql.review.onBehalfOf'],
+          observedAt: new Date().toISOString(),
+        },
+      },
+    };
+  });

--- a/apps/web/src/routers/github-pr-review-graphql-schema.test.ts
+++ b/apps/web/src/routers/github-pr-review-graphql-schema.test.ts
@@ -42,8 +42,8 @@ const introspection = JSON.parse(readFileSync(introspectionPath, 'utf8'));
 const githubSchema = buildClientSchema(introspection);
 
 describe('github-pr-review-router GraphQL documents', () => {
-  test('exports exactly 15 documents (sanity guard for the export record)', () => {
-    expect(Object.keys(PR_REVIEW_GRAPHQL_DOCUMENTS)).toHaveLength(15);
+  test('exports exactly 17 documents (sanity guard for the export record)', () => {
+    expect(Object.keys(PR_REVIEW_GRAPHQL_DOCUMENTS)).toHaveLength(17);
   });
 
   test.each(Object.entries(PR_REVIEW_GRAPHQL_DOCUMENTS))(

--- a/apps/web/src/routers/github-pr-review-router.ts
+++ b/apps/web/src/routers/github-pr-review-router.ts
@@ -48,6 +48,7 @@ import {
   PR_CONTEXT_REVISION_QUERY,
 } from '@/lib/github-pr-review/context-reader';
 import { PR_CONTEXT_PEOPLE_QUERIES } from '@/lib/github-pr-review/context-people';
+import { PR_CONTEXT_REVIEW_QUERIES } from '@/lib/github-pr-review/context-reviews';
 import { getGitHubUserAccessToken } from '@/lib/integrations/platforms/github/user-token-client';
 import {
   AutoMergeMethodSchema,
@@ -543,6 +544,7 @@ export const PR_REVIEW_GRAPHQL_DOCUMENTS = {
   PULL_REQUEST_FRAGMENT_QUERY,
   PR_CONTEXT_REVISION_QUERY,
   ...PR_CONTEXT_PEOPLE_QUERIES,
+  ...PR_CONTEXT_REVIEW_QUERIES,
   REVIEW_THREADS_QUERY,
   REVIEW_THREAD_COMMENTS_FOLLOWUP_QUERY,
   CONVERSATION_COMMENTS_QUERY,


### PR DESCRIPTION
No new behavior — this change prepares review information without changing the pull request screens or review actions.

---

## Summary

`PR_CONTEXT_REVIEW_QUERIES` defines `latestOpinionatedReviews` with `writersOnly: false` and `latestReviews`; `contextReviewSchema` preserves review identifiers, actors, states, commits, and nullable submission times.
Unrecognized states become `UNKNOWN`, unreadable commits and timestamps become null, and `PENDING` reviews have no submission time.
`attributionSchema` and normalized `onBehalfOf` data keep team attribution separate from approval, with retryable partial or unknown coverage instead of false completeness.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-reviews.ts` — Added source (111 changed lines). Adds server-only documents with 100-review pages and up to 100 attributed teams, including counts and cursors. Selects `User`, `Bot`, and `Mannequin` author details; requires nonempty review identifiers and maps team authors to null. Deduplicates attributed teams by identifier and retains valid teams when other attribution data is unreadable. Complete attribution requires a final page and counts that match valid, unique team nodes. Incomplete attribution is partial when valid teams remain, otherwise unknown. Source metadata records availability, retryability, the `attribution-incomplete` reason, provenance, and observation time without substituting that time for submission time.

</details>

`PR_REVIEW_GRAPHQL_DOCUMENTS` registers both review documents so the existing GraphQL schema checks validate their selections.
The live `getPullRequestContext` query keeps its inputs and responses unchanged; registration neither reads reviews nor selects current decisions.

<details>
<summary>Files</summary>

- `apps/web/src/routers/github-pr-review-router.ts` — Modified source (2 changed lines). Imports the review documents and adds them to the exported registry without changing route execution.

</details>

Tests: 2 files changed. `apps/web/src/lib/github-pr-review/context-reviews-schema.test.ts` added (185 changed lines, 33 normalization cases); `apps/web/src/routers/github-pr-review-graphql-schema.test.ts` modified (4 changed lines, validation for both review documents).
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual tests: not run at this level; live backend and iOS verification requires the completed stack tip.
- This level defines review documents and normalization without attaching review reads.

## Reviewer Notes

### Human steps

No human steps are necessary before merge or after merge.

### Scope and automated checks

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- Review range: `mobile-pr-review-context-5458-s6...mobile-pr-review-context-5458-s7` only.
- The handoff reports 52 passing tests across two suites, plus passing changed-file lint, format, and whitespace checks.
- The read-only provider observation covers six returned reviews, not hidden or pending reviews.
- That observation does not verify approval-to-comment, changes-requested-to-comment, repeated decisions, dismissal, re-request, pending visibility, or `latestOpinionatedReviews` supersession.
- Normalization tests validate local rules, not undocumented GitHub transition behavior.

### Notes

This level prepares review source contracts without attaching review reads. Live backend and iOS verification will run on the completed stack tip.









<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695 ← this PR
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
