### PR TITLE
feat(pr-review): integrate typed linked issue context

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-issues.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-issues.test.ts
@@ -1,0 +1,236 @@
+import type { Octokit } from '@octokit/rest';
+import {
+  createContextReadBudget,
+  readPullRequestContext,
+  PR_CONTEXT_REVISION_QUERY,
+} from './context-reader';
+import { PR_CONTEXT_ISSUE_QUERIES } from './context-issues';
+import { PR_CONTEXT_PEOPLE_QUERIES } from './context-people';
+import { PR_CONTEXT_REVIEW_QUERIES } from './context-reviews';
+import { GitHubPrReviewContextSchema } from './context-dtos';
+
+const fields = ['closingIssuesReferences', 'timelineItems'] as const;
+type Field = (typeof fields)[number];
+const prEndpoint = { __typename: 'PullRequest', id: 'PR' };
+const title = 'A full issue title '.repeat(30);
+const issue = (id = 'I', repository = 'o/r') => ({
+  __typename: 'Issue',
+  id,
+  number: 7,
+  title,
+  state: 'OPEN',
+  url: `https://github.com/${repository}/issues/7`,
+  repository: { nameWithOwner: repository },
+});
+function event(type: string, index = 1, source: unknown = prEndpoint, target: unknown = issue()) {
+  const base = {
+    __typename: type,
+    id: `E${index}`,
+    createdAt: new Date(Date.UTC(2026, 7, 29, 0, 0, index)).toISOString(),
+  };
+  if (type === 'ConnectedEvent' || type === 'DisconnectedEvent')
+    return { ...base, source, subject: target };
+  if (type === 'CrossReferencedEvent')
+    return { ...base, source, target, referencedAt: base.createdAt, willCloseTarget: true };
+  return { ...base, duplicate: source, canonical: target };
+}
+const page = (
+  field: string,
+  nodes: unknown[],
+  totalCount = nodes.length,
+  next: string | null = null,
+  errors?: unknown[]
+) => ({
+  data: {
+    data: {
+      repository: {
+        pullRequest: {
+          id: 'PR',
+          [field]: { nodes, totalCount, pageInfo: { hasNextPage: next !== null, endCursor: next } },
+        },
+      },
+    },
+    errors,
+  },
+});
+let budget: ReturnType<typeof createContextReadBudget>;
+beforeEach(() => {
+  jest.useFakeTimers();
+  budget = createContextReadBudget();
+});
+afterEach(() => {
+  budget.close();
+  jest.useRealTimers();
+});
+async function run(serve: (field: Field, after: string | null) => unknown) {
+  const revision = {
+    prNodeId: 'PR',
+    number: 1,
+    headSha: 'head',
+    baseRef: 'main',
+    baseSha: 'base',
+    baseRepoFullName: 'o/r',
+  };
+  const octokit = {
+    pulls: {
+      get: async () => ({
+        data: {
+          node_id: 'PR',
+          number: 1,
+          title: 'PR',
+          body: 'Fixes other/repo#99',
+          user: null,
+          state: 'open',
+          head: { ref: 'feature', sha: 'head' },
+          base: { ref: 'main', sha: 'base', repo: { full_name: 'o/r' } },
+          commits: 1,
+          changed_files: 1,
+          additions: 1,
+          deletions: 0,
+          mergeable: null,
+        },
+      }),
+    },
+    request: async (
+      _route: string,
+      body: { query: string; variables: { after: string | null } }
+    ) => {
+      if (body.query === PR_CONTEXT_REVISION_QUERY)
+        return {
+          data: {
+            data: {
+              repository: {
+                pullRequest: {
+                  id: 'PR',
+                  number: 1,
+                  headRefOid: 'head',
+                  baseRefName: 'main',
+                  baseRefOid: 'base',
+                  baseRepository: { nameWithOwner: 'o/r' },
+                },
+              },
+            },
+          },
+        };
+      const field = fields.find(field => PR_CONTEXT_ISSUE_QUERIES[field] === body.query);
+      if (field) return serve(field, body.variables.after);
+      const sibling = Object.entries({
+        ...PR_CONTEXT_PEOPLE_QUERIES,
+        ...PR_CONTEXT_REVIEW_QUERIES,
+      }).find(([, query]) => query === body.query)?.[0];
+      if (!sibling) throw new Error('Unexpected request');
+      return page(sibling, []);
+    },
+  } as unknown as Octokit;
+  return GitHubPrReviewContextSchema.parse(
+    await readPullRequestContext(
+      octokit,
+      { owner: 'o', repo: 'r', number: 1, expectedRevision: revision },
+      budget
+    )
+  );
+}
+
+it('deduplicates by issue ID without losing categories, direction, full titles, or repository identity', async () => {
+  const result = await run(field =>
+    page(
+      field,
+      field === 'closingIssuesReferences'
+        ? [issue()]
+        : [
+            event('ConnectedEvent'),
+            event('CrossReferencedEvent', 2, issue(), prEndpoint),
+            event('MarkedAsDuplicateEvent', 3),
+            event('ConnectedEvent', 4, issue(), prEndpoint),
+            event('ConnectedEvent', 5, prEndpoint, {
+              ...issue('OTHER', 'other/repo'),
+              state: 'CLOSED',
+            }),
+          ]
+    )
+  );
+  expect(result.issues).toMatchObject({ completeness: 'complete', knownCount: 2, totalCount: 2 });
+  expect(result.issues.items).toEqual([
+    {
+      id: 'I',
+      number: 7,
+      title,
+      state: 'OPEN',
+      url: 'https://github.com/o/r/issues/7',
+      repository: 'o/r',
+      relationships: [
+        {
+          category: 'closing',
+          membership: 'current',
+          evidenceId: 'I',
+          sourceId: 'PR',
+          targetId: 'I',
+        },
+        {
+          category: 'connected',
+          membership: 'current',
+          evidenceId: 'E1',
+          sourceId: 'PR',
+          targetId: 'I',
+        },
+        {
+          category: 'referenced',
+          membership: 'historical',
+          evidenceId: 'E2',
+          sourceId: 'I',
+          targetId: 'PR',
+        },
+        {
+          category: 'duplicate',
+          membership: 'current',
+          evidenceId: 'E3',
+          sourceId: 'PR',
+          targetId: 'I',
+        },
+        {
+          category: 'connected',
+          membership: 'current',
+          evidenceId: 'E4',
+          sourceId: 'I',
+          targetId: 'PR',
+        },
+      ],
+    },
+    {
+      id: 'OTHER',
+      number: 7,
+      title,
+      state: 'CLOSED',
+      url: 'https://github.com/other/repo/issues/7',
+      repository: 'other/repo',
+      relationships: [
+        {
+          category: 'connected',
+          membership: 'current',
+          evidenceId: 'E5',
+          sourceId: 'PR',
+          targetId: 'OTHER',
+        },
+      ],
+    },
+  ]);
+});
+
+it('reports complete supported emptiness without parsing body references or claiming universal coverage', async () => {
+  const result = await run(field => page(field, []));
+  expect(result).toMatchObject({
+    issueCoverage: 'supported-pr-sources',
+    issues: {
+      items: [],
+      knownCount: 0,
+      totalCount: 0,
+      completeness: 'complete',
+      hasNextPage: false,
+      source: {
+        availability: 'available',
+        retryable: false,
+        provenance: ['graphql.closingIssuesReferences', 'graphql.timelineItems'],
+      },
+    },
+  });
+});

