### PR TITLE
feat(pr-review): normalize applicable merge policies

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-rules.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-rules.test.ts
@@ -144,8 +144,8 @@ test.each(inherited)('retains inherited $type without evaluating it', rule => {
 
 const unknownBinding = { kind: 'unknown' };
 test.each([
-  [7, { kind: 'app', appId: 7 }, { kind: 'app', appId: 7 }],
-  [-1, { kind: 'any' }, unknownBinding],
+  [7, { kind: 'app', appId: 7 }, { kind: 'app', appId: 7 }] as const,
+  [-1, { kind: 'any' }, unknownBinding] as const,
   ...[null, undefined, 0, -2, 7.5, Number.MAX_SAFE_INTEGER + 1].map(
     id => [id, unknownBinding, unknownBinding] as const
   ),

--- a/apps/web/src/lib/github-pr-review/context-rules.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-rules.test.ts
@@ -1,0 +1,383 @@
+import type { RestEndpointMethodTypes } from '@octokit/rest';
+import { type GitHubPrReviewSource, GitHubPrReviewContextSchema } from './context-dtos';
+import { normalizeContextPolicies } from './context-rules';
+
+type Repos = RestEndpointMethodTypes['repos'];
+const base = { baseRepoFullName: 'kilo/upstream', baseRef: 'release/1', baseSha: 'base' };
+const revision = { ...base, prNodeId: 'PR_1', number: 1, headSha: 'head' };
+const observedAt = '2026-08-29T12:00:00Z';
+const collection = (items: unknown[], provenance: string) => ({
+  items,
+  knownCount: items.length,
+  totalCount: items.length,
+  completeness: 'complete' as const,
+  hasNextPage: false,
+  endCursor: null,
+  source: {
+    availability: 'available' as const,
+    retryable: false,
+    reason: null,
+    observedAt,
+    provenance: [provenance],
+  },
+});
+const classic = (items: unknown[] = []) => collection(items, 'rest.branchProtection');
+const rules = (items: unknown[] = []) => collection(items, 'rest.branchRules');
+const origin = {
+  ruleset_id: 12,
+  ruleset_source: 'kilo',
+  ruleset_source_type: 'Organization',
+} as const;
+const signature = {
+  type: 'required_signatures',
+  ...origin,
+} satisfies Repos['getBranchRules']['response']['data'][number];
+const protection = {
+  enforce_admins: { enabled: true, url: 'https://api.github.com/admins' },
+  required_status_checks: {
+    strict: true,
+    contexts: ['ci', 'legacy'],
+    checks: [
+      { context: 'ci', app_id: 7 },
+      { context: 'ci', app_id: 8 },
+    ],
+  },
+  required_pull_request_reviews: {
+    required_approving_review_count: 2,
+    dismiss_stale_reviews: true,
+    require_code_owner_reviews: true,
+    require_last_push_approval: true,
+    bypass_pull_request_allowances: { users: [], teams: [], apps: [] },
+  },
+  required_conversation_resolution: { enabled: true },
+  required_signatures: { enabled: true, url: 'https://api.github.com/signatures' },
+  required_linear_history: { enabled: true },
+  allow_force_pushes: { enabled: false },
+  lock_branch: { enabled: false },
+} satisfies Repos['getBranchProtection']['response']['data'];
+const inherited = [
+  {
+    type: 'pull_request',
+    parameters: {
+      required_approving_review_count: 3,
+      dismiss_stale_reviews_on_push: true,
+      require_code_owner_review: true,
+      require_last_push_approval: true,
+      required_review_thread_resolution: true,
+    },
+  },
+  {
+    type: 'required_deployments',
+    parameters: { required_deployment_environments: ['production'] },
+  },
+  {
+    type: 'workflows',
+    parameters: {
+      workflows: [
+        { repository_id: 42, path: '.github/workflows/ci.yml', ref: 'release', sha: 'workflow' },
+      ],
+    },
+  },
+  {
+    type: 'required_status_checks',
+    parameters: {
+      strict_required_status_checks_policy: true,
+      do_not_enforce_on_create: false,
+      required_status_checks: [{ context: 'ci', integration_id: 7 }],
+    },
+  },
+  signature,
+] satisfies Repos['getBranchRules']['response']['data'];
+function normalize(classicItems: unknown[], branchItems: unknown[]) {
+  return normalizeContextPolicies(revision, classic(classicItems), rules(branchItems));
+}
+
+test.each([false, true])('retains classic parameters without inferring bypass (%s)', enabled => {
+  const configuration = {
+    ...protection,
+    enforce_admins: { ...protection.enforce_admins, enabled },
+  };
+  const result = normalize([configuration], []);
+  expect(result.completeness).toBe('complete');
+  expect(result.items[0]?.policy).toMatchObject({
+    parameters: configuration,
+    base,
+    viewerBypass: 'unknown',
+    viewerEnforcement: 'unknown',
+    bypassActors: null,
+  });
+  expect(result.items.flatMap(item => (item.check ? [item.check] : []))).toEqual([
+    { name: 'ci', kind: 'unknown', application: { kind: 'app', appId: 7 } },
+    { name: 'ci', kind: 'unknown', application: { kind: 'app', appId: 8 } },
+    { name: 'legacy', kind: 'unknown', application: { kind: 'unknown' } },
+  ]);
+  expect(new Set(result.items.map(item => item.id)).size).toBe(4);
+  expect(
+    GitHubPrReviewContextSchema.parse({ revision, requirements: result }).requirements
+  ).toEqual(result);
+});
+
+test.each(inherited)('retains inherited $type without evaluating it', rule => {
+  const result = normalize([], [{ ...rule, ...origin }]);
+  expect(result.completeness).toBe('complete');
+  expect(result.items[0]?.policy).toMatchObject({
+    base,
+    ruleType: rule.type,
+    enforcement: 'active',
+    viewerEnforcement: 'unknown',
+    viewerBypass: 'unknown',
+    bypassActors: null,
+    parameters: 'parameters' in rule ? rule.parameters : null,
+    ruleset: { id: 12, source: 'kilo', sourceType: 'Organization' },
+  });
+  for (const item of result.items) {
+    expect(item.state).toBe('unavailable');
+    expect(item.evidence[0]).toMatchObject({
+      source: 'rest.branchRules',
+      headSha: 'head',
+      baseSha: 'base',
+      evaluatedSha: null,
+      observedAt,
+    });
+  }
+});
+
+const unknownBinding = { kind: 'unknown' };
+test.each([
+  [7, { kind: 'app', appId: 7 }, { kind: 'app', appId: 7 }],
+  [-1, { kind: 'any' }, unknownBinding],
+  ...[null, undefined, 0, -2, 7.5, Number.MAX_SAFE_INTEGER + 1].map(
+    id => [id, unknownBinding, unknownBinding] as const
+  ),
+])('normalizes binding %s without inventing a wildcard', (id, classicBinding, rulesetBinding) => {
+  const classicCheck = { context: 'ci', ...(id === undefined ? {} : { app_id: id }) };
+  const rulesetCheck = { context: 'ci', ...(id === undefined ? {} : { integration_id: id }) };
+  const result = normalize(
+    [{ required_status_checks: { strict: true, contexts: ['ci'], checks: [classicCheck] } }],
+    [
+      {
+        ...origin,
+        type: 'required_status_checks',
+        parameters: {
+          strict_required_status_checks_policy: true,
+          required_status_checks: [rulesetCheck],
+        },
+      },
+    ]
+  );
+  expect(result.items.flatMap(item => (item.check ? [item.check.application] : []))).toEqual([
+    classicBinding,
+    rulesetBinding,
+  ]);
+});
+
+test.each(['active', 'evaluate', 'disabled'] as const)(
+  'does not treat an unfiltered %s ruleset as applicable branch rules',
+  enforcement => {
+    const definition = {
+      id: 12,
+      name: 'Other branches',
+      source: 'kilo',
+      enforcement,
+      rules: [{ type: 'required_signatures' }],
+    } satisfies Repos['getRepoRuleset']['response']['data'];
+    expect(normalize([], [definition])).toMatchObject({
+      items: [],
+      completeness: 'unknown',
+      totalCount: null,
+      source: { availability: 'unavailable' },
+    });
+  }
+);
+
+test.each([
+  ['denied', false, 'forbidden'],
+  ['unavailable', false, 'not_found'],
+  ['unavailable', true, 'deadline'],
+  ['partial', true, 'pagination-incomplete'],
+  ['stale', true, 'revision-mismatch'],
+] satisfies [GitHubPrReviewSource['availability'], boolean, string][])(
+  'preserves %s evidence and retry metadata',
+  (availability, retryable, reason) => {
+    const failed = { ...rules(), source: { ...rules().source, availability, retryable, reason } };
+    const malformed = { ...failed, items: [null] };
+    for (const [classicSource, rulesSource] of [
+      [failed, rules()],
+      [classic(), failed],
+      [classic(), malformed],
+    ] as const) {
+      const empty = normalizeContextPolicies(revision, classicSource, rulesSource);
+      expect(empty).toMatchObject({
+        items: [],
+        completeness: 'unknown',
+        totalCount: null,
+        source: {
+          availability: availability === 'partial' ? 'unavailable' : availability,
+          retryable,
+          reason,
+        },
+      });
+    }
+    const partial = normalizeContextPolicies(revision, classic([protection]), {
+      ...rules([signature]),
+      source: failed.source,
+    });
+    expect(partial).toMatchObject({
+      completeness: 'partial',
+      totalCount: null,
+      source: { availability: availability === 'stale' ? 'stale' : 'partial', retryable, reason },
+    });
+    expect(
+      partial.items.filter(item => item.check === null).map(item => item.policy?.source)
+    ).toEqual(['classic', 'ruleset']);
+  }
+);
+
+test.each([
+  [{ contexts: ['ci'] }, { kind: 'unknown' }],
+  [{ checks: [{ context: 'ci', app_id: 7 }] }, { kind: 'app', appId: 7 }],
+])('keeps partial check configuration %j retryable', (configuration, application) => {
+  const result = normalize([{ required_status_checks: { strict: true, ...configuration } }], []);
+  expect(result).toMatchObject({
+    completeness: 'partial',
+    totalCount: null,
+    source: { retryable: true },
+  });
+  expect(result.items.flatMap(item => (item.check ? [item.check] : []))).toEqual([
+    { name: 'ci', kind: 'unknown', application },
+  ]);
+});
+
+test.each([{}, { parameters: null }])(
+  'keeps missing required-check parameters incomplete (%j)',
+  configuration => {
+    const result = normalize([], [{ ...origin, type: 'required_status_checks', ...configuration }]);
+    expect(result).toMatchObject({
+      completeness: 'partial',
+      knownCount: 1,
+      totalCount: null,
+      source: {
+        availability: 'partial',
+        retryable: true,
+        reason: 'invalid-policy-data',
+        observedAt,
+        provenance: ['rest.branchProtection', 'rest.branchRules'],
+      },
+      items: [
+        {
+          kind: 'required_status_checks',
+          state: 'unavailable',
+          check: null,
+          policy: {
+            source: 'ruleset',
+            ruleType: 'required_status_checks',
+            parameters: null,
+            ruleset: { id: 12, source: 'kilo', sourceType: 'Organization' },
+          },
+        },
+      ],
+    });
+  }
+);
+
+test('keeps an explicit empty required-check list complete without evaluating it', () => {
+  const rule = {
+    ...origin,
+    type: 'required_status_checks',
+    parameters: {
+      strict_required_status_checks_policy: true,
+      required_status_checks: [],
+    },
+  } satisfies Repos['getBranchRules']['response']['data'][number];
+  expect(normalize([], [rule])).toMatchObject({
+    completeness: 'complete',
+    knownCount: 1,
+    totalCount: 1,
+    source: { availability: 'available', retryable: false, reason: null },
+    items: [
+      {
+        kind: 'required_status_checks',
+        state: 'unavailable',
+        check: null,
+        policy: { parameters: rule.parameters },
+      },
+    ],
+  });
+});
+
+test('confirms empty policies only when both sources explicitly prove absence', () => {
+  expect(normalize([], [])).toMatchObject({
+    items: [],
+    completeness: 'complete',
+    totalCount: 0,
+    source: { availability: 'available' },
+  });
+  for (const raw of [null, {}, { url: 'https://api.github.com/protection' }]) {
+    expect(normalize([raw], [])).toMatchObject({
+      items: [],
+      completeness: 'unknown',
+      totalCount: null,
+    });
+  }
+});
+
+test.each([
+  { completeness: 'partial' as const },
+  { completeness: 'unknown' as const },
+  { knownCount: 1 },
+  { totalCount: 1 },
+  { hasNextPage: null },
+])('rejects incomplete empty evidence %j', metadata => {
+  expect(normalizeContextPolicies(revision, classic(), { ...rules(), ...metadata })).toMatchObject({
+    completeness: 'unknown',
+    totalCount: null,
+  });
+});
+
+test('preserves unfinished pagination', () => {
+  const result = normalizeContextPolicies(revision, classic(), {
+    ...rules(),
+    hasNextPage: true,
+    endCursor: 'next',
+  });
+  expect(result).toMatchObject({
+    completeness: 'unknown',
+    totalCount: null,
+    hasNextPage: true,
+    endCursor: 'next',
+  });
+});
+
+test.each([
+  null,
+  { type: '' },
+  { type: 'future', parameters: { invalid: Infinity } },
+  {
+    id: 4,
+    ref: 'refs/heads/release/1',
+    before_sha: 'old',
+    after_sha: 'base',
+    result: 'pass',
+    evaluation_result: 'pass',
+  },
+])('rejects malformed or historical evidence %j', raw => {
+  const parameters = { nested: [{ enabled: false, limit: 3, value: null }] };
+  const result = normalize([], [{ ...origin, type: 'future_rule', parameters }, raw]);
+  expect(result).toMatchObject({ completeness: 'partial', totalCount: null });
+  expect(result.items[0]).toMatchObject({
+    kind: 'future_rule',
+    state: 'unavailable',
+    policy: { parameters },
+  });
+});
+
+test('does not invent a missing base identity', () => {
+  const incompleteBase = { ...base, baseRepoFullName: null, baseSha: null };
+  const result = normalizeContextPolicies(
+    { ...revision, ...incompleteBase },
+    classic(),
+    rules([signature])
+  );
+  expect(result.completeness).toBe('partial');
+  expect(result.items[0]?.policy?.base).toEqual(incompleteBase);
+});

--- a/apps/web/src/lib/github-pr-review/context-rules.ts
+++ b/apps/web/src/lib/github-pr-review/context-rules.ts
@@ -1,0 +1,202 @@
+import 'server-only';
+
+import { z } from 'zod';
+import {
+  GitHubPrReviewPolicySchema,
+  type GitHubPrReviewContext,
+  type GitHubPrReviewRevision,
+} from './context-dtos';
+
+type Requirements = GitHubPrReviewContext['requirements'];
+type PolicyCollection = Omit<Requirements, 'items'> & { items: unknown[] };
+const parametersSchema = z.record(z.string(), z.json());
+const branchRuleSchema = z.object({
+  type: z.string().min(1),
+  parameters: z.unknown().optional(),
+  ruleset_id: z.number().int().positive().optional(),
+  ruleset_source: z.string().min(1).optional(),
+  ruleset_source_type: z.enum(['Repository', 'Organization', 'Enterprise']).optional(),
+});
+const checkSchema = z.object({
+  context: z.string().min(1),
+  app_id: z.unknown().optional(),
+  integration_id: z.unknown().optional(),
+});
+
+// Collections must describe completed reads, not turn a 404 or an omitted body into an empty list.
+// Only a source that proves no classic protection can supply a complete empty classic collection.
+export function normalizeContextPolicies(
+  revision: GitHubPrReviewRevision,
+  classic: PolicyCollection,
+  branchRules: PolicyCollection
+): Requirements {
+  const { baseRepoFullName, baseRef, baseSha } = revision;
+  const items: Requirements['items'] = [];
+  let invalid = false;
+  let invalidRetryable = false;
+  for (const [source, collection] of [
+    ['classic', classic],
+    ['ruleset', branchRules],
+  ] as const) {
+    const markInvalid = () => {
+      invalid = true;
+      invalidRetryable ||= collection.source.availability === 'available';
+    };
+    for (const [index, raw] of collection.items.entries()) {
+      const rule = source === 'ruleset' ? branchRuleSchema.safeParse(raw) : null;
+      const configuration = parametersSchema.safeParse(
+        source === 'classic' ? raw : rule?.data?.parameters
+      );
+      if (source === 'ruleset' && !rule?.success) {
+        markInvalid();
+        continue;
+      }
+      if (
+        source === 'classic' &&
+        (!configuration.success ||
+          !Object.keys(configuration.data).some(
+            key => !['url', 'name', 'protection_url'].includes(key)
+          ))
+      ) {
+        markInvalid();
+        continue;
+      }
+      if (!configuration.success && (source === 'classic' || rule?.data?.parameters != null))
+        markInvalid();
+      const parameters = configuration.success ? configuration.data : null;
+      const ruleType = rule?.data?.type ?? 'branch_protection';
+      const rulesetId = rule?.data?.ruleset_id ?? null;
+      const policy = GitHubPrReviewPolicySchema.parse({
+        id: JSON.stringify([source, baseRepoFullName, baseRef, rulesetId, ruleType, index]),
+        source,
+        // getBranchRules returns only active rules, including inherited rules, not ruleset definitions.
+        enforcement: 'active',
+        base: { baseRepoFullName, baseRef, baseSha },
+        ruleType,
+        parameters,
+        ruleset:
+          source === 'ruleset'
+            ? {
+                id: rulesetId,
+                source: rule?.data?.ruleset_source ?? null,
+                sourceType: rule?.data?.ruleset_source_type ?? null,
+              }
+            : null,
+      });
+      const requirement: Requirements['items'][number] = {
+        id: policy.id,
+        kind: ruleType,
+        title: ruleType,
+        state: 'unavailable',
+        policy,
+        check: null,
+        evidence: collection.source.provenance.map(provenance => ({
+          source: provenance,
+          policyId: policy.id,
+          observation: 'policy-configuration',
+          headSha: revision.headSha,
+          baseSha,
+          evaluatedSha: null,
+          observedAt: collection.source.observedAt,
+        })),
+      };
+      items.push(requirement);
+      const status =
+        source === 'classic'
+          ? parameters?.required_status_checks
+          : ruleType === 'required_status_checks'
+            ? parameters
+            : undefined;
+      if (status == null && ruleType !== 'required_status_checks') continue;
+      const statusParameters = parametersSchema.safeParse(status);
+      if (!statusParameters.success) {
+        markInvalid();
+        continue;
+      }
+      const checks =
+        source === 'classic'
+          ? statusParameters.data.checks
+          : statusParameters.data.required_status_checks;
+      const contexts = source === 'classic' ? statusParameters.data.contexts : undefined;
+      const names = new Set<string>();
+      let checkIndex = 0;
+      const addCheck = (value: unknown) => {
+        const parsed = checkSchema.safeParse(value);
+        if (!parsed.success) {
+          markInvalid();
+          return;
+        }
+        const { context, app_id, integration_id } = parsed.data;
+        const appId = source === 'classic' ? app_id : integration_id;
+        items.push({
+          ...requirement,
+          id: `${policy.id}:check:${checkIndex++}`,
+          kind: 'status-check',
+          title: context,
+          check: {
+            name: context,
+            // Configuration names neither a run nor a status; observations must retain both kinds.
+            kind: 'unknown',
+            application:
+              typeof appId === 'number' && Number.isSafeInteger(appId) && appId > 0
+                ? { kind: 'app', appId }
+                : source === 'classic' && appId === -1
+                  ? { kind: 'any' }
+                  : { kind: 'unknown' },
+          },
+        });
+        names.add(context);
+      };
+      if (Array.isArray(checks)) checks.forEach(addCheck);
+      else markInvalid();
+      if (Array.isArray(contexts)) {
+        for (const context of contexts) {
+          if (typeof context !== 'string' || !names.has(context)) addCheck({ context });
+        }
+      } else if (source === 'classic') markInvalid();
+    }
+  }
+  const collections = [classic, branchRules];
+  const sources = collections.map(collection => collection.source);
+  const failure = sources.find(source => source.availability !== 'available');
+  const complete =
+    !invalid &&
+    Boolean(baseRepoFullName && baseRef && baseSha) &&
+    collections.every(
+      collection =>
+        collection.source.availability === 'available' &&
+        collection.completeness === 'complete' &&
+        collection.hasNextPage === false &&
+        collection.knownCount === collection.items.length &&
+        (collection.totalCount === null || collection.totalCount === collection.items.length)
+    );
+  return {
+    items,
+    knownCount: items.length,
+    totalCount: complete ? items.length : null,
+    completeness: complete ? 'complete' : items.length ? 'partial' : 'unknown',
+    hasNextPage: collections.some(collection => collection.hasNextPage === true)
+      ? true
+      : collections.every(collection => collection.hasNextPage === false)
+        ? false
+        : null,
+    endCursor: branchRules.endCursor,
+    source: {
+      observedAt: branchRules.source.observedAt ?? classic.source.observedAt,
+      provenance: [...new Set(sources.flatMap(source => source.provenance))],
+      availability: complete
+        ? 'available'
+        : sources.some(source => source.availability === 'stale')
+          ? 'stale'
+          : items.length
+            ? 'partial'
+            : failure?.availability === 'denied'
+              ? 'denied'
+              : 'unavailable',
+      retryable: sources.some(source => source.retryable) || invalidRetryable,
+      reason: complete
+        ? null
+        : (failure?.reason ?? (invalid ? 'invalid-policy-data' : 'policy-source-incomplete')),
+    },
+  };
+}


### PR DESCRIPTION
No new behavior — this level prepares merge requirements without changing the app's screens or actions.

---

## Summary

`normalizeContextPolicies` converts `PolicyCollection` inputs into `GitHubPrReviewContext.requirements` for an exact base revision, preserving classic protection, active inherited rules, and their evidence. `GitHubPrReviewPolicySchema` keeps viewer enforcement and bypass unknown; requirements remain `unavailable`, and check kinds remain `unknown` because configuration proves no evaluation. The contract retains policy parameters and app bindings, but requires complete reads before proving absence or a total count.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-rules.ts` — adds the server-only normalizer with JavaScript Object Notation (JSON) validation, distinct policy/check identifiers, and revision evidence without an evaluated commit. Preserves ruleset origins, unknown rule types, and separately bound checks with the same name. Positive safe integers identify apps; only classic `app_id: -1` allows any app, and other missing or invalid bindings stay unknown. Adds legacy contexts only when no existing check names them. Rejects malformed policies, metadata-only protection, unfiltered ruleset definitions, and historical evaluation records. Configured checks with missing parameters or lists remain incomplete; explicit empty lists can stay complete without evaluation. Completion requires full base identity, available and complete sources, finished pagination, and consistent item counts. Preserves failure reasons and retryability, prioritizes stale availability, and marks invalid data from available sources retryable. Unifies provenance, keeps the branch-rule timestamp or classic fallback, and retains the branch-rule cursor.

</details>

`normalizeContextPolicies` tests check the normalized output against `GitHubPrReviewContextSchema` and distinguish absent policies from incomplete or unusable evidence. The app-specific and classic-wildcard rows use `as const` to retain fixed, three-column tuples without changing test values or runtime behavior.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-rules.test.ts` — adds 383 lines covering classic and inherited rules, check bindings, base identity, failure metadata, pagination, malformed data, missing parameters, and explicit emptiness. Preserves tuple types for the two binding-table rows used by `test.each`.

</details>

Tests: 1 file added, `context-rules.test.ts` (383 added lines).
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

No manual tests ran because no production consumer calls the new normalizer yet.

No manual provider, backend, or iOS feature scenario ran for this level. The owner prohibits new end-to-end (E2E) slots and bundles.

## Reviewer Notes

### Scope

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- This description covers level 15, from `mobile-pr-review-context-5458-s14` to `mobile-pr-review-context-5458-s15`.
- All 27 existing PRs remain part of one incomplete stack.
- This refresh uses the repaired review refs, not the frozen source `HEAD` or the owner's uncommitted callback patch.

### Historical automated proof

The previous description reported these historical results, not current-head proof:

- All 40 focused cases passed, including the original 37.
- Changed-file lint, formatting, and whitespace checks passed.

The current handoff records owning and cumulative snapshots with 40 passing tests, scoped test-root types, lint, and formatting.

- The checked repair propagated through level 23.
- No product checks ran during this refresh.
- Current-head continuous integration (CI), bot, thread, and final description gates remain required.

### Human steps

No deployment, migration, or configuration step is known for these level-specific diffs.

- **before merge — When the owner permits runtime work, complete live backend and iOS feature verification on the completed stack tip.**
- **before merge — Do not ask for review or merge before the complete-stack human-ready gate.** The owner retains product merge authority.
- **after merge:** None.

### Notes

This level adds policy normalization without connecting production reads. Live backend and iOS verification will run on the completed stack tip.

Live backend and iOS feature verification remains required on the completed stack tip.

The owner currently prohibits new E2E slots and bundles; this hold does not waive runtime verification.

Levels 24 and 25 have prepared repairs and partial proof, but publication remains pending a workflow operation for an unpublished propagated baseline.

Their required three-root type checks have not passed; no failed publication proof is applied.

The owner descoped large-text/font-scaling, theme variants, contrast rendering, scaled-text layout, and screen-reader presentation.

Functional accessibility labels, roles, identifiers, selectors, default appearance flows, and all non-visual criteria remain required.

This is an interim description refresh; the complete-stack readiness gate remains open.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712 ← this PR
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)

