### PR TITLE
fix(extension): invalidate ended browser task approvals

### DIFF
--- a/apps/extension/entrypoints/sidepanel/browser-task-supervision-slot.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-supervision-slot.tsx
@@ -1,0 +1,8 @@
+import { createContext, useContext } from 'react';
+import type { ReactNode } from 'react';
+
+// The provider supplies controls later. Local cards add no wrapper or spacing.
+export const BrowserTaskSupervisionContext = createContext<ReactNode>(null);
+
+export const BrowserTaskSupervisionSlot = (): ReactNode =>
+  useContext(BrowserTaskSupervisionContext);

--- a/apps/extension/entrypoints/sidepanel/pending-approval.test.ts
+++ b/apps/extension/entrypoints/sidepanel/pending-approval.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines, no-unsafe-type-assertion, require-await, jest/no-hooks, jest/valid-title, promise/avoid-new, vitest/prefer-expect-type-of -- test fixture constraints */
+/* eslint-disable jest/no-conditional-in-test -- The table exhausts both draft kinds and every authority-loss boundary. */
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { getDefaultStore } from 'jotai';
 import type { PendingAgentMemoryDraft } from '@/src/shared/agent-memories';
@@ -132,6 +133,20 @@ describe(applyApprovalDecision, () => {
     // Must still return rejected, not throw.
     expect(outcome).toStrictEqual({ status: 'rejected' });
   });
