### PR TITLE
feat(pr-review): select source-backed review decisions

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-reviews.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-reviews.test.ts
@@ -1,0 +1,352 @@
+import { contextReviewSchema, resolveContextReviewDecisions } from './context-reviews';
+import type { GitHubPrReviewContext } from './context-dtos';
+
+const fields = ['latestOpinionatedReviews', 'latestReviews'] as const;
+type Field = (typeof fields)[number];
+const submittedAt = '2026-08-25T12:00:00+02:00';
+const later = '2026-08-26T10:00:00Z';
+const person = (id = 'U') => ({
+  __typename: 'User',
+  id,
+  login: 'same-login',
+  name: null,
+  avatarUrl: null,
+  url: null,
+});
+const connection = (nodes: unknown[], totalCount = nodes.length, next: string | null = null) => ({
+  nodes,
+  totalCount,
+  pageInfo: { hasNextPage: next !== null, endCursor: next },
+});
+const review = (state = 'APPROVED', id = 'decision', patch: Record<string, unknown> = {}) => ({
+  id,
+  state,
+  author: person(),
+  submittedAt,
+  commit: { oid: 'reviewed-commit' },
+  onBehalfOf: connection([]),
+  createdAt: later,
+  updatedAt: later,
+  ...patch,
+});
+type Reviews = GitHubPrReviewContext['reviewDecisions'];
+
+// These are normalized source collections, not reader transport fixtures.
+const page = (
+  field: Field,
+  nodes: unknown[],
+  availability: Reviews['source']['availability'] = 'available'
+): Reviews => {
+  const complete = availability === 'available';
+  return {
+    items: nodes.map(node => contextReviewSchema.parse(node)),
+    knownCount: nodes.length,
+    totalCount: complete ? nodes.length : null,
+    hasNextPage: availability === 'partial' ? true : complete ? false : null,
+    endCursor: availability === 'partial' ? `${field}-next` : null,
+    completeness: complete ? 'complete' : nodes.length ? 'partial' : 'unknown',
+    source: {
+      availability,
+      retryable: !complete && availability !== 'denied',
+      reason: complete ? null : availability,
+      provenance: [`graphql.${field}`],
+      observedAt: later,
+    },
+  };
+};
+
+async function run(serve: (field: Field) => Reviews) {
+  const opinionated = serve('latestOpinionatedReviews');
+  const reviewActivity = serve('latestReviews');
+  return {
+    reviewDecisions: resolveContextReviewDecisions(opinionated, reviewActivity),
+    reviewActivity,
+  };
+}
+
+// These synthetic responses exercise the conservative policy, not undocumented provider transitions.
+it.each([
+  ['APPROVED', 'APPROVED', 'APPROVED'],
+  ['APPROVED', 'CHANGES_REQUESTED', 'UNKNOWN'],
+  ['APPROVED', 'COMMENTED', 'APPROVED'],
+  ['APPROVED', 'DISMISSED', 'UNKNOWN'],
+  ['APPROVED', 'PENDING', 'UNKNOWN'],
+  ['APPROVED', null, 'UNKNOWN'],
+  ['CHANGES_REQUESTED', 'APPROVED', 'UNKNOWN'],
+  ['CHANGES_REQUESTED', 'CHANGES_REQUESTED', 'CHANGES_REQUESTED'],
+  ['CHANGES_REQUESTED', 'COMMENTED', 'CHANGES_REQUESTED'],
+  ['CHANGES_REQUESTED', 'DISMISSED', 'UNKNOWN'],
+  ['CHANGES_REQUESTED', 'PENDING', 'UNKNOWN'],
+  ['CHANGES_REQUESTED', null, 'UNKNOWN'],
+  ['COMMENTED', 'APPROVED', 'UNKNOWN'],
+  ['COMMENTED', 'CHANGES_REQUESTED', 'UNKNOWN'],
+  ['COMMENTED', 'COMMENTED', null],
+  ['COMMENTED', 'DISMISSED', 'UNKNOWN'],
+  ['COMMENTED', 'PENDING', 'UNKNOWN'],
+  ['COMMENTED', null, 'UNKNOWN'],
+  ['DISMISSED', 'APPROVED', 'UNKNOWN'],
+  ['DISMISSED', 'CHANGES_REQUESTED', 'UNKNOWN'],
+  ['DISMISSED', 'COMMENTED', 'DISMISSED'],
+  ['DISMISSED', 'DISMISSED', 'DISMISSED'],
+  ['DISMISSED', 'PENDING', 'UNKNOWN'],
+  ['DISMISSED', null, 'UNKNOWN'],
+  ['PENDING', 'APPROVED', 'UNKNOWN'],
+  ['PENDING', 'CHANGES_REQUESTED', 'UNKNOWN'],
+  ['PENDING', 'COMMENTED', 'UNKNOWN'],
+  ['PENDING', 'DISMISSED', 'UNKNOWN'],
+  ['PENDING', 'PENDING', 'UNKNOWN'],
+  ['PENDING', null, 'UNKNOWN'],
+  ['UNKNOWN', 'APPROVED', 'UNKNOWN'],
+  ['UNKNOWN', 'CHANGES_REQUESTED', 'UNKNOWN'],
+  ['UNKNOWN', 'COMMENTED', 'UNKNOWN'],
+  ['UNKNOWN', 'DISMISSED', 'UNKNOWN'],
+  ['UNKNOWN', 'PENDING', 'UNKNOWN'],
+  ['UNKNOWN', 'UNKNOWN', 'UNKNOWN'],
+  ['UNKNOWN', null, 'UNKNOWN'],
+  ['APPROVED', 'UNKNOWN', 'UNKNOWN'],
+  ['CHANGES_REQUESTED', 'UNKNOWN', 'UNKNOWN'],
+  ['COMMENTED', 'UNKNOWN', 'UNKNOWN'],
+  ['DISMISSED', 'UNKNOWN', 'UNKNOWN'],
+  ['PENDING', 'UNKNOWN', 'UNKNOWN'],
+  [null, 'UNKNOWN', 'UNKNOWN'],
+  [null, 'APPROVED', 'APPROVED'],
+  [null, 'CHANGES_REQUESTED', 'CHANGES_REQUESTED'],
+  [null, 'COMMENTED', null],
+  [null, 'DISMISSED', 'DISMISSED'],
+  [null, 'PENDING', 'UNKNOWN'],
+  [null, null, null],
+])('resolves opinionated %s beside latest %s as %s', async (opinionated, activity, expected) => {
+  const latestId = opinionated === activity ? 'decision' : 'activity';
+  const latestTime = opinionated === activity ? submittedAt : later;
+  const result = await run(field =>
+    page(
+      field,
+      field === 'latestOpinionatedReviews'
+        ? opinionated
+          ? [review(opinionated)]
+          : []
+        : activity
+          ? [review(activity, latestId, { submittedAt: latestTime })]
+          : []
+    )
+  );
+  expect(
+    result.reviewDecisions.items.map(({ id, state, submittedAt: time }) => ({ id, state, time }))
+  ).toEqual(
+    expected
+      ? [
+          {
+            id: opinionated ? 'decision' : latestId,
+            state: expected,
+            time:
+              (opinionated ?? activity) === 'PENDING'
+                ? null
+                : opinionated
+                  ? submittedAt
+                  : latestTime,
+          },
+        ]
+      : []
+  );
+  expect(result.reviewDecisions.source).toMatchObject({
+    availability: expected === 'UNKNOWN' ? 'partial' : 'available',
+    retryable: expected === 'UNKNOWN',
+  });
+  expect(result.reviewActivity.items).toMatchObject(
+    activity
+      ? [{ id: latestId, state: activity, submittedAt: activity === 'PENDING' ? null : latestTime }]
+      : []
+  );
+});
+
+it.each([
+  ['state', { state: 'CHANGES_REQUESTED' }],
+  ['commit', { commit: { oid: 'contradictory-commit' } }],
+  ['submission', { submittedAt: later }],
+  ['review ID', { id: 'other-approval' }],
+  ['actor ID', { author: person('other') }],
+  ['actor type', { author: { ...person(), __typename: 'Bot' } }],
+  ['missing actor', { author: null }],
+  ['unknown state', { state: 'FUTURE_STATE' }],
+  ['older comment', { id: 'comment', state: 'COMMENTED', submittedAt: '2020-01-01T00:00:00Z' }],
+])('does not assert a decision after contradictory %s responses', async (_name, patch) => {
+  const result = await run(field =>
+    page(field, [review('APPROVED', 'decision', field === 'latestReviews' ? patch : {})])
+  );
+  expect(result.reviewDecisions.items.length).toBeGreaterThan(0);
+  expect(result.reviewDecisions.items.every(item => item.state === 'UNKNOWN')).toBe(true);
+  expect(result.reviewDecisions.source).toMatchObject({
+    availability: 'partial',
+    reason: 'review-inconsistent',
+    retryable: true,
+  });
+});
+
+it.each(fields)('does not rank two decisions for one actor in %s by time', async duplicate => {
+  const result = await run(field =>
+    page(
+      field,
+      field === duplicate
+        ? [review(), review('CHANGES_REQUESTED', 'other', { submittedAt: later })]
+        : [review()]
+    )
+  );
+  expect(result.reviewDecisions.items).toMatchObject([{ state: 'UNKNOWN' }]);
+  expect(result.reviewDecisions.source.reason).toBe('review-inconsistent');
+});
+
+it('keeps actor IDs, types, and deleted review identities distinct despite identical logins', async () => {
+  const reviews = [
+    ...['User', 'Bot', 'Mannequin'].map((kind, i) =>
+      review('APPROVED', `typed-${i}`, { author: { ...person(`U${i}`), __typename: kind } })
+    ),
+    review('APPROVED', 'deleted-1', { author: null }),
+    review('CHANGES_REQUESTED', 'deleted-2', { author: null }),
+  ];
+  const result = await run(field => page(field, reviews));
+  expect(result.reviewDecisions.items).toMatchObject([
+    { id: 'typed-0', actor: { id: 'U0', kind: 'User', login: 'same-login' } },
+    { id: 'typed-1', actor: { id: 'U1', kind: 'Bot' } },
+    { id: 'typed-2', actor: { id: 'U2', kind: 'Mannequin' } },
+    { id: 'deleted-1', actor: null, state: 'APPROVED' },
+    { id: 'deleted-2', actor: null, state: 'CHANGES_REQUESTED' },
+  ]);
+  expect(result.reviewDecisions.knownCount).toBe(5);
+});
+
+it.each(fields)('retains a consistent decision when %s is partial', async partial => {
+  const result = await run(field =>
+    page(field, [review()], field === partial ? 'partial' : 'available')
+  );
+  expect(result.reviewDecisions).toMatchObject({
+    items: [{ id: 'decision', state: 'APPROVED', submittedAt }],
+    completeness: 'partial',
+    totalCount: null,
+    hasNextPage: true,
+    endCursor: null,
+    source: {
+      availability: 'partial',
+      retryable: true,
+      provenance: ['graphql.latestOpinionatedReviews', 'graphql.latestReviews'],
+    },
+  });
+});
+
+it.each(
+  fields.flatMap(field =>
+    (['partial', 'denied', 'unavailable'] as const).map(
+      availability => [field, availability] as const
+    )
+  )
+)('does not infer absence from %s being %s', async (missing, availability) => {
+  const result = await run(field =>
+    page(field, field === missing ? [] : [review()], field === missing ? availability : 'available')
+  );
+  expect(result.reviewDecisions).toMatchObject({
+    items: [{ state: 'UNKNOWN', submittedAt }],
+    completeness: 'partial',
+    totalCount: null,
+    source: { availability: 'partial', reason: availability, retryable: availability !== 'denied' },
+  });
+});
+
+it.each(['available', 'denied', 'unavailable'] as const)(
+  'distinguishes %s sources without reviews from complete empty evidence',
+  async availability => {
+    const result = await run(field => page(field, [], availability));
+    expect(result.reviewDecisions).toMatchObject({
+      items: [],
+      knownCount: 0,
+      totalCount: availability === 'available' ? 0 : null,
+      completeness: availability === 'available' ? 'complete' : 'unknown',
+      source: { availability, retryable: availability === 'unavailable' },
+    });
+  }
+);
+
+it.each([null, undefined, 'invalid'])(
+  'never borrows a clock for selected submission %p',
+  async time => {
+    for (const state of ['APPROVED', 'COMMENTED']) {
+      const result = await run(field =>
+        page(field, [
+          field === 'latestOpinionatedReviews'
+            ? review('APPROVED', 'decision', { submittedAt: time })
+            : review(state, state === 'APPROVED' ? 'decision' : 'comment', { submittedAt: later }),
+        ])
+      );
+      expect(result.reviewDecisions.items).toMatchObject([
+        { id: 'decision', state: 'APPROVED', submittedAt: null },
+      ]);
+      expect(result.reviewActivity.items).toMatchObject([{ state, submittedAt: later }]);
+    }
+  }
+);
+
+it('compares equal instants without replacing the selected submission representation', async () => {
+  const result = await run(field =>
+    page(field, [
+      review('APPROVED', 'decision', {
+        submittedAt: field === 'latestReviews' ? '2026-08-25T10:00:00Z' : submittedAt,
+      }),
+    ])
+  );
+  expect(result.reviewDecisions.items).toMatchObject([{ state: 'APPROVED', submittedAt }]);
+});
+
+it('rejects conflicting review identities across reviewer groups without erasing a sibling', async () => {
+  const result = await run(field =>
+    page(field, [
+      ...(field === 'latestOpinionatedReviews'
+        ? [review(), review('CHANGES_REQUESTED', 'other', { author: person('other') })]
+        : [
+            review('COMMENTED', 'comment', { submittedAt: later }),
+            review('COMMENTED', 'decision', { author: person('other'), submittedAt: later }),
+          ]),
+      review('APPROVED', 'stable', { author: person('stable') }),
+    ])
+  );
+  expect(result.reviewDecisions.items).toMatchObject([
+    { id: 'decision', state: 'UNKNOWN' },
+    { id: 'other', state: 'UNKNOWN' },
+    { id: 'stable', state: 'APPROVED' },
+  ]);
+  expect(result.reviewDecisions.source).toMatchObject({
+    availability: 'partial',
+    reason: 'review-inconsistent',
+    retryable: true,
+  });
+});
+
+it.each([false, true])(
+  'keeps explicit team attribution %p separate from a decision',
+  async attributed => {
+    const team = {
+      __typename: 'Team',
+      id: 'T',
+      teamName: 'Requested team',
+      slug: 'team',
+      teamAvatarUrl: null,
+      url: null,
+    };
+    const result = await run(field =>
+      page(field, [
+        field === 'latestOpinionatedReviews'
+          ? review('APPROVED', 'decision', { onBehalfOf: connection(attributed ? [team] : []) })
+          : review('COMMENTED', 'comment', { submittedAt: later, onBehalfOf: connection([team]) }),
+      ])
+    );
+    expect(result.reviewDecisions.items).toMatchObject([
+      {
+        id: 'decision',
+        actor: { id: 'U', kind: 'User' },
+        state: 'APPROVED',
+        onBehalfOf: { items: attributed ? [{ id: 'T', kind: 'Team', teamSlug: 'team' }] : [] },
+      },
+    ]);
+    expect(result.reviewDecisions.items).toHaveLength(1);
+    expect(result.reviewActivity.items[0]?.onBehalfOf.items).toMatchObject([
+      { id: 'T', kind: 'Team' },
+    ]);
+  }
+);

