### PR TITLE
feat(pr-review): read applicable merge policies

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-people.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-people.test.ts
@@ -1,4 +1,4 @@
-import type { Octokit } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import {
   createContextReadBudget,
   readPullRequestContext,
@@ -111,8 +111,17 @@ async function run(
   fallback: Partial<PullRequestRestData> = rest,
   requests: string[] = []
 ) {
+  const policyClient = new Octokit();
+  const deniedPolicy = async () => {
+    throw { status: 403 };
+  };
   const octokit = {
     pulls: { get: async () => ({ data: { ...pr, ...fallback } }) },
+    repos: {
+      getBranchProtection: deniedPolicy,
+      getBranchRules: Object.assign(deniedPolicy, policyClient.repos.getBranchRules),
+    },
+    paginate: policyClient.paginate,
     request: async (
       _route: string,
       body: { query: string; variables: { after: string | null }; request: { signal: AbortSignal } }
@@ -180,6 +189,7 @@ it('traverses more than 100 entries independently without per-person requests', 
     });
     expect(result[field].items).toHaveLength(counts[field]);
   }
+  expect(result.requirements.source).toMatchObject({ availability: 'denied', retryable: false });
   // Two pages per people collection; registered sibling sources do not weaken this bound.
   expect(
     requests.filter(query => Object.values(PR_CONTEXT_PEOPLE_QUERIES).includes(query))

--- a/apps/web/src/lib/github-pr-review/context-reader.ts
+++ b/apps/web/src/lib/github-pr-review/context-reader.ts
@@ -32,6 +32,7 @@ import {
   contextIssueEventSchema,
   resolveContextIssues,
 } from './context-issues';
+import { normalizeContextPolicies } from './context-rules';
 
 const collectionQueries = {
   ...PR_CONTEXT_PEOPLE_QUERIES,
@@ -462,6 +463,94 @@ export async function readPullRequestContext(
     ]);
     return resolveContextIssues(context.revision.prNodeId, closing, history);
   }
+  async function collectPolicies() {
+    const { baseRepoFullName, baseRef, baseSha } = context.revision;
+    const [owner, repo, extra] = baseRepoFullName?.split('/') ?? [];
+    if (!owner || !repo || extra || !baseRef || !baseSha) return context.requirements;
+    const parameters = { owner, repo, branch: baseRef };
+    const classic: Collection<unknown> = { ...context.requirements, items: [] };
+    const rules: Collection<unknown> = { ...context.requirements, items: [] };
+    await Promise.all([
+      (async () => {
+        const result = await read('rest.branchProtection', async signal => {
+          const response = await octokit.repos.getBranchProtection({
+            ...parameters,
+            request: { signal },
+          });
+          if (response.status !== 200) throw new Error('Incomplete branch protection response');
+          return response;
+        });
+        classic.source = result.source;
+        if (result.data) {
+          classic.items = [result.data.data];
+          classic.completeness = 'complete';
+          classic.hasNextPage = false;
+        } else if (result.source.reason === 'not_found') {
+          // A 404 or nullable rule cannot prove absence; require an explicitly unprotected matching branch.
+          const absence = await read('rest.branch', async signal => {
+            const response = await octokit.repos.getBranch({ ...parameters, request: { signal } });
+            if (response.status !== 200) throw new Error('Incomplete branch response');
+            return z
+              .object({
+                name: z.literal(baseRef),
+                commit: z.object({ sha: z.literal(baseSha) }),
+                protected: z.boolean(),
+              })
+              .parse(response.data);
+          });
+          if (absence.source.availability !== 'available') classic.source = absence.source;
+          else if (absence.data?.protected === false) {
+            classic.source = absence.source;
+            classic.completeness = 'complete';
+            classic.hasNextPage = false;
+          }
+          classic.source.provenance = [...result.source.provenance, ...absence.source.provenance];
+        }
+        classic.knownCount = classic.items.length;
+      })(),
+      (async () => {
+        const stopped = new Error('Policy pagination stopped');
+        const urls = new Set<string>();
+        // The paginator drops request.signal and converts raw 409/null responses to empty arrays.
+        // Read and validate each page before it reaches that normalization.
+        try {
+          const requestPage = Object.assign(
+            async (params: Parameters<typeof octokit.repos.getBranchRules>[0]) => {
+              const result = await read('rest.branchRules', async signal => {
+                if (!params?.url || urls.has(params.url)) throw new Error('Repeated policy page');
+                urls.add(params.url);
+                const response = await octokit.repos.getBranchRules({
+                  ...params,
+                  request: { signal },
+                });
+                if (response.status !== 200 || !Array.isArray(response.data))
+                  throw new Error('Incomplete branch rules response');
+                return response;
+              });
+              rules.source = result.source;
+              if (!result.data) throw stopped;
+              return result.data;
+            },
+            octokit.repos.getBranchRules
+          );
+          for await (const page of octokit.paginate.iterator(requestPage, {
+            ...parameters,
+            per_page: 100,
+          })) {
+            rules.items.push(...page.data);
+            rules.hasNextPage = true;
+          }
+          rules.completeness = 'complete';
+          rules.hasNextPage = false;
+        } catch (error) {
+          if (isHttp401(error)) throw error;
+          if (error !== stopped) rules.source = failedSource(error, 'rest.branchRules');
+        }
+        rules.knownCount = rules.items.length;
+      })(),
+    ]);
+    return normalizeContextPolicies(context.revision, classic, rules);
+  }
   [
     context.labels,
     context.assignees,
@@ -469,6 +558,7 @@ export async function readPullRequestContext(
     context.reviewDecisions,
     context.reviewActivity,
     context.issues,
+    context.requirements,
   ] = await Promise.all([
     collect('labels', contextLabelSchema, context.labels, (known, current) => ({
       ...current,
@@ -496,6 +586,7 @@ export async function readPullRequestContext(
     collectReviews('latestOpinionatedReviews', context.reviewDecisions),
     collectReviews('latestReviews', context.reviewActivity),
     collectIssues(),
+    collectPolicies(),
   ]);
   // Final null fields can hide contradictions between the two connections.
   for (const review of context.reviewDecisions.items) {

--- a/apps/web/src/lib/github-pr-review/context-reader.ts
+++ b/apps/web/src/lib/github-pr-review/context-reader.ts
@@ -517,7 +517,8 @@ export async function readPullRequestContext(
           const requestPage = Object.assign(
             async (params: Parameters<typeof octokit.repos.getBranchRules>[0]) => {
               const result = await read('rest.branchRules', async signal => {
-                if (!params?.url || urls.has(params.url)) throw new Error('Repeated policy page');
+                if (typeof params?.url !== 'string' || !params.url || urls.has(params.url))
+                  throw new Error('Repeated policy page');
                 urls.add(params.url);
                 const response = await octokit.repos.getBranchRules({
                   ...params,

--- a/apps/web/src/lib/github-pr-review/context-rules-integration.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-rules-integration.test.ts
@@ -1,0 +1,362 @@
+import { Octokit } from '@octokit/rest';
+import {
+  createContextReadBudget,
+  readPullRequestContext,
+  PR_CONTEXT_REVISION_QUERY,
+} from './context-reader';
+import { GitHubPrReviewContextSchema } from './context-dtos';
+import { PR_CONTEXT_PEOPLE_QUERIES } from './context-people';
+import { PR_CONTEXT_REVIEW_QUERIES } from './context-reviews';
+import { PR_CONTEXT_ISSUE_QUERIES } from './context-issues';
+
+const revision = {
+  prNodeId: 'PR',
+  number: 1,
+  headSha: 'head',
+  baseRepoFullName: 'upstream/policies',
+  baseRef: 'release/1',
+  baseSha: 'base',
+};
+const branchPath = '/repos/upstream/policies/branches/release/1';
+const protectionPath = `${branchPath}/protection`;
+const unprotected = { name: 'release/1', commit: { sha: 'base' }, protected: false };
+const rulesPath = '/repos/upstream/policies/rules/branches/release/1';
+const nextPage =
+  'https://api.github.com/repos/upstream/policies/rules/branches/release%2F1?per_page=100&page=2';
+const rule = {
+  type: 'required_deployments',
+  parameters: { required_deployment_environments: ['production'] },
+  ruleset_id: 7,
+  ruleset_source: 'upstream',
+  ruleset_source_type: 'Organization',
+};
+const protection = {
+  required_status_checks: {
+    strict: true,
+    contexts: ['ci'],
+    checks: [
+      { context: 'ci', app_id: 7 },
+      { context: 'ci', app_id: -1 },
+      { context: 'ci', app_id: null },
+    ],
+  },
+  required_pull_request_reviews: {
+    required_approving_review_count: 2,
+    require_code_owner_reviews: true,
+    require_last_push_approval: true,
+    dismiss_stale_reviews: true,
+  },
+  required_conversation_resolution: { enabled: true },
+  required_signatures: { enabled: true },
+};
+const collections = {
+  ...PR_CONTEXT_PEOPLE_QUERIES,
+  ...PR_CONTEXT_REVIEW_QUERIES,
+  ...PR_CONTEXT_ISSUE_QUERIES,
+};
+const empty = { nodes: [], totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null } };
+const failure = (status: number) => Response.json({ message: 'provider-only' }, { status });
+let budget: ReturnType<typeof createContextReadBudget>;
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.spyOn(console, 'info').mockImplementation(() => undefined);
+  budget = createContextReadBudget();
+});
+afterEach(() => {
+  budget.close();
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+async function run(
+  serve: (
+    url: URL,
+    options: RequestInit
+  ) => Response | undefined | Promise<Response | undefined> = () => undefined
+) {
+  const requests: string[] = [];
+  let active = 0,
+    peak = 0;
+  const octokit = new Octokit({
+    request: {
+      fetch: async (input: string | URL | Request, options: RequestInit = {}) => {
+        const url = new URL(String(input));
+        requests.push(decodeURIComponent(url.pathname) + url.search);
+        peak = Math.max(peak, ++active);
+        try {
+          const response = await serve(url, options);
+          if (response) return response;
+          const path = decodeURIComponent(url.pathname);
+          if (path === '/repos/o/r/pulls/1')
+            return Response.json({
+              node_id: 'PR',
+              number: 1,
+              title: 'PR',
+              body: null,
+              user: null,
+              state: 'open',
+              head: { ref: 'feature', sha: 'head', repo: { full_name: 'fork/r' } },
+              base: {
+                ref: 'release/1',
+                sha: 'base',
+                repo: { full_name: 'upstream/policies', default_branch: 'main' },
+              },
+              commits: 1,
+              changed_files: 1,
+              additions: 1,
+              deletions: 0,
+              mergeable: null,
+            });
+          if (path === protectionPath) return Response.json(protection);
+          if (path === branchPath) return Response.json(unprotected);
+          if (path === rulesPath) return Response.json([rule]);
+          const { query } = JSON.parse(String(options.body));
+          if (query === PR_CONTEXT_REVISION_QUERY)
+            return Response.json({
+              data: {
+                repository: {
+                  pullRequest: {
+                    id: 'PR',
+                    number: 1,
+                    headRefOid: 'head',
+                    baseRefName: 'release/1',
+                    baseRefOid: 'base',
+                    baseRepository: { nameWithOwner: 'upstream/policies' },
+                  },
+                },
+              },
+            });
+          const field = Object.entries(collections).find(([, document]) => document === query)?.[0];
+          if (!field) throw new Error('Unexpected request');
+          return Response.json({ data: { repository: { pullRequest: { [field]: empty } } } });
+        } finally {
+          active--;
+        }
+      },
+    },
+  });
+  const context = GitHubPrReviewContextSchema.parse(
+    await readPullRequestContext(
+      octokit,
+      { owner: 'o', repo: 'r', number: 1, expectedRevision: revision },
+      budget
+    )
+  );
+  return { context, requests, peak };
+}
+
+it('reads exact-base classic and inherited active policies without evaluating them', async () => {
+  const { context, requests } = await run(url =>
+    decodeURIComponent(url.pathname) === rulesPath
+      ? Response.json([
+          rule,
+          { ...rule, type: 'future_rule', parameters: { nested: [true, null] } },
+        ])
+      : undefined
+  );
+  expect(context.requirements).toMatchObject({
+    completeness: 'complete',
+    knownCount: 6,
+    source: { availability: 'available' },
+  });
+  const policies = context.requirements.items.filter(item => item.check === null);
+  expect(policies.map(item => item.kind)).toEqual([
+    'branch_protection',
+    'required_deployments',
+    'future_rule',
+  ]);
+  expect(policies[0]?.policy?.parameters).toEqual(protection);
+  expect(policies[1]?.policy).toMatchObject({
+    parameters: rule.parameters,
+    ruleset: { id: 7, source: 'upstream', sourceType: 'Organization' },
+  });
+  for (const item of context.requirements.items) {
+    expect(item).toMatchObject({
+      state: 'unavailable',
+      policy: {
+        enforcement: 'active',
+        viewerBypass: 'unknown',
+        viewerEnforcement: 'unknown',
+        bypassActors: null,
+        base: { baseRepoFullName: 'upstream/policies', baseRef: 'release/1', baseSha: 'base' },
+      },
+      evidence: [expect.objectContaining({ headSha: 'head', baseSha: 'base', evaluatedSha: null })],
+    });
+  }
+  expect(context.requirements.items.flatMap(item => (item.check ? [item.check] : []))).toEqual([
+    { name: 'ci', kind: 'unknown', application: { kind: 'app', appId: 7 } },
+    { name: 'ci', kind: 'unknown', application: { kind: 'any' } },
+    { name: 'ci', kind: 'unknown', application: { kind: 'unknown' } },
+  ]);
+  expect(requests.filter(path => path.startsWith('/repos/upstream/'))).toEqual([
+    protectionPath,
+    `${rulesPath}?per_page=100`,
+  ]);
+  expect(context.labels.completeness).toBe('complete');
+});
+
+it.each(['done', '503', '403', '409', 'null', 'repeat'])(
+  'preserves policy pages through %s',
+  async outcome => {
+    let pages = 0;
+    const { context, requests } = await run(url => {
+      if (decodeURIComponent(url.pathname) !== rulesPath) return;
+      if (++pages > 2) return failure(503);
+      if (!url.searchParams.has('page'))
+        return Response.json(
+          Array.from({ length: 100 }, (_, index) => ({ ...rule, ruleset_id: index + 1 })),
+          { headers: { link: `<${nextPage}>; rel="next"` } }
+        );
+      if (outcome === 'null') return Response.json(null);
+      if (!['done', 'repeat'].includes(outcome)) return failure(Number(outcome));
+      return Response.json([{ ...rule, ruleset_id: 101 }], {
+        headers: outcome === 'repeat' ? { link: `<${nextPage}>; rel="next"` } : {},
+      });
+    });
+    expect(
+      context.requirements.items.filter(item => item.policy?.source === 'ruleset')
+    ).toHaveLength(['done', 'repeat'].includes(outcome) ? 101 : 100);
+    expect(context.requirements).toMatchObject({
+      completeness: outcome === 'done' ? 'complete' : 'partial',
+      hasNextPage: outcome !== 'done',
+      source: {
+        availability: outcome === 'done' ? 'available' : 'partial',
+        retryable: !['done', '403'].includes(outcome),
+      },
+    });
+    expect(requests.filter(path => path.startsWith(rulesPath))).toHaveLength(2);
+    expect(context.labels.completeness).toBe('complete');
+  }
+);
+
+it.each([protectionPath, rulesPath])(
+  'isolates denied and transient policy failures at %s',
+  async path => {
+    for (const status of [403, 404, 409, 503]) {
+      const { context } = await run(url => {
+        if (decodeURIComponent(url.pathname) === path) return failure(status);
+      });
+      // The default exact-ref probe proves classic absence after 404; a rules 404 never does.
+      const complete = path === protectionPath && status === 404;
+      expect(context.requirements).toMatchObject({
+        completeness: complete ? 'complete' : 'partial',
+        source: { availability: complete ? 'available' : 'partial', retryable: status >= 409 },
+      });
+      expect(
+        context.requirements.items.some(
+          item => item.policy?.source === (path === rulesPath ? 'classic' : 'ruleset')
+        )
+      ).toBe(true);
+      expect(context.labels.completeness).toBe('complete');
+      expect(JSON.stringify(context)).not.toContain('provider-only');
+    }
+  }
+);
+
+it('confirms empty policies only after explicit exact-ref absence and empty active rules', async () => {
+  const { context } = await run(url => {
+    if (decodeURIComponent(url.pathname) === protectionPath) return failure(404);
+    if (decodeURIComponent(url.pathname) === rulesPath) return Response.json([]);
+  });
+  expect(context.requirements).toMatchObject({
+    items: [],
+    completeness: 'complete',
+    totalCount: 0,
+    hasNextPage: false,
+    source: { availability: 'available', retryable: false },
+  });
+});
+
+it.each([
+  [null, true],
+  [{}, true],
+  [{ ...unprotected, protected: undefined }, true],
+  [{ ...unprotected, protected: null }, true],
+  [{ ...unprotected, protected: true }, false],
+  [{ ...unprotected, name: 'main' }, true],
+  [{ ...unprotected, commit: { sha: 'other' } }, true],
+  [403, false],
+  [404, false],
+  [503, true],
+] as const)(
+  'does not turn ambiguous classic absence %j into no policies',
+  async (branch, retryable) => {
+    const { context } = await run(url => {
+      if (decodeURIComponent(url.pathname) === protectionPath) return failure(404);
+      if (decodeURIComponent(url.pathname) === rulesPath) return Response.json([]);
+      if (decodeURIComponent(url.pathname) === branchPath)
+        return typeof branch === 'number' ? failure(branch) : Response.json(branch);
+    });
+    expect(context.requirements).toMatchObject({
+      items: [],
+      completeness: 'unknown',
+      totalCount: null,
+      source: { retryable },
+    });
+    expect(context.requirements.source.availability).not.toBe('available');
+    expect(context.labels.completeness).toBe('complete');
+  }
+);
+
+it.each([200, 503, 401])('shares one policy authentication probe with status %s', async status => {
+  let pulls = 0;
+  const pending = run(url => {
+    const path = decodeURIComponent(url.pathname);
+    if (path === protectionPath || path === rulesPath) return failure(401);
+    if (path === '/repos/o/r/pulls/1' && ++pulls > 1 && status !== 200) return failure(status);
+  });
+  if (status === 401) await expect(pending).rejects.toMatchObject({ status: 401 });
+  else {
+    const { context, peak } = await pending;
+    expect(context.requirements).toMatchObject({
+      items: [],
+      completeness: 'unknown',
+      source: {
+        availability: status === 200 ? 'denied' : 'unavailable',
+        retryable: status !== 200,
+        reason: status === 200 ? 'optional-permission-denied' : 'credential-probe-inconclusive',
+      },
+    });
+    expect(context.labels.completeness).toBe('complete');
+    expect(peak).toBeLessThanOrEqual(4);
+  }
+  expect(pulls).toBe(2);
+});
+
+it('shares four request slots and aborts late policy pages at the ten-second deadline', async () => {
+  const started = Promise.withResolvers<void>();
+  let aborted = false;
+  const pending = run((url, options) => {
+    if (decodeURIComponent(url.pathname) !== rulesPath) return;
+    if (!url.searchParams.has('page'))
+      return Response.json([rule], { headers: { link: `<${nextPage}>; rel="next"` } });
+    started.resolve();
+    return new Promise(resolve =>
+      options.signal?.addEventListener(
+        'abort',
+        () => {
+          aborted = true;
+          resolve(Response.json([{ ...rule, ruleset_id: 99 }]));
+        },
+        { once: true }
+      )
+    );
+  });
+  await started.promise;
+  await jest.advanceTimersByTimeAsync(10_000);
+  const { context, peak, requests } = await pending;
+  expect(
+    context.requirements.items
+      .filter(item => item.policy?.source === 'ruleset')
+      .map(item => item.policy?.ruleset?.id)
+  ).toEqual([7]);
+  expect(context.requirements.source).toMatchObject({
+    availability: 'unavailable',
+    reason: 'deadline',
+    retryable: true,
+  });
+  expect(context.labels.completeness).toBe('complete');
+  expect(aborted).toBe(true);
+  expect(peak).toBe(4);
+  expect(requests.filter(path => path.startsWith(rulesPath))).toHaveLength(2);
+});

--- a/apps/web/src/lib/github-pr-review/context-rules-integration.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-rules-integration.test.ts
@@ -28,7 +28,7 @@ const rule = {
   parameters: { required_deployment_environments: ['production'] },
   ruleset_id: 7,
   ruleset_source: 'upstream',
-  ruleset_source_type: 'Organization',
+  ruleset_source_type: 'Organization' as const,
 };
 const protection = {
   required_status_checks: {
@@ -72,7 +72,8 @@ async function run(
   serve: (
     url: URL,
     options: RequestInit
-  ) => Response | undefined | Promise<Response | undefined> = () => undefined
+  ) => Response | undefined | Promise<Response | undefined> = () => undefined,
+  configure?: (octokit: Octokit) => void
 ) {
   const requests: string[] = [];
   let active = 0,
@@ -135,6 +136,7 @@ async function run(
       },
     },
   });
+  configure?.(octokit);
   const context = GitHubPrReviewContextSchema.parse(
     await readPullRequestContext(
       octokit,
@@ -144,6 +146,39 @@ async function run(
   );
   return { context, requests, peak };
 }
+
+it.each([
+  {},
+  { url: undefined },
+  { url: null },
+  { url: '' },
+  { url: false },
+  { url: 0 },
+  { url: true },
+  { url: 42 },
+  { url: {} },
+  { url: [] },
+])('rejects invalid policy page parameters %p without adding ruleset evidence', async params => {
+  const { context } = await run(undefined, octokit => {
+    jest.spyOn(octokit.repos, 'getBranchRules').mockResolvedValue({
+      status: 200,
+      url: nextPage,
+      headers: {},
+      data: [{ ...rule, type: 'required_deployments' }],
+    });
+    jest.spyOn(octokit.paginate, 'iterator').mockImplementation(async function* (requestPage) {
+      // @ts-expect-error These parameters are invalid on purpose to test runtime rejection.
+      yield await requestPage(params);
+    });
+  });
+  expect(context.requirements.items.filter(item => item.policy?.source === 'ruleset')).toEqual([]);
+  expect(context.requirements.items.some(item => item.policy?.source === 'classic')).toBe(true);
+  expect(context.requirements).toMatchObject({
+    completeness: 'partial',
+    source: { availability: 'partial', retryable: true },
+  });
+  expect(context.labels.completeness).toBe('complete');
+});
 
 it('reads exact-base classic and inherited active policies without evaluating them', async () => {
   const { context, requests } = await run(url =>
@@ -235,6 +270,7 @@ it.each([protectionPath, rulesPath])(
     for (const status of [403, 404, 409, 503]) {
       const { context } = await run(url => {
         if (decodeURIComponent(url.pathname) === path) return failure(status);
+        return undefined;
       });
       // The default exact-ref probe proves classic absence after 404; a rules 404 never does.
       const complete = path === protectionPath && status === 404;
@@ -257,6 +293,7 @@ it('confirms empty policies only after explicit exact-ref absence and empty acti
   const { context } = await run(url => {
     if (decodeURIComponent(url.pathname) === protectionPath) return failure(404);
     if (decodeURIComponent(url.pathname) === rulesPath) return Response.json([]);
+    return undefined;
   });
   expect(context.requirements).toMatchObject({
     items: [],
@@ -286,6 +323,7 @@ it.each([
       if (decodeURIComponent(url.pathname) === rulesPath) return Response.json([]);
       if (decodeURIComponent(url.pathname) === branchPath)
         return typeof branch === 'number' ? failure(branch) : Response.json(branch);
+      return undefined;
     });
     expect(context.requirements).toMatchObject({
       items: [],
@@ -304,6 +342,7 @@ it.each([200, 503, 401])('shares one policy authentication probe with status %s'
     const path = decodeURIComponent(url.pathname);
     if (path === protectionPath || path === rulesPath) return failure(401);
     if (path === '/repos/o/r/pulls/1' && ++pulls > 1 && status !== 200) return failure(status);
+    return undefined;
   });
   if (status === 401) await expect(pending).rejects.toMatchObject({ status: 401 });
   else {

--- a/apps/web/src/routers/github-pr-review-router.test.ts
+++ b/apps/web/src/routers/github-pr-review-router.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 import { TRPCError } from '@trpc/server';
+import { Octokit } from '@octokit/rest';
 import { createCallerFactory } from '@/lib/trpc/init';
 import type { User } from '@kilocode/db/schema';
 import {
@@ -77,6 +78,8 @@ type OctokitMock = {
   git: { deleteRef: jest.Mock };
   repos: {
     get: jest.Mock;
+    getBranchProtection: jest.Mock;
+    getBranchRules: jest.Mock;
     listCommitStatusesForRef: jest.Mock;
   };
   checks: {
@@ -112,6 +115,7 @@ function buildOctokit(token: string): OctokitMock {
   const existing = tokenOctokits.get(token);
   if (existing) return existing;
   const checks = { listForRef: jest.fn() };
+  const policyClient = new Octokit();
   const octokit: OctokitMock = {
     __token: token,
     pulls: {
@@ -128,13 +132,23 @@ function buildOctokit(token: string): OctokitMock {
     git: { deleteRef: jest.fn() },
     repos: {
       get: jest.fn(),
+      getBranchProtection: jest.fn().mockResolvedValue({
+        status: 200,
+        data: { required_linear_history: { enabled: true } },
+      }),
+      getBranchRules: Object.assign(
+        jest.fn().mockResolvedValue({ status: 200, headers: {}, data: [] }),
+        policyClient.repos.getBranchRules
+      ),
       listCommitStatusesForRef: jest.fn(),
     },
     checks,
-    // listChecks calls paginate(checks.listForRef, …) then
-    // paginate(repos.listCommitStatusesForRef, …); dispatch on the method.
-    paginate: jest.fn(async (method: unknown) =>
-      method === checks.listForRef ? checkRunsFixture : commitStatusesFixture
+    // Keep legacy listChecks fixtures separate from installed policy pagination.
+    paginate: Object.assign(
+      jest.fn(async (method: unknown) =>
+        method === checks.listForRef ? checkRunsFixture : commitStatusesFixture
+      ),
+      { iterator: policyClient.paginate.iterator }
     ),
     request: jest.fn(),
   };
@@ -1339,7 +1353,7 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
       jest.restoreAllMocks();
     });
 
-    it('enriches people, labels, reviews, and issues without claiming unattached readers are empty', async () => {
+    it('enriches people, reviews, issues, and policies without claiming unattached readers are empty', async () => {
       const result = await caller.getPullRequestContext(contextInput);
       expect(result.revision).toEqual(revision);
       expect(result.labels).toMatchObject({
@@ -1361,15 +1375,18 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
           source: { availability: 'available' },
         });
       }
-      for (const collection of [result.requirements, result.checks]) {
-        expect(collection).toMatchObject({
-          items: [],
-          completeness: 'unknown',
-          totalCount: null,
-          hasNextPage: null,
-          source: { availability: 'unavailable', reason: 'not-requested' },
-        });
-      }
+      expect(result.requirements).toMatchObject({
+        items: [{ kind: 'branch_protection', state: 'unavailable' }],
+        completeness: 'complete',
+        source: { availability: 'available' },
+      });
+      expect(result.checks).toMatchObject({
+        items: [],
+        completeness: 'unknown',
+        totalCount: null,
+        hasNextPage: null,
+        source: { availability: 'unavailable', reason: 'not-requested' },
+      });
       expect(result.queue).toMatchObject({
         membership: { state: 'unknown', source: { availability: 'unavailable' } },
         position: { value: null, source: { availability: 'unavailable' } },
@@ -1541,7 +1558,10 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
         second.request.mockResolvedValue(contextEnvelope(revision, 'rotated'));
         const result = await caller.getPullRequestContext(contextInput);
         expect(result.labels.items[0]?.name).toBe('rotated');
-        expect(result.requirements.source.reason).toBe('not-requested');
+        expect(result.requirements).toMatchObject({
+          items: [{ kind: 'branch_protection', state: 'unavailable' }],
+          source: { availability: 'available', reason: null },
+        });
         expect(getGitHubUserAccessToken).toHaveBeenNthCalledWith(2, 'user-1', {
           op: 'rotate',
           staleAuthorizationId: 'auth_1',


### PR DESCRIPTION
- Pull request context now includes protection rules for the target branch, including rules inherited from an organization.
- If GitHub cannot confirm all rules, pull request context keeps known information and distinguishes incomplete information from confirmed absence.

---

## Summary

The optional `getPullRequestContext` route fills `requirements` with classic protection and active rulesets for the pull request’s base repository and branch. Policy reads share four request slots, the ten-second deadline, authentication probing, and revision checks, preserving known evidence when later reads fail. The response keeps its existing shape; policies remain unevaluated, and viewer enforcement and bypass remain unknown.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-reader.ts` — integrates `normalizeContextPolicies` into parallel context reads and skips policy collection when the base identity is incomplete. A classic 404 requires an explicitly unprotected branch matching the base name and commit before confirming absence. Policy and absence reads require status 200. Ruleset pages request 100 items and require array data plus a nonempty, unrepeated string URL before paginator normalization. The wrapper restores the abort signal, retains completed pages after failures, and propagates confirmed credential rejection to the existing retry flow.

</details>

Policy integration tests exercise Octokit pagination against mocked HTTP responses, including ten malformed page-parameter cases. The `serve` fixture accepts `Response | undefined` directly or through a promise, while literal `Organization` and branch/retry tuples retain their types. An intentional `@ts-expect-error` permits malformed runtime input; policy mocks isolate people reads and preserve legacy check fixtures.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-rules-integration.test.ts` — adds coverage for exact-base and inherited policies, unknown rule types, and required-check application identities. It covers pagination failures, repeated URLs, explicit and uncertain absence, shared authentication probes, concurrency, and deadline cancellation. The optional `configure` hook injects malformed paginator parameters; rejected parameters preserve classic evidence without adding ruleset evidence. The fixtures retain readonly branch/retry tuples and limit the expected type error to the deliberately invalid call.
- `apps/web/src/lib/github-pr-review/context-people.test.ts` — supplies denied policy mocks with installed endpoint metadata and pagination. It asserts nonretryable policy denial while retaining independent people pagination coverage.
- `apps/web/src/routers/github-pr-review-router.test.ts` — adds classic protection and ruleset mocks with installed paginator metadata while keeping legacy check pagination separate. Context and credential-rotation assertions now expect available policy evidence with unevaluated branch protection; checks and queue remain unavailable.

</details>

Tests: 3 files changed: `context-rules-integration.test.ts` added (401 lines), `context-people.test.ts` updated (12 changed lines), and `github-pr-review-router.test.ts` updated (50 changed lines).
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

No manual tests ran for this level. Live backend and iOS verification will run on the completed stack tip.

No manual provider, backend, or iOS feature scenario has run for these levels. The owner prohibits new end-to-end (E2E) slots and bundles, so runtime verification remains pending.

## Reviewer Notes

### Human steps

- **before merge: Do not ask for review or merge before the complete-stack human-ready gate.**
- **before merge:** When the owner permits execution, complete live provider, backend, and iOS feature verification on the completed stack tip.
- **before merge:** Pass the required three-root type checks for levels 24 and 25.
- **before merge:** Complete the workflow operation for the unpublished propagated baseline before publishing levels 24 and 25.
- **before merge:** Complete the current-head continuous integration (CI), bot, thread, and final description gates.
- **after merge:** No additional human step is known for this level.

No deployment, migration, or configuration step is known for these level-specific diffs.
The owner retains product merge authority.

### Scope

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- This description covers level 16, from `mobile-pr-review-context-5458-s15` to `mobile-pr-review-context-5458-s16`.
- This level collects policy evidence without evaluating it or changing mobile behavior.
- Evaluation, mobile behavior, fixture validation, actual-provider comparisons, and live verification remain pending.
- No GraphQL document changed.
- All 27 existing PRs remain part of one incomplete stack.

### Historical automated proof

- The handoff records historical proof, not checks from this refresh.
- Before publication, level 16 passed 34 owning integration cases, 132 cumulative integration cases, scoped types, and formatting.
- Later inherited repairs change review hashes without adding those inherited files to these PR diffs.
- These results do not establish current-head or complete-stack readiness.
- No product check ran during this refresh.
- The migration repair has separate live proof; it does not verify this level-specific diff.

### Notes

This level adds policy evidence to optional backend context. Live backend and iOS verification will run on the completed stack tip.

Live backend and iOS feature verification remains required on the completed stack tip.

The owner currently prohibits new E2E slots and bundles; this hold does not waive runtime verification.

Levels 24 and 25 have prepared repairs and partial proof, but publication remains pending a workflow operation for an unpublished propagated baseline.

Their required three-root type checks have not passed; no failed publication proof is applied.

The owner descoped large-text/font-scaling, theme variants, contrast rendering, scaled-text layout, and screen-reader presentation.

Functional accessibility labels, roles, identifiers, selectors, default appearance flows, and all non-visual criteria remain required.

This is an interim description refresh; the complete-stack readiness gate remains open.

The ladder records the stack and its required workflow, not completed verification.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713 ← this PR
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)