+
+  it.each(['memory', 'workflow'] as const)(
+    'preserves the legacy local %s cleanup-failure outcome',
+    async kind => {
+      const storage = createStorage({ failRemoveItem: true });
+      const draft = kind === 'memory' ? memoryDraft() : workflowDraft();
+      const savedKey = kind === 'memory' ? 'local:kiloAgentMemories' : 'local:kiloAgentWorkflows';
+      await expect(applyApprovalDecision(storage, kind, draft, true)).resolves.toStrictEqual({
+        reason: 'Storage remove failed.',
+        status: 'failed',
+      });
+      expect(storage.values.get(savedKey)).toHaveLength(1);
+    }
+  );
 
   it('approve saves memory once and returns approved with savedId', async () => {
     const storage = createStorage();
@@ -1118,5 +1133,359 @@ describe(requestApproval, () => {
       status: 'approved',
     });
     await promise;
+  });
+});
+
+const waitForApproval = async () => {
+  await vi.waitFor(() => {
+    expect(getDefaultStore().get(pendingApprovalAtom)).toBeDefined();
+  });
+  const entry = getDefaultStore().get(pendingApprovalAtom);
+  if (!entry) {
+    throw new Error('Expected an approval card.');
+  }
+  return entry;
+};
+
+const liveInvocation = () => ({
+  executionGuard: () => {},
+  expiresAt: Date.now() + 60_000,
+  invocationId: 'delegated-invocation',
+  isLive: () => true,
+});
+
+describe.each(['memory', 'workflow'] as const)('delegated %s approval', kind => {
+  const makeDraft = kind === 'memory' ? memoryDraft : workflowDraft;
+  const pendingKey =
+    kind === 'memory' ? 'local:kiloPendingAgentMemoryDraft' : 'local:kiloPendingWorkflowSave';
+  const savedKey = kind === 'memory' ? 'local:kiloAgentMemories' : 'local:kiloAgentWorkflows';
+
+  beforeEach(clearAtom);
+  afterEach(() => {
+    clearAtom();
+    vi.restoreAllMocks();
+  });
+
+  it('saves once and rejects a replay even before the card settles', async () => {
+    const storage = createStorage();
+    const controller = new AbortController();
+    const approval = requestApproval(
+      storage,
+      kind,
+      makeDraft(),
+      controller.signal,
+      liveInvocation()
+    );
+    const entry = await waitForApproval();
+    const first = await applyApprovalDecision(
+      storage,
+      kind,
+      structuredClone(entry.draft),
+      true,
+      entry
+    );
+    const replay = await applyApprovalDecision(storage, kind, entry.draft, true, entry);
+    entry.settle(first);
+    await expect(approval).resolves.toMatchObject({ status: 'approved' });
+    expect(replay).toStrictEqual({ status: 'aborted' });
+    expect(storage.values.get(savedKey)).toHaveLength(1);
+  });
+
+  it('rejects a reloaded delegated record without current in-memory authority', async () => {
+    const storage = createStorage();
+    const controller = new AbortController();
+    const approval = requestApproval(
+      storage,
+      kind,
+      makeDraft(),
+      controller.signal,
+      liveInvocation()
+    );
+    const entry = await waitForApproval();
+    getDefaultStore().set(pendingApprovalAtom, undefined);
+    const reloaded = structuredClone(entry.draft);
+    const outcome = await applyApprovalDecision(storage, kind, reloaded, true);
+    controller.abort();
+    await approval;
+    expect(outcome).toStrictEqual({ status: 'aborted' });
+    expect(storage.values.has(savedKey)).toBe(false);
+    expect(storage.values.has(pendingKey)).toBe(false);
+  });
+
+  it('rejects a cancelled card click and clears the persisted draft', async () => {
+    const storage = createStorage();
+    const controller = new AbortController();
+    const approval = requestApproval(
+      storage,
+      kind,
+      makeDraft(),
+      controller.signal,
+      liveInvocation()
+    );
+    const entry = await waitForApproval();
+    controller.abort();
+    const outcome = await applyApprovalDecision(storage, kind, entry.draft, true, entry);
+    entry.settle({ autoApproved: false, savedId: 'late', status: 'approved' });
+    await expect(approval).resolves.toStrictEqual({ status: 'aborted' });
+    expect(outcome).toStrictEqual({ status: 'aborted' });
+    expect(storage.values.has(savedKey)).toBe(false);
+    expect(storage.values.has(pendingKey)).toBe(false);
+  });
+
+  it.each(['abort', 'terminal', 'lease'] as const)(
+    'rechecks %s after the saved-store read, before issuing a write',
+    async stop => {
+      const storage = createStorage();
+      const controller = new AbortController();
+      const authority = { active: true, lease: true };
+      const approval = requestApproval(storage, kind, makeDraft(), controller.signal, {
+        ...liveInvocation(),
+        executionGuard: () => {
+          if (!authority.lease) {
+            throw new Error('Lease ended.');
+          }
+        },
+        isLive: () => authority.active,
+      });
+      const entry = await waitForApproval();
+      const read = Promise.withResolvers<unknown>();
+      const reading = Promise.withResolvers<void>();
+      storage.getItem = key => {
+        if (key === savedKey) {
+          reading.resolve();
+          return read.promise;
+        }
+        return storage.values.get(key);
+      };
+      const applying = applyApprovalDecision(storage, kind, entry.draft, true, entry);
+      await reading.promise;
+      if (stop === 'abort') {
+        controller.abort();
+      } else if (stop === 'terminal') {
+        authority.active = false;
+      } else {
+        authority.lease = false;
+      }
+      read.resolve([]);
+      const outcome = await applying;
+      controller.abort();
+      await approval;
+      expect(outcome).toStrictEqual({ status: 'aborted' });
+      expect(storage.values.has(savedKey)).toBe(false);
+    }
+  );
+
+  it('expires an approval before a retained click can save', async () => {
+    const storage = createStorage();
+    const controller = new AbortController();
+    const invocation = liveInvocation();
+    const approval = requestApproval(storage, kind, makeDraft(), controller.signal, invocation);
+    const entry = await waitForApproval();
+    vi.spyOn(Date, 'now').mockReturnValue(invocation.expiresAt);
+    const outcome = await applyApprovalDecision(storage, kind, entry.draft, true, entry);
+    controller.abort();
+    await approval;
+    expect(outcome).toStrictEqual({ status: 'aborted' });
+    expect(storage.values.has(savedKey)).toBe(false);
+    expect(storage.values.has(pendingKey)).toBe(false);
+  });
+
+  it.each(['local', 'delegated'] as const)(
+    'does not clear a newer %s draft when the old invocation aborts',
+    async replacementKind => {
+      const storage = createStorage();
+      const controller = new AbortController();
+      const approval = requestApproval(
+        storage,
+        kind,
+        makeDraft(),
+        controller.signal,
+        liveInvocation()
+      );
+      const entry = await waitForApproval();
+      const replacement =
+        replacementKind === 'local'
+          ? makeDraft({ createdAt: 42 })
+          : { ...entry.draft, origin: { ...entry.draft.origin, approvalId: 'newer' } };
+      storage.values.set(pendingKey, replacement);
+      controller.abort();
+      await approval;
+      await applyApprovalDecision(storage, kind, entry.draft, true, entry);
+      expect(storage.values.get(pendingKey)).toStrictEqual(replacement);
+      expect(storage.values.has(savedKey)).toBe(false);
+    }
+  );
+
+  it('cleans up a draft whose issued persistence finishes after abort', async () => {
+    const storage = createStorage();
+    const controller = new AbortController();
+    const issued = Promise.withResolvers<void>();
+    const written = Promise.withResolvers<void>();
+    const setItem = storage.setItem.bind(storage);
+    storage.setItem = async (key, value) => {
+      await setItem(key, value);
+      if (key === pendingKey) {
+        issued.resolve();
+        await written.promise;
+      }
+    };
+    const approval = requestApproval(
+      storage,
+      kind,
+      makeDraft(),
+      controller.signal,
+      liveInvocation()
+    );
+    await issued.promise;
+    controller.abort();
+    written.resolve();
+    await expect(approval).resolves.toStrictEqual({ status: 'aborted' });
+    expect(storage.values.has(pendingKey)).toBe(false);
+    expect(getDefaultStore().get(pendingApprovalAtom)).toBeUndefined();
+  });
+
+  it('does not claim that Stop undoes an already-issued save', async () => {
+    const storage = createStorage();
+    const controller = new AbortController();
+    const approval = requestApproval(
+      storage,
+      kind,
+      makeDraft(),
+      controller.signal,
+      liveInvocation()
+    );
+    const entry = await waitForApproval();
+    const issued = Promise.withResolvers<void>();
+    const saved = Promise.withResolvers<void>();
+    const setItem = storage.setItem.bind(storage);
+    storage.setItem = async (key, value) => {
+      await setItem(key, value);
+      if (key === savedKey) {
+        issued.resolve();
+        await saved.promise;
+      }
+    };
+    const applying = applyApprovalDecision(storage, kind, entry.draft, true, entry);
+    await issued.promise;
+    controller.abort();
+    await expect(approval).resolves.toStrictEqual({ status: 'aborted' });
+    saved.resolve();
+    await expect(applying).resolves.toMatchObject({ status: 'approved' });
+    expect(storage.values.get(savedKey)).toHaveLength(1);
+  });
+
+  it('keeps a newer atom entry when a retained settlement callback runs', async () => {
+    const storage = createStorage();
+    const controller = new AbortController();
+    const first = requestApproval(storage, kind, makeDraft(), controller.signal, liveInvocation());
+    const oldEntry = await waitForApproval();
+    controller.abort();
+    await first;
+    const second = requestApproval(storage, kind, makeDraft({ createdAt: 2 }), abortSignal());
+    const entry = await waitForApproval();
+    oldEntry.settle({ status: 'rejected' });
+    expect(getDefaultStore().get(pendingApprovalAtom)?.draft.createdAt).toBe(2);
+    const outcome = await applyApprovalDecision(storage, kind, entry.draft, true, entry);
+    entry.settle(outcome);
+    await expect(second).resolves.toMatchObject({ status: 'approved' });
+    expect(storage.values.get(savedKey)).toHaveLength(1);
+  });
+
+  it('does not persist a draft or auto-approve after terminal settings reads', async () => {
+    const storage = createStorage();
+    const controller = new AbortController();
+    const settings = Promise.withResolvers<unknown>();
+    storage.getItem = () => settings.promise;
+    let active = true;
+    const approval = requestApproval(storage, kind, makeDraft(), controller.signal, {
+      ...liveInvocation(),
+      isLive: () => active,
+    });
+    active = false;
+    settings.resolve({ ...autoApproveSettings(), ...autoApproveMemorySettings() });
+    await expect(approval).resolves.toStrictEqual({ status: 'aborted' });
+    expect(storage.values.size).toBe(0);
+    expect(getDefaultStore().get(pendingLockAtom)).toBe(false);
+  });
+
+  it('expires the card and stored draft without requiring another click', async () => {
+    vi.useFakeTimers();
+    const storage = createStorage();
+    const controller = new AbortController();
+    try {
+      const approval = requestApproval(storage, kind, makeDraft(), controller.signal, {
+        ...liveInvocation(),
+        expiresAt: Date.now() + 1000,
+      });
+      await waitForApproval();
+      await vi.advanceTimersByTimeAsync(1000);
+      await expect(approval).resolves.toStrictEqual({ status: 'aborted' });
+      expect(storage.values.has(pendingKey)).toBe(false);
+      expect(getDefaultStore().get(pendingApprovalAtom)).toBeUndefined();
+    } finally {
+      controller.abort();
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports an issued save honestly when draft cleanup fails', async () => {
+    const storage = createStorage({ failRemoveItem: true });
+    const controller = new AbortController();
+    const approval = requestApproval(
+      storage,
+      kind,
+      makeDraft(),
+      controller.signal,
+      liveInvocation()
+    );
+    const entry = await waitForApproval();
+    const outcome = await applyApprovalDecision(storage, kind, entry.draft, true, entry);
+    entry.settle(outcome);
+    await expect(approval).resolves.toMatchObject({ status: 'approved' });
+    expect(storage.values.get(savedKey)).toHaveLength(1);
+    const replay = await applyApprovalDecision(storage, kind, entry.draft, true, entry);
+    expect(replay).toStrictEqual({ status: 'aborted' });
+    expect(storage.values.get(savedKey)).toHaveLength(1);
+  });
+});
+
+describe('delegated workflow update writes', () => {
+  beforeEach(clearAtom);
+  afterEach(clearAtom);
+
+  it('rechecks invocation authority after reading the workflow being replaced', async () => {
+    const storage = createStorage();
+    const existing = { ...workflowDraft({ createdAt: 1 }), id: 'wf-existing', updatedAt: 1 };
+    storage.values.set('local:kiloAgentWorkflows', [existing]);
+    const controller = new AbortController();
+    let active = true;
+    const approval = requestApproval(
+      storage,
+      'workflow',
+      workflowDraft({ name: 'Replacement', workflowId: existing.id }),
+      controller.signal,
+      {
+        ...liveInvocation(),
+        isLive: () => active,
+      }
+    );
+    const entry = await waitForApproval();
+    const reading = Promise.withResolvers<void>();
+    const read = Promise.withResolvers<unknown>();
+    storage.getItem = key => {
+      if (key === 'local:kiloAgentWorkflows') {
+        reading.resolve();
+        return read.promise;
+      }
+      return storage.values.get(key);
+    };
+    const applying = applyApprovalDecision(storage, 'workflow', entry.draft, true, entry);
+    await reading.promise;
+    active = false;
+    read.resolve([existing]);
+    await expect(applying).resolves.toStrictEqual({ status: 'aborted' });
+    controller.abort();
+    await approval;
+    expect(storage.values.get('local:kiloAgentWorkflows')).toStrictEqual([existing]);
   });
 });

--- a/apps/extension/entrypoints/sidepanel/pending-approval.ts
+++ b/apps/extension/entrypoints/sidepanel/pending-approval.ts
@@ -1,6 +1,16 @@
 /* eslint-disable max-lines -- Request, persistence, and auto-approve share one lock and one settle contract. */
 import { atom, getDefaultStore } from 'jotai';
-import type { PendingAgentMemoryDraft } from '@/src/shared/agent-memories';
+import {
+  approvalOriginSchema,
+  matchesDelegatedApproval,
+  pendingAgentMemoryDraftSchema,
+} from '@/src/shared/agent-memories';
+import type {
+  ApprovalOrigin,
+  DelegatedApprovalOrigin,
+  NormalizedPendingAgentMemoryDraft,
+  PendingAgentMemoryDraft,
+} from '@/src/shared/agent-memories';
 import { loadMemorySettings } from '@/src/shared/agent-memory-settings';
 import type { AgentMemorySettingsStorageArea } from '@/src/shared/agent-memory-settings';
 import {
@@ -9,8 +19,14 @@ import {
   savePendingAgentMemoryDraft,
 } from '@/src/shared/agent-memories-storage';
 import type { AgentMemoriesStorageArea } from '@/src/shared/agent-memories-storage';
-import type { AgentWorkflowInput, PendingAgentWorkflowDraft } from '@/src/shared/agent-workflows';
-import { hashWorkflowScript } from '@/src/shared/agent-workflows';
+import { ExecutionStoppedError, isExecutionStopped } from '@/src/shared/agent-tool-results';
+import type { ExecutionGuard } from '@/src/shared/agent-tool-results';
+import type {
+  AgentWorkflowInput,
+  NormalizedPendingAgentWorkflowDraft,
+  PendingAgentWorkflowDraft,
+} from '@/src/shared/agent-workflows';
+import { hashWorkflowScript, pendingAgentWorkflowDraftSchema } from '@/src/shared/agent-workflows';
 import {
   addAgentWorkflow,
   clearPendingWorkflowDraft,
@@ -19,8 +35,6 @@ import {
   updateAgentWorkflow,
 } from '@/src/shared/agent-workflows-storage';
 import type { AgentWorkflowsStorageArea } from '@/src/shared/agent-workflows-storage';
-
-// ---------- types ----------
 
 /* AutoApproved is true only for saves applied without a card, enabled by the
    per-kind auto-approve setting. Every card approval reports false. */
@@ -31,134 +45,169 @@ export type ApprovalOutcome =
   | { status: 'failed'; reason: string };
 
 export type ApprovalKind = 'workflow' | 'memory';
-
+// Legacy producer inputs permit absent origin; current card consumers use normalized entries.
 export type ApprovalDraft = PendingAgentMemoryDraft | PendingAgentWorkflowDraft;
 
-export type PendingApprovalEntry =
-  | {
-      draft: PendingAgentMemoryDraft;
-      kind: 'memory';
-      settle: (outcome: ApprovalOutcome) => void;
-    }
-  | {
-      draft: PendingAgentWorkflowDraft;
-      kind: 'workflow';
-      settle: (outcome: ApprovalOutcome) => void;
-    };
+/** Only the delegated caller supplies these checks, never model arguments or persisted data. */
+export type DelegatedApprovalScope = Pick<DelegatedApprovalOrigin, 'invocationId' | 'expiresAt'> & {
+  isLive: () => boolean;
+  executionGuard: ExecutionGuard;
+};
 
-// ---------- atom ----------
+export type PendingApprovalEntry = (
+  | { draft: NormalizedPendingAgentMemoryDraft; kind: 'memory' }
+  | { draft: NormalizedPendingAgentWorkflowDraft; kind: 'workflow' }
+) & {
+  settle: (outcome: ApprovalOutcome) => void;
+  isLive?: () => boolean;
+};
 
 export const pendingApprovalAtom = atom<PendingApprovalEntry | undefined>();
+// Synchronous single-flight lock, including settings reads and draft persistence.
+export const pendingLockAtom = atom<boolean>(false);
+const decidedApprovals = new WeakSet<PendingApprovalEntry>();
 
-// Synchronous single-flight lock set before persisting, cleared on settle or persist failure.
-const pendingLockAtom = atom<boolean>(false);
-export { pendingLockAtom };
-
-// ---------- shared storage type ----------
-
-/* Unified storage area that satisfies the memory, memory-settings, and
-   workflow storage contracts. */
 type UnifiedStorage = AgentMemoriesStorageArea &
   AgentMemorySettingsStorageArea &
   AgentWorkflowsStorageArea;
 
-// ---------- draft persistence helpers ----------
+export const approvalDraftKey = (draft: PendingApprovalEntry['draft']): string =>
+  JSON.stringify([
+    approvalOriginSchema.parse(draft.origin),
+    draft.createdAt,
+    'text' in draft ? draft.text : draft.script,
+  ]);
 
-const isMemoryDraft = (
-  draft: ApprovalDraft | Record<string, unknown>
-): draft is PendingAgentMemoryDraft => 'text' in draft;
+const matchesApprovalEntry = (
+  kind: ApprovalKind,
+  draft: PendingApprovalEntry['draft'],
+  entry: PendingApprovalEntry | undefined
+): boolean => entry?.kind === kind && approvalDraftKey(entry.draft) === approvalDraftKey(draft);
 
-const isWorkflowDraft = (
-  draft: ApprovalDraft | Record<string, unknown>
-): draft is PendingAgentWorkflowDraft => 'script' in draft && 'scopeOrigin' in draft;
+const isOriginLive = (
+  kind: ApprovalKind,
+  origin: ApprovalOrigin,
+  entry: PendingApprovalEntry | undefined
+): boolean => {
+  if (origin.kind === 'local') {
+    // Old local draft records reload without a runner, including background-created memories.
+    // Remove this branch only after all old local callers and stored drafts retire.
+    return true;
+  }
+  return (
+    Date.now() < origin.expiresAt &&
+    entry?.kind === kind &&
+    matchesDelegatedApproval(entry.draft.origin, origin) &&
+    entry.isLive?.() === true
+  );
+};
 
-const persistDraft = async (
+export const isApprovalDraftLive = (
+  kind: ApprovalKind,
+  draft: PendingApprovalEntry['draft'],
+  entry = getDefaultStore().get(pendingApprovalAtom)
+): boolean => isOriginLive(kind, draft.origin, entry);
+
+// eslint-disable-next-line max-params -- Both cards must settle only their own contextual entry.
+export const settleMatchingApproval = (
+  store: ReturnType<typeof getDefaultStore>,
+  kind: ApprovalKind,
+  draft: PendingApprovalEntry['draft'],
+  outcome: ApprovalOutcome
+): void => {
+  const entry = store.get(pendingApprovalAtom);
+  if (!entry || !matchesApprovalEntry(kind, draft, entry)) {
+    return;
+  }
+  if (
+    outcome.status === 'failed' &&
+    entry.draft.origin.kind === 'delegated' &&
+    isApprovalDraftLive(kind, draft, entry)
+  ) {
+    // Keep the runner waiting for explicit recovery while this delegated approval remains live.
+    return;
+  }
+  entry.settle(outcome);
+  if (store.get(pendingApprovalAtom) === entry) {
+    store.set(pendingApprovalAtom, undefined);
+  }
+};
+
+// eslint-disable-next-line max-params -- Preserve the local cleanup-failure contract without retracting delegated saves.
+const clearDraft = async (
   storage: UnifiedStorage,
   kind: ApprovalKind,
-  draft: ApprovalDraft | Record<string, unknown>
+  origin: ApprovalOrigin,
+  reportLocalFailure = false
 ): Promise<void> => {
-  if (kind === 'memory' && isMemoryDraft(draft)) {
-    await savePendingAgentMemoryDraft(storage, draft);
-    return;
+  const expected = origin.kind === 'delegated' ? origin : undefined;
+  try {
+    await (kind === 'memory'
+      ? clearPendingAgentMemoryDraft(storage, expected)
+      : clearPendingWorkflowDraft(storage, expected));
+  } catch (error) {
+    // Old local approvals report cleanup failures. Remove this branch after those callers retire.
+    if (reportLocalFailure && origin.kind === 'local') {
+      throw error;
+    }
+    // A failed cleanup cannot undo an issued save. Tagged drafts still fail closed on reload.
   }
-  if (kind === 'workflow' && isWorkflowDraft(draft)) {
-    await savePendingWorkflowDraft(storage, draft);
-    return;
-  }
-  throw new Error('Approval draft does not match its kind.');
 };
 
-const clearDraft = async (storage: UnifiedStorage, kind: ApprovalKind): Promise<void> => {
-  if (kind === 'memory') {
-    await clearPendingAgentMemoryDraft(storage);
-    return;
+/** Hide and discard only the invalid delegated draft, never a replacement or a local selection. */
+export const discardInactiveApprovalDraft = async (
+  storage: UnifiedStorage,
+  kind: ApprovalKind,
+  draft: PendingApprovalEntry['draft']
+): Promise<void> => {
+  if (draft.origin.kind === 'delegated') {
+    await clearDraft(storage, kind, draft.origin);
   }
-  await clearPendingWorkflowDraft(storage);
 };
 
-// ---------- public API ----------
-
-/**
- * Persist a save decision.
- *
- * Approve: persist the record FIRST, then clear the stored draft, return approved
- * with autoApproved false (a card approval).
- * Persist failure (e.g. store full): KEEP the draft and return { status: 'failed', reason }.
- * Reject: clear the draft, return rejected.
- *
- * The caller disables its buttons while applying so persist-then-clear cannot double-fire.
- */
-// eslint-disable-next-line max-params -- The public approval contract needs storage, kind, draft, and decision.
-export const applyApprovalDecision = async (
+// eslint-disable-next-line max-params -- The internal guard reaches the actual storage write after awaited preparation.
+const persistApprovalDecision = async (
   storage: UnifiedStorage,
   kind: ApprovalKind,
   draft: ApprovalDraft | Record<string, unknown>,
-  approved: boolean
+  approved: boolean,
+  executionGuard: ExecutionGuard | undefined
 ): Promise<ApprovalOutcome> => {
+  const origin = approvalOriginSchema.parse(draft.origin);
   if (!approved) {
-    try {
-      await clearDraft(storage, kind);
-    } catch {
-      // Draft could not be cleared — still report rejected so the caller does not throw.
-    }
+    await clearDraft(storage, kind, origin);
     return { status: 'rejected' };
   }
 
   if (kind === 'memory') {
-    if (!isMemoryDraft(draft)) {
+    const parsed = pendingAgentMemoryDraftSchema.safeParse(draft);
+    if (!parsed.success) {
       return { reason: 'Approval draft does not match its kind.', status: 'failed' };
     }
-    const memoryDraft = draft;
-    const input = {
-      createdAt: memoryDraft.createdAt,
-      pageTitle: memoryDraft.pageTitle,
-      pageUrl: memoryDraft.pageUrl,
-      text: memoryDraft.text,
-      ...(memoryDraft.truncated === undefined ? {} : { truncated: memoryDraft.truncated }),
-      ...(memoryDraft.note !== undefined && memoryDraft.note.trim().length > 0
-        ? { note: memoryDraft.note.trim() }
-        : {}),
-    };
-    try {
-      const saved = await addAgentMemory(storage, input);
-      await clearPendingAgentMemoryDraft(storage);
-      return { autoApproved: false, savedId: saved.id, status: 'approved' };
-    } catch (error) {
-      if (error instanceof Error && error.name === 'AgentMemoryStoreFullError') {
-        return { reason: 'Memory store is full.', status: 'failed' };
-      }
-      return {
-        reason: error instanceof Error ? error.message : 'Failed to save memory.',
-        status: 'failed',
-      };
-    }
+    const memoryDraft = parsed.data;
+    const saved = await addAgentMemory(
+      storage,
+      {
+        createdAt: memoryDraft.createdAt,
+        pageTitle: memoryDraft.pageTitle,
+        pageUrl: memoryDraft.pageUrl,
+        text: memoryDraft.text,
+        ...(memoryDraft.truncated === undefined ? {} : { truncated: memoryDraft.truncated }),
+        ...(memoryDraft.note !== undefined && memoryDraft.note.trim().length > 0
+          ? { note: memoryDraft.note.trim() }
+          : {}),
+      },
+      executionGuard
+    );
+    await clearDraft(storage, kind, origin, true);
+    return { autoApproved: false, savedId: saved.id, status: 'approved' };
   }
 
-  // Workflow persistence.
-  if (!isWorkflowDraft(draft)) {
+  const parsed = pendingAgentWorkflowDraftSchema.safeParse(draft);
+  if (!parsed.success) {
     return { reason: 'Approval draft does not match its kind.', status: 'failed' };
   }
-  const workflowDraft = draft;
+  const workflowDraft = parsed.data;
   const approvedScriptHash = await hashWorkflowScript(workflowDraft.script);
   const input: AgentWorkflowInput = {
     approvedScriptHash,
@@ -166,9 +215,7 @@ export const applyApprovalDecision = async (
     name: workflowDraft.name,
     scopeOrigin: workflowDraft.scopeOrigin,
     script: workflowDraft.script,
-    // Empty string is the "cleared" sentinel (survives JSON, never a valid real value).
-    // Map it to undefined so updateAgentWorkflow detects the key via Object.hasOwn
-    // And removes the field from storage. Params use the empty array the same way.
+    // Empty string is the cleared sentinel. Preserve Object.hasOwn update semantics.
     ...(workflowDraft.params === undefined
       ? {}
       : { params: workflowDraft.params.length === 0 ? undefined : workflowDraft.params }),
@@ -179,159 +226,228 @@ export const applyApprovalDecision = async (
       ? {}
       : { startUrl: workflowDraft.startUrl === '' ? undefined : workflowDraft.startUrl }),
   };
-
-  try {
-    if (workflowDraft.workflowId !== undefined) {
-      // Update existing workflow.
-      const updated = await updateAgentWorkflow(storage, workflowDraft.workflowId, input);
-      await clearPendingWorkflowDraft(storage);
-      return { autoApproved: false, savedId: updated.id, status: 'approved' };
-    }
-
-    // Create new workflow.
-    const saved = await addAgentWorkflow(storage, input);
-    await clearPendingWorkflowDraft(storage);
-    return { autoApproved: false, savedId: saved.id, status: 'approved' };
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AgentWorkflowStoreFullError') {
-      return { reason: 'Workflow store is full.', status: 'failed' };
-    }
-    return {
-      reason: error instanceof Error ? error.message : 'Failed to save workflow.',
-      status: 'failed',
-    };
-  }
+  const saved =
+    workflowDraft.workflowId === undefined
+      ? await addAgentWorkflow(storage, input, executionGuard)
+      : await updateAgentWorkflow(storage, workflowDraft.workflowId, input, executionGuard);
+  await clearDraft(storage, kind, origin, true);
+  return { autoApproved: false, savedId: saved.id, status: 'approved' };
 };
 
-/**
- * Request user approval for a save. Persists the draft to storage FIRST, then sets the atom,
- * and returns a Promise that settles exactly once (first-wins).
- *
- * Both kinds check their auto-approve setting before persisting the draft: a workflow
- * save reads autoApproveWorkflowChanges, a memory save reads autoApproveMemorySaves.
- * When the setting enables it, the save applies immediately without a card and returns
- * approved with autoApproved true. A failed settings read falls back to the approval
- * card (the cautious path, since auto-approve cannot be verified); a hash failure
- * returns failed.
- *
- * Single-flight: if another approval is already pending, returns failed immediately.
- * Persist failure: returns failed without setting the atom — the card never shows.
- *
- * On signal abort: clears the atom and the stored draft and settles aborted.
- * On settle: ALWAYS clears the atom entry.
- */
-// eslint-disable-next-line max-params -- The public approval contract needs storage, kind, draft, and signal.
-export const requestApproval = async (
+/** Recheck at decision and actual write, after hashing and storage reads have completed. */
+// eslint-disable-next-line max-params -- Preserve local callers; cards can pass their contextual atom entry.
+export const applyApprovalDecision = async (
   storage: UnifiedStorage,
   kind: ApprovalKind,
   draft: ApprovalDraft | Record<string, unknown>,
-  signal: AbortSignal
+  approved: boolean,
+  entry = getDefaultStore().get(pendingApprovalAtom)
+): Promise<ApprovalOutcome> => {
+  const parsed = approvalOriginSchema.safeParse(draft.origin);
+  if (!parsed.success) {
+    return { status: 'aborted' };
+  }
+  const origin = parsed.data;
+  const isLive = (): boolean => isOriginLive(kind, origin, entry);
+  if (!isLive()) {
+    await clearDraft(storage, kind, origin);
+    return { status: 'aborted' };
+  }
+  if (origin.kind === 'delegated' && entry) {
+    if (decidedApprovals.has(entry)) {
+      return { status: 'aborted' };
+    }
+    decidedApprovals.add(entry);
+  }
+  const guard = (): void => {
+    if (!isLive()) {
+      throw new ExecutionStoppedError('Approval is no longer active.', 'cancelled');
+    }
+    // Stop prevents future writes; it cannot retract a write after issuance.
+  };
+  let outcome: ApprovalOutcome = { status: 'aborted' };
+  try {
+    outcome = await persistApprovalDecision(
+      storage,
+      kind,
+      draft,
+      approved,
+      origin.kind === 'delegated' ? guard : undefined
+    );
+  } catch (error) {
+    if (isExecutionStopped(error)) {
+      await clearDraft(storage, kind, origin);
+    } else {
+      let reason = error instanceof Error ? error.message : `Failed to save ${kind}.`;
+      if (error instanceof Error && error.name === 'AgentMemoryStoreFullError') {
+        reason = 'Memory store is full.';
+      } else if (error instanceof Error && error.name === 'AgentWorkflowStoreFullError') {
+        reason = 'Workflow store is full.';
+      }
+      outcome = { reason, status: 'failed' };
+    }
+  }
+  if (outcome.status === 'failed' && origin.kind === 'delegated' && entry) {
+    decidedApprovals.delete(entry);
+  }
+  return outcome;
+};
+
+/**
+ * Persist before displaying a card. Local callers retain settings-based auto-approval and reload.
+ * Delegated callers supply live invocation checks and a deadline; neither is recovered from disk.
+ * Settlement is first-wins. Aborting invalidates the entry before asynchronous cleanup completes.
+ */
+// eslint-disable-next-line max-params -- The optional delegated scope preserves the old signal-only call form.
+export const requestApproval = async (
+  storage: UnifiedStorage,
+  kind: ApprovalKind,
+  input: ApprovalDraft | Record<string, unknown>,
+  signal: AbortSignal,
+  invocation?: DelegatedApprovalScope
 ): Promise<ApprovalOutcome> => {
   const atomStore = getDefaultStore();
-
-  // Single-flight check using a synchronous lock.
   if (atomStore.get(pendingLockAtom)) {
     return { reason: 'Another approval is already pending.', status: 'failed' };
   }
   atomStore.set(pendingLockAtom, true);
 
-  let autoApprove = false;
-  try {
-    if (kind === 'workflow') {
-      const workflowSettings = await loadWorkflowSettings(storage);
-      autoApprove = workflowSettings.autoApproveWorkflowChanges;
-    } else {
-      const memorySettings = await loadMemorySettings(storage);
-      autoApprove = memorySettings.autoApproveMemorySaves;
-    }
-  } catch {
-    // A failed settings read must not block the save.
-    // Auto-approve cannot be verified, so fall through to the approval card.
-    autoApprove = false;
-  }
-
-  if (autoApprove) {
-    try {
-      if (signal.aborted) {
-        return { status: 'aborted' };
-      }
-      const outcome = await applyApprovalDecision(storage, kind, draft, true);
-      if (outcome.status === 'approved') {
-        return { autoApproved: true, savedId: outcome.savedId, status: 'approved' };
-      }
-      return outcome;
-    } catch (error) {
-      return {
-        reason: error instanceof Error ? error.message : `Failed to save ${kind}.`,
-        status: 'failed',
-      };
-    } finally {
-      atomStore.set(pendingLockAtom, false);
-    }
-  }
-
-  // Persist the draft FIRST. If persist fails, clear the lock and return failed.
-  try {
-    await persistDraft(storage, kind, draft);
-  } catch (error) {
+  // Old local requestApproval callers omit the invocation scope.
+  // Remove this call form after all old local callers and stored drafts retire.
+  const parsedOrigin = approvalOriginSchema.safeParse(
+    invocation
+      ? {
+          approvalId: crypto.randomUUID(),
+          expiresAt: invocation.expiresAt,
+          invocationId: invocation.invocationId,
+          kind: 'delegated',
+        }
+      : input.origin
+  );
+  if (!parsedOrigin.success) {
     atomStore.set(pendingLockAtom, false);
-    return {
-      reason: error instanceof Error ? error.message : 'Failed to persist draft.',
-      status: 'failed',
-    };
+    return { status: 'aborted' };
   }
+  const origin = parsedOrigin.data;
+  const draft = { ...input, origin };
+  let settled = false;
+  let published = false;
+  let entry: PendingApprovalEntry | undefined = undefined;
+  const isLive = (): boolean => {
+    try {
+      if (
+        settled ||
+        signal.aborted ||
+        (published && atomStore.get(pendingApprovalAtom) !== entry)
+      ) {
+        return false;
+      }
+      if (origin.kind === 'delegated') {
+        if (!invocation || Date.now() >= origin.expiresAt || !invocation.isLive()) {
+          return false;
+        }
+        invocation.executionGuard();
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const guard = (): void => {
+    if (!isLive()) {
+      throw new ExecutionStoppedError('Approval is no longer active.', 'cancelled');
+    }
+  };
 
-  // eslint-disable-next-line promise/avoid-new -- intentional promise for first-wins abort handling
-  return new Promise<ApprovalOutcome>(resolve => {
-    let settled = false;
+  try {
+    let autoApprove = false;
+    try {
+      if (kind === 'workflow') {
+        const settings = await loadWorkflowSettings(storage);
+        autoApprove = settings.autoApproveWorkflowChanges;
+      } else {
+        const settings = await loadMemorySettings(storage);
+        autoApprove = settings.autoApproveMemorySaves;
+      }
+    } catch {
+      // A failed settings read cannot grant auto-approval. Show the existing card instead.
+    }
+    if (!isLive()) {
+      if (origin.kind === 'delegated') {
+        await clearDraft(storage, kind, origin);
+      }
+      return { status: 'aborted' };
+    }
 
+    const memory = kind === 'memory' ? pendingAgentMemoryDraftSchema.safeParse(draft) : undefined;
+    const workflow =
+      kind === 'workflow' ? pendingAgentWorkflowDraftSchema.safeParse(draft) : undefined;
+    const pending = Promise.withResolvers<ApprovalOutcome>();
+    let expiryTimer: ReturnType<typeof setTimeout> | undefined = undefined;
     const settle = (outcome: ApprovalOutcome): void => {
       if (settled) {
         return;
       }
+      const finalOutcome: ApprovalOutcome =
+        origin.kind === 'delegated' && !isLive() ? { status: 'aborted' } : outcome;
       settled = true;
-      atomStore.set(pendingApprovalAtom, undefined);
-      atomStore.set(pendingLockAtom, false);
-      resolve(outcome);
+      signal.removeEventListener('abort', onAbort);
+      clearTimeout(expiryTimer);
+      if (origin.kind === 'delegated' && finalOutcome.status !== 'approved') {
+        void clearDraft(storage, kind, origin);
+      }
+      if (atomStore.get(pendingApprovalAtom) === entry) {
+        atomStore.set(pendingApprovalAtom, undefined);
+      }
+      pending.resolve(finalOutcome);
     };
-
-    if (signal.aborted) {
-      settle({ status: 'aborted' });
-      void clearDraft(storage, kind);
-      return;
-    }
-
     const onAbort = (): void => {
+      if (origin.kind === 'local') {
+        void clearDraft(storage, kind, origin);
+      }
       settle({ status: 'aborted' });
-      void clearDraft(storage, kind);
     };
-
-    signal.addEventListener('abort', onAbort, { once: true });
-
-    // Set the atom entry synchronously so the card can render it.
-    // Branch on kind so TypeScript can narrow the discriminated union.
-    if (kind === 'memory' && isMemoryDraft(draft)) {
-      const memoryDraft = draft;
-      atomStore.set(pendingApprovalAtom, {
-        draft: memoryDraft,
-        kind: 'memory',
-        settle: finalOutcome => {
-          signal.removeEventListener('abort', onAbort);
-          settle(finalOutcome);
-        },
-      });
-    } else if (kind === 'workflow' && isWorkflowDraft(draft)) {
-      const workflowDraft = draft;
-      atomStore.set(pendingApprovalAtom, {
-        draft: workflowDraft,
-        kind: 'workflow',
-        settle: finalOutcome => {
-          signal.removeEventListener('abort', onAbort);
-          settle(finalOutcome);
-        },
-      });
+    if (memory?.success === true) {
+      entry = { draft: memory.data, isLive, kind: 'memory', settle };
+    } else if (workflow?.success === true) {
+      entry = { draft: workflow.data, isLive, kind: 'workflow', settle };
     } else {
-      settle({ reason: 'Approval draft does not match its kind.', status: 'failed' });
+      return { reason: 'Approval draft does not match its kind.', status: 'failed' };
     }
-  });
+
+    if (autoApprove) {
+      const outcome = await applyApprovalDecision(storage, kind, entry.draft, true, entry);
+      return outcome.status === 'approved' ? { ...outcome, autoApproved: true } : outcome;
+    }
+
+    await (entry.kind === 'memory'
+      ? savePendingAgentMemoryDraft(storage, entry.draft, guard)
+      : savePendingWorkflowDraft(storage, entry.draft, guard));
+    if (!isLive()) {
+      await clearDraft(storage, kind, origin);
+      return { status: 'aborted' };
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+    if (origin.kind === 'delegated') {
+      expiryTimer = setTimeout(onAbort, Math.min(origin.expiresAt - Date.now(), 2_147_483_647));
+    }
+    published = true;
+    atomStore.set(pendingApprovalAtom, entry);
+    return await pending.promise;
+  } catch (error) {
+    if (isExecutionStopped(error)) {
+      await clearDraft(storage, kind, origin);
+      return { status: 'aborted' };
+    }
+    return {
+      reason: error instanceof Error ? error.message : 'Failed to persist draft.',
+      status: 'failed',
+    };
+  } finally {
+    settled = true;
+    // A retained callback must not release another request's entry or lock.
+    if (!published || atomStore.get(pendingApprovalAtom) === undefined) {
+      atomStore.set(pendingLockAtom, false);
+    }
+  }
 };

--- a/apps/extension/entrypoints/sidepanel/pending-memory-save-card.tsx
+++ b/apps/extension/entrypoints/sidepanel/pending-memory-save-card.tsx
@@ -1,11 +1,19 @@
 /* eslint-disable max-lines -- card states + draft form push past 300, and splitting would scatter related logic */
 import { storage } from '#imports';
-import { useAtom, useSetAtom } from 'jotai';
-import { useEffect, useRef, useState } from 'react';
+import { useAtomValue, useSetAtom, useStore } from 'jotai';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { JSX } from 'react';
-import { MAX_MEMORY_NOTE_LENGTH } from '@/src/shared/agent-memories';
-import type { PendingAgentMemoryDraft } from '@/src/shared/agent-memories';
-import { applyApprovalDecision, pendingApprovalAtom } from './pending-approval';
+import { MAX_MEMORY_NOTE_LENGTH, pendingAgentMemoryDraftSchema } from '@/src/shared/agent-memories';
+import type { NormalizedPendingAgentMemoryDraft } from '@/src/shared/agent-memories';
+import {
+  applyApprovalDecision,
+  approvalDraftKey,
+  discardInactiveApprovalDraft,
+  isApprovalDraftLive,
+  pendingApprovalAtom,
+  settleMatchingApproval,
+} from './pending-approval';
+import { BrowserTaskSupervisionSlot } from './browser-task-supervision-slot';
 import {
   buildDraftSelectionPreview,
   classifySaveError,
@@ -26,8 +34,27 @@ const primaryButtonClass =
   'type-label h-8 rounded-md bg-brand-primary px-3 text-brand-primary-foreground transition hover:bg-brand-primary-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-background disabled:cursor-not-allowed disabled:bg-surface-selected disabled:text-foreground-subtle';
 
 export const PendingMemorySaveCard = (): JSX.Element | null => {
-  const { isLoaded, loadError, memories, pendingDraft, reload } = useAgentMemories();
-  const [approvalEntry, setApprovalEntry] = useAtom(pendingApprovalAtom);
+  const {
+    isLoaded,
+    loadError,
+    memories,
+    pendingDraft: legacyStoredDraft,
+    reload,
+  } = useAgentMemories();
+  // Old memory hooks expose optional origin; normalize until those hook contracts retire.
+  const storedDraft = useMemo(() => {
+    const parsed = pendingAgentMemoryDraftSchema.safeParse(legacyStoredDraft);
+    return parsed.success ? parsed.data : undefined;
+  }, [legacyStoredDraft]);
+  const approvalEntry = useAtomValue(pendingApprovalAtom);
+  const atomStore = useStore();
+  const entryDraft = approvalEntry?.kind === 'memory' ? approvalEntry.draft : undefined;
+  const hasDelegatedDraft =
+    entryDraft?.origin.kind === 'delegated' || storedDraft?.origin.kind === 'delegated';
+  // Old local cards prefer background selections. Keep this order until those producers retire.
+  const candidate = hasDelegatedDraft ? (entryDraft ?? storedDraft) : (storedDraft ?? entryDraft);
+  const pendingDraft =
+    candidate && isApprovalDraftLive('memory', candidate, approvalEntry) ? candidate : undefined;
   const setSettingsOpen = useSetAtom(settingsDialogOpenAtom);
   const [savedConfirmation, setSavedConfirmation] = useState(false);
   const [saveError, setSaveError] = useState<string | undefined>();
@@ -35,34 +62,33 @@ export const PendingMemorySaveCard = (): JSX.Element | null => {
   const [isSaving, setIsSaving] = useState(false);
   const [fullOutcome, setFullOutcome] = useState(false);
   const lastDraftKeyRef = useRef<string | null>(null);
+  const currentDraftKeyRef = useRef<string | null>(null);
+  currentDraftKeyRef.current = pendingDraft ? approvalDraftKey(pendingDraft) : null;
+  const savingDraftKeyRef = useRef<string | null>(null);
   const noteTextareaRef = useRef<HTMLTextAreaElement>(null);
   const focusedDraftKeyRef = useRef<string | null>(null);
-  const settledRef = useRef(false);
 
   useEffect(() => {
-    if (pendingDraft === undefined) {
-      lastDraftKeyRef.current = null;
+    if (candidate && !pendingDraft) {
+      void discardInactiveApprovalDraft(storage, 'memory', candidate);
+    }
+  }, [candidate, pendingDraft]);
+
+  useEffect(() => {
+    const draftKey = pendingDraft ? approvalDraftKey(pendingDraft) : null;
+    if (lastDraftKeyRef.current !== draftKey) {
+      setSaveError(undefined);
+      setNote(pendingDraft?.note ?? '');
+      setFullOutcome(false);
+      setIsSaving(false);
+      savingDraftKeyRef.current = null;
+      if (pendingDraft) {
+        setSavedConfirmation(false);
+      }
+    }
+    if (!pendingDraft) {
       focusedDraftKeyRef.current = null;
-      settledRef.current = false;
-      return;
     }
-
-    const draftKey = `${pendingDraft.createdAt}:${pendingDraft.text}`;
-    if (lastDraftKeyRef.current !== null && lastDraftKeyRef.current !== draftKey) {
-      setSavedConfirmation(false);
-      setSaveError(undefined);
-      setNote(pendingDraft.note ?? '');
-      setFullOutcome(false);
-      settledRef.current = false;
-    } else if (lastDraftKeyRef.current === null) {
-      // Fresh draft while confirmation may still be showing from a prior save.
-      setSavedConfirmation(false);
-      setSaveError(undefined);
-      setNote(pendingDraft.note ?? '');
-      setFullOutcome(false);
-      settledRef.current = false;
-    }
-
     lastDraftKeyRef.current = draftKey;
   }, [pendingDraft]);
 
@@ -85,7 +111,7 @@ export const PendingMemorySaveCard = (): JSX.Element | null => {
       return;
     }
 
-    const draftKey = `${pendingDraft.createdAt}:${pendingDraft.text}`;
+    const draftKey = approvalDraftKey(pendingDraft);
     if (focusedDraftKeyRef.current === draftKey) {
       return;
     }
@@ -98,16 +124,20 @@ export const PendingMemorySaveCard = (): JSX.Element | null => {
     return null;
   }
 
-  const handleCancel = (): void => {
-    // Settle the atom first if one exists for memory kind.
-    if (approvalEntry !== undefined && approvalEntry.kind === 'memory' && !settledRef.current) {
-      settledRef.current = true;
-      approvalEntry.settle({ status: 'rejected' });
-      setApprovalEntry(undefined);
-    }
-    // ApplyApprovalDecision for reject clears the draft.
-    if (pendingDraft !== undefined) {
-      void applyApprovalDecision(storage, 'memory', pendingDraft, false);
+  const handleCancel = async (): Promise<void> => {
+    if (pendingDraft) {
+      const key = approvalDraftKey(pendingDraft);
+      const outcome = await applyApprovalDecision(
+        storage,
+        'memory',
+        pendingDraft,
+        false,
+        atomStore.get(pendingApprovalAtom)
+      );
+      settleMatchingApproval(atomStore, 'memory', pendingDraft, outcome);
+      if (currentDraftKeyRef.current !== key && currentDraftKeyRef.current !== null) {
+        return;
+      }
     }
     setSavedConfirmation(false);
     setSaveError(undefined);
@@ -124,60 +154,61 @@ export const PendingMemorySaveCard = (): JSX.Element | null => {
   };
 
   const handleSave = async (): Promise<void> => {
-    if (pendingDraft === undefined || isSaving) {
+    if (!pendingDraft || savingDraftKeyRef.current !== null) {
       return;
     }
-
+    const key = approvalDraftKey(pendingDraft);
+    savingDraftKeyRef.current = key;
     setIsSaving(true);
     try {
       const trimmedNote = note.trim();
-      const finalDraft: PendingAgentMemoryDraft = {
+      const finalDraft: NormalizedPendingAgentMemoryDraft = {
         ...pendingDraft,
         note: trimmedNote.length > 0 ? trimmedNote : undefined,
       };
-
-      const outcome = await applyApprovalDecision(storage, 'memory', finalDraft, true);
-
+      const outcome = await applyApprovalDecision(
+        storage,
+        'memory',
+        finalDraft,
+        true,
+        atomStore.get(pendingApprovalAtom)
+      );
+      settleMatchingApproval(atomStore, 'memory', finalDraft, outcome);
+      if (currentDraftKeyRef.current !== key && currentDraftKeyRef.current !== null) {
+        return;
+      }
       if (outcome.status === 'approved') {
-        // Settle the atom if one exists.
-        if (approvalEntry !== undefined && approvalEntry.kind === 'memory' && !settledRef.current) {
-          settledRef.current = true;
-          approvalEntry.settle(outcome);
-          setApprovalEntry(undefined);
-        }
         setSaveError(undefined);
         setSavedConfirmation(true);
         setNote('');
         return;
       }
-
       if (outcome.status === 'failed') {
-        // The draft stays in storage, but the tool caller needs the failure.
-        if (approvalEntry !== undefined && approvalEntry.kind === 'memory' && !settledRef.current) {
-          settledRef.current = true;
-          approvalEntry.settle(outcome);
-          setApprovalEntry(undefined);
-        }
-
-        // Only true store-full outcomes set the full view; generic failures stay retryable.
+        // Store-full and retryable failures retain their existing distinct guidance.
         if (outcome.reason === 'Memory store is full.') {
           setFullOutcome(true);
           reload();
           return;
         }
-
         setSaveError(SAVE_ERROR_MESSAGE);
+      } else {
+        reload();
       }
     } catch (error) {
+      if (currentDraftKeyRef.current !== key) {
+        return;
+      }
       if (classifySaveError(error) === 'full') {
         setFullOutcome(true);
         reload();
         return;
       }
-
       setSaveError(SAVE_ERROR_MESSAGE);
     } finally {
-      setIsSaving(false);
+      if (savingDraftKeyRef.current === key) {
+        savingDraftKeyRef.current = null;
+        setIsSaving(false);
+      }
     }
   };
 
@@ -191,6 +222,7 @@ export const PendingMemorySaveCard = (): JSX.Element | null => {
       role="dialog"
     >
       <div className="w-full max-w-sm rounded-xl border border-border bg-surface-raised p-3 shadow-lg shadow-black/50">
+        <BrowserTaskSupervisionSlot />
         {view.kind === 'confirmation' ? (
           <div className="flex flex-col gap-3">
             <p className="type-body text-foreground">{CONFIRMATION_MESSAGE}</p>
@@ -280,7 +312,13 @@ export const PendingMemorySaveCard = (): JSX.Element | null => {
                 </div>
 
                 <div className="flex justify-end gap-2">
-                  <button className={secondaryButtonClass} onClick={handleCancel} type="button">
+                  <button
+                    className={secondaryButtonClass}
+                    onClick={() => {
+                      void handleCancel();
+                    }}
+                    type="button"
+                  >
                     Cancel
                   </button>
                   <button

--- a/apps/extension/entrypoints/sidepanel/pending-workflow-save-card.test.ts
+++ b/apps/extension/entrypoints/sidepanel/pending-workflow-save-card.test.ts
@@ -1,16 +1,32 @@
 /* eslint-disable capitalized-comments, id-length, jest/max-expects, jest/no-hooks, jest/no-untyped-mock-factory, max-dependencies, max-lines, sort-keys, vitest/prefer-import-in-mock -- test fixture constraints */
 /* eslint-disable import/first */
+/* eslint-disable jest/no-conditional-in-test, jest/no-conditional-expect -- The table runs both cards with their distinct existing views and controls. */
 // @vitest-environment jsdom
 
 import { createElement } from 'react';
-import { Provider, createStore } from 'jotai';
+import { Provider, createStore, getDefaultStore } from 'jotai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, fireEvent, render, waitFor, cleanup } from '@testing-library/react';
-import type { AgentWorkflow, PendingAgentWorkflowDraft } from '@/src/shared/agent-workflows';
+import { act, fireEvent, render, waitFor, cleanup, within } from '@testing-library/react';
+import { BrowserTaskSupervisionContext } from './browser-task-supervision-slot';
+import type { ApprovalOutcome, PendingApprovalEntry } from './pending-approval';
+import {
+  DEFAULT_WORKFLOW_SETTINGS,
+  pendingAgentWorkflowDraftSchema,
+} from '@/src/shared/agent-workflows';
+import type {
+  AgentWorkflow,
+  NormalizedPendingAgentWorkflowDraft,
+  PendingAgentWorkflowDraft,
+} from '@/src/shared/agent-workflows';
+import { pendingAgentMemoryDraftSchema } from '@/src/shared/agent-memories';
 import { deriveWorkflowSaveCardState } from './pending-workflow-save-card-state';
 
 vi.mock('#imports', () => ({
-  storage: {},
+  storage: {
+    getItem: () => null,
+    removeItem: () => {},
+    setItem: () => {},
+  },
 }));
 
 vi.mock('@/src/shared/agent-workflows-storage', () => ({
@@ -39,15 +55,17 @@ vi.mock('./use-agent-memories', () => ({
   useAgentMemories: vi.fn(),
 }));
 
+import { storage } from '#imports';
 import {
   addAgentWorkflow,
   loadAgentWorkflows,
   loadPendingWorkflowDraft,
+  loadWorkflowSettings,
 } from '@/src/shared/agent-workflows-storage';
 import type { AgentMemory, PendingAgentMemoryDraft } from '@/src/shared/agent-memories';
 import { addAgentMemory, clearPendingAgentMemoryDraft } from '@/src/shared/agent-memories-storage';
 import { useAgentMemories } from './use-agent-memories';
-import { pendingApprovalAtom } from './pending-approval';
+import { pendingApprovalAtom, pendingLockAtom, requestApproval } from './pending-approval';
 import { PendingMemorySaveCard } from './pending-memory-save-card';
 import { PendingWorkflowSaveCard } from './pending-workflow-save-card';
 
@@ -58,22 +76,22 @@ const mockAddAgentMemory = vi.mocked(addAgentMemory);
 const mockClearPendingAgentMemoryDraft = vi.mocked(clearPendingAgentMemoryDraft);
 const mockUseAgentMemories = vi.mocked(useAgentMemories);
 
-const draft = (overrides: Partial<PendingAgentWorkflowDraft> = {}): PendingAgentWorkflowDraft => ({
-  createdAt: 1_700_000_000_000,
-  description: 'A test workflow',
-  name: 'Test Workflow',
-  scopeOrigin: 'https://example.com',
-  script: 'return { done: true, result: 1 };',
-  ...overrides,
-});
+const draft = (overrides: Partial<PendingAgentWorkflowDraft> = {}) =>
+  pendingAgentWorkflowDraftSchema.parse({
+    createdAt: 1_700_000_000_000,
+    description: 'A test workflow',
+    name: 'Test Workflow',
+    scopeOrigin: 'https://example.com',
+    script: 'return { done: true, result: 1 };',
+    ...overrides,
+  });
 
-const draftAlt: PendingAgentWorkflowDraft = {
+const draftAlt = draft({
   createdAt: 1_700_000_000_001,
   description: 'Another workflow',
   name: 'Second',
-  scopeOrigin: 'https://example.com',
   script: 'return { done: true, result: 2 };',
-};
+});
 
 const baseInput = {
   isSaving: false,
@@ -150,7 +168,8 @@ describe('workflow save card state', () => {
   });
 });
 
-const updateDraft: PendingAgentWorkflowDraft = {
+const updateDraft: NormalizedPendingAgentWorkflowDraft = {
+  origin: { kind: 'local' },
   createdAt: 1_700_000_000_000,
   description: 'Updated workflow',
   name: 'My Update',
@@ -339,7 +358,8 @@ describe('workflow save card script diff render', () => {
     ...overrides,
   });
 
-  const changedDraft: PendingAgentWorkflowDraft = {
+  const changedDraft: NormalizedPendingAgentWorkflowDraft = {
+    origin: { kind: 'local' },
     createdAt: 1_700_000_000_000,
     description: 'Updated workflow',
     name: 'My Update',
@@ -348,12 +368,13 @@ describe('workflow save card script diff render', () => {
     workflowId: 'wf-1',
   };
 
-  const identicalDraft: PendingAgentWorkflowDraft = {
+  const identicalDraft: NormalizedPendingAgentWorkflowDraft = {
     ...changedDraft,
     script: storedScript,
   };
 
-  const createDraft: PendingAgentWorkflowDraft = {
+  const createDraft: NormalizedPendingAgentWorkflowDraft = {
+    origin: { kind: 'local' },
     createdAt: 1_700_000_000_000,
     description: 'New workflow',
     name: 'New Workflow',
@@ -551,15 +572,14 @@ describe('workflow save card second approval resets settled guard and stale erro
   });
 });
 
-const memoryDraft = (
-  overrides: Partial<PendingAgentMemoryDraft> = {}
-): PendingAgentMemoryDraft => ({
-  createdAt: 1_700_000_000_000,
-  pageTitle: 'Test Page',
-  pageUrl: 'https://example.com/page',
-  text: 'Selected text for memory',
-  ...overrides,
-});
+const memoryDraft = (overrides: Partial<PendingAgentMemoryDraft> = {}) =>
+  pendingAgentMemoryDraftSchema.parse({
+    createdAt: 1_700_000_000_000,
+    pageTitle: 'Test Page',
+    pageUrl: 'https://example.com/page',
+    text: 'Selected text for memory',
+    ...overrides,
+  });
 
 const emptyMemories: AgentMemory[] = [];
 
@@ -598,14 +618,13 @@ describe('workflow save card reject-A then approve-B settles', () => {
     // Click Reject on A.
     fireEvent.click(getByText('Reject'));
 
-    expect(settleA).toHaveBeenCalledWith({ status: 'rejected' });
-    // eslint-disable-next-line vitest/prefer-called-once, vitest/prefer-called-times -- conflicting rules
-    expect(settleA).toHaveBeenCalledTimes(1);
-
-    // Wait for handleCancel's setPendingDraft(undefined) to complete.
+    // Rejection clears storage before settling the matching approval.
     await waitFor(() => {
       expect(queryByText('Approve and save')).toBeNull();
     });
+    expect(settleA).toHaveBeenCalledWith({ status: 'rejected' });
+    // eslint-disable-next-line vitest/prefer-called-once, vitest/prefer-called-times -- conflicting rules
+    expect(settleA).toHaveBeenCalledTimes(1);
 
     // Set atom B after A is fully settled.
     store.set(pendingApprovalAtom, {
@@ -753,7 +772,9 @@ describe('workflow save card persisted draft recovery', () => {
 
   it('renders a new approval card after a persisted missing-original update loaded on reload', async () => {
     // Reload path loads a persisted update whose original workflow is missing.
-    mockLoadPendingWorkflowDraft.mockResolvedValue(updateDraft);
+    mockLoadPendingWorkflowDraft.mockResolvedValue(
+      pendingAgentWorkflowDraftSchema.parse(updateDraft)
+    );
     mockLoadAgentWorkflows.mockResolvedValue([]);
 
     const { getByText, queryByText, rerender } = render(createElement(PendingWorkflowSaveCard), {
@@ -791,7 +812,8 @@ describe('workflow save card persisted draft recovery', () => {
     const oldScript =
       "const greeting = 'hello';\nconst count = 1;\nreturn { done: true, result: count };";
 
-    const persistedUpdate: PendingAgentWorkflowDraft = {
+    const persistedUpdate: NormalizedPendingAgentWorkflowDraft = {
+      origin: { kind: 'local' },
       createdAt: 1_700_000_000_000,
       description: 'Persisted update',
       name: 'Persisted',
@@ -812,7 +834,9 @@ describe('workflow save card persisted draft recovery', () => {
     };
 
     // Reload path loads a persisted update and its old stored script.
-    mockLoadPendingWorkflowDraft.mockResolvedValue(persistedUpdate);
+    mockLoadPendingWorkflowDraft.mockResolvedValue(
+      pendingAgentWorkflowDraftSchema.parse(persistedUpdate)
+    );
     mockLoadAgentWorkflows.mockResolvedValue([stored]);
 
     const { container, getByText, queryByText, rerender } = render(
@@ -962,5 +986,468 @@ describe('memory save card retryable error for generic failure', () => {
     expect(settle).toHaveBeenCalledWith(
       expect.objectContaining({ reason: 'quota exceeded', status: 'failed' })
     );
+  });
+});
+
+describe('background memory draft compatibility', () => {
+  it('shows a newer local selection without losing the unrelated local approval', () => {
+    const store = createStore();
+    const local = memoryDraft({ text: 'Pending local agent selection' });
+    const background = memoryDraft({ createdAt: 2, text: 'New background selection' });
+    store.set(pendingApprovalAtom, { draft: local, kind: 'memory', settle: vi.fn() });
+    const loaded = {
+      isLoaded: true,
+      loadError: false,
+      memories: emptyMemories,
+      pendingDraft: { ...background, origin: undefined },
+      reload: vi.fn(),
+    };
+    mockUseAgentMemories.mockReturnValue(loaded);
+    const view = render(createElement(PendingMemorySaveCard), { wrapper: createWrapper(store) });
+    expect(view.getByText('New background selection')).toBeDefined();
+    mockUseAgentMemories.mockReturnValue({ ...loaded, pendingDraft: undefined });
+    view.rerender(createElement(PendingMemorySaveCard));
+    expect(view.getByText('Pending local agent selection')).toBeDefined();
+  });
+});
+
+const supervision = createElement(
+  'div',
+  null,
+  createElement('span', null, 'CLI owner — Example tab'),
+  createElement('button', { type: 'button' }, 'Stop CLI task')
+);
+const createSupervisedWrapper = (store: ReturnType<typeof createStore>) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(
+      Provider,
+      { store },
+      createElement(BrowserTaskSupervisionContext.Provider, { value: supervision }, children)
+    );
+  };
+
+describe.each([
+  { kind: 'memory' as const, Component: PendingMemorySaveCard, saveName: 'Save memory' },
+  { kind: 'workflow' as const, Component: PendingWorkflowSaveCard, saveName: 'Approve and save' },
+])('$kind approval lifetime and supervision', ({ kind, Component, saveName }) => {
+  let store = createStore();
+  let saved: (AgentMemory | AgentWorkflow)[] = [];
+  let saveGate: Promise<void> | null = null;
+  let saveStarted = Promise.withResolvers<void>();
+  const reload = vi.fn();
+
+  const setStoredDraft = (entry?: PendingApprovalEntry): void => {
+    mockUseAgentMemories.mockReturnValue({
+      isLoaded: true,
+      loadError: false,
+      memories: [],
+      pendingDraft: entry?.kind === 'memory' ? entry.draft : undefined,
+      reload,
+    });
+    mockLoadPendingWorkflowDraft.mockResolvedValue(
+      entry?.kind === 'workflow' ? pendingAgentWorkflowDraftSchema.parse(entry.draft) : undefined
+    );
+  };
+  const makeEntry = (approvalId = 'first'): PendingApprovalEntry => {
+    const origin = {
+      kind: 'delegated' as const,
+      approvalId,
+      invocationId: 'invocation',
+      expiresAt: Date.now() + 60_000,
+    };
+    return kind === 'memory'
+      ? {
+          kind,
+          draft: memoryDraft({ origin, note: approvalId }),
+          isLive: () => true,
+          settle: vi.fn(),
+        }
+      : { kind, draft: draft({ origin, name: approvalId }), isLive: () => true, settle: vi.fn() };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = createStore();
+    saved = [];
+    saveGate = null;
+    saveStarted = Promise.withResolvers<void>();
+    mockLoadAgentWorkflows.mockResolvedValue([]);
+    setStoredDraft(
+      kind === 'memory'
+        ? { kind, draft: memoryDraft(), settle: vi.fn() }
+        : { kind, draft: draft(), settle: vi.fn() }
+    );
+    mockAddAgentMemory.mockImplementation(async (_storage, input) => {
+      saveStarted.resolve();
+      await saveGate;
+      const record = { ...input, id: 'saved-memory' };
+      saved.push(record);
+      return record;
+    });
+    mockAddAgentWorkflow.mockImplementation(async (_storage, input) => {
+      saveStarted.resolve();
+      await saveGate;
+      const record = { ...input, id: 'saved-workflow', createdAt: 1, updatedAt: 1 };
+      saved.push(record);
+      return record;
+    });
+  });
+
+  it('makes a retained save click inert when cancellation wins before React renders', async () => {
+    let live = true;
+    const result = Promise.withResolvers<ApprovalOutcome>();
+    const entry = { ...makeEntry(), isLive: () => live, settle: result.resolve };
+    setStoredDraft(entry);
+    store.set(pendingApprovalAtom, entry);
+    const view = render(createElement(Component), { wrapper: createWrapper(store) });
+    const button = await view.findByRole('button', { name: saveName });
+    live = false;
+    fireEvent.click(button);
+    await expect(result.promise).resolves.toStrictEqual({ status: 'aborted' });
+    await waitFor(() => {
+      expect(view.queryByRole('dialog')).toBeNull();
+    });
+    expect(saved).toStrictEqual([]);
+  });
+
+  it('clears a loaded delegated card when its atom ends and an empty reload arrives', async () => {
+    const entry = makeEntry();
+    setStoredDraft(entry);
+    store.set(pendingApprovalAtom, entry);
+    const view = render(createElement(Component), { wrapper: createWrapper(store) });
+    await view.findByRole('button', { name: saveName });
+    await act(async () => {
+      store.set(pendingApprovalAtom, undefined);
+      await Promise.resolve();
+    });
+    setStoredDraft(undefined);
+    view.rerender(createElement(Component));
+    await waitFor(() => {
+      expect(view.queryByRole('dialog')).toBeNull();
+    });
+    expect(view.queryByRole('button', { name: saveName })).toBeNull();
+    expect(saved).toStrictEqual([]);
+  });
+
+  it('does not recover delegated authority from a persisted draft on mount', async () => {
+    const entry = makeEntry();
+    setStoredDraft(entry);
+    const read = Promise.withResolvers<Awaited<ReturnType<typeof loadPendingWorkflowDraft>>>();
+    mockLoadPendingWorkflowDraft.mockReturnValue(read.promise);
+    const view = render(createElement(Component), { wrapper: createWrapper(store) });
+    await act(async () => {
+      read.resolve(
+        entry.kind === 'workflow' ? pendingAgentWorkflowDraftSchema.parse(entry.draft) : undefined
+      );
+      await read.promise;
+    });
+    expect(view.queryByRole('dialog')).toBeNull();
+    expect(saved).toStrictEqual([]);
+  });
+
+  it('keeps the newer card after a stale asynchronous draft load', async () => {
+    const oldEntry = makeEntry();
+    const nextEntry = makeEntry('replacement');
+    const read = Promise.withResolvers<Awaited<ReturnType<typeof loadPendingWorkflowDraft>>>();
+    setStoredDraft(undefined);
+    mockLoadPendingWorkflowDraft.mockReturnValue(read.promise);
+    const view = render(createElement(Component), { wrapper: createWrapper(store) });
+    await act(async () => {
+      store.set(pendingApprovalAtom, nextEntry);
+      await Promise.resolve();
+    });
+    await view.findByRole('button', { name: saveName });
+    await act(async () => {
+      read.resolve(
+        oldEntry.kind === 'workflow'
+          ? pendingAgentWorkflowDraftSchema.parse(oldEntry.draft)
+          : undefined
+      );
+      await read.promise;
+      setStoredDraft(oldEntry);
+      view.rerender(createElement(Component));
+    });
+    if (kind === 'memory') {
+      expect(view.getByDisplayValue('replacement')).toBeDefined();
+    } else {
+      expect(view.getByText('replacement')).toBeDefined();
+    }
+    expect(view.getByRole('button', { name: saveName }).hasAttribute('disabled')).toBe(false);
+  });
+
+  it('does not clear a newer draft or its atom when an old save completes', async () => {
+    const gate = Promise.withResolvers<void>();
+    saveGate = gate.promise;
+    const oldEntry = makeEntry();
+    const nextEntry = makeEntry('replacement');
+    setStoredDraft(oldEntry);
+    store.set(pendingApprovalAtom, oldEntry);
+    const view = render(createElement(Component), { wrapper: createWrapper(store) });
+    fireEvent.click(await view.findByRole('button', { name: saveName }));
+    await saveStarted.promise;
+    await act(async () => {
+      setStoredDraft(nextEntry);
+      store.set(pendingApprovalAtom, nextEntry);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      gate.resolve();
+      await gate.promise;
+    });
+    await waitFor(() => {
+      expect(saved).toHaveLength(1);
+    });
+    if (kind === 'memory') {
+      expect(view.getByDisplayValue('replacement')).toBeDefined();
+    } else {
+      expect(view.getByText('replacement')).toBeDefined();
+    }
+    expect(store.get(pendingApprovalAtom)?.draft.origin).toStrictEqual(nextEntry.draft.origin);
+    expect(view.getByRole('button', { name: saveName }).hasAttribute('disabled')).toBe(false);
+  });
+
+  it.each(['full', 'retryable'] as const)(
+    'keeps a real delegated %s failure pending until an explicit retry succeeds',
+    async failure => {
+      store = getDefaultStore();
+      store.set(pendingApprovalAtom, undefined);
+      store.set(pendingLockAtom, false);
+      setStoredDraft(undefined);
+      vi.mocked(loadWorkflowSettings).mockResolvedValue(DEFAULT_WORKFLOW_SETTINGS);
+      const error = new Error('quota exceeded');
+      if (failure === 'full') {
+        error.name =
+          kind === 'memory' ? 'AgentMemoryStoreFullError' : 'AgentWorkflowStoreFullError';
+      }
+      if (kind === 'memory') {
+        mockAddAgentMemory.mockRejectedValueOnce(error);
+      } else {
+        mockAddAgentWorkflow.mockRejectedValueOnce(error);
+      }
+      const controller = new AbortController();
+      const approval = requestApproval(
+        storage,
+        kind,
+        kind === 'memory' ? memoryDraft() : draft(),
+        controller.signal,
+        {
+          invocationId: 'retry-invocation',
+          expiresAt: Date.now() + 60_000,
+          isLive: () => true,
+          executionGuard: () => {},
+        }
+      );
+      const view = render(createElement(Component), { wrapper: createSupervisedWrapper(store) });
+      try {
+        const save = await view.findByRole('button', { name: saveName });
+        if (kind === 'memory') {
+          fireEvent.change(view.getByRole('textbox', { name: 'Memory note (optional)' }), {
+            target: { value: 'Keep this edited note' },
+          });
+        }
+        fireEvent.click(save);
+        const messages = {
+          memory: {
+            full: 'Memory is full. Delete memories to save new ones.',
+            retryable: "Couldn't save memory. Try again.",
+          },
+          workflow: { full: 'Workflow store is full.', retryable: 'quota exceeded' },
+        };
+        await view.findByText(messages[kind][failure]);
+        const dialog = within(view.getByRole('dialog'));
+        expect(dialog.getByRole('button', { name: 'Stop CLI task' }).hasAttribute('disabled')).toBe(
+          false
+        );
+        if (kind === 'memory') {
+          expect(view.getByDisplayValue('Keep this edited note')).toBeDefined();
+          if (failure === 'full') {
+            expect(dialog.getByRole('button', { name: 'Manage memories' })).toBeDefined();
+          }
+        }
+        const retry = dialog.getByRole('button', {
+          name: kind === 'memory' && failure === 'retryable' ? 'Retry' : saveName,
+        });
+        expect(retry.hasAttribute('disabled')).toBe(false);
+        expect(store.get(pendingLockAtom)).toBe(true);
+        expect(saved).toStrictEqual([]);
+
+        fireEvent.click(retry);
+        await expect(approval).resolves.toStrictEqual({
+          status: 'approved',
+          autoApproved: false,
+          savedId: kind === 'memory' ? 'saved-memory' : 'saved-workflow',
+        });
+        expect(saved).toHaveLength(1);
+        expect(store.get(pendingApprovalAtom)).toBeUndefined();
+        expect(store.get(pendingLockAtom)).toBe(false);
+        if (kind === 'memory') {
+          expect(saved[0]).toMatchObject({ note: 'Keep this edited note' });
+          await view.findByText('Saved to memory');
+          expect(
+            within(view.getByRole('dialog')).getByRole('button', { name: 'Stop CLI task' })
+          ).toBeDefined();
+          fireEvent.click(view.getByRole('button', { name: 'Done' }));
+        }
+        await waitFor(() => {
+          expect(view.queryByRole('dialog')).toBeNull();
+        });
+      } finally {
+        controller.abort();
+        await approval;
+      }
+    }
+  );
+
+  it.each(['terminal', 'cancelled', 'expired', 'reloaded'] as const)(
+    'keeps a real delegated retry inert after authority becomes %s',
+    async stop => {
+      store = getDefaultStore();
+      store.set(pendingApprovalAtom, undefined);
+      store.set(pendingLockAtom, false);
+      setStoredDraft(undefined);
+      vi.mocked(loadWorkflowSettings).mockResolvedValue(DEFAULT_WORKFLOW_SETTINGS);
+      if (kind === 'memory') {
+        mockAddAgentMemory.mockRejectedValueOnce(new Error('quota exceeded'));
+      } else {
+        mockAddAgentWorkflow.mockRejectedValueOnce(new Error('quota exceeded'));
+      }
+      const controller = new AbortController();
+      const expiresAt = Date.now() + 60_000;
+      let live = true;
+      const approval = requestApproval(
+        storage,
+        kind,
+        kind === 'memory' ? memoryDraft() : draft(),
+        controller.signal,
+        {
+          invocationId: 'ended-retry-invocation',
+          expiresAt,
+          isLive: () => live,
+          executionGuard: () => {},
+        }
+      );
+      const now = vi.spyOn(Date, 'now');
+      const view = render(createElement(Component), { wrapper: createWrapper(store) });
+      try {
+        fireEvent.click(await view.findByRole('button', { name: saveName }));
+        await view.findByText(
+          kind === 'memory' ? "Couldn't save memory. Try again." : 'quota exceeded'
+        );
+        setStoredDraft(store.get(pendingApprovalAtom));
+        const retry = view.getByRole('button', { name: kind === 'memory' ? 'Retry' : saveName });
+        await act(async () => {
+          if (stop === 'terminal') {
+            live = false;
+          } else if (stop === 'cancelled') {
+            controller.abort();
+          } else if (stop === 'expired') {
+            now.mockReturnValue(expiresAt);
+          } else {
+            store.set(pendingApprovalAtom, undefined);
+          }
+          fireEvent.click(retry);
+          await Promise.resolve();
+        });
+        controller.abort();
+        await expect(approval).resolves.toStrictEqual({ status: 'aborted' });
+        await waitFor(() => {
+          expect(view.queryByRole('dialog')).toBeNull();
+        });
+        expect(saved).toStrictEqual([]);
+        expect(store.get(pendingApprovalAtom)).toBeUndefined();
+        expect(store.get(pendingLockAtom)).toBe(false);
+      } finally {
+        now.mockRestore();
+        controller.abort();
+        await approval;
+      }
+    }
+  );
+
+  it('keeps supervision inside editing and saving, then preserves the existing completion view', async () => {
+    const gate = Promise.withResolvers<void>();
+    saveGate = gate.promise;
+    const view = render(createElement(Component), { wrapper: createSupervisedWrapper(store) });
+    const button = await view.findByRole('button', { name: saveName });
+    const dialog = view.getByRole('dialog');
+    expect(within(dialog).getByText('CLI owner — Example tab')).toBeDefined();
+    fireEvent.click(button);
+    await saveStarted.promise;
+    const stop = within(dialog).getByRole('button', { name: 'Stop CLI task' });
+    stop.focus();
+    expect(document.activeElement).toBe(stop);
+    expect(stop.hasAttribute('disabled')).toBe(false);
+    await act(async () => {
+      gate.resolve();
+      await gate.promise;
+    });
+    await waitFor(() => {
+      expect(saved).toHaveLength(1);
+    });
+    setStoredDraft(undefined);
+    view.rerender(createElement(Component));
+    if (kind === 'memory') {
+      await view.findByText('Saved to memory');
+      expect(
+        within(view.getByRole('dialog')).getByRole('button', { name: 'Stop CLI task' })
+      ).toBeDefined();
+      fireEvent.click(view.getByRole('button', { name: 'Done' }));
+    }
+    await waitFor(() => {
+      expect(view.queryByRole('dialog')).toBeNull();
+    });
+  });
+
+  it.each(['full', 'retryable'] as const)(
+    'keeps supervision inside the %s save state',
+    async failure => {
+      const error = new Error('quota exceeded');
+      if (failure === 'full') {
+        error.name =
+          kind === 'memory' ? 'AgentMemoryStoreFullError' : 'AgentWorkflowStoreFullError';
+      }
+      mockAddAgentMemory.mockRejectedValue(error);
+      mockAddAgentWorkflow.mockRejectedValue(error);
+      const view = render(createElement(Component), { wrapper: createSupervisedWrapper(store) });
+      fireEvent.click(await view.findByRole('button', { name: saveName }));
+      const messages = {
+        memory: {
+          full: 'Memory is full. Delete memories to save new ones.',
+          retryable: "Couldn't save memory. Try again.",
+        },
+        workflow: { full: 'Workflow store is full.', retryable: 'quota exceeded' },
+      };
+      await view.findByText(messages[kind][failure]);
+      const stop = within(view.getByRole('dialog')).getByRole('button', { name: 'Stop CLI task' });
+      expect(stop.hasAttribute('disabled')).toBe(false);
+      expect(saved).toStrictEqual([]);
+    }
+  );
+
+  it('keeps supervision and recovery controls inside load errors', async () => {
+    mockLoadPendingWorkflowDraft.mockRejectedValue(new Error('Read failed.'));
+    mockUseAgentMemories.mockReturnValue({
+      isLoaded: true,
+      loadError: true,
+      memories: [],
+      pendingDraft: memoryDraft(),
+      reload,
+    });
+    const view = render(createElement(Component), { wrapper: createSupervisedWrapper(store) });
+    const recovery = kind === 'memory' ? 'Retry' : 'Dismiss';
+    await view.findByRole('button', { name: recovery });
+    expect(
+      within(view.getByRole('dialog')).getByRole('button', { name: 'Stop CLI task' })
+    ).toBeDefined();
+    expect(view.queryByRole('button', { name: saveName })).toBeNull();
+  });
+
+  it('retains local reload approval without a supervision provider', async () => {
+    const view = render(createElement(Component), { wrapper: createWrapper(store) });
+    fireEvent.click(await view.findByRole('button', { name: saveName }));
+    await waitFor(() => {
+      expect(saved).toHaveLength(1);
+    });
+    expect(view.queryByRole('button', { name: 'Stop CLI task' })).toBeNull();
   });
 });

--- a/apps/extension/entrypoints/sidepanel/pending-workflow-save-card.tsx
+++ b/apps/extension/entrypoints/sidepanel/pending-workflow-save-card.tsx
@@ -1,10 +1,22 @@
+/* eslint-disable max-lines -- Modal states and invocation invalidation share one component lifecycle. */
 import { storage } from '#imports';
-import { useAtom } from 'jotai';
+import { useAtomValue, useStore } from 'jotai';
 import { useEffect, useRef, useState } from 'react';
 import type { JSX } from 'react';
-import type { AgentWorkflow, PendingAgentWorkflowDraft } from '@/src/shared/agent-workflows';
+import type {
+  AgentWorkflow,
+  NormalizedPendingAgentWorkflowDraft,
+} from '@/src/shared/agent-workflows';
 import { loadAgentWorkflows, loadPendingWorkflowDraft } from '@/src/shared/agent-workflows-storage';
-import { applyApprovalDecision, pendingApprovalAtom } from './pending-approval';
+import {
+  applyApprovalDecision,
+  approvalDraftKey,
+  discardInactiveApprovalDraft,
+  isApprovalDraftLive,
+  pendingApprovalAtom,
+  settleMatchingApproval,
+} from './pending-approval';
+import { BrowserTaskSupervisionSlot } from './browser-task-supervision-slot';
 import { deriveWorkflowSaveCardState } from './pending-workflow-save-card-state';
 import { WorkflowScriptDiff } from './workflow-script-diff.tsx';
 
@@ -15,67 +27,82 @@ const primaryButtonClass =
   'type-label h-8 rounded-md bg-brand-primary px-3 text-brand-primary-foreground transition hover:bg-brand-primary-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-background disabled:cursor-not-allowed disabled:bg-surface-selected disabled:text-foreground-subtle';
 
 export const PendingWorkflowSaveCard = (): JSX.Element | null => {
-  const [approvalEntry, setApprovalEntry] = useAtom(pendingApprovalAtom);
-  const [pendingDraft, setPendingDraft] = useState<PendingAgentWorkflowDraft | undefined>();
+  const approvalEntry = useAtomValue(pendingApprovalAtom);
+  const atomStore = useStore();
+  const [loadedDraft, setPendingDraft] = useState<
+    NormalizedPendingAgentWorkflowDraft | undefined
+  >();
+  const pendingDraft =
+    loadedDraft && isApprovalDraftLive('workflow', loadedDraft, approvalEntry)
+      ? loadedDraft
+      : undefined;
+  const currentDraftKeyRef = useRef<string | null>(null);
+  currentDraftKeyRef.current = pendingDraft ? approvalDraftKey(pendingDraft) : null;
   const [loaded, setLoaded] = useState(false);
   const [saveError, setSaveError] = useState<string | undefined>();
   const [loadError, setLoadError] = useState<string | undefined>();
   const [isSaving, setIsSaving] = useState(false);
   const [storedWorkflow, setStoredWorkflow] = useState<AgentWorkflow | undefined>();
-  const settledRef = useRef(false);
+  const savingDraftKeyRef = useRef<string | null>(null);
   const lastDraftKeyRef = useRef<string | null>(null);
   const loadFailedRef = useRef(false);
 
-  // Load draft and atom on mount. Ignore results and errors from superseded runs.
+  useEffect(() => {
+    if (loadedDraft && !pendingDraft) {
+      setPendingDraft(undefined);
+      setSaveError(undefined);
+      setLoadError(undefined);
+      setStoredWorkflow(undefined);
+      void discardInactiveApprovalDraft(storage, 'workflow', loadedDraft);
+    }
+  }, [loadedDraft, pendingDraft]);
+
+  // Ignore superseded loads and recheck live authority after every asynchronous read.
   useEffect(() => {
     let cancelled = false;
 
-    const loadStoredWorkflow = async (workflowId: string): Promise<void> => {
-      const workflows = await loadAgentWorkflows(storage);
-      if (cancelled) {
-        return;
-      }
-      const existing = workflows.find(wf => wf.id === workflowId);
-      if (existing === undefined) {
-        setLoadError('The original workflow was deleted. This update cannot be saved.');
-      } else {
-        setStoredWorkflow(existing);
-      }
-    };
-
     void (async () => {
       try {
-        if (approvalEntry !== undefined && approvalEntry.kind === 'workflow') {
-          const { draft } = approvalEntry;
-          const draftKey = `${draft.createdAt}:${draft.script}`;
-          if (lastDraftKeyRef.current !== draftKey || loadFailedRef.current) {
-            // New draft or a recovery from a reload-path failure: reset stale state.
-            settledRef.current = false;
-            loadFailedRef.current = false;
-            setSaveError(undefined);
-            setLoadError(undefined);
-            setStoredWorkflow(undefined);
-          }
-          lastDraftKeyRef.current = draftKey;
-          setPendingDraft(draft);
-
-          if (draft.workflowId !== undefined) {
-            await loadStoredWorkflow(draft.workflowId);
-          }
-
-          return;
-        }
-
-        // Reload path: check stored draft.
-        const storedDraft = await loadPendingWorkflowDraft(storage);
+        const candidate =
+          approvalEntry?.kind === 'workflow'
+            ? approvalEntry.draft
+            : await loadPendingWorkflowDraft(storage);
         if (cancelled) {
           return;
         }
-        if (storedDraft !== undefined) {
-          lastDraftKeyRef.current = `${storedDraft.createdAt}:${storedDraft.script}`;
-          setPendingDraft(storedDraft);
-          if (storedDraft.workflowId !== undefined) {
-            await loadStoredWorkflow(storedDraft.workflowId);
+        const draft =
+          candidate &&
+          isApprovalDraftLive('workflow', candidate, atomStore.get(pendingApprovalAtom))
+            ? candidate
+            : undefined;
+        if (candidate && !draft) {
+          void discardInactiveApprovalDraft(storage, 'workflow', candidate);
+        }
+        const draftKey = draft ? approvalDraftKey(draft) : null;
+        if (lastDraftKeyRef.current !== draftKey || loadFailedRef.current) {
+          loadFailedRef.current = false;
+          setSaveError(undefined);
+          setLoadError(undefined);
+          setStoredWorkflow(undefined);
+          setIsSaving(false);
+          savingDraftKeyRef.current = null;
+        }
+        lastDraftKeyRef.current = draftKey;
+        // An empty reload must clear component-local state, not retain the previous card.
+        setPendingDraft(draft);
+        if (draft?.workflowId !== undefined) {
+          const workflows = await loadAgentWorkflows(storage);
+          if (
+            cancelled ||
+            !isApprovalDraftLive('workflow', draft, atomStore.get(pendingApprovalAtom))
+          ) {
+            return;
+          }
+          const existing = workflows.find(workflow => workflow.id === draft.workflowId);
+          if (existing === undefined) {
+            setLoadError('The original workflow was deleted. This update cannot be saved.');
+          } else {
+            setStoredWorkflow(existing);
           }
         }
       } catch {
@@ -95,17 +122,22 @@ export const PendingWorkflowSaveCard = (): JSX.Element | null => {
     return () => {
       cancelled = true;
     };
-  }, [approvalEntry]);
+  }, [approvalEntry, atomStore]);
 
   const handleCancel = async (): Promise<void> => {
-    if (approvalEntry !== undefined && approvalEntry.kind === 'workflow' && !settledRef.current) {
-      settledRef.current = true;
-      approvalEntry.settle({ status: 'rejected' });
-      setApprovalEntry(undefined);
-    }
-    // ApplyApprovalDecision for reject clears the draft + storage.
-    if (pendingDraft !== undefined) {
-      await applyApprovalDecision(storage, 'workflow', pendingDraft, false);
+    if (pendingDraft) {
+      const key = approvalDraftKey(pendingDraft);
+      const outcome = await applyApprovalDecision(
+        storage,
+        'workflow',
+        pendingDraft,
+        false,
+        atomStore.get(pendingApprovalAtom)
+      );
+      settleMatchingApproval(atomStore, 'workflow', pendingDraft, outcome);
+      if (currentDraftKeyRef.current !== key && currentDraftKeyRef.current !== null) {
+        return;
+      }
       setPendingDraft(undefined);
     }
     setSaveError(undefined);
@@ -113,46 +145,39 @@ export const PendingWorkflowSaveCard = (): JSX.Element | null => {
   };
 
   const handleApprove = async (): Promise<void> => {
-    if (pendingDraft === undefined || isSaving) {
+    if (!pendingDraft || savingDraftKeyRef.current !== null) {
       return;
     }
-
+    const key = approvalDraftKey(pendingDraft);
+    savingDraftKeyRef.current = key;
     setIsSaving(true);
-
     try {
-      const outcome = await applyApprovalDecision(storage, 'workflow', pendingDraft, true);
-
-      if (outcome.status === 'approved') {
-        if (
-          approvalEntry !== undefined &&
-          approvalEntry.kind === 'workflow' &&
-          !settledRef.current
-        ) {
-          settledRef.current = true;
-          approvalEntry.settle(outcome);
-          setApprovalEntry(undefined);
-        }
-        setPendingDraft(undefined);
-        setSaveError(undefined);
+      const outcome = await applyApprovalDecision(
+        storage,
+        'workflow',
+        pendingDraft,
+        true,
+        atomStore.get(pendingApprovalAtom)
+      );
+      settleMatchingApproval(atomStore, 'workflow', pendingDraft, outcome);
+      if (currentDraftKeyRef.current !== key && currentDraftKeyRef.current !== null) {
         return;
       }
-
       if (outcome.status === 'failed') {
-        if (
-          approvalEntry !== undefined &&
-          approvalEntry.kind === 'workflow' &&
-          !settledRef.current
-        ) {
-          settledRef.current = true;
-          approvalEntry.settle(outcome);
-          setApprovalEntry(undefined);
-        }
         setSaveError(outcome.reason);
+      } else {
+        setPendingDraft(undefined);
+        setSaveError(undefined);
       }
     } catch (error) {
-      setSaveError(error instanceof Error ? error.message : "Couldn't save workflow.");
+      if (currentDraftKeyRef.current === key) {
+        setSaveError(error instanceof Error ? error.message : "Couldn't save workflow.");
+      }
     } finally {
-      setIsSaving(false);
+      if (savingDraftKeyRef.current === key) {
+        savingDraftKeyRef.current = null;
+        setIsSaving(false);
+      }
     }
   };
 
@@ -177,6 +202,7 @@ export const PendingWorkflowSaveCard = (): JSX.Element | null => {
       role="dialog"
     >
       <div className="flex max-h-full w-full max-w-sm flex-col rounded-xl border border-border bg-surface-raised p-3 shadow-lg shadow-black/50">
+        <BrowserTaskSupervisionSlot />
         {view.kind === 'loadError' ? (
           <div className="flex flex-col gap-3">
             <p className="type-body text-status-red-400">{view.message}</p>

--- a/apps/extension/src/shared/agent-memories-storage.test.ts
+++ b/apps/extension/src/shared/agent-memories-storage.test.ts
@@ -1,5 +1,11 @@
+/* eslint-disable jest/no-conditional-in-test -- Storage fixtures route delayed reads; the table runs every origin case. */
 import { describe, expect, it } from 'vitest';
-import { MAX_MEMORY_COUNT, MAX_MEMORY_NOTE_LENGTH, agentMemoryInputSchema } from './agent-memories';
+import {
+  MAX_MEMORY_COUNT,
+  MAX_MEMORY_NOTE_LENGTH,
+  agentMemoryInputSchema,
+  buildPendingMemoryDraft,
+} from './agent-memories';
 import type { AgentMemory, PendingAgentMemoryDraft } from './agent-memories';
 import {
   AGENT_MEMORIES_STORAGE_KEY,
@@ -143,7 +149,10 @@ describe('agent memories storage', () => {
       truncated: true,
     };
     await savePendingAgentMemoryDraft(storage, draft);
-    await expect(loadPendingAgentMemoryDraft(storage)).resolves.toStrictEqual(draft);
+    await expect(loadPendingAgentMemoryDraft(storage)).resolves.toStrictEqual({
+      ...draft,
+      origin: { kind: 'local' },
+    });
 
     const replacement: PendingAgentMemoryDraft = {
       createdAt: 100,
@@ -152,7 +161,10 @@ describe('agent memories storage', () => {
       text: 'replacement',
     };
     await savePendingAgentMemoryDraft(storage, replacement);
-    await expect(loadPendingAgentMemoryDraft(storage)).resolves.toStrictEqual(replacement);
+    await expect(loadPendingAgentMemoryDraft(storage)).resolves.toStrictEqual({
+      ...replacement,
+      origin: { kind: 'local' },
+    });
 
     await clearPendingAgentMemoryDraft(storage);
     await expect(loadPendingAgentMemoryDraft(storage)).resolves.toBeUndefined();
@@ -164,5 +176,113 @@ describe('agent memories storage', () => {
 
     await expect(loadPendingAgentMemoryDraft(storage)).resolves.toBeUndefined();
     expect(storage.values.has(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY)).toBe(false);
+  });
+});
+
+const delegatedOrigin = {
+  approvalId: 'approval-1',
+  expiresAt: 1_800_000_000_000,
+  invocationId: 'invocation-1',
+  kind: 'delegated' as const,
+};
+
+describe('invocation-scoped memory drafts', () => {
+  it('retains background selections and their old metadata-free producer form', async () => {
+    const storage = createStorage();
+    const selection = buildPendingMemoryDraft({
+      now: 20,
+      pageTitle: 'Background page',
+      pageUrl: 'https://example.com/background?private=value',
+      selectionText: '  From the context menu  ',
+    });
+    if (!selection) {
+      throw new Error('Expected a selection.');
+    }
+    await savePendingAgentMemoryDraft(storage, selection);
+    const loaded = await loadPendingAgentMemoryDraft(storage);
+    await clearPendingAgentMemoryDraft(storage, delegatedOrigin);
+    expect(loaded).toMatchObject({
+      origin: { kind: 'local' },
+      pageUrl: 'https://example.com/background',
+      text: 'From the context menu',
+    });
+    await expect(loadPendingAgentMemoryDraft(storage)).resolves.toStrictEqual(loaded);
+  });
+
+  it('does not replace a local draft when the delegated write guard fails', async () => {
+    const storage = createStorage();
+    await savePendingAgentMemoryDraft(storage, baseInput);
+    await expect(
+      savePendingAgentMemoryDraft(storage, { ...baseInput, origin: delegatedOrigin }, () => {
+        throw new Error('Invocation ended.');
+      })
+    ).rejects.toThrow('Invocation ended.');
+    await expect(loadPendingAgentMemoryDraft(storage)).resolves.toStrictEqual({
+      ...baseInput,
+      origin: { kind: 'local' },
+    });
+  });
+
+  it('preserves delegated identity through storage and clears only its matching approval', async () => {
+    const storage = createStorage();
+    const draft = { ...baseInput, origin: delegatedOrigin };
+    await savePendingAgentMemoryDraft(storage, draft);
+    const loaded = await loadPendingAgentMemoryDraft(storage);
+    await clearPendingAgentMemoryDraft(storage, { ...delegatedOrigin, approvalId: 'older' });
+    expect(loaded).toStrictEqual(draft);
+    await expect(loadPendingAgentMemoryDraft(storage)).resolves.toStrictEqual(draft);
+    await clearPendingAgentMemoryDraft(storage, delegatedOrigin);
+    await expect(loadPendingAgentMemoryDraft(storage)).resolves.toBeUndefined();
+  });
+
+  it('loads old local records without requiring invocation authority', async () => {
+    const storage = createStorage();
+    storage.values.set(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY, baseInput);
+    await expect(loadPendingAgentMemoryDraft(storage)).resolves.toStrictEqual({
+      ...baseInput,
+      origin: { kind: 'local' },
+    });
+  });
+
+  it.each([
+    { kind: 'delegated' },
+    { ...delegatedOrigin, invocationId: '' },
+    { ...delegatedOrigin, approvalId: '' },
+    { ...delegatedOrigin, expiresAt: 'tomorrow' },
+    { ...delegatedOrigin, kind: 'unknown' },
+  ])('rejects malformed origin instead of treating it as local: %j', async origin => {
+    const storage = createStorage();
+    storage.values.set(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY, { ...baseInput, origin });
+    await expect(loadPendingAgentMemoryDraft(storage)).resolves.toBeUndefined();
+    expect(storage.values.has(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY)).toBe(false);
+  });
+
+  it.each([
+    { kind: 'local' as const },
+    { ...delegatedOrigin, approvalId: 'approval-2', invocationId: 'invocation-2' },
+    { ...delegatedOrigin, approvalId: 'approval-2' },
+  ])('preserves a replacement during an asynchronous clear: %j', async origin => {
+    const storage = createStorage();
+    const draft = { ...baseInput, origin: delegatedOrigin };
+    await savePendingAgentMemoryDraft(storage, draft);
+    const readStarted = Promise.withResolvers<void>();
+    const read = Promise.withResolvers<unknown>();
+    const getItem = storage.getItem.bind(storage);
+    let delayRead = true;
+    storage.getItem = key => {
+      if (delayRead && key === PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY) {
+        delayRead = false;
+        readStarted.resolve();
+        return read.promise;
+      }
+      return getItem(key);
+    };
+    const clearing = clearPendingAgentMemoryDraft(storage, delegatedOrigin);
+    await readStarted.promise;
+    const replacement = { ...baseInput, origin, text: 'new selection' };
+    const replacing = savePendingAgentMemoryDraft(storage, replacement);
+    read.resolve(draft);
+    await Promise.all([clearing, replacing]);
+    await expect(loadPendingAgentMemoryDraft(storage)).resolves.toStrictEqual(replacement);
   });
 });

--- a/apps/extension/src/shared/agent-memories-storage.ts
+++ b/apps/extension/src/shared/agent-memories-storage.ts
@@ -3,10 +3,42 @@ import {
   MAX_MEMORY_COUNT,
   agentMemoryInputSchema,
   agentMemorySchema,
+  matchesDelegatedApproval,
   pendingAgentMemoryDraftSchema,
   storedAgentMemoriesSchema,
 } from './agent-memories';
-import type { AgentMemory, AgentMemoryInput, PendingAgentMemoryDraft } from './agent-memories';
+import type {
+  AgentMemory,
+  AgentMemoryInput,
+  DelegatedApprovalOrigin,
+  NormalizedPendingAgentMemoryDraft,
+  PendingAgentMemoryDraft,
+} from './agent-memories';
+import type { ExecutionGuard } from './agent-tool-results';
+
+const draftStorageQueues = new Map<string, Promise<void>>();
+
+/** Serialize comparison and removal with every draft writer, including background selections. */
+export const withPendingDraftStorageLock = async <Result>(
+  key: string,
+  work: () => Promise<Result>
+): Promise<Result> => {
+  const previous = draftStorageQueues.get(key);
+  const finished = Promise.withResolvers<void>();
+  draftStorageQueues.set(key, finished.promise);
+  try {
+    await previous;
+    const locks = globalThis.navigator?.locks;
+    // Old local-only environments without Web Locks retain their in-context storage behavior.
+    // Remove this fallback after those environments retire; delegation requires native locks.
+    return locks === undefined ? await work() : await locks.request(key, work);
+  } finally {
+    finished.resolve();
+    if (draftStorageQueues.get(key) === finished.promise) {
+      draftStorageQueues.delete(key);
+    }
+  }
+};
 
 export const AGENT_MEMORIES_STORAGE_KEY = 'local:kiloAgentMemories';
 export const PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY = 'local:kiloPendingAgentMemoryDraft';
@@ -42,8 +74,10 @@ const toAgentMemory = (value: z.infer<typeof agentMemorySchema>): AgentMemory =>
 
 const toPendingDraft = (
   value: z.infer<typeof pendingAgentMemoryDraftSchema>
-): PendingAgentMemoryDraft => ({
+): NormalizedPendingAgentMemoryDraft => ({
   createdAt: value.createdAt,
+  // Old local draft records lack origin; the schema normalizes them until those records retire.
+  origin: value.origin,
   pageTitle: value.pageTitle,
   pageUrl: value.pageUrl,
   text: value.text,
@@ -77,7 +111,9 @@ export const saveAgentMemories = async (
 
 export const addAgentMemory = async (
   storageArea: AgentMemoriesStorageArea,
-  input: AgentMemoryInput
+  input: AgentMemoryInput,
+  // Old local storage callers omit the guard. Remove this optional form after those callers retire.
+  executionGuard?: ExecutionGuard
 ): Promise<AgentMemory> => {
   const parsedInput = agentMemoryInputSchema.parse(input);
   const memories = await loadAgentMemories(storageArea);
@@ -98,6 +134,7 @@ export const addAgentMemory = async (
   };
 
   const memory = toAgentMemory(agentMemorySchema.parse(candidate));
+  executionGuard?.();
   await saveAgentMemories(storageArea, [...memories, memory]);
   return memory;
 };
@@ -113,33 +150,50 @@ export const deleteAgentMemory = async (
   );
 };
 
-export const savePendingAgentMemoryDraft = async (
+export const savePendingAgentMemoryDraft = (
   storageArea: AgentMemoriesStorageArea,
-  draft: PendingAgentMemoryDraft
-): Promise<void> => {
-  const parsed = toPendingDraft(pendingAgentMemoryDraftSchema.parse(draft));
-  await storageArea.setItem(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY, parsed);
-};
+  draft: PendingAgentMemoryDraft,
+  // Old local storage callers omit the guard. Remove this optional form after those callers retire.
+  executionGuard?: ExecutionGuard
+): Promise<void> =>
+  withPendingDraftStorageLock(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY, async () => {
+    const parsed = toPendingDraft(pendingAgentMemoryDraftSchema.parse(draft));
+    executionGuard?.();
+    await storageArea.setItem(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY, parsed);
+  });
 
-export const loadPendingAgentMemoryDraft = async (
+export const loadPendingAgentMemoryDraft = (
   storageArea: AgentMemoriesStorageArea
-): Promise<PendingAgentMemoryDraft | undefined> => {
-  const value = await storageArea.getItem(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY);
-  if (value === null || value === undefined) {
-    return undefined;
-  }
+): Promise<NormalizedPendingAgentMemoryDraft | undefined> =>
+  withPendingDraftStorageLock(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY, async () => {
+    const value = await storageArea.getItem(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY);
+    if (value === null || value === undefined) {
+      return;
+    }
 
-  const parsed = pendingAgentMemoryDraftSchema.safeParse(value);
-  if (!parsed.success) {
+    const parsed = pendingAgentMemoryDraftSchema.safeParse(value);
+    if (!parsed.success) {
+      await storageArea.removeItem(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY);
+      return;
+    }
+
+    return toPendingDraft(parsed.data);
+  });
+
+export const clearPendingAgentMemoryDraft = (
+  storageArea: AgentMemoriesStorageArea,
+  expected?: DelegatedApprovalOrigin
+): Promise<void> =>
+  withPendingDraftStorageLock(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY, async () => {
+    if (expected !== undefined) {
+      const current = pendingAgentMemoryDraftSchema.safeParse(
+        await storageArea.getItem(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY)
+      );
+      if (!current.success || !matchesDelegatedApproval(current.data.origin, expected)) {
+        return;
+      }
+    }
+    // Old local callers clear the sole draft without an invocation comparison.
+    // Remove that call form only after all old local draft producers retire.
     await storageArea.removeItem(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY);
-    return undefined;
-  }
-
-  return toPendingDraft(parsed.data);
-};
-
-export const clearPendingAgentMemoryDraft = async (
-  storageArea: AgentMemoriesStorageArea
-): Promise<void> => {
-  await storageArea.removeItem(PENDING_AGENT_MEMORY_DRAFT_STORAGE_KEY);
-};
+  });

--- a/apps/extension/src/shared/agent-memories.ts
+++ b/apps/extension/src/shared/agent-memories.ts
@@ -22,7 +22,32 @@ export interface AgentMemory {
 
 export type AgentMemoryInput = Omit<AgentMemory, 'id'>;
 
+const localApprovalOriginSchema = z.object({ kind: z.literal('local') });
+export const delegatedApprovalOriginSchema = z.object({
+  approvalId: z.string().min(1),
+  expiresAt: z.number().int().nonnegative(),
+  invocationId: z.string().min(1),
+  kind: z.literal('delegated'),
+});
+export const approvalOriginSchema = z
+  .discriminatedUnion('kind', [localApprovalOriginSchema, delegatedApprovalOriginSchema])
+  // Old local draft records, including background selections, have no origin.
+  // Remove this default only after all origin-free producers and stored drafts retire.
+  .default({ kind: 'local' });
+export type ApprovalOrigin = z.infer<typeof approvalOriginSchema>;
+export type DelegatedApprovalOrigin = z.infer<typeof delegatedApprovalOriginSchema>;
+
+export const matchesDelegatedApproval = (
+  origin: ApprovalOrigin,
+  expected: DelegatedApprovalOrigin
+): boolean =>
+  origin.kind === 'delegated' &&
+  origin.invocationId === expected.invocationId &&
+  origin.approvalId === expected.approvalId &&
+  origin.expiresAt === expected.expiresAt;
+
 export interface PendingAgentMemoryDraft {
+  origin?: ApprovalOrigin | undefined;
   text: string;
   note?: string | undefined;
   pageTitle: string;
@@ -56,10 +81,15 @@ export const agentMemoryInputSchema = z
 
 export const storedAgentMemoriesSchema = z.array(z.unknown());
 
+export type NormalizedPendingAgentMemoryDraft = PendingAgentMemoryDraft & {
+  origin: ApprovalOrigin;
+};
+
 export const pendingAgentMemoryDraftSchema = z
   .object({
     createdAt: z.number(),
     note: z.string().max(MAX_MEMORY_NOTE_LENGTH).optional(),
+    origin: approvalOriginSchema,
     pageTitle: z.string(),
     pageUrl: z.string(),
     text: z.string(),
@@ -109,11 +139,13 @@ export const buildPendingMemoryDraft = ({
   pageTitle,
   pageUrl,
   now,
+  origin,
 }: {
   selectionText: string | undefined;
   pageTitle: string;
   pageUrl: string;
   now: number;
+  origin?: ApprovalOrigin | undefined;
 }): PendingAgentMemoryDraft | undefined => {
   const trimmed = (selectionText ?? '').trim();
   if (trimmed.length === 0) {
@@ -128,6 +160,7 @@ export const buildPendingMemoryDraft = ({
     pageTitle,
     pageUrl: pageUrl === '' ? '' : sanitizeTabContextUrl(pageUrl),
     text,
+    ...(origin === undefined ? {} : { origin }),
     ...(truncated ? { truncated: true } : {}),
   };
 };

--- a/apps/extension/src/shared/agent-workflows-storage.test.ts
+++ b/apps/extension/src/shared/agent-workflows-storage.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines -- Contract review repairs added tests for pathPrefix/startUrl clearing; splitting would obscure coverage. */
+/* eslint-disable jest/no-conditional-in-test -- Storage fixtures route delayed reads; the table runs every origin case. */
 import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_WORKFLOW_SETTINGS,
@@ -256,7 +257,10 @@ describe('agent workflows storage', () => {
       workflowId: 'existing-id',
     };
     await savePendingWorkflowDraft(storage, draft);
-    await expect(loadPendingWorkflowDraft(storage)).resolves.toStrictEqual(draft);
+    await expect(loadPendingWorkflowDraft(storage)).resolves.toStrictEqual({
+      ...draft,
+      origin: { kind: 'local' },
+    });
 
     const replacement: PendingAgentWorkflowDraft = {
       createdAt: 100,
@@ -266,7 +270,10 @@ describe('agent workflows storage', () => {
       script: 'return 2;',
     };
     await savePendingWorkflowDraft(storage, replacement);
-    await expect(loadPendingWorkflowDraft(storage)).resolves.toStrictEqual(replacement);
+    await expect(loadPendingWorkflowDraft(storage)).resolves.toStrictEqual({
+      ...replacement,
+      origin: { kind: 'local' },
+    });
 
     await clearPendingWorkflowDraft(storage);
     await expect(loadPendingWorkflowDraft(storage)).resolves.toBeUndefined();
@@ -464,5 +471,93 @@ describe('workflow params storage', () => {
     const created = await baseCreate(storage, { params });
     const updated = await updateAgentWorkflow(storage, created.id, { name: 'Renamed' });
     expect(updated.params).toStrictEqual(params);
+  });
+});
+
+const delegatedOrigin = {
+  approvalId: 'approval-1',
+  expiresAt: 1_800_000_000_000,
+  invocationId: 'invocation-1',
+  kind: 'delegated' as const,
+};
+
+describe('invocation-scoped workflow drafts', () => {
+  it('does not replace a local draft when the delegated write guard fails', async () => {
+    const storage = createStorage();
+    const local = { ...baseInput, createdAt: 1 };
+    await savePendingWorkflowDraft(storage, local);
+    await expect(
+      savePendingWorkflowDraft(storage, { ...local, origin: delegatedOrigin }, () => {
+        throw new Error('Invocation ended.');
+      })
+    ).rejects.toThrow('Invocation ended.');
+    await expect(loadPendingWorkflowDraft(storage)).resolves.toStrictEqual({
+      ...local,
+      origin: { kind: 'local' },
+    });
+  });
+
+  it('preserves delegated identity through storage and clears only its matching approval', async () => {
+    const storage = createStorage();
+    const draft = { ...baseInput, createdAt: 1, origin: delegatedOrigin };
+    await savePendingWorkflowDraft(storage, draft);
+    const loaded = await loadPendingWorkflowDraft(storage);
+    await clearPendingWorkflowDraft(storage, { ...delegatedOrigin, approvalId: 'older' });
+    expect(loaded).toStrictEqual(draft);
+    await expect(loadPendingWorkflowDraft(storage)).resolves.toStrictEqual(draft);
+    await clearPendingWorkflowDraft(storage, delegatedOrigin);
+    await expect(loadPendingWorkflowDraft(storage)).resolves.toBeUndefined();
+  });
+
+  it('loads old local records without requiring invocation authority', async () => {
+    const storage = createStorage();
+    storage.values.set(PENDING_WORKFLOW_SAVE_STORAGE_KEY, { ...baseInput, createdAt: 1 });
+    await expect(loadPendingWorkflowDraft(storage)).resolves.toStrictEqual({
+      ...baseInput,
+      createdAt: 1,
+      origin: { kind: 'local' },
+    });
+  });
+
+  it.each([
+    { kind: 'delegated' },
+    { ...delegatedOrigin, invocationId: '' },
+    { ...delegatedOrigin, approvalId: '' },
+    { ...delegatedOrigin, expiresAt: 'tomorrow' },
+    { ...delegatedOrigin, kind: 'unknown' },
+  ])('rejects malformed origin instead of treating it as local: %j', async origin => {
+    const storage = createStorage();
+    storage.values.set(PENDING_WORKFLOW_SAVE_STORAGE_KEY, { ...baseInput, createdAt: 1, origin });
+    await expect(loadPendingWorkflowDraft(storage)).resolves.toBeUndefined();
+    expect(storage.values.has(PENDING_WORKFLOW_SAVE_STORAGE_KEY)).toBe(false);
+  });
+
+  it.each([
+    { kind: 'local' as const },
+    { ...delegatedOrigin, approvalId: 'approval-2', invocationId: 'invocation-2' },
+    { ...delegatedOrigin, approvalId: 'approval-2' },
+  ])('preserves a replacement during an asynchronous clear: %j', async origin => {
+    const storage = createStorage();
+    const draft = { ...baseInput, createdAt: 1, origin: delegatedOrigin };
+    await savePendingWorkflowDraft(storage, draft);
+    const readStarted = Promise.withResolvers<void>();
+    const read = Promise.withResolvers<unknown>();
+    const getItem = storage.getItem.bind(storage);
+    let delayRead = true;
+    storage.getItem = key => {
+      if (delayRead && key === PENDING_WORKFLOW_SAVE_STORAGE_KEY) {
+        delayRead = false;
+        readStarted.resolve();
+        return read.promise;
+      }
+      return getItem(key);
+    };
+    const clearing = clearPendingWorkflowDraft(storage, delegatedOrigin);
+    await readStarted.promise;
+    const replacement = { ...baseInput, createdAt: 2, name: 'New draft', origin };
+    const replacing = savePendingWorkflowDraft(storage, replacement);
+    read.resolve(draft);
+    await Promise.all([clearing, replacing]);
+    await expect(loadPendingWorkflowDraft(storage)).resolves.toStrictEqual(replacement);
   });
 });

--- a/apps/extension/src/shared/agent-workflows-storage.ts
+++ b/apps/extension/src/shared/agent-workflows-storage.ts
@@ -1,4 +1,8 @@
 import type { z } from 'zod';
+import type { ExecutionGuard } from './agent-tool-results';
+import { matchesDelegatedApproval } from './agent-memories';
+import type { DelegatedApprovalOrigin } from './agent-memories';
+import { withPendingDraftStorageLock } from './agent-memories-storage';
 import {
   DEFAULT_WORKFLOW_SETTINGS,
   MAX_WORKFLOW_COUNT,
@@ -12,6 +16,7 @@ import type {
   AgentWorkflow,
   AgentWorkflowInput,
   AgentWorkflowSettings,
+  NormalizedPendingAgentWorkflowDraft,
   PendingAgentWorkflowDraft,
 } from './agent-workflows';
 
@@ -55,11 +60,13 @@ const toAgentWorkflow = (value: z.infer<typeof agentWorkflowSchema>): AgentWorkf
 
 const toPendingDraft = (
   value: z.infer<typeof pendingAgentWorkflowDraftSchema>
-): PendingAgentWorkflowDraft => {
-  const draft: PendingAgentWorkflowDraft = {
+): NormalizedPendingAgentWorkflowDraft => {
+  const draft: NormalizedPendingAgentWorkflowDraft = {
     createdAt: value.createdAt,
     description: value.description,
     name: value.name,
+    // Old local draft records lack origin; the schema normalizes them until those records retire.
+    origin: value.origin,
     scopeOrigin: value.scopeOrigin,
     script: value.script,
   };
@@ -108,7 +115,9 @@ export const saveAgentWorkflows = async (
 
 export const addAgentWorkflow = async (
   storageArea: AgentWorkflowsStorageArea,
-  input: AgentWorkflowInput
+  input: AgentWorkflowInput,
+  // Old local storage callers omit the guard. Remove this optional form after those callers retire.
+  executionGuard?: ExecutionGuard
 ): Promise<AgentWorkflow> => {
   const parsedInput = agentWorkflowInputSchema.parse(input);
   const workflows = await loadAgentWorkflows(storageArea);
@@ -135,14 +144,18 @@ export const addAgentWorkflow = async (
   };
 
   const workflow = toAgentWorkflow(agentWorkflowSchema.parse(candidate));
+  executionGuard?.();
   await saveAgentWorkflows(storageArea, [...workflows, workflow]);
   return workflow;
 };
 
+// eslint-disable-next-line max-params -- The optional guard preserves the existing update API.
 export const updateAgentWorkflow = async (
   storageArea: AgentWorkflowsStorageArea,
   id: string,
-  updates: Partial<AgentWorkflowInput>
+  updates: Partial<AgentWorkflowInput>,
+  // Old local storage callers omit the guard. Remove this optional form after those callers retire.
+  executionGuard?: ExecutionGuard
 ): Promise<AgentWorkflow> => {
   const workflows = await loadAgentWorkflows(storageArea);
   const existing = workflows.find(workflow => workflow.id === id);
@@ -181,6 +194,7 @@ export const updateAgentWorkflow = async (
 
   const validated = toAgentWorkflow(agentWorkflowSchema.parse(updated));
   const replaced = workflows.map(workflow => (workflow.id === id ? validated : workflow));
+  executionGuard?.();
   await saveAgentWorkflows(storageArea, replaced);
   return validated;
 };
@@ -196,36 +210,53 @@ export const deleteAgentWorkflow = async (
   );
 };
 
-export const savePendingWorkflowDraft = async (
+export const savePendingWorkflowDraft = (
   storageArea: AgentWorkflowsStorageArea,
-  draft: PendingAgentWorkflowDraft
-): Promise<void> => {
-  const parsed = toPendingDraft(pendingAgentWorkflowDraftSchema.parse(draft));
-  await storageArea.setItem(PENDING_WORKFLOW_SAVE_STORAGE_KEY, parsed);
-};
+  draft: PendingAgentWorkflowDraft,
+  // Old local storage callers omit the guard. Remove this optional form after those callers retire.
+  executionGuard?: ExecutionGuard
+): Promise<void> =>
+  withPendingDraftStorageLock(PENDING_WORKFLOW_SAVE_STORAGE_KEY, async () => {
+    const parsed = toPendingDraft(pendingAgentWorkflowDraftSchema.parse(draft));
+    executionGuard?.();
+    await storageArea.setItem(PENDING_WORKFLOW_SAVE_STORAGE_KEY, parsed);
+  });
 
-export const loadPendingWorkflowDraft = async (
+export const loadPendingWorkflowDraft = (
   storageArea: AgentWorkflowsStorageArea
-): Promise<PendingAgentWorkflowDraft | undefined> => {
-  const value = await storageArea.getItem(PENDING_WORKFLOW_SAVE_STORAGE_KEY);
-  if (value === null || value === undefined) {
-    return undefined;
-  }
+): Promise<NormalizedPendingAgentWorkflowDraft | undefined> =>
+  withPendingDraftStorageLock(PENDING_WORKFLOW_SAVE_STORAGE_KEY, async () => {
+    const value = await storageArea.getItem(PENDING_WORKFLOW_SAVE_STORAGE_KEY);
+    if (value === null || value === undefined) {
+      return;
+    }
 
-  const parsed = pendingAgentWorkflowDraftSchema.safeParse(value);
-  if (!parsed.success) {
+    const parsed = pendingAgentWorkflowDraftSchema.safeParse(value);
+    if (!parsed.success) {
+      await storageArea.removeItem(PENDING_WORKFLOW_SAVE_STORAGE_KEY);
+      return;
+    }
+
+    return toPendingDraft(parsed.data);
+  });
+
+export const clearPendingWorkflowDraft = (
+  storageArea: AgentWorkflowsStorageArea,
+  expected?: DelegatedApprovalOrigin
+): Promise<void> =>
+  withPendingDraftStorageLock(PENDING_WORKFLOW_SAVE_STORAGE_KEY, async () => {
+    if (expected !== undefined) {
+      const current = pendingAgentWorkflowDraftSchema.safeParse(
+        await storageArea.getItem(PENDING_WORKFLOW_SAVE_STORAGE_KEY)
+      );
+      if (!current.success || !matchesDelegatedApproval(current.data.origin, expected)) {
+        return;
+      }
+    }
+    // Old local callers clear the sole draft without an invocation comparison.
+    // Remove that call form only after all old local draft producers retire.
     await storageArea.removeItem(PENDING_WORKFLOW_SAVE_STORAGE_KEY);
-    return undefined;
-  }
-
-  return toPendingDraft(parsed.data);
-};
-
-export const clearPendingWorkflowDraft = async (
-  storageArea: AgentWorkflowsStorageArea
-): Promise<void> => {
-  await storageArea.removeItem(PENDING_WORKFLOW_SAVE_STORAGE_KEY);
-};
+  });
 
 export const loadWorkflowSettings = async (
   storageArea: AgentWorkflowsStorageArea

--- a/apps/extension/src/shared/agent-workflows.ts
+++ b/apps/extension/src/shared/agent-workflows.ts
@@ -1,5 +1,7 @@
 /* eslint-disable max-lines -- Single domain module for workflow types, validation, search, and formatting; splitting would scatter the contract. */
 import { z } from 'zod';
+import { approvalOriginSchema } from './agent-memories';
+import type { ApprovalOrigin } from './agent-memories';
 import { sanitizeTabContextText } from './tab-context-sanitize';
 
 export const MAX_WORKFLOW_COUNT = 100;
@@ -48,6 +50,7 @@ export type AgentWorkflowInput = Omit<
 };
 
 export interface PendingAgentWorkflowDraft {
+  origin?: ApprovalOrigin | undefined;
   workflowId?: string | undefined;
   name: string;
   description: string;
@@ -107,11 +110,16 @@ export const agentWorkflowInputSchema = z
 
 export const storedAgentWorkflowsSchema = z.array(z.unknown());
 
+export type NormalizedPendingAgentWorkflowDraft = PendingAgentWorkflowDraft & {
+  origin: ApprovalOrigin;
+};
+
 export const pendingAgentWorkflowDraftSchema = z
   .object({
     createdAt: z.number(),
     description: z.string().max(MAX_WORKFLOW_DESCRIPTION_LENGTH),
     name: z.string().max(MAX_WORKFLOW_NAME_LENGTH),
+    origin: approvalOriginSchema,
     params: workflowParamsSchema.optional(),
     pathPrefix: z.string().nullable().optional(),
     scopeOrigin: z.string(),


### PR DESCRIPTION
- Workflow save prompts disappear when there is no draft left to save.
- A newer memory or workflow draft no longer inherits an older prompt’s save result, error, or disabled buttons.
- Repeated clicks cannot start a second save while the same draft is saving.

---

## Summary

`DelegatedApprovalScope` adds trusted `isLive` and `executionGuard` callbacks to `requestApproval`; `PendingApprovalEntry` requires normalized drafts, and persisted metadata grants no delegated authority. `applyApprovalDecision` returns `aborted` for expired, cancelled, replayed, or unproven reloaded approvals and rechecks authority before writes; Stop cannot undo an issued save. `settleMatchingApproval` keeps failed live delegated approvals pending for explicit retry, while terminal settlement clears only matching approval state.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/pending-approval.ts` — Source, modified, 570 changed lines. Generates fresh approval IDs, validates draft kinds, and adds expiry timers with first-wins settlement. Keeps one approval lock across settings reads and draft persistence; automatic approval retains the settings fallback. Preserves local cleanup errors, but delegated cleanup failures cannot retract a successful save. Prevents retained callbacks from clearing another request’s entry or lock.
- `apps/extension/entrypoints/sidepanel/pending-approval.test.ts` — Test, modified, 369 changed lines. Updates the approval lifecycle tests.

</details>

`ApprovalOrigin` uses `approvalOriginSchema` to distinguish local drafts from `DelegatedApprovalOrigin`, whose `delegatedApprovalOriginSchema` requires `invocationId`, `approvalId`, and `expiresAt`. `PendingAgentMemoryDraft` and `PendingAgentWorkflowDraft` keep optional origins; `NormalizedPendingAgentMemoryDraft` and `NormalizedPendingAgentWorkflowDraft` require them. `pendingAgentMemoryDraftSchema` and `pendingAgentWorkflowDraftSchema` default absent origins to local, preserving existing drafts and background selections without migration.

<details>
<summary>Files</summary>

- `apps/extension/src/shared/agent-memories.ts` — Source, modified, 33 changed lines. Defines origin validation, exact delegated approval matching, and normalized memory drafts. Requires nonempty delegated IDs and a nonnegative integer expiry; `buildPendingMemoryDraft` passes through an optional origin.
- `apps/extension/src/shared/agent-workflows.ts` — Source, modified, 8 changed lines. Shares origin validation and adds the normalized workflow draft type while preserving optional producer metadata.

</details>

`withPendingDraftStorageLock` serializes draft access with a queue and Web Locks; the fallback retains local, in-context behavior. `addAgentMemory`, `addAgentWorkflow`, `updateAgentWorkflow`, `savePendingAgentMemoryDraft`, and `savePendingWorkflowDraft` accept optional `ExecutionGuard` callbacks immediately before writes. `clearPendingAgentMemoryDraft` and `clearPendingWorkflowDraft` accept an expected `DelegatedApprovalOrigin`, preventing stale cleanup from deleting replacements; old callers still clear unconditionally.

<details>
<summary>Files</summary>

- `apps/extension/src/shared/agent-memories-storage.ts` — Source, modified, 110 changed lines. Adds the shared queue and native lock, preserves origins in serialization, and returns normalized drafts. Guards saves after awaited preparation and serializes comparison with removal, including writes from background selections.
- `apps/extension/src/shared/agent-workflows-storage.ts` — Source, modified, 89 changed lines. Uses the shared lock for draft reads, saves, and conditional removal. Preserves origins, returns normalized drafts, and guards workflow creation, updates, and draft writes.
- `apps/extension/src/shared/agent-memories-storage.test.ts` — Test, modified, 126 changed lines. Updates the memory draft persistence tests.
- `apps/extension/src/shared/agent-workflows-storage.test.ts` — Test, modified, 99 changed lines. Updates the workflow draft persistence tests.

</details>

`PendingMemorySaveCard` and `PendingWorkflowSaveCard` use `approvalDraftKey`, `isApprovalDraftLive`, and `discardInactiveApprovalDraft` to hide stale delegated cards and protect newer drafts. Empty reloads clear old workflow forms, and save failures keep retry or rejection controls while the delegated invocation remains live. Local drafts still reload, background memory selections keep priority, and per-draft save locks prevent repeated clicks from starting duplicate saves.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/pending-memory-save-card.tsx` — Source, modified, 168 changed lines. Normalizes stored drafts, prefers the active entry when delegation is involved, and reads decisions from the component’s atom store. Resets note, error, and busy state by draft identity; ignores older save or cancellation results. Renders the supervision slot in every visible state, including saved confirmation.
- `apps/extension/entrypoints/sidepanel/pending-workflow-save-card.tsx` — Source, modified, 198 changed lines. Rechecks liveness after asynchronous loads and clears form, error, comparison, and busy state when drafts disappear or change. Ignores superseded loads and decisions, retains explicit recovery after live delegated save failures, and renders the supervision slot throughout the modal.
- `apps/extension/entrypoints/sidepanel/pending-workflow-save-card.test.ts` — Test, modified, 561 changed lines. Updates the approval card tests.

</details>

`BrowserTaskSupervisionContext` defaults to `null`; `BrowserTaskSupervisionSlot` places supplied content inside both approval dialogs without adding a wrapper or spacing. The slot remains available during editing, saving, errors, full storage, and memory confirmation, so supervision stays within the modal boundary. This level adds no provider controls and does not enable complete delegated execution.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/browser-task-supervision-slot.tsx` — Source, added, 8 changed lines. Adds the shared context and slot; an absent provider renders nothing and leaves the local layout unchanged.

</details>

Tests: 4 modified files—`pending-approval.test.ts`, `pending-workflow-save-card.test.ts`, `agent-memories-storage.test.ts`, and `agent-workflows-storage.test.ts`—with 1,155 changed lines.
Generated: 0 files changed.

---

## Verification

Manual browser verification has not run; this level does not enable the complete provider feature. Live browser verification remains pending, and the handoff includes no end-to-end (E2E) report.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Human steps

- **before merge:** Complete all section gates, including checks with native Chrome, Firefox, the real command-line interface (CLI), and the local relay.
- **before merge:** After the gates pass, merge the lower stack levels before this level.
- **after merge:** Continue merging the higher stack levels in order.

This level needs no new environment values, secrets, data migration, feature flags, or cache resets.

### Context

- This description covers Cloud level 9, from `browser-task-0787-s8` to `browser-task-0787-s9`, not the complete section.
- The base is [Cloud level 8](https://github.com/Kilo-Org/cloud/pull/5694), which supplies browser execution coordination.
- The companion [CLI level 6](https://github.com/Kilo-Org/kilocode/pull/13567) supplies owned browser-job support.
- The handoff reports 188 passing tests and all five scoped checks passing. These are automated results, not manual browser evidence.

### Notes

Live browser verification is pending. Native Chrome and Firefox behavior, the real CLI, and the local relay remain required before human-ready.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `browser-task-0787` — #5638
2. `browser-task-0787-s2` — #5644
3. `browser-task-0787-s3` — #5648
4. `browser-task-0787-s4` — #5653
7. `browser-task-0787-s7` — #5681
8. `browser-task-0787-s8` — #5694
9. `browser-task-0787-s9` — #5698 ← this PR
10. `browser-task-0787-s10` — #5702
11. `browser-task-0787-s11` — #5716
12. `browser-task-0787-s12` — #5734
13. `browser-task-0787-s13` — #5742 (tip)