--- a/apps/web/src/lib/github-pr-review/context-issues.ts
+++ b/apps/web/src/lib/github-pr-review/context-issues.ts
@@ -1,7 +1,11 @@
 import 'server-only';
 
 import { z } from 'zod';
-import { GitHubPrReviewIssueSchema, GitHubPrReviewTimestampSchema } from './context-dtos';
+import {
+  GitHubPrReviewIssueSchema,
+  GitHubPrReviewTimestampSchema,
+  type GitHubPrReviewContext,
+} from './context-dtos';
 
 const endpointFragment = /* GraphQL */ `
   fragment ContextIssueEndpoint on Node {
@@ -102,3 +106,114 @@ export const contextIssueEventSchema = z
     target:
       'canonical' in event ? event.canonical : 'subject' in event ? event.subject : event.target,
   }));
+
+type Issue = GitHubPrReviewContext['issues']['items'][number];
+type Collection<T> = Omit<GitHubPrReviewContext['issues'], 'items'> & { items: T[] };
+
+export function resolveContextIssues(
+  prId: string,
+  closing: Collection<z.output<typeof contextIssueSchema>>,
+  history: Collection<z.output<typeof contextIssueEventSchema>>
+): GitHubPrReviewContext['issues'] {
+  const ordered = history.items.every(
+    (event, index) =>
+      event.createdAt !== null &&
+      (index === 0 ||
+        Date.parse(event.createdAt) >= Date.parse(history.items[index - 1]?.createdAt ?? ''))
+  );
+  const historyComplete =
+    history.completeness === 'complete' &&
+    ordered &&
+    history.items.every(event => event.source !== null && event.target !== null);
+  const relationships = new Map<
+    string,
+    {
+      issue: z.output<typeof contextIssueSchema>;
+      relationship: Issue['relationships'][number];
+    }
+  >();
+  for (const issue of closing.items) {
+    relationships.set(`closing:${issue.id}`, {
+      issue,
+      relationship: {
+        category: 'closing',
+        membership: 'current',
+        evidenceId: issue.id,
+        sourceId: prId,
+        targetId: issue.id,
+      },
+    });
+  }
+  for (const event of history.items) {
+    const { source, target, category } = event;
+    if (!source || !target) continue;
+    const issue =
+      source.id === prId && source.__typename === 'PullRequest'
+        ? target
+        : target.id === prId && target.__typename === 'PullRequest'
+          ? source
+          : null;
+    if (issue?.__typename !== 'Issue') continue;
+    const current = historyComplete && category !== 'referenced';
+    const key = current ? JSON.stringify([category, source.id, target.id]) : event.id;
+    if (current && event.removed) relationships.delete(key);
+    else
+      relationships.set(key, {
+        issue,
+        relationship: {
+          category,
+          membership: current ? 'current' : 'historical',
+          evidenceId: event.id,
+          sourceId: source.id,
+          targetId: target.id,
+        },
+      });
+  }
+  const issues = new Map<string, Issue>();
+  for (const { issue, relationship } of relationships.values()) {
+    const known: Issue = issues.get(issue.id) ?? {
+      id: issue.id,
+      number: issue.number,
+      title: issue.title,
+      state: issue.state,
+      url: issue.url,
+      repository: issue.repository.nameWithOwner,
+      relationships: [],
+    };
+    known.url ??= issue.url;
+    known.relationships.push(relationship);
+    issues.set(issue.id, known);
+  }
+  const sources = [closing.source, history.source];
+  const failure = sources.find(source => source.availability !== 'available');
+  const complete = closing.completeness === 'complete' && historyComplete;
+  // Counts cover supported PR-side sources, not every outgoing or inaccessible relationship.
+  return {
+    items: [...issues.values()],
+    knownCount: issues.size,
+    totalCount: complete ? issues.size : null,
+    completeness: complete ? 'complete' : issues.size ? 'partial' : 'unknown',
+    hasNextPage: [closing, history].some(source => source.hasNextPage === true)
+      ? true
+      : [closing, history].every(source => source.hasNextPage === false)
+        ? false
+        : null,
+    endCursor: null,
+    source: {
+      ...closing.source,
+      observedAt: history.source.observedAt ?? closing.source.observedAt,
+      provenance: sources.flatMap(source => source.provenance),
+      availability: complete
+        ? 'available'
+        : issues.size
+          ? 'partial'
+          : failure?.availability === 'denied'
+            ? 'denied'
+            : 'unavailable',
+      retryable:
+        sources.some(source => source.retryable) ||
+        (!ordered && history.source.availability === 'available'),
+      reason: complete ? null : (failure?.reason ?? 'issue-history-incomplete'),
+    },
+  };
+}

--- a/apps/web/src/lib/github-pr-review/context-reader.ts
+++ b/apps/web/src/lib/github-pr-review/context-reader.ts
@@ -26,7 +26,18 @@ import {
   resolveContextReviewDecisions,
 } from './context-reviews';
 
-const collectionQueries = { ...PR_CONTEXT_PEOPLE_QUERIES, ...PR_CONTEXT_REVIEW_QUERIES };
+import {
+  PR_CONTEXT_ISSUE_QUERIES,
+  contextIssueSchema,
+  contextIssueEventSchema,
+  resolveContextIssues,
+} from './context-issues';
+
+const collectionQueries = {
+  ...PR_CONTEXT_PEOPLE_QUERIES,
+  ...PR_CONTEXT_REVIEW_QUERIES,
+  ...PR_CONTEXT_ISSUE_QUERIES,
+};
 const deadlineError = new Error('PR context deadline');
 type PrInput = { owner: string; repo: string; number: number };
 export type ContextReadResult<T> = { data: T | null; source: GitHubPrReviewSource };
@@ -443,12 +454,21 @@ export async function readPullRequestContext(
       }
     );
   };
+  async function collectIssues() {
+    const empty = { ...context.issues, items: [] };
+    const [closing, history] = await Promise.all([
+      collect('closingIssuesReferences', contextIssueSchema, empty, (_known, current) => current),
+      collect('timelineItems', contextIssueEventSchema, empty, (_known, current) => current),
+    ]);
+    return resolveContextIssues(context.revision.prNodeId, closing, history);
+  }
   [
     context.labels,
     context.assignees,
     context.reviewRequests,
     context.reviewDecisions,
     context.reviewActivity,
+    context.issues,
   ] = await Promise.all([
     collect('labels', contextLabelSchema, context.labels, (known, current) => ({
       ...current,
@@ -475,6 +495,7 @@ export async function readPullRequestContext(
     ),
     collectReviews('latestOpinionatedReviews', context.reviewDecisions),
     collectReviews('latestReviews', context.reviewActivity),
+    collectIssues(),
   ]);
   // Final null fields can hide contradictions between the two connections.
   for (const review of context.reviewDecisions.items) {

--- a/apps/web/src/routers/github-pr-review-router.test.ts
+++ b/apps/web/src/routers/github-pr-review-router.test.ts
@@ -1315,6 +1315,8 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
                 reviewRequests: empty,
                 latestOpinionatedReviews: empty,
                 latestReviews: empty,
+                closingIssuesReferences: empty,
+                timelineItems: empty,
                 privatePayload: 'provider-only',
               },
             },
@@ -1337,7 +1339,7 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
       jest.restoreAllMocks();
     });
 
-    it('enriches people, labels, and reviews without claiming unattached readers are empty', async () => {
+    it('enriches people, labels, reviews, and issues without claiming unattached readers are empty', async () => {
       const result = await caller.getPullRequestContext(contextInput);
       expect(result.revision).toEqual(revision);
       expect(result.labels).toMatchObject({
@@ -1352,14 +1354,14 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
         openedAt: '2026-01-01T00:00:00Z',
         closedAt: null,
       });
-      for (const collection of [result.reviewDecisions, result.reviewActivity]) {
+      for (const collection of [result.reviewDecisions, result.reviewActivity, result.issues]) {
         expect(collection).toMatchObject({
           items: [],
           completeness: 'complete',
           source: { availability: 'available' },
         });
       }
-      for (const collection of [result.issues, result.requirements, result.checks]) {
+      for (const collection of [result.requirements, result.checks]) {
         expect(collection).toMatchObject({
           items: [],
           completeness: 'unknown',


### PR DESCRIPTION
- Pull request context now includes closing, connected, referenced, and duplicate issues, with full titles, issue numbers, status, repository names, and available links.
- Issue links distinguish current relationships from historical evidence. Results disclose gaps in supported sources without claiming to cover every possible issue reference.

---

## Summary

`resolveContextIssues` fills `GitHubPrReviewContext.issues` with closing, connected, referenced, and duplicate relationships, merging issues by identity while preserving direction and evidence.
Closing links stay current; connected and duplicate links require complete, ordered history with known endpoints before the reader treats additions or removals as current.
Reference links and usable links from incomplete histories remain historical; `issueCoverage` stays `supported-pr-sources`, not universal coverage.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-issues.ts` — Modified (+116/-1 lines). Adds relationship resolution, unique issue counts, and combined source metadata. Preserves numbers, full titles, state, repository identity, and available links; later evidence can fill a missing link. Filters events to the requested pull request and an issue without parsing body references. Incomplete results keep known issues, expose a null total, and combine pagination, provenance, availability, and retry metadata. The combined collection exposes no resume cursor.
- `apps/web/src/lib/github-pr-review/context-issues.test.ts` — Added (+236/-0 lines). Covers identity, direction, multiple categories, cross-repository issues, full titles, and complete supported emptiness without parsing body references.

