### PR TITLE
feat(pr-review): integrate independent review context reads

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-people.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-people.test.ts
@@ -5,8 +5,20 @@ import {
   PR_CONTEXT_REVISION_QUERY,
 } from './context-reader';
 import { PR_CONTEXT_PEOPLE_QUERIES } from './context-people';
+import { PR_REVIEW_GRAPHQL_DOCUMENTS } from '@/routers/github-pr-review-router';
 import { GitHubPrReviewContextSchema } from './context-dtos';
 import type { PullRequestRestData } from './mappers';
+import type * as TrpcServer from '@trpc/server';
+
+// The registry identifies allowed sibling sources without starting router services.
+jest.mock('@/lib/trpc/init', () => {
+  const { initTRPC } = jest.requireActual<typeof TrpcServer>('@trpc/server');
+  const t = initTRPC.create();
+  return { baseProcedure: t.procedure, createTRPCRouter: t.router };
+});
+jest.mock('@/lib/drizzle', () => ({}));
+jest.mock('@kilocode/db/operation-ledger', () => ({}));
+jest.mock('@/lib/integrations/platforms/github/user-token-client', () => ({}));
 
 const fields = ['labels', 'assignees', 'reviewRequests'] as const;
 type Field = (typeof fields)[number];
@@ -124,8 +136,11 @@ async function run(
           },
         };
       const field = fields.find(field => PR_CONTEXT_PEOPLE_QUERIES[field] === body.query);
-      if (!field) throw new Error('Unexpected per-person request');
-      return serve(field, body.variables.after, body.request.signal);
+      if (field) return serve(field, body.variables.after, body.request.signal);
+      if (!Object.values(PR_REVIEW_GRAPHQL_DOCUMENTS).includes(body.query))
+        throw new Error('Unexpected per-person request');
+      // Registered sibling sources are outside this fixture's people evidence.
+      return { data: { data: { repository: { pullRequest: {} } } } };
     },
   } as unknown as Octokit;
   return GitHubPrReviewContextSchema.parse(
@@ -165,8 +180,13 @@ it('traverses more than 100 entries independently without per-person requests', 
     });
     expect(result[field].items).toHaveLength(counts[field]);
   }
