### PR TITLE
feat(pr-review): define linked issue source contracts

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-issues-schema.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-issues-schema.test.ts
@@ -1,0 +1,145 @@
+import { contextIssueEventSchema, contextIssueSchema } from './context-issues';
+
+const createdAt = '2026-08-28T12:00:00+02:00';
+const pr = { __typename: 'PullRequest', id: 'PR_current' };
+const issue = {
+  __typename: 'Issue',
+  id: 'I_first',
+  number: 7,
+  title: `  ${'Full issue title with details beyond a narrow screen. '.repeat(6)}  `,
+  state: 'OPEN',
+  repository: { nameWithOwner: 'owner/repo' },
+  url: 'https://github.com/owner/repo/issues/7',
+};
+
+it('preserves full issue data and same-number identities across repositories', () => {
+  const otherIssue = {
+    ...issue,
+    id: 'I_other',
+    state: 'CLOSED',
+    repository: { nameWithOwner: 'other/repo' },
+    url: 'https://github.com/other/repo/issues/7',
+  };
+  expect([issue, otherIssue].map(value => contextIssueSchema.parse(value))).toEqual([
+    issue,
+    otherIssue,
+  ]);
+});
+
+it.each([null, undefined, 'not a URL'])('retains issue identity when its URL is %p', url => {
+  expect(contextIssueSchema.parse({ ...issue, url })).toEqual({ ...issue, url: null });
+});
+
+it.each([
+  { __typename: 'PullRequest' },
+  { id: '' },
+  { id: null },
+  { id: undefined },
+  { number: 0 },
+  { number: -1 },
+  { number: 1.5 },
+  { number: '7' },
+  { number: undefined },
+  { title: null },
+  { title: undefined },
+  { state: 'MERGED' },
+  { state: undefined },
+  { repository: null },
+  { repository: {} },
+  { repository: { nameWithOwner: '' } },
+  { repository: { nameWithOwner: 7 } },
+])('rejects malformed issue fields %p', patch => {
+  expect(contextIssueSchema.safeParse({ ...issue, ...patch }).success).toBe(false);
+});
+
+it.each([null, undefined, {}, pr])('rejects a missing or non-issue node %p', node => {
+  expect(contextIssueSchema.safeParse(node).success).toBe(false);
+});
+
+describe.each([
+  ['ConnectedEvent', 'source', 'subject', 'connected', false],
+  ['DisconnectedEvent', 'source', 'subject', 'connected', true],
+  ['CrossReferencedEvent', 'source', 'target', 'referenced', false],
+  ['MarkedAsDuplicateEvent', 'duplicate', 'canonical', 'duplicate', false],
+  ['UnmarkedAsDuplicateEvent', 'duplicate', 'canonical', 'duplicate', true],
+] as const)('%s', (type, sourceField, targetField, category, removed) => {
+  const event = (source: unknown, target: unknown, patch: Record<string, unknown> = {}) => ({
+    __typename: type,
+    id: 'event-id',
+    createdAt,
+    [sourceField]: source,
+    [targetField]: target,
+    ...(type === 'CrossReferencedEvent'
+      ? { referencedAt: '2026-08-29T09:00:00Z', willCloseTarget: true }
+      : {}),
+    ...patch,
+  });
+
+  it.each([
+    ['PR to issue', pr, issue],
+    ['issue to PR', issue, pr],
+    ['deleted source', null, issue],
+    ['deleted target', issue, null],
+    ['deleted endpoints', null, null],
+  ])('preserves %s with its category and removal marker', (_direction, source, target) => {
+    expect(contextIssueEventSchema.parse(event(source, target))).toEqual({
+      id: 'event-id',
+      createdAt,
+      category,
+      removed,
+      source,
+      target,
+    });
+  });
+
+  it.each([null, undefined, 'invalid', '2026-08-28T12:00:00'])(
+    'retains evidence with unavailable creation time %p without borrowing another clock',
+    time => {
+      expect(contextIssueEventSchema.parse(event(pr, issue, { createdAt: time }))).toEqual({
+        id: 'event-id',
+        createdAt: null,
+        category,
+        removed,
+        source: pr,
+        target: issue,
+      });
+    }
+  );
+
+  it.each([
+    undefined,
+    {},
+    { __typename: 'User', id: 'U' },
+    { ...pr, id: '' },
+    { ...issue, id: '' },
+    { ...issue, number: 0 },
+  ])('rejects malformed endpoint %p in either position', endpoint => {
+    expect(() => contextIssueEventSchema.parse(event(endpoint, issue))).toThrow();
+    expect(() => contextIssueEventSchema.parse(event(pr, endpoint))).toThrow();
+  });
+
+  it.each([null, undefined, 'not a URL'])('retains an issue endpoint with URL %p', url => {
+    const endpoint = { ...issue, url };
+    expect(contextIssueEventSchema.parse(event(pr, endpoint)).target).toEqual({
+      ...issue,
+      url: null,
+    });
+    expect(contextIssueEventSchema.parse(event(endpoint, pr)).source).toEqual({
+      ...issue,
+      url: null,
+    });
+  });
+
+  it.each(['', null, undefined])('rejects unavailable event identity %p', id => {
+    expect(() => contextIssueEventSchema.parse(event(pr, issue, { id }))).toThrow();
+  });
+});
+
+it.each([
+  null,
+  undefined,
+  {},
+  { __typename: 'LabeledEvent', id: 'event-id', createdAt, source: pr, target: issue },
+])('rejects missing or unsupported event %p', event => {
+  expect(contextIssueEventSchema.safeParse(event).success).toBe(false);
+});

