### PR TITLE
feat(pr-review): preserve structured policy evidence

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-dtos.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-dtos.test.ts
@@ -1,6 +1,7 @@
 import {
   GitHubPrReviewApplicationBindingSchema,
   GitHubPrReviewContextSchema,
+  GitHubPrReviewRequirementSchema,
 } from './context-dtos';
 import {
   GitHubPrReviewChecksResultSchema,
@@ -99,6 +100,25 @@ const evidence = [
     observedAt,
   },
 ];
+const legacyPolicy = { id: 'rule-1', source: 'classic', enforcement: 'active' };
+const policyDefaults = {
+  base: null,
+  ruleType: null,
+  parameters: null,
+  ruleset: null,
+  viewerEnforcement: 'unknown',
+  viewerBypass: 'unknown',
+  bypassActors: null,
+};
+const legacyRequirement = {
+  id: 'rule-1',
+  kind: 'status-check',
+  title: 'CI',
+  state: 'unmet',
+  policy: legacyPolicy,
+  check: { name: 'ci', kind: 'check-run', application: { kind: 'app', appId: 1 } },
+  evidence,
+};
 const fullContext = {
   revision,
   observedAt,
@@ -167,15 +187,7 @@ const fullContext = {
   ]),
   issueCoverage: 'supported-pr-sources',
   requirements: complete([
-    {
-      id: 'rule-1',
-      kind: 'status-check',
-      title: 'CI',
-      state: 'unmet',
-      policy: { id: 'rule-1', source: 'classic', enforcement: 'active' },
-      check: { name: 'ci', kind: 'check-run', application: { kind: 'app', appId: 1 } },
-      evidence,
-    },
+    { ...legacyRequirement, policy: { ...legacyPolicy, ...policyDefaults } },
   ]),
   checks: complete([
     {
@@ -220,6 +232,160 @@ const fullContext = {
   },
 };
 
+test.each(['active', 'evaluate', 'disabled', 'unknown'])(
+  'normalizes legacy policies with %s enforcement without inventing evidence',
+  enforcement => {
+    const input = { ...legacyRequirement, policy: { ...legacyPolicy, enforcement } };
+    expect(GitHubPrReviewRequirementSchema.parse(input)).toStrictEqual({
+      ...input,
+      policy: { ...input.policy, ...policyDefaults },
+    });
+  }
+);
+
+test.each([
+  [
+    'pull_request',
+    {
+      required_approving_review_count: 2,
+      require_code_owner_review: true,
+      require_last_push_approval: true,
+      dismiss_stale_reviews_on_push: true,
+      required_review_thread_resolution: true,
+    },
+  ],
+  [
+    'required_status_checks',
+    {
+      strict_required_status_checks_policy: true,
+      required_status_checks: [{ context: 'ci', integration_id: 7 }, { context: 'unbound' }],
+    },
+  ],
+  ['required_deployments', { required_deployment_environments: ['production'] }],
+  ['required_signatures', {}],
+  [
+    'workflows',
+    {
+      workflows: [
+        {
+          repository_id: 42,
+          path: '.github/workflows/ci.yml',
+          ref: 'release',
+          sha: 'workflow-sha',
+        },
+      ],
+    },
+  ],
+  ['future_rule', { nested: [{ enabled: false, limit: 3, label: 'opaque', value: null }] }],
+])('retains %s policy evidence without evaluating it', (ruleType, parameters) => {
+  const input = {
+    ...legacyRequirement,
+    state: 'unavailable',
+    check: null,
+    evidence: [],
+    policy: {
+      ...legacyPolicy,
+      ...policyDefaults,
+      source: 'ruleset',
+      ruleType,
+      parameters,
+      base: { baseRepoFullName: 'kilo/upstream', baseRef: 'release/1', baseSha: 'release-sha' },
+      ruleset: { id: 7, source: 'kilo', sourceType: 'Organization' },
+      bypassActors: [{ actorId: 7, actorType: 'Integration', bypassMode: 'pull_request' }],
+    },
+  };
+  const { context } = NormalizedGitHubPrReviewOverviewSchema.parse({
+    ...oldOverview,
+    context: { revision, requirements: complete([input]) },
+  });
+  expect(context.requirements.items).toStrictEqual([input]);
+});
+
+test.each([
+  ['enforced', 'never'],
+  ['not-enforced', 'always'],
+  ['unknown', 'pull_requests_only'],
+  ['not-enforced', 'exempt'],
+  ['unknown', 'unknown'],
+])(
+  'retains viewer enforcement %s and bypass %s independently',
+  (viewerEnforcement, viewerBypass) => {
+    const policy = {
+      ...legacyPolicy,
+      ...policyDefaults,
+      viewerEnforcement,
+      viewerBypass,
+      bypassActors: [],
+    };
+    expect(
+      GitHubPrReviewRequirementSchema.parse({ ...legacyRequirement, policy }).policy
+    ).toStrictEqual(policy);
+  }
+);
+
+test('preserves nullable policy identities without inventing bypass or check bindings', () => {
+  const absent = { ...legacyRequirement, policy: null, check: null };
+  expect(GitHubPrReviewRequirementSchema.parse(absent)).toStrictEqual(absent);
+  const policy = {
+    ...legacyPolicy,
+    ...policyDefaults,
+    base: { baseRepoFullName: null, baseRef: 'release/1', baseSha: null },
+    ruleset: {},
+    bypassActors: [{ actorType: 'DeployKey' }],
+  };
+  expect(GitHubPrReviewRequirementSchema.parse({ ...absent, policy }).policy).toStrictEqual({
+    ...policy,
+    ruleset: { id: null, source: null, sourceType: null },
+    bypassActors: [{ actorType: 'DeployKey', actorId: null, bypassMode: 'unknown' }],
+  });
+});
+
+test.each([
+  ['encoded parameters', { parameters: '{"required_approving_review_count":2}' }],
+  ['undefined parameter values', { parameters: { nested: [undefined] } }],
+  ['function parameter values', { parameters: { nested: { callback: () => true } } }],
+  ['non-finite parameter values', { parameters: { limit: Infinity } }],
+  ['invalid base identity', { base: { baseRepoFullName: null, baseRef: 'release', baseSha: 17 } }],
+  ['empty rule type', { ruleType: '' }],
+  ['invalid ruleset identity', { ruleset: { id: -1 } }],
+  ['invalid ruleset source type', { ruleset: { sourceType: 'User' } }],
+  ['invalid viewer enforcement', { viewerEnforcement: 'active' }],
+  ['invalid viewer bypass', { viewerBypass: 'allowed' }],
+  ['invalid actor identity', { bypassActors: [{ actorType: 'Team', actorId: '12' }] }],
+  ['invalid actor type', { bypassActors: [{ actorType: 'User' }] }],
+  ['invalid bypass mode', { bypassActors: [{ actorType: 'Team', bypassMode: 'never' }] }],
+])('rejects %s in structured policy evidence', (_name, invalid) => {
+  expect(
+    GitHubPrReviewRequirementSchema.safeParse({
+      ...legacyRequirement,
+      policy: { ...legacyPolicy, ...invalid },
+    }).success
+  ).toBe(false);
+});
+
+test.each([
+  ['partial', true],
+  ['stale', true],
+  ['unavailable', true],
+  ['denied', false],
+])(
+  'preserves policy evidence and retryability when its source is %s',
+  (availability, retryable) => {
+    const requirements = {
+      ...fullContext.requirements,
+      source: { ...source, availability, retryable, reason: 'policy-source-failure' },
+      completeness: 'unknown',
+    };
+    const context = GitHubPrReviewContextSchema.parse({
+      revision,
+      requirements,
+      labels: complete([]),
+    });
+    expect(context.requirements).toStrictEqual(requirements);
+    expect(context.labels).toStrictEqual(complete([]));
+  }
+);
+
 test('normalizes omitted sources without claiming complete empty collections', () => {
   const context = GitHubPrReviewContextSchema.parse({ revision });
   for (const collection of [
@@ -261,7 +427,13 @@ test('preserves successful siblings, exact lifecycle times, and confirmed emptin
     closedAt: null,
     mergedAt: null,
   };
-  const input = { revision, labels, lifecycle, assignees: complete([]) };
+  const input = {
+    revision,
+    labels,
+    lifecycle,
+    assignees: complete([]),
+    requirements: complete([]),
+  };
   expect(GitHubPrReviewContextSchema.parse(input)).toMatchObject(input);
 });
 
@@ -306,6 +478,10 @@ test.each([{ kind: 'app', appId: 1 }, { kind: 'any' }, { kind: 'unknown' }])(
   'preserves the explicit application binding %j',
   binding => {
     expect(GitHubPrReviewApplicationBindingSchema.parse(binding)).toEqual(binding);
+    const check = { ...legacyRequirement.check, application: binding };
+    expect(
+      GitHubPrReviewRequirementSchema.parse({ ...legacyRequirement, check }).check
+    ).toStrictEqual(check);
   }
 );
 

--- a/apps/web/src/lib/github-pr-review/context-dtos.ts
+++ b/apps/web/src/lib/github-pr-review/context-dtos.ts
@@ -140,20 +140,64 @@ export const GitHubPrReviewApplicationBindingSchema = z.discriminatedUnion('kind
   z.object({ kind: z.literal('unknown') }).strict(),
 ]);
 
+export const GitHubPrReviewPolicySchema = z
+  .object({
+    id: z.string().min(1),
+    source: z.enum(['classic', 'ruleset', 'github']),
+    enforcement: z.enum(['active', 'evaluate', 'disabled', 'unknown']),
+    // Old policies contain only id, source, and enforcement. Retain defaults until all old clients, servers, and records are gone.
+    base: GitHubPrReviewRevisionSchema.pick({
+      baseRepoFullName: true,
+      baseRef: true,
+      baseSha: true,
+    })
+      .nullable()
+      .default(null),
+    ruleType: nullableId.default(null),
+    // JSON parameters preserve unsupported rules without claiming an evaluated outcome.
+    parameters: z.record(z.string(), z.json()).nullable().default(null),
+    ruleset: z
+      .object({
+        id: z.number().int().positive().nullable().default(null),
+        source: nullableId.default(null),
+        sourceType: z.enum(['Repository', 'Organization', 'Enterprise']).nullable().default(null),
+      })
+      .strict()
+      .nullable()
+      .default(null),
+    viewerEnforcement: z.enum(['enforced', 'not-enforced', 'unknown']).default('unknown'),
+    viewerBypass: z
+      .enum(['always', 'pull_requests_only', 'never', 'exempt', 'unknown'])
+      .default('unknown'),
+    // An omitted actor list is not evidence that bypass is unavailable to the viewer.
+    bypassActors: z
+      .array(
+        z
+          .object({
+            actorId: z.number().int().positive().nullable().default(null),
+            actorType: z.enum([
+              'Integration',
+              'OrganizationAdmin',
+              'RepositoryRole',
+              'Team',
+              'DeployKey',
+            ]),
+            bypassMode: z.enum(['always', 'pull_request', 'exempt', 'unknown']).default('unknown'),
+          })
+          .strict()
+      )
+      .nullable()
+      .default(null),
+  })
+  .strict();
+
 export const GitHubPrReviewRequirementSchema = z
   .object({
     id: z.string().min(1),
     kind: z.string().min(1),
     title: z.string(),
     state: z.enum(['met', 'unmet', 'unavailable']),
-    policy: z
-      .object({
-        id: z.string().min(1),
-        source: z.enum(['classic', 'ruleset', 'github']),
-        enforcement: z.enum(['active', 'evaluate', 'disabled', 'unknown']),
-      })
-      .strict()
-      .nullable(),
+    policy: GitHubPrReviewPolicySchema.nullable(),
     check: z
       .object({
         name: z.string().min(1),


### PR DESCRIPTION
No new behavior — this change expands review policy information without changing what users see or can do.

---

## Summary

`GitHubPrReviewPolicySchema` now preserves exact-base identity, rule parameters, and ruleset provenance while keeping viewer enforcement and bypass independent.
`GitHubPrReviewRequirementSchema` uses this contract; legacy policies still parse, and omitted evidence becomes explicit `null` or `unknown` values.
Unsupported parameters remain evidence rather than evaluated outcomes, and omitted bypass actors remain unknown rather than an empty list.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-dtos.ts` — modified, 60 changed lines. Exports the strict policy schema and retains nullable requirement policies with the existing identity, source, and enforcement fields. Adds `base` repository, branch, and commit identity, nullable `ruleType`, and JavaScript Object Notation (JSON) objects in `parameters`. Adds nullable `ruleset` identity, source, and repository, organization, or enterprise provenance with strict validation. `viewerEnforcement` distinguishes `enforced`, `not-enforced`, and `unknown`; independent `viewerBypass` supports `always`, `pull_requests_only`, `never`, `exempt`, and `unknown`. Adds nullable `bypassActors` for integrations, organization administrators, repository roles, teams, and deploy keys. Ruleset and actor identifiers accept positive integers or `null`; actor bypass modes support `always`, `pull_request`, `exempt`, and `unknown`. Missing actor identifiers default to `null`, and missing actor bypass modes default to `unknown`.

</details>

Tests: 1 modified file, `apps/web/src/lib/github-pr-review/context-dtos.test.ts` (196 changed lines), covers legacy defaults, structured evidence, invalid values, source failures, and confirmed empty requirements.
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

No manual tests ran because this level changes only policy contracts; live backend and iOS verification waits for the completed stack tip.
Policy normalization, network reads, evaluations, mobile behavior, fixture validation, and live verification remain pending.

## Reviewer Notes

### Scope

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- This description covers level 14, from `mobile-pr-review-context-5458-s13` to `mobile-pr-review-context-5458-s14`.

### Supplied automated evidence

- The focused schema suite passed 53 cases using the repository configuration without database setup or environment-file loading.
- Changed-file lint, formatting, and whitespace checks passed.

Repository-wide type, build, and other checks remain pending.

### Human steps

None before merge or after merge.

### Notes

This level adds compatible policy evidence fields. Live backend and iOS verification will run on the completed stack tip.









<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709 ← this PR
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