--- a/apps/web/src/lib/github-pr-review/context-reviews.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-reviews.test.ts
@@ -1,4 +1,8 @@
-import { contextReviewSchema, resolveContextReviewDecisions } from './context-reviews';
+import {
+  contextReviewEvidenceConflicts,
+  contextReviewSchema,
+  resolveContextReviewDecisions,
+} from './context-reviews';
 import type { GitHubPrReviewContext } from './context-dtos';
 
 const fields = ['latestOpinionatedReviews', 'latestReviews'] as const;
@@ -55,14 +59,27 @@ const page = (
   };
 };
 
-async function run(serve: (field: Field) => Reviews) {
+async function run(serve: (field: Field) => Reviews, conflictingReviewIds?: ReadonlySet<string>) {
   const opinionated = serve('latestOpinionatedReviews');
   const reviewActivity = serve('latestReviews');
   return {
-    reviewDecisions: resolveContextReviewDecisions(opinionated, reviewActivity),
+    reviewDecisions: resolveContextReviewDecisions(
+      opinionated,
+      reviewActivity,
+      conflictingReviewIds
+    ),
     reviewActivity,
   };
 }
+
+it('does not mistake unavailable evidence for a review conflict', () => {
+  const known = contextReviewSchema.parse(review());
+  const unavailable = contextReviewSchema.parse(
+    review('UNKNOWN', 'decision', { submittedAt: null, commit: null })
+  );
+  expect(contextReviewEvidenceConflicts(known, unavailable)).toBe(false);
+  expect(contextReviewEvidenceConflicts(unavailable, known)).toBe(false);
+});
 
 // These synthetic responses exercise the conservative policy, not undocumented provider transitions.
 it.each([
@@ -247,6 +264,145 @@ it.each(
     completeness: 'partial',
     totalCount: null,
     source: { availability: 'partial', reason: availability, retryable: availability !== 'denied' },
+  });
+});
+
+describe.each(fields)('%s state errors', failedField => {
+  it.each([
+    { error: 'FORBIDDEN', reason: 'graphql-denied', retryable: false },
+    { error: 'INTERNAL', reason: 'graphql-incomplete', retryable: true },
+  ])('preserves source metadata after $error', async ({ reason, retryable }) => {
+    const result = await run(field => {
+      const failed = field === failedField;
+      const reviews = page(field, [
+        review(failed ? 'UNKNOWN' : 'APPROVED'),
+        review('APPROVED', 'unaffected', { author: person('other') }),
+      ]);
+      if (failed) {
+        reviews.completeness = 'partial';
+        reviews.source = { ...reviews.source, availability: 'partial', reason, retryable };
+      }
+      return reviews;
+    });
+    expect(result.reviewDecisions).toMatchObject({
+      items: [
+        { id: 'decision', state: 'UNKNOWN', submittedAt, commitSha: 'reviewed-commit' },
+        { id: 'unaffected', state: 'APPROVED' },
+      ],
+      knownCount: 2,
+      totalCount: null,
+      hasNextPage: null,
+      endCursor: null,
+      completeness: 'partial',
+      source: {
+        availability: 'partial',
+        reason,
+        retryable,
+        provenance: ['graphql.latestOpinionatedReviews', 'graphql.latestReviews'],
+        observedAt: later,
+      },
+    });
+    expect(result.reviewActivity.items).toMatchObject([
+      { id: 'decision', state: failedField === 'latestReviews' ? 'UNKNOWN' : 'APPROVED' },
+      { id: 'unaffected', state: 'APPROVED' },
+    ]);
+  });
+
+  it.each([
+    ['commit', { commit: { oid: 'contradictory-commit' } }],
+    ['submission', { submittedAt: later }],
+    ['actor ID', { author: person('other') }],
+  ])('retains contradictory %s evidence beside a denied state', async (_name, patch) => {
+    const result = await run(field => {
+      const failed = field === failedField;
+      const reviews = page(field, [
+        review(failed ? 'UNKNOWN' : 'APPROVED', 'decision', failed ? patch : {}),
+      ]);
+      if (failed) {
+        reviews.completeness = 'partial';
+        reviews.source = {
+          ...reviews.source,
+          availability: 'partial',
+          reason: 'graphql-denied',
+          retryable: false,
+        };
+      }
+      return reviews;
+    });
+    expect(result.reviewDecisions.items.length).toBeGreaterThan(0);
+    expect(result.reviewDecisions.items.every(item => item.state === 'UNKNOWN')).toBe(true);
+    expect(result.reviewDecisions).toMatchObject({
+      totalCount: null,
+      completeness: 'partial',
+      source: { availability: 'partial', reason: 'review-inconsistent', retryable: true },
+    });
+  });
+});
+
+describe.each(fields)('%s sibling state errors', failedField => {
+  it.each([
+    { error: 'FORBIDDEN', reason: 'graphql-denied', retryable: false },
+    { error: 'INTERNAL', reason: 'graphql-incomplete', retryable: true },
+  ])('retains explicit conflict metadata beside $error', async ({ reason, retryable }) => {
+    const result = await run(
+      field => {
+        const failed = field === failedField;
+        const reviews = page(field, [
+          review(field === 'latestOpinionatedReviews' ? 'UNKNOWN' : 'APPROVED', 'decision', {
+            submittedAt: field === 'latestOpinionatedReviews' ? null : submittedAt,
+            commit: field === 'latestOpinionatedReviews' ? null : { oid: 'reviewed-commit' },
+          }),
+          review(failed ? 'UNKNOWN' : 'APPROVED', 'failed', { author: person('failed') }),
+          review('APPROVED', 'unaffected', { author: person('unaffected') }),
+        ]);
+        if (failed) {
+          reviews.completeness = 'partial';
+          reviews.source = { ...reviews.source, availability: 'partial', reason, retryable };
+        }
+        return reviews;
+      },
+      new Set(['decision'])
+    );
+    expect(result.reviewDecisions).toMatchObject({
+      items: [
+        { id: 'decision', state: 'UNKNOWN', submittedAt: null, commitSha: null },
+        { id: 'failed', state: 'UNKNOWN' },
+        { id: 'unaffected', state: 'APPROVED', submittedAt, commitSha: 'reviewed-commit' },
+      ],
+      knownCount: 3,
+      totalCount: null,
+      hasNextPage: null,
+      endCursor: null,
+      completeness: 'partial',
+      source: {
+        availability: 'partial',
+        reason: 'review-inconsistent',
+        retryable: true,
+        provenance: ['graphql.latestOpinionatedReviews', 'graphql.latestReviews'],
+        observedAt: later,
+      },
+    });
+    expect(result.reviewActivity.items).toMatchObject([
+      { id: 'decision', state: 'APPROVED', submittedAt, commitSha: 'reviewed-commit' },
+      { id: 'failed', state: failedField === 'latestReviews' ? 'UNKNOWN' : 'APPROVED' },
+      { id: 'unaffected', state: 'APPROVED' },
+    ]);
+  });
+});
+
+it('rejects matching final observations for an explicitly conflicted review', async () => {
+  const result = await run(
+    field => page(field, [review(), review('APPROVED', 'stable', { author: person('stable') })]),
+    new Set(['decision'])
+  );
+  expect(result.reviewDecisions).toMatchObject({
+    items: [
+      { id: 'decision', state: 'UNKNOWN' },
+      { id: 'stable', state: 'APPROVED' },
+    ],
+    totalCount: null,
+    completeness: 'partial',
+    source: { availability: 'partial', reason: 'review-inconsistent', retryable: true },
   });
 });
 