--- a/apps/web/src/lib/github-pr-review/context-issues.ts
+++ b/apps/web/src/lib/github-pr-review/context-issues.ts
@@ -1,0 +1,104 @@
+import 'server-only';
+
+import { z } from 'zod';
+import { GitHubPrReviewIssueSchema, GitHubPrReviewTimestampSchema } from './context-dtos';
+
+const endpointFragment = /* GraphQL */ `
+  fragment ContextIssueEndpoint on Node {
+    id __typename
+    ... on Issue { number title state url repository { nameWithOwner } }
+  }
+`;
+export const PR_CONTEXT_ISSUE_QUERIES = {
+  closingIssuesReferences: /* GraphQL */ `
+    query PrReviewContextClosingIssues($owner: String!, $name: String!, $number: Int!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          id
+          closingIssuesReferences(first: 100, after: $after, userLinkedOnly: false) {
+            totalCount
+            pageInfo { hasNextPage endCursor }
+            nodes { ...ContextIssueEndpoint }
+          }
+        }
+      }
+    }
+    ${endpointFragment}
+  `,
+  timelineItems: /* GraphQL */ `
+    query PrReviewContextIssueEvents($owner: String!, $name: String!, $number: Int!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          id
+          timelineItems(first: 100, after: $after, itemTypes: [CONNECTED_EVENT, DISCONNECTED_EVENT, CROSS_REFERENCED_EVENT, MARKED_AS_DUPLICATE_EVENT, UNMARKED_AS_DUPLICATE_EVENT]) {
+            totalCount
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              __typename
+              ... on ConnectedEvent { id createdAt source { ...ContextIssueEndpoint } subject { ...ContextIssueEndpoint } }
+              ... on DisconnectedEvent { id createdAt source { ...ContextIssueEndpoint } subject { ...ContextIssueEndpoint } }
+              ... on CrossReferencedEvent { id createdAt referencedAt source { ...ContextIssueEndpoint } target { ...ContextIssueEndpoint } willCloseTarget }
+              ... on MarkedAsDuplicateEvent { id createdAt canonical { ...ContextIssueEndpoint } duplicate { ...ContextIssueEndpoint } }
+              ... on UnmarkedAsDuplicateEvent { id createdAt canonical { ...ContextIssueEndpoint } duplicate { ...ContextIssueEndpoint } }
+            }
+          }
+        }
+      }
+    }
+    ${endpointFragment}
+  `,
+};
+
+export const contextIssueSchema = GitHubPrReviewIssueSchema.omit({
+  relationships: true,
+  repository: true,
+}).extend({
+  __typename: z.literal('Issue'),
+  repository: z.object({ nameWithOwner: z.string().min(1) }),
+  url: GitHubPrReviewIssueSchema.shape.url.catch(null),
+});
+const endpointSchema = z
+  .discriminatedUnion('__typename', [
+    contextIssueSchema,
+    z.object({ __typename: z.literal('PullRequest'), id: z.string().min(1) }),
+  ])
+  .nullable();
+const eventFields = {
+  id: z.string().min(1),
+  createdAt: GitHubPrReviewTimestampSchema.nullable().catch(null),
+};
+export const contextIssueEventSchema = z
+  .union([
+    z.object({
+      ...eventFields,
+      __typename: z.enum(['ConnectedEvent', 'DisconnectedEvent']),
+      source: endpointSchema,
+      subject: endpointSchema,
+    }),
+    z.object({
+      ...eventFields,
+      __typename: z.literal('CrossReferencedEvent'),
+      source: endpointSchema,
+      target: endpointSchema,
+    }),
+    z.object({
+      ...eventFields,
+      __typename: z.enum(['MarkedAsDuplicateEvent', 'UnmarkedAsDuplicateEvent']),
+      canonical: endpointSchema,
+      duplicate: endpointSchema,
+    }),
+  ])
+  .transform(event => ({
+    id: event.id,
+    createdAt: event.createdAt,
+    category:
+      'canonical' in event
+        ? ('duplicate' as const)
+        : 'subject' in event
+          ? ('connected' as const)
+          : ('referenced' as const),
+    removed: ['DisconnectedEvent', 'UnmarkedAsDuplicateEvent'].includes(event.__typename),
+    source: 'duplicate' in event ? event.duplicate : event.source,
+    target:
+      'canonical' in event ? event.canonical : 'subject' in event ? event.subject : event.target,
+  }));

