### PR TITLE
feat(extension): persist browser jobs and profile consent

### DIFF
--- a/apps/extension/src/shared/auth-browser-fence.test.ts
+++ b/apps/extension/src/shared/auth-browser-fence.test.ts
@@ -1,0 +1,184 @@
+/* eslint-disable import/no-nodejs-modules, jest/no-hooks, jest/no-conditional-in-test, jest/no-conditional-expect, require-await, typescript/require-await, unicorn/no-await-expression-member -- The transition matrix checks the distinct outcomes of each real auth path with native leases. */
+import { locks as nativeLocks } from 'node:worker_threads';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  BROWSER_EXECUTION_SAFETY_KEY,
+  createBrowserExecutionCoordinator,
+} from '../../entrypoints/sidepanel/browser-execution-lock';
+import type {
+  BrowserAdmission,
+  BrowserExecutionLease,
+} from '../../entrypoints/sidepanel/browser-execution-lock';
+import {
+  AUTH_STORAGE_KEY,
+  BROWSER_PROVIDER_IDENTITY_KEY,
+  clearStoredSession,
+  saveStoredAuth,
+  validateAuthToken,
+} from './auth';
+import {
+  BROWSER_PROVIDER_SETTINGS_KEY,
+  loadBrowserProvider,
+  saveBrowserProviderSettings,
+} from './browser-provider-settings';
+
+const leases = new Set<BrowserExecutionLease>();
+const lease = (admission: BrowserAdmission): BrowserExecutionLease => {
+  if (!admission.admitted) {
+    throw new Error(admission.reason);
+  }
+  leases.add(admission.lease);
+  return admission.lease;
+};
+const profile = () => {
+  const auth = { token: 'token-a', userEmail: 'a@example.test' };
+  const values = new Map<string, unknown>([[AUTH_STORAGE_KEY, auth]]);
+  const storageArea = {
+    clear: () => {
+      throw new Error('A storage clear would erase the safety fence.');
+    },
+    getItem: (key: `local:${string}`) => structuredClone(values.get(key)),
+    removeItem: (key: `local:${string}`) => {
+      values.delete(key);
+    },
+    removeItems: (keys: `local:${string}`[]) => {
+      for (const key of keys) {
+        values.delete(key);
+      }
+    },
+    setItem: (key: `local:${string}`, value: unknown) => {
+      values.set(key, structuredClone(value));
+    },
+    snapshot: (_base: 'local') =>
+      Object.fromEntries([...values].map(([key, value]) => [key.slice(6), value])),
+    watch: () => () => {},
+  };
+  const panel = () =>
+    createBrowserExecutionCoordinator({ locks: nativeLocks as LockManager, storageArea });
+  return { auth, panel, storageArea, values };
+};
+const transitions = ['sign-out', 'invalid-401', 'invalid-403', 'account-change', 'reload'] as const;
+
+describe('auth cleanup preserves uncertain browser execution', () => {
+  afterEach(async () => {
+    await Promise.all([...leases].map(held => held.release()));
+    leases.clear();
+  });
+
+  it.each(
+    transitions.flatMap(transition => [false, true].map(allTabs => ({ allTabs, transition })))
+  )(
+    'keeps local and delegated work fenced through $transition (allTabs=$allTabs)',
+    async ({ allTabs, transition }) => {
+      const state = profile();
+      const panel = state.panel();
+      const owner = lease(await panel.acquireProviderOwner());
+      const context = { auth: state.auth, owner, storageArea: state.storageArea };
+      const initial = await loadBrowserProvider(context);
+      await saveBrowserProviderSettings(context, {
+        ...initial.settings,
+        enabled: true,
+        model: 'selected',
+      });
+      state.values.set('local:kiloBrowserTasks', { privateHistory: 'account-a-history' });
+      state.values.set('local:futureAccountKey', 'private account data');
+      const local = lease(await panel.acquireLocal());
+      const action = Promise.withResolvers<void>();
+      const work = local.run(async guard => {
+        guard();
+        await action.promise;
+      });
+      await local.quarantine(7);
+      const safety = { ...(allTabs ? { allTabs: true } : {}), tabIds: [7], version: 1 };
+      state.values.set(BROWSER_EXECUTION_SAFETY_KEY, safety);
+      let { auth } = state;
+      try {
+        if (transition === 'sign-out') {
+          await clearStoredSession(state.storageArea);
+        } else if (transition === 'invalid-401' || transition === 'invalid-403') {
+          const result = await validateAuthToken({
+            apiBaseUrl: 'https://example.test',
+            fetch: () => new Response(null, { status: transition === 'invalid-401' ? 401 : 403 }),
+            token: auth.token,
+          });
+          expect(result.status).toBe('invalid');
+          if (result.status === 'invalid') {
+            await clearStoredSession(state.storageArea);
+          }
+        } else if (transition === 'account-change') {
+          auth = { token: 'token-b', userEmail: 'b@example.test' };
+          await saveStoredAuth(state.storageArea, auth);
+        }
+        expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toBe(safety);
+        expect(state.values.get(BROWSER_PROVIDER_IDENTITY_KEY)).toStrictEqual(initial.identity);
+        if (transition !== 'reload') {
+          expect(state.values.has('local:kiloBrowserTasks')).toBe(false);
+          expect(state.values.has('local:futureAccountKey')).toBe(false);
+          expect(state.values.has(BROWSER_PROVIDER_SETTINGS_KEY)).toBe(false);
+          await saveStoredAuth(state.storageArea, auth);
+          expect((await loadBrowserProvider({ ...context, auth })).settings.enabled).toBe(false);
+        }
+        const reloaded = state.panel();
+        expect((await reloaded.acquireLocal()).admitted).toBe(false);
+        expect(
+          (await panel.acquireDelegated(owner, 'ses_parent', new AbortController().signal)).admitted
+        ).toBe(false);
+        await expect(reloaded.recover(async () => [])).resolves.toMatchObject({ recovered: false });
+      } finally {
+        action.resolve();
+        await work;
+        await local.release();
+      }
+      const reloaded = state.panel();
+      await expect(reloaded.recover(async () => [7])).resolves.toMatchObject({ recovered: false });
+      if (allTabs) {
+        await expect(reloaded.recover(async () => [42])).resolves.toMatchObject({
+          recovered: false,
+        });
+      }
+      await expect(reloaded.recover(async () => [])).resolves.toMatchObject({ recovered: true });
+      const resumedLocal = lease(await reloaded.acquireLocal());
+      await expect(resumedLocal.run(async () => 'explicit local work')).resolves.toBe(
+        'explicit local work'
+      );
+      await resumedLocal.release();
+      const resumedDelegated = lease(
+        await panel.acquireDelegated(owner, 'ses_new_invocation', new AbortController().signal)
+      );
+      await expect(resumedDelegated.run(async () => 'explicit delegated work')).resolves.toBe(
+        'explicit delegated work'
+      );
+      expect(state.values.get(BROWSER_PROVIDER_IDENTITY_KEY)).toStrictEqual(initial.identity);
+    }
+  );
+
+  it('preserves a newer complete safety record when quarantine changes during key enumeration', async () => {
+    const state = profile();
+    const newer = { allTabs: true, futureSafetyField: { keep: true }, tabIds: [7, 8], version: 1 };
+    state.values.set(BROWSER_EXECUTION_SAFETY_KEY, { tabIds: [7], version: 1 });
+    const { snapshot } = state.storageArea;
+    state.storageArea.snapshot = base => {
+      const captured = snapshot(base);
+      state.values.set(BROWSER_EXECUTION_SAFETY_KEY, newer);
+      return captured;
+    };
+    await clearStoredSession(state.storageArea);
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toBe(newer);
+    expect(state.values.has(AUTH_STORAGE_KEY)).toBe(false);
+  });
+
+  it('fails account switching without cleanup support instead of adopting account data', async () => {
+    const state = profile();
+    await expect(
+      saveStoredAuth(
+        {
+          getItem: state.storageArea.getItem,
+          removeItem: state.storageArea.removeItem,
+          setItem: state.storageArea.setItem,
+        },
+        { token: 'token-b', userEmail: 'b@example.test' }
+      )
+    ).rejects.toThrow('Account cleanup is unavailable');
+    expect(state.values.get(AUTH_STORAGE_KEY)).toStrictEqual(state.auth);
+  });
+});

--- a/apps/extension/src/shared/auth-storage-boundary.test.ts
+++ b/apps/extension/src/shared/auth-storage-boundary.test.ts
@@ -1,0 +1,202 @@
+/* eslint-disable import/no-nodejs-modules, max-depth, jest/no-conditional-in-test -- This Node-only inventory resolves storage aliases and tests forbidden syntax. */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const root = fileURLToPath(new URL('../../', import.meta.url));
+const sources = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return sources(path);
+    }
+    return /\.[cm]?[jt]sx?$/u.test(path) && !/\.(?:test|spec|d)\./u.test(path) ? [path] : [];
+  });
+
+const inventory = (path: string, text: string): string[] => {
+  const source = ts.createSourceFile(
+    path,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    path.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+  const aliases = new Map<string, ts.Expression | string>();
+  const literal = (node: ts.Node): string | undefined =>
+    ts.isStringLiteralLike(node) || ts.isIdentifier(node) ? node.text : undefined;
+  const name = (node: ts.Expression, seen = new Set<string>()): string => {
+    if (ts.isIdentifier(node)) {
+      const target = aliases.get(node.text);
+      if (target === undefined || seen.has(node.text)) {
+        return node.text;
+      }
+      return typeof target === 'string' ? target : name(target, new Set([...seen, node.text]));
+    }
+    if (ts.isPropertyAccessExpression(node)) {
+      return `${name(node.expression, seen)}.${node.name.text}`;
+    }
+    if (ts.isElementAccessExpression(node)) {
+      const property = node.argumentExpression;
+      const target = ts.isIdentifier(property) ? aliases.get(property.text) : property;
+      const key =
+        target !== undefined && typeof target !== 'string' && ts.isStringLiteralLike(target)
+          ? target.text
+          : '*';
+      return `${name(node.expression, seen)}.${key}`;
+    }
+    if (
+      ts.isParenthesizedExpression(node) ||
+      ts.isAsExpression(node) ||
+      ts.isNonNullExpression(node)
+    ) {
+      return name(node.expression, seen);
+    }
+    if (ts.isCallExpression(node) && name(node.expression, seen).endsWith('.bind')) {
+      return name(node.expression, seen).slice(0, -5);
+    }
+    return '';
+  };
+  const bind = (binding: ts.BindingName, target: ts.Expression | string): void => {
+    if (ts.isIdentifier(binding)) {
+      aliases.set(binding.text, target);
+    } else if (ts.isObjectBindingPattern(binding)) {
+      for (const element of binding.elements) {
+        const base = typeof target === 'string' ? target : name(target);
+        bind(element.name, `${base}.${literal(element.propertyName ?? element.name) ?? '*'}`);
+      }
+    }
+  };
+  const collect = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const module = node.moduleSpecifier.text;
+      const bindings = node.importClause?.namedBindings;
+      if (bindings !== undefined && ts.isNamedImports(bindings)) {
+        for (const element of bindings.elements) {
+          const imported = element.propertyName?.text ?? element.name.text;
+          aliases.set(element.name.text, imported);
+        }
+      } else if (bindings !== undefined && ts.isNamespaceImport(bindings)) {
+        aliases.set(bindings.name.text, module.includes('storage') ? 'wxt' : 'imports');
+      }
+      if (node.importClause?.name !== undefined && /browser|webextension-polyfill/u.test(module)) {
+        aliases.set(node.importClause.name.text, 'browser');
+      }
+    }
+    if (ts.isVariableDeclaration(node) && node.initializer !== undefined) {
+      bind(node.name, node.initializer);
+    }
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left)
+    ) {
+      aliases.set(node.left.text, node.right);
+    }
+    ts.forEachChild(node, collect);
+  };
+  collect(source);
+  const failures = new Set<string>();
+  const report = (node: ts.Node): void => {
+    failures.add(
+      `${path}:${source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1}: unprotected local-storage clear`
+    );
+  };
+  const inspect = (node: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
+      const resolved = name(node);
+      // Reject extracting the method too; calling an alias cannot bypass the boundary.
+      if (
+        /(?:^|\.)(?:browser|chrome)\.storage\.(?:local|\*)\.(?:clear|\*)$/u.test(resolved) ||
+        /(?:^|\.)storage\.(?:local|\*)\.(?:clear|\*)$/u.test(resolved)
+      ) {
+        report(node);
+      }
+    }
+    if (ts.isCallExpression(node)) {
+      const resolved = name(node.expression);
+      const [argument] = node.arguments;
+      const target =
+        argument !== undefined && ts.isIdentifier(argument) ? aliases.get(argument.text) : argument;
+      const area =
+        target !== undefined && typeof target !== 'string' && ts.isStringLiteralLike(target)
+          ? target.text
+          : undefined;
+      // Any clear('local') is forbidden, including a parameter alias or a future storage wrapper.
+      if (
+        /(?:^|\.)clear(?:\.call|\.apply)?$/u.test(resolved) &&
+        !/\.storage\.(?:sync|session|managed)\.clear$/u.test(resolved) &&
+        area !== 'sync' &&
+        area !== 'session' &&
+        area !== 'managed' &&
+        (area === 'local' || /(?:^|\.)storage\./u.test(resolved))
+      ) {
+        report(node);
+      }
+      if (/(?:^|\.)(?:storage|storage\.local)\.\*$/u.test(resolved)) {
+        report(node);
+      }
+    }
+    if (ts.isBindingElement(node) && ts.isIdentifier(node.name)) {
+      const resolved = name(node.name);
+      if (/(?:^|\.)storage\.local\.clear$/u.test(resolved)) {
+        report(node);
+      }
+    }
+    ts.forEachChild(node, inspect);
+  };
+  inspect(source);
+  return [...failures];
+};
+
+const forbidden = [
+  'browser.storage.local.clear()',
+  'chrome.storage.local["clear"]()',
+  'import { browser as api } from "#imports"; api.storage.local.clear()',
+  'import { storage as saved } from "#imports"; saved.clear("local")',
+  'import { storage as saved } from "wxt/utils/storage"; const wipe = saved.clear.bind(saved); wipe("local")',
+  'import { storage as saved } from "@wxt-dev/storage"; saved["clear"]("local")',
+  'import * as kit from "#imports"; kit.browser.storage.local.clear()',
+  'import browserApi from "webextension-polyfill"; browserApi.storage.local.clear()',
+  'const area = browser.storage.local; area.clear()',
+  'const { local: area } = browser.storage; const { clear: wipe } = area; wipe()',
+  'const wipe = browser.storage.local.clear; wipe()',
+  'const key = "clear"; browser.storage.local[key]()',
+  'browser.storage.local[unknownMethod]()',
+  'storage[unknownMethod]("local")',
+  'const area = "local"; storage.clear(area)',
+  'storage.clear(unknownArea)',
+  'storageArea.clear("local")',
+  'import { storage as saved } from "#imports"; const { clear: wipe } = saved; wipe("local")',
+  'const local = "local"; browser.storage[local].clear()',
+  'const clearMethod = "clear"; storage[clearMethod]("local")',
+];
+
+describe('auth storage safety boundary', () => {
+  it('reports every production clear site across extension sources', () => {
+    const files = [...sources(join(root, 'entrypoints')), ...sources(join(root, 'src'))];
+    const failures = files.flatMap(path =>
+      inventory(relative(root, path), readFileSync(path, 'utf8'))
+    );
+    expect(failures).toStrictEqual([]);
+  });
+
+  it.each(forbidden)('rejects the mutation: %s', text => {
+    expect(inventory('mutation.ts', text)).toStrictEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^mutation\.ts:\d+: unprotected local-storage clear$/u),
+      ])
+    );
+  });
+
+  it.each([
+    'await storage.removeItems(["local:kiloAuth"]);',
+    'await storage.snapshot("local");',
+    'browser.storage.sync.clear();',
+    'storage.clear("session");',
+    'const text = "browser.storage.local.clear()";',
+  ])('permits nondestructive or nonlocal storage operations: %s', text => {
+    expect(inventory('allowed.ts', text)).toStrictEqual([]);
+  });
+});