-  // Two pages per collection and the final revision read, without identity lookups.
-  expect(requests).toHaveLength(7);
+  // Two pages per people collection; registered sibling sources do not weaken this bound.
+  expect(
+    requests.filter(query => Object.values(PR_CONTEXT_PEOPLE_QUERIES).includes(query))
+  ).toHaveLength(6);
+  expect(requests.every(query => Object.values(PR_REVIEW_GRAPHQL_DOCUMENTS).includes(query))).toBe(
+    true
+  );
 });
 
 describe.each(fields)('%s completeness', field => {

--- a/apps/web/src/lib/github-pr-review/context-reader.ts
+++ b/apps/web/src/lib/github-pr-review/context-reader.ts
@@ -22,7 +22,7 @@ import {
 import {
   PR_CONTEXT_REVIEW_QUERIES,
   contextReviewSchema,
-  contextReviewsAgree,
+  contextReviewEvidenceConflicts,
   resolveContextReviewDecisions,
 } from './context-reviews';
 
@@ -376,11 +376,13 @@ export async function readPullRequestContext(
     latestOpinionatedReviews: new Map<string, z.output<typeof contextReviewSchema>>(),
     latestReviews: new Map<string, z.output<typeof contextReviewSchema>>(),
   };
+  const conflictingReviewIds = new Set<string>();
   const collectReviews = (
     field: keyof typeof PR_CONTEXT_REVIEW_QUERIES,
     fallback: GitHubPrReviewContext['reviewDecisions']
   ) => {
     const evidence = reviewEvidence[field];
+    const pageConflicts = new Set<string>();
     return collect(
       field,
       contextReviewSchema,
@@ -410,12 +412,7 @@ export async function readPullRequestContext(
         const current: z.output<typeof contextReviewSchema> = {
           ...review,
           submittedAt,
-          // A failed field or conflicting page cannot establish a current decision.
-          state:
-            state.source.availability !== 'available' ||
-            (previous && !contextReviewsAgree(previous, { ...review, submittedAt }))
-              ? 'UNKNOWN'
-              : review.state,
+          state: state.source.availability === 'available' ? review.state : 'UNKNOWN',
           onBehalfOf: {
             ...review.onBehalfOf,
             completeness: available
@@ -430,12 +427,18 @@ export async function readPullRequestContext(
             },
           },
         };
-        // Null observations cannot erase comparison evidence or supply public field values.
+        if (previous && contextReviewEvidenceConflicts(previous, current)) {
+          pageConflicts.add(review.id);
+          conflictingReviewIds.add(review.id);
+        }
+        // Missing observations cannot erase comparison evidence or supply public field values.
         evidence.set(review.id, {
           ...current,
+          state: current.state === 'UNKNOWN' ? (previous?.state ?? 'UNKNOWN') : current.state,
           submittedAt: current.submittedAt ?? previous?.submittedAt ?? null,
           commitSha: current.commitSha ?? previous?.commitSha ?? null,
         });
+        if (pageConflicts.has(review.id)) current.state = 'UNKNOWN';
         return current;
       }
     );
@@ -477,13 +480,15 @@ export async function readPullRequestContext(
   for (const review of context.reviewDecisions.items) {
     const opinionated = reviewEvidence.latestOpinionatedReviews.get(review.id);
     const activity = reviewEvidence.latestReviews.get(review.id);
-    if (opinionated && activity && !contextReviewsAgree(opinionated, activity)) {
+    if (opinionated && activity && contextReviewEvidenceConflicts(opinionated, activity)) {
+      conflictingReviewIds.add(review.id);
       review.state = 'UNKNOWN';
     }
   }
   context.reviewDecisions = resolveContextReviewDecisions(
     context.reviewDecisions,
-    context.reviewActivity
+    context.reviewActivity,
+    conflictingReviewIds
   );
   const final = decodeContextGraphQlSource(
     await read('graphql.revision', async (signal): Promise<unknown> => {

--- a/apps/web/src/lib/github-pr-review/context-reader.ts
+++ b/apps/web/src/lib/github-pr-review/context-reader.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import type { Octokit } from '@octokit/rest';
 import {
   GitHubPrReviewContextSchema,
+  GitHubPrReviewTimestampSchema,
   type GitHubPrReviewContext,
   type GitHubPrReviewRevision,
   type GitHubPrReviewSource,
@@ -18,7 +19,14 @@ import {
   contextReviewRequestSchema,
   mergeKnownContextIdentity,
 } from './context-people';
+import {
+  PR_CONTEXT_REVIEW_QUERIES,
+  contextReviewSchema,
+  contextReviewsAgree,
+  resolveContextReviewDecisions,
+} from './context-reviews';
 
+const collectionQueries = { ...PR_CONTEXT_PEOPLE_QUERIES, ...PR_CONTEXT_REVIEW_QUERIES };
 const deadlineError = new Error('PR context deadline');
 type PrInput = { owner: string; repo: string; number: number };
 export type ContextReadResult<T> = { data: T | null; source: GitHubPrReviewSource };
@@ -222,7 +230,7 @@ const graphQlRevisionSchema = z
   );
 
 function invalidateRevision(context: GitHubPrReviewContext, source: GitHubPrReviewSource) {
-  for (const collection of [context.requirements, context.checks]) {
+  for (const collection of [context.reviewDecisions, context.requirements, context.checks]) {
     collection.source = source;
     collection.completeness = 'unknown';
   }
@@ -255,11 +263,12 @@ export async function readPullRequestContext(
   const read = createContextSourceReader(octokit, input, budget);
   type Collection<T> = Omit<GitHubPrReviewContext['labels'], 'items'> & { items: T[] };
   async function collect<T extends { id: string | null } | null>(
-    field: keyof typeof PR_CONTEXT_PEOPLE_QUERIES,
+    field: keyof typeof collectionQueries,
     node: z.ZodType<T>,
     fallback: Collection<T>,
     merge: (known: T, current: T) => T,
-    matches = (known: T, current: T) => known?.id != null && known.id === current?.id
+    matches = (known: T, current: T) => known?.id != null && known.id === current?.id,
+    normalize: (item: T, result: ContextReadResult<unknown>, index: number) => T = item => item
   ): Promise<Collection<T>> {
     const schema = z.object({
       nodes: z.array(node.nullable().catch(null)).nullish().catch(null),
@@ -289,23 +298,20 @@ export async function readPullRequestContext(
       ),
     });
     for (;;) {
-      const page = decodeContextGraphQlSource(
-        await read(`graphql.${field}`, async (signal): Promise<unknown> => {
-          const response = await octokit.request('POST /graphql', {
-            query: PR_CONTEXT_PEOPLE_QUERIES[field],
-            variables: {
-              owner: input.owner,
-              name: input.repo,
-              number: input.number,
-              after: collection.endCursor,
-            },
-            request: { signal },
-          });
-          return response.data;
-        }),
-        ['repository', 'pullRequest', field],
-        schema
-      );
+      const result = await read(`graphql.${field}`, async (signal): Promise<unknown> => {
+        const response = await octokit.request('POST /graphql', {
+          query: collectionQueries[field],
+          variables: {
+            owner: input.owner,
+            name: input.repo,
+            number: input.number,
+            after: collection.endCursor,
+          },
+          request: { signal },
+        });
+        return response.data;
+      });
+      const page = decodeContextGraphQlSource(result, ['repository', 'pullRequest', field], schema);
       collection.source = page.source;
       if (page.source.availability !== 'available') incomplete = markIncomplete();
       if (!page.data) break;
@@ -321,8 +327,8 @@ export async function readPullRequestContext(
       collection.totalCount = totalCount ?? collection.totalCount;
       collection.hasNextPage = pageInfo?.hasNextPage ?? null;
       collection.endCursor = pageInfo?.endCursor ?? null;
-      for (const item of nodes ?? []) {
-        if (item?.id) entries.set(item.id, item);
+      for (const [index, item] of (nodes ?? []).entries()) {
+        if (item?.id) entries.set(item.id, normalize(item, result, index));
         else incomplete = markIncomplete();
       }
       if (!pageInfo?.hasNextPage) break;
@@ -366,7 +372,81 @@ export async function readPullRequestContext(
       : 'complete';
     return collection;
   }
-  [context.labels, context.assignees, context.reviewRequests] = await Promise.all([
+  const reviewEvidence = {
+    latestOpinionatedReviews: new Map<string, z.output<typeof contextReviewSchema>>(),
+    latestReviews: new Map<string, z.output<typeof contextReviewSchema>>(),
+  };
+  const collectReviews = (
+    field: keyof typeof PR_CONTEXT_REVIEW_QUERIES,
+    fallback: GitHubPrReviewContext['reviewDecisions']
+  ) => {
+    const evidence = reviewEvidence[field];
+    return collect(
+      field,
+      contextReviewSchema,
+      fallback,
+      (_known, current) => current,
+      undefined,
+      (review, result, index) => {
+        const attribution = decodeContextGraphQlSource(
+          result,
+          ['repository', 'pullRequest', field, 'nodes', index, 'onBehalfOf'],
+          z.object({})
+        );
+        const state = decodeContextGraphQlSource(
+          result,
+          ['repository', 'pullRequest', field, 'nodes', index, 'state'],
+          z.string()
+        );
+        const submission = decodeContextGraphQlSource(
+          result,
+          ['repository', 'pullRequest', field, 'nodes', index, 'submittedAt'],
+          GitHubPrReviewTimestampSchema.nullable()
+        );
+        const submittedAt =
+          submission.source.availability === 'available' ? review.submittedAt : null;
+        const available = attribution.source.availability === 'available';
+        const previous = evidence.get(review.id);
+        const current: z.output<typeof contextReviewSchema> = {
+          ...review,
+          submittedAt,
+          // A failed field or conflicting page cannot establish a current decision.
+          state:
+            state.source.availability !== 'available' ||
+            (previous && !contextReviewsAgree(previous, { ...review, submittedAt }))
+              ? 'UNKNOWN'
+              : review.state,
+          onBehalfOf: {
+            ...review.onBehalfOf,
+            completeness: available
+              ? review.onBehalfOf.completeness
+              : review.onBehalfOf.knownCount
+                ? 'partial'
+                : 'unknown',
+            source: {
+              ...(available ? review.onBehalfOf.source : attribution.source),
+              observedAt: attribution.source.observedAt,
+              provenance: [`graphql.${field}.onBehalfOf`],
+            },
+          },
+        };
+        // Null observations cannot erase comparison evidence or supply public field values.
+        evidence.set(review.id, {
+          ...current,
+          submittedAt: current.submittedAt ?? previous?.submittedAt ?? null,
+          commitSha: current.commitSha ?? previous?.commitSha ?? null,
+        });
+        return current;
+      }
+    );
+  };
+  [
+    context.labels,
+    context.assignees,
+    context.reviewRequests,
+    context.reviewDecisions,
+    context.reviewActivity,
+  ] = await Promise.all([
     collect('labels', contextLabelSchema, context.labels, (known, current) => ({
       ...current,
       color: current.color ?? known.color,
@@ -390,7 +470,21 @@ export async function readPullRequestContext(
           ? known.id === current.id
           : known.reviewer?.id != null && known.reviewer.id === current.reviewer?.id
     ),
+    collectReviews('latestOpinionatedReviews', context.reviewDecisions),
+    collectReviews('latestReviews', context.reviewActivity),
   ]);
+  // Final null fields can hide contradictions between the two connections.
+  for (const review of context.reviewDecisions.items) {
+    const opinionated = reviewEvidence.latestOpinionatedReviews.get(review.id);
+    const activity = reviewEvidence.latestReviews.get(review.id);
+    if (opinionated && activity && !contextReviewsAgree(opinionated, activity)) {
+      review.state = 'UNKNOWN';
+    }
+  }
+  context.reviewDecisions = resolveContextReviewDecisions(
+    context.reviewDecisions,
+    context.reviewActivity
+  );
   const final = decodeContextGraphQlSource(
     await read('graphql.revision', async (signal): Promise<unknown> => {
       const response = await octokit.request('POST /graphql', {

--- a/apps/web/src/lib/github-pr-review/context-reviews-integration.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-reviews-integration.test.ts
@@ -1,0 +1,336 @@
+import type { Octokit } from '@octokit/rest';
+import {
+  createContextReadBudget,
+  readPullRequestContext,
+  PR_CONTEXT_REVISION_QUERY,
+} from './context-reader';
+import { PR_CONTEXT_REVIEW_QUERIES } from './context-reviews';
+import { PR_CONTEXT_PEOPLE_QUERIES } from './context-people';
+import { GitHubPrReviewContextSchema } from './context-dtos';
+import type { PullRequestRestData } from './mappers';
+
+const fields = ['latestOpinionatedReviews', 'latestReviews'] as const;
+type Field = (typeof fields)[number];
+const submittedAt = '2026-08-25T12:00:00+02:00';
+const later = '2026-08-26T10:00:00Z';
+const person = (id = 'U') => ({
+  __typename: 'User',
+  id,
+  login: 'same-login',
+  name: null,
+  avatarUrl: null,
+  url: null,
+});
+const connection = (nodes: unknown[], totalCount = nodes.length, next: string | null = null) => ({
+  nodes,
+  totalCount,
+  pageInfo: { hasNextPage: next !== null, endCursor: next },
+});
+const review = (state = 'APPROVED', id = 'decision', patch: Record<string, unknown> = {}) => ({
+  id,
+  state,
+  author: person(),
+  submittedAt,
+  commit: { oid: 'reviewed-commit' },
+  onBehalfOf: connection([]),
+  createdAt: later,
+  updatedAt: later,
+  ...patch,
+});
+const page = (
+  field: string,
+  nodes: unknown[],
+  totalCount = nodes.length,
+  next: string | null = null,
+  errors?: unknown[]
+) => ({
+  data: {
+    data: { repository: { pullRequest: { [field]: connection(nodes, totalCount, next) } } },
+    errors,
+  },
+});
+const revision = {
+  prNodeId: 'PR_1',
+  number: 1,
+  headSha: 'head',
+  baseRef: 'main',
+  baseSha: 'base',
+  baseRepoFullName: 'o/r',
+};
+const pr: PullRequestRestData = {
+  node_id: 'PR_1',
+  number: 1,
+  title: 'PR',
+  body: null,
+  user: null,
+  state: 'open',
+  head: { ref: 'feature', sha: 'head' },
+  base: { ref: 'main', sha: 'base', repo: { full_name: 'o/r' } },
+  commits: 1,
+  changed_files: 1,
+  additions: 1,
+  deletions: 0,
+  mergeable: null,
+};
+let budget: ReturnType<typeof createContextReadBudget>;
+beforeEach(() => {
+  jest.useFakeTimers();
+  budget = createContextReadBudget();
+});
+afterEach(() => {
+  budget.close();
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+async function run(
+  serve: (field: Field, after: string | null, signal: AbortSignal) => unknown,
+  requests: unknown[] = [],
+  finalHead = 'head'
+) {
+  const octokit = {
+    pulls: { get: async () => ({ data: pr }) },
+    request: async (
+      _route: string,
+      body: { query: string; variables: { after: string | null }; request: { signal: AbortSignal } }
+    ) => {
+      if (body.query === PR_CONTEXT_REVISION_QUERY)
+        return {
+          data: {
+            data: {
+              repository: {
+                pullRequest: {
+                  id: 'PR_1',
+                  number: 1,
+                  headRefOid: finalHead,
+                  baseRefName: 'main',
+                  baseRefOid: 'base',
+                  baseRepository: { nameWithOwner: 'o/r' },
+                },
+              },
+            },
+          },
+        };
+      const field = fields.find(field => PR_CONTEXT_REVIEW_QUERIES[field] === body.query);
+      if (field) return serve(field, body.variables.after, body.request.signal);
+      const people = Object.entries(PR_CONTEXT_PEOPLE_QUERIES).find(
+        ([, query]) => query === body.query
+      )?.[0];
+      if (!people) throw new Error('Unexpected request');
+      return page(people, people === 'reviewRequests' ? requests : []);
+    },
+  } as unknown as Octokit;
+  return GitHubPrReviewContextSchema.parse(
+    await readPullRequestContext(
+      octokit,
+      {
+        owner: 'o',
+        repo: 'r',
+        number: 1,
+        expectedRevision: revision,
+      },
+      budget
+    )
+  );
+}
+
+it('keeps complete empty reviews separate from outstanding requests', async () => {
+  const result = await run(
+    field => page(field, []),
+    [{ id: 'request', requestedReviewer: person() }]
+  );
+  for (const reviews of [result.reviewDecisions, result.reviewActivity])
+    expect(reviews).toMatchObject({
+      items: [],
+      completeness: 'complete',
+      knownCount: 0,
+      totalCount: 0,
+      source: { availability: 'available' },
+    });
+  expect(result.reviewRequests.items).toHaveLength(1);
+});
+
+it('traverses both review connections beyond 100 with independent cursors', async () => {
+  const result = await run((field, after) => {
+    if (after !== null && after !== `${field}-next`) throw new Error('Wrong review cursor');
+    const count = field === 'latestOpinionatedReviews' ? 101 : 102;
+    return page(
+      field,
+      Array.from({ length: after ? count - 100 : 100 }, (_, n) => {
+        const i = n + (after ? 100 : 0);
+        return review(i === 101 ? 'COMMENTED' : 'APPROVED', `R${i}`, { author: person(`U${i}`) });
+      }),
+      count,
+      after ? null : `${field}-next`
+    );
+  });
+  expect(result.reviewDecisions).toMatchObject({
+    knownCount: 101,
+    totalCount: 101,
+    completeness: 'complete',
+    hasNextPage: false,
+    source: {
+      availability: 'available',
+      retryable: false,
+      provenance: ['graphql.latestOpinionatedReviews', 'graphql.latestReviews'],
+    },
+  });
+  expect(result.reviewActivity).toMatchObject({
+    knownCount: 102,
+    totalCount: 102,
+    completeness: 'complete',
+    hasNextPage: false,
+    source: { availability: 'available', provenance: ['graphql.latestReviews'] },
+  });
+  expect(result.reviewDecisions.items[100]).toMatchObject({
+    id: 'R100',
+    actor: { id: 'U100' },
+    state: 'APPROVED',
+    submittedAt,
+    commitSha: 'reviewed-commit',
+  });
+});
+
+it('marks current decisions stale after a head change without erasing submitted activity', async () => {
+  jest.spyOn(console, 'info').mockImplementation(() => undefined);
+  const result = await run(field => page(field, [review()]), [], 'new-head');
+  expect(result.reviewDecisions).toMatchObject({
+    items: [{ id: 'decision' }],
+    completeness: 'unknown',
+    source: { availability: 'stale', retryable: true },
+  });
+  expect(result.reviewActivity).toMatchObject({
+    items: [{ id: 'decision', submittedAt }],
+    source: { availability: 'available' },
+  });
+});
+
+describe.each(fields)('%s null-page evidence', field => {
+  it.each([
+    {
+      name: 'timestamp and commit',
+      missing: { submittedAt: null, commit: null },
+      changed: { submittedAt: later, commit: { oid: 'other-commit' } },
+    },
+    { name: 'timestamp', missing: { submittedAt: null }, changed: { submittedAt: later } },
+    { name: 'commit', missing: { commit: null }, changed: { commit: { oid: 'other-commit' } } },
+  ])('keeps $name conflicts unknown across a null observation', async ({ missing, changed }) => {
+    const result = await run((other, after) =>
+      page(
+        other,
+        [
+          review(
+            'APPROVED',
+            'decision',
+            other !== field || after === 'last' ? changed : after ? missing : {}
+          ),
+        ],
+        1,
+        other !== field || after === 'last' ? null : after ? 'last' : 'middle'
+      )
+    );
+    expect(result.reviewDecisions).toMatchObject({
+      items: [{ id: 'decision', state: 'UNKNOWN' }],
+      knownCount: 1,
+      totalCount: null,
+      completeness: 'partial',
+      source: { availability: 'partial', retryable: true, reason: 'review-inconsistent' },
+    });
+  });
+
+  it('does not publish comparison values when the final observation is null', async () => {
+    const result = await run((other, after) =>
+      page(
+        other,
+        [
+          review(
+            'APPROVED',
+            'decision',
+            other !== field || after ? { submittedAt: null, commit: null } : {}
+          ),
+        ],
+        1,
+        other === field && !after ? 'last' : null
+      )
+    );
+    for (const reviews of [result.reviewDecisions, result.reviewActivity])
+      expect(reviews).toMatchObject({
+        items: [{ id: 'decision', state: 'APPROVED', submittedAt: null, commitSha: null }],
+        completeness: 'complete',
+      });
+  });
+});
+
+describe.each(fields)('%s final-null cross-connection evidence', nullField => {
+  describe.each(fields)('%s completes last', slowField => {
+    async function readWithFinalNull(changed: Record<string, unknown>) {
+      const pending = run(async (field, after) => {
+        if (field === slowField) await new Promise(resolve => setTimeout(resolve, 1));
+        return page(
+          field,
+          [
+            review(
+              'APPROVED',
+              'decision',
+              field !== nullField ? changed : after ? { submittedAt: null, commit: null } : {}
+            ),
+            review('APPROVED', 'sibling', { author: person('sibling') }),
+          ],
+          2,
+          field === nullField && !after ? 'last' : null
+        );
+      });
+      await jest.advanceTimersByTimeAsync(10);
+      return pending;
+    }
+
+    it.each([
+      {
+        name: 'timestamp and commit',
+        changed: { submittedAt: later, commit: { oid: 'other-commit' } },
+      },
+      { name: 'timestamp', changed: { submittedAt: later } },
+      { name: 'commit', changed: { commit: { oid: 'other-commit' } } },
+    ])('keeps $name conflicts unknown without losing siblings', async ({ changed }) => {
+      const result = await readWithFinalNull(changed);
+      expect(result.reviewDecisions).toMatchObject({
+        items: [
+          { id: 'decision', state: 'UNKNOWN' },
+          { id: 'sibling', state: 'APPROVED', submittedAt, commitSha: 'reviewed-commit' },
+        ],
+        knownCount: 2,
+        totalCount: null,
+        completeness: 'partial',
+        source: { availability: 'partial', retryable: true, reason: 'review-inconsistent' },
+      });
+      expect(result.reviewActivity).toMatchObject({
+        items: [
+          { id: 'decision', state: 'APPROVED' },
+          { id: 'sibling', state: 'APPROVED' },
+        ],
+        completeness: 'complete',
+        source: { availability: 'available', retryable: false },
+      });
+      const nullable =
+        nullField === 'latestOpinionatedReviews' ? result.reviewDecisions : result.reviewActivity;
+      expect(nullable.items[0]).toMatchObject({ submittedAt: null, commitSha: null });
+    });
+
+    it('keeps consistent evidence complete without borrowing final null values', async () => {
+      const result = await readWithFinalNull({});
+      for (const reviews of [result.reviewDecisions, result.reviewActivity])
+        expect(reviews).toMatchObject({
+          items: [
+            { id: 'decision', state: 'APPROVED' },
+            { id: 'sibling', state: 'APPROVED', submittedAt, commitSha: 'reviewed-commit' },
+          ],
+          knownCount: 2,
+          totalCount: 2,
+          completeness: 'complete',
+          source: { availability: 'available', retryable: false },
+        });
+      const nullable =
+        nullField === 'latestOpinionatedReviews' ? result.reviewDecisions : result.reviewActivity;
+      expect(nullable.items[0]).toMatchObject({ submittedAt: null, commitSha: null });
+    });
+  });
+});

--- a/apps/web/src/lib/github-pr-review/context-reviews-integration.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-reviews-integration.test.ts
@@ -334,3 +334,218 @@ describe.each(fields)('%s final-null cross-connection evidence', nullField => {
     });
   });
 });
+
+describe.each(fields)('%s sibling state errors', failedField => {
+  describe.each(fields)('%s completes last', slowField => {
+    it.each([
+      {
+        state: 'CHANGES_REQUESTED',
+        error: 'FORBIDDEN',
+        reason: 'review-inconsistent',
+        retryable: true,
+      },
+      {
+        state: 'CHANGES_REQUESTED',
+        error: 'INTERNAL',
+        reason: 'review-inconsistent',
+        retryable: true,
+      },
+      { state: 'APPROVED', error: 'FORBIDDEN', reason: 'graphql-denied', retryable: false },
+      { state: 'APPROVED', error: 'INTERNAL', reason: 'graphql-incomplete', retryable: true },
+    ])(
+      'keeps $state evidence separate from $error',
+      async ({ state, error, reason, retryable }) => {
+        const pending = run(async (field, after) => {
+          if (field === slowField) await new Promise(resolve => setTimeout(resolve, 1));
+          return page(
+            field,
+            [
+              review(field === 'latestReviews' ? state : 'APPROVED'),
+              review('APPROVED', 'failed', { author: person('failed') }),
+              review('APPROVED', 'stable', { author: person('stable') }),
+            ],
+            3,
+            field === failedField && !after ? 'last' : null,
+            field === failedField
+              ? [{ type: error, path: ['repository', 'pullRequest', field, 'nodes', 1, 'state'] }]
+              : undefined
+          );
+        });
+        await jest.advanceTimersByTimeAsync(10);
+        const result = await pending;
+        expect(result.reviewDecisions).toMatchObject({
+          items: [
+            { id: 'decision', state: state === 'APPROVED' ? 'APPROVED' : 'UNKNOWN' },
+            { id: 'failed', state: 'UNKNOWN' },
+            { id: 'stable', state: 'APPROVED', submittedAt, commitSha: 'reviewed-commit' },
+          ],
+          knownCount: 3,
+          totalCount: null,
+          completeness: 'partial',
+          source: {
+            availability: 'partial',
+            reason,
+            retryable,
+            provenance: ['graphql.latestOpinionatedReviews', 'graphql.latestReviews'],
+          },
+        });
+        expect(result.reviewActivity.items).toMatchObject([
+          { id: 'decision', state, submittedAt, commitSha: 'reviewed-commit' },
+          { id: 'failed', state: failedField === 'latestReviews' ? 'UNKNOWN' : 'APPROVED' },
+          { id: 'stable', state: 'APPROVED' },
+        ]);
+        expect(result.reviewActivity.source).toMatchObject({
+          availability: failedField === 'latestReviews' ? 'partial' : 'available',
+          reason:
+            failedField !== 'latestReviews'
+              ? null
+              : error === 'FORBIDDEN'
+                ? 'graphql-denied'
+                : 'graphql-incomplete',
+          retryable: failedField === 'latestReviews' && error === 'INTERNAL',
+        });
+      }
+    );
+  });
+});
+
+describe.each(fields)('%s retained conflicts beside denial', changingField => {
+  describe.each(fields)('%s completes last', slowField => {
+    it.each([
+      { name: 'state across pages', acrossPages: true, changed: { state: 'CHANGES_REQUESTED' } },
+      { name: 'timestamp across pages', acrossPages: true, changed: { submittedAt: later } },
+      {
+        name: 'commit across pages',
+        acrossPages: true,
+        changed: { commit: { oid: 'other-commit' } },
+      },
+      {
+        name: 'timestamp and commit across pages',
+        acrossPages: true,
+        changed: { submittedAt: later, commit: { oid: 'other-commit' } },
+      },
+      { name: 'timestamp across connections', acrossPages: false, changed: { submittedAt: later } },
+      {
+        name: 'commit across connections',
+        acrossPages: false,
+        changed: { commit: { oid: 'other-commit' } },
+      },
+      {
+        name: 'timestamp and commit across connections',
+        acrossPages: false,
+        changed: { submittedAt: later, commit: { oid: 'other-commit' } },
+      },
+    ])('retains $name after final null observations', async ({ acrossPages, changed }) => {
+      const pending = run(async (field, after) => {
+        if (field === slowField) await new Promise(resolve => setTimeout(resolve, 1));
+        const patch =
+          after === 'last' || (acrossPages && field !== changingField)
+            ? { submittedAt: null, commit: null }
+            : acrossPages
+              ? after
+                ? changed
+                : {}
+              : field === changingField
+                ? {}
+                : changed;
+        return page(
+          field,
+          [
+            review('APPROVED', 'decision', patch),
+            review('APPROVED', 'failed', { author: person('failed') }),
+            review('APPROVED', 'stable', { author: person('stable') }),
+          ],
+          3,
+          after === 'last' || (acrossPages && field !== changingField)
+            ? null
+            : acrossPages && !after
+              ? 'middle'
+              : 'last',
+          field === changingField
+            ? [
+                {
+                  type: 'FORBIDDEN',
+                  path: ['repository', 'pullRequest', field, 'nodes', 1, 'state'],
+                },
+              ]
+            : undefined
+        );
+      });
+      await jest.advanceTimersByTimeAsync(10);
+      const result = await pending;
+      expect(result.reviewDecisions).toMatchObject({
+        items: [
+          { id: 'decision', state: 'UNKNOWN', submittedAt: null, commitSha: null },
+          { id: 'failed', state: 'UNKNOWN' },
+          { id: 'stable', state: 'APPROVED', submittedAt, commitSha: 'reviewed-commit' },
+        ],
+        knownCount: 3,
+        totalCount: null,
+        completeness: 'partial',
+        source: {
+          availability: 'partial',
+          reason: 'review-inconsistent',
+          retryable: true,
+          provenance: ['graphql.latestOpinionatedReviews', 'graphql.latestReviews'],
+        },
+      });
+      expect(result.reviewActivity.items).toMatchObject([
+        {
+          id: 'decision',
+          state: acrossPages && changingField === 'latestReviews' ? 'UNKNOWN' : 'APPROVED',
+          submittedAt: null,
+          commitSha: null,
+        },
+        { id: 'failed', state: changingField === 'latestReviews' ? 'UNKNOWN' : 'APPROVED' },
+        { id: 'stable', state: 'APPROVED' },
+      ]);
+    });
+
+    it('retains known state through an unavailable page', async () => {
+      const pending = run(async (field, after) => {
+        if (field === slowField) await new Promise(resolve => setTimeout(resolve, 1));
+        const missingState = field === changingField && after === 'missing';
+        const final = field !== changingField || after === 'last';
+        return page(
+          field,
+          [
+            review(final ? 'CHANGES_REQUESTED' : 'APPROVED', 'decision', {
+              ...(missingState ? { state: null } : {}),
+              ...(after || final ? { submittedAt: null, commit: null } : {}),
+            }),
+            review('APPROVED', 'failed', { author: person('failed') }),
+          ],
+          2,
+          final ? null : after ? 'last' : 'missing',
+          field === changingField
+            ? [
+                {
+                  type: 'FORBIDDEN',
+                  path: ['repository', 'pullRequest', field, 'nodes', 1, 'state'],
+                },
+                ...(missingState
+                  ? [
+                      {
+                        type: 'FORBIDDEN',
+                        path: ['repository', 'pullRequest', field, 'nodes', 0, 'state'],
+                      },
+                    ]
+                  : []),
+              ]
+            : undefined
+        );
+      });
+      await jest.advanceTimersByTimeAsync(10);
+      const result = await pending;
+      expect(result.reviewDecisions).toMatchObject({
+        items: [
+          { id: 'decision', state: 'UNKNOWN', submittedAt: null, commitSha: null },
+          { id: 'failed', state: 'UNKNOWN' },
+        ],
+        totalCount: null,
+        completeness: 'partial',
+        source: { availability: 'partial', reason: 'review-inconsistent', retryable: true },
+      });
+    });
+  });
+});

--- a/apps/web/src/routers/github-pr-review-router.test.ts
+++ b/apps/web/src/routers/github-pr-review-router.test.ts
@@ -1313,6 +1313,8 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
                 },
                 assignees: empty,
                 reviewRequests: empty,
+                latestOpinionatedReviews: empty,
+                latestReviews: empty,
                 privatePayload: 'provider-only',
               },
             },
@@ -1335,7 +1337,7 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
       jest.restoreAllMocks();
     });
 
-    it('enriches people and labels without claiming that unattached readers are empty', async () => {
+    it('enriches people, labels, and reviews without claiming unattached readers are empty', async () => {
       const result = await caller.getPullRequestContext(contextInput);
       expect(result.revision).toEqual(revision);
       expect(result.labels).toMatchObject({
@@ -1350,13 +1352,14 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
         openedAt: '2026-01-01T00:00:00Z',
         closedAt: null,
       });
-      for (const collection of [
-        result.reviewDecisions,
-        result.reviewActivity,
-        result.issues,
-        result.requirements,
-        result.checks,
-      ]) {
+      for (const collection of [result.reviewDecisions, result.reviewActivity]) {
+        expect(collection).toMatchObject({
+          items: [],
+          completeness: 'complete',
+          source: { availability: 'available' },
+        });
+      }
+      for (const collection of [result.issues, result.requirements, result.checks]) {
         expect(collection).toMatchObject({
           items: [],
           completeness: 'unknown',
@@ -1456,6 +1459,7 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
         });
         expect(result.revision).toEqual(initial);
         for (const source of [
+          result.reviewDecisions.source,
           result.requirements.source,
           result.checks.source,
           result.queue.membership.source,


### PR DESCRIPTION
- Pull request context now includes GitHub review decisions and recent review activity, separate from outstanding review requests.
- If GitHub returns conflicting review details, the affected decision remains uncertain even when later responses omit those details.
- If the pull request changes during loading, review decisions become outdated while review activity remains available.

---

## Summary

`getPullRequestContext` now populates `reviewDecisions` and `reviewActivity`; this level changes backend responses, not mobile presentation.
`latestOpinionatedReviews` and `latestReviews` paginate independently within the existing ten-second deadline and four-request concurrency limit; confirmed empty traversals report complete collections.
The reader decodes `state`, `submittedAt`, and `onBehalfOf` errors separately, preserving field-level uncertainty and attribution provenance for callers.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-reader.ts` — Modified; 145 changed lines. Adds review pagination with identifier deduplication, per-field decoding, retained conflict evidence, and revision checks for decisions.
- `apps/web/src/lib/github-pr-review/context-people.test.ts` — Modified; 28 changed lines. Allows only registered sibling queries, mocks router dependencies, and preserves six people-page requests without per-person lookups.

</details>

`readPullRequestContext` gives `resolveContextReviewDecisions` genuine `conflictingReviewIds`; unavailable fields alone do not establish contradictions.
It retains state, timestamp, and commit contradictions across pages, connections, null observations, and source failures, producing partial, retryable `UNKNOWN` decisions with `review-inconsistent`.
Source error metadata stays intact unless genuine conflicts require `review-inconsistent`; comparison evidence cannot fill null public `submittedAt` or `commitSha` values.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-reviews-integration.test.ts` — Added; 551 lines. Covers empty reviews, independent pagination, null observations, retained conflicts, sibling failures, completion order, and revision changes.

</details>

`reviewDecisions` now joins the revision fence for requirements, checks, and queue data, preventing changed pull requests from presenting decisions as current.
If revision checks fail, `reviewDecisions.completeness` becomes `unknown`; mismatches set `stale` availability, while missing or failed reads set `unavailable` or `denied`.
`reviewActivity` keeps its records, while `issues`, `requirements`, `checks`, and `queue` still have no readers attached by this level.

<details>
<summary>Files</summary>

- `apps/web/src/routers/github-pr-review-router.test.ts` — Modified; 20 changed lines. Supplies both review connections, checks confirmed empty collections, and includes review decisions in revision-mismatch assertions.

</details>

Tests: 1 file added — `context-reviews-integration.test.ts`; 2 files updated — `context-people.test.ts`, `github-pr-review-router.test.ts` (3 total).
Generated: 0 files.

---

## Visual Changes

Visual Changes: N/A

## Verification

No manual provider, backend, or iOS feature scenario has run for this level.
The owner prohibits new end-to-end (E2E) slots and bundles.
Live backend and iOS verification waits for the completed stack tip.

## Reviewer Notes

### Human steps

No deployment, migration, or configuration step is known for these level-specific diffs.
The owner retains product merge authority.

- **before merge:** When the owner permits runtime work, complete live backend and iOS feature verification on the completed stack tip.
- **before merge:** Complete each level's current-head continuous integration (CI), bot, thread, and final description gates.
- **before merge:** Do not ask for review or merge before the complete-stack human-ready gate.

No after-merge step is known for this level.

### Historical automated proof

- The level-9 metadata-reader repair preserved 27 baseline cases and added 48 cases; all 75 integration cases and five scoped checks passed.
- Its fresh review returned `No findings.` before publication.
- These results precede this refresh; no generation-20 product checks ran.
- Historical proof does not establish current-head readiness or a completed runtime gate.

### Scope and evidence

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- This description covers only `mobile-pr-review-context-5458-s8...mobile-pr-review-context-5458-s9`.
- Reviewed base: `627b0870a13c438f3af01b84ac17e142784fdb85`; reviewed head: `0996ef8679fcaba45b8f6025b934808298e162e2`.
- The frozen source HEAD and the owner's uncommitted callback patch are outside this review.
- All 27 existing pull requests remain part of one incomplete stack.
- Synthetic fixtures test conservative handling of returned evidence, not undocumented provider transitions.

### Notes

This level attaches review context reads. Live backend and iOS verification will run on the completed stack tip.

Live backend and iOS feature verification remains required on the completed stack tip.

The owner currently prohibits new E2E slots and bundles; this hold does not waive runtime verification.

Levels 24 and 25 have prepared repairs and partial proof, but publication remains pending a workflow operation for an unpublished propagated baseline.

Their required three-root type checks have not passed; no failed publication proof is applied.

The owner descoped large-text/font-scaling, theme variants, contrast rendering, scaled-text layout, and screen-reader presentation.

Functional accessibility labels, roles, identifiers, selectors, default appearance flows, and all non-visual criteria remain required.

This is an interim description refresh; the complete-stack readiness gate remains open.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699 ← this PR
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)