</details>

`getPullRequestContext` now obtains `closingIssuesReferences` and `timelineItems` through `readPullRequestContext`, using both paginated queries in `PR_CONTEXT_ISSUE_QUERIES`.
Both sources share the ten-second budget and four-request limit with other context reads, retaining authentication checks, revision checks, and independent source results.
Existing callers can now receive complete empty issue results instead of unknown placeholders; requirements and checks remain unknown.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-reader.ts` — Modified (+22/-1 lines). Registers issue queries, collects both connections concurrently, and resolves issues alongside people and reviews. Reuses the existing pagination, source-error handling, and retry metadata.
- `apps/web/src/routers/github-pr-review-router.test.ts` — Modified (+5/-3 lines). Supplies both empty issue sources and expects complete issues while requirements and checks stay unknown.

</details>

Tests: 2 files changed — `context-issues.test.ts` added and `github-pr-review-router.test.ts` updated; the handoff reports 300 passing tests across five focused suites.
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

No manual tests ran for this level because live backend and iOS verification will run on the completed stack tip.

## Reviewer Notes

### Scope and automated evidence

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- Scope: level 12 only, from `mobile-pr-review-context-5458-s11` to `mobile-pr-review-context-5458-s12`.
- This level adds backend data without changing mobile presentation.
- The handoff reports passing changed-file checks and a passing fresh implementation review.

### Human steps

No human steps are required before merge or after merge.

### Notes

This level attaches linked-issue context reads. Live backend and iOS verification will run on the completed stack tip.









<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707 ← this PR
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
