### PR TITLE
test(pr-review): cover linked issue source failures

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-issues.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-issues.test.ts
@@ -216,6 +216,229 @@ it('deduplicates by issue ID without losing categories, direction, full titles, 
   ]);
 });
 
+describe.each([
+  ['ConnectedEvent', 'DisconnectedEvent'],
+  ['MarkedAsDuplicateEvent', 'UnmarkedAsDuplicateEvent'],
+])('%s removal', (added, removed) => {
+  it.each([false, true])('replays complete history with reversed endpoints=%s', async reversed => {
+    const source = reversed ? issue() : prEndpoint;
+    const target = reversed ? prEndpoint : issue();
+    const result = await run(field =>
+      page(
+        field,
+        field === 'timelineItems'
+          ? [event(added, 1, source, target), event(removed, 2, source, target)]
+          : []
+      )
+    );
+    expect(result.issues).toMatchObject({
+      items: [],
+      knownCount: 0,
+      totalCount: 0,
+      completeness: 'complete',
+      source: { availability: 'available' },
+    });
+  });
+  it('removes only the matching category and directed endpoint key', async () => {
+    const result = await run(field =>
+      page(
+        field,
+        field === 'closingIssuesReferences'
+          ? [issue()]
+          : [
+              event(added),
+              event(added, 2, issue(), prEndpoint),
+              event(removed, 3),
+              event('CrossReferencedEvent', 4),
+            ]
+      )
+    );
+    expect(result.issues.items[0]?.relationships).toMatchObject([
+      { category: 'closing', membership: 'current' },
+      { evidenceId: 'E2', sourceId: 'I', targetId: 'PR', membership: 'current' },
+      { category: 'referenced', membership: 'historical' },
+    ]);
+  });
+});
+
+it.each([
+  [issue(), issue('OTHER')],
+  [{ ...prEndpoint, id: 'OTHER_PR' }, issue()],
+  [prEndpoint, { ...prEndpoint, id: 'OTHER_PR' }],
+])('ignores endpoints that do not join this PR to an issue: %p', async (source, target) => {
+  const result = await run(field =>
+    page(field, field === 'timelineItems' ? [event('ConnectedEvent', 1, source, target)] : [])
+  );
+  expect(result.issues).toMatchObject({ items: [], completeness: 'complete' });
+});
+
+it('paginates both sources past 100 entries with independent cursors', async () => {
+  const result = await run((field, after) => {
+    if (after !== null && after !== field) throw new Error('Wrong cursor');
+    return page(
+      field,
+      Array.from({ length: after ? 1 : 100 }, (_, i) => {
+        const index = i + (after ? 101 : 1);
+        const endpoint = issue(`${field}-${index}`);
+        return field === 'closingIssuesReferences'
+          ? endpoint
+          : event('ConnectedEvent', index, prEndpoint, endpoint);
+      }),
+      101,
+      after ? null : field
+    );
+  });
+  expect(result.issues).toMatchObject({
+    completeness: 'complete',
+    knownCount: 202,
+    totalCount: 202,
+    hasNextPage: false,
+    source: { availability: 'available' },
+  });
+  expect(result.issues.items).toHaveLength(202);
+  expect(result.issues.items.every(item => item.relationships[0]?.membership === 'current')).toBe(
+    true
+  );
+});
+
+it.each([403, 503])(
+  'retains additions and removals as historical after a failed page: %s',
+  async status => {
+    const result = await run((field, after) => {
+      if (field === 'closingIssuesReferences') return page(field, [issue()]);
+      if (after) throw { status };
+      return page(field, [event('ConnectedEvent'), event('DisconnectedEvent', 2)], 3, 'next');
+    });
+    expect(result.issues).toMatchObject({
+      completeness: 'partial',
+      totalCount: null,
+      hasNextPage: true,
+      source: { availability: 'partial', retryable: status === 503 },
+    });
+    expect(result.issues.items[0]?.relationships).toMatchObject([
+      { category: 'closing', membership: 'current' },
+      { evidenceId: 'E1', membership: 'historical' },
+      { evidenceId: 'E2', membership: 'historical' },
+    ]);
+    expect(result.labels.completeness).toBe('complete');
+  }
+);
+
+it.each([
+  ['null source', event('DisconnectedEvent', 2, null), false],
+  ['deleted issue', event('UnmarkedAsDuplicateEvent', 2, prEndpoint, null), false],
+  ['null node', null, true],
+  [
+    'malformed issue',
+    event('DisconnectedEvent', 2, prEndpoint, { ...issue(), number: null }),
+    true,
+  ],
+  ['invalid time', { ...event('DisconnectedEvent', 2), createdAt: 'invalid' }, true],
+  [
+    'unordered events',
+    { ...event('DisconnectedEvent', 2), createdAt: '2026-08-28T00:00:00Z' },
+    true,
+  ],
+])('does not replay incomplete history: %s', async (_name, broken, retryable) => {
+  const result = await run(field =>
+    page(field, field === 'timelineItems' ? [event('ConnectedEvent'), broken] : [])
+  );
+  expect(result.issues).toMatchObject({
+    completeness: 'partial',
+    source: { availability: 'partial', retryable },
+  });
+  expect(result.issues.items[0]?.relationships[0]).toMatchObject({
+    evidenceId: 'E1',
+    membership: 'historical',
+  });
+});
+
+it.each(['repeat', 'null-page', 'count-change'])(
+  'keeps incomplete pagination historical: %s',
+  async fault => {
+    const result = await run((field, after) => {
+      if (field === 'closingIssuesReferences') return page(field, []);
+      if (!after) return page(field, [event('ConnectedEvent')], 2, 'next');
+      if (fault === 'null-page')
+        return { data: { data: { repository: { pullRequest: { timelineItems: null } } } } };
+      return page(
+        field,
+        [event('DisconnectedEvent', 2)],
+        fault === 'count-change' ? 3 : 2,
+        fault === 'repeat' ? 'next' : null
+      );
+    });
+    expect(result.issues).toMatchObject({ completeness: 'partial', source: { retryable: true } });
+    expect(
+      result.issues.items[0]?.relationships.every(link => link.membership === 'historical')
+    ).toBe(true);
+  }
+);
+
+it.each(fields)('preserves the successful sibling when %s is denied', async denied => {
+  const result = await run(field => {
+    if (field === denied)
+      return page(field, [], 0, null, [
+        { type: 'FORBIDDEN', path: ['repository', 'pullRequest', field] },
+      ]);
+    return page(field, field === 'timelineItems' ? [event('ConnectedEvent')] : [issue()]);
+  });
+  expect(result.issues).toMatchObject({
+    knownCount: 1,
+    completeness: 'partial',
+    source: { availability: 'partial', retryable: false, reason: 'graphql-denied' },
+  });
+  expect(result.issues.items[0]?.relationships).toMatchObject([{ membership: 'current' }]);
+});
+
+it.each([
+  ['FORBIDDEN', false, 'graphql-denied'],
+  ['INTERNAL', true, 'graphql-incomplete'],
+])(
+  'preserves the retry policy for an event timestamp error: %s',
+  async (type, retryable, reason) => {
+    const result = await run(field => {
+      if (field !== 'timelineItems') return page(field, []);
+      return page(field, [{ ...event('ConnectedEvent'), createdAt: null }], 1, null, [
+        { type, path: ['repository', 'pullRequest', field, 'nodes', 0, 'createdAt'] },
+      ]);
+    });
+    expect(result.issues).toMatchObject({ completeness: 'partial', source: { retryable, reason } });
+    expect(result.issues.items[0]?.relationships).toMatchObject([
+      { evidenceId: 'E1', membership: 'historical' },
+    ]);
+  }
+);
+
+it.each([403, 503])('does not turn a failed source into supported emptiness: %s', async status => {
+  const result = await run(() => {
+    throw { status };
+  });
+  expect(result.issues).toMatchObject({
+    items: [],
+    completeness: 'unknown',
+    totalCount: null,
+    source: { availability: status === 403 ? 'denied' : 'unavailable', retryable: status === 503 },
+  });
+});
+
+it('retains known event evidence when the shared deadline aborts a later page', async () => {
+  const pending = run((field, after) =>
+    field === 'closingIssuesReferences'
+      ? page(field, [])
+      : after
+        ? new Promise(() => undefined)
+        : page(field, [event('ConnectedEvent')], 2, 'next')
+  );
+  await jest.advanceTimersByTimeAsync(10_000);
+  const result = await pending;
+  expect(result.issues).toMatchObject({
+    completeness: 'partial',
+    source: { retryable: true, reason: 'deadline' },
+  });
+  expect(result.issues.items[0]?.relationships).toMatchObject([{ membership: 'historical' }]);
+});
+
 it('reports complete supported emptiness without parsing body references or claiming universal coverage', async () => {
   const result = await run(field => page(field, []));
   expect(result).toMatchObject({
@@ -234,3 +457,20 @@ it('reports complete supported emptiness without parsing body references or clai
     },
   });
 });