--- a/apps/web/src/lib/github-pr-review/context-reviews.ts
+++ b/apps/web/src/lib/github-pr-review/context-reviews.ts
@@ -129,17 +129,30 @@ export function contextReviewsAgree(first: Review, second: Review) {
   );
 }
 
-export function resolveContextReviewDecisions(opinionated: Reviews, activity: Reviews): Reviews {
+export function contextReviewEvidenceConflicts(first: Review, second: Review) {
+  // UNKNOWN supplies no contradictory state evidence; keep comparing all other fields.
+  return !contextReviewsAgree(first, {
+    ...second,
+    state: first.state === 'UNKNOWN' || second.state === 'UNKNOWN' ? first.state : second.state,
+  });
+}
+
+export function resolveContextReviewDecisions(
+  opinionated: Reviews,
+  activity: Reviews,
+  conflictingReviewIds?: ReadonlySet<string>
+): Reviews {
   const groups = new Map<string, { opinionated: Review[]; activity: Review[] }>();
   const reviewsById = new Map<string, Review>();
-  const conflicts = new Set<string>();
+  // Collectors retain genuine conflicts separately from normalized UNKNOWN states.
+  const conflicts = new Set(conflictingReviewIds);
   for (const [field, reviews] of [
     ['opinionated', opinionated],
     ['activity', activity],
   ] as const) {
     for (const review of reviews.items) {
       const previous = reviewsById.get(review.id);
-      if (previous && !contextReviewsAgree(previous, review)) conflicts.add(review.id);
+      if (previous && contextReviewEvidenceConflicts(previous, review)) conflicts.add(review.id);
       reviewsById.set(review.id, review);
       const key = reviewerKey(review);
       const group = groups.get(key) ?? { opinionated: [], activity: [] };

--- a/apps/web/src/lib/github-pr-review/context-reviews.ts
+++ b/apps/web/src/lib/github-pr-review/context-reviews.ts
@@ -109,3 +109,113 @@ export const contextReviewSchema = z
       },
     };
   });