--- a/apps/extension/src/shared/auth.test.ts
+++ b/apps/extension/src/shared/auth.test.ts
@@ -32,30 +32,48 @@ const createStorage = (initialValue?: unknown): AuthStorageArea & { value: unkno
       expect(key).toBe(AUTH_STORAGE_KEY);
       storedValue = undefined;
     },
+    removeItems: keys => {
+      if (keys.includes(AUTH_STORAGE_KEY)) {
+        storedValue = undefined;
+      }
+    },
     setItem: (key, value) => {
       expect(key).toBe(AUTH_STORAGE_KEY);
       storedValue = value;
     },
+    snapshot: () => (storedValue === undefined ? {} : { kiloAuth: storedValue }),
     get value() {
       return storedValue;
     },
   };
 };
 
-const createSessionStorage = (): {
-  readonly clearCalls: string[];
-  readonly storage: Parameters<typeof clearStoredSession>[0];
-} => {
-  const clearCalls: string[] = [];
-
-  return {
-    clearCalls,
-    storage: {
-      clear: base => {
-        clearCalls.push(base);
-      },
+const createSessionStorage = () => {
+  const safety = { allTabs: true, tabIds: [7], version: 1 };
+  const identity = { providerId: 'stable-profile', providerProof: 'private-proof', version: 1 };
+  const values = new Map<string, unknown>([
+    ['local:kiloBrowserExecutionSafety', safety],
+    ['local:kiloBrowserProviderIdentity', identity],
+    ['local:kiloAuth', { token: 'token-1' }],
+    ['local:kiloAgentConversations', ['old local history']],
+    ['local:kiloBrowserTasks', ['delegated history']],
+    ['local:kiloBrowserProviderSettings', { enabled: true }],
+    ['local:unknownAccountKey', 'future account data'],
+    ['local:unknownAccountKey$', { version: 2 }],
+  ]);
+  const storage = {
+    clear: () => {
+      throw new Error('Unprotected storage clear is forbidden.');
     },
+    removeItems: (keys: `local:${string}`[]) => {
+      for (const key of keys) {
+        values.delete(key);
+      }
+    },
+    snapshot: (_base: 'local') =>
+      Object.fromEntries([...values].map(([key, value]) => [key.slice(6), value])),
   };
+  return { identity, safety, storage, values };
 };
 
 const withStubbedEnv = (env: Record<string, string>, assertion: () => void): void => {
@@ -121,12 +139,23 @@ describe('extension auth storage', () => {
     expect(storage.value).toBeUndefined();
   });
 
-  it('clears all local extension storage for explicit logout', async () => {
-    const { clearCalls, storage } = createSessionStorage();
-
+  it('removes every nonprotected account key without clearing the profile safety records', async () => {
+    const { identity, safety, storage, values } = createSessionStorage();
     await clearStoredSession(storage);
+    expect([...values]).toStrictEqual([
+      ['local:kiloBrowserExecutionSafety', safety],
+      ['local:kiloBrowserProviderIdentity', identity],
+    ]);
+  });
 
-    expect(clearCalls).toStrictEqual(['local']);
+  it('keeps the safety records when key enumeration fails instead of falling back to clear', async () => {
+    const { safety, storage, values } = createSessionStorage();
+    storage.snapshot = () => {
+      throw new Error('Enumeration failed.');
+    };
+    await expect(clearStoredSession(storage)).rejects.toThrow('Enumeration failed.');
+    expect(values.get('local:kiloBrowserExecutionSafety')).toBe(safety);
+    expect(values.get('local:unknownAccountKey')).toBe('future account data');
   });
 });
 

--- a/apps/extension/src/shared/auth.ts
+++ b/apps/extension/src/shared/auth.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
+import { BROWSER_EXECUTION_SAFETY_KEY } from '../../entrypoints/sidepanel/browser-execution-lock';
 
 export const AUTH_STORAGE_KEY = 'local:kiloAuth';
+// Keep credentials separate from a8's execution record, whose writer owns its complete format.
+export const BROWSER_PROVIDER_IDENTITY_KEY = 'local:kiloBrowserProviderIdentity';
 export const DEFAULT_KILO_API_BASE_URL = 'https://app.kilo.ai';
 export const DEFAULT_LOCAL_KILO_API_BASE_URL = 'http://localhost:3000';
 
@@ -11,14 +14,52 @@ export interface StoredAuth {
 
 type MaybePromise<Value> = Promise<Value> | Value;
 
-export interface AuthStorageArea {
+export interface AuthStorageArea extends Partial<SessionStorageArea> {
   getItem(key: typeof AUTH_STORAGE_KEY): MaybePromise<unknown>;
   removeItem(key: typeof AUTH_STORAGE_KEY): MaybePromise<void>;
   setItem(key: typeof AUTH_STORAGE_KEY, value: StoredAuth): MaybePromise<void>;
 }
 export interface SessionStorageArea {
-  clear(base: 'local'): MaybePromise<void>;
+  snapshot(base: 'local'): MaybePromise<Record<string, unknown>>;
+  removeItems(keys: `local:${string}`[]): MaybePromise<void>;
 }
+
+// eslint-disable-next-line promise/prefer-await-to-then -- The resolved promise seeds the serialized write queue.
+let profileWrites = Promise.resolve();
+/** Serialize account writes with auth cleanup, including across panels when native locks exist. */
+export const withBrowserProfileStorageLock = <Result>(
+  work: () => Promise<Result>
+): Promise<Result> => {
+  const previous = profileWrites;
+  const result = (async () => {
+    await previous;
+    const locks = globalThis.navigator?.locks;
+    return locks === undefined ? work() : locks.request('kilo:browser-profile-storage', work);
+  })();
+  // A failed write must reject its caller without poisoning later cleanup or recovery.
+  profileWrites = (async () => {
+    try {
+      await result;
+    } catch {
+      // The returned result still rejects; only the queue barrier absorbs the failure.
+    }
+  })();
+  return result;
+};
+
+const protectedProfileKeys = new Set(
+  [BROWSER_EXECUTION_SAFETY_KEY, BROWSER_PROVIDER_IDENTITY_KEY].flatMap(key => [
+    key.slice(6),
+    `${key.slice(6)}$`,
+  ])
+);
+const removeAccountStorage = async (storageArea: SessionStorageArea): Promise<void> => {
+  const keys = Object.keys(await storageArea.snapshot('local'))
+    .filter(key => !protectedProfileKeys.has(key))
+    .map<`local:${string}`>(key => `local:${key}`);
+  // Never clear and restore: a concurrent quarantine write must remain intact throughout logout.
+  await storageArea.removeItems(keys);
+};
 
 export type FetchLike = (input: string, init?: RequestInit) => MaybePromise<Response>;
 
@@ -101,20 +142,36 @@ export const loadStoredAuth = async (
 ): Promise<StoredAuth | undefined> =>
   normalizeStoredAuth(await storageArea.getItem(AUTH_STORAGE_KEY));
 
-export const saveStoredAuth = async (
-  storageArea: AuthStorageArea,
-  auth: StoredAuth
-): Promise<void> => {
-  await storageArea.setItem(AUTH_STORAGE_KEY, auth);
-};
+export const saveStoredAuth = (storageArea: AuthStorageArea, auth: StoredAuth): Promise<void> =>
+  withBrowserProfileStorageLock(async () => {
+    const previous = await loadStoredAuth(storageArea);
+    const changedAccount =
+      previous !== undefined &&
+      (previous.userEmail !== undefined && auth.userEmail !== undefined
+        ? previous.userEmail !== auth.userEmail
+        : previous.token !== auth.token);
+    if (changedAccount) {
+      const { snapshot, removeItems } = storageArea;
+      // Legacy auth-only adapters can save initial auth, but cannot safely switch accounts.
+      // Remove this compatibility branch when all auth-only adapters retire.
+      if (snapshot === undefined || removeItems === undefined) {
+        throw new Error('Account cleanup is unavailable. Sign out before changing accounts.');
+      }
+      await removeAccountStorage({
+        removeItems: keys => removeItems.call(storageArea, keys),
+        snapshot: base => snapshot.call(storageArea, base),
+      });
+    }
+    await storageArea.setItem(AUTH_STORAGE_KEY, auth);
+  });
 
-export const clearStoredAuth = async (storageArea: AuthStorageArea): Promise<void> => {
-  await storageArea.removeItem(AUTH_STORAGE_KEY);
-};
+export const clearStoredAuth = (storageArea: AuthStorageArea): Promise<void> =>
+  withBrowserProfileStorageLock(async () => {
+    await storageArea.removeItem(AUTH_STORAGE_KEY);
+  });
 
-export const clearStoredSession = async (storageArea: SessionStorageArea): Promise<void> => {
-  await storageArea.clear('local');
-};
+export const clearStoredSession = (storageArea: SessionStorageArea): Promise<void> =>
+  withBrowserProfileStorageLock(() => removeAccountStorage(storageArea));
 
 const parseDeviceAuthRequest = (value: unknown): DeviceAuthRequest => {
   const parsed = deviceAuthRequestSchema.safeParse(value);

--- a/apps/extension/src/shared/browser-provider-settings.test.ts
+++ b/apps/extension/src/shared/browser-provider-settings.test.ts
@@ -1,0 +1,214 @@
+/* eslint-disable import/no-nodejs-modules, jest/no-hooks, require-await, typescript/require-await, unicorn/no-await-expression-member, typescript/no-unsafe-assignment -- Storage fixtures implement browser APIs; matcher objects inspect persisted outcomes. */
+import { locks as nativeLocks } from 'node:worker_threads';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createBrowserExecutionCoordinator } from '../../entrypoints/sidepanel/browser-execution-lock';
+import type { BrowserExecutionLease } from '../../entrypoints/sidepanel/browser-execution-lock';
+import {
+  AUTH_STORAGE_KEY,
+  BROWSER_PROVIDER_IDENTITY_KEY,
+  clearStoredSession,
+  saveStoredAuth,
+} from './auth';
+import {
+  BROWSER_PROVIDER_SETTINGS_KEY,
+  browserAccountKey,
+  loadBrowserProvider,
+  saveBrowserProviderLabel,
+  saveBrowserProviderSettings,
+} from './browser-provider-settings';
+import type { BrowserProfileStorage } from './browser-provider-settings';
+
+const leases: BrowserExecutionLease[] = [];
+const auth = { token: 'account-a-token', userEmail: 'a@example.test' };
+const profile = async () => {
+  const values = new Map<string, unknown>([[AUTH_STORAGE_KEY, auth]]);
+  const storageArea: BrowserProfileStorage & Parameters<typeof clearStoredSession>[0] = {
+    getItem: key => structuredClone(values.get(key)),
+    removeItems: keys => {
+      for (const key of keys) {
+        values.delete(key);
+      }
+    },
+    setItem: (key, value) => {
+      values.set(key, structuredClone(value));
+    },
+    snapshot: () => Object.fromEntries([...values].map(([key, value]) => [key.slice(6), value])),
+  };
+  const panel = createBrowserExecutionCoordinator({
+    locks: nativeLocks as LockManager,
+    storageArea: { ...storageArea, watch: () => () => {} },
+  });
+  const admitted = await panel.acquireProviderOwner();
+  if (!admitted.admitted) {
+    throw new Error(admitted.reason);
+  }
+  leases.push(admitted.lease);
+  return { context: { auth, owner: admitted.lease, storageArea }, panel, values };
+};
+
+describe('browser provider settings', () => {
+  afterEach(async () => {
+    await Promise.all(leases.splice(0).map(lease => lease.release()));
+  });
+
+  it('creates one stable private identity under the provider owner and defaults to disabled Safe mode', async () => {
+    const { context, panel, values } = await profile();
+    const [first, second] = await Promise.all([
+      loadBrowserProvider(context),
+      loadBrowserProvider(context),
+    ]);
+    expect(second).toStrictEqual(first);
+    expect(first.settings).toStrictEqual({
+      enabled: false,
+      mode: 'safe',
+      model: '',
+      thinkingEffort: '',
+    });
+    expect(values.get(BROWSER_PROVIDER_IDENTITY_KEY)).toStrictEqual(first.identity);
+    expect((await panel.acquireProviderOwner()).admitted).toBe(false);
+    await saveBrowserProviderLabel(context, 'Work browser');
+    expect((await loadBrowserProvider(context)).identity).toStrictEqual({
+      ...first.identity,
+      label: 'Work browser',
+    });
+  });
+
+  it('requires explicit model selection before enablement and persists independent defaults', async () => {
+    const { context, values } = await profile();
+    const local = {
+      activeConversationId: 'local',
+      conversations: [
+        {
+          events: [
+            {
+              id: 'local-event',
+              role: 'user',
+              text: 'Private local conversation',
+              type: 'message',
+            },
+          ],
+          id: 'local',
+          mode: 'dangerous',
+          model: 'local-model',
+          title: 'Local conversation',
+          updatedAt: '2026-08-29T00:00:00.000Z',
+        },
+      ],
+      openConversationIds: ['local'],
+    };
+    values.set('local:kiloAgentConversations', local);
+    const { settings } = await loadBrowserProvider(context);
+    await expect(
+      saveBrowserProviderSettings(context, { ...settings, enabled: true })
+    ).rejects.toMatchObject({ code: 'model_required', retryable: false });
+    expect((await loadBrowserProvider(context)).settings.enabled).toBe(false);
+    const selected = {
+      enabled: true,
+      mode: 'safe' as const,
+      model: 'selected-model',
+      thinkingEffort: 'high',
+    };
+    await saveBrowserProviderSettings(context, selected);
+    expect((await loadBrowserProvider(context)).settings).toStrictEqual(selected);
+    expect(values.get('local:kiloAgentConversations')).toStrictEqual(local);
+  });
+
+  it('clears enablement and defaults on account change while retaining identity', async () => {
+    const { context } = await profile();
+    const first = await loadBrowserProvider(context);
+    await saveBrowserProviderSettings(context, {
+      ...first.settings,
+      enabled: true,
+      model: 'chosen',
+    });
+    const nextAuth = { token: 'account-b-token', userEmail: 'b@example.test' };
+    await saveStoredAuth({ ...context.storageArea, removeItem: () => {} }, nextAuth);
+    await expect(loadBrowserProvider(context)).rejects.toMatchObject({ code: 'owner_mismatch' });
+    const next = await loadBrowserProvider({ ...context, auth: nextAuth });
+    expect(next).toStrictEqual({ identity: first.identity, settings: first.settings });
+  });
+
+  it('does not restore enablement through stale writes after sign-out', async () => {
+    const { context, values } = await profile();
+    const first = await loadBrowserProvider(context);
+    const { storageArea } = context;
+    await clearStoredSession(storageArea);
+    await expect(
+      saveBrowserProviderSettings(context, { ...first.settings, enabled: true, model: 'chosen' })
+    ).rejects.toMatchObject({ code: 'owner_mismatch' });
+    expect(values.has(BROWSER_PROVIDER_SETTINGS_KEY)).toBe(false);
+    expect(values.get(BROWSER_PROVIDER_IDENTITY_KEY)).toStrictEqual(first.identity);
+  });
+
+  it('rejects lost ownership before creating credentials or writing settings', async () => {
+    const { context, values } = await profile();
+    await context.owner.release();
+    await expect(loadBrowserProvider(context)).rejects.toMatchObject({
+      code: 'owner_mismatch',
+      retryable: false,
+    });
+    expect(values.has(BROWSER_PROVIDER_IDENTITY_KEY)).toBe(false);
+    expect(values.has(BROWSER_PROVIDER_SETTINGS_KEY)).toBe(false);
+  });
+
+  it('fails closed on corrupt identity without replacing its private proof', async () => {
+    const { context, values } = await profile();
+    const corrupt = { providerProof: 'do-not-disclose-this-proof', version: 9 };
+    values.set(BROWSER_PROVIDER_IDENTITY_KEY, corrupt);
+    await expect(loadBrowserProvider(context)).rejects.toMatchObject({
+      code: 'storage_failure',
+      message: expect.not.stringContaining(corrupt.providerProof),
+    });
+    expect(values.get(BROWSER_PROVIDER_IDENTITY_KEY)).toBe(corrupt);
+  });
+
+  it('reports storage failure without claiming enablement', async () => {
+    const { context, values } = await profile();
+    const first = await loadBrowserProvider(context);
+    const previous = values.get(BROWSER_PROVIDER_SETTINGS_KEY);
+    context.storageArea.setItem = () => {
+      throw new Error('private storage detail');
+    };
+    await expect(
+      saveBrowserProviderSettings(context, { ...first.settings, enabled: true, model: 'chosen' })
+    ).rejects.toMatchObject({
+      code: 'storage_failure',
+      message: expect.not.stringContaining('private storage detail'),
+      retryable: true,
+    });
+    expect(values.get(BROWSER_PROVIDER_SETTINGS_KEY)).toStrictEqual(previous);
+  });
+
+  it('rejects lost ownership during an awaited read without creating credentials', async () => {
+    const { context, values } = await profile();
+    const gate = Promise.withResolvers<void>();
+    const entered = Promise.withResolvers<void>();
+    const { getItem } = context.storageArea;
+    context.storageArea.getItem = async key => {
+      entered.resolve();
+      await gate.promise;
+      return getItem(key);
+    };
+    const loading = loadBrowserProvider(context);
+    await entered.promise;
+    await context.owner.release();
+    gate.resolve();
+    await expect(loading).rejects.toMatchObject({ code: 'owner_mismatch' });
+    expect(values.has(BROWSER_PROVIDER_IDENTITY_KEY)).toBe(false);
+  });
+
+  it('keeps legacy email-free accounts isolated without persisting their tokens', async () => {
+    const { context, values } = await profile();
+    const legacy = { token: 'legacy-private-token', userEmail: undefined };
+    values.set(AUTH_STORAGE_KEY, legacy);
+    await loadBrowserProvider({ ...context, auth: legacy });
+    const first = values.get(BROWSER_PROVIDER_SETTINGS_KEY);
+    values.set(AUTH_STORAGE_KEY, { ...legacy, token: 'different-token' });
+    await loadBrowserProvider({ ...context, auth: { ...legacy, token: 'different-token' } });
+    expect(values.get(BROWSER_PROVIDER_SETTINGS_KEY)).not.toStrictEqual(first);
+    expect(JSON.stringify(first)).not.toContain(legacy.token);
+    await expect(browserAccountKey(auth)).resolves.toBe(
+      await browserAccountKey({ ...auth, token: 'refreshed-token' })
+    );
+  });
+});

--- a/apps/extension/src/shared/browser-provider-settings.ts
+++ b/apps/extension/src/shared/browser-provider-settings.ts
@@ -1,0 +1,256 @@
+import {
+  BROWSER_FRAME_MAX_BYTES,
+  browserProviderIdSchema,
+} from '@kilocode/cloud-agent-sdk/schemas';
+import { z } from 'zod';
+import type { BrowserExecutionLease } from '../../entrypoints/sidepanel/browser-execution-lock';
+import { agentMemorySettingsSchema } from './agent-memory-settings';
+import { agentWorkflowSettingsSchema } from './agent-workflows';
+import {
+  AUTH_STORAGE_KEY,
+  BROWSER_PROVIDER_IDENTITY_KEY,
+  normalizeStoredAuth,
+  withBrowserProfileStorageLock,
+} from './auth';
+import type { StoredAuth } from './auth';
+import { normalizeRemoteMcpStore } from './remote-mcp-storage';
+import { webMcpSettingsSchema } from './web-mcp-settings';
+
+export const BROWSER_PROVIDER_SETTINGS_KEY = 'local:kiloBrowserProviderSettings';
+
+export type BrowserPersistenceCode =
+  | 'storage_failure'
+  | 'owner_mismatch'
+  | 'model_required'
+  | 'unsupported'
+  | 'invalid_request'
+  | 'invocation_expired'
+  | 'invocation_conflict'
+  | 'conversation_busy'
+  | 'not_found'
+  | 'capacity_exceeded';
+
+export class BrowserPersistenceError extends Error {
+  readonly code: BrowserPersistenceCode;
+  readonly retryable: boolean;
+
+  constructor(code: BrowserPersistenceCode, message: string) {
+    super(message);
+    this.name = 'BrowserPersistenceError';
+    this.code = code;
+    this.retryable = code === 'storage_failure' || code === 'capacity_exceeded';
+  }
+}
+
+// eslint-disable-next-line typescript/consistent-type-definitions -- Repository guidance prefers type declarations.
+export type BrowserProfileStorage = {
+  // eslint-disable-next-line anti-slop/no-unknown-returns -- Each consumer validates the raw persisted value at its storage boundary.
+  getItem: (key: `local:${string}`) => unknown;
+  setItem: (key: `local:${string}`, value: unknown) => void | Promise<void>;
+};
+// eslint-disable-next-line typescript/consistent-type-definitions -- Repository guidance prefers type declarations.
+export type BrowserProfileContext = {
+  readonly auth: StoredAuth;
+  readonly owner: BrowserExecutionLease;
+  readonly storageArea: BrowserProfileStorage;
+};
+
+const labelSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(128)
+  .refine(value => new TextEncoder().encode(value).byteLength <= 128);
+const identitySchema = z.strictObject({
+  label: labelSchema,
+  providerId: browserProviderIdSchema,
+  providerProof: z.string().regex(/^[a-f0-9]{64}$/u),
+  version: z.literal(1),
+});
+export type BrowserProviderIdentity = z.infer<typeof identitySchema>;
+
+export const browserProviderSettingsSchema = z.strictObject({
+  enabled: z.boolean(),
+  mode: z.enum(['safe', 'dangerous']),
+  model: z.string().trim().max(1024),
+  thinkingEffort: z.string().max(128),
+});
+export type BrowserProviderSettings = z.infer<typeof browserProviderSettingsSchema>;
+const settingsRecordSchema = z.strictObject({
+  accountKey: z.string().min(1),
+  settings: browserProviderSettingsSchema,
+  version: z.literal(1),
+});
+const defaultSettings = (): BrowserProviderSettings => ({
+  enabled: false,
+  mode: 'safe',
+  model: '',
+  thinkingEffort: '',
+});
+
+export const browserApprovalSettingsSchema = z.strictObject({
+  memorySettings: agentMemorySettingsSchema,
+  mode: z.enum(['safe', 'dangerous']),
+  model: z.string().trim().min(1).max(1024),
+  organizationId: z.string().min(1).max(128).nullable(),
+  remoteMcpServers: z
+    .array(z.unknown())
+    .transform(servers => normalizeRemoteMcpStore({ servers }).servers),
+  thinkingEffort: z.string().max(128),
+  webMcpSettings: webMcpSettingsSchema,
+  workflowSettings: agentWorkflowSettingsSchema,
+});
+export type BrowserApprovalSettings = z.infer<typeof browserApprovalSettingsSchema>;
+
+const hex = (bytes: Uint8Array): string =>
+  [...bytes].map(byte => byte.toString(16).padStart(2, '0')).join('');
+
+export const browserAccountKey = async (auth: StoredAuth): Promise<string> => {
+  // Older auth records can lack an email. Keep token-scoped isolation until those records retire.
+  const identity = auth.userEmail === undefined ? `token:${auth.token}` : `email:${auth.userEmail}`;
+  return hex(
+    new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(identity)))
+  );
+};
+
+/** Auth cleanup uses the same write lock; a stopped owner cannot restore cleared account data. */
+export const withBrowserProfileStorage = <Result>(
+  context: BrowserProfileContext,
+  work: (accountKey: string) => Promise<Result>
+): Promise<Result> =>
+  withBrowserProfileStorageLock(async () => {
+    const assertOwner = (): void => {
+      try {
+        if (context.owner.kind !== 'provider') {
+          throw new Error('Provider ownership required.');
+        }
+        context.owner.guard();
+      } catch {
+        throw new BrowserPersistenceError(
+          'owner_mismatch',
+          'This panel no longer owns the browser provider.'
+        );
+      }
+    };
+    try {
+      assertOwner();
+      const auth = normalizeStoredAuth(await context.storageArea.getItem(AUTH_STORAGE_KEY));
+      if (auth?.token !== context.auth.token || auth.userEmail !== context.auth.userEmail) {
+        throw new BrowserPersistenceError(
+          'owner_mismatch',
+          'The signed-in account changed. Browser work cannot resume.'
+        );
+      }
+      const accountKey = await browserAccountKey(auth);
+      assertOwner();
+      const result = await work(accountKey);
+      assertOwner();
+      return result;
+    } catch (error) {
+      if (error instanceof BrowserPersistenceError) {
+        throw error;
+      }
+      // Storage and validation errors can include private settings. Never forward their raw text.
+      throw new BrowserPersistenceError(
+        'storage_failure',
+        'Browser task storage is unavailable. No unrecorded work can start. Restore storage access and retry.'
+      );
+    }
+  });
+
+export const loadBrowserProvider = (context: BrowserProfileContext) =>
+  withBrowserProfileStorage(context, async accountKey => {
+    const rawIdentity = await context.storageArea.getItem(BROWSER_PROVIDER_IDENTITY_KEY);
+    const missingIdentity = rawIdentity === null || rawIdentity === undefined;
+    const providerId = missingIdentity ? `bp_${crypto.randomUUID()}` : undefined;
+    const identity = identitySchema.parse(
+      rawIdentity ?? {
+        label: `Browser profile ${providerId?.slice(3, 11)}`,
+        providerId,
+        providerProof: hex(crypto.getRandomValues(new Uint8Array(32))),
+        version: 1,
+      }
+    );
+    if (missingIdentity) {
+      context.owner.guard();
+      await context.storageArea.setItem(BROWSER_PROVIDER_IDENTITY_KEY, identity);
+    }
+    const rawSettings = await context.storageArea.getItem(BROWSER_PROVIDER_SETTINGS_KEY);
+    const record =
+      rawSettings === null || rawSettings === undefined
+        ? undefined
+        : settingsRecordSchema.parse(rawSettings);
+    const settings = record?.accountKey === accountKey ? record.settings : defaultSettings();
+    if (settings.enabled && settings.model.length === 0) {
+      throw new BrowserPersistenceError(
+        'model_required',
+        'Select a model before enabling CLI tasks.'
+      );
+    }
+    if (record?.accountKey !== accountKey) {
+      context.owner.guard();
+      await context.storageArea.setItem(BROWSER_PROVIDER_SETTINGS_KEY, {
+        accountKey,
+        settings,
+        version: 1,
+      });
+    }
+    return { identity, settings };
+  });
+
+export const saveBrowserProviderSettings = (
+  context: BrowserProfileContext,
+  settings: BrowserProviderSettings
+): Promise<BrowserProviderSettings> =>
+  withBrowserProfileStorage(context, async accountKey => {
+    const parsed = browserProviderSettingsSchema.parse(settings);
+    if (parsed.enabled && parsed.model.length === 0) {
+      throw new BrowserPersistenceError(
+        'model_required',
+        'Select a model before enabling CLI tasks.'
+      );
+    }
+    context.owner.guard();
+    await context.storageArea.setItem(BROWSER_PROVIDER_SETTINGS_KEY, {
+      accountKey,
+      settings: parsed,
+      version: 1,
+    });
+    return parsed;
+  });
+
+export const saveBrowserProviderLabel = (
+  context: BrowserProfileContext,
+  label: string
+): Promise<BrowserProviderIdentity> =>
+  withBrowserProfileStorage(context, async () => {
+    const identity = identitySchema.parse(
+      await context.storageArea.getItem(BROWSER_PROVIDER_IDENTITY_KEY)
+    );
+    const updated = { ...identity, label: labelSchema.parse(label) };
+    context.owner.guard();
+    await context.storageArea.setItem(BROWSER_PROVIDER_IDENTITY_KEY, updated);
+    return updated;
+  });
+
+const jsonSchema = z.json();
+/** Reject non-JSON values rather than silently dropping evidence or tool output. */
+export const browserRecordBytes = (value: unknown): number => {
+  try {
+    return new TextEncoder().encode(JSON.stringify(jsonSchema.parse(value))).byteLength;
+  } catch {
+    throw new BrowserPersistenceError(
+      'invalid_request',
+      'Browser task data must be JSON-serializable. No unrecorded work can start.'
+    );
+  }
+};
+
+export const assertBrowserRecordSize = (value: unknown, reservedBytes = 0): void => {
+  if (browserRecordBytes(value) + reservedBytes >= BROWSER_FRAME_MAX_BYTES) {
+    throw new BrowserPersistenceError(
+      'storage_failure',
+      'Browser task data exceeds the storage limit. No unrecorded work can start.'
+    );
+  }
+};

--- a/apps/extension/src/shared/browser-task-store.test.ts
+++ b/apps/extension/src/shared/browser-task-store.test.ts
@@ -1,0 +1,885 @@
+/* eslint-disable import/no-nodejs-modules, max-lines, jest/no-hooks, jest/no-conditional-in-test, require-await, typescript/require-await, unicorn/no-await-expression-member, typescript/no-unsafe-assignment, typescript/no-unsafe-type-assertion -- Mutation fixtures change persisted records deliberately; matcher objects inspect observable outcomes. */
+import { locks as nativeLocks } from 'node:worker_threads';
+import type {
+  BrowserProviderInboundMessage,
+  BrowserResult,
+} from '@kilocode/cloud-agent-sdk/schemas';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  BROWSER_EXECUTION_SAFETY_KEY,
+  createBrowserExecutionCoordinator,
+} from '../../entrypoints/sidepanel/browser-execution-lock';
+import type { BrowserExecutionLease } from '../../entrypoints/sidepanel/browser-execution-lock';
+import { createAssistantMessage, createSafeToolCall, createToolResult } from './agent-conversation';
+import { AUTH_STORAGE_KEY, clearStoredSession } from './auth';
+import { loadBrowserProvider } from './browser-provider-settings';
+import type { BrowserApprovalSettings, BrowserProfileStorage } from './browser-provider-settings';
+import { BROWSER_TASK_STORAGE_KEY, openBrowserTaskStore } from './browser-task-store';
+import type { StoredBrowserJob } from './browser-task-store';
+
+type Delivery = Extract<BrowserProviderInboundMessage, { type: 'provider_job' }>;
+const start = 1_788_000_000_000;
+const day = 24 * 60 * 60 * 1000;
+const leases: BrowserExecutionLease[] = [];
+const settings = (): BrowserApprovalSettings => ({
+  memorySettings: { autoApproveMemorySaves: false },
+  mode: 'safe',
+  model: 'explicit-model',
+  organizationId: null,
+  remoteMcpServers: [],
+  thinkingEffort: 'high',
+  webMcpSettings: { allowWebMcpInSafeMode: false },
+  workflowSettings: {
+    allowWorkflowsInSafeMode: false,
+    autoApproveWorkflowChanges: false,
+    autoApproveWorkflowRuns: false,
+  },
+});
+const tab = {
+  effectiveMode: 'safe' as const,
+  tabId: 7,
+  title: 'Approved tab',
+  url: 'https://example.test/task',
+};
+const resultFor = (delivery: Delivery): BrowserResult => ({
+  browserTaskId: delivery.job.browserTaskId,
+  effectsUncertain: false,
+  evidence: [],
+  invocationId: delivery.job.invocationId,
+  jobId: delivery.job.jobId,
+  providerId: delivery.job.providerId,
+  reason: 'completed',
+  status: 'succeeded',
+  summary: 'The page contains the requested text.',
+});
+const setup = async () => {
+  let time = start;
+  const auth = { token: 'token-a', userEmail: 'a@example.test' };
+  const values = new Map<string, unknown>([
+    [AUTH_STORAGE_KEY, auth],
+    [
+      'local:kiloAgentConversations',
+      {
+        activeConversationId: 'visible-local-id',
+        conversations: [
+          {
+            events: [createAssistantMessage('private local transcript')],
+            id: 'visible-local-id',
+            mode: 'dangerous',
+            model: 'local-model',
+            title: 'Local conversation',
+            updatedAt: new Date(start).toISOString(),
+          },
+        ],
+        openConversationIds: ['visible-local-id'],
+      },
+    ],
+    ['local:kiloAgentConversation', [createAssistantMessage('private legacy transcript')]],
+  ]);
+  const storageArea: BrowserProfileStorage & Parameters<typeof clearStoredSession>[0] = {
+    getItem: key => structuredClone(values.get(key)),
+    removeItems: keys => {
+      for (const key of keys) {
+        values.delete(key);
+      }
+    },
+    setItem: (key, value) => {
+      values.set(key, structuredClone(value));
+    },
+    snapshot: () => Object.fromEntries([...values].map(([key, value]) => [key.slice(6), value])),
+  };
+  const panel = createBrowserExecutionCoordinator({
+    locks: nativeLocks as LockManager,
+    storageArea: { ...storageArea, watch: () => () => {} },
+  });
+  const admission = await panel.acquireProviderOwner();
+  if (!admission.admitted) {
+    throw new Error(admission.reason);
+  }
+  const owner = admission.lease;
+  leases.push(owner);
+  const context = { auth, owner, storageArea };
+  const { identity } = await loadBrowserProvider(context);
+  const store = await openBrowserTaskStore(context, () => time);
+  const delivery = (overrides: Partial<Delivery> = {}): Delivery => ({
+    conversationMode: 'new',
+    goal: 'Read the requested page text.',
+    job: {
+      browserTaskId: `bt_${crypto.randomUUID()}`,
+      createdAt: new Date(time).toISOString(),
+      deadlines: {
+        approval: new Date(time + 120_000).toISOString(),
+        queue: new Date(time + 600_000).toISOString(),
+      },
+      expiresAt: new Date(time + 7 * day).toISOString(),
+      generation: 1,
+      invocationId: `b1.${time}.${crypto.randomUUID().replaceAll('-', '')}${crypto.randomUUID().replaceAll('-', '')}`,
+      jobId: `bj_${crypto.randomUUID()}`,
+      payloadFingerprint: 'a'.repeat(64),
+      providerId: identity.providerId,
+      status: 'awaiting_approval',
+    },
+    ownerLabel: 'ses_parent_a',
+    type: 'provider_job',
+    ...overrides,
+  });
+  const complete = async (message: Delivery) => {
+    await store.approve(message.job.invocationId, tab, settings());
+    const events = [
+      ...(await store.history(message.job.browserTaskId, message.ownerLabel)),
+      createAssistantMessage('Observed page text.'),
+    ];
+    return store.finish(message.job.invocationId, resultFor(message), events);
+  };
+  return {
+    complete,
+    context,
+    delivery,
+    now: () => time,
+    panel,
+    setTime: (value: number) => {
+      time = value;
+    },
+    storageArea,
+    store,
+    values,
+  };
+};
+
+describe('delegated browser job persistence', () => {
+  afterEach(async () => {
+    await Promise.all(leases.splice(0).map(lease => lease.release()));
+  });
+
+  it('keeps goal-only histories separate from local conversations and unrelated parents', async () => {
+    const state = await setup();
+    const oldLocal = {
+      current: structuredClone(state.values.get('local:kiloAgentConversations')),
+      legacy: structuredClone(state.values.get('local:kiloAgentConversation')),
+    };
+    const first = state.delivery();
+    const second = state.delivery({ goal: 'A separate goal.', ownerLabel: 'ses_parent_b' });
+    await Promise.all([state.store.accept(first), state.store.accept(second)]);
+    await expect(
+      state.store.history(first.job.browserTaskId, first.ownerLabel)
+    ).resolves.toMatchObject([{ role: 'user', text: first.goal }]);
+    await expect(
+      state.store.history(second.job.browserTaskId, second.ownerLabel)
+    ).resolves.toMatchObject([{ role: 'user', text: second.goal }]);
+    expect(JSON.stringify(state.values.get(BROWSER_TASK_STORAGE_KEY))).not.toContain('private');
+    expect({
+      current: state.values.get('local:kiloAgentConversations'),
+      legacy: state.values.get('local:kiloAgentConversation'),
+    }).toStrictEqual(oldLocal);
+    await expect(
+      state.store.history(first.job.browserTaskId, second.ownerLabel)
+    ).rejects.toMatchObject({ code: 'owner_mismatch' });
+  });
+
+  it.each(['awaiting_approval', 'running', 'succeeded'] as const)(
+    'makes duplicate delivery a lookup at %s without another history write',
+    async phase => {
+      const state = await setup();
+      const message = state.delivery();
+      await state.store.accept(message);
+      if (phase === 'running') {
+        await state.store.approve(message.job.invocationId, tab, settings());
+      }
+      if (phase === 'succeeded') {
+        await state.complete(message);
+      }
+      const before = structuredClone(state.values.get(BROWSER_TASK_STORAGE_KEY));
+      const write = state.storageArea.setItem;
+      state.storageArea.setItem = () => {
+        throw new Error('A lookup must not write.');
+      };
+      try {
+        const duplicate = await state.store.accept(message);
+        expect(duplicate).toMatchObject({ job: { snapshot: { status: phase } }, kind: 'existing' });
+        expect(state.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(before);
+      } finally {
+        state.storageArea.setItem = write;
+      }
+    }
+  );
+
+  it.each([
+    'goal',
+    'ownerLabel',
+    'conversationMode',
+    'fingerprint',
+    'generation',
+    'jobId',
+    'browserTaskId',
+  ] as const)(
+    'rejects a conflicting immutable %s without changing the accepted record',
+    async field => {
+      const state = await setup();
+      const message = state.delivery();
+      const accepted = await state.store.accept(message);
+      const changed = structuredClone(message);
+      if (field === 'goal') {
+        changed.goal = 'Different goal';
+      }
+      if (field === 'ownerLabel') {
+        changed.ownerLabel = 'ses_other';
+      }
+      if (field === 'conversationMode') {
+        changed.conversationMode = 'continue';
+      }
+      if (field === 'fingerprint') {
+        changed.job.payloadFingerprint = 'b'.repeat(64);
+      }
+      if (field === 'generation') {
+        changed.job.generation += 1;
+      }
+      if (field === 'jobId') {
+        changed.job.jobId = `bj_${crypto.randomUUID()}`;
+      }
+      if (field === 'browserTaskId') {
+        changed.job.browserTaskId = `bt_${crypto.randomUUID()}`;
+      }
+      await expect(state.store.accept(changed)).rejects.toMatchObject({
+        code: 'invocation_conflict',
+        retryable: false,
+      });
+      await expect(state.store.lookup(message.job.invocationId)).resolves.toStrictEqual(
+        accepted.job
+      );
+    }
+  );
+
+  it('rejects absent legacy intent instead of creating a new conversation', async () => {
+    const state = await setup();
+    const legacy = state.delivery();
+    delete legacy.conversationMode;
+    await expect(state.store.accept(legacy)).rejects.toMatchObject({
+      code: 'unsupported',
+      retryable: false,
+    });
+    await expect(state.store.list()).resolves.toStrictEqual([]);
+    await expect(
+      state.store.history(legacy.job.browserTaskId, legacy.ownerLabel)
+    ).rejects.toMatchObject({ code: 'not_found' });
+  });
+
+  it.each(['queued', 'awaiting_approval'] as const)(
+    'settles legacy %s work with unknown intent and never grants approval after reload',
+    async phase => {
+      const state = await setup();
+      const message = state.delivery();
+      const accepted = await state.store.accept(message);
+      const raw = state.values.get(BROWSER_TASK_STORAGE_KEY) as {
+        jobs: { intent: { conversationMode?: string } }[];
+      };
+      const [legacy] = raw.jobs;
+      if (legacy === undefined) {
+        throw new Error('Missing fixture job.');
+      }
+      delete legacy.intent.conversationMode;
+      Object.assign(legacy, { snapshot: { ...message.job, status: phase } });
+      const reloaded = await openBrowserTaskStore(state.context, state.now);
+      await expect(reloaded.lookup(message.job.invocationId)).resolves.toMatchObject({
+        intent: { conversationMode: 'unknown' },
+        snapshot: {
+          result: { effectsUncertain: false, reason: 'unsupported' },
+          status: 'interrupted',
+        },
+      });
+      await expect(
+        reloaded.approve(message.job.invocationId, tab, settings())
+      ).rejects.toMatchObject({ code: 'invalid_request' });
+      expect(accepted.job.snapshot.status).toBe('awaiting_approval');
+    }
+  );
+
+  it('requires owned, retained history and fresh settings and tab consent for continuation', async () => {
+    const state = await setup();
+    const first = state.delivery();
+    await state.store.accept(first);
+    await state.complete(first);
+    const next = state.delivery({
+      conversationMode: 'continue',
+      goal: 'Follow up only this browser history.',
+    });
+    next.job.browserTaskId = first.job.browserTaskId;
+    const accepted = await state.store.accept(next);
+    expect(accepted.job.approval).toBeNull();
+    expect(accepted.job.snapshot.approvedTab).toBeUndefined();
+    const approvedSettings = {
+      ...settings(),
+      mode: 'dangerous' as const,
+      model: 'new-explicit-model',
+      organizationId: 'org-selected',
+    };
+    const approvedTab = { ...tab, effectiveMode: 'dangerous' as const, tabId: 8 };
+    await state.store.approve(next.job.invocationId, approvedTab, approvedSettings);
+    approvedSettings.model = 'changed-after-approval';
+    approvedSettings.workflowSettings.autoApproveWorkflowRuns = true;
+    approvedTab.tabId = 99;
+    await expect(state.store.lookup(next.job.invocationId)).resolves.toMatchObject({
+      approval: {
+        settings: {
+          model: 'new-explicit-model',
+          organizationId: 'org-selected',
+          workflowSettings: { autoApproveWorkflowRuns: false },
+        },
+        tab: { tabId: 8 },
+      },
+      snapshot: { status: 'running' },
+    });
+    await expect(
+      state.store.history(first.job.browserTaskId, first.ownerLabel)
+    ).resolves.toMatchObject([
+      { text: first.goal },
+      { text: 'Observed page text.' },
+      { text: next.goal },
+    ]);
+    await expect(state.store.approve(next.job.invocationId, tab, settings())).rejects.toMatchObject(
+      { code: 'invalid_request' }
+    );
+  });
+
+  it.each(['missing', 'owner', 'provider', 'busy'] as const)(
+    'rejects %s continuation rather than starting another conversation',
+    async reason => {
+      const state = await setup();
+      const first = state.delivery();
+      await state.store.accept(first);
+      if (reason !== 'busy') {
+        await state.complete(first);
+      }
+      const next = state.delivery({ conversationMode: 'continue' });
+      if (reason !== 'missing') {
+        next.job.browserTaskId = first.job.browserTaskId;
+      }
+      if (reason === 'owner') {
+        next.ownerLabel = 'ses_other';
+      }
+      if (reason === 'provider') {
+        next.job.providerId = `bp_${crypto.randomUUID()}`;
+      }
+      await expect(state.store.accept(next)).rejects.toMatchObject({
+        code: {
+          busy: 'conversation_busy',
+          missing: 'not_found',
+          owner: 'owner_mismatch',
+          provider: 'owner_mismatch',
+        }[reason],
+        retryable: false,
+      });
+      await expect(state.store.list()).resolves.toHaveLength(1);
+    }
+  );
+
+  it('persists sanitized history and honest empty evidence before returning terminal completion', async () => {
+    const state = await setup();
+    const message = state.delivery();
+    await state.store.accept(message);
+    await state.store.approve(message.job.invocationId, tab, settings());
+    const call = createSafeToolCall({ name: 'get_viewport_screenshot', tabId: tab.tabId });
+    const screenshot = createToolResult({
+      ok: true,
+      toolCallId: call.id,
+      value: { dataUrl: 'data:image/png;base64,private-image-bytes', mediaType: 'image/png' },
+    });
+    const events = [
+      ...(await state.store.history(message.job.browserTaskId, message.ownerLabel)),
+      call,
+      screenshot,
+      createAssistantMessage('Observed the page.'),
+    ];
+    const gate = Promise.withResolvers<void>();
+    const write = state.storageArea.setItem;
+    let writing = false;
+    let completed = false;
+    state.storageArea.setItem = async (key, value) => {
+      writing = true;
+      await gate.promise;
+      await write(key, value);
+    };
+    const finish = (async () => {
+      const job = await state.store.finish(message.job.invocationId, resultFor(message), events);
+      completed = true;
+      return job;
+    })();
+    try {
+      await vi.waitFor(() => {
+        expect(writing).toBe(true);
+      });
+      expect(completed).toBe(false);
+      expect(JSON.stringify(state.values.get(BROWSER_TASK_STORAGE_KEY))).not.toContain(
+        'Observed the page.'
+      );
+    } finally {
+      gate.resolve();
+    }
+    const finished = await finish;
+    state.storageArea.setItem = write;
+    expect(finished.snapshot.result).toMatchObject({ evidence: [], status: 'succeeded' });
+    const reloaded = await openBrowserTaskStore(state.context, state.now);
+    expect((await reloaded.lookup(message.job.invocationId)).snapshot.result).toStrictEqual(
+      resultFor(message)
+    );
+    const history = await reloaded.history(message.job.browserTaskId, message.ownerLabel);
+    expect(JSON.stringify(history)).not.toContain('private-image-bytes');
+    expect(history).toContainEqual(
+      expect.objectContaining({
+        value: {
+          mediaType: 'image/png',
+          note: 'Viewport screenshot omitted from persisted history.',
+        },
+      })
+    );
+  });
+
+  it('interrupts in-flight work on reload and keeps its durable fence after expiry', async () => {
+    const state = await setup();
+    const message = state.delivery();
+    await state.store.accept(message);
+    await state.store.approve(message.job.invocationId, tab, settings());
+    const reloaded = await openBrowserTaskStore(state.context, state.now);
+    await expect(reloaded.lookup(message.job.invocationId)).resolves.toMatchObject({
+      snapshot: { result: { effectsUncertain: true }, status: 'interrupted' },
+      uncertaintyFence: true,
+    });
+    expect({
+      admitted: (await state.panel.acquireLocal()).admitted,
+      delivery: (await reloaded.accept(message)).kind,
+    }).toStrictEqual({ admitted: false, delivery: 'existing' });
+    state.setTime(start + 7 * day);
+    await reloaded.removeExpired();
+    await expect(reloaded.list()).resolves.toStrictEqual([]);
+    expect(state.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+    await expect(reloaded.lookup(message.job.invocationId)).rejects.toMatchObject({
+      code: 'invocation_expired',
+    });
+  });
+
+  it('keeps terminal results first-wins and does not rewrite cancelled history with late success', async () => {
+    const state = await setup();
+    const message = state.delivery();
+    await state.store.accept(message);
+    const cancelled: BrowserResult = {
+      ...resultFor(message),
+      effectsUncertain: false,
+      reason: 'cancelled',
+      status: 'cancelled',
+      summary: 'Stopped before approval.',
+    };
+    const events = await state.store.history(message.job.browserTaskId, message.ownerLabel);
+    await state.store.finish(message.job.invocationId, cancelled, events);
+    expect(
+      (
+        await state.store.finish(message.job.invocationId, resultFor(message), [
+          createAssistantMessage('Late success'),
+        ])
+      ).snapshot.result
+    ).toStrictEqual(cancelled);
+    await expect(
+      state.store.history(message.job.browserTaskId, message.ownerLabel)
+    ).resolves.toStrictEqual(events);
+  });
+
+  it.each(['accept', 'approve', 'finish'] as const)(
+    'does not report %s when its storage write fails',
+    async phase => {
+      const state = await setup();
+      const message = state.delivery();
+      if (phase !== 'accept') {
+        await state.store.accept(message);
+      }
+      if (phase === 'finish') {
+        await state.store.approve(message.job.invocationId, tab, settings());
+      }
+      const before = structuredClone(state.values.get(BROWSER_TASK_STORAGE_KEY));
+      state.storageArea.setItem = () => {
+        throw new Error('Quota exceeded with private context');
+      };
+      const operations = {
+        accept: () => state.store.accept(message),
+        approve: () => state.store.approve(message.job.invocationId, tab, settings()),
+        finish: () =>
+          state.store.finish(message.job.invocationId, resultFor(message), [
+            createAssistantMessage('Unrecorded result'),
+          ]),
+      };
+      const work = operations[phase]();
+      await expect(work).rejects.toMatchObject({
+        code: 'storage_failure',
+        message: expect.not.stringContaining('private context'),
+        retryable: true,
+      });
+      expect(state.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(before);
+    }
+  );
+
+  it('rejects oversized multibyte goals, oversized evidence, and unrecordable approval snapshots', async () => {
+    const state = await setup();
+    await expect(
+      state.store.accept(state.delivery({ goal: 'é'.repeat(8193) }))
+    ).rejects.toMatchObject({ code: 'invalid_request' });
+    const message = state.delivery();
+    await state.store.accept(message);
+    const approval = settings();
+    approval.remoteMcpServers = [
+      {
+        allowInSafeMode: false,
+        auth: { type: 'none' },
+        cachedTools: [{ inputSchema: { description: 'x'.repeat(70_000) }, name: 'tool' }],
+        displayName: 'Server',
+        enabled: true,
+        id: 'server',
+        slug: 'server',
+        status: 'connected',
+        url: 'https://example.test/mcp',
+      },
+    ];
+    await expect(
+      state.store.approve(message.job.invocationId, tab, approval)
+    ).rejects.toMatchObject({ code: 'storage_failure' });
+    expect((await state.store.lookup(message.job.invocationId)).snapshot.status).toBe(
+      'awaiting_approval'
+    );
+    await state.store.approve(message.job.invocationId, tab, settings());
+    await expect(
+      state.store.finish(
+        message.job.invocationId,
+        {
+          ...resultFor(message),
+          evidence: Array.from({ length: 9 }, () => ({ text: 'x'.repeat(8192) })),
+        },
+        []
+      )
+    ).rejects.toMatchObject({ code: 'invalid_request' });
+    expect((await state.store.lookup(message.job.invocationId)).snapshot.status).toBe('running');
+  });
+
+  it.each([Number.NaN, 1n, () => 'not JSON'])(
+    'rejects nonserializable tool output (%s) instead of silently dropping it',
+    async value => {
+      const state = await setup();
+      const message = state.delivery();
+      await state.store.accept(message);
+      const before = structuredClone(state.values.get(BROWSER_TASK_STORAGE_KEY));
+      await expect(
+        state.store.saveHistory(message.job.invocationId, [
+          createToolResult({ ok: true, toolCallId: 'tool', value }),
+        ])
+      ).rejects.toMatchObject({ code: 'invalid_request', retryable: false });
+      expect(state.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(before);
+    }
+  );
+
+  it('retains shared history until the last invocation expires and denies expired continuation', async () => {
+    const state = await setup();
+    const first = state.delivery();
+    await state.store.accept(first);
+    await state.complete(first);
+    state.setTime(start + day);
+    const next = state.delivery({ conversationMode: 'continue', goal: 'Follow-up' });
+    next.job.browserTaskId = first.job.browserTaskId;
+    await state.store.accept(next);
+    await state.complete(next);
+    state.setTime(start + 7 * day);
+    await state.store.removeExpired();
+    await expect(state.store.list()).resolves.toHaveLength(1);
+    await expect(
+      state.store.history(first.job.browserTaskId, first.ownerLabel)
+    ).resolves.toHaveLength(4);
+    state.setTime(start + 8 * day);
+    await expect(
+      state.store.history(first.job.browserTaskId, first.ownerLabel)
+    ).rejects.toMatchObject({ code: 'invocation_expired' });
+    await state.store.removeExpired();
+    const late = state.delivery({ conversationMode: 'continue' });
+    late.job.browserTaskId = first.job.browserTaskId;
+    await expect(state.store.accept(late)).rejects.toMatchObject({ code: 'not_found' });
+    await expect(state.store.list()).resolves.toStrictEqual([]);
+  });
+
+  it('clears account histories and refuses stale writes or foreign-account adoption after sign-out', async () => {
+    const state = await setup();
+    const message = state.delivery();
+    await state.store.accept(message);
+    await clearStoredSession(state.storageArea);
+    await expect(state.store.lookup(message.job.invocationId)).rejects.toMatchObject({
+      code: 'owner_mismatch',
+    });
+    await expect(
+      state.store.saveHistory(message.job.invocationId, [createAssistantMessage('stale')])
+    ).rejects.toMatchObject({ code: 'owner_mismatch' });
+    expect(state.values.has(BROWSER_TASK_STORAGE_KEY)).toBe(false);
+    const auth = { token: 'token-b', userEmail: 'b@example.test' };
+    state.values.set(AUTH_STORAGE_KEY, auth);
+    const next = await openBrowserTaskStore({ ...state.context, auth }, state.now);
+    await expect(next.list()).resolves.toStrictEqual([]);
+    await expect(next.accept({ ...message, conversationMode: 'continue' })).rejects.toMatchObject({
+      code: 'not_found',
+    });
+  });
+
+  it('rejects corrupt storage rather than replacing it with an empty delegated store', async () => {
+    const state = await setup();
+    const corrupt = { jobs: ['private-corrupt-history'], version: 99 };
+    state.values.set(BROWSER_TASK_STORAGE_KEY, corrupt);
+    await expect(openBrowserTaskStore(state.context, state.now)).rejects.toMatchObject({
+      code: 'storage_failure',
+    });
+    expect(state.values.get(BROWSER_TASK_STORAGE_KEY)).toBe(corrupt);
+  });
+
+  it('captures delivery and approval inputs before waiting behind another storage write', async () => {
+    const state = await setup();
+    const first = state.delivery();
+    await state.store.accept(first);
+    const gate = Promise.withResolvers<void>();
+    const { setItem } = state.storageArea;
+    let writing = false;
+    state.storageArea.setItem = async (key, value) => {
+      writing = true;
+      await gate.promise;
+      await setItem(key, value);
+    };
+    const updating = state.store.saveHistory(first.job.invocationId, [
+      createAssistantMessage('Earlier write'),
+    ]);
+    await vi.waitFor(() => {
+      expect(writing).toBe(true);
+    });
+    const snapshot = settings();
+    const approving = state.store.approve(first.job.invocationId, tab, snapshot);
+    const second = state.delivery({ goal: 'Original delivered goal' });
+    const accepting = state.store.accept(second);
+    snapshot.model = 'mutated after consent';
+    second.goal = 'mutated after delivery';
+    gate.resolve();
+    await Promise.all([updating, approving, accepting]);
+    state.storageArea.setItem = setItem;
+    await expect(state.store.lookup(first.job.invocationId)).resolves.toMatchObject({
+      approval: { settings: { model: 'explicit-model' } },
+    });
+    await expect(
+      state.store.history(second.job.browserTaskId, second.ownerLabel)
+    ).resolves.toMatchObject([{ text: 'Original delivered goal' }]);
+  });
+
+  it('serializes native storage writes with logout so a delayed writer cannot restore account data', async () => {
+    vi.stubGlobal('navigator', { locks: nativeLocks });
+    const state = await setup();
+    const message = state.delivery();
+    const gate = Promise.withResolvers<void>();
+    const { setItem } = state.storageArea;
+    let writing = false;
+    state.storageArea.setItem = async (key, value) => {
+      writing = true;
+      await gate.promise;
+      await setItem(key, value);
+    };
+    const accepting = state.store.accept(message);
+    await vi.waitFor(() => {
+      expect(writing).toBe(true);
+    });
+    const clearing = clearStoredSession(state.storageArea);
+    const stale = (async () => {
+      await expect(
+        state.store.saveHistory(message.job.invocationId, [createAssistantMessage('stale')])
+      ).rejects.toMatchObject({ code: 'owner_mismatch' });
+    })();
+    gate.resolve();
+    try {
+      await Promise.all([accepting, clearing, stale]);
+      expect(state.values.has(BROWSER_TASK_STORAGE_KEY)).toBe(false);
+      expect(state.values.has(AUTH_STORAGE_KEY)).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('retains bounded observed evidence with a maximum UTF-8 goal and a large approval snapshot', async () => {
+    const state = await setup();
+    const message = state.delivery({ goal: 'é'.repeat(8192) });
+    await state.store.accept(message);
+    const approval = settings();
+    approval.remoteMcpServers = [
+      {
+        allowInSafeMode: false,
+        auth: { type: 'none' },
+        cachedTools: [{ inputSchema: { description: 'x'.repeat(40_000) }, name: 'tool' }],
+        displayName: 'Server',
+        enabled: true,
+        id: 'server',
+        slug: 'server',
+        status: 'connected',
+        url: 'https://example.test/mcp',
+      },
+    ];
+    await state.store.approve(message.job.invocationId, tab, approval);
+    const result = {
+      ...resultFor(message),
+      evidence: Array.from({ length: 3 }, () => ({
+        text: 'é'.repeat(4096),
+        title: 'Observed title',
+        url: 'https://example.test/evidence',
+      })),
+      summary: 's'.repeat(32 * 1024),
+    };
+    const history = await state.store.history(message.job.browserTaskId, message.ownerLabel);
+    await state.store.finish(message.job.invocationId, result, history);
+    const reloaded = await openBrowserTaskStore(state.context, state.now);
+    await expect(reloaded.lookup(message.job.invocationId)).resolves.toMatchObject({
+      snapshot: { result },
+    });
+    await expect(
+      reloaded.history(message.job.browserTaskId, message.ownerLabel)
+    ).resolves.toStrictEqual(history);
+  });
+
+  it('rejects invalid consent and expired approval without changing the recorded invocation', async () => {
+    const state = await setup();
+    const message = state.delivery();
+    await state.store.accept(message);
+    await expect(
+      state.store.approve(message.job.invocationId, tab, { ...settings(), model: '' })
+    ).rejects.toMatchObject({ code: 'model_required', retryable: false });
+    await expect(
+      state.store.approve(
+        message.job.invocationId,
+        { ...tab, effectiveMode: 'dangerous' },
+        settings()
+      )
+    ).rejects.toMatchObject({ code: 'invalid_request', retryable: false });
+    state.setTime(start + 120_000);
+    await expect(
+      state.store.approve(message.job.invocationId, tab, settings())
+    ).rejects.toMatchObject({ code: 'invocation_expired' });
+    await expect(state.store.lookup(message.job.invocationId)).resolves.toMatchObject({
+      approval: null,
+      snapshot: { status: 'awaiting_approval' },
+    });
+  });
+
+  it('rejects a foreign terminal result even when the recorded invocation is already terminal', async () => {
+    const state = await setup();
+    const message = state.delivery();
+    await state.store.accept(message);
+    const finished = await state.complete(message);
+    const foreign = resultFor(state.delivery({ ownerLabel: 'ses_other' }));
+    await expect(state.store.finish(message.job.invocationId, foreign, [])).rejects.toMatchObject({
+      code: 'invalid_request',
+    });
+    await expect(state.store.lookup(message.job.invocationId)).resolves.toStrictEqual(finished);
+  });
+
+  it('rejects oversized history without evicting the previous transcript', async () => {
+    const state = await setup();
+    const message = state.delivery();
+    await state.store.accept(message);
+    const before = await state.store.history(message.job.browserTaskId, message.ownerLabel);
+    await expect(
+      state.store.saveHistory(message.job.invocationId, [
+        createAssistantMessage('é'.repeat(70_000)),
+      ])
+    ).rejects.toMatchObject({ code: 'storage_failure' });
+    await expect(
+      state.store.history(message.job.browserTaskId, message.ownerLabel)
+    ).resolves.toStrictEqual(before);
+  });
+
+  it('excludes the active job from the 100-job queue limit and rejects a larger stored queue', async () => {
+    const state = await setup();
+    const first = state.delivery();
+    await state.store.accept(first);
+    const raw = state.values.get(BROWSER_TASK_STORAGE_KEY) as {
+      histories: unknown[];
+      jobs: StoredBrowserJob[];
+    };
+    const [template] = raw.jobs;
+    if (template === undefined) {
+      throw new Error('Missing fixture.');
+    }
+    const queued = (index: number): StoredBrowserJob => {
+      const job = structuredClone(template);
+      const handle = {
+        browserTaskId: `bt_${crypto.randomUUID()}` as const,
+        invocationId: `b1.${start}.${index.toString(16).padStart(64, '0')}`,
+        jobId: `bj_${crypto.randomUUID()}` as const,
+        status: 'queued' as const,
+      };
+      job.intent.job = { ...job.intent.job, ...handle };
+      job.snapshot = { ...job.snapshot, ...handle };
+      return job;
+    };
+    raw.jobs = Array.from({ length: 100 }, (_value, index) => queued(index));
+    raw.histories = raw.jobs.map(job => ({
+      browserTaskId: job.snapshot.browserTaskId,
+      events: [],
+      expiresAt: job.snapshot.expiresAt,
+      ownerLabel: job.intent.ownerLabel,
+      providerId: job.snapshot.providerId,
+    }));
+    const active = state.delivery();
+    await expect(state.store.accept(active)).resolves.toMatchObject({ kind: 'accepted' });
+    const recorded = state.values.get(BROWSER_TASK_STORAGE_KEY) as { jobs: StoredBrowserJob[] };
+    recorded.jobs.push(queued(100));
+    const before = structuredClone(recorded);
+    await expect(state.store.lookup(active.job.invocationId)).rejects.toMatchObject({
+      code: 'capacity_exceeded',
+    });
+    expect(state.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(before);
+  });
+
+  it.each(['expired', 'future', 'renewed'] as const)(
+    'rejects %s invocation lifetimes before admission',
+    async kind => {
+      const state = await setup();
+      const message = state.delivery();
+      if (kind === 'renewed') {
+        message.job.expiresAt = new Date(start + 8 * day).toISOString();
+      } else {
+        const createdAt = kind === 'expired' ? start - 7 * day : start + 300_001;
+        message.job.invocationId = `b1.${createdAt}.${'a'.repeat(64)}`;
+        message.job.createdAt = new Date(createdAt).toISOString();
+        message.job.expiresAt = new Date(createdAt + 7 * day).toISOString();
+        message.job.deadlines = { approval: message.job.expiresAt, queue: message.job.expiresAt };
+      }
+      await expect(state.store.accept(message)).rejects.toMatchObject({
+        code: kind === 'expired' ? 'invocation_expired' : 'invalid_request',
+        retryable: false,
+      });
+      await expect(state.store.list()).resolves.toStrictEqual([]);
+    }
+  );
+
+  it('rejects the 1,001st retained job without evicting an accepted result', async () => {
+    const state = await setup();
+    const first = state.delivery();
+    await state.store.accept(first);
+    await state.complete(first);
+    const raw = state.values.get(BROWSER_TASK_STORAGE_KEY) as { jobs: StoredBrowserJob[] };
+    const [template] = raw.jobs;
+    if (template === undefined) {
+      throw new Error('Missing fixture.');
+    }
+    raw.jobs = Array.from({ length: 1000 }, (_value, index) => {
+      const job = structuredClone(template);
+      const invocationId = `b1.${start}.${index.toString(16).padStart(64, '0')}`;
+      const jobId = `bj_${crypto.randomUUID()}` as const;
+      job.intent.job.invocationId = invocationId;
+      job.intent.job.jobId = jobId;
+      job.snapshot.invocationId = invocationId;
+      job.snapshot.jobId = jobId;
+      if (job.snapshot.result !== undefined) {
+        job.snapshot.result.invocationId = invocationId;
+        job.snapshot.result.jobId = jobId;
+      }
+      return job;
+    });
+    const before = structuredClone(raw);
+    await expect(state.store.accept(state.delivery())).rejects.toMatchObject({
+      code: 'capacity_exceeded',
+      retryable: true,
+    });
+    expect(state.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(before);
+  });
+});

--- a/apps/extension/src/shared/browser-task-store.ts
+++ b/apps/extension/src/shared/browser-task-store.ts
@@ -1,0 +1,562 @@
+/* eslint-disable max-lines -- The bounded store keeps its schema, transitions, and retention checks in one owned module. */
+import {
+  BROWSER_GOAL_MAX_BYTES,
+  BROWSER_RESULT_MAX_BYTES,
+  browserApprovedTabSchema,
+  browserInvocationIdSchema,
+  browserJobSnapshotSchema,
+  browserProviderInboundMessageSchema,
+  browserProviderIdSchema,
+  browserResultSchema,
+  browserTaskIdSchema,
+  browserTerminalStatusSchema,
+} from '@kilocode/cloud-agent-sdk/schemas';
+import type {
+  BrowserJobSnapshot,
+  BrowserProviderInboundMessage,
+  BrowserResult,
+} from '@kilocode/cloud-agent-sdk/schemas';
+import { z } from 'zod';
+import { conversationEventsSchema } from '../../entrypoints/sidepanel/agent-conversation-schemas';
+import { createUserMessage } from './agent-conversation';
+import type { AgentConversationEvent } from './agent-conversation';
+import { toPersistedConversationEvents } from './agent-conversation-persistence';
+import {
+  BrowserPersistenceError,
+  assertBrowserRecordSize,
+  browserApprovalSettingsSchema,
+  loadBrowserProvider,
+  withBrowserProfileStorage,
+} from './browser-provider-settings';
+import type { BrowserApprovalSettings, BrowserProfileContext } from './browser-provider-settings';
+
+export const BROWSER_TASK_STORAGE_KEY = 'local:kiloBrowserTasks';
+const retentionMs = 7 * 24 * 60 * 60 * 1000;
+const futureSkewMs = 5 * 60 * 1000;
+const executionMs = 10 * 60 * 1000;
+const maxJobs = 1000;
+const maxQueued = 100;
+type ProviderJob = Extract<BrowserProviderInboundMessage, { type: 'provider_job' }>;
+const modeSchema = z.enum(['new', 'continue', 'unknown']);
+const intentSchema = z.strictObject({
+  // Old provider_job frames omit mode. Remove this fallback only after old peers and records retire.
+  conversationMode: modeSchema.default('unknown'),
+  goal: z
+    .string()
+    .min(1)
+    .max(BROWSER_GOAL_MAX_BYTES)
+    .refine(goal => new TextEncoder().encode(goal).byteLength <= BROWSER_GOAL_MAX_BYTES),
+  job: browserJobSnapshotSchema,
+  ownerLabel: z.string().min(1).max(128),
+});
+const approvalSchema = z.strictObject({
+  approvedAt: z.iso.datetime({ precision: 3 }),
+  settings: browserApprovalSettingsSchema,
+  tab: browserApprovedTabSchema,
+});
+const jobSchema = z.strictObject({
+  approval: approvalSchema.nullable(),
+  intent: intentSchema,
+  snapshot: browserJobSnapshotSchema,
+  uncertaintyFence: z.boolean(),
+});
+const historySchema = z.strictObject({
+  browserTaskId: browserTaskIdSchema,
+  events: conversationEventsSchema,
+  expiresAt: z.iso.datetime({ precision: 3 }),
+  ownerLabel: z.string().min(1).max(128),
+  providerId: browserProviderIdSchema,
+});
+const storeSchema = z.strictObject({
+  accountKey: z.string().min(1),
+  histories: z.array(historySchema).max(maxJobs),
+  jobs: z.array(jobSchema).max(maxJobs),
+  providerId: browserProviderIdSchema,
+  version: z.literal(1),
+});
+export type StoredBrowserJob = z.infer<typeof jobSchema>;
+type BrowserTaskState = z.infer<typeof storeSchema>;
+export type BrowserTaskHistory = z.infer<typeof historySchema>;
+
+const terminal = (job: BrowserJobSnapshot): boolean =>
+  browserTerminalStatusSchema.safeParse(job.status).success;
+const binding = (job: BrowserJobSnapshot): string =>
+  JSON.stringify([
+    job.providerId,
+    job.browserTaskId,
+    job.jobId,
+    job.invocationId,
+    job.generation,
+    job.payloadFingerprint,
+    job.createdAt,
+    job.expiresAt,
+    job.deadlines.queue,
+  ]);
+const expiresAt = (invocationId: string): number =>
+  Number(browserInvocationIdSchema.parse(invocationId).split('.')[1]) + retentionMs;
+const checkLifetime = (invocationId: string, now: number): void => {
+  const expiry = expiresAt(invocationId);
+  if (expiry <= now) {
+    throw new BrowserPersistenceError(
+      'invocation_expired',
+      'This browser invocation expired. It cannot execute or retrieve a retained result.'
+    );
+  }
+  if (expiry - retentionMs > now + futureSkewMs) {
+    throw new BrowserPersistenceError(
+      'invalid_request',
+      'The browser invocation timestamp is invalid.'
+    );
+  }
+};
+const interruptedResult = (
+  job: BrowserJobSnapshot,
+  effectsUncertain: boolean,
+  unknownIntent = false
+): BrowserResult => ({
+  browserTaskId: job.browserTaskId,
+  effectsUncertain,
+  evidence: [],
+  invocationId: job.invocationId,
+  jobId: job.jobId,
+  providerId: job.providerId,
+  reason: unknownIntent ? 'unsupported' : 'provider_unavailable',
+  status: 'interrupted',
+  summary: unknownIntent
+    ? 'The legacy invocation has no proven conversation intent. Start a new task explicitly.'
+    : 'The browser provider was interrupted. Retrieve status; do not replay this invocation. Close affected tabs before explicit recovery.',
+});
+
+/** Opening a new owner lifetime reconciles recorded work; it never resumes execution. */
+export const openBrowserTaskStore = async (
+  context: BrowserProfileContext,
+  now: () => number = Date.now
+) => {
+  const { identity } = await loadBrowserProvider(context);
+  const empty = (accountKey: string): BrowserTaskState => ({
+    accountKey,
+    histories: [],
+    jobs: [],
+    providerId: identity.providerId,
+    version: 1,
+  });
+  const read = async (accountKey: string): Promise<BrowserTaskState> => {
+    const raw = await context.storageArea.getItem(BROWSER_TASK_STORAGE_KEY);
+    if (raw === null || raw === undefined) {
+      return empty(accountKey);
+    }
+    const state = storeSchema.parse(raw);
+    if (state.accountKey !== accountKey) {
+      return empty(accountKey);
+    }
+    if (state.providerId !== identity.providerId) {
+      throw new BrowserPersistenceError(
+        'owner_mismatch',
+        'Browser history belongs to a different provider.'
+      );
+    }
+    const invocations = new Set<string>();
+    const jobs = new Set<string>();
+    const histories = new Set<string>();
+    for (const history of state.histories) {
+      if (histories.has(history.browserTaskId) || history.providerId !== state.providerId) {
+        throw new BrowserPersistenceError(
+          'storage_failure',
+          'Browser conversation bindings are invalid.'
+        );
+      }
+      histories.add(history.browserTaskId);
+      assertBrowserRecordSize(history);
+    }
+    for (const job of state.jobs) {
+      const { snapshot } = job;
+      if (
+        invocations.has(snapshot.invocationId) ||
+        jobs.has(snapshot.jobId) ||
+        snapshot.providerId !== state.providerId ||
+        binding(snapshot) !== binding(job.intent.job) ||
+        Date.parse(snapshot.expiresAt) !== expiresAt(snapshot.invocationId)
+      ) {
+        throw new BrowserPersistenceError(
+          'storage_failure',
+          'Browser invocation bindings are invalid.'
+        );
+      }
+      invocations.add(snapshot.invocationId);
+      jobs.add(snapshot.jobId);
+      assertBrowserRecordSize(job);
+    }
+    if (state.jobs.filter(job => job.snapshot.status === 'queued').length > maxQueued) {
+      throw new BrowserPersistenceError(
+        'capacity_exceeded',
+        'The browser queue exceeds its storage limit.'
+      );
+    }
+    return state;
+  };
+  const persist = async (state: BrowserTaskState): Promise<void> => {
+    for (const history of state.histories) {
+      assertBrowserRecordSize(history);
+    }
+    for (const job of state.jobs) {
+      // Reserve terminal capacity before execution, including JSON framing and phase metadata.
+      assertBrowserRecordSize(job, terminal(job.snapshot) ? 0 : BROWSER_RESULT_MAX_BYTES + 1024);
+    }
+    context.owner.guard();
+    await context.storageArea.setItem(BROWSER_TASK_STORAGE_KEY, storeSchema.parse(state));
+  };
+  const interrupt = async (job: StoredBrowserJob): Promise<void> => {
+    if (terminal(job.snapshot)) {
+      return;
+    }
+    const uncertain = job.snapshot.status === 'running';
+    if (uncertain) {
+      const tab = job.snapshot.approvedTab ?? job.approval?.tab;
+      if (tab === undefined) {
+        throw new BrowserPersistenceError(
+          'storage_failure',
+          'An interrupted browser job has no recorded tab. Browser storage needs recovery.'
+        );
+      }
+      await context.owner.quarantine(tab.tabId);
+    }
+    const result = interruptedResult(
+      job.snapshot,
+      uncertain,
+      job.intent.conversationMode === 'unknown'
+    );
+    job.snapshot = { ...job.snapshot, result, status: result.status };
+    job.uncertaintyFence ||= uncertain;
+  };
+  const prune = async (state: BrowserTaskState): Promise<void> => {
+    for (const job of state.jobs) {
+      if (Date.parse(job.snapshot.expiresAt) <= now()) {
+        // eslint-disable-next-line no-await-in-loop -- Persist each affected-tab fence before deleting its expired job.
+        await interrupt(job);
+      }
+    }
+    state.jobs = state.jobs.filter(job => Date.parse(job.snapshot.expiresAt) > now());
+    const retained = new Set(state.jobs.map(job => job.snapshot.browserTaskId));
+    state.histories = state.histories.filter(history => retained.has(history.browserTaskId));
+  };
+  const findJob = (state: BrowserTaskState, invocationId: string): StoredBrowserJob => {
+    checkLifetime(invocationId, now());
+    const job = state.jobs.find(candidate => candidate.snapshot.invocationId === invocationId);
+    if (job === undefined) {
+      throw new BrowserPersistenceError(
+        'not_found',
+        'The browser invocation is not recorded for this account.'
+      );
+    }
+    return job;
+  };
+  const historyFor = (
+    state: BrowserTaskState,
+    browserTaskId: string,
+    ownerLabel: string
+  ): BrowserTaskHistory => {
+    const history = state.histories.find(candidate => candidate.browserTaskId === browserTaskId);
+    if (history === undefined) {
+      throw new BrowserPersistenceError(
+        'not_found',
+        'Browser conversation history is missing or expired. Start a new task explicitly.'
+      );
+    }
+    if (history.providerId !== identity.providerId || history.ownerLabel !== ownerLabel) {
+      throw new BrowserPersistenceError(
+        'owner_mismatch',
+        'This browser conversation belongs to a different owner or provider.'
+      );
+    }
+    if (Date.parse(history.expiresAt) <= now()) {
+      throw new BrowserPersistenceError(
+        'invocation_expired',
+        'Browser conversation history expired. Start a new task explicitly.'
+      );
+    }
+    return history;
+  };
+  const transaction = <Result>(
+    work: (state: BrowserTaskState) => Result | Promise<Result>,
+    initialize = false
+  ): Promise<Result> =>
+    withBrowserProfileStorage(context, async accountKey => {
+      const state = await read(accountKey);
+      const before = JSON.stringify(state);
+      const result = await work(state);
+      if (initialize || JSON.stringify(state) !== before) {
+        await persist(state);
+      }
+      return structuredClone(result);
+    });
+
+  await transaction(async state => {
+    for (const job of state.jobs) {
+      // eslint-disable-next-line no-await-in-loop -- Reload settles every recorded job before accepting new work.
+      await interrupt(job);
+    }
+    await prune(state);
+  }, true);
+
+  return {
+    accept: (
+      message: ProviderJob
+    ): Promise<{ kind: 'accepted' | 'existing'; job: StoredBrowserJob }> => {
+      const parsed = browserProviderInboundMessageSchema.safeParse(message);
+      return transaction(async state => {
+        if (!parsed.success || parsed.data.type !== 'provider_job') {
+          throw new BrowserPersistenceError(
+            'invalid_request',
+            'The browser invocation is invalid or its goal exceeds 16 KiB.'
+          );
+        }
+        const delivery = parsed.data;
+        const intent = intentSchema.parse({
+          conversationMode: delivery.conversationMode ?? 'unknown',
+          goal: delivery.goal,
+          job: delivery.job,
+          ownerLabel: delivery.ownerLabel,
+        });
+        checkLifetime(intent.job.invocationId, now());
+        if (Date.parse(intent.job.expiresAt) !== expiresAt(intent.job.invocationId)) {
+          throw new BrowserPersistenceError(
+            'invalid_request',
+            'The browser invocation expiry does not match its encoded lifetime.'
+          );
+        }
+        if (intent.job.providerId !== identity.providerId) {
+          throw new BrowserPersistenceError(
+            'owner_mismatch',
+            'The browser invocation targets a different provider.'
+          );
+        }
+        const existing = state.jobs.find(
+          job => job.snapshot.invocationId === intent.job.invocationId
+        );
+        if (existing !== undefined) {
+          if (JSON.stringify(existing.intent) !== JSON.stringify(intent)) {
+            throw new BrowserPersistenceError(
+              'invocation_conflict',
+              'This invocation conflicts with its recorded intent. It cannot execute again.'
+            );
+          }
+          return { job: existing, kind: 'existing' };
+        }
+        if (intent.conversationMode === 'unknown') {
+          throw new BrowserPersistenceError(
+            'unsupported',
+            'The legacy invocation has no proven conversation intent. It cannot execute.'
+          );
+        }
+        if (state.jobs.some(job => job.snapshot.jobId === intent.job.jobId)) {
+          throw new BrowserPersistenceError(
+            'invocation_conflict',
+            'This browser job ID already belongs to another invocation.'
+          );
+        }
+        await prune(state);
+        // A provider_job is the active queue head. read() bounds retained queued rows separately.
+        if (state.jobs.length >= maxJobs) {
+          throw new BrowserPersistenceError(
+            'capacity_exceeded',
+            'Browser task storage is full. Retained jobs cannot be evicted. Retry after expiry.'
+          );
+        }
+        if (
+          state.jobs.some(
+            job =>
+              job.snapshot.browserTaskId === intent.job.browserTaskId && !terminal(job.snapshot)
+          )
+        ) {
+          throw new BrowserPersistenceError(
+            'conversation_busy',
+            'This browser conversation already has unfinished work. Retrieve its status first.'
+          );
+        }
+        let history = state.histories.find(
+          candidate => candidate.browserTaskId === intent.job.browserTaskId
+        );
+        if (intent.conversationMode === 'continue') {
+          history = historyFor(state, intent.job.browserTaskId, intent.ownerLabel);
+        } else {
+          if (history !== undefined) {
+            throw new BrowserPersistenceError(
+              'invocation_conflict',
+              'A new browser task cannot replace an existing conversation.'
+            );
+          }
+          history = {
+            browserTaskId: intent.job.browserTaskId,
+            events: [],
+            expiresAt: intent.job.expiresAt,
+            ownerLabel: intent.ownerLabel,
+            providerId: intent.job.providerId,
+          };
+          state.histories.push(history);
+        }
+        history.events.push(createUserMessage(intent.goal));
+        history.expiresAt = new Date(
+          Math.max(Date.parse(history.expiresAt), Date.parse(intent.job.expiresAt))
+        ).toISOString();
+        const job: StoredBrowserJob = {
+          approval: null,
+          intent,
+          snapshot: intent.job,
+          uncertaintyFence: false,
+        };
+        state.jobs.push(job);
+        return { job, kind: 'accepted' };
+      });
+    },
+    approve: async (
+      invocationId: string,
+      tab: z.infer<typeof browserApprovedTabSchema>,
+      settings: BrowserApprovalSettings
+    ): Promise<StoredBrowserJob> => {
+      // Capture consent before awaiting the write queue; later settings changes cannot increase authority.
+      const modelSelected = settings.model.trim().length > 0;
+      const parsed = approvalSchema.safeParse({
+        approvedAt: new Date(now()).toISOString(),
+        settings,
+        tab,
+      });
+      if (parsed.success) {
+        assertBrowserRecordSize(parsed.data);
+      }
+      const approval = parsed.success ? structuredClone(parsed.data) : undefined;
+      const approvedJob = await transaction(state => {
+        const job = findJob(state, invocationId);
+        if (
+          job.snapshot.status !== 'awaiting_approval' ||
+          job.approval !== null ||
+          job.intent.conversationMode === 'unknown'
+        ) {
+          throw new BrowserPersistenceError(
+            'invalid_request',
+            'This invocation cannot accept another tab approval.'
+          );
+        }
+        if (
+          job.snapshot.deadlines.approval === undefined ||
+          Date.parse(job.snapshot.deadlines.approval) <= now()
+        ) {
+          throw new BrowserPersistenceError(
+            'invocation_expired',
+            'The tab approval deadline expired. This invocation cannot start.'
+          );
+        }
+        if (!modelSelected) {
+          throw new BrowserPersistenceError(
+            'model_required',
+            'Select a model before approving this browser task.'
+          );
+        }
+        if (approval === undefined) {
+          throw new BrowserPersistenceError(
+            'invalid_request',
+            'The browser approval settings or tab are invalid.'
+          );
+        }
+        if (approval.settings.mode !== approval.tab.effectiveMode) {
+          throw new BrowserPersistenceError(
+            'invalid_request',
+            'The approved tab mode must match the approved settings.'
+          );
+        }
+        job.approval = approval;
+        job.snapshot = {
+          ...job.snapshot,
+          approvedTab: approval.tab,
+          deadlines: {
+            ...job.snapshot.deadlines,
+            execution: new Date(
+              Math.min(now() + executionMs, Date.parse(job.snapshot.expiresAt))
+            ).toISOString(),
+          },
+          status: 'running',
+        };
+        return job;
+      });
+      return approvedJob;
+    },
+    finish: (
+      invocationId: string,
+      result: BrowserResult,
+      events: AgentConversationEvent[]
+    ): Promise<StoredBrowserJob> =>
+      transaction(async state => {
+        const job = findJob(state, invocationId);
+        const parsed = browserResultSchema.safeParse(result);
+        const snapshot = parsed.success
+          ? browserJobSnapshotSchema.safeParse({
+              ...job.snapshot,
+              result: parsed.data,
+              status: parsed.data.status,
+            })
+          : undefined;
+        if (
+          snapshot?.success !== true ||
+          (result.status === 'succeeded' &&
+            job.snapshot.status !== 'running' &&
+            !terminal(job.snapshot))
+        ) {
+          throw new BrowserPersistenceError(
+            'invalid_request',
+            'The browser result is invalid, oversized, or does not match the approved invocation.'
+          );
+        }
+        if (terminal(job.snapshot)) {
+          return job;
+        }
+        if (result.effectsUncertain) {
+          const tab = job.approval?.tab;
+          if (tab === undefined) {
+            throw new BrowserPersistenceError(
+              'invalid_request',
+              'Uncertain browser work requires its recorded tab.'
+            );
+          }
+          await context.owner.quarantine(tab.tabId);
+        }
+        const history = historyFor(state, job.snapshot.browserTaskId, job.intent.ownerLabel);
+        const persisted = toPersistedConversationEvents(events);
+        assertBrowserRecordSize(persisted);
+        history.events = conversationEventsSchema.parse(persisted);
+        job.snapshot = snapshot.data;
+        job.uncertaintyFence = result.effectsUncertain;
+        return job;
+      }),
+    history: (browserTaskId: string, ownerLabel: string): Promise<AgentConversationEvent[]> =>
+      withBrowserProfileStorage(context, async accountKey => {
+        const history = historyFor(await read(accountKey), browserTaskId, ownerLabel);
+        // eslint-disable-next-line typescript/no-unsafe-type-assertion -- The event schema validates each event; JSON validation rejects explicitly undefined optional properties.
+        return structuredClone(history.events) as AgentConversationEvent[];
+      }),
+    list: (): Promise<StoredBrowserJob[]> =>
+      withBrowserProfileStorage(context, async accountKey => {
+        const state = await read(accountKey);
+        return state.jobs.filter(job => Date.parse(job.snapshot.expiresAt) > now());
+      }),
+    lookup: (invocationId: string): Promise<StoredBrowserJob> =>
+      withBrowserProfileStorage(context, async accountKey =>
+        structuredClone(findJob(await read(accountKey), invocationId))
+      ),
+    removeExpired: (): Promise<void> => transaction(prune),
+    saveHistory: (invocationId: string, events: AgentConversationEvent[]): Promise<void> =>
+      transaction(state => {
+        const job = findJob(state, invocationId);
+        if (terminal(job.snapshot)) {
+          throw new BrowserPersistenceError(
+            'invalid_request',
+            'A terminal browser invocation cannot change its history.'
+          );
+        }
+        const persisted = toPersistedConversationEvents(events);
+        assertBrowserRecordSize(persisted);
+        historyFor(state, job.snapshot.browserTaskId, job.intent.ownerLabel).events =
+          conversationEventsSchema.parse(persisted);
+      }),
+  };
+};
+
+export type BrowserTaskStore = Awaited<ReturnType<typeof openBrowserTaskStore>>;


### PR DESCRIPTION
- After an uncertain browser action, safety blocks remain after sign-out, expired sign-in, and account changes until you complete recovery.
- Switching accounts now removes the previous account's saved extension data before the new account signs in.

---

## Summary

Authentication cleanup preserves the complete safety record, including `allTabs`, and `BROWSER_PROVIDER_IDENTITY_KEY`, while deleting every other local key. `SessionStorageArea` replaces `clear` with `snapshot` and `removeItems`; `AuthStorageArea` makes these optional, so older adapters must sign out before switching accounts. `withBrowserProfileStorageLock` serializes account writes and cleanup, using the `kilo:browser-profile-storage` Web Lock when available.

<details>
<summary>Files</summary>

- `apps/extension/src/shared/auth.ts` — Source, modified, +71/−14 lines. Preserves identity and safety records, their WXT metadata, and unknown safety fields without clearing or rewriting them. Removes other local keys, including unknown account data, histories, and provider enablement. Detects account changes by email, or token for older records; serializes authentication saves and token-only removal. Uses an in-context queue without native locks; failed writes do not block later cleanup.
- `apps/extension/src/shared/auth-browser-fence.test.ts` — Test, added, +184/−0 lines. Covers protected safety records across authentication transitions and reload, with local and delegated work blocked until recovery.
- `apps/extension/src/shared/auth.test.ts` — Test, modified, +45/−16 lines. Replaces clear-only storage doubles and blanket-clear assertions with selective removal checks, including unknown account keys.

</details>

`BrowserProviderIdentity` keeps a stable identifier, private proof, and label; account-bound `BrowserProviderSettings` start disabled, in Safe mode, with empty model and thinking defaults. `browserProviderSettingsSchema` and `browserApprovalSettingsSchema` validate provider settings and `BrowserApprovalSettings`; enablement and approval require a selected model independent of local conversations. `withBrowserProfileStorage` checks `BrowserProfileContext` ownership and `BrowserProfileStorage` authentication; `BrowserPersistenceError` uses `BrowserPersistenceCode` to hide private details and mark only storage/capacity failures retryable.

<details>
<summary>Files</summary>

- `apps/extension/src/shared/browser-provider-settings.ts` — Source, added, +256/−0 lines. Adds version-1 identity under `BROWSER_PROVIDER_IDENTITY_KEY` and account settings under `BROWSER_PROVIDER_SETTINGS_KEY`; neither uses local conversation settings. Creates a random identifier and a 32-byte private proof; label changes preserve both and enforce a 128-byte limit. Hashes email for account isolation, with token-based hashing for older records without email. Loads another account with disabled defaults and rejects stale authentication or non-provider owners around storage operations. Approval snapshots include model, mode, thinking effort, organization, memory/workflow settings, and web/remote Model Context Protocol (MCP) settings. Requires JavaScript Object Notation (JSON) values and records below 128 kibibytes (KiB).
- `apps/extension/src/shared/browser-provider-settings.test.ts` — Test, added, +214/−0 lines. Adds coverage for identity persistence, account isolation, disabled and Safe defaults, model selection, ownership checks, and storage failures.

</details>

`BrowserTaskStore` stores `StoredBrowserJob` and `BrowserTaskHistory` under `BROWSER_TASK_STORAGE_KEY`, isolating account, provider, and owner bindings without changing local conversations. Missing `conversationMode` becomes `unknown` and cannot execute; exact duplicates return status, conflicts fail, and continuations require matching retained history. Callers must await bounded writes for fresh approval snapshots, history, and terminal results; reload interrupts unfinished work and retains uncertainty fences instead of replaying execution.

<details>
<summary>Files</summary>

- `apps/extension/src/shared/browser-task-store.ts` — Source, added, +562/−0 lines. Adds the version-1 delegated store with goal-only histories, immutable intent and terminal results, per-invocation approval time/tab/settings, and one unfinished invocation per conversation. Validates provider, owner, job, invocation, generation, fingerprint, and encoded-expiry bindings; rejects new tasks that replace existing history. Keeps results for seven days from the invocation timestamp and rejects timestamps over five minutes ahead. Allows up to 1,000 jobs and 1,000 histories, with 100 queued jobs, 16 KiB goals, and 64 KiB results. Each record stays below 128 KiB. Reserves terminal capacity before execution and never evicts unexpired jobs. Approval requires an unexpired deadline and matching tab mode; its ten-minute execution deadline cannot exceed invocation expiry. Reuses the event sanitizer, omitting screenshot bytes, and validates bounded JSON evidence, including empty evidence. Persists uncertainty blocks before settlement or expiry removal; drops history only when no retained job needs it. Rejects edits to terminal history and returns the recorded result on repeated settlement. Missing, expired, or mismatched continuation history returns an explicit error rather than starting another conversation.
- `apps/extension/src/shared/browser-task-store.test.ts` — Test, added, +885/−0 lines. Adds regression coverage for history separation, continuation intent, duplicates, immutable results, approval snapshots, reload interruption, authentication changes, storage limits, expiry, and evidence sanitization.

</details>

A TypeScript abstract syntax tree (AST) inventory rejects local-storage clear access in production code, including imported aliases and computed methods. It reports every detected location, so new clear sites cannot silently bypass protected profile persistence; explicit key removal and nonlocal clearing remain allowed.

<details>
<summary>Files</summary>

- `apps/extension/src/shared/auth-storage-boundary.test.ts` — Test, added, +202/−0 lines. Scans extension production sources while excluding tests and declarations. Adds mutation fixtures for direct browser calls, WXT calls, imported aliases, destructured or bound methods, and computed access. Permits snapshots, selective removal, nonlocal clearing, and source strings that merely mention forbidden syntax.

</details>

Tests: 5 files changed—4 added (`auth-browser-fence.test.ts`, `auth-storage-boundary.test.ts`, `browser-provider-settings.test.ts`, `browser-task-store.test.ts`) and 1 modified (`auth.test.ts`); +1,530/−16 lines.
Generated: 0 files changed.

---

## Verification

No manual tests ran for this level. Provider execution, controls, and live verification belong to later stack levels, so native browser verification remains pending. The handoff includes no end-to-end (E2E) report.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Human steps

- **before merge: After the complete section passes its gates, merge all lower stack levels first.**
- **after merge: Merge the higher stack levels in order.**

The orchestrator owns the unfinished verification gates. The code creates its local records automatically; this level requires no migration, new environment value, or manual secret setup.

### Context

- Scope: Cloud level 10, `browser-task-0787-s9...browser-task-0787-s10`; 8 files, 2,419 additions, and 30 deletions.
- This level adds persistence and protected cleanup; it does not enable the complete provider feature.
- Stack base: [Cloud level 9, #5698](https://github.com/Kilo-Org/cloud/pull/5698).
- Companion tip: [command-line interface (CLI) level 6, #13567](https://github.com/Kilo-Org/kilocode/pull/13567).
- Cloud worktree: `/Users/igor/Projects/.worktrees/browser-task-0787`; branch `browser-task-0787-s10`.
- CLI worktree: `/Users/igor/Projects/.worktrees/browser-task-0787-kilocode`; branch `browser-task-0787-s6`. This level includes no CLI changes.
- The handoff reports 101 passing tests and four passing scoped checks: Vitest, formatting, type-aware lint/type checking, and whitespace validation.

### Notes

Live browser verification is pending. Native Chrome and Firefox behavior, the real CLI, and the local relay remain required before human-ready.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `browser-task-0787` — #5638
2. `browser-task-0787-s2` — #5644
3. `browser-task-0787-s3` — #5648
4. `browser-task-0787-s4` — #5653
7. `browser-task-0787-s7` — #5681
8. `browser-task-0787-s8` — #5694
9. `browser-task-0787-s9` — #5698
10. `browser-task-0787-s10` — #5702 ← this PR
11. `browser-task-0787-s11` — #5716
12. `browser-task-0787-s12` — #5734
13. `browser-task-0787-s13` — #5742 (tip)