+
+it.each([null, 'https://github.com/o/r/issues/7'])(
+  'retains issue identity and the available link across relationships: %s',
+  async url => {
+    const result = await run(field =>
+      page(
+        field,
+        field === 'closingIssuesReferences'
+          ? [{ ...issue(), url: null }]
+          : [event('ConnectedEvent', 1, prEndpoint, { ...issue(), url })]
+      )
+    );
+    expect(result.issues.items).toMatchObject([
+      { id: 'I', title, repository: 'o/r', number: 7, url },
+    ]);
+  }
+);


### PR DESCRIPTION
No new behavior — this level adds linked-issue regression tests only.

---

## Summary

Linked-issue regressions cover removals, directed endpoints, pagination, partial history, denial, retry metadata, shared deadlines, and nullable links.
They assert reader results rather than mock calls or implementation constants; production behavior and existing contracts remain unchanged.
The suite retains two core cases and the shared helpers, and restores the saved original's fixtures, tables, names, and assertions.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-issues.test.ts` — Modified test file (+240/-0 lines). Restores both removal event pairs, both endpoint directions, relationship categories, and directed keys. Covers unrelated issues, other pull requests, null or deleted endpoints, malformed issues, and invalid or unordered timestamps. Checks independent cursors beyond 100 entries, failed pages, repeated cursors, null pages, changed counts, and the shared deadline. Checks historical evidence, successful siblings, denial versus transient failures, retry metadata, issue identity, and the available sibling URL when a link is missing.

</details>

Tests: 1 file modified — `context-issues.test.ts`; 30 cases restored, 32 total cases, and 24 assertion sites.
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

No manual tests ran because this level changes tests only; live backend and iOS verification will run on the completed stack tip.

## Reviewer Notes

### Scope

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- This description covers level 13 only, from `mobile-pr-review-context-5458-s12` to `mobile-pr-review-context-5458-s13`.

### Supplied automated evidence

- Jest passed all 32 cases in one suite; comparison with the saved original found no differences.
- The launcher used the repository configuration with `runInBand`, omitted `globalSetup` and `setupFilesAfterEnv`, and disabled caching.
- Omitting setup prevented environment reads and database resets; Jest artifacts used the approved temporary directory.
- Oxlint reported zero warnings and errors; formatting and whitespace checks passed.

The current round did not rerun router or schema suites, repository-wide tests, type checks, or builds.
Provider comparisons, mobile behavior, fixture validation, and live runtime verification remain outside this level's evidence.

### Human steps

No human steps are required before merge or after merge.

### Notes

This level adds linked-issue regression tests only. Live backend and iOS verification will run on the completed stack tip.









<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708 ← this PR
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