+
+const reviewerKey = (review: Review) =>
+  review.actor?.id ? `${review.actor.kind}:${review.actor.id}` : `review:${review.id}`;
+const isDecision = (review: Review) =>
+  ['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(review.state);
+
+export function contextReviewsAgree(first: Review, second: Review) {
+  return (
+    first.id === second.id &&
+    first.state === second.state &&
+    reviewerKey(first) === reviewerKey(second) &&
+    !(first.commitSha && second.commitSha && first.commitSha !== second.commitSha) &&
+    !(
+      first.submittedAt &&
+      second.submittedAt &&
+      Date.parse(first.submittedAt) !== Date.parse(second.submittedAt)
+    )
+  );
+}
+
+export function resolveContextReviewDecisions(opinionated: Reviews, activity: Reviews): Reviews {
+  const groups = new Map<string, { opinionated: Review[]; activity: Review[] }>();
+  const reviewsById = new Map<string, Review>();
+  const conflicts = new Set<string>();
+  for (const [field, reviews] of [
+    ['opinionated', opinionated],
+    ['activity', activity],
+  ] as const) {
+    for (const review of reviews.items) {
+      const previous = reviewsById.get(review.id);
+      if (previous && !contextReviewsAgree(previous, review)) conflicts.add(review.id);
+      reviewsById.set(review.id, review);
+      const key = reviewerKey(review);
+      const group = groups.get(key) ?? { opinionated: [], activity: [] };
+      group[field].push(review);
+      groups.set(key, group);
+    }
+  }
+  const incomplete = [opinionated, activity].find(reviews => reviews.completeness !== 'complete');
+  let inconsistent = false;
+  const items: Review[] = [];
+  for (const group of groups.values()) {
+    const decision = group.opinionated[0];
+    const latest = group.activity[0];
+    const selected = decision ?? latest;
+    if (!selected) continue;
+    const sameReview = decision && latest && contextReviewsAgree(decision, latest);
+    const laterComment =
+      decision &&
+      latest?.state === 'COMMENTED' &&
+      decision.id !== latest.id &&
+      !(
+        decision.submittedAt &&
+        latest.submittedAt &&
+        Date.parse(latest.submittedAt) < Date.parse(decision.submittedAt)
+      );
+    // A review ID must agree across reviewer groups too, even beside a different later comment.
+    const conflicted = [...group.opinionated, ...group.activity].some(review =>
+      conflicts.has(review.id)
+    );
+    // Do not rank conflicting decisions by a clock or resurrect an approval after dismissal.
+    const supported =
+      !conflicted &&
+      group.opinionated.length <= 1 &&
+      group.activity.length <= 1 &&
+      (decision
+        ? isDecision(decision) && (sameReview || laterComment)
+        : !incomplete && latest && isDecision(latest));
+    if (supported) items.push(selected);
+    else if (
+      conflicted ||
+      group.opinionated.some(isDecision) ||
+      group.activity.some(isDecision) ||
+      group.opinionated.length > 1 ||
+      group.activity.length > 1 ||
+      selected.state === 'UNKNOWN' ||
+      latest?.state === 'UNKNOWN' ||
+      selected.state === 'PENDING' ||
+      latest?.state === 'PENDING' ||
+      (decision && !latest)
+    ) {
+      inconsistent ||=
+        conflicted ||
+        !incomplete ||
+        Boolean(decision && latest && decision.state !== 'UNKNOWN' && latest.state !== 'UNKNOWN');
+      items.push({ ...selected, state: 'UNKNOWN' });
+    }
+  }
+  const complete = !incomplete && !inconsistent;
+  return {
+    items,
+    knownCount: items.length,
+    totalCount: complete ? items.length : null,
+    hasNextPage: opinionated.hasNextPage || activity.hasNextPage ? true : complete ? false : null,
+    // The two connections have independent cursors; this derived collection has no single cursor.
+    endCursor: null,
+    completeness: complete ? 'complete' : items.length ? 'partial' : 'unknown',
+    source: {
+      ...(incomplete?.source ?? opinionated.source),
+      availability: complete
+        ? 'available'
+        : items.length || inconsistent
+          ? 'partial'
+          : (incomplete?.source.availability ?? 'unavailable'),
+      reason: inconsistent ? 'review-inconsistent' : (incomplete?.source.reason ?? null),
+      retryable: inconsistent || opinionated.source.retryable || activity.source.retryable,
+      provenance: [...new Set([...opinionated.source.provenance, ...activity.source.provenance])],
+    },
+  };
+}


### PR DESCRIPTION
No new behavior — The app does not yet use the new review-decision selection.

---

## Summary

`resolveContextReviewDecisions` combines `latestOpinionatedReviews` and `latestReviews` into conservative `reviewDecisions`, retaining supported decisions and using `UNKNOWN` when evidence cannot support them. `contextReviewsAgree` compares review evidence; `contextReviewEvidenceConflicts` treats `UNKNOWN` states as unavailable evidence while still checking identity, commit, and submission time. The optional `conflictingReviewIds` input preserves genuine conflicts; source errors retain their metadata unless contradictions require retryable `review-inconsistent` results.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-reviews.ts` — Adds reviewer grouping by actor type and ID, with a review-ID fallback for missing actors. Keeps matching `APPROVED`, `CHANGES_REQUESTED`, and `DISMISSED` decisions, or decisions followed by comments whose known submission times do not contradict that order. Accepts activity-only decisions only with complete sources; omits comment-only activity and marks duplicate, pending, missing, or conflicting evidence `UNKNOWN`. Keeps selected timestamps, commits, and team attribution without borrowing comment metadata, ranking competing decisions by time, or inferring team approvals. Allows missing commit IDs or submission times and compares known submission instants without changing the selected timestamp text. Preserves unaffected reviewers and the original activity collection. Reports known counts, complete-only totals, partial/unknown results, page availability, and no shared cursor. Combines retry flags, merges provenance, and retains metadata from the first incomplete source, or the opinionated source when both are complete.
- `apps/web/src/lib/github-pr-review/context-reviews.test.ts` — Adds synthetic source fixtures and coverage for decision combinations, identity conflicts, incomplete sources, source errors, explicit conflict IDs, timestamps, and team attribution. Checks unchanged activity and unaffected reviewers without asserting undocumented provider transitions.

</details>

Tests: 1 file added, `context-reviews.test.ts` (508 added lines).
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

No manual product tests ran for this level; reader integration and mobile presentation remain pending.
Live backend and iOS verification requires the completed stack tip.

The owner prohibits new end-to-end (E2E) slots and bundles.

## Reviewer Notes

### Human steps

- **before merge:** After the owner lifts the E2E hold, complete live backend and iOS feature verification on the completed stack tip.
- **before merge:** Do not ask for review or merge before the complete-stack human-ready gate.
- **after merge:** No level-specific deployment, migration, or configuration step is known.

The owner retains product merge authority.

### Scope and evidence

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- Review range: `mobile-pr-review-context-5458-s7...mobile-pr-review-context-5458-s8` only.
- All 27 pull requests (PRs) remain one incomplete stack.
- Current-head continuous integration (CI), bot reviews, review threads, and the final description gate remain independently required.

### Historical automated proof

- The level-8 metadata-contract repair passed 179 focused tests and a fresh `No findings.` review before publication.
- This refresh ran no product checks; historical proof does not close the current-head or complete-stack gates.

### Notes

This level adds conservative decision selection without attaching review reads. Live backend and iOS verification will run on the completed stack tip.

Live backend and iOS feature verification remains required on the completed stack tip.

The owner currently prohibits new E2E slots and bundles; this hold does not waive runtime verification.

Levels 24 and 25 have prepared repairs and partial proof, but publication remains pending a workflow operation for an unpublished propagated baseline.

Their required three-root type checks have not passed; no failed publication proof is applied.

The owner descoped large-text/font-scaling, theme variants, contrast rendering, scaled-text layout, and screen-reader presentation.

Functional accessibility labels, roles, identifiers, selectors, default appearance flows, and all non-visual criteria remain required.

This is an interim description refresh; the complete-stack readiness gate remains open.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696 ← this PR
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)