--- a/apps/web/src/routers/github-pr-review-graphql-schema.test.ts
+++ b/apps/web/src/routers/github-pr-review-graphql-schema.test.ts
@@ -42,8 +42,8 @@ const introspection = JSON.parse(readFileSync(introspectionPath, 'utf8'));
 const githubSchema = buildClientSchema(introspection);
 
 describe('github-pr-review-router GraphQL documents', () => {
-  test('exports exactly 17 documents (sanity guard for the export record)', () => {
-    expect(Object.keys(PR_REVIEW_GRAPHQL_DOCUMENTS)).toHaveLength(17);
+  test('exports exactly 19 documents (sanity guard for the export record)', () => {
+    expect(Object.keys(PR_REVIEW_GRAPHQL_DOCUMENTS)).toHaveLength(19);
   });
 
   test.each(Object.entries(PR_REVIEW_GRAPHQL_DOCUMENTS))(

--- a/apps/web/src/routers/github-pr-review-router.ts
+++ b/apps/web/src/routers/github-pr-review-router.ts
@@ -49,6 +49,7 @@ import {
 } from '@/lib/github-pr-review/context-reader';
 import { PR_CONTEXT_PEOPLE_QUERIES } from '@/lib/github-pr-review/context-people';
 import { PR_CONTEXT_REVIEW_QUERIES } from '@/lib/github-pr-review/context-reviews';
+import { PR_CONTEXT_ISSUE_QUERIES } from '@/lib/github-pr-review/context-issues';
 import { getGitHubUserAccessToken } from '@/lib/integrations/platforms/github/user-token-client';
 import {
   AutoMergeMethodSchema,
@@ -545,6 +546,7 @@ export const PR_REVIEW_GRAPHQL_DOCUMENTS = {
   PR_CONTEXT_REVISION_QUERY,
   ...PR_CONTEXT_PEOPLE_QUERIES,
   ...PR_CONTEXT_REVIEW_QUERIES,
+  ...PR_CONTEXT_ISSUE_QUERIES,
   REVIEW_THREADS_QUERY,
   REVIEW_THREAD_COMMENTS_FOLLOWUP_QUERY,
   CONVERSATION_COMMENTS_QUERY,


### PR DESCRIPTION
No new behavior — the work prepares linked-issue support without changing the mobile app.

---

## Summary

`PR_CONTEXT_ISSUE_QUERIES` adds `PrReviewContextClosingIssues` and `PrReviewContextIssueEvents` with `ContextIssueEndpoint`; `PR_REVIEW_GRAPHQL_DOCUMENTS` registers both for validation without activating reads.
`contextIssueSchema` validates issue and repository identity; `contextIssueEventSchema` maps five event types into directed `connected`, `referenced`, or `duplicate` records with `removed` markers.
Invalid `createdAt` values and URLs become `null`, and endpoints remain nullable; validation covers `ConnectedEvent`, `DisconnectedEvent`, `CrossReferencedEvent`, `MarkedAsDuplicateEvent`, and `UnmarkedAsDuplicateEvent`.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-issues.ts` — Added (+104/-0 lines). Adds server-only queries with 100-item cursor pages, total counts, and the pull request identity. Closing references set `userLinkedOnly: false`; both queries include issue numbers, titles, states, URLs, and repository names. Cross-reference selections also include `referencedAt` and `willCloseTarget`; normalization retains `createdAt`, not these two fields. Raw issue inputs omit `relationships` and require nonempty `repository.nameWithOwner`; endpoints accept only `Issue`, `PullRequest`, or `null`. Connected events map `source` to `subject`; cross-references retain `source` and `target`; duplicate events map `duplicate` to `canonical`. Event identifiers must be nonempty; disconnect and unmark events set `removed`.
- `apps/web/src/routers/github-pr-review-router.ts` — Modified (+2/-0 lines). Imports the linked-issue queries and adds them to the document registry; existing routes and reader calls remain unchanged.
- `apps/web/src/lib/github-pr-review/context-issues-schema.test.ts` — Added (+145/-0 lines). Adds 134 direct normalization cases for the linked-issue schemas.
- `apps/web/src/routers/github-pr-review-graphql-schema.test.ts` — Modified (+2/-2 lines). Updates GraphQL schema validation coverage for the expanded document registry.

</details>

Tests: 2 files changed: `context-issues-schema.test.ts` added and `github-pr-review-graphql-schema.test.ts` updated; 134 direct normalization cases added.
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

No manual tests ran for this level because it defines source contracts without connecting the reader or changing mobile presentation.
Provider, fixture, mobile, and runtime acceptance remain in their approved later phases.

## Reviewer Notes

### Human steps

No human steps are required before merge or after merge.

### Scope and automated evidence

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- Scope: level 11 only, from `mobile-pr-review-context-5458-s10` to `mobile-pr-review-context-5458-s11`.
- The handoff reports 155 passing tests across both changed suites, six passing scoped checks, and a passing fresh implementation review.

### Notes

This level defines linked-issue source contracts. Reader integration and live backend/iOS verification remain pending on the completed stack tip.









<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706 ← this PR
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
