### PR TITLE
feat(extension): execute delegated browser jobs in the panel

### DIFF
--- a/apps/extension/entrypoints/sidepanel/browser-task-provider.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider.test.tsx
@@ -1,0 +1,1731 @@
+/* eslint-disable max-lines, init-declarations, import/max-dependencies, import/first, import/no-nodejs-modules, jest/no-hooks, jest/no-untyped-mock-factory, jest/no-conditional-in-test, jest/no-conditional-expect, jest/max-expects, vitest/prefer-import-in-mock, require-await, typescript/require-await, typescript/consistent-type-definitions, typescript/no-unsafe-assignment, typescript/no-unsafe-type-assertion, unicorn/no-await-expression-member -- Table-driven lifetime scenarios check each transition and its durable effects; fixtures retain the browser API types. */
+// @vitest-environment jsdom
+import { locks as nativeLocks } from 'node:worker_threads';
+import { webcrypto } from 'node:crypto';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  BrowserJobSnapshot,
+  BrowserProviderInboundMessage,
+  BrowserProviderOutboundMessage,
+  BrowserResult,
+} from '@kilocode/cloud-agent-sdk/schemas';
+import { browserProviderOutboundMessageSchema } from '@kilocode/cloud-agent-sdk/schemas';
+import { BrowserProviderError } from '@kilocode/cloud-agent-sdk/user-web-connection';
+import type {
+  BrowserProviderState,
+  BrowserProviderRegistration,
+  BrowserProviderApprovalInput,
+  BrowserProviderCancelInput,
+  BrowserProviderUnavailableInput,
+  BrowserProviderQuiescenceInput,
+  BrowserProviderResultInput,
+} from '@kilocode/cloud-agent-sdk/user-web-connection';
+import type { BrowserRunContext } from './browser-run-context';
+import type { LlmTurnOutcome } from '@/src/shared/agent-llm-turn-runner-core';
+import type { AgentConversationEvent } from '@/src/shared/agent-conversation';
+
+const fixture = vi.hoisted(() => ({
+  actions: [] as string[],
+  failWrite: '',
+  permissions: new Set<() => void>(),
+  removed: new Set<(id: number) => void>(),
+  tabs: [
+    { id: 7, title: 'Approved tab', url: 'https://example.test/task' },
+    { id: 8, title: 'Other tab', url: 'https://other.test/' },
+  ],
+  turn: async (
+    _context: BrowserRunContext,
+    _events: AgentConversationEvent[]
+  ): Promise<LlmTurnOutcome> => {
+    throw new Error('Set the test turn.');
+  },
+  updated: new Set<(id: number, info: { url?: string }) => void>(),
+  values: new Map<string, unknown>(),
+  watchers: new Map<string, Set<() => void>>(),
+  writes: [] as string[],
+}));
+vi.mock('#imports', () => ({
+  browser: {
+    permissions: {
+      onRemoved: {
+        addListener: (fn: () => void) => fixture.permissions.add(fn),
+        removeListener: (fn: () => void) => fixture.permissions.delete(fn),
+      },
+    },
+    tabs: {
+      get: async (id: number) => {
+        const tab = fixture.tabs.find(item => item.id === id);
+        if (tab === undefined) {
+          throw new Error('Tab closed');
+        }
+        return tab;
+      },
+      onRemoved: {
+        addListener: (fn: (id: number) => void) => fixture.removed.add(fn),
+        removeListener: (fn: (id: number) => void) => fixture.removed.delete(fn),
+      },
+      onUpdated: {
+        addListener: (fn: (id: number, info: { url?: string }) => void) => fixture.updated.add(fn),
+        removeListener: (fn: (id: number, info: { url?: string }) => void) =>
+          fixture.updated.delete(fn),
+      },
+      query: async () => structuredClone(fixture.tabs),
+    },
+  },
+  storage: {
+    getItem: (key: string) => structuredClone(fixture.values.get(key)),
+    removeItem: (key: string) => {
+      fixture.values.delete(key);
+    },
+    setItem: async (key: string, value: unknown) => {
+      if (fixture.failWrite === key) {
+        throw new Error('Private storage failure');
+      }
+      fixture.values.set(key, structuredClone(value));
+      fixture.writes.push(key);
+      for (const notify of fixture.watchers.get(key) ?? []) {
+        notify();
+      }
+    },
+    watch: (key: string, fn: () => void) => {
+      const listeners = fixture.watchers.get(key) ?? new Set<() => void>();
+      fixture.watchers.set(key, listeners);
+      listeners.add(fn);
+      return () => {
+        listeners.delete(fn);
+      };
+    },
+  },
+}));
+vi.mock('./use-gateway-models', () => ({
+  useGatewayModels: () => ({ modelOptions: [{ id: 'selected-model', supportsImages: true }] }),
+}));
+vi.mock(import('./browser-run-context'), async importOriginal => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    runBrowserTurn: (context: BrowserRunContext, events: AgentConversationEvent[]) =>
+      context.lease.run(async guard => {
+        guard();
+        return fixture.turn(context, events);
+      }),
+  };
+});
+
+import { browser, storage } from '#imports';
+import {
+  AUTH_STORAGE_KEY,
+  BROWSER_PROVIDER_IDENTITY_KEY,
+  clearStoredSession,
+} from '@/src/shared/auth';
+import { createAssistantMessage } from '@/src/shared/agent-conversation';
+import { BROWSER_TASK_STORAGE_KEY } from '@/src/shared/browser-task-store';
+import type { StoredBrowserJob } from '@/src/shared/browser-task-store';
+import {
+  createBrowserExecutionCoordinator,
+  BROWSER_EXECUTION_SAFETY_KEY,
+  PROVIDER_OWNER_LOCK,
+} from './browser-execution-lock';
+import type { BrowserExecutionLease } from './browser-execution-lock';
+import {
+  BrowserTaskProvider,
+  createBrowserTaskProviderRuntime,
+  useBrowserTask,
+} from './browser-task-provider';
+import type { BrowserTaskProviderRuntime } from './browser-task-provider';
+import { applyApprovalDecision, pendingApprovalAtom, pendingLockAtom } from './pending-approval';
+
+type Delivery = Extract<BrowserProviderInboundMessage, { type: 'provider_job' }>;
+type Fence = { invocationId: string; tabId?: number };
+const runtimes: BrowserTaskProviderRuntime[] = [];
+const localLeases: BrowserExecutionLease[] = [];
+const auth = { token: 'test-account-token', userEmail: 'owner@example.test' };
+const defaults = {
+  enabled: true,
+  mode: 'safe' as const,
+  model: 'selected-model',
+  thinkingEffort: 'high',
+};
+const outcome = (): LlmTurnOutcome => ({
+  effectsUncertain: false,
+  reason: 'completed',
+  status: 'succeeded',
+  summary: 'Observed the requested page.',
+  toolResults: [],
+});
+const terminalResult = (
+  job: BrowserJobSnapshot,
+  reason: Exclude<BrowserResult['reason'], 'completed'>,
+  status: Exclude<BrowserResult['status'], 'succeeded'> = 'interrupted'
+): BrowserResult => ({
+  browserTaskId: job.browserTaskId,
+  effectsUncertain: job.status === 'running',
+  evidence: [],
+  invocationId: job.invocationId,
+  jobId: job.jobId,
+  providerId: job.providerId,
+  reason,
+  status,
+  summary: `Relay settled ${reason}.`,
+});
+const relay = () => {
+  let state: BrowserProviderState = { status: 'ready' };
+  let registration: BrowserProviderRegistration | undefined;
+  let generation = 0;
+  let fence: Fence | undefined;
+  let acknowledgeApproval = true;
+  let acknowledgeHeartbeat = true;
+  let acknowledgeTerminal = true;
+  const queued = new Map<string, Delivery>();
+  const rows = new Map<string, BrowserJobSnapshot>();
+  const messages = new Set<(message: BrowserProviderInboundMessage) => void>();
+  const states = new Set<(value: BrowserProviderState) => void>();
+  const outbound: BrowserProviderOutboundMessage[] = [];
+  const events: string[] = [];
+  const heartbeatTimes: number[] = [];
+  const setState = (next: BrowserProviderState): void => {
+    state = next;
+    for (const listener of states) {
+      listener(next);
+    }
+  };
+  const send = (message: BrowserProviderInboundMessage): void => {
+    for (const listener of messages) {
+      listener(structuredClone(message));
+    }
+  };
+  const snapshot = (): void => {
+    if (registration !== undefined) {
+      send({
+        generation,
+        jobs: [...rows.values()].filter(job => job.generation === generation),
+        providerId: registration.providerId,
+        type: 'provider_snapshot',
+      });
+    }
+  };
+  const record = (message: BrowserProviderOutboundMessage): void => {
+    outbound.push(browserProviderOutboundMessageSchema.parse(message));
+  };
+  const renew = () => {
+    if (registration === undefined) {
+      throw new Error('No provider');
+    }
+    const lease = {
+      generation,
+      leaseExpiresAt: new Date(Date.now() + 15_000).toISOString(),
+      providerId: registration.providerId,
+      requestId: crypto.randomUUID(),
+      type: 'provider_lease_ack' as const,
+    };
+    setState({ lease, status: 'registered' });
+    return lease;
+  };
+  const settle = (job: BrowserJobSnapshot, result: BrowserResult): void => {
+    if (rows.get(job.jobId)?.result !== undefined) {
+      return;
+    }
+    rows.set(job.jobId, { ...job, result, status: result.status });
+    queued.delete(job.jobId);
+    if (acknowledgeTerminal) {
+      snapshot();
+    }
+  };
+  const dispatch = (message: Delivery): void => {
+    rows.set(message.job.jobId, message.job);
+    fence = { invocationId: message.job.invocationId };
+    send(message);
+  };
+  const connection = {
+    approveBrowserProviderJob: (input: BrowserProviderApprovalInput) => {
+      record({ ...input, type: 'provider_approval' });
+      const job = rows.get(input.jobId);
+      if (job === undefined) {
+        throw new Error('Unknown job');
+      }
+      if (input.approval.decision === 'denied') {
+        settle(job, terminalResult(job, 'approval_denied', 'failed'));
+        return;
+      }
+      fence = { invocationId: job.invocationId, tabId: input.approval.tab.tabId };
+      rows.set(job.jobId, {
+        ...job,
+        approvedTab: input.approval.tab,
+        deadlines: { ...job.deadlines, execution: new Date(Date.now() + 600_000).toISOString() },
+        status: 'running',
+      });
+      if (acknowledgeApproval) {
+        snapshot();
+      }
+    },
+    cancelBrowserProviderJob: (input: BrowserProviderCancelInput) => {
+      record({ ...input, type: 'provider_cancel' });
+      const job = rows.get(input.jobId);
+      if (job === undefined) {
+        throw new Error('Unknown job');
+      }
+      if (job.status === 'running') {
+        setState({ reason: 'cancelled', retryable: true, status: 'unavailable' });
+      }
+      send({ ...input, reason: 'cancelled', type: 'provider_job_cancel' });
+      settle(job, terminalResult(job, 'cancelled', 'cancelled'));
+    },
+    getBrowserProviderState: () => state,
+    heartbeatBrowserProvider: async () => {
+      heartbeatTimes.push(Date.now());
+      if (registration === undefined) {
+        throw new BrowserProviderError('provider_unavailable', true);
+      }
+      if (acknowledgeHeartbeat) {
+        renew();
+      }
+      return {
+        generation,
+        jobs: [...rows.values()].filter(job => job.generation === generation),
+        providerId: registration.providerId,
+        type: 'provider_snapshot' as const,
+      };
+    },
+    markBrowserProviderUnavailable: (input: BrowserProviderUnavailableInput) => {
+      record({ ...input, type: 'provider_unavailable' });
+      setState({ reason: input.reason, retryable: true, status: 'unavailable' });
+      for (const job of rows.values()) {
+        if (job.result === undefined) {
+          settle(job, terminalResult(job, input.reason));
+        }
+      }
+    },
+    onBrowserProviderMessage: (listener: (message: BrowserProviderInboundMessage) => void) => {
+      messages.add(listener);
+      return () => {
+        messages.delete(listener);
+      };
+    },
+    onBrowserProviderStateChange: (listener: (value: BrowserProviderState) => void) => {
+      states.add(listener);
+      return () => {
+        states.delete(listener);
+      };
+    },
+    quiesceBrowserProviderJob: (input: BrowserProviderQuiescenceInput) => {
+      record({ ...input, type: 'provider_quiesced' });
+      if (rows.get(input.jobId)?.result === undefined) {
+        throw new Error('Premature quiescence');
+      }
+      if (fence?.invocationId !== input.invocationId || fence.tabId !== input.tabId) {
+        throw new Error('Quiescence must match the dispatched fence');
+      }
+      events.push('quiesced');
+      fence = undefined;
+      const next = queued.values().next().value;
+      if (next !== undefined && state.status === 'registered') {
+        queued.delete(next.job.jobId);
+        dispatch(next);
+      }
+    },
+    registerBrowserProvider: async (input: BrowserProviderRegistration) => {
+      record({
+        ...input,
+        enabled: true,
+        requestId: crypto.randomUUID(),
+        type: 'provider_register',
+      });
+      registration = input;
+      if (
+        fence !== undefined &&
+        (input.recovery?.invocationId !== fence.invocationId ||
+          input.recovery?.tabId !== fence.tabId)
+      ) {
+        setState({ reason: 'provider_unavailable', retryable: true, status: 'unavailable' });
+        throw new BrowserProviderError('provider_unavailable', true);
+      }
+      events.push(input.recovery === undefined ? 'registered' : 'recovered');
+      fence = undefined;
+      generation += 1;
+      return renew();
+    },
+    requestBrowserProviderStatus: async () => {
+      events.push('status');
+      if (registration === undefined) {
+        throw new BrowserProviderError('provider_unavailable', true);
+      }
+      return {
+        jobs: [...rows.values()],
+        providerId: registration.providerId,
+        requestId: crypto.randomUUID(),
+        type: 'provider_status_result' as const,
+        ...(fence === undefined ? {} : { unresolvedFence: fence }),
+      };
+    },
+    retain: () => () => {
+      events.push('released');
+    },
+    retryConnection: () => {
+      setState({ status: 'ready' });
+    },
+    sendBrowserProviderResult: (input: BrowserProviderResultInput) => {
+      record({ ...input, type: 'provider_result' });
+      const persisted = fixture.values.get(BROWSER_TASK_STORAGE_KEY) as {
+        jobs: StoredBrowserJob[];
+      };
+      if (
+        !persisted.jobs.some(
+          job =>
+            job.snapshot.invocationId === input.invocationId && job.snapshot.result !== undefined
+        )
+      ) {
+        throw new Error('Result before persistence');
+      }
+      events.push('result');
+      const job = rows.get(input.jobId);
+      if (job === undefined) {
+        throw new Error('Unknown job');
+      }
+      settle(job, input.result);
+    },
+  };
+  const delivery = (overrides: Partial<Delivery> = {}): Delivery => {
+    if (registration === undefined) {
+      throw new Error('No provider');
+    }
+    const now = Date.now();
+    return {
+      conversationMode: 'new',
+      goal: 'Read the requested page.',
+      job: {
+        browserTaskId: `bt_${crypto.randomUUID()}`,
+        createdAt: new Date(now).toISOString(),
+        deadlines: {
+          approval: new Date(now + 120_000).toISOString(),
+          queue: new Date(now + 600_000).toISOString(),
+        },
+        expiresAt: new Date(now + 604_800_000).toISOString(),
+        generation,
+        invocationId: `b1.${now}.${'a'.repeat(32)}${crypto.randomUUID().replaceAll('-', '')}`,
+        jobId: `bj_${crypto.randomUUID()}`,
+        payloadFingerprint: 'a'.repeat(64),
+        providerId: registration.providerId,
+        status: 'awaiting_approval',
+      },
+      ownerLabel: 'ses_parent_a',
+      type: 'provider_job',
+      ...overrides,
+    };
+  };
+  return {
+    connection,
+    delivery,
+    dispatch,
+    enqueue: (message: Delivery) => {
+      queued.set(message.job.jobId, message);
+      rows.set(message.job.jobId, { ...message.job, status: 'queued' });
+      snapshot();
+    },
+    events,
+    heartbeatTimes,
+    outbound,
+    renew,
+    rows,
+    send,
+    setApprovalAck: (value: boolean) => {
+      acknowledgeApproval = value;
+    },
+    setFence: (value: Fence) => {
+      fence = value;
+    },
+    setHeartbeatAck: (value: boolean) => {
+      acknowledgeHeartbeat = value;
+    },
+    setState,
+    setTerminalAck: (value: boolean) => {
+      acknowledgeTerminal = value;
+    },
+    settle,
+    snapshot,
+  };
+};
+const setup = async (enabled = true, supportsLocks = true) => {
+  const transport = relay();
+  const coordinator = createBrowserExecutionCoordinator({
+    locks: supportsLocks ? (nativeLocks as LockManager) : undefined,
+    storageArea: storage,
+  });
+  const runtime = createBrowserTaskProviderRuntime({
+    auth,
+    connection: transport.connection,
+    coordinator,
+    organizationId: 'org-approved',
+    storageArea: storage,
+    supportsImages: () => true,
+  });
+  runtimes.push(runtime);
+  await runtime.start();
+  if (enabled && supportsLocks) {
+    await runtime.setSettings(defaults);
+  }
+  return { coordinator, runtime, transport };
+};
+const waitForConsent = async (runtime: BrowserTaskProviderRuntime) => {
+  await waitFor(() => {
+    expect(runtime.getSnapshot().phase).toBe('awaiting_approval');
+  });
+};
+const waitForDone = async (runtime: BrowserTaskProviderRuntime) => {
+  await waitFor(() => {
+    expect(runtime.getSnapshot().active).toBeUndefined();
+  });
+};
+
+describe('enabled browser provider owner', () => {
+  beforeEach(() => {
+    vi.stubGlobal('crypto', webcrypto);
+    fixture.actions = [];
+    fixture.writes = [];
+    fixture.failWrite = '';
+    fixture.values.clear();
+    fixture.values.set(AUTH_STORAGE_KEY, auth);
+    fixture.tabs = [
+      { id: 7, title: 'Approved tab', url: 'https://example.test/task' },
+      { id: 8, title: 'Other tab', url: 'https://other.test/' },
+    ];
+    fixture.turn = async (context, events) => {
+      context.executionGuard();
+      fixture.actions.push(
+        `run:${context.selectedTab.id}:${events.filter(event => event.type === 'message' && event.role === 'user').length}`
+      );
+      context.appendEvents([createAssistantMessage('Observed the requested page.')]);
+      return outcome();
+    };
+    getDefaultStore().set(pendingApprovalAtom, undefined);
+    getDefaultStore().set(pendingLockAtom, false);
+  });
+  afterEach(async () => {
+    await Promise.all(localLeases.splice(0).map(lease => lease.release()));
+    await Promise.all(runtimes.splice(0).map(runtime => runtime.dispose()));
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    fixture.watchers.clear();
+    fixture.removed.clear();
+    fixture.permissions.clear();
+    fixture.updated.clear();
+  });
+
+  it('stays disabled with an empty queue until a model is explicitly selected', async () => {
+    const { runtime, transport } = await setup(false);
+    expect(runtime.getSnapshot()).toMatchObject({
+      active: undefined,
+      jobs: [],
+      phase: 'disabled',
+      settings: { enabled: false, mode: 'safe', model: '' },
+    });
+    await runtime.setSettings({ ...defaults, model: '' });
+    expect(runtime.getSnapshot()).toMatchObject({
+      message: expect.stringContaining('Select a model'),
+      retryable: false,
+    });
+    expect(transport.outbound).toHaveLength(0);
+    expect(fixture.actions).toStrictEqual([]);
+  });
+
+  it('keeps a competing panel away from profile proof and delegated work', async () => {
+    const first = await setup();
+    const writes = [...fixture.writes];
+    const second = await setup(false);
+    expect(second.runtime.getSnapshot()).toMatchObject({
+      message: expect.stringContaining('Another panel'),
+      phase: 'owned_elsewhere',
+      profile: undefined,
+    });
+    expect(fixture.writes).toStrictEqual(writes);
+    expect(second.transport.outbound).toStrictEqual([]);
+    expect(JSON.stringify(first.runtime.getSnapshot())).not.toContain('providerProof');
+  });
+
+  it.each([
+    { phase: 'unsupported', reason: 'unsupported', retryable: false },
+    { phase: 'unavailable', reason: 'provider_unavailable', retryable: true },
+  ] as const)('exposes $phase without a stale connecting state', async expected => {
+    const { runtime, transport } = await setup();
+    transport.setState({
+      reason: expected.reason,
+      retryable: expected.retryable,
+      status: 'unavailable',
+    });
+    transport.send(transport.delivery());
+    expect(runtime.getSnapshot()).toMatchObject({
+      active: undefined,
+      phase: expected.phase,
+      retryable: expected.retryable,
+    });
+    expect(fixture.actions).toStrictEqual([]);
+  });
+
+  it('fails closed when native Web Locks are unavailable', async () => {
+    const { runtime, transport } = await setup(false, false);
+    expect(runtime.getSnapshot()).toMatchObject({
+      message: expect.stringContaining('Web Locks'),
+      phase: 'unsupported',
+    });
+    expect(fixture.values.has(BROWSER_PROVIDER_IDENTITY_KEY)).toBe(false);
+    expect(transport.outbound).toStrictEqual([]);
+  });
+
+  it('persists consent, waits for relay running, and records history before result and quiescence', async () => {
+    const { runtime, transport } = await setup();
+    transport.setApprovalAck(false);
+    const message = transport.delivery();
+    transport.dispatch(message);
+    await waitForConsent(runtime);
+    expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({
+      jobs: [{ approval: null, intent: { goal: message.goal } }],
+    });
+    await runtime.approve(message.job.jobId, 7);
+    await waitFor(() => {
+      expect(transport.outbound.some(frame => frame.type === 'provider_approval')).toBe(true);
+    });
+    expect(fixture.actions).toStrictEqual([]);
+    expect(runtime.getSnapshot().active).toMatchObject({
+      approval: {
+        settings: {
+          mode: 'safe',
+          model: 'selected-model',
+          organizationId: 'org-approved',
+          thinkingEffort: 'high',
+        },
+        tab: { tabId: 7, title: 'Approved tab', url: 'https://example.test/task' },
+      },
+      goal: message.goal,
+      ownerLabel: 'ses_parent_a',
+    });
+    transport.snapshot();
+    await waitForDone(runtime);
+    expect(fixture.actions).toStrictEqual(['run:7:1']);
+    expect(runtime.getSnapshot()).toMatchObject({
+      phase: 'idle',
+      result: { evidence: [], status: 'succeeded', summary: 'Observed the requested page.' },
+    });
+    expect(transport.events.slice(-2)).toStrictEqual(['result', 'quiesced']);
+    expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({
+      histories: [{ events: [{ text: message.goal }, { text: 'Observed the requested page.' }] }],
+    });
+  });
+
+  it('freezes settings at approval while local runs drain and never retargets an active tab', async () => {
+    const { coordinator, runtime, transport } = await setup();
+    const local = await coordinator.acquireLocal();
+    if (!local.admitted) {
+      throw new Error(local.reason);
+    }
+    localLeases.push(local.lease);
+    const message = transport.delivery();
+    transport.dispatch(message);
+    await waitForConsent(runtime);
+    await runtime.approve(message.job.jobId, 7);
+    await waitFor(() => {
+      expect(runtime.getSnapshot().phase).toBe('waiting');
+    });
+    await runtime.setSettings({
+      ...defaults,
+      mode: 'dangerous',
+      model: 'later-model',
+      thinkingEffort: 'low',
+    });
+    fixture.tabs.reverse();
+    expect(runtime.getSnapshot().active?.approval?.settings).toMatchObject({
+      mode: 'safe',
+      model: 'selected-model',
+      thinkingEffort: 'high',
+    });
+    expect(runtime.getSnapshot().active?.job.deadlines.approval).toBe(
+      message.job.deadlines.approval
+    );
+    expect((await coordinator.acquireLocal()).admitted).toBe(false);
+    await local.lease.release();
+    await waitForDone(runtime);
+    expect(fixture.actions).toStrictEqual(['run:7:1']);
+    expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({
+      jobs: [{ approval: { settings: { mode: 'safe', model: 'selected-model' } } }],
+    });
+  });
+
+  it('looks up duplicates and continues only isolated browser history with fresh consent', async () => {
+    const { runtime, transport } = await setup();
+    fixture.values.set('local:kiloAgentConversations', {
+      transcript: 'parent or local transcript must not enter',
+    });
+    const first = transport.delivery();
+    transport.dispatch(first);
+    await waitForConsent(runtime);
+    transport.send(first);
+    await runtime.approve(first.job.jobId, 7);
+    await waitForDone(runtime);
+    transport.send(first);
+    await runtime.refreshStatus();
+    const next = transport.delivery({ conversationMode: 'continue', goal: 'Read a follow-up.' });
+    next.job.browserTaskId = first.job.browserTaskId;
+    transport.dispatch(next);
+    await waitForConsent(runtime);
+    expect(runtime.getSnapshot().active?.approval).toBeUndefined();
+    expect(fixture.actions).toStrictEqual(['run:7:1']);
+    await runtime.approve(next.job.jobId, 8);
+    await waitForDone(runtime);
+    expect(fixture.actions).toStrictEqual(['run:7:1', 'run:8:2']);
+    expect(JSON.stringify(fixture.values.get(BROWSER_TASK_STORAGE_KEY))).not.toContain(
+      'parent or local transcript'
+    );
+  });
+
+  it.each(['accept', 'approve', 'finish'] as const)(
+    'does not announce unrecorded work when %s storage fails',
+    async phase => {
+      const { runtime, transport } = await setup();
+      const message = transport.delivery();
+      if (phase === 'accept') {
+        fixture.failWrite = BROWSER_TASK_STORAGE_KEY;
+      }
+      transport.dispatch(message);
+      if (phase !== 'accept') {
+        await waitForConsent(runtime);
+        if (phase === 'approve') {
+          fixture.failWrite = BROWSER_TASK_STORAGE_KEY;
+        }
+        if (phase === 'finish') {
+          fixture.turn = async context => {
+            fixture.actions.push('executed');
+            context.appendEvents([createAssistantMessage('Not persisted')]);
+            fixture.failWrite = BROWSER_TASK_STORAGE_KEY;
+            return outcome();
+          };
+        }
+        await runtime.approve(message.job.jobId, 7);
+      }
+      await waitForDone(runtime);
+      expect(transport.outbound.filter(frame => frame.type === 'provider_result')).toStrictEqual(
+        []
+      );
+      expect(fixture.actions).toStrictEqual(phase === 'finish' ? ['executed'] : []);
+      expect(JSON.stringify(runtime.getSnapshot())).not.toContain('Private storage failure');
+      expect(runtime.getSnapshot()).toMatchObject({
+        message: expect.stringContaining('storage is unavailable'),
+        retryable: true,
+      });
+      fixture.failWrite = '';
+    }
+  );
+
+  it('cancels queued work with provider authority, without disturbing the active approval', async () => {
+    const { runtime, transport } = await setup();
+    const active = transport.delivery();
+    transport.dispatch(active);
+    await waitForConsent(runtime);
+    const queued = { ...transport.delivery().job, status: 'queued' as const };
+    transport.rows.set(queued.jobId, queued);
+    transport.snapshot();
+    runtime.cancel(queued.jobId);
+    expect(runtime.getSnapshot().active?.job.jobId).toBe(active.job.jobId);
+    expect(transport.rows.get(queued.jobId)?.status).toBe('cancelled');
+    expect(transport.outbound.filter(frame => frame.type === 'provider_cancel')).toMatchObject([
+      { generation: queued.generation, jobId: queued.jobId, providerId: queued.providerId },
+    ]);
+    expect(
+      JSON.stringify(transport.outbound.filter(frame => frame.type === 'provider_cancel'))
+    ).not.toContain('capability');
+    expect(fixture.actions).toStrictEqual([]);
+  });
+
+  it('cancels a pending memory approval and prevents any later agent action or stale save', async () => {
+    const { runtime, transport } = await setup();
+    fixture.turn = async context => {
+      await context.requestApproval('memory', {
+        createdAt: Date.now(),
+        pageTitle: 'Approved tab',
+        pageUrl: 'https://example.test/task',
+        text: 'A memory',
+      });
+      context.executionGuard();
+      fixture.actions.push('after approval');
+      return outcome();
+    };
+    const message = transport.delivery();
+    transport.dispatch(message);
+    await waitForConsent(runtime);
+    await runtime.approve(message.job.jobId, 7);
+    await waitFor(() => {
+      expect(getDefaultStore().get(pendingApprovalAtom)?.kind).toBe('memory');
+    });
+    const pending = getDefaultStore().get(pendingApprovalAtom);
+    if (pending === undefined) {
+      throw new Error('Missing approval');
+    }
+    runtime.cancel(message.job.jobId);
+    await waitForDone(runtime);
+    expect(
+      (await applyApprovalDecision(storage, 'memory', pending.draft, true, pending)).status
+    ).toBe('aborted');
+    expect(fixture.actions).toStrictEqual([]);
+    expect(getDefaultStore().get(pendingApprovalAtom)).toBeUndefined();
+    expect(fixture.values.has('local:kiloAgentMemories')).toBe(false);
+    expect(runtime.getSnapshot().result?.status).toBe('cancelled');
+  });
+
+  it('waits for an issued action to unwind after Stop and keeps uncertain execution quarantined', async () => {
+    const { coordinator, runtime, transport } = await setup();
+    const gate = Promise.withResolvers<void>();
+    fixture.turn = async context => {
+      context.executionGuard();
+      fixture.actions.push('issued');
+      await gate.promise;
+      context.executionGuard();
+      fixture.actions.push('subsequent');
+      return outcome();
+    };
+    const message = transport.delivery();
+    transport.dispatch(message);
+    await waitForConsent(runtime);
+    await runtime.approve(message.job.jobId, 7);
+    await waitFor(() => {
+      expect(fixture.actions).toStrictEqual(['issued']);
+    });
+    runtime.cancel(message.job.jobId);
+    expect((await coordinator.acquireLocal()).admitted).toBe(false);
+    expect(transport.events).not.toContain('quiesced');
+    gate.resolve();
+    await waitForDone(runtime);
+    expect(fixture.actions).toStrictEqual(['issued']);
+    expect(runtime.getSnapshot().result).toMatchObject({
+      effectsUncertain: true,
+      status: 'cancelled',
+    });
+    expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+    expect((await coordinator.acquireLocal()).admitted).toBe(false);
+    expect(transport.events).not.toContain('quiesced');
+  });
+
+  it.each([undefined, 7])(
+    'recovers an expired fence with tab %s by status, closure, and a fresh generation',
+    async tabId => {
+      const { runtime, transport } = await setup();
+      const fence: Fence = {
+        invocationId: `b1.${Date.now() - 700_000_000}.${'b'.repeat(64)}`,
+        ...(tabId === undefined ? {} : { tabId }),
+      };
+      transport.setFence(fence);
+      transport.setState({
+        reason: 'provider_unavailable',
+        retryable: true,
+        status: 'unavailable',
+      });
+      if (tabId !== undefined) {
+        const bound = fixture.tabs.find(tab => tab.id === tabId);
+        if (bound === undefined) {
+          throw new Error('Missing affected tab');
+        }
+        bound.url = 'chrome://settings';
+        await runtime.recover();
+        expect(transport.events).not.toContain('recovered');
+        fixture.tabs = fixture.tabs.filter(tab => tab.id !== tabId);
+      }
+      await runtime.recover();
+      expect(transport.events.indexOf('status')).toBeLessThan(
+        transport.events.indexOf('recovered')
+      );
+      expect(
+        transport.outbound.findLast(frame => frame.type === 'provider_register')
+      ).toMatchObject({
+        recovery: { invocationId: fence.invocationId, locksDrained: true, tabClosed: true },
+      });
+      if (tabId === undefined) {
+        expect(JSON.stringify(transport.outbound.at(-1))).not.toContain('tabId');
+      }
+      expect(runtime.getSnapshot()).toMatchObject({ active: undefined, phase: 'idle' });
+      expect(fixture.actions).toStrictEqual([]);
+      const fresh = transport.delivery({ goal: 'Explicit work after recovery.' });
+      transport.dispatch(fresh);
+      await waitForConsent(runtime);
+      await runtime.approve(fresh.job.jobId, 8);
+      await waitForDone(runtime);
+      expect(fixture.actions).toStrictEqual(['run:8:1']);
+    }
+  );
+
+  it('passes every open tab to all-tabs recovery, including tabs outside the affected list', async () => {
+    const { runtime, transport } = await setup();
+    fixture.values.set(BROWSER_EXECUTION_SAFETY_KEY, { allTabs: true, tabIds: [7], version: 1 });
+    fixture.tabs = fixture.tabs.filter(tab => tab.id !== 7);
+    const fence = { invocationId: `b1.${Date.now() - 700_000_000}.${'c'.repeat(64)}` };
+    transport.setFence(fence);
+    await runtime.recover();
+    expect(runtime.getSnapshot().message).toContain('Close all target tabs');
+    expect(transport.events).not.toContain('recovered');
+    fixture.tabs = [];
+    await runtime.recover();
+    expect(runtime.getSnapshot().phase).toBe('idle');
+    expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      tabIds: [],
+      version: 1,
+    });
+  });
+
+  it('keeps the account-independent fence when authentication clears during issued work', async () => {
+    const { runtime, transport } = await setup();
+    const gate = Promise.withResolvers<void>();
+    fixture.turn = async context => {
+      fixture.actions.push('issued');
+      await gate.promise;
+      context.executionGuard();
+      fixture.actions.push('later');
+      return outcome();
+    };
+    const message = transport.delivery();
+    transport.dispatch(message);
+    await waitForConsent(runtime);
+    await runtime.approve(message.job.jobId, 7);
+    await waitFor(() => {
+      expect(fixture.actions).toStrictEqual(['issued']);
+    });
+    const disposing = runtime.dispose();
+    await waitFor(() => {
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+    });
+    await clearStoredSession({
+      removeItems: keys => {
+        for (const key of keys) {
+          fixture.values.delete(key);
+        }
+      },
+      snapshot: () =>
+        Object.fromEntries([...fixture.values].map(([key, value]) => [key.slice(6), value])),
+    });
+    gate.resolve();
+    await disposing;
+    expect(fixture.actions).toStrictEqual(['issued']);
+    expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+    expect(fixture.values.has(BROWSER_TASK_STORAGE_KEY)).toBe(false);
+  });
+
+  it('rejects stale generations and running snapshots that have no live consent', async () => {
+    const { runtime, transport } = await setup();
+    const stale = transport.delivery();
+    stale.job.generation += 1;
+    transport.send(stale);
+    const historical = transport.delivery().job;
+    transport.send({
+      generation: historical.generation,
+      jobs: [
+        {
+          ...historical,
+          approvedTab: {
+            effectiveMode: 'safe',
+            tabId: 7,
+            title: 'Old consent',
+            url: 'https://example.test/',
+          },
+          status: 'running',
+        },
+      ],
+      providerId: historical.providerId,
+      type: 'provider_snapshot',
+    });
+    await runtime.refreshStatus();
+    expect({ actions: fixture.actions, active: runtime.getSnapshot().active }).toStrictEqual({
+      actions: [],
+      active: undefined,
+    });
+    expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({ jobs: [] });
+  });
+
+  it('keeps relay cancellation immutable when a late success snapshot arrives', async () => {
+    const { runtime, transport } = await setup();
+    const message = transport.delivery();
+    transport.dispatch(message);
+    await waitForConsent(runtime);
+    runtime.cancel(message.job.jobId);
+    await waitForDone(runtime);
+    const late: BrowserJobSnapshot = {
+      ...message.job,
+      result: {
+        browserTaskId: message.job.browserTaskId,
+        effectsUncertain: false,
+        evidence: [],
+        invocationId: message.job.invocationId,
+        jobId: message.job.jobId,
+        providerId: message.job.providerId,
+        reason: 'completed',
+        status: 'succeeded',
+        summary: 'Late success',
+      },
+      status: 'succeeded',
+    };
+    transport.send({
+      generation: message.job.generation,
+      jobs: [late],
+      providerId: message.job.providerId,
+      type: 'provider_snapshot',
+    });
+    expect(runtime.getSnapshot()).toMatchObject({
+      jobs: [{ jobId: message.job.jobId, status: 'cancelled' }],
+      result: { reason: 'cancelled', status: 'cancelled' },
+    });
+    expect(fixture.actions).toStrictEqual([]);
+  });
+
+  it.each(['rejection', 'cancellation', 'cancellation while waiting'] as const)(
+    'offers fresh FIFO consent after %s without recovery',
+    async termination => {
+      const { coordinator, runtime, transport } = await setup();
+      let local: BrowserExecutionLease | undefined;
+      if (termination === 'cancellation while waiting') {
+        const admission = await coordinator.acquireLocal();
+        if (!admission.admitted) {
+          throw new Error(admission.reason);
+        }
+        local = admission.lease;
+        localLeases.push(local);
+      }
+      const first = transport.delivery();
+      const next = transport.delivery({ goal: 'Read the next page.', ownerLabel: 'ses_parent_b' });
+      transport.dispatch(first);
+      await waitForConsent(runtime);
+      transport.enqueue(next);
+      if (local !== undefined) {
+        await runtime.approve(first.job.jobId, 7);
+        await waitFor(() => {
+          expect(runtime.getSnapshot().phase).toBe('waiting');
+        });
+      }
+      transport.setTerminalAck(false);
+      if (termination === 'rejection') {
+        runtime.reject(first.job.jobId);
+      } else {
+        runtime.cancel(first.job.jobId);
+      }
+      const reason = termination === 'rejection' ? 'approval_denied' : 'cancelled';
+      await waitFor(() => {
+        expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({
+          jobs: [{ approval: null, snapshot: { result: { effectsUncertain: false, reason } } }],
+        });
+      });
+      expect(runtime.getSnapshot().active?.job.jobId).toBe(first.job.jobId);
+      expect(transport.connection.getBrowserProviderState().status).toBe('registered');
+      expect(transport.rows.get(next.job.jobId)?.status).toBe('queued');
+      expect(transport.events).not.toContain('quiesced');
+      expect(fixture.actions).toStrictEqual([]);
+
+      transport.setTerminalAck(true);
+      transport.snapshot();
+      await waitFor(() => {
+        expect(runtime.getSnapshot()).toMatchObject({
+          active: { approval: undefined, goal: next.goal, job: { jobId: next.job.jobId } },
+          phase: 'awaiting_approval',
+          result: { reason },
+        });
+      });
+      expect(
+        transport.outbound.find(frame => frame.type === 'provider_quiesced')
+      ).not.toHaveProperty('tabId');
+      expect(fixture.actions).toStrictEqual([]);
+      await local?.release();
+      await waitFor(() => {
+        expect(coordinator.getSnapshot().delegated).toBe('idle');
+      });
+      await runtime.approve(next.job.jobId, 8);
+      await waitForDone(runtime);
+      expect(fixture.actions).toStrictEqual(['run:8:1']);
+      expect(runtime.getSnapshot().phase).toBe('idle');
+      expect(transport.rows.get(first.job.jobId)?.result).toMatchObject({ reason });
+      expect(transport.events).not.toContain('recovered');
+    }
+  );
+
+  it.each(['rejection', 'cancellation'] as const)(
+    'preserves the next consent when a stale tab approval resumes after %s',
+    async termination => {
+      const { runtime, transport } = await setup();
+      const idleMessage = runtime.getSnapshot().message;
+      const first = transport.delivery();
+      const next = transport.delivery({ goal: 'Read the next page.', ownerLabel: 'ses_parent_b' });
+      transport.dispatch(first);
+      await waitForConsent(runtime);
+      transport.enqueue(next);
+      const tabs = await browser.tabs.query({});
+      const tabsApi: {
+        query: (queryInfo: Parameters<typeof browser.tabs.query>[0]) => Promise<typeof tabs>;
+      } = browser.tabs;
+      const enumerating = Promise.withResolvers<void>();
+      const resume = Promise.withResolvers<void>();
+      const query = vi.spyOn(tabsApi, 'query').mockImplementationOnce(async () => {
+        enumerating.resolve();
+        await resume.promise;
+        return tabs;
+      });
+      const approving = runtime.approve(first.job.jobId, 7);
+      try {
+        await enumerating.promise;
+        if (termination === 'rejection') {
+          runtime.reject(first.job.jobId);
+        } else {
+          runtime.cancel(first.job.jobId);
+        }
+        await waitFor(() => {
+          expect(runtime.getSnapshot()).toMatchObject({
+            active: {
+              approval: undefined,
+              goal: next.goal,
+              job: { jobId: next.job.jobId },
+              ownerLabel: next.ownerLabel,
+            },
+            phase: 'awaiting_approval',
+          });
+        });
+        const awaitingConsent = runtime.getSnapshot();
+        resume.resolve();
+        await approving;
+        expect(runtime.getSnapshot()).toStrictEqual(awaitingConsent);
+        expect(fixture.actions).toStrictEqual([]);
+        await runtime.approve(next.job.jobId, 8);
+        await waitForDone(runtime);
+        expect(fixture.actions).toStrictEqual(['run:8:1']);
+        expect(runtime.getSnapshot()).toMatchObject({
+          message: idleMessage,
+          phase: 'idle',
+          result: { jobId: next.job.jobId, reason: 'completed', status: 'succeeded' },
+        });
+      } finally {
+        resume.resolve();
+        await approving;
+        query.mockRestore();
+      }
+    }
+  );
+
+  it.each([
+    { reason: 'provider_unavailable', retryable: true },
+    { reason: 'permission_denied', retryable: false },
+  ] as const)(
+    'reports current tab approval failure $reason without starting work',
+    async failure => {
+      const { runtime, transport } = await setup();
+      const message = transport.delivery();
+      transport.dispatch(message);
+      await waitForConsent(runtime);
+      const tabs = await browser.tabs.query({});
+      const tabsApi: {
+        query: (queryInfo: Parameters<typeof browser.tabs.query>[0]) => Promise<typeof tabs>;
+      } = browser.tabs;
+      const query = vi
+        .spyOn(tabsApi, 'query')
+        .mockRejectedValueOnce(new BrowserProviderError(failure.reason, failure.retryable));
+      try {
+        await runtime.approve(message.job.jobId, 7);
+        expect(runtime.getSnapshot()).toMatchObject({
+          active: { approval: undefined, job: { jobId: message.job.jobId } },
+          message: expect.stringContaining(failure.reason),
+          phase: 'unavailable',
+          retryable: failure.retryable,
+        });
+        expect(fixture.actions).toStrictEqual([]);
+      } finally {
+        query.mockRestore();
+      }
+      if (failure.retryable) {
+        await runtime.approve(message.job.jobId, 7);
+        await waitForDone(runtime);
+        expect(fixture.actions).toStrictEqual(['run:7:1']);
+        expect(runtime.getSnapshot().result).toMatchObject({ status: 'succeeded' });
+      } else {
+        runtime.reject(message.job.jobId);
+        await waitForDone(runtime);
+        expect(fixture.actions).toStrictEqual([]);
+        expect(runtime.getSnapshot().result).toMatchObject({ reason: 'approval_denied' });
+      }
+    }
+  );
+
+  it.each(['drained', 'failed'] as const)(
+    'waits for a %s lease release before acknowledging quiescence',
+    async releaseOutcome => {
+      const { coordinator, runtime, transport } = await setup();
+      const releasing = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const acquire = coordinator.acquireDelegated;
+      const admissionSpy = vi
+        .spyOn(coordinator, 'acquireDelegated')
+        .mockImplementationOnce(async (...args) => {
+          const admission = await acquire(...args);
+          if (!admission.admitted) {
+            return admission;
+          }
+          localLeases.push(admission.lease);
+          return {
+            admitted: true,
+            lease: {
+              ...admission.lease,
+              release: async () => {
+                releasing.resolve();
+                await release.promise;
+                if (releaseOutcome === 'failed') {
+                  throw new Error('Execution lease did not drain');
+                }
+                await admission.lease.release();
+              },
+            },
+          };
+        });
+      const first = transport.delivery();
+      const next = transport.delivery({ goal: 'Read after drainage.' });
+      transport.dispatch(first);
+      await waitForConsent(runtime);
+      transport.enqueue(next);
+      await runtime.approve(first.job.jobId, 7);
+      await releasing.promise;
+      admissionSpy.mockRestore();
+      try {
+        expect(runtime.getSnapshot().active?.job.status).toBe('succeeded');
+        expect(transport.rows.get(next.job.jobId)?.status).toBe('queued');
+        expect(transport.events).not.toContain('quiesced');
+      } finally {
+        release.resolve();
+      }
+      if (releaseOutcome === 'failed') {
+        await waitForDone(runtime);
+        expect(runtime.getSnapshot().phase).toBe('recovery');
+        expect(transport.rows.get(next.job.jobId)?.status).toBe('queued');
+        expect(transport.events).not.toContain('quiesced');
+      } else {
+        await waitFor(() => {
+          expect(runtime.getSnapshot()).toMatchObject({
+            active: { approval: undefined, job: { jobId: next.job.jobId } },
+            phase: 'awaiting_approval',
+          });
+        });
+      }
+      expect(fixture.actions).toStrictEqual(['run:7:1']);
+    }
+  );
+
+  it.each(['workflow', 'memory', 'browser'] as const)(
+    'invalidates %s authority revoked during pending tab enumeration',
+    async permission => {
+      const { runtime, transport } = await setup();
+      const key =
+        permission === 'workflow' ? 'local:kiloWorkflowSettings' : 'local:kiloMemorySettings';
+      const flag =
+        permission === 'workflow' ? 'allowWorkflowsInSafeMode' : 'autoApproveMemorySaves';
+      await storage.setItem(key, { [flag]: true });
+      const message = transport.delivery();
+      transport.dispatch(message);
+      await waitForConsent(runtime);
+      const tabs = await browser.tabs.query({});
+      const tabsApi: {
+        query: (queryInfo: Parameters<typeof browser.tabs.query>[0]) => Promise<typeof tabs>;
+      } = browser.tabs;
+      const enumerating = Promise.withResolvers<void>();
+      const resume = Promise.withResolvers<void>();
+      const query = vi.spyOn(tabsApi, 'query').mockImplementationOnce(async () => {
+        enumerating.resolve();
+        await resume.promise;
+        return tabs;
+      });
+      const approving = runtime.approve(message.job.jobId, 7);
+      await enumerating.promise;
+      if (permission === 'browser') {
+        for (const listener of fixture.permissions) {
+          listener();
+        }
+      } else {
+        await storage.setItem(key, { [flag]: false });
+      }
+      resume.resolve();
+      await approving;
+      query.mockRestore();
+      await waitForDone(runtime);
+      expect(fixture.actions).toStrictEqual([]);
+      expect(runtime.getSnapshot().result).toMatchObject({ reason: 'permission_denied' });
+      expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({
+        jobs: [{ approval: null, snapshot: { result: { reason: 'permission_denied' } } }],
+      });
+      expect(transport.outbound.filter(frame => frame.type === 'provider_approval')).toStrictEqual(
+        []
+      );
+    }
+  );
+
+  it('ignores an old permission-read failure after FIFO advances to an approved job', async () => {
+    const { coordinator, runtime, transport } = await setup();
+    const local = await coordinator.acquireLocal();
+    if (!local.admitted) {
+      throw new Error(local.reason);
+    }
+    localLeases.push(local.lease);
+    const first = transport.delivery();
+    const next = transport.delivery({
+      goal: 'Read after cancellation.',
+      ownerLabel: 'ses_parent_b',
+    });
+    transport.dispatch(first);
+    await waitForConsent(runtime);
+    transport.enqueue(next);
+    await runtime.approve(first.job.jobId, 7);
+    await waitFor(() => {
+      expect(runtime.getSnapshot().phase).toBe('waiting');
+    });
+    const read = Promise.withResolvers<unknown>();
+    const reading = Promise.withResolvers<void>();
+    const storageApi = storage as { getItem: (key: string) => unknown };
+    const { getItem } = storageApi;
+    const spy = vi.spyOn(storageApi, 'getItem').mockImplementation(key => {
+      if (key === 'local:kiloRemoteMcpServers') {
+        reading.resolve();
+        return read.promise;
+      }
+      return getItem(key);
+    });
+    const running = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    fixture.turn = async context => {
+      running.resolve();
+      await finish.promise;
+      context.executionGuard();
+      fixture.actions.push('next job');
+      return outcome();
+    };
+    try {
+      await storage.setItem('local:kiloMemorySettings', { autoApproveMemorySaves: false });
+      await reading.promise;
+      spy.mockRestore();
+      runtime.cancel(first.job.jobId);
+      await waitFor(() => {
+        expect(runtime.getSnapshot()).toMatchObject({
+          active: { job: { jobId: next.job.jobId } },
+          phase: 'awaiting_approval',
+        });
+      });
+      await local.lease.release();
+      await runtime.approve(next.job.jobId, 8);
+      await running.promise;
+      await act(async () => {
+        read.reject(new Error('Old permission read failed'));
+        await expect(read.promise).rejects.toThrow('Old permission read failed');
+      });
+      expect(runtime.getSnapshot()).toMatchObject({
+        active: { job: { jobId: next.job.jobId } },
+        phase: 'running',
+      });
+      finish.resolve();
+      await waitForDone(runtime);
+      expect(fixture.actions).toStrictEqual(['next job']);
+      expect(runtime.getSnapshot().result).toMatchObject({
+        jobId: next.job.jobId,
+        reason: 'completed',
+      });
+      expect(transport.outbound.some(frame => frame.type === 'provider_unavailable')).toBe(false);
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).not.toMatchObject({ tabIds: [8] });
+    } finally {
+      spy.mockRestore();
+      read.resolve({ servers: [] });
+      finish.resolve();
+    }
+  });
+
+  it.each(['workflow', 'memory'] as const)(
+    'blocks an approved %s action while permission validation waits for storage',
+    async permission => {
+      const { runtime, transport } = await setup();
+      const key =
+        permission === 'workflow' ? 'local:kiloWorkflowSettings' : 'local:kiloMemorySettings';
+      const flag =
+        permission === 'workflow' ? 'allowWorkflowsInSafeMode' : 'autoApproveMemorySaves';
+      await storage.setItem(key, { [flag]: true });
+      const running = Promise.withResolvers<void>();
+      const actNow = Promise.withResolvers<void>();
+      fixture.turn = async context => {
+        running.resolve();
+        await actNow.promise;
+        context.executionGuard();
+        fixture.actions.push(`revoked ${permission} action`);
+        return outcome();
+      };
+      const message = transport.delivery();
+      transport.dispatch(message);
+      await waitForConsent(runtime);
+      await runtime.approve(message.job.jobId, 7);
+      await running.promise;
+      const read = Promise.withResolvers<unknown>();
+      const reading = Promise.withResolvers<void>();
+      const storageApi = storage as { getItem: (key: string) => unknown };
+      const { getItem } = storageApi;
+      const spy = vi.spyOn(storageApi, 'getItem').mockImplementation(storageKey => {
+        if (storageKey === 'local:kiloRemoteMcpServers') {
+          reading.resolve();
+          return read.promise;
+        }
+        return getItem(storageKey);
+      });
+      try {
+        await storage.setItem(key, { [flag]: false });
+        await reading.promise;
+        actNow.resolve();
+        await waitForDone(runtime);
+        expect(fixture.actions).toStrictEqual([]);
+        expect(runtime.getSnapshot().result).toMatchObject({ reason: 'permission_denied' });
+      } finally {
+        spy.mockRestore();
+        read.resolve({ servers: [] });
+        actNow.resolve();
+      }
+    }
+  );
+
+  it('requires every overlapping permission check before unchanged authority can run', async () => {
+    const { runtime, transport } = await setup();
+    const running = Promise.withResolvers<() => void>();
+    const finish = Promise.withResolvers<void>();
+    fixture.turn = async context => {
+      running.resolve(context.executionGuard);
+      await finish.promise;
+      context.executionGuard();
+      fixture.actions.push('validated action');
+      return outcome();
+    };
+    const message = transport.delivery();
+    transport.dispatch(message);
+    await waitForConsent(runtime);
+    await runtime.approve(message.job.jobId, 7);
+    const guard = await running.promise;
+    const first = Promise.withResolvers<unknown>();
+    const second = Promise.withResolvers<unknown>();
+    const reads = [first, second];
+    const storageApi = storage as { getItem: (key: string) => unknown };
+    const { getItem } = storageApi;
+    const spy = vi.spyOn(storageApi, 'getItem').mockImplementation(key => {
+      if (key === 'local:kiloRemoteMcpServers') {
+        return reads.shift()?.promise;
+      }
+      return getItem(key);
+    });
+    try {
+      await storage.setItem('local:kiloMemorySettings', { autoApproveMemorySaves: false });
+      await storage.setItem('local:kiloWorkflowSettings', { allowWorkflowsInSafeMode: false });
+      expect(reads).toHaveLength(0);
+      expect(guard).toThrow('permission_denied');
+      await act(async () => {
+        first.resolve({ servers: [] });
+        await first.promise;
+      });
+      expect(guard).toThrow('permission_denied');
+      await act(async () => {
+        second.resolve({ servers: [] });
+        await second.promise;
+      });
+      expect(guard).not.toThrow();
+      finish.resolve();
+      await waitForDone(runtime);
+      expect(fixture.actions).toStrictEqual(['validated action']);
+      expect(runtime.getSnapshot().result?.reason).toBe('completed');
+    } finally {
+      spy.mockRestore();
+      first.resolve({ servers: [] });
+      second.resolve({ servers: [] });
+      finish.resolve();
+    }
+  });
+
+  it.each(['binding', 'closed', 'uninspectable'] as const)(
+    'interrupts %s tab loss before the next action',
+    async kind => {
+      const { runtime, transport } = await setup();
+      const gate = Promise.withResolvers<void>();
+      fixture.turn = async context => {
+        fixture.actions.push('issued');
+        await gate.promise;
+        context.executionGuard();
+        fixture.actions.push('later');
+        return outcome();
+      };
+      const message = transport.delivery();
+      transport.dispatch(message);
+      await waitForConsent(runtime);
+      await runtime.approve(message.job.jobId, 7);
+      await waitFor(() => {
+        expect(fixture.actions).toStrictEqual(['issued']);
+      });
+      const running = transport.rows.get(message.job.jobId);
+      if (running?.approvedTab === undefined) {
+        throw new Error('Missing running fixture');
+      }
+      if (kind === 'binding') {
+        transport.rows.set(running.jobId, {
+          ...running,
+          approvedTab: { ...running.approvedTab, tabId: 8 },
+        });
+        transport.snapshot();
+      }
+      if (kind === 'closed') {
+        fixture.tabs = fixture.tabs.filter(tab => tab.id !== 7);
+        for (const listener of fixture.removed) {
+          listener(7);
+        }
+      }
+      if (kind === 'uninspectable') {
+        for (const listener of fixture.updated) {
+          listener(7, { url: 'chrome://settings' });
+        }
+      }
+      gate.resolve();
+      await waitForDone(runtime);
+      expect(fixture.actions).toStrictEqual(['issued']);
+      expect(runtime.getSnapshot().result).toMatchObject({
+        reason: 'tab_lost',
+        status: 'interrupted',
+      });
+    }
+  );
+
+  it('heartbeats every five seconds and cannot renew an expired local lease with a late acknowledgement', async () => {
+    vi.useFakeTimers();
+    const { runtime, transport } = await setup();
+    const start = Date.now();
+    const message = transport.delivery();
+    transport.dispatch(message);
+    await vi.waitFor(() => {
+      expect(runtime.getSnapshot().phase).toBe('awaiting_approval');
+    });
+    transport.setHeartbeatAck(false);
+    await vi.advanceTimersByTimeAsync(15_001);
+    await vi.waitFor(() => {
+      expect(runtime.getSnapshot().active).toBeUndefined();
+    });
+    expect(transport.heartbeatTimes.slice(0, 2)).toStrictEqual([start + 5000, start + 10_000]);
+    expect(runtime.getSnapshot().result?.reason).toBe('lease_expired');
+    transport.renew();
+    transport.dispatch(transport.delivery());
+    await vi.advanceTimersByTimeAsync(1);
+    expect({ actions: fixture.actions, active: runtime.getSnapshot().active }).toStrictEqual({
+      actions: [],
+      active: undefined,
+    });
+  });
+
+  it.each(['approval_timeout', 'execution_timeout'] as const)(
+    'enforces the relay %s deadline locally',
+    async reason => {
+      vi.useFakeTimers();
+      const { runtime, transport } = await setup();
+      const gate = Promise.withResolvers<void>();
+      fixture.turn = async context => {
+        fixture.actions.push('issued');
+        await gate.promise;
+        context.executionGuard();
+        fixture.actions.push('later');
+        return outcome();
+      };
+      const message = transport.delivery();
+      message.job.deadlines.approval = new Date(Date.now() + 1000).toISOString();
+      transport.dispatch(message);
+      await vi.waitFor(() => {
+        expect(runtime.getSnapshot().phase).toBe('awaiting_approval');
+      });
+      if (reason === 'execution_timeout') {
+        transport.setApprovalAck(false);
+        await runtime.approve(message.job.jobId, 7);
+        await vi.waitFor(() => {
+          expect(transport.rows.get(message.job.jobId)?.status).toBe('running');
+        });
+        const running = transport.rows.get(message.job.jobId);
+        if (running === undefined) {
+          throw new Error('Missing running fixture');
+        }
+        transport.rows.set(running.jobId, {
+          ...running,
+          deadlines: { ...running.deadlines, execution: new Date(Date.now() + 500).toISOString() },
+        });
+        transport.snapshot();
+        await vi.waitFor(() => {
+          expect(fixture.actions).toStrictEqual(['issued']);
+        });
+      }
+      await vi.advanceTimersByTimeAsync(1100);
+      gate.resolve();
+      await vi.waitFor(() => {
+        expect(runtime.getSnapshot().active).toBeUndefined();
+      });
+      expect(runtime.getSnapshot().result?.reason).toBe(reason);
+      expect(fixture.actions).not.toContain('later');
+    }
+  );
+
+  it.each(['disconnect', 'disable', 'permission', 'organization', 'auth'] as const)(
+    'aborts on %s while an issued action unwinds',
+    async cause => {
+      const { runtime, transport } = await setup();
+      const gate = Promise.withResolvers<void>();
+      let signal: AbortSignal | undefined;
+      fixture.turn = async context => {
+        ({ signal } = context.abort);
+        fixture.actions.push('issued');
+        await gate.promise;
+        context.executionGuard();
+        fixture.actions.push('later');
+        return outcome();
+      };
+      const message = transport.delivery();
+      transport.dispatch(message);
+      await waitForConsent(runtime);
+      await runtime.approve(message.job.jobId, 7);
+      await waitFor(() => {
+        expect(fixture.actions).toStrictEqual(['issued']);
+      });
+      if (cause === 'disconnect') {
+        transport.setState({ status: 'disconnected' });
+      }
+      if (cause === 'disable') {
+        await runtime.setSettings({ ...defaults, enabled: false });
+      }
+      if (cause === 'permission') {
+        for (const listener of fixture.permissions) {
+          listener();
+        }
+      }
+      if (cause === 'organization') {
+        await storage.setItem('local:kiloSelectedOrganizationId', 'new-org');
+      }
+      if (cause === 'auth') {
+        await storage.setItem(AUTH_STORAGE_KEY, {
+          token: 'other-token',
+          userEmail: 'other@example.test',
+        });
+      }
+      try {
+        expect(signal?.aborted).toBe(true);
+      } finally {
+        gate.resolve();
+        await runtime.dispose();
+      }
+      expect(fixture.actions).toStrictEqual(['issued']);
+      expect(transport.events).not.toContain('quiesced');
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+    }
+  );
+
+  it('withdraws a locally quarantined provider and recovers after the SDK clears its proof cache', async () => {
+    const { coordinator, runtime, transport } = await setup();
+    let proofAvailable = true;
+    const register = transport.connection.registerBrowserProvider;
+    const unavailable = transport.connection.markBrowserProviderUnavailable;
+    const status = transport.connection.requestBrowserProviderStatus;
+    transport.connection.registerBrowserProvider = input => {
+      proofAvailable = true;
+      return register(input);
+    };
+    transport.connection.markBrowserProviderUnavailable = input => {
+      proofAvailable = false;
+      unavailable(input);
+    };
+    transport.connection.requestBrowserProviderStatus = async () => {
+      if (!proofAvailable) {
+        throw new BrowserProviderError('provider_unavailable', true);
+      }
+      return status();
+    };
+    const admission = await coordinator.acquireLocal();
+    if (!admission.admitted) {
+      throw new Error(admission.reason);
+    }
+    localLeases.push(admission.lease);
+    await admission.lease.quarantine(8);
+    await admission.lease.release();
+    await waitFor(() => {
+      expect(runtime.getSnapshot().phase).toBe('recovery');
+    });
+    expect(transport.connection.getBrowserProviderState().status).toBe('unavailable');
+    fixture.tabs = fixture.tabs.filter(tab => tab.id !== 8);
+    await runtime.recover();
+    expect(runtime.getSnapshot().phase).toBe('idle');
+    expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      tabIds: [],
+      version: 1,
+    });
+    expect(fixture.actions).toStrictEqual([]);
+  });
+
+  it('requires drained native locks before fresh recovery registration', async () => {
+    const { coordinator, runtime, transport } = await setup();
+    transport.setFence({ invocationId: `b1.${Date.now() - 700_000_000}.${'d'.repeat(64)}` });
+    const admission = await coordinator.acquireLocal();
+    if (!admission.admitted) {
+      throw new Error(admission.reason);
+    }
+    localLeases.push(admission.lease);
+    await runtime.recover();
+    expect(runtime.getSnapshot().message).toContain('unwinding');
+    expect(transport.events).not.toContain('recovered');
+    await admission.lease.release();
+    await runtime.recover();
+    expect(transport.events).toContain('recovered');
+    expect(fixture.actions).toStrictEqual([]);
+  });
+
+  it('reloads recorded work as status rather than replaying old consent or actions', async () => {
+    const { runtime, transport } = await setup();
+    const message = transport.delivery();
+    transport.dispatch(message);
+    await waitForConsent(runtime);
+    await runtime.dispose();
+    const coordinator = createBrowserExecutionCoordinator({
+      locks: nativeLocks as LockManager,
+      storageArea: storage,
+    });
+    const reopened = createBrowserTaskProviderRuntime({
+      auth,
+      connection: transport.connection,
+      coordinator,
+      organizationId: 'org-approved',
+      storageArea: storage,
+    });
+    runtimes.push(reopened);
+    await reopened.start();
+    transport.setState({ status: 'ready' });
+    await reopened.refreshStatus();
+    transport.send(message);
+    expect({ actions: fixture.actions, active: reopened.getSnapshot().active }).toStrictEqual({
+      actions: [],
+      active: undefined,
+    });
+    expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({
+      jobs: [{ snapshot: { status: 'interrupted' } }],
+    });
+    expect(transport.outbound.filter(frame => frame.type === 'provider_approval')).toStrictEqual(
+      []
+    );
+  });
+
+  it('owns and releases the provider through the injectable component lifetime', async () => {
+    vi.stubGlobal('navigator', { locks: nativeLocks });
+    const transport = relay();
+    const View = () => {
+      const { state } = useBrowserTask();
+      return <output>{state.phase}</output>;
+    };
+    const mounted = render(
+      <BrowserTaskProvider auth={auth} connection={transport.connection} organizationId={undefined}>
+        <View />
+      </BrowserTaskProvider>,
+      { reactStrictMode: true }
+    );
+    await screen.findByText('disabled');
+    expect((await nativeLocks.query()).held?.some(lock => lock.name === PROVIDER_OWNER_LOCK)).toBe(
+      true
+    );
+    act(() => {
+      mounted.unmount();
+    });
+    await waitFor(async () => {
+      expect(
+        (await nativeLocks.query()).held?.some(lock => lock.name === PROVIDER_OWNER_LOCK)
+      ).toBe(false);
+    });
+    expect(transport.outbound).toStrictEqual([]);
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/browser-task-provider.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider.test.tsx
@@ -936,40 +936,313 @@ describe('enabled browser provider owner', () => {
     expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({ jobs: [] });
   });
 
-  it('keeps relay cancellation immutable when a late success snapshot arrives', async () => {
+  describe.each(['provider_snapshot', 'provider_status_result'] as const)(
+    '%s queue metadata',
+    pageType => {
+      it.each(['awaiting_approval', 'running', 'cancelled'] as const)(
+        'preserves paginated ranks through a queued-to-%s transition without granting authority',
+        async status => {
+          vi.useFakeTimers();
+          const { runtime, transport } = await setup();
+          const startedAt = Date.now();
+          const head: BrowserJobSnapshot = {
+            ...transport.delivery().job,
+            jobId: 'bj_ffffffff-ffff-4fff-8fff-ffffffffffff',
+          };
+          const first: BrowserJobSnapshot = {
+            ...head,
+            ownerLabel: 'ses_parent_a',
+            queuePosition: 1,
+            status: 'queued',
+          };
+          const second: BrowserJobSnapshot = {
+            ...transport.delivery().job,
+            jobId: 'bj_00000000-0000-4000-8000-000000000001',
+            ownerLabel: 'ses_parent_b',
+            queuePosition: 2,
+            status: 'queued',
+          };
+          const legacy: BrowserJobSnapshot = {
+            ...transport.delivery().job,
+            jobId: 'bj_80000000-0000-4000-8000-000000000001',
+            status: 'queued',
+          };
+          let firstPage = [second, legacy];
+          let lastPage = [first];
+          const page = (cursor?: string) => ({
+            jobs: structuredClone(cursor === legacy.jobId ? lastPage : firstPage),
+            ...(cursor === legacy.jobId ? {} : { nextCursor: legacy.jobId }),
+          });
+          transport.connection.heartbeatBrowserProvider = async (cursor?: string) => ({
+            ...page(cursor),
+            generation: head.generation,
+            providerId: head.providerId,
+            type: 'provider_snapshot',
+          });
+          transport.connection.requestBrowserProviderStatus = async (cursor?: string) => ({
+            ...page(cursor),
+            providerId: head.providerId,
+            requestId: crypto.randomUUID(),
+            type: 'provider_status_result',
+          });
+          const refresh = () =>
+            pageType === 'provider_snapshot'
+              ? vi.advanceTimersByTimeAsync(5000)
+              : runtime.refreshStatus();
+          const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+          const writes = [...fixture.writes];
+          const outbound = structuredClone(transport.outbound);
+          await vi.advanceTimersByTimeAsync(1000);
+          await refresh();
+          const previous = runtime.getSnapshot();
+          const previousCopy = structuredClone(previous);
+          expect(previous.jobs).toStrictEqual([second, legacy, first]);
+          expect(previous.jobs[1]).not.toHaveProperty('ownerLabel');
+          expect(previous.jobs[1]).not.toHaveProperty('queuePosition');
+
+          const promoted = { ...second, queuePosition: 1 };
+          delete promoted.ownerLabel;
+          const transitioned: BrowserJobSnapshot = {
+            ...head,
+            ownerLabel: 'ses_parent_a',
+            status,
+            ...(status === 'running'
+              ? {
+                  approvedTab: {
+                    effectiveMode: 'safe' as const,
+                    tabId: 7,
+                    title: 'Approved tab',
+                    url: 'https://example.test/task',
+                  },
+                  deadlines: {
+                    ...head.deadlines,
+                    execution: new Date(startedAt + 600_000).toISOString(),
+                  },
+                }
+              : {}),
+            ...(status === 'cancelled'
+              ? { result: terminalResult(head, 'cancelled', 'cancelled') }
+              : {}),
+          };
+          firstPage = [promoted, legacy];
+          lastPage = [transitioned];
+          await refresh();
+          expect(runtime.getSnapshot().jobs).toStrictEqual([promoted, legacy, transitioned]);
+          expect(runtime.getSnapshot().jobs[0]).not.toHaveProperty('ownerLabel');
+          expect(runtime.getSnapshot().jobs[2]).not.toHaveProperty('queuePosition');
+          expect(previous).toStrictEqual(previousCopy);
+          await runtime.approve(head.jobId, 7);
+          await runtime.approve(legacy.jobId, 8);
+          expect(runtime.getSnapshot()).toMatchObject({ active: undefined, phase: 'idle' });
+          expect(fixture.actions).toStrictEqual([]);
+          expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+          expect(fixture.writes).toStrictEqual(writes);
+          expect(transport.outbound).toStrictEqual(outbound);
+
+          await vi.advanceTimersByTimeAsync(startedAt + 15_001 - Date.now());
+          expect(runtime.getSnapshot().phase).toBe('interrupted');
+          expect(fixture.actions).toStrictEqual([]);
+        }
+      );
+
+      it.each([
+        'browserTaskId',
+        'generation',
+        'invocationId',
+        'payloadFingerprint',
+        'providerId',
+      ] as const)('rejects terminal metadata with a different %s', async field => {
+        const { runtime, transport } = await setup();
+        const { job } = transport.delivery();
+        const terminal: BrowserJobSnapshot = {
+          ...job,
+          ownerLabel: 'ses_parent_a',
+          result: terminalResult(job, 'cancelled', 'cancelled'),
+          status: 'cancelled',
+        };
+        transport.rows.set(job.jobId, terminal);
+        transport.snapshot();
+        const previous = structuredClone(runtime.getSnapshot());
+        const different: BrowserJobSnapshot = {
+          ...transport.delivery().job,
+          generation: job.generation + 1,
+          payloadFingerprint: 'b'.repeat(64),
+          providerId: `bp_${crypto.randomUUID()}`,
+        };
+        const wrong: BrowserJobSnapshot = {
+          ...job,
+          [field]: different[field],
+          ownerLabel: 'ses_parent_other',
+          queuePosition: 1,
+          status: 'queued',
+        };
+        if (pageType === 'provider_snapshot') {
+          transport.send({
+            generation: wrong.generation,
+            jobs: [wrong],
+            providerId: wrong.providerId,
+            type: 'provider_snapshot',
+          });
+        } else {
+          transport.connection.requestBrowserProviderStatus = async () => ({
+            jobs: [wrong],
+            providerId: wrong.providerId,
+            requestId: crypto.randomUUID(),
+            type: 'provider_status_result',
+          });
+          if (field === 'providerId') {
+            const request = runtime.refreshStatus();
+            await expect(request).rejects.toThrow('owner_mismatch');
+          } else {
+            await runtime.refreshStatus();
+          }
+        }
+        expect(runtime.getSnapshot()).toStrictEqual(previous);
+        expect(fixture.actions).toStrictEqual([]);
+        expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({ jobs: [] });
+      });
+    }
+  );
+
+  it('exposes current status metadata without treating it as consent or a live running acknowledgement', async () => {
     const { runtime, transport } = await setup();
+    transport.setApprovalAck(false);
     const message = transport.delivery();
     transport.dispatch(message);
     await waitForConsent(runtime);
-    runtime.cancel(message.job.jobId);
-    await waitForDone(runtime);
-    const late: BrowserJobSnapshot = {
+    const running: BrowserJobSnapshot = {
       ...message.job,
-      result: {
-        browserTaskId: message.job.browserTaskId,
-        effectsUncertain: false,
-        evidence: [],
-        invocationId: message.job.invocationId,
-        jobId: message.job.jobId,
-        providerId: message.job.providerId,
-        reason: 'completed',
-        status: 'succeeded',
-        summary: 'Late success',
+      approvedTab: {
+        effectiveMode: 'safe',
+        tabId: 7,
+        title: 'Approved tab',
+        url: 'https://example.test/task',
       },
-      status: 'succeeded',
+      deadlines: {
+        ...message.job.deadlines,
+        execution: new Date(Date.now() + 600_000).toISOString(),
+      },
+      ownerLabel: message.ownerLabel,
+      status: 'running',
     };
-    transport.send({
-      generation: message.job.generation,
-      jobs: [late],
-      providerId: message.job.providerId,
-      type: 'provider_snapshot',
-    });
+    transport.rows.set(message.job.jobId, running);
+    await runtime.refreshStatus();
     expect(runtime.getSnapshot()).toMatchObject({
-      jobs: [{ jobId: message.job.jobId, status: 'cancelled' }],
-      result: { reason: 'cancelled', status: 'cancelled' },
+      active: { approval: undefined, job: { status: 'awaiting_approval' } },
+      jobs: [running],
+      phase: 'awaiting_approval',
     });
     expect(fixture.actions).toStrictEqual([]);
+    expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({
+      jobs: [{ approval: null, snapshot: { status: 'awaiting_approval' } }],
+    });
+
+    await runtime.approve(message.job.jobId, 7);
+    await waitFor(() => {
+      expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({
+        jobs: [{ approval: { tab: { tabId: 7 } } }],
+      });
+    });
+    await runtime.refreshStatus();
+    expect(runtime.getSnapshot().phase).toBe('waiting');
+    expect(fixture.actions).toStrictEqual([]);
+    transport.snapshot();
+    await waitForDone(runtime);
+    expect(fixture.actions).toStrictEqual(['run:7:1']);
+    expect(runtime.getSnapshot().result?.status).toBe('succeeded');
   });
+
+  it.each(['provider_snapshot', 'provider_status_result'] as const)(
+    'restores terminal owners from %s without changing cancellation or stored results',
+    async pageType => {
+      const { runtime, transport } = await setup();
+      const message = transport.delivery();
+      const initial: BrowserJobSnapshot = {
+        ...message.job,
+        ownerLabel: message.ownerLabel,
+        queuePosition: 1,
+        status: 'queued',
+      };
+      transport.rows.set(initial.jobId, initial);
+      transport.snapshot();
+      const queuedSnapshot = runtime.getSnapshot();
+      const queuedCopy = structuredClone(queuedSnapshot);
+      expect(queuedSnapshot.jobs).toStrictEqual([initial]);
+      transport.dispatch(message);
+      await waitForConsent(runtime);
+      const queued: BrowserJobSnapshot = {
+        ...transport.delivery().job,
+        ownerLabel: 'ses_parent_b',
+        queuePosition: 2,
+        status: 'queued',
+      };
+      transport.rows.set(queued.jobId, queued);
+      transport.snapshot();
+      runtime.cancel(message.job.jobId);
+      await waitForDone(runtime);
+      const terminal = transport.rows.get(message.job.jobId);
+      if (terminal?.result === undefined) {
+        throw new Error('Missing terminal fixture');
+      }
+      const previous = runtime.getSnapshot();
+      const previousCopy = structuredClone(previous);
+      expect(previous.jobs[0]).not.toHaveProperty('ownerLabel');
+      expect(previous.jobs[0]).not.toHaveProperty('queuePosition');
+      expect(previous.result).toMatchObject({ reason: 'cancelled', status: 'cancelled' });
+      const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+      const writes = [...fixture.writes];
+      const outbound = structuredClone(transport.outbound);
+      const refresh = async (): Promise<void> => {
+        if (pageType === 'provider_snapshot') {
+          transport.snapshot();
+          return;
+        }
+        await runtime.refreshStatus();
+      };
+      const labelled = { ...terminal, ownerLabel: message.ownerLabel };
+      transport.rows.set(message.job.jobId, labelled);
+      transport.rows.set(queued.jobId, { ...queued, queuePosition: 1 });
+      await refresh();
+      const restored = {
+        ...previous,
+        jobs: [labelled, { ...queued, queuePosition: 1 }],
+      };
+      expect(runtime.getSnapshot()).toStrictEqual(restored);
+
+      const late: BrowserJobSnapshot = {
+        ...message.job,
+        ownerLabel: message.ownerLabel,
+        result: {
+          browserTaskId: message.job.browserTaskId,
+          effectsUncertain: false,
+          evidence: [],
+          invocationId: message.job.invocationId,
+          jobId: message.job.jobId,
+          providerId: message.job.providerId,
+          reason: 'completed',
+          status: 'succeeded',
+          summary: 'Late success',
+        },
+        status: 'succeeded',
+      };
+      transport.rows.set(message.job.jobId, late);
+      await refresh();
+      expect(runtime.getSnapshot()).toStrictEqual(restored);
+      transport.rows.set(message.job.jobId, terminal);
+      await refresh();
+      expect(runtime.getSnapshot()).toStrictEqual(restored);
+      transport.rows.set(message.job.jobId, initial);
+      await refresh();
+      expect(runtime.getSnapshot()).toStrictEqual(restored);
+      expect(runtime.getSnapshot().jobs[0]).not.toHaveProperty('queuePosition');
+      expect(previous).toStrictEqual(previousCopy);
+      expect(queuedSnapshot).toStrictEqual(queuedCopy);
+      expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+      expect(fixture.writes).toStrictEqual(writes);
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect(fixture.actions).toStrictEqual([]);
+    }
+  );
 
   it.each(['rejection', 'cancellation', 'cancellation while waiting'] as const)(
     'offers fresh FIFO consent after %s without recovery',
@@ -989,6 +1262,16 @@ describe('enabled browser provider owner', () => {
       transport.dispatch(first);
       await waitForConsent(runtime);
       transport.enqueue(next);
+      const queued: BrowserJobSnapshot = {
+        ...next.job,
+        ownerLabel: next.ownerLabel,
+        queuePosition: 1,
+        status: 'queued',
+      };
+      transport.rows.set(next.job.jobId, queued);
+      transport.snapshot();
+      const beforeDispatch = runtime.getSnapshot();
+      expect(beforeDispatch.jobs).toContainEqual(queued);
       if (local !== undefined) {
         await runtime.approve(first.job.jobId, 7);
         await waitFor(() => {
@@ -1022,6 +1305,12 @@ describe('enabled browser provider owner', () => {
           result: { reason },
         });
       });
+      expect(runtime.getSnapshot().active?.ownerLabel).toBe(next.ownerLabel);
+      expect(runtime.getSnapshot().active?.job).not.toHaveProperty('queuePosition');
+      expect(
+        runtime.getSnapshot().jobs.find(job => job.jobId === next.job.jobId)
+      ).not.toHaveProperty('queuePosition');
+      expect(beforeDispatch.jobs).toContainEqual(queued);
       expect(
         transport.outbound.find(frame => frame.type === 'provider_quiesced')
       ).not.toHaveProperty('tabId');

--- a/apps/extension/entrypoints/sidepanel/browser-task-provider.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider.test.tsx
@@ -2817,6 +2817,144 @@ describe('enabled browser provider owner', () => {
     );
   });
 
+  it.each([
+    { replacements: 2, scenario: 'a completed intermediate disposal' },
+    { replacements: 4, scenario: 'repeated scope replacements' },
+  ])('retains earlier drainage across $scenario', async ({ replacements }) => {
+    vi.stubGlobal('navigator', { locks: nativeLocks });
+    const transport = relay();
+    const drain = Promise.withResolvers<void>();
+    const runTurn = fixture.turn;
+    let signal: AbortSignal | undefined;
+    let current: BrowserTaskProviderRuntime | undefined;
+    fixture.turn = async context => {
+      ({ signal } = context.abort);
+      context.executionGuard();
+      fixture.actions.push('issued');
+      await drain.promise;
+      context.executionGuard();
+      fixture.actions.push('after disposal');
+      return outcome();
+    };
+    const View = () => {
+      const task = useBrowserTask();
+      current = task;
+      return <output>{task.state.phase}</output>;
+    };
+    const view = (organizationId: string) => (
+      <BrowserTaskProvider
+        auth={auth}
+        connection={transport.connection}
+        organizationId={organizationId}
+      >
+        <View />
+      </BrowserTaskProvider>
+    );
+    const mounted = render(view('org-0'));
+    try {
+      await screen.findByText('disabled');
+      if (current === undefined) {
+        throw new Error('Missing provider runtime');
+      }
+      const first = current;
+      await act(async () => {
+        await first.setSettings(defaults);
+      });
+      const message = transport.delivery();
+      act(() => {
+        transport.dispatch(message);
+      });
+      await screen.findByText('awaiting_approval');
+      await act(async () => {
+        await first.approve(message.job.jobId, 7);
+      });
+      await waitFor(() => {
+        expect(fixture.actions).toStrictEqual(['issued']);
+      });
+
+      for (let replacement = 1; replacement <= replacements; replacement += 1) {
+        act(() => {
+          mounted.rerender(view(`org-${replacement}`));
+        });
+        expect(signal?.aborted).toBe(true);
+        // Let no-work cleanup settle while the first runtime still drains its issued action.
+        // eslint-disable-next-line no-await-in-loop -- Commit and flush each replacement before the next scope.
+        await act(async () => {
+          transport.setState({ status: 'ready' });
+          await nativeLocks.query();
+        });
+        expect(current.getSnapshot()).toMatchObject({
+          active: undefined,
+          jobs: [],
+          phase: 'connecting',
+          profile: undefined,
+        });
+        expect(fixture.actions).toStrictEqual(['issued']);
+      }
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+      expect(
+        (await nativeLocks.query()).held?.some(lock => lock.name === PROVIDER_OWNER_LOCK)
+      ).toBe(true);
+
+      await act(async () => {
+        drain.resolve();
+      });
+      await screen.findByText('recovery');
+      const newest = current;
+      expect(newest.getSnapshot()).toMatchObject({
+        active: undefined,
+        unresolvedFence: { invocationId: message.job.invocationId, tabId: 7 },
+      });
+      expect(transport.rows.get(message.job.jobId)?.result).toMatchObject({
+        effectsUncertain: true,
+        reason: 'provider_unavailable',
+        status: 'interrupted',
+      });
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+      expect(fixture.actions).toStrictEqual(['issued']);
+      fixture.tabs = fixture.tabs.filter(tab => tab.id !== 7);
+      await act(async () => {
+        await newest.recover();
+      });
+      expect(screen.getByText('idle')).toBeDefined();
+      expect(fixture.actions).toStrictEqual(['issued']);
+
+      fixture.turn = runTurn;
+      const fresh = transport.delivery({ goal: 'New work in the latest scope.' });
+      act(() => {
+        transport.dispatch(fresh);
+      });
+      await screen.findByText('awaiting_approval');
+      expect(fixture.actions).toStrictEqual(['issued']);
+      await act(async () => {
+        await newest.approve(fresh.job.jobId, 8);
+      });
+      await screen.findByText('idle');
+      expect(fixture.actions).toStrictEqual(['issued', 'run:8:1']);
+      expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({
+        jobs: [
+          { snapshot: { result: { status: 'interrupted' } } },
+          {
+            approval: { settings: { organizationId: `org-${replacements}` } },
+            snapshot: { result: { jobId: fresh.job.jobId, status: 'succeeded' } },
+          },
+        ],
+      });
+    } finally {
+      await act(async () => {
+        drain.resolve();
+        mounted.unmount();
+      });
+      await waitFor(async () => {
+        expect(
+          (await nativeLocks.query()).held?.some(
+            lock => lock.name === PROVIDER_OWNER_LOCK || lock.name === BROWSER_EXECUTION_LOCK
+          )
+        ).toBe(false);
+      });
+    }
+  });
+
   it('owns and releases the provider through the injectable component lifetime', async () => {
     vi.stubGlobal('navigator', { locks: nativeLocks });
     const transport = relay();

--- a/apps/extension/entrypoints/sidepanel/browser-task-provider.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider.test.tsx
@@ -125,6 +125,7 @@ import { BROWSER_TASK_STORAGE_KEY } from '@/src/shared/browser-task-store';
 import type { StoredBrowserJob } from '@/src/shared/browser-task-store';
 import {
   createBrowserExecutionCoordinator,
+  BROWSER_EXECUTION_LOCK,
   BROWSER_EXECUTION_SAFETY_KEY,
   PROVIDER_OWNER_LOCK,
 } from './browser-execution-lock';
@@ -173,6 +174,8 @@ const terminalResult = (
 const relay = () => {
   let state: BrowserProviderState = { status: 'ready' };
   let registration: BrowserProviderRegistration | undefined;
+  // Relay history retains its binding after the SDK clears its registration proof.
+  let cachedRegistration: BrowserProviderRegistration | undefined;
   let generation = 0;
   let fence: Fence | undefined;
   let acknowledgeApproval = true;
@@ -290,6 +293,7 @@ const relay = () => {
     },
     markBrowserProviderUnavailable: (input: BrowserProviderUnavailableInput) => {
       record({ ...input, type: 'provider_unavailable' });
+      cachedRegistration = undefined;
       setState({ reason: input.reason, retryable: true, status: 'unavailable' });
       for (const job of rows.values()) {
         if (job.result === undefined) {
@@ -333,6 +337,7 @@ const relay = () => {
         type: 'provider_register',
       });
       registration = input;
+      cachedRegistration = input;
       if (
         fence !== undefined &&
         (input.recovery?.invocationId !== fence.invocationId ||
@@ -346,14 +351,24 @@ const relay = () => {
       generation += 1;
       return renew();
     },
-    requestBrowserProviderStatus: async () => {
+    requestBrowserProviderStatus: async (
+      _cursor?: string,
+      identity?: Pick<BrowserProviderRegistration, 'providerId' | 'providerProof'>
+    ) => {
       events.push('status');
-      if (registration === undefined) {
+      const provider = identity ?? cachedRegistration;
+      if (provider === undefined) {
         throw new BrowserProviderError('provider_unavailable', true);
+      }
+      if (
+        provider.providerId !== registration?.providerId ||
+        provider.providerProof !== registration.providerProof
+      ) {
+        throw new BrowserProviderError('owner_mismatch', false);
       }
       return {
         jobs: [...rows.values()],
-        providerId: registration.providerId,
+        providerId: provider.providerId,
         requestId: crypto.randomUUID(),
         type: 'provider_status_result' as const,
         ...(fence === undefined ? {} : { unresolvedFence: fence }),
@@ -801,6 +816,836 @@ describe('enabled browser provider owner', () => {
     expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
     expect((await coordinator.acquireLocal()).admitted).toBe(false);
     expect(transport.events).not.toContain('quiesced');
+  });
+
+  describe('recovery preparation', () => {
+    it('prepares a withdrawn profile without restoring cached proof or execution authority', async () => {
+      const { coordinator, runtime, transport } = await setup();
+      const admission = await coordinator.acquireLocal();
+      if (!admission.admitted) {
+        throw new Error(admission.reason);
+      }
+      localLeases.push(admission.lease);
+      await admission.lease.quarantine(8);
+      await admission.lease.release();
+      await waitFor(() => {
+        expect(runtime.getSnapshot().phase).toBe('recovery');
+      });
+      await expect(transport.connection.requestBrowserProviderStatus()).rejects.toThrow(
+        'provider_unavailable'
+      );
+      fixture.tabs = fixture.tabs.filter(tab => tab.id !== 8);
+      const previous = structuredClone(runtime.getSnapshot());
+      const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+      const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+      const outbound = structuredClone(transport.outbound);
+      const writes = [...fixture.writes];
+
+      await expect(runtime.prepareRecovery()).resolves.toMatchObject({ ready: true });
+      await expect(transport.connection.requestBrowserProviderStatus()).rejects.toThrow(
+        'provider_unavailable'
+      );
+      expect(transport.connection.getBrowserProviderState().status).toBe('unavailable');
+      expect(runtime.getSnapshot()).toStrictEqual(previous);
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+      expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+      expect(fixture.writes).toStrictEqual(writes);
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect((await coordinator.acquireLocal()).admitted).toBe(false);
+      expect(fixture.actions).toStrictEqual([]);
+    });
+
+    it.each([undefined, 0, 7])(
+      'reports a closed, drained fence with tab %s without recovering or changing results',
+      async tabId => {
+        const { coordinator, runtime, transport } = await setup();
+        const message = transport.delivery();
+        transport.dispatch(message);
+        await waitForConsent(runtime);
+        await runtime.approve(message.job.jobId, 7);
+        await waitForDone(runtime);
+        const fence: Fence = {
+          invocationId: `b1.${Date.now() - 700_000_000}.${'b'.repeat(64)}`,
+          ...(tabId === undefined ? {} : { tabId }),
+        };
+        transport.setFence(fence);
+        transport.setState({
+          reason: 'provider_unavailable',
+          retryable: true,
+          status: 'unavailable',
+        });
+        const safety = { allTabs: true, tabIds: [0, 7], version: 1 };
+        fixture.values.set(BROWSER_EXECUTION_SAFETY_KEY, safety);
+        fixture.tabs = [];
+        await coordinator.refresh();
+        const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+        const result = structuredClone(runtime.getSnapshot().result);
+        const outbound = structuredClone(transport.outbound);
+        const writes = [...fixture.writes];
+
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+          ready: true,
+          reason: expect.stringContaining('Recover explicitly'),
+        });
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({ ready: true });
+        expect(runtime.getSnapshot()).toMatchObject({
+          active: undefined,
+          phase: 'recovery',
+          result,
+        });
+        await expect(runtime.refreshStatus()).resolves.toStrictEqual(fence);
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+        expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+        expect(fixture.writes).toStrictEqual(writes);
+        expect(transport.outbound).toStrictEqual(outbound);
+        expect(fixture.actions).toStrictEqual(['run:7:1']);
+        expect((await coordinator.acquireLocal()).admitted).toBe(false);
+      }
+    );
+
+    it('cannot prepare while an active task still awaits consent', async () => {
+      const { runtime, transport } = await setup();
+      transport.dispatch(transport.delivery());
+      await waitForConsent(runtime);
+      const previous = runtime.getSnapshot();
+      const outbound = structuredClone(transport.outbound);
+      const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+      await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+        ready: false,
+        reason: expect.stringContaining('unwinding'),
+      });
+      expect(runtime.getSnapshot()).toStrictEqual(previous);
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+      expect(fixture.actions).toStrictEqual([]);
+    });
+
+    it('keeps an empty provider empty without creating recovery authority', async () => {
+      const { runtime, transport } = await setup();
+      const previous = runtime.getSnapshot();
+      const writes = [...fixture.writes];
+      const outbound = structuredClone(transport.outbound);
+      await expect(runtime.prepareRecovery()).resolves.toMatchObject({ ready: true });
+      expect(runtime.getSnapshot()).toStrictEqual(previous);
+      expect(fixture.writes).toStrictEqual(writes);
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect(fixture.actions).toStrictEqual([]);
+    });
+
+    it.each([
+      { kind: 'remote zero', openId: 0, reason: 'Close the affected tab', tabId: 0, tabIds: [] },
+      {
+        kind: 'remote uninspectable',
+        openId: 7,
+        reason: 'Close the affected tab',
+        tabId: 7,
+        tabIds: [],
+      },
+      {
+        kind: 'local zero',
+        openId: 0,
+        reason: 'Close all affected tabs',
+        tabId: undefined,
+        tabIds: [0],
+      },
+      {
+        kind: 'allTabs',
+        openId: 8,
+        reason: 'Close all target tabs',
+        tabId: undefined,
+        tabIds: [7],
+      },
+      { kind: 'allTabs', openId: 0, reason: 'Close all target tabs', tabId: undefined, tabIds: [] },
+    ])('blocks an open $kind tab outside the inspectable inventory', async testCase => {
+      const { coordinator, runtime, transport } = await setup();
+      const fence: Fence = {
+        invocationId: `b1.${Date.now() - 700_000_000}.${'c'.repeat(64)}`,
+        ...(testCase.tabId === undefined ? {} : { tabId: testCase.tabId }),
+      };
+      transport.setFence(fence);
+      const safety = {
+        ...(testCase.kind === 'allTabs' ? { allTabs: true } : {}),
+        tabIds: testCase.tabIds,
+        version: 1,
+      };
+      fixture.values.set(BROWSER_EXECUTION_SAFETY_KEY, safety);
+      fixture.tabs = [{ id: testCase.openId, title: 'Uninspectable', url: 'chrome://settings' }];
+      await coordinator.refresh();
+      const outbound = structuredClone(transport.outbound);
+      await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+        ready: false,
+        reason: expect.stringContaining(testCase.reason),
+      });
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+      await expect(runtime.refreshStatus()).resolves.toStrictEqual(fence);
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect(fixture.actions).toStrictEqual([]);
+    });
+
+    it('retrieves a fresh fence instead of reusing a status request that predates preparation', async () => {
+      const { runtime, transport } = await setup();
+      const requested = Promise.withResolvers<void>();
+      const resume = Promise.withResolvers<void>();
+      const status = transport.connection.requestBrowserProviderStatus;
+      const spy = vi
+        .spyOn(transport.connection, 'requestBrowserProviderStatus')
+        .mockImplementationOnce(async () => {
+          const page = await status();
+          requested.resolve();
+          await resume.promise;
+          return page;
+        });
+      const retrieving = runtime.refreshStatus();
+      await requested.promise;
+      const fence = { invocationId: `b1.${Date.now()}.${'f'.repeat(64)}`, tabId: 0 };
+      transport.setFence(fence);
+      fixture.tabs = [{ id: 0, title: 'Affected tab', url: 'chrome://settings' }];
+      const preparing = runtime.prepareRecovery();
+      try {
+        resume.resolve();
+        await retrieving;
+        await expect(preparing).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('Close the affected tab'),
+        });
+        expect(runtime.getSnapshot().unresolvedFence).toStrictEqual(fence);
+        expect(transport.events).not.toContain('recovered');
+        expect(fixture.actions).toStrictEqual([]);
+      } finally {
+        resume.resolve();
+        await retrieving;
+        await preparing;
+        spy.mockRestore();
+      }
+    });
+
+    it('enumerates again under the native lock instead of reusing the preflight tab list', async () => {
+      const { coordinator, runtime, transport } = await setup();
+      transport.setFence({ invocationId: `b1.${Date.now()}.${'d'.repeat(64)}`, tabId: 0 });
+      fixture.tabs = [];
+      const prepare = coordinator.prepareRecovery;
+      const spy = vi.spyOn(coordinator, 'prepareRecovery').mockImplementationOnce(getTabs => {
+        fixture.tabs = [{ id: 0, title: 'Affected tab', url: 'chrome://settings' }];
+        return prepare(getTabs);
+      });
+      try {
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('Close the affected tab'),
+        });
+        expect(transport.events).not.toContain('recovered');
+        expect(fixture.actions).toStrictEqual([]);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it.each([
+      { code: 'provider_unavailable', guidance: 'Reopen the signed-in panel', retryable: true },
+      { code: 'request_timeout', guidance: 'Reconnect and retrieve status', retryable: true },
+      { code: 'permission_denied', guidance: 'Restore provider access', retryable: false },
+    ] as const)('fails closed on $code status without probing registration', async failure => {
+      const { runtime, transport } = await setup();
+      const previous = runtime.getSnapshot();
+      const outbound = structuredClone(transport.outbound);
+      const writes = [...fixture.writes];
+      transport.connection.requestBrowserProviderStatus = async () => {
+        throw new BrowserProviderError(failure.code, failure.retryable);
+      };
+      await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+        ready: false,
+        reason: expect.stringContaining(failure.guidance),
+      });
+      expect(runtime.getSnapshot()).toStrictEqual(previous);
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect(fixture.writes).toStrictEqual(writes);
+      expect(fixture.actions).toStrictEqual([]);
+    });
+
+    it('rejects a foreign provider on a later status page before tab or safety preparation', async () => {
+      const { runtime, transport } = await setup();
+      const { providerId } = transport.delivery().job;
+      transport.connection.requestBrowserProviderStatus = async (cursor?: string) => ({
+        jobs: [],
+        providerId: cursor === undefined ? providerId : `bp_${crypto.randomUUID()}`,
+        requestId: crypto.randomUUID(),
+        type: 'provider_status_result',
+        ...(cursor === undefined ? { nextCursor: 'next' } : {}),
+      });
+      const writes = [...fixture.writes];
+      const outbound = structuredClone(transport.outbound);
+      await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+        ready: false,
+        reason: expect.stringContaining('owning signed-in panel'),
+      });
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect(fixture.writes).toStrictEqual(writes);
+      expect(fixture.actions).toStrictEqual([]);
+    });
+
+    it.each(['tabs', 'storage'] as const)(
+      'returns concrete guidance for failed %s access',
+      async failed => {
+        const { runtime, transport } = await setup();
+        const tabs = await browser.tabs.query({});
+        const tabsApi: {
+          query: (queryInfo: Parameters<typeof browser.tabs.query>[0]) => Promise<typeof tabs>;
+        } = browser.tabs;
+        const storageApi = storage as { getItem: (key: string) => unknown };
+        const { getItem } = storageApi;
+        const query = vi.spyOn(tabsApi, 'query');
+        const read = vi.spyOn(storageApi, 'getItem');
+        if (failed === 'tabs') {
+          query.mockRejectedValueOnce(new Error('Private browser error'));
+        } else {
+          read.mockImplementation(key => {
+            if (key === BROWSER_EXECUTION_SAFETY_KEY) {
+              throw new Error('Private storage error');
+            }
+            return getItem(key);
+          });
+        }
+        try {
+          const readiness = await runtime.prepareRecovery();
+          expect(readiness).toMatchObject({
+            ready: false,
+            reason: expect.stringContaining(
+              failed === 'tabs' ? 'Restore browser tab access' : 'Restore storage'
+            ),
+          });
+          expect(readiness.reason).not.toContain('Private');
+          expect(transport.events).not.toContain('recovered');
+          expect(fixture.values.has(BROWSER_EXECUTION_SAFETY_KEY)).toBe(false);
+          expect(fixture.actions).toStrictEqual([]);
+        } finally {
+          query.mockRestore();
+          read.mockRestore();
+        }
+      }
+    );
+
+    it.each(['disabled', 'disposed', 'unsupported'] as const)(
+      'cannot prepare a %s provider',
+      async state => {
+        const { runtime, transport } = await setup(state !== 'disabled', state !== 'unsupported');
+        if (state === 'disposed') {
+          await runtime.dispose();
+        }
+        const outbound = structuredClone(transport.outbound);
+        const writes = [...fixture.writes];
+        const guidance = {
+          disabled: 'Enable CLI tasks',
+          disposed: 'Reopen the signed-in panel',
+          unsupported: 'Restore browser Web Locks support',
+        };
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining(guidance[state]),
+        });
+        expect(transport.outbound).toStrictEqual(outbound);
+        expect(fixture.writes).toStrictEqual(writes);
+        expect(fixture.actions).toStrictEqual([]);
+      }
+    );
+
+    it('rejects a released provider owner after status retrieval starts', async () => {
+      const transport = relay();
+      const coordinator = createBrowserExecutionCoordinator({
+        locks: nativeLocks as LockManager,
+        storageArea: storage,
+      });
+      const owner = await coordinator.acquireProviderOwner();
+      if (!owner.admitted) {
+        throw new Error(owner.reason);
+      }
+      const runtime = createBrowserTaskProviderRuntime({
+        auth,
+        connection: transport.connection,
+        coordinator: { ...coordinator, acquireProviderOwner: async () => owner },
+        organizationId: 'org-approved',
+        storageArea: storage,
+      });
+      runtimes.push(runtime);
+      await runtime.start();
+      await runtime.setSettings(defaults);
+      const requested = Promise.withResolvers<void>();
+      const resume = Promise.withResolvers<void>();
+      const status = transport.connection.requestBrowserProviderStatus;
+      transport.connection.requestBrowserProviderStatus = async () => {
+        const page = await status();
+        requested.resolve();
+        await resume.promise;
+        return page;
+      };
+      const preparing = runtime.prepareRecovery();
+      try {
+        await requested.promise;
+        await owner.lease.release();
+        resume.resolve();
+        await expect(preparing).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('Use the owning panel'),
+        });
+        expect(fixture.actions).toStrictEqual([]);
+        expect(transport.events).not.toContain('recovered');
+      } finally {
+        resume.resolve();
+        await preparing;
+      }
+    });
+
+    it.each([
+      { operation: 'registration', response: 'page' },
+      { operation: 'registration', response: 'failure' },
+      { operation: 'recovery', response: 'page' },
+      { operation: 'recovery', response: 'failure' },
+      { operation: 'recovery registration', response: 'page' },
+      { operation: 'recovery registration', response: 'failure' },
+      { operation: 'recovery bootstrap', response: 'page' },
+      { operation: 'recovery bootstrap', response: 'failure' },
+    ] as const)(
+      'does not publish stale $operation status $response into a changed account',
+      async ({ operation, response }) => {
+        const { runtime, transport } = await setup();
+        if (operation === 'registration') {
+          await runtime.setSettings({ ...defaults, enabled: false });
+        }
+        const paused = Promise.withResolvers<void>();
+        const resume = Promise.withResolvers<void>();
+        const status = transport.connection.requestBrowserProviderStatus;
+        const spy = vi.spyOn(transport.connection, 'requestBrowserProviderStatus');
+        if (operation === 'recovery registration') {
+          spy.mockImplementationOnce(status);
+        } else if (operation === 'recovery bootstrap') {
+          spy.mockRejectedValueOnce(new BrowserProviderError('provider_unavailable', true));
+        }
+        spy.mockImplementationOnce(async () => {
+          const page = await status();
+          const staleJob = transport.delivery().job;
+          paused.resolve();
+          await resume.promise;
+          if (response === 'failure') {
+            throw new BrowserProviderError('disconnected', true);
+          }
+          return {
+            ...page,
+            jobs: [staleJob],
+            unresolvedFence: { invocationId: staleJob.invocationId, tabId: 0 },
+          };
+        });
+        const pending =
+          operation === 'registration' ? runtime.setSettings(defaults) : runtime.recover();
+        try {
+          await paused.promise;
+          await storage.setItem(AUTH_STORAGE_KEY, {
+            token: 'other-token',
+            userEmail: 'other@example.test',
+          });
+          const previous = structuredClone(runtime.getSnapshot());
+          const outbound = structuredClone(transport.outbound);
+          const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+          resume.resolve();
+          await pending;
+          expect(runtime.getSnapshot()).toStrictEqual(previous);
+          expect(transport.outbound).toStrictEqual(outbound);
+          expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+          expect(fixture.actions).toStrictEqual([]);
+        } finally {
+          resume.resolve();
+          await pending;
+          spy.mockRestore();
+        }
+      }
+    );
+
+    describe.each(['registration', 'recovery registration', 'recovery bootstrap'] as const)(
+      'pending %s lifetime',
+      operation => {
+        it.each([
+          { change: 'auth', response: 'success', stage: 'request' },
+          { change: 'auth', response: 'failure', stage: 'request' },
+          { change: 'auth', response: 'success', stage: 'coordinator refresh' },
+          { change: 'auth', response: 'failure', stage: 'coordinator refresh' },
+          { change: 'dispose', response: 'success', stage: 'coordinator refresh' },
+          { change: 'dispose', response: 'failure', stage: 'coordinator refresh' },
+        ] as const)(
+          'ignores delayed $stage $response after $change without withdrawing a replacement',
+          async ({ change, response, stage }) => {
+            const { coordinator, runtime, transport } = await setup();
+            if (operation === 'registration') {
+              await runtime.setSettings({ ...defaults, enabled: false });
+            }
+            const paused = Promise.withResolvers<void>();
+            const resume = Promise.withResolvers<void>();
+            const pause = async () => {
+              paused.resolve();
+              await resume.promise;
+              if (response === 'failure') {
+                throw new BrowserProviderError('permission_denied', false);
+              }
+            };
+            const register = transport.connection.registerBrowserProvider;
+            const { refresh } = coordinator;
+            const spy =
+              stage === 'request'
+                ? vi
+                    .spyOn(transport.connection, 'registerBrowserProvider')
+                    .mockImplementationOnce(async input => {
+                      const lease = await register(input);
+                      await pause();
+                      return lease;
+                    })
+                : vi.spyOn(coordinator, 'refresh').mockImplementationOnce(async () => {
+                    await refresh();
+                    await pause();
+                  });
+            const statusSpy =
+              operation === 'recovery bootstrap'
+                ? vi
+                    .spyOn(transport.connection, 'requestBrowserProviderStatus')
+                    .mockRejectedValueOnce(new BrowserProviderError('provider_unavailable', true))
+                : undefined;
+            const pending =
+              operation === 'registration' ? runtime.setSettings(defaults) : runtime.recover();
+            try {
+              await paused.promise;
+              if (change === 'dispose') {
+                await runtime.dispose();
+              } else {
+                await storage.setItem(AUTH_STORAGE_KEY, {
+                  token: 'other-token',
+                  userEmail: 'other@example.test',
+                });
+                const previousRegistration = transport.outbound.findLast(
+                  frame => frame.type === 'provider_register'
+                );
+                if (previousRegistration === undefined) {
+                  throw new Error('Missing registration');
+                }
+                // A replacement provider must survive the old registration's completion.
+                await register({
+                  generation: previousRegistration.generation + 1,
+                  label: previousRegistration.label,
+                  providerId: previousRegistration.providerId,
+                  providerProof: previousRegistration.providerProof,
+                });
+                fixture.values.set(BROWSER_EXECUTION_SAFETY_KEY, { tabIds: [8], version: 1 });
+                await refresh();
+              }
+              const previous = structuredClone(runtime.getSnapshot());
+              const providerState = structuredClone(transport.connection.getBrowserProviderState());
+              const outbound = structuredClone(transport.outbound);
+              const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+              const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+              resume.resolve();
+              await pending;
+              expect(runtime.getSnapshot()).toStrictEqual(previous);
+              expect(transport.connection.getBrowserProviderState()).toStrictEqual(providerState);
+              expect(transport.outbound).toStrictEqual(outbound);
+              expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+              expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+              expect(fixture.actions).toStrictEqual([]);
+            } finally {
+              resume.resolve();
+              await pending;
+              spy.mockRestore();
+              statusSpy?.mockRestore();
+            }
+          }
+        );
+      }
+    );
+
+    it('keeps preparation valid across a matching lease renewal', async () => {
+      const { coordinator, runtime, transport } = await setup();
+      const paused = Promise.withResolvers<void>();
+      const resume = Promise.withResolvers<void>();
+      const prepare = coordinator.prepareRecovery;
+      const spy = vi.spyOn(coordinator, 'prepareRecovery').mockImplementationOnce(async getTabs => {
+        const readiness = await prepare(getTabs);
+        paused.resolve();
+        await resume.promise;
+        return readiness;
+      });
+      const preparing = runtime.prepareRecovery();
+      try {
+        await paused.promise;
+        transport.renew();
+        const previous = structuredClone(runtime.getSnapshot());
+        const outbound = structuredClone(transport.outbound);
+        resume.resolve();
+        await expect(preparing).resolves.toMatchObject({ ready: true });
+        expect(runtime.getSnapshot()).toStrictEqual(previous);
+        expect(transport.outbound).toStrictEqual(outbound);
+        expect(fixture.actions).toStrictEqual([]);
+      } finally {
+        resume.resolve();
+        await preparing;
+        spy.mockRestore();
+      }
+    });
+
+    describe.each(['status', 'later status page', 'tabs', 'coordinator'] as const)(
+      'pending %s completion',
+      stage => {
+        it.each([
+          'invocation',
+          'finished invocation',
+          'disable',
+          'auth',
+          'organization',
+          'dispose',
+          'generation',
+          'provider binding',
+          'disconnect',
+          'reconnect',
+        ] as const)('cannot report ready or change a newer state after %s', async change => {
+          const { coordinator, runtime, transport } = await setup();
+          const retainedFence = { invocationId: `b1.${Date.now()}.${'e'.repeat(64)}` };
+          const queued: BrowserJobSnapshot = {
+            ...transport.delivery().job,
+            ownerLabel: 'ses_parent_old',
+            queuePosition: 1,
+            status: 'queued',
+          };
+          transport.rows.set(queued.jobId, queued);
+          transport.setFence(retainedFence);
+          if (change === 'disconnect' || change === 'reconnect') {
+            transport.setState({
+              reason: 'provider_unavailable',
+              retryable: true,
+              status: 'unavailable',
+            });
+          }
+          await runtime.refreshStatus();
+          const paused = Promise.withResolvers<void>();
+          const resume = Promise.withResolvers<void>();
+          const pause = async () => {
+            paused.resolve();
+            await resume.promise;
+          };
+          if (stage === 'status' || stage === 'later status page') {
+            const status = transport.connection.requestBrowserProviderStatus;
+            const staleJob = transport.delivery().job;
+            vi.spyOn(transport.connection, 'requestBrowserProviderStatus').mockImplementation(
+              async (cursor?: string) => {
+                const page = await status();
+                if (stage === 'later status page' && cursor === undefined) {
+                  return { ...page, jobs: [], nextCursor: 'next' };
+                }
+                await pause();
+                return {
+                  ...page,
+                  jobs: [...page.jobs, staleJob],
+                  unresolvedFence: { invocationId: staleJob.invocationId, tabId: 0 },
+                };
+              }
+            );
+          } else if (stage === 'tabs') {
+            const tabs = await browser.tabs.query({});
+            const tabsApi: {
+              query: (queryInfo: Parameters<typeof browser.tabs.query>[0]) => Promise<typeof tabs>;
+            } = browser.tabs;
+            vi.spyOn(tabsApi, 'query').mockImplementationOnce(async () => {
+              await pause();
+              return tabs;
+            });
+          } else {
+            const prepare = coordinator.prepareRecovery;
+            vi.spyOn(coordinator, 'prepareRecovery').mockImplementationOnce(async getTabs => {
+              const readiness = await prepare(getTabs);
+              await pause();
+              return readiness;
+            });
+          }
+          const preparing = runtime.prepareRecovery();
+          try {
+            await paused.promise;
+            transport.rows.set(queued.jobId, {
+              ...queued,
+              ownerLabel: 'ses_parent_new',
+              queuePosition: 2,
+            });
+            transport.snapshot();
+            if (change === 'invocation' || change === 'finished invocation') {
+              const message = transport.delivery();
+              transport.dispatch(message);
+              await waitForConsent(runtime);
+              if (change === 'finished invocation') {
+                runtime.reject(message.job.jobId);
+                await waitForDone(runtime);
+              }
+            } else if (change === 'disable') {
+              await runtime.setSettings({ ...defaults, enabled: false });
+            } else if (change === 'auth') {
+              await storage.setItem(AUTH_STORAGE_KEY, {
+                token: 'other-token',
+                userEmail: 'other@example.test',
+              });
+            } else if (change === 'organization') {
+              await storage.setItem('local:kiloSelectedOrganizationId', 'other-org');
+            } else if (change === 'dispose') {
+              await runtime.dispose();
+            } else if (change === 'disconnect' || change === 'reconnect') {
+              transport.setState({ status: 'disconnected' });
+              if (change === 'reconnect') {
+                transport.setState({ status: 'negotiating' });
+                transport.setState({
+                  reason: 'provider_unavailable',
+                  retryable: true,
+                  status: 'unavailable',
+                });
+              }
+            } else {
+              const state = transport.connection.getBrowserProviderState();
+              if (state.status !== 'registered') {
+                throw new Error('Expected a registered provider');
+              }
+              transport.setState({
+                ...state,
+                lease: {
+                  ...state.lease,
+                  ...(change === 'generation'
+                    ? { generation: state.lease.generation + 1 }
+                    : { providerId: `bp_${crypto.randomUUID()}` }),
+                },
+              });
+            }
+            const previous = structuredClone(runtime.getSnapshot());
+            const outbound = structuredClone(transport.outbound);
+            const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+            const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+            resume.resolve();
+            await expect(preparing).resolves.toMatchObject({
+              ready: false,
+              reason: expect.stringMatching(/Wait|Enable|Reopen/u),
+            });
+            expect(runtime.getSnapshot()).toStrictEqual(previous);
+            expect(runtime.getSnapshot().unresolvedFence).toStrictEqual(retainedFence);
+            expect(transport.outbound).toStrictEqual(outbound);
+            expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+            expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+            expect(fixture.actions).toStrictEqual([]);
+          } finally {
+            resume.resolve();
+            await preparing;
+            vi.restoreAllMocks();
+          }
+        });
+      }
+    );
+
+    it('retries only eligible failed releases after successful status without clearing the fence', async () => {
+      const { coordinator, runtime, transport } = await setup();
+      const admission = await coordinator.acquireLocal();
+      if (!admission.admitted) {
+        throw new Error(admission.reason);
+      }
+      localLeases.push(admission.lease);
+      const resume = Promise.withResolvers<void>();
+      const work = admission.lease.run(() => resume.promise);
+      fixture.failWrite = BROWSER_EXECUTION_SAFETY_KEY;
+      await expect(admission.lease.quarantine(7)).rejects.toThrow('Private storage failure');
+      await expect(admission.lease.release()).rejects.toThrow('Private storage failure');
+      fixture.tabs = [];
+      const status = transport.connection.requestBrowserProviderStatus;
+      try {
+        fixture.failWrite = '';
+        transport.connection.requestBrowserProviderStatus = async () => {
+          throw new BrowserProviderError('provider_unavailable', true);
+        };
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('Reopen the signed-in panel'),
+        });
+        expect(fixture.values.has(BROWSER_EXECUTION_SAFETY_KEY)).toBe(false);
+        transport.connection.requestBrowserProviderStatus = status;
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('unwinding'),
+        });
+        expect(fixture.values.has(BROWSER_EXECUTION_SAFETY_KEY)).toBe(false);
+        expect(
+          (await nativeLocks.query()).held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
+        ).toBe(true);
+        resume.resolve();
+        await work;
+        transport.setFence({ invocationId: `b1.${Date.now()}.${'a'.repeat(64)}`, tabId: 0 });
+        fixture.tabs = [{ id: 0, title: 'Affected tab', url: 'chrome://settings' }];
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('Close the affected tab'),
+        });
+        expect(fixture.values.has(BROWSER_EXECUTION_SAFETY_KEY)).toBe(false);
+        fixture.tabs = [];
+        fixture.failWrite = BROWSER_EXECUTION_SAFETY_KEY;
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('Restore storage'),
+        });
+        fixture.failWrite = '';
+        const outbound = structuredClone(transport.outbound);
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({ ready: true });
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+          tabIds: [7],
+          version: 1,
+        });
+        expect(
+          (await nativeLocks.query()).held?.some(lock => lock.name === BROWSER_EXECUTION_LOCK)
+        ).toBe(false);
+        expect((await coordinator.acquireLocal()).admitted).toBe(false);
+        expect(transport.outbound).toStrictEqual(outbound);
+        expect(fixture.actions).toStrictEqual([]);
+      } finally {
+        fixture.failWrite = '';
+        transport.connection.requestBrowserProviderStatus = status;
+        resume.resolve();
+        await work;
+        await coordinator.prepareRecovery(async () => []);
+      }
+    });
+
+    it.each(['remote tab', 'allTabs', 'execution lock', 'status', 'disable'] as const)(
+      'rechecks %s during actual recovery after a ready result',
+      async change => {
+        const { coordinator, runtime, transport } = await setup();
+        transport.setFence({ invocationId: `b1.${Date.now()}.${'e'.repeat(64)}`, tabId: 7 });
+        fixture.tabs = [];
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({ ready: true });
+        if (change === 'remote tab') {
+          fixture.tabs = [{ id: 7, title: 'Affected', url: 'chrome://settings' }];
+        } else if (change === 'allTabs') {
+          fixture.values.set(BROWSER_EXECUTION_SAFETY_KEY, {
+            allTabs: true,
+            tabIds: [],
+            version: 1,
+          });
+          fixture.tabs = [{ id: 8, title: 'Other', url: 'chrome://settings' }];
+        } else if (change === 'execution lock') {
+          const local = await coordinator.acquireLocal();
+          if (!local.admitted) {
+            throw new Error(local.reason);
+          }
+          localLeases.push(local.lease);
+        } else if (change === 'status') {
+          transport.connection.requestBrowserProviderStatus = async () => {
+            throw new BrowserProviderError('permission_denied', false);
+          };
+        } else {
+          await runtime.setSettings({ ...defaults, enabled: false });
+        }
+        const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+        await runtime.recover();
+        expect(transport.events).not.toContain('recovered');
+        expect(
+          transport.outbound.filter(
+            frame => frame.type === 'provider_register' && frame.recovery !== undefined
+          )
+        ).toStrictEqual([]);
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+        expect(fixture.actions).toStrictEqual([]);
+      }
+    );
   });
 
   it.each([undefined, 7])(
@@ -1900,24 +2745,6 @@ describe('enabled browser provider owner', () => {
 
   it('withdraws a locally quarantined provider and recovers after the SDK clears its proof cache', async () => {
     const { coordinator, runtime, transport } = await setup();
-    let proofAvailable = true;
-    const register = transport.connection.registerBrowserProvider;
-    const unavailable = transport.connection.markBrowserProviderUnavailable;
-    const status = transport.connection.requestBrowserProviderStatus;
-    transport.connection.registerBrowserProvider = input => {
-      proofAvailable = true;
-      return register(input);
-    };
-    transport.connection.markBrowserProviderUnavailable = input => {
-      proofAvailable = false;
-      unavailable(input);
-    };
-    transport.connection.requestBrowserProviderStatus = async () => {
-      if (!proofAvailable) {
-        throw new BrowserProviderError('provider_unavailable', true);
-      }
-      return status();
-    };
     const admission = await coordinator.acquireLocal();
     if (!admission.admitted) {
       throw new Error(admission.reason);

--- a/apps/extension/entrypoints/sidepanel/browser-task-provider.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider.test.tsx
@@ -360,8 +360,15 @@ const relay = () => {
       if (provider === undefined) {
         throw new BrowserProviderError('provider_unavailable', true);
       }
+      // The relay deletes withdrawn providers without retained jobs or fences.
       if (
-        provider.providerId !== registration?.providerId ||
+        registration === undefined ||
+        (cachedRegistration === undefined && rows.size === 0 && fence === undefined)
+      ) {
+        throw new BrowserProviderError('not_found', false);
+      }
+      if (
+        provider.providerId !== registration.providerId ||
         provider.providerProof !== registration.providerProof
       ) {
         throw new BrowserProviderError('owner_mismatch', false);
@@ -821,6 +828,8 @@ describe('enabled browser provider owner', () => {
   describe('recovery preparation', () => {
     it('prepares a withdrawn profile without restoring cached proof or execution authority', async () => {
       const { coordinator, runtime, transport } = await setup();
+      const { job } = transport.delivery();
+      transport.settle(job, terminalResult(job, 'cancelled', 'cancelled'));
       const admission = await coordinator.acquireLocal();
       if (!admission.admitted) {
         throw new Error(admission.reason);
@@ -1124,31 +1133,27 @@ describe('enabled browser provider owner', () => {
       }
     );
 
-    it.each(['disabled', 'disposed', 'unsupported'] as const)(
-      'cannot prepare a %s provider',
-      async state => {
-        const { runtime, transport } = await setup(state !== 'disabled', state !== 'unsupported');
-        if (state === 'disposed') {
-          await runtime.dispose();
-        }
-        const outbound = structuredClone(transport.outbound);
-        const writes = [...fixture.writes];
-        const guidance = {
-          disabled: 'Enable CLI tasks',
-          disposed: 'Reopen the signed-in panel',
-          unsupported: 'Restore browser Web Locks support',
-        };
-        await expect(runtime.prepareRecovery()).resolves.toMatchObject({
-          ready: false,
-          reason: expect.stringContaining(guidance[state]),
-        });
-        expect(transport.outbound).toStrictEqual(outbound);
-        expect(fixture.writes).toStrictEqual(writes);
-        expect(fixture.actions).toStrictEqual([]);
+    it.each(['disposed', 'unsupported'] as const)('cannot prepare a %s provider', async state => {
+      const { runtime, transport } = await setup(true, state !== 'unsupported');
+      if (state === 'disposed') {
+        await runtime.dispose();
       }
-    );
+      const outbound = structuredClone(transport.outbound);
+      const writes = [...fixture.writes];
+      const guidance = {
+        disposed: 'Reopen the signed-in panel',
+        unsupported: 'Restore browser Web Locks support',
+      };
+      await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+        ready: false,
+        reason: expect.stringContaining(guidance[state]),
+      });
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect(fixture.writes).toStrictEqual(writes);
+      expect(fixture.actions).toStrictEqual([]);
+    });
 
-    it('rejects a released provider owner after status retrieval starts', async () => {
+    it.each([true, false])('rejects a released provider owner with enabled=%s', async enabled => {
       const transport = relay();
       const coordinator = createBrowserExecutionCoordinator({
         locks: nativeLocks as LockManager,
@@ -1168,14 +1173,19 @@ describe('enabled browser provider owner', () => {
       runtimes.push(runtime);
       await runtime.start();
       await runtime.setSettings(defaults);
+      if (!enabled) {
+        await runtime.setSettings({ ...defaults, enabled: false });
+      }
       const requested = Promise.withResolvers<void>();
       const resume = Promise.withResolvers<void>();
       const status = transport.connection.requestBrowserProviderStatus;
-      transport.connection.requestBrowserProviderStatus = async () => {
-        const page = await status();
-        requested.resolve();
-        await resume.promise;
-        return page;
+      transport.connection.requestBrowserProviderStatus = async (...args) => {
+        try {
+          return await status(...args);
+        } finally {
+          requested.resolve();
+          await resume.promise;
+        }
       };
       const preparing = runtime.prepareRecovery();
       try {
@@ -1186,6 +1196,12 @@ describe('enabled browser provider owner', () => {
           ready: false,
           reason: expect.stringContaining('Use the owning panel'),
         });
+        const previous = structuredClone(runtime.getSnapshot());
+        const outbound = structuredClone(transport.outbound);
+        await runtime.recover();
+        expect(runtime.getSnapshot()).toStrictEqual(previous);
+        expect(transport.outbound).toStrictEqual(outbound);
+        expect(fixture.values.has(BROWSER_EXECUTION_SAFETY_KEY)).toBe(false);
         expect(fixture.actions).toStrictEqual([]);
         expect(transport.events).not.toContain('recovered');
       } finally {
@@ -1537,6 +1553,8 @@ describe('enabled browser provider owner', () => {
 
     it('retries only eligible failed releases after successful status without clearing the fence', async () => {
       const { coordinator, runtime, transport } = await setup();
+      const { job } = transport.delivery();
+      transport.settle(job, terminalResult(job, 'cancelled', 'cancelled'));
       const admission = await coordinator.acquireLocal();
       if (!admission.admitted) {
         throw new Error(admission.reason);
@@ -1643,6 +1661,490 @@ describe('enabled browser provider owner', () => {
           )
         ).toStrictEqual([]);
         expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+        expect(fixture.actions).toStrictEqual([]);
+      }
+    );
+  });
+
+  describe('disabled local recovery', () => {
+    const disabledQuarantine = async (previouslyEnabled = false, fence?: Fence) => {
+      const context = await setup(previouslyEnabled);
+      if (fence !== undefined) {
+        context.transport.setFence(fence);
+      }
+      const admission = await context.coordinator.acquireLocal();
+      if (!admission.admitted) {
+        throw new Error(admission.reason);
+      }
+      localLeases.push(admission.lease);
+      await admission.lease.quarantine(7);
+      await admission.lease.release();
+      if (previouslyEnabled) {
+        await context.runtime.setSettings({ ...defaults, enabled: false });
+      }
+      fixture.tabs = fixture.tabs.filter(tab => tab.id !== 7);
+      return context;
+    };
+
+    it.each([
+      { previouslyEnabled: false, reload: false },
+      { previouslyEnabled: false, reload: true },
+      { previouslyEnabled: true, reload: false },
+      { previouslyEnabled: true, reload: true },
+    ])(
+      'restores local control from absent status with previouslyEnabled=$previouslyEnabled and reload=$reload',
+      async ({ previouslyEnabled, reload }) => {
+        vi.useFakeTimers();
+        const initial = await disabledQuarantine(previouslyEnabled);
+        const { transport } = initial;
+        let { coordinator, runtime } = initial;
+        if (reload) {
+          await runtime.dispose();
+          coordinator = createBrowserExecutionCoordinator({
+            locks: nativeLocks as LockManager,
+            storageArea: storage,
+          });
+          runtime = createBrowserTaskProviderRuntime({
+            auth,
+            connection: transport.connection,
+            coordinator,
+            organizationId: 'org-approved',
+            storageArea: storage,
+          });
+          runtimes.push(runtime);
+          await runtime.start();
+        }
+        const identity = fixture.values.get(BROWSER_PROVIDER_IDENTITY_KEY) as Pick<
+          BrowserProviderRegistration,
+          'providerId' | 'providerProof'
+        >;
+        await expect(
+          transport.connection.requestBrowserProviderStatus(undefined, identity)
+        ).rejects.toMatchObject({ code: 'not_found' });
+        await coordinator.refresh();
+        expect(coordinator.getSnapshot().quarantinedTabIds).toStrictEqual([7]);
+        const outbound = structuredClone(transport.outbound);
+        const providerState = structuredClone(transport.connection.getBrowserProviderState());
+        const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+        const savedSettings = structuredClone(
+          fixture.values.get('local:kiloBrowserProviderSettings')
+        );
+        const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({ ready: true });
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+        expect((await coordinator.acquireLocal()).admitted).toBe(false);
+        await runtime.recover();
+        expect(runtime.getSnapshot()).toMatchObject({
+          active: undefined,
+          jobs: [],
+          message: expect.stringContaining('CLI tasks remain disabled'),
+          phase: 'disabled',
+          result: undefined,
+          settings: { enabled: false },
+          unresolvedFence: undefined,
+        });
+        expect(coordinator.getSnapshot().quarantinedTabIds).toStrictEqual([]);
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+          tabIds: [],
+          version: 1,
+        });
+        expect(fixture.values.get('local:kiloBrowserProviderSettings')).toStrictEqual(
+          savedSettings
+        );
+        expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+        if (previouslyEnabled) {
+          transport.send(transport.delivery());
+        }
+        await vi.advanceTimersByTimeAsync(20_000);
+        expect(transport.outbound).toStrictEqual(outbound);
+        expect(transport.heartbeatTimes).toStrictEqual([]);
+        expect(transport.connection.getBrowserProviderState()).toStrictEqual(providerState);
+        expect(fixture.actions).toStrictEqual([]);
+        const local = await coordinator.acquireLocal();
+        expect(local.admitted).toBe(true);
+        if (local.admitted) {
+          localLeases.push(local.lease);
+        }
+      }
+    );
+
+    it.each([undefined, 0, 7])(
+      'retains a remote fence with tab %s without registration',
+      async tabId => {
+        const fence: Fence = {
+          invocationId: `b1.${Date.now() - 700_000_000}.${'b'.repeat(64)}`,
+          ...(tabId === undefined ? {} : { tabId }),
+        };
+        const { coordinator, runtime, transport } = await disabledQuarantine(true, fence);
+        const outbound = structuredClone(transport.outbound);
+        const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('remote browser task still requires recovery'),
+        });
+        await runtime.recover();
+        expect(runtime.getSnapshot()).toMatchObject({
+          active: undefined,
+          message: expect.stringContaining(
+            'Enable CLI tasks, retrieve status, then recover explicitly'
+          ),
+          settings: { enabled: false },
+          unresolvedFence: fence,
+        });
+        expect(coordinator.getSnapshot().quarantinedTabIds).toStrictEqual([7]);
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+        expect(transport.outbound).toStrictEqual(outbound);
+        expect((await coordinator.acquireLocal()).admitted).toBe(false);
+        expect(fixture.actions).toStrictEqual([]);
+      }
+    );
+
+    it.each([
+      { code: 'provider_unavailable', retryable: true },
+      { code: 'request_timeout', retryable: true },
+      { code: 'disconnected', retryable: true },
+      { code: 'permission_denied', retryable: false },
+      { code: 'owner_mismatch', retryable: false },
+      { code: 'invalid_request', retryable: false },
+    ] as const)('requires fresh status after $code without registering', async failure => {
+      const { coordinator, runtime, transport } = await disabledQuarantine();
+      await expect(runtime.prepareRecovery()).resolves.toMatchObject({ ready: true });
+      const outbound = structuredClone(transport.outbound);
+      const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+      transport.connection.requestBrowserProviderStatus = async () => {
+        throw new BrowserProviderError(failure.code, failure.retryable);
+      };
+      await expect(runtime.prepareRecovery()).resolves.toMatchObject({ ready: false });
+      await runtime.recover();
+      expect(runtime.getSnapshot()).toMatchObject({
+        message: expect.stringContaining('Retrieve status before explicit recovery'),
+        retryable: failure.retryable,
+        settings: { enabled: false },
+      });
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect((await coordinator.acquireLocal()).admitted).toBe(false);
+      expect(fixture.actions).toStrictEqual([]);
+    });
+
+    it('does not treat an untyped not_found error as authenticated absence', async () => {
+      const { coordinator, runtime, transport } = await disabledQuarantine();
+      const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+      transport.connection.requestBrowserProviderStatus = async () => {
+        throw new Error('not_found');
+      };
+      await expect(runtime.prepareRecovery()).resolves.toMatchObject({ ready: false });
+      await runtime.recover();
+      expect(runtime.getSnapshot()).toMatchObject({
+        message: expect.stringContaining('Restore access'),
+        phase: 'recovery',
+        settings: { enabled: false },
+      });
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+      expect((await coordinator.acquireLocal()).admitted).toBe(false);
+      expect(transport.outbound).toStrictEqual([]);
+      expect(fixture.actions).toStrictEqual([]);
+    });
+
+    it('does not discard a fence when a later status page returns not_found', async () => {
+      const fence = { invocationId: `b1.${Date.now()}.${'b'.repeat(64)}`, tabId: 7 };
+      const { coordinator, runtime, transport } = await disabledQuarantine(true, fence);
+      await runtime.refreshStatus();
+      const status = transport.connection.requestBrowserProviderStatus;
+      transport.connection.requestBrowserProviderStatus = async (...args) => {
+        if (args[0] !== undefined) {
+          throw new BrowserProviderError('not_found', false);
+        }
+        return { ...(await status(...args)), nextCursor: 'next' };
+      };
+      const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+      const outbound = structuredClone(transport.outbound);
+      await expect(runtime.prepareRecovery()).resolves.toMatchObject({ ready: false });
+      await runtime.recover();
+      expect(runtime.getSnapshot()).toMatchObject({
+        settings: { enabled: false },
+        unresolvedFence: fence,
+      });
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+      expect((await coordinator.acquireLocal()).admitted).toBe(false);
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect(fixture.actions).toStrictEqual([]);
+    });
+
+    it.each(['prepareRecovery', 'recover'] as const)(
+      'cannot reuse an earlier failed absence request for %s',
+      async operation => {
+        const { coordinator, runtime, transport } = await disabledQuarantine();
+        const paused = Promise.withResolvers<void>();
+        const resume = Promise.withResolvers<void>();
+        const spy = vi
+          .spyOn(transport.connection, 'requestBrowserProviderStatus')
+          .mockImplementationOnce(async () => {
+            paused.resolve();
+            await resume.promise;
+            throw new BrowserProviderError('not_found', false);
+          })
+          .mockRejectedValue(new BrowserProviderError('permission_denied', false));
+        const retrieving = (async () => {
+          try {
+            await runtime.refreshStatus();
+          } catch (error) {
+            expect(error).toMatchObject({ reason: 'provider_lost' });
+          }
+        })();
+        await paused.promise;
+        const pending = runtime[operation]();
+        const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+        try {
+          resume.resolve();
+          await retrieving;
+          const readiness = await pending;
+          if (operation === 'prepareRecovery') {
+            expect(readiness).toMatchObject({ ready: false });
+          }
+          expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+          expect((await coordinator.acquireLocal()).admitted).toBe(false);
+          expect(runtime.getSnapshot().settings?.enabled).toBe(false);
+          expect(transport.outbound).toStrictEqual([]);
+          expect(fixture.actions).toStrictEqual([]);
+        } finally {
+          resume.resolve();
+          await retrieving;
+          await pending;
+          spy.mockRestore();
+        }
+        await runtime.recover();
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+          tabIds: [],
+          version: 1,
+        });
+        expect(transport.outbound).toStrictEqual([]);
+        expect(fixture.actions).toStrictEqual([]);
+      }
+    );
+
+    it.each(['prepareRecovery', 'recover'] as const)(
+      'rejects an absence reply after the %s status deadline',
+      async operation => {
+        vi.useFakeTimers();
+        const { coordinator, runtime, transport } = await disabledQuarantine();
+        const paused = Promise.withResolvers<void>();
+        const resume = Promise.withResolvers<void>();
+        transport.connection.requestBrowserProviderStatus = async () => {
+          paused.resolve();
+          await resume.promise;
+          throw new BrowserProviderError('not_found', false);
+        };
+        const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+        const pending = runtime[operation]();
+        await paused.promise;
+        vi.setSystemTime(Date.now() + 30_001);
+        resume.resolve();
+        const readiness = await pending;
+        if (operation === 'prepareRecovery') {
+          expect(readiness).toMatchObject({ ready: false });
+        }
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+        expect((await coordinator.acquireLocal()).admitted).toBe(false);
+        expect(runtime.getSnapshot().settings?.enabled).toBe(false);
+        expect(transport.outbound).toStrictEqual([]);
+        expect(fixture.actions).toStrictEqual([]);
+      }
+    );
+
+    it.each(['open tab', 'allTabs', 'tab read', 'storage read', 'storage write'] as const)(
+      'retains local quarantine after a failed %s check',
+      async failure => {
+        const { runtime, transport } = await disabledQuarantine();
+        const tabs = await browser.tabs.query({});
+        const tabsApi: {
+          query: (queryInfo: Parameters<typeof browser.tabs.query>[0]) => Promise<typeof tabs>;
+        } = browser.tabs;
+        const storageApi = storage as { getItem: (key: string) => unknown };
+        const { getItem } = storageApi;
+        if (failure === 'open tab') {
+          fixture.tabs = [{ id: 7, title: 'Affected tab', url: 'chrome://settings' }];
+        } else if (failure === 'allTabs') {
+          fixture.values.set(BROWSER_EXECUTION_SAFETY_KEY, {
+            allTabs: true,
+            tabIds: [7],
+            version: 1,
+          });
+        } else if (failure === 'tab read') {
+          vi.spyOn(tabsApi, 'query').mockRejectedValue(new Error('Private tab failure'));
+        } else if (failure === 'storage read') {
+          vi.spyOn(storageApi, 'getItem').mockImplementation(key => {
+            if (key === BROWSER_EXECUTION_SAFETY_KEY) {
+              throw new Error('Private storage failure');
+            }
+            return getItem(key);
+          });
+        } else {
+          fixture.failWrite = BROWSER_EXECUTION_SAFETY_KEY;
+        }
+        const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+        const outbound = structuredClone(transport.outbound);
+        try {
+          await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+            ready: failure === 'storage write',
+          });
+          await runtime.recover();
+          expect(runtime.getSnapshot()).toMatchObject({
+            phase: 'recovery',
+            settings: { enabled: false },
+          });
+          expect(runtime.getSnapshot().message).not.toContain('Private');
+          expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+          expect(transport.outbound).toStrictEqual(outbound);
+          expect(fixture.actions).toStrictEqual([]);
+        } finally {
+          fixture.failWrite = '';
+          vi.restoreAllMocks();
+        }
+      }
+    );
+
+    it('waits for native execution to drain before disabled recovery', async () => {
+      const { runtime, transport } = await disabledQuarantine();
+      const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+      const outbound = structuredClone(transport.outbound);
+      await nativeLocks.request(BROWSER_EXECUTION_LOCK, { mode: 'shared' }, async () => {
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('unwinding'),
+        });
+        await runtime.recover();
+        expect(runtime.getSnapshot().message).toContain('unwinding');
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+      });
+      await runtime.recover();
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+        tabIds: [],
+        version: 1,
+      });
+      expect(runtime.getSnapshot().settings?.enabled).toBe(false);
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect(fixture.actions).toStrictEqual([]);
+    });
+
+    describe.each(['preparation status', 'status', 'tabs', 'coordinator'] as const)(
+      'pending disabled %s recovery',
+      stage => {
+        it.each([
+          'settings',
+          'enable',
+          'auth',
+          'organization',
+          'dispose',
+          'disconnect',
+          'generation',
+        ] as const)('keeps quarantine and newer state after %s', async change => {
+          const { coordinator, runtime, transport } = await disabledQuarantine(true);
+          const paused = Promise.withResolvers<void>();
+          const resume = Promise.withResolvers<void>();
+          const pause = async () => {
+            paused.resolve();
+            await resume.promise;
+          };
+          if (stage === 'status' || stage === 'preparation status') {
+            const status = transport.connection.requestBrowserProviderStatus;
+            vi.spyOn(transport.connection, 'requestBrowserProviderStatus').mockImplementationOnce(
+              async (...args) => {
+                try {
+                  return await status(...args);
+                } finally {
+                  await pause();
+                }
+              }
+            );
+          } else if (stage === 'tabs') {
+            const tabs = await browser.tabs.query({});
+            const tabsApi: {
+              query: (queryInfo: Parameters<typeof browser.tabs.query>[0]) => Promise<typeof tabs>;
+            } = browser.tabs;
+            vi.spyOn(tabsApi, 'query').mockImplementationOnce(async () => {
+              await pause();
+              return tabs;
+            });
+          } else {
+            const { recover } = coordinator;
+            vi.spyOn(coordinator, 'recover').mockImplementationOnce(async getTabs => {
+              await pause();
+              return recover(getTabs);
+            });
+          }
+          const pending =
+            stage === 'preparation status' ? runtime.prepareRecovery() : runtime.recover();
+          try {
+            await paused.promise;
+            if (change === 'settings' || change === 'enable') {
+              await runtime.setSettings({
+                ...defaults,
+                enabled: change === 'enable',
+                model: 'new-model',
+              });
+            } else if (change === 'auth') {
+              await storage.setItem(AUTH_STORAGE_KEY, {
+                token: 'new-token',
+                userEmail: 'other@example.test',
+              });
+            } else if (change === 'organization') {
+              await storage.setItem('local:kiloSelectedOrganizationId', 'other-org');
+            } else if (change === 'dispose') {
+              await runtime.dispose();
+            } else if (change === 'disconnect') {
+              transport.setState({ status: 'disconnected' });
+            } else {
+              const { job } = transport.delivery();
+              transport.setState({
+                lease: {
+                  generation: job.generation + 1,
+                  leaseExpiresAt: new Date(Date.now() + 15_000).toISOString(),
+                  providerId: job.providerId,
+                  requestId: crypto.randomUUID(),
+                  type: 'provider_lease_ack',
+                },
+                status: 'registered',
+              });
+            }
+            const previous = structuredClone(runtime.getSnapshot());
+            const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+            const outbound = structuredClone(transport.outbound);
+            resume.resolve();
+            const readiness = await pending;
+            if (stage === 'preparation status') {
+              expect(readiness).toMatchObject({ ready: false });
+            }
+            expect(runtime.getSnapshot()).toStrictEqual(previous);
+            expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+            expect(transport.outbound).toStrictEqual(outbound);
+            expect(fixture.actions).toStrictEqual([]);
+          } finally {
+            resume.resolve();
+            await pending;
+            vi.restoreAllMocks();
+          }
+        });
+      }
+    );
+
+    it.each([AUTH_STORAGE_KEY, 'local:kiloSelectedOrganizationId'] as const)(
+      'cannot recover an already revoked lifetime after %s changes',
+      async key => {
+        const { runtime, transport } = await disabledQuarantine();
+        await storage.setItem(key, null);
+        const previous = structuredClone(runtime.getSnapshot());
+        const safety = structuredClone(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY));
+        const outbound = structuredClone(transport.outbound);
+        await expect(runtime.prepareRecovery()).resolves.toMatchObject({
+          ready: false,
+          reason: expect.stringContaining('Reopen the signed-in panel'),
+        });
+        await expect(runtime.refreshStatus()).rejects.toThrow('provider_lost');
+        await runtime.recover();
+        expect(runtime.getSnapshot()).toStrictEqual(previous);
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+        expect(transport.outbound).toStrictEqual(outbound);
         expect(fixture.actions).toStrictEqual([]);
       }
     );
@@ -2234,12 +2736,12 @@ describe('enabled browser provider owner', () => {
     }
   );
 
-  it.each([
-    { reason: 'provider_unavailable', retryable: true },
-    { reason: 'permission_denied', retryable: false },
-  ] as const)(
-    'reports current tab approval failure $reason without starting work',
-    async failure => {
+  describe.each(['settings', 'tabs'] as const)('approval %s failures', source => {
+    it.each([
+      { raw: false, reason: 'provider_unavailable', retryable: true },
+      { raw: false, reason: 'permission_denied', retryable: false },
+      { raw: true, reason: 'runner_failed', retryable: true },
+    ] as const)('retains only retryable consent after $reason', async failure => {
       const { runtime, transport } = await setup();
       const message = transport.delivery();
       transport.dispatch(message);
@@ -2248,31 +2750,153 @@ describe('enabled browser provider owner', () => {
       const tabsApi: {
         query: (queryInfo: Parameters<typeof browser.tabs.query>[0]) => Promise<typeof tabs>;
       } = browser.tabs;
-      const query = vi
-        .spyOn(tabsApi, 'query')
-        .mockRejectedValueOnce(new BrowserProviderError(failure.reason, failure.retryable));
+      const storageApi = storage as { getItem: (key: string) => unknown };
+      const { getItem } = storageApi;
+      const error = failure.raw
+        ? new Error('Private read failure')
+        : new BrowserProviderError(failure.reason, failure.retryable);
+      const read =
+        source === 'tabs'
+          ? vi.spyOn(tabsApi, 'query').mockRejectedValueOnce(error)
+          : vi.spyOn(storageApi, 'getItem').mockImplementation(key => {
+              if (key === 'local:kiloRemoteMcpServers') {
+                throw error;
+              }
+              return getItem(key);
+            });
       try {
         await runtime.approve(message.job.jobId, 7);
-        expect(runtime.getSnapshot()).toMatchObject({
-          active: { approval: undefined, job: { jobId: message.job.jobId } },
-          message: expect.stringContaining(failure.reason),
-          phase: 'unavailable',
-          retryable: failure.retryable,
-        });
+        if (failure.retryable) {
+          expect(runtime.getSnapshot()).toMatchObject({
+            active: {
+              approval: undefined,
+              goal: message.goal,
+              job: { deadlines: message.job.deadlines, jobId: message.job.jobId },
+              ownerLabel: message.ownerLabel,
+            },
+            message: expect.stringContaining('approve this goal again before its deadline'),
+            phase: 'awaiting_approval',
+            retryable: true,
+          });
+          expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({
+            jobs: [{ approval: null, snapshot: { status: 'awaiting_approval' } }],
+          });
+          expect(
+            transport.outbound.filter(frame => frame.type === 'provider_approval')
+          ).toStrictEqual([]);
+        } else {
+          await waitForDone(runtime);
+          expect(runtime.getSnapshot()).toMatchObject({
+            active: undefined,
+            result: { reason: 'permission_denied' },
+            retryable: false,
+          });
+          expect(runtime.getSnapshot().phase).not.toBe('awaiting_approval');
+        }
+        expect(JSON.stringify(runtime.getSnapshot())).not.toContain('Private');
         expect(fixture.actions).toStrictEqual([]);
       } finally {
-        query.mockRestore();
+        read.mockRestore();
       }
       if (failure.retryable) {
+        await runtime.setSettings({ ...defaults, model: 'retry-model' });
+        await storage.setItem('local:kiloWorkflowSettings', { allowWorkflowsInSafeMode: true });
+        await runtime.approve('different-job', 8);
+        expect(runtime.getSnapshot().active?.approval).toBeUndefined();
+        expect(fixture.actions).toStrictEqual([]);
         await runtime.approve(message.job.jobId, 7);
         await waitForDone(runtime);
         expect(fixture.actions).toStrictEqual(['run:7:1']);
-        expect(runtime.getSnapshot().result).toMatchObject({ status: 'succeeded' });
+        expect(runtime.getSnapshot()).toMatchObject({
+          message: expect.stringContaining('Keep this panel open'),
+          result: { jobId: message.job.jobId, status: 'succeeded' },
+          retryable: false,
+        });
+        expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toMatchObject({
+          jobs: [
+            {
+              approval: {
+                settings: {
+                  model: 'retry-model',
+                  workflowSettings: { allowWorkflowsInSafeMode: true },
+                },
+              },
+            },
+          ],
+        });
       } else {
-        runtime.reject(message.job.jobId);
-        await waitForDone(runtime);
+        await runtime.approve(message.job.jobId, 7);
+        await runtime.refreshStatus();
+        expect(runtime.getSnapshot().active).toBeUndefined();
+        expect(runtime.getSnapshot().result).toMatchObject({ reason: 'permission_denied' });
         expect(fixture.actions).toStrictEqual([]);
-        expect(runtime.getSnapshot().result).toMatchObject({ reason: 'approval_denied' });
+      }
+    });
+  });
+
+  it.each(['cancel', 'reject', 'permission', 'disable', 'expiry'] as const)(
+    'ignores a delayed retryable read error after %s revokes the same consent',
+    async cause => {
+      vi.useFakeTimers();
+      const { runtime, transport } = await setup();
+      const message = transport.delivery();
+      message.job.deadlines.approval = new Date(Date.now() + 1000).toISOString();
+      transport.dispatch(message);
+      await vi.waitFor(() => {
+        expect(runtime.getSnapshot().phase).toBe('awaiting_approval');
+      });
+      const tabs = await browser.tabs.query({});
+      const tabsApi: {
+        query: (queryInfo: Parameters<typeof browser.tabs.query>[0]) => Promise<typeof tabs>;
+      } = browser.tabs;
+      const paused = Promise.withResolvers<void>();
+      const resume = Promise.withResolvers<void>();
+      const query = vi.spyOn(tabsApi, 'query').mockImplementationOnce(async () => {
+        paused.resolve();
+        await resume.promise;
+        throw new BrowserProviderError('provider_unavailable', true);
+      });
+      const approving = runtime.approve(message.job.jobId, 7);
+      try {
+        await paused.promise;
+        transport.setTerminalAck(false);
+        if (cause === 'cancel') {
+          runtime.cancel(message.job.jobId);
+        } else if (cause === 'reject') {
+          runtime.reject(message.job.jobId);
+        } else if (cause === 'permission') {
+          for (const listener of fixture.permissions) {
+            listener();
+          }
+        } else if (cause === 'disable') {
+          await runtime.setSettings({ ...defaults, enabled: false });
+        } else {
+          await vi.advanceTimersByTimeAsync(1001);
+        }
+        await vi.advanceTimersByTimeAsync(0);
+        const previous = structuredClone(runtime.getSnapshot());
+        expect(previous.active?.job.jobId).toBe(message.job.jobId);
+        resume.resolve();
+        await approving;
+        expect(runtime.getSnapshot()).toStrictEqual(previous);
+        expect(fixture.actions).toStrictEqual([]);
+        transport.setTerminalAck(true);
+        transport.snapshot();
+        await vi.waitFor(() => {
+          expect(runtime.getSnapshot().active).toBeUndefined();
+        });
+        await runtime.approve(message.job.jobId, 7);
+        expect(runtime.getSnapshot().phase).not.toBe('awaiting_approval');
+        expect(
+          transport.outbound.filter(
+            frame => frame.type === 'provider_approval' && frame.approval.decision === 'approved'
+          )
+        ).toStrictEqual([]);
+        expect(fixture.actions).toStrictEqual([]);
+      } finally {
+        resume.resolve();
+        await approving;
+        query.mockRestore();
       }
     }
   );
@@ -2745,6 +3369,8 @@ describe('enabled browser provider owner', () => {
 
   it('withdraws a locally quarantined provider and recovers after the SDK clears its proof cache', async () => {
     const { coordinator, runtime, transport } = await setup();
+    const { job } = transport.delivery();
+    transport.settle(job, terminalResult(job, 'cancelled', 'cancelled'));
     const admission = await coordinator.acquireLocal();
     if (!admission.admitted) {
       throw new Error(admission.reason);
@@ -2782,6 +3408,301 @@ describe('enabled browser provider owner', () => {
     expect(transport.events).toContain('recovered');
     expect(fixture.actions).toStrictEqual([]);
   });
+
+  it('replaces a local fallback with the same job’s authoritative terminal result after drainage', async () => {
+    vi.useFakeTimers();
+    const { runtime, transport } = await setup();
+    const message = transport.delivery();
+    transport.setTerminalAck(false);
+    fixture.turn = async context => {
+      context.executionGuard();
+      fixture.actions.push('issued');
+      const running = transport.rows.get(message.job.jobId);
+      if (running === undefined) {
+        throw new Error('Missing running job');
+      }
+      // The cancellation wins at the relay, but its delivery is lost before local completion.
+      transport.settle(running, terminalResult(running, 'cancelled', 'cancelled'));
+      return outcome();
+    };
+    transport.dispatch(message);
+    await vi.waitFor(() => {
+      expect(runtime.getSnapshot().phase).toBe('awaiting_approval');
+    });
+    await runtime.approve(message.job.jobId, 7);
+    await vi.waitFor(() => {
+      expect(transport.outbound.some(frame => frame.type === 'provider_result')).toBe(true);
+    });
+    await runtime.setSettings({ ...defaults, enabled: false });
+    await vi.advanceTimersByTimeAsync(10_001);
+    await vi.waitFor(() => {
+      expect(runtime.getSnapshot().active).toBeUndefined();
+    });
+    expect(runtime.getSnapshot().result).toMatchObject({
+      jobId: message.job.jobId,
+      reason: 'completed',
+      status: 'succeeded',
+    });
+    const authoritative = transport.rows.get(message.job.jobId)?.result;
+    expect(authoritative).toMatchObject({ effectsUncertain: true, reason: 'cancelled' });
+    const outbound = structuredClone(transport.outbound);
+    const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+    await runtime.refreshStatus();
+    expect(runtime.getSnapshot()).toMatchObject({
+      active: undefined,
+      result: authoritative,
+      settings: { enabled: false },
+    });
+    expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+    expect(transport.outbound).toStrictEqual(outbound);
+    expect(fixture.actions).toStrictEqual(['issued']);
+  });
+
+  describe.each([true, false])('recovered outcomes with delegation enabled=%s', enabled => {
+    it.each([
+      { effectsUncertain: false, reason: 'completed', status: 'succeeded' },
+      { effectsUncertain: true, reason: 'effects_uncertain', status: 'interrupted' },
+    ] as const)(
+      'restores an authoritative $reason result and affected identities without an invocation',
+      async settlement => {
+        const { reason } = settlement;
+        const { runtime, transport } = await setup();
+        const message = transport.delivery();
+        const result: BrowserResult = {
+          ...terminalResult(message.job, 'effects_uncertain'),
+          ...settlement,
+          evidence: [
+            {
+              text: 'Confirmed page observation',
+              title: 'Observed tab',
+              url: 'https://example.test/task',
+            },
+          ],
+          summary:
+            reason === 'completed'
+              ? 'Confirmed the requested page.'
+              : 'Only the first observation is confirmed; later effects are unknown.',
+        };
+        const terminal: BrowserJobSnapshot = {
+          ...message.job,
+          approvedTab: {
+            effectiveMode: 'safe',
+            tabId: 7,
+            title: 'Approved tab',
+            url: 'https://example.test/task',
+          },
+          ownerLabel: message.ownerLabel,
+          result,
+          status: result.status,
+        };
+        transport.rows.set(terminal.jobId, terminal);
+        const fence = { invocationId: terminal.invocationId, tabId: 7 };
+        if (reason === 'effects_uncertain') {
+          transport.setFence(fence);
+          fixture.values.set(BROWSER_EXECUTION_SAFETY_KEY, { tabIds: [7, 8], version: 1 });
+        }
+        if (!enabled) {
+          await runtime.setSettings({ ...defaults, enabled: false });
+        }
+        await runtime.dispose();
+        transport.setState({ status: 'ready' });
+        const coordinator = createBrowserExecutionCoordinator({
+          locks: nativeLocks as LockManager,
+          storageArea: storage,
+        });
+        const reopened = createBrowserTaskProviderRuntime({
+          auth,
+          connection: transport.connection,
+          coordinator,
+          organizationId: 'org-approved',
+          storageArea: storage,
+        });
+        runtimes.push(reopened);
+        const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+        await reopened.start();
+        if (enabled) {
+          expect(reopened.getSnapshot().result).toStrictEqual(result);
+        }
+        const outbound = structuredClone(transport.outbound);
+        await reopened.refreshStatus();
+        await coordinator.refresh();
+        expect(reopened.getSnapshot()).toMatchObject({
+          active: undefined,
+          jobs: [terminal],
+          result,
+          settings: { enabled },
+          unresolvedFence: reason === 'effects_uncertain' ? fence : undefined,
+        });
+        expect(coordinator.getSnapshot().quarantinedTabIds).toStrictEqual(
+          reason === 'effects_uncertain' ? [7, 8] : []
+        );
+        await reopened.approve(terminal.jobId, 7);
+        transport.send(message);
+        expect(reopened.getSnapshot().active).toBeUndefined();
+        expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+        expect(transport.outbound).toStrictEqual(outbound);
+        expect(fixture.actions).toStrictEqual([]);
+      }
+    );
+  });
+
+  it.each([false, true])(
+    'selects immutable recovered outcomes independently of reversed pages=%s',
+    async reversed => {
+      const { runtime, transport } = await setup();
+      const now = Date.now();
+      const clock = vi
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(now - 2000)
+        .mockReturnValueOnce(now - 1000)
+        .mockReturnValueOnce(now - 1000);
+      const oldest: BrowserJobSnapshot = {
+        ...transport.delivery().job,
+        jobId: 'bj_ffffffff-ffff-4fff-8fff-ffffffffffff',
+      };
+      const earlierTie: BrowserJobSnapshot = {
+        ...transport.delivery().job,
+        jobId: 'bj_00000000-0000-4000-8000-000000000001',
+      };
+      const latest: BrowserJobSnapshot = {
+        ...transport.delivery().job,
+        jobId: 'bj_80000000-0000-4000-8000-000000000001',
+      };
+      clock.mockRestore();
+      const terminals = [oldest, earlierTie, latest];
+      for (const job of terminals) {
+        job.ownerLabel = 'ses_history_owner';
+        job.result = terminalResult(job, 'cancelled', 'cancelled');
+        job.status = 'cancelled';
+      }
+      const expected = latest;
+      let pages = reversed ? terminals.toReversed() : terminals;
+      transport.connection.requestBrowserProviderStatus = async (cursor?: string) => {
+        const index = cursor === undefined ? 0 : Number(cursor);
+        return {
+          jobs: pages.slice(index, index + 1),
+          providerId: latest.providerId,
+          requestId: crypto.randomUUID(),
+          type: 'provider_status_result',
+          ...(index === pages.length - 1 ? {} : { nextCursor: String(index + 1) }),
+        };
+      };
+      const outbound = structuredClone(transport.outbound);
+      const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+      await runtime.refreshStatus();
+      expect(runtime.getSnapshot().result).toStrictEqual(expected?.result);
+      const previous = structuredClone(runtime.getSnapshot());
+      pages = pages.toReversed();
+      await runtime.refreshStatus();
+      expect(runtime.getSnapshot()).toStrictEqual(previous);
+      pages = [
+        {
+          ...latest,
+          ownerLabel: 'ses_history_owner',
+          result: {
+            ...terminalResult(latest, 'provider_lost'),
+            summary: 'Late conflicting terminal data',
+          },
+          status: 'interrupted',
+        },
+      ];
+      await runtime.refreshStatus();
+      expect(runtime.getSnapshot()).toStrictEqual(previous);
+      expect(runtime.getSnapshot().jobs.find(job => job.jobId === latest.jobId)).toStrictEqual(
+        expected
+      );
+      expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect(fixture.actions).toStrictEqual([]);
+    }
+  );
+
+  it.each([false, true])(
+    'selects newer outcomes after displayed history expires with reversed pages=%s',
+    async reversed => {
+      vi.useFakeTimers();
+      const { runtime, transport } = await setup();
+      const now = Date.now();
+      const expired: BrowserJobSnapshot = {
+        ...transport.delivery().job,
+        createdAt: new Date(now - 2000).toISOString(),
+        expiresAt: new Date(now + 1000).toISOString(),
+      };
+      expired.result = terminalResult(expired, 'cancelled', 'cancelled');
+      expired.status = 'cancelled';
+      transport.rows.set(expired.jobId, expired);
+      await runtime.refreshStatus();
+      const original = runtime.getSnapshot();
+      const originalCopy = structuredClone(original);
+      vi.setSystemTime(now + 1001);
+      await runtime.setSettings({ ...defaults, enabled: false });
+      expect(runtime.getSnapshot().jobs).toStrictEqual([]);
+      expect(runtime.getSnapshot().result).toStrictEqual(expired.result);
+
+      const earlierTie: BrowserJobSnapshot = {
+        ...transport.delivery().job,
+        createdAt: new Date(now - 1000).toISOString(),
+        jobId: 'bj_00000000-0000-4000-8000-000000000001',
+      };
+      const latest: BrowserJobSnapshot = {
+        ...transport.delivery().job,
+        createdAt: earlierTie.createdAt,
+        jobId: 'bj_80000000-0000-4000-8000-000000000001',
+      };
+      for (const job of [earlierTie, latest]) {
+        job.ownerLabel = 'ses_history_owner';
+        job.result = terminalResult(job, 'cancelled', 'cancelled');
+        job.status = 'cancelled';
+      }
+      let pages = reversed ? [latest, earlierTie] : [earlierTie, latest];
+      transport.connection.requestBrowserProviderStatus = async (cursor?: string) => {
+        const index = cursor === undefined ? 0 : Number(cursor);
+        return {
+          jobs: pages.slice(index, index + 1),
+          providerId: latest.providerId,
+          requestId: crypto.randomUUID(),
+          type: 'provider_status_result',
+          ...(index === pages.length - 1 ? {} : { nextCursor: String(index + 1) }),
+        };
+      };
+      const outbound = structuredClone(transport.outbound);
+      const persisted = structuredClone(fixture.values.get(BROWSER_TASK_STORAGE_KEY));
+      await runtime.refreshStatus();
+      expect(runtime.getSnapshot()).toMatchObject({
+        active: undefined,
+        result: latest.result,
+        settings: { enabled: false },
+      });
+      const selected = structuredClone(runtime.getSnapshot());
+      pages = pages.toReversed();
+      await runtime.refreshStatus();
+      expect(runtime.getSnapshot()).toStrictEqual(selected);
+      expect(original).toStrictEqual(originalCopy);
+      await runtime.approve(latest.jobId, 7);
+      expect(runtime.getSnapshot().active).toBeUndefined();
+      expect(transport.outbound).toStrictEqual(outbound);
+      expect(fixture.values.get(BROWSER_TASK_STORAGE_KEY)).toStrictEqual(persisted);
+      expect(fixture.actions).toStrictEqual([]);
+
+      vi.setSystemTime(Date.parse(latest.expiresAt) + 1);
+      await runtime.setSettings({ ...defaults, enabled: false });
+      const retained = structuredClone(runtime.getSnapshot());
+      expect(retained.jobs).toStrictEqual([]);
+      pages = [
+        {
+          ...latest,
+          result: {
+            ...terminalResult(latest, 'provider_lost'),
+            summary: 'Late conflicting terminal',
+          },
+          status: 'interrupted',
+        },
+      ];
+      await runtime.refreshStatus();
+      expect(runtime.getSnapshot()).toStrictEqual(retained);
+      expect(fixture.actions).toStrictEqual([]);
+    }
+  );
 
   it('reloads recorded work as status rather than replaying old consent or actions', async () => {
     const { runtime, transport } = await setup();

--- a/apps/extension/entrypoints/sidepanel/browser-task-provider.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider.tsx
@@ -392,9 +392,17 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
       )
     );
   };
-  const consumeJob = (job: BrowserJobSnapshot): void => {
+  const consumeJob = (job: BrowserJobSnapshot, acknowledgeRunning = true): void => {
     const previous = jobs.get(job.jobId);
-    if (previous !== undefined && (!sameJob(previous, job) || previous.result !== undefined)) {
+    if (previous !== undefined && !sameJob(previous, job)) {
+      return;
+    }
+    if (previous?.result !== undefined) {
+      // Later provider pages can supply an owner without replacing the first terminal snapshot.
+      if (job.ownerLabel !== undefined && job.ownerLabel !== previous.ownerLabel) {
+        jobs.set(job.jobId, { ...previous, ownerLabel: job.ownerLabel });
+        publish();
+      }
       return;
     }
     jobs.set(job.jobId, job);
@@ -409,7 +417,7 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           job.result.reason === 'completed' ? 'provider_unavailable' : job.result.reason
         );
         publish({ result: job.result });
-      } else if (job.status === 'running') {
+      } else if (job.status === 'running' && acknowledgeRunning) {
         if (current.selected === undefined || !sameTab(job.approvedTab, current.selected.tab)) {
           needsRecovery = true;
           unavailable('tab_lost', current.started);
@@ -440,10 +448,8 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           }
           fence = page.unresolvedFence ?? fence;
           for (const job of page.jobs) {
-            // Historical running rows never acknowledge approval or grant a lease.
-            if (job.result !== undefined || job.generation !== generation) {
-              consumeJob(job);
-            }
+            // Status pages update display state, but never acknowledge approval or grant a lease.
+            consumeJob(job, false);
           }
           cursor = page.nextCursor;
           if (cursor !== undefined && cursors.has(cursor)) {

--- a/apps/extension/entrypoints/sidepanel/browser-task-provider.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider.tsx
@@ -1612,7 +1612,10 @@ export const BrowserTaskProvider = ({
     })();
     return () => {
       cancelled = true;
-      closing.current = lifetime.dispose();
+      // Retain earlier drainage even if this runtime never started.
+      closing.current = (async () => {
+        await Promise.all([previous, lifetime.dispose()]);
+      })();
     };
   }, [connection, organizationId, token, userEmail]);
   return runtime === undefined ? null : (

--- a/apps/extension/entrypoints/sidepanel/browser-task-provider.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider.tsx
@@ -48,7 +48,11 @@ import type { BrowserTaskStore, StoredBrowserJob } from '@/src/shared/browser-ta
 import { REMOTE_MCP_STORAGE_KEY } from '@/src/shared/remote-mcp-storage';
 import { WEB_MCP_SETTINGS_STORAGE_KEY } from '@/src/shared/web-mcp-settings';
 import { getBrowserExecutionCoordinator } from './browser-execution-lock';
-import type { BrowserExecutionCoordinator, BrowserExecutionLease } from './browser-execution-lock';
+import type {
+  BrowserExecutionCoordinator,
+  BrowserExecutionLease,
+  BrowserRecoveryReadiness,
+} from './browser-execution-lock';
 import {
   browserTaskFailure,
   getBrowserTaskTabs,
@@ -196,11 +200,12 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
   let leaseUntil = 0;
   let leaseTimer: ReturnType<typeof setTimeout> | undefined = undefined;
   let heartbeatTimer: ReturnType<typeof setInterval> | undefined = undefined;
-  let registering: Promise<void> | undefined = undefined;
+  let registering: Promise<'cancelled' | undefined> | undefined = undefined;
   let starting: Promise<void> | undefined = undefined;
   let statusRequest: Promise<BrowserProviderStatusResult['unresolvedFence']> | undefined =
     undefined;
   let recovering = false;
+  let recoveryRevision = 0;
   let snapshot: BrowserTaskProviderSnapshot = {
     active: undefined,
     jobs: [],
@@ -432,22 +437,50 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
   let lastStatus: { fence: BrowserProviderStatusResult['unresolvedFence'] } | undefined;
   const refreshStatus = (): Promise<BrowserProviderStatusResult['unresolvedFence']> => {
     statusRequest ??= (async () => {
+      const providerOwner = owner;
+      const providerProfile = profile;
+      const providerIdentity = identity;
+      const providerSettings = settings;
+      const providerGeneration = generation;
+      const revision = recoveryRevision;
+      const guard = (): void => {
+        if (
+          disposed ||
+          owner !== providerOwner ||
+          profile !== providerProfile ||
+          identity !== providerIdentity ||
+          settings !== providerSettings ||
+          generation !== providerGeneration ||
+          recoveryRevision !== revision
+        ) {
+          throw new ExecutionStoppedError('provider_lost');
+        }
+        try {
+          // Read-only history needs the panel owner, not a registered execution lease.
+          providerOwner?.guard();
+        } catch {
+          throw new ExecutionStoppedError('provider_lost');
+        }
+      };
       const deadline = Date.now() + 30_000;
       const cursors = new Set<string>();
       let cursor: string | undefined = undefined;
       let fence: BrowserProviderStatusResult['unresolvedFence'] = undefined;
       try {
         do {
-          if (disposed || Date.now() >= deadline) {
+          guard();
+          if (Date.now() >= deadline) {
             throw new ExecutionStoppedError('provider_unavailable');
           }
           // eslint-disable-next-line no-await-in-loop -- Follow bounded history pages without granting execution.
-          const page = await connection.requestBrowserProviderStatus(cursor);
-          if (page.providerId !== identity?.providerId) {
+          const page = await connection.requestBrowserProviderStatus(cursor, providerIdentity);
+          guard();
+          if (page.providerId !== providerIdentity?.providerId) {
             throw new ExecutionStoppedError('owner_mismatch');
           }
           fence = page.unresolvedFence ?? fence;
           for (const job of page.jobs) {
+            guard();
             // Status pages update display state, but never acknowledge approval or grant a lease.
             consumeJob(job, false);
           }
@@ -459,51 +492,79 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
             cursors.add(cursor);
           }
         } while (cursor !== undefined);
+        guard();
         lastStatus = { fence: structuredClone(fence) };
         publish({ unresolvedFence: fence });
         return fence;
+      } catch (error) {
+        guard();
+        throw error;
       } finally {
         statusRequest = undefined;
       }
     })();
     return statusRequest;
   };
-  const register = (recovery?: BrowserProviderRegistration['recovery']): Promise<void> => {
-    registering ??= (async () => {
+  const register = (
+    recovery?: BrowserProviderRegistration['recovery']
+  ): Promise<'cancelled' | undefined> => {
+    registering ??= (async (): Promise<'cancelled' | undefined> => {
+      const providerOwner = owner;
+      const providerProfile = profile;
+      const providerIdentity = identity;
+      const providerSettings = settings;
+      const guard = (): void => {
+        // Registration changes its own generation and transport state, not its owning lifetime.
+        if (
+          disposed ||
+          owner !== providerOwner ||
+          profile !== providerProfile ||
+          identity !== providerIdentity ||
+          settings !== providerSettings
+        ) {
+          throw new ExecutionStoppedError('provider_lost');
+        }
+        try {
+          providerOwner?.guard();
+        } catch {
+          throw new ExecutionStoppedError('provider_lost');
+        }
+      };
       try {
         if (
-          profile === undefined ||
-          identity === undefined ||
-          disposed ||
-          settings?.enabled !== true
+          providerProfile === undefined ||
+          providerIdentity === undefined ||
+          providerSettings?.enabled !== true
         ) {
-          return;
+          return 'cancelled';
         }
-        profile.owner.guard();
+        guard();
         publish({
           message: 'Connecting the enabled browser provider. Keep this panel open.',
           phase: 'connecting',
         });
+        guard();
         try {
           await connection.registerBrowserProvider({
             generation,
-            label: identity.label,
-            providerId: identity.providerId,
-            providerProof: identity.providerProof,
+            label: providerIdentity.label,
+            providerId: providerIdentity.providerId,
+            providerProof: providerIdentity.providerProof,
             ...(recovery === undefined ? {} : { recovery }),
           });
         } catch (error) {
-          // A rejected registration still installs the stable proof for read-only status discovery.
+          guard();
+          // A rejected registration can still leave an authoritative recovery fence.
           const fence = await refreshStatus();
+          guard();
           needsRecovery ||= fence !== undefined;
           throw error;
         }
+        guard();
         await refreshStatus();
-        if (disposed || !settings.enabled) {
-          unavailable('provider_unavailable');
-          return;
-        }
+        guard();
         await coordinator.refresh();
+        guard();
         const execution = coordinator.getSnapshot();
         if (
           execution.quarantinedTabIds.length > 0 ||
@@ -512,6 +573,7 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           needsRecovery = true;
           unavailable('effects_uncertain', true);
         }
+        guard();
         publish({
           message: needsRecovery
             ? (execution.blockedReason ??
@@ -520,16 +582,34 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           phase: restingPhase(),
         });
       } catch (error) {
+        try {
+          guard();
+        } catch {
+          return 'cancelled';
+        }
+        if (error instanceof ExecutionStoppedError && error.reason === 'provider_lost') {
+          // Recovery must stop too; background registration callers can ignore this outcome.
+          return 'cancelled';
+        }
         reportError(error);
       } finally {
         registering = undefined;
       }
+      return undefined;
     })();
     return registering;
   };
   const onState = (state: BrowserProviderState): void => {
     if (disposed) {
       return;
+    }
+    // Matching lease renewals preserve read-only work; transport and binding changes invalidate it.
+    if (
+      state.status !== 'registered' ||
+      state.lease.providerId !== identity?.providerId ||
+      state.lease.generation !== generation
+    ) {
+      recoveryRevision += 1;
     }
     if (state.status === 'registered') {
       if (
@@ -899,6 +979,8 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
       work: undefined,
     };
     current = invocation;
+    // An invocation can finish while readiness awaits status or tab access.
+    recoveryRevision += 1;
     jobs.set(message.job.jobId, message.job);
     publish({
       message: 'Recording the accepted browser task before tab consent.',
@@ -1134,6 +1216,18 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
     })();
     return starting;
   };
+  const getRecoveryTabIds = async (
+    fence: BrowserProviderStatusResult['unresolvedFence'],
+    guard: () => void
+  ): Promise<number[]> => {
+    const tabs = await browser.tabs.query({});
+    guard();
+    if (fence?.tabId !== undefined && tabs.some(tab => tab.id === fence.tabId)) {
+      throw new ExecutionStoppedError('tab_lost');
+    }
+    // Include every open ID, even if an affected tab navigated to an uninspectable address.
+    return tabs.flatMap(tab => (tab.id === undefined ? [] : [tab.id]));
+  };
   const approvalRequests = new WeakSet<Invocation>();
   return {
     approve: async (jobId: string, tabId: number): Promise<void> => {
@@ -1222,13 +1316,124 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
       }
     },
     getSnapshot: (): BrowserTaskProviderSnapshot => snapshot,
+    prepareRecovery: async (): Promise<BrowserRecoveryReadiness> => {
+      const providerOwner = owner;
+      const providerSettings = settings;
+      const providerGeneration = generation;
+      const revision = recoveryRevision;
+      const guard = (): void => {
+        if (coordinator.getSnapshot().delegationUnavailableReason !== undefined) {
+          throw new BrowserPersistenceError(
+            'unsupported',
+            'Recovery requires Web Locks. Restore browser Web Locks support before recovering.'
+          );
+        }
+        if (disposed || providerOwner === undefined || owner !== providerOwner) {
+          throw new BrowserPersistenceError(
+            'owner_mismatch',
+            'This panel no longer owns the browser provider. Reopen the signed-in panel before checking recovery.'
+          );
+        }
+        if (settings?.enabled !== true) {
+          throw new BrowserPersistenceError(
+            'invalid_request',
+            'Enable CLI tasks in the signed-in panel before checking recovery.'
+          );
+        }
+        if (current !== undefined) {
+          throw new BrowserPersistenceError(
+            'invalid_request',
+            'Browser actions are still unwinding. Wait before recovery.'
+          );
+        }
+        if (
+          recovering ||
+          registering !== undefined ||
+          revision !== recoveryRevision ||
+          settings !== providerSettings ||
+          generation !== providerGeneration
+        ) {
+          throw new BrowserPersistenceError(
+            'invalid_request',
+            'The browser provider changed. Wait for it to settle, then check recovery again.'
+          );
+        }
+        try {
+          providerOwner.guard();
+        } catch {
+          throw new BrowserPersistenceError(
+            'owner_mismatch',
+            'This panel no longer owns the browser provider. Use the owning panel to check recovery.'
+          );
+        }
+      };
+      let reason =
+        'Recovery status could not be retrieved. Reconnect and retrieve status before checking recovery again.';
+      const notReady = (error: unknown): BrowserRecoveryReadiness => {
+        if (error instanceof BrowserPersistenceError) {
+          ({ message: reason } = error);
+        } else if (error instanceof ExecutionStoppedError && error.reason === 'tab_lost') {
+          reason =
+            'Close the affected tab before recovery. Status retrieval cannot approve execution.';
+        } else if (error instanceof ExecutionStoppedError && error.reason === 'owner_mismatch') {
+          reason =
+            'Recovery status belongs to another provider. Reopen the owning signed-in panel before checking recovery.';
+        } else if (
+          error instanceof BrowserProviderError &&
+          error.code === 'provider_unavailable' &&
+          error.retryable
+        ) {
+          reason =
+            'Recovery status is unavailable. Reopen the signed-in panel and retrieve status before checking recovery again.';
+        } else if (error instanceof BrowserProviderError && !error.retryable) {
+          reason = `Recovery status is unavailable: ${error.code}. Restore provider access before checking recovery again.`;
+        }
+        // A stale check must not change the current invocation or publish recovery authority.
+        return { ready: false, reason };
+      };
+      try {
+        guard();
+        // An earlier status request can predate this preparation's provider state.
+        await statusRequest;
+        guard();
+        const fence = await refreshStatus();
+        guard();
+        reason =
+          'Open tabs could not be checked. Restore browser tab access before checking recovery again.';
+        // Check remote closure before retrying releases, then enumerate again under the native lock.
+        await getRecoveryTabIds(fence, guard);
+        let tabFailure: BrowserRecoveryReadiness | undefined;
+        const readiness = await coordinator.prepareRecovery(async () => {
+          try {
+            return await getRecoveryTabIds(fence, guard);
+          } catch (error) {
+            tabFailure = notReady(error);
+            throw error;
+          }
+        });
+        if (readiness.ready) {
+          guard();
+        }
+        return tabFailure ?? readiness;
+      } catch (error) {
+        try {
+          guard();
+        } catch (lifecycleError) {
+          return notReady(lifecycleError);
+        }
+        return notReady(error);
+      }
+    },
     recover: async (): Promise<void> => {
       if (recovering || disposed || owner === undefined || settings?.enabled !== true) {
         return;
       }
       recovering = true;
+      recoveryRevision += 1;
       try {
-        await registering;
+        if ((await registering) === 'cancelled') {
+          return;
+        }
         let fence: BrowserProviderStatusResult['unresolvedFence'];
         try {
           fence = await refreshStatus();
@@ -1238,7 +1443,9 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           }
           // A normal registration attempt installs the proof for status; it cannot clear a retained fence.
           const previousStatus = lastStatus;
-          await register();
+          if ((await register()) === 'cancelled') {
+            return;
+          }
           if (lastStatus === undefined || lastStatus === previousStatus) {
             throw new ExecutionStoppedError('provider_unavailable');
           }
@@ -1253,25 +1460,21 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           return;
         }
         owner.guard();
-        const recovery = await coordinator.recover(async () => {
-          const tabs = await browser.tabs.query({});
-          owner?.guard();
-          if (disposed || settings?.enabled !== true || current !== undefined) {
-            throw new ExecutionStoppedError('provider_unavailable');
-          }
-          if (fence?.tabId !== undefined && tabs.some(tab => tab.id === fence.tabId)) {
-            throw new ExecutionStoppedError('tab_lost');
-          }
-          // Include every open ID, even if an affected tab navigated to an uninspectable address.
-          return tabs.flatMap(tab => (tab.id === undefined ? [] : [tab.id]));
-        });
+        const recovery = await coordinator.recover(() =>
+          getRecoveryTabIds(fence, () => {
+            owner?.guard();
+            if (disposed || settings?.enabled !== true || current !== undefined) {
+              throw new ExecutionStoppedError('provider_unavailable');
+            }
+          })
+        );
         if (!recovery.recovered) {
           publish({ message: recovery.reason, phase: 'recovery' });
           return;
         }
         unavailable('provider_unavailable');
         needsRecovery = false;
-        await register(
+        const registration = await register(
           fence === undefined
             ? undefined
             : {
@@ -1281,6 +1484,9 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
                 ...(fence.tabId === undefined ? {} : { tabId: fence.tabId }),
               }
         );
+        if (registration === 'cancelled') {
+          return;
+        }
         assertLease();
         publish({
           message:
@@ -1288,6 +1494,9 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           phase: 'idle',
         });
       } catch (error) {
+        if (error instanceof ExecutionStoppedError && error.reason === 'provider_lost') {
+          return;
+        }
         needsRecovery = true;
         if (error instanceof ExecutionStoppedError && error.reason === 'tab_lost') {
           publish({
@@ -1327,6 +1536,7 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
       if (profile === undefined || disposed) {
         return;
       }
+      recoveryRevision += 1;
       if (!next.enabled) {
         unavailable('provider_unavailable', current?.started === true);
       }

--- a/apps/extension/entrypoints/sidepanel/browser-task-provider.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider.tsx
@@ -1,0 +1,1414 @@
+/* eslint-disable max-lines, init-declarations, unicorn/no-useless-undefined, import/max-dependencies, typescript/consistent-type-definitions -- Owner admission initializes pending handles; TypeScript requires an explicit value for empty deferred settlement. */
+import { browser, storage } from '#imports';
+import {
+  browserFailureReasonSchema,
+  browserProviderInboundMessageSchema,
+} from '@kilocode/cloud-agent-sdk/schemas';
+import type {
+  BrowserJobSnapshot,
+  BrowserProviderInboundMessage,
+  BrowserResult,
+} from '@kilocode/cloud-agent-sdk/schemas';
+import { BrowserProviderError } from '@kilocode/cloud-agent-sdk/user-web-connection';
+import type {
+  BrowserProviderConnection,
+  BrowserProviderRegistration,
+  BrowserProviderState,
+  BrowserProviderStatusResult,
+  UserWebConnection,
+} from '@kilocode/cloud-agent-sdk/user-web-connection';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import type { ReactNode } from 'react';
+import type { AgentConversationEvent } from '@/src/shared/agent-conversation';
+import { MEMORY_SETTINGS_STORAGE_KEY } from '@/src/shared/agent-memory-settings';
+import { ExecutionStoppedError } from '@/src/shared/agent-tool-results';
+import { WORKFLOW_SETTINGS_STORAGE_KEY } from '@/src/shared/agent-workflows-storage';
+import { AUTH_STORAGE_KEY, getKiloApiBaseUrl } from '@/src/shared/auth';
+import type { StoredAuth } from '@/src/shared/auth';
+import {
+  BrowserPersistenceError,
+  loadBrowserProvider,
+  saveBrowserProviderSettings,
+} from '@/src/shared/browser-provider-settings';
+import type {
+  BrowserApprovalSettings,
+  BrowserProfileContext,
+  BrowserProviderIdentity,
+  BrowserProviderSettings,
+} from '@/src/shared/browser-provider-settings';
+import { openBrowserTaskStore } from '@/src/shared/browser-task-store';
+import type { BrowserTaskStore, StoredBrowserJob } from '@/src/shared/browser-task-store';
+import { REMOTE_MCP_STORAGE_KEY } from '@/src/shared/remote-mcp-storage';
+import { WEB_MCP_SETTINGS_STORAGE_KEY } from '@/src/shared/web-mcp-settings';
+import { getBrowserExecutionCoordinator } from './browser-execution-lock';
+import type { BrowserExecutionCoordinator, BrowserExecutionLease } from './browser-execution-lock';
+import {
+  browserTaskFailure,
+  getBrowserTaskTabs,
+  readBrowserTaskSettings,
+  runBrowserTask,
+} from './browser-task-runner';
+import type { BrowserTaskStorage } from './browser-task-runner';
+import { useGatewayModels } from './use-gateway-models';
+
+type Delivery = Extract<BrowserProviderInboundMessage, { type: 'provider_job' }>;
+type FailureReason = Exclude<BrowserResult['reason'], 'completed'>;
+type Consent = {
+  settings: BrowserApprovalSettings;
+  supportsImages: boolean;
+  tab: NonNullable<BrowserJobSnapshot['approvedTab']>;
+};
+type Connection = BrowserProviderConnection & Pick<UserWebConnection, 'retain' | 'retryConnection'>;
+type ObservableStorage = BrowserTaskStorage & {
+  watch: (key: `local:${string}`, listener: () => void) => () => void;
+};
+type VisibleSettings = Omit<BrowserApprovalSettings, 'remoteMcpServers'> & {
+  remoteMcpServers: Pick<
+    BrowserApprovalSettings['remoteMcpServers'][number],
+    'id' | 'displayName' | 'url' | 'enabled' | 'allowInSafeMode'
+  >[];
+};
+export type BrowserTaskProviderSnapshot = {
+  readonly active:
+    | {
+        goal: string;
+        ownerLabel: string;
+        job: BrowserJobSnapshot;
+        approval: { tab: Consent['tab']; settings: VisibleSettings } | undefined;
+      }
+    | undefined;
+  readonly jobs: readonly BrowserJobSnapshot[];
+  readonly message: string;
+  readonly phase:
+    | 'connecting'
+    | 'disabled'
+    | 'idle'
+    | 'owned_elsewhere'
+    | 'unsupported'
+    | 'unavailable'
+    | 'awaiting_approval'
+    | 'waiting'
+    | 'running'
+    | 'interrupted'
+    | 'recovery';
+  readonly profile: Pick<BrowserProviderIdentity, 'label' | 'providerId'> | undefined;
+  readonly result: BrowserResult | undefined;
+  readonly retryable: boolean;
+  readonly settings: BrowserProviderSettings | undefined;
+  readonly unresolvedFence: BrowserProviderStatusResult['unresolvedFence'];
+};
+
+type Invocation = {
+  abort: AbortController;
+  consent: ReturnType<typeof Promise.withResolvers<Consent | undefined>>;
+  delivery: Delivery;
+  events: AgentConversationEvent[];
+  lease: BrowserExecutionLease | undefined;
+  permissionChecks: number;
+  record: StoredBrowserJob | undefined;
+  relay: BrowserJobSnapshot;
+  running: ReturnType<typeof Promise.withResolvers<BrowserJobSnapshot | undefined>>;
+  selected: Consent | undefined;
+  started: boolean;
+  terminal: ReturnType<typeof Promise.withResolvers<BrowserJobSnapshot | undefined>>;
+  timer: ReturnType<typeof setTimeout> | undefined;
+  work: Promise<void> | undefined;
+};
+
+const jobBinding = (job: BrowserJobSnapshot) => ({
+  browserTaskId: job.browserTaskId,
+  generation: job.generation,
+  invocationId: job.invocationId,
+  jobId: job.jobId,
+  providerId: job.providerId,
+});
+const sameJob = (left: BrowserJobSnapshot, right: BrowserJobSnapshot): boolean =>
+  JSON.stringify(jobBinding(left)) === JSON.stringify(jobBinding(right)) &&
+  left.payloadFingerprint === right.payloadFingerprint;
+const sameTab = (
+  left: BrowserJobSnapshot['approvedTab'],
+  right: BrowserJobSnapshot['approvedTab']
+): boolean =>
+  left !== undefined &&
+  right !== undefined &&
+  left.tabId === right.tabId &&
+  left.url === right.url &&
+  left.title === right.title &&
+  left.effectiveMode === right.effectiveMode;
+const visibleSettings = (settings: BrowserApprovalSettings): VisibleSettings => ({
+  ...settings,
+  remoteMcpServers: settings.remoteMcpServers.map(
+    ({ allowInSafeMode, displayName, enabled, id, url }) => ({
+      allowInSafeMode,
+      displayName,
+      enabled,
+      id,
+      url,
+    })
+  ),
+});
+const failureReason = (error: unknown): FailureReason => {
+  let reason = 'runner_failed';
+  if (error instanceof ExecutionStoppedError) {
+    ({ reason } = error);
+  }
+  if (error instanceof BrowserProviderError || error instanceof BrowserPersistenceError) {
+    reason = error.code;
+  }
+  const parsed = browserFailureReasonSchema.safeParse(reason);
+  return parsed.success ? parsed.data : 'provider_unavailable';
+};
+
+export type BrowserTaskProviderOptions = {
+  readonly auth: StoredAuth;
+  readonly connection: Connection;
+  readonly organizationId: string | undefined;
+  readonly coordinator?: BrowserExecutionCoordinator;
+  readonly storageArea?: ObservableStorage;
+  readonly supportsImages?: (model: string) => boolean;
+};
+
+/** Snapshots never start work. Only a newly persisted delivery and explicit consent can do so. */
+export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOptions) => {
+  const { auth, connection, organizationId } = options;
+  const coordinator = options.coordinator ?? getBrowserExecutionCoordinator();
+  const storageArea = options.storageArea ?? storage;
+  const listeners = new Set<() => void>();
+  const jobs = new Map<string, BrowserJobSnapshot>();
+  const cleanup: (() => void)[] = [];
+  let current: Invocation | undefined = undefined;
+  let owner: BrowserExecutionLease | undefined = undefined;
+  let profile: BrowserProfileContext | undefined = undefined;
+  let identity: BrowserProviderIdentity | undefined = undefined;
+  let store: BrowserTaskStore | undefined = undefined;
+  let settings: BrowserProviderSettings | undefined = undefined;
+  let disposed = false;
+  let needsRecovery = false;
+  let generation = 0;
+  let revokedGeneration = 0;
+  let leaseUntil = 0;
+  let leaseTimer: ReturnType<typeof setTimeout> | undefined = undefined;
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined = undefined;
+  let registering: Promise<void> | undefined = undefined;
+  let starting: Promise<void> | undefined = undefined;
+  let statusRequest: Promise<BrowserProviderStatusResult['unresolvedFence']> | undefined =
+    undefined;
+  let recovering = false;
+  let snapshot: BrowserTaskProviderSnapshot = {
+    active: undefined,
+    jobs: [],
+    message: 'CLI tasks require an enabled, signed-in open panel.',
+    phase: 'connecting',
+    profile: undefined,
+    result: undefined,
+    retryable: false,
+    settings: undefined,
+    unresolvedFence: undefined,
+  };
+  const publish = (change: Partial<BrowserTaskProviderSnapshot> = {}): void => {
+    for (const [id, job] of jobs) {
+      if (Date.parse(job.expiresAt) <= Date.now()) {
+        jobs.delete(id);
+      }
+    }
+    // Consumers receive copies, never mutable references to approved execution settings.
+    snapshot = structuredClone({
+      ...snapshot,
+      active:
+        current === undefined
+          ? undefined
+          : {
+              approval:
+                current.selected === undefined
+                  ? undefined
+                  : {
+                      settings: visibleSettings(current.selected.settings),
+                      tab: current.selected.tab,
+                    },
+              goal: current.delivery.goal,
+              job: current.relay,
+              ownerLabel: current.delivery.ownerLabel,
+            },
+      jobs: [...jobs.values()],
+      profile:
+        identity === undefined
+          ? undefined
+          : { label: identity.label, providerId: identity.providerId },
+      settings,
+      ...change,
+    });
+    for (const listener of listeners) {
+      listener();
+    }
+  };
+  const restingPhase = (): BrowserTaskProviderSnapshot['phase'] => {
+    if (settings?.enabled !== true) {
+      return 'disabled';
+    }
+    if (needsRecovery) {
+      return 'recovery';
+    }
+    if (current !== undefined) {
+      return snapshot.phase;
+    }
+    return leaseUntil > Date.now() ? 'idle' : 'connecting';
+  };
+  const stopInvocation = (reason: FailureReason): void => {
+    if (current === undefined || current.abort.signal.aborted) {
+      return;
+    }
+    const uncertain = current.started && reason !== 'cancelled' && reason !== 'approval_denied';
+    current.abort.abort(
+      new ExecutionStoppedError(
+        reason,
+        reason === 'cancelled' ? 'cancelled' : 'interrupted',
+        uncertain
+      )
+    );
+    current.consent.resolve(undefined);
+    current.running.resolve(undefined);
+  };
+  const unavailable = (reason: FailureReason, effectsUncertain = false): void => {
+    stopInvocation(reason);
+    leaseUntil = 0;
+    revokedGeneration = Math.max(revokedGeneration, generation);
+    clearTimeout(leaseTimer);
+    const affected = current?.selected?.tab.tabId;
+    const lease = current?.lease ?? owner;
+    if (effectsUncertain && affected !== undefined && lease !== undefined) {
+      needsRecovery = true;
+      // The safety record is independent of auth cleanup and contains no account history.
+      void (async () => {
+        try {
+          await lease.quarantine(affected);
+        } catch {
+          publish({
+            message: 'Browser safety storage is unavailable. Restore storage before recovery.',
+            phase: 'recovery',
+          });
+        }
+      })();
+    }
+    if (identity !== undefined && generation > 0) {
+      try {
+        connection.markBrowserProviderUnavailable({
+          effectsUncertain,
+          generation,
+          providerId: identity.providerId,
+          reason,
+        });
+      } catch {
+        /* The relay lease, not teardown delivery, settles disconnected work. */
+      }
+    }
+  };
+  const invocationErrors = new WeakMap<Invocation, string>();
+  const reportError = (error: unknown): void => {
+    const message =
+      error instanceof BrowserPersistenceError
+        ? error.message
+        : `Browser provider unavailable: ${failureReason(error)}. Retrieve status before explicit recovery.`;
+    if (current !== undefined) {
+      invocationErrors.set(current, message);
+    }
+    publish({
+      message,
+      phase: needsRecovery ? 'recovery' : 'unavailable',
+      retryable:
+        error instanceof BrowserPersistenceError || error instanceof BrowserProviderError
+          ? error.retryable
+          : false,
+    });
+  };
+  const assertLease = (): void => {
+    owner?.guard();
+    if (disposed || owner === undefined || settings?.enabled !== true) {
+      throw new ExecutionStoppedError('provider_unavailable');
+    }
+    const state = connection.getBrowserProviderState();
+    if (
+      leaseUntil <= Date.now() ||
+      generation <= revokedGeneration ||
+      state.status !== 'registered' ||
+      state.lease.generation !== generation ||
+      state.lease.providerId !== identity?.providerId
+    ) {
+      throw new ExecutionStoppedError('lease_expired');
+    }
+  };
+  const guardInvocation = (invocation: Invocation, running = false): void => {
+    invocation.abort.signal.throwIfAborted();
+    assertLease();
+    if (
+      current !== invocation ||
+      invocation.relay.generation !== generation ||
+      invocation.relay.result !== undefined
+    ) {
+      throw new ExecutionStoppedError('provider_lost');
+    }
+    if (invocation.permissionChecks > 0) {
+      // Frozen consent cannot authorize actions while live permissions remain unverified.
+      throw new ExecutionStoppedError('permission_denied');
+    }
+    const deadline = running
+      ? invocation.relay.deadlines.execution
+      : invocation.delivery.job.deadlines.approval;
+    if (
+      deadline === undefined ||
+      Date.parse(deadline) <= Date.now() ||
+      Date.parse(invocation.relay.expiresAt) <= Date.now()
+    ) {
+      throw new ExecutionStoppedError(running ? 'execution_timeout' : 'approval_timeout');
+    }
+    if (
+      running &&
+      (invocation.relay.status !== 'running' ||
+        !sameTab(invocation.relay.approvedTab, invocation.selected?.tab))
+    ) {
+      throw new ExecutionStoppedError('tab_lost');
+    }
+  };
+  const phaseDeadline = (invocation: Invocation, deadline: string, reason: FailureReason): void => {
+    clearTimeout(invocation.timer);
+    invocation.timer = setTimeout(
+      () => {
+        needsRecovery = true;
+        unavailable(reason, invocation.started);
+        publish({
+          message: `Browser task stopped: ${reason}. Retrieve status before recovery.`,
+          phase: 'interrupted',
+        });
+      },
+      Math.max(
+        0,
+        Math.min(Date.parse(deadline), Date.parse(invocation.relay.expiresAt)) - Date.now()
+      )
+    );
+  };
+  const consumeJob = (job: BrowserJobSnapshot): void => {
+    const previous = jobs.get(job.jobId);
+    if (previous !== undefined && (!sameJob(previous, job) || previous.result !== undefined)) {
+      return;
+    }
+    jobs.set(job.jobId, job);
+    if (current !== undefined && sameJob(current.relay, job)) {
+      if (current.relay.result !== undefined) {
+        return;
+      }
+      if (job.result !== undefined) {
+        current.relay = job;
+        current.terminal.resolve(job);
+        stopInvocation(
+          job.result.reason === 'completed' ? 'provider_unavailable' : job.result.reason
+        );
+        publish({ result: job.result });
+      } else if (job.status === 'running') {
+        if (current.selected === undefined || !sameTab(job.approvedTab, current.selected.tab)) {
+          needsRecovery = true;
+          unavailable('tab_lost', current.started);
+          return;
+        }
+        current.relay = job;
+        current.running.resolve(job);
+      }
+    }
+    publish();
+  };
+  let lastStatus: { fence: BrowserProviderStatusResult['unresolvedFence'] } | undefined;
+  const refreshStatus = (): Promise<BrowserProviderStatusResult['unresolvedFence']> => {
+    statusRequest ??= (async () => {
+      const deadline = Date.now() + 30_000;
+      const cursors = new Set<string>();
+      let cursor: string | undefined = undefined;
+      let fence: BrowserProviderStatusResult['unresolvedFence'] = undefined;
+      try {
+        do {
+          if (disposed || Date.now() >= deadline) {
+            throw new ExecutionStoppedError('provider_unavailable');
+          }
+          // eslint-disable-next-line no-await-in-loop -- Follow bounded history pages without granting execution.
+          const page = await connection.requestBrowserProviderStatus(cursor);
+          if (page.providerId !== identity?.providerId) {
+            throw new ExecutionStoppedError('owner_mismatch');
+          }
+          fence = page.unresolvedFence ?? fence;
+          for (const job of page.jobs) {
+            // Historical running rows never acknowledge approval or grant a lease.
+            if (job.result !== undefined || job.generation !== generation) {
+              consumeJob(job);
+            }
+          }
+          cursor = page.nextCursor;
+          if (cursor !== undefined && cursors.has(cursor)) {
+            throw new ExecutionStoppedError('invalid_request');
+          }
+          if (cursor !== undefined) {
+            cursors.add(cursor);
+          }
+        } while (cursor !== undefined);
+        lastStatus = { fence: structuredClone(fence) };
+        publish({ unresolvedFence: fence });
+        return fence;
+      } finally {
+        statusRequest = undefined;
+      }
+    })();
+    return statusRequest;
+  };
+  const register = (recovery?: BrowserProviderRegistration['recovery']): Promise<void> => {
+    registering ??= (async () => {
+      try {
+        if (
+          profile === undefined ||
+          identity === undefined ||
+          disposed ||
+          settings?.enabled !== true
+        ) {
+          return;
+        }
+        profile.owner.guard();
+        publish({
+          message: 'Connecting the enabled browser provider. Keep this panel open.',
+          phase: 'connecting',
+        });
+        try {
+          await connection.registerBrowserProvider({
+            generation,
+            label: identity.label,
+            providerId: identity.providerId,
+            providerProof: identity.providerProof,
+            ...(recovery === undefined ? {} : { recovery }),
+          });
+        } catch (error) {
+          // A rejected registration still installs the stable proof for read-only status discovery.
+          const fence = await refreshStatus();
+          needsRecovery ||= fence !== undefined;
+          throw error;
+        }
+        await refreshStatus();
+        if (disposed || !settings.enabled) {
+          unavailable('provider_unavailable');
+          return;
+        }
+        await coordinator.refresh();
+        const execution = coordinator.getSnapshot();
+        if (
+          execution.quarantinedTabIds.length > 0 ||
+          (execution.delegated === 'idle' && execution.blockedReason !== undefined)
+        ) {
+          needsRecovery = true;
+          unavailable('effects_uncertain', true);
+        }
+        publish({
+          message: needsRecovery
+            ? (execution.blockedReason ??
+              'Retrieve status, close affected tabs, then recover explicitly.')
+            : 'CLI tasks are enabled. Keep this panel open.',
+          phase: restingPhase(),
+        });
+      } catch (error) {
+        reportError(error);
+      } finally {
+        registering = undefined;
+      }
+    })();
+    return registering;
+  };
+  const onState = (state: BrowserProviderState): void => {
+    if (disposed) {
+      return;
+    }
+    if (state.status === 'registered') {
+      if (
+        state.lease.providerId !== identity?.providerId ||
+        state.lease.generation <= revokedGeneration
+      ) {
+        return;
+      }
+      if (current !== undefined && state.lease.generation !== generation) {
+        stopInvocation('provider_lost');
+        needsRecovery = true;
+      }
+      if (leaseUntil !== 0 && leaseUntil <= Date.now() && state.lease.generation === generation) {
+        unavailable('lease_expired', current?.started === true);
+        return;
+      }
+      ({ generation } = state.lease);
+      leaseUntil = Math.min(Date.parse(state.lease.leaseExpiresAt), Date.now() + 15_000);
+      clearTimeout(leaseTimer);
+      leaseTimer = setTimeout(
+        () => {
+          needsRecovery ||= current !== undefined;
+          unavailable('lease_expired', current?.started === true);
+          publish({
+            message: 'The provider lease expired. Retrieve status before recovery.',
+            phase: 'interrupted',
+          });
+        },
+        Math.max(0, leaseUntil - Date.now())
+      );
+      return;
+    }
+    revokedGeneration = Math.max(revokedGeneration, generation);
+    leaseUntil = 0;
+    clearTimeout(leaseTimer);
+    if (state.status === 'ready') {
+      // Clear the SDK's reconnect registration before it can advertise a quarantined profile.
+      if (settings?.enabled === true && needsRecovery) {
+        unavailable('provider_unavailable');
+      }
+      if (settings?.enabled === true && !needsRecovery) {
+        void register();
+      }
+      return;
+    }
+    if (current !== undefined) {
+      needsRecovery = true;
+      const parsed =
+        state.status === 'unavailable'
+          ? browserFailureReasonSchema.safeParse(state.reason)
+          : undefined;
+      stopInvocation(parsed?.success === true ? parsed.data : 'provider_lost');
+    }
+    if (settings?.enabled !== true) {
+      return;
+    }
+    let phase: BrowserTaskProviderSnapshot['phase'] = needsRecovery ? 'recovery' : 'connecting';
+    if (state.status === 'unavailable' && !needsRecovery) {
+      phase = 'unavailable';
+    }
+    if (state.status === 'unavailable' && state.reason === 'unsupported') {
+      phase = 'unsupported';
+    }
+    publish({
+      message:
+        state.status === 'unavailable'
+          ? `Browser provider unavailable: ${state.reason}. Retrieve status before explicit recovery.`
+          : 'The relay connection is unavailable. Reconnect and retrieve status; no browser actions will replay.',
+      phase,
+      retryable: state.status === 'unavailable' ? state.retryable : true,
+    });
+  };
+  const runInvocation = async (invocation: Invocation): Promise<void> => {
+    const taskStore = store;
+    const providerOwner = owner;
+    if (taskStore === undefined || providerOwner === undefined) {
+      return;
+    }
+    let result = browserTaskFailure(invocation.relay, 'provider_unavailable');
+    let uncertain = false;
+    let quiescence: BrowserJobSnapshot | undefined;
+    try {
+      const accepted = await taskStore.accept(invocation.delivery);
+      invocation.record = accepted.job;
+      invocation.events = await taskStore.history(
+        invocation.relay.browserTaskId,
+        invocation.delivery.ownerLabel
+      );
+      if (accepted.kind === 'existing') {
+        needsRecovery = true;
+        publish({ result: accepted.job.snapshot.result });
+        throw new ExecutionStoppedError('provider_unavailable');
+      }
+      guardInvocation(invocation);
+      publish({
+        message: 'Approve one specific tab for this owner and goal, or reject the task.',
+        phase: 'awaiting_approval',
+      });
+      const consent = await invocation.consent.promise;
+      guardInvocation(invocation);
+      if (consent === undefined) {
+        throw new ExecutionStoppedError('approval_denied');
+      }
+      invocation.selected = consent;
+      publish({
+        message: 'Waiting for local browser runs to drain. The approval deadline still applies.',
+        phase: 'waiting',
+      });
+      const admission = await coordinator.acquireDelegated(
+        providerOwner,
+        invocation.delivery.ownerLabel,
+        invocation.abort.signal
+      );
+      if (!admission.admitted) {
+        invocation.abort.signal.throwIfAborted();
+        throw new ExecutionStoppedError('provider_unavailable');
+      }
+      invocation.lease = admission.lease;
+      guardInvocation(invocation);
+      const tabs = await getBrowserTaskTabs();
+      if (!tabs.some(tab => tab.id === consent.tab.tabId)) {
+        throw new ExecutionStoppedError('tab_lost');
+      }
+      invocation.record = await taskStore.approve(
+        invocation.relay.invocationId,
+        consent.tab,
+        consent.settings
+      );
+      guardInvocation(invocation);
+      connection.approveBrowserProviderJob({
+        ...jobBinding(invocation.relay),
+        approval: { decision: 'approved', tab: consent.tab },
+      });
+      const running = await invocation.running.promise;
+      guardInvocation(invocation, true);
+      if (running === undefined || running.deadlines.execution === undefined) {
+        throw new ExecutionStoppedError('provider_lost');
+      }
+      phaseDeadline(invocation, running.deadlines.execution, 'execution_timeout');
+      invocation.started = true;
+      publish({
+        message:
+          'This CLI task owns browser control. Stop prevents future actions, not actions already issued.',
+        phase: 'running',
+      });
+      const completed = await runBrowserTask({
+        abort: invocation.abort,
+        apiBaseUrl: getKiloApiBaseUrl(),
+        events: invocation.events,
+        executionGuard: () => {
+          guardInvocation(invocation, true);
+        },
+        fetch: (input, init) => globalThis.fetch(input, init),
+        job: running,
+        lease: admission.lease,
+        remoteFetch: globalThis.fetch,
+        settings: consent.settings,
+        storage: storageArea,
+        supportsImages: consent.supportsImages,
+        token: auth.token,
+      });
+      invocation.events = completed.events;
+      uncertain = completed.outcome.effectsUncertain;
+      ({ result } = completed);
+    } catch (error) {
+      const stopped = error instanceof ExecutionStoppedError ? error : undefined;
+      uncertain = stopped?.effectsUncertain ?? invocation.started;
+      result = browserTaskFailure(invocation.relay, failureReason(error), uncertain);
+      if (stopped === undefined) {
+        reportError(error);
+      }
+    }
+    try {
+      uncertain ||= invocation.relay.result?.effectsUncertain === true && invocation.started;
+      if (uncertain && invocation.selected !== undefined) {
+        needsRecovery = true;
+        await (invocation.lease ?? providerOwner).quarantine(invocation.selected.tab.tabId);
+      }
+      if (invocation.record === undefined) {
+        unavailable(result.reason === 'completed' ? 'provider_unavailable' : result.reason);
+      } else {
+        // A pre-approval relay fence does not imply an issued local action or invent a tab.
+        // Record observed local execution; the relay result remains the displayed authority.
+        const persistedResult =
+          invocation.record.approval === null ? result : (invocation.relay.result ?? result);
+        const saved = await taskStore.finish(
+          invocation.relay.invocationId,
+          persistedResult,
+          invocation.events
+        );
+        result = invocation.relay.result ?? saved.snapshot.result ?? result;
+      }
+      if (
+        invocation.relay.result === undefined &&
+        invocation.selected !== undefined &&
+        invocation.started
+      ) {
+        try {
+          assertLease();
+          connection.sendBrowserProviderResult({
+            ...jobBinding(invocation.relay),
+            result,
+            tab: invocation.selected.tab,
+          });
+        } catch {
+          needsRecovery = true;
+          // Never buffer or resend terminal updates through a later generation.
+        }
+      } else if (
+        invocation.relay.result === undefined &&
+        result.reason !== 'approval_denied' &&
+        result.reason !== 'cancelled'
+      ) {
+        unavailable(result.reason === 'completed' ? 'provider_unavailable' : result.reason);
+      }
+      // Rejection and cancellation already request settlement; wait without withdrawing queued work.
+      if (disposed) {
+        invocation.terminal.resolve(undefined);
+      }
+      const timeout = setTimeout(() => {
+        invocation.terminal.resolve(undefined);
+      }, 10_000);
+      const terminal =
+        invocation.relay.result === undefined
+          ? await invocation.terminal.promise
+          : invocation.relay;
+      clearTimeout(timeout);
+      if (
+        !uncertain &&
+        terminal?.result !== undefined &&
+        invocation.record !== undefined &&
+        (terminal.approvedTab === undefined
+          ? !invocation.started
+          : invocation.record.approval !== null &&
+            sameTab(terminal.approvedTab, invocation.selected?.tab))
+      ) {
+        quiescence = terminal;
+      } else {
+        needsRecovery = true;
+      }
+      publish({ result: terminal?.result ?? result });
+    } catch (error) {
+      needsRecovery = true;
+      unavailable('provider_unavailable', invocation.started);
+      reportError(error);
+    } finally {
+      clearTimeout(invocation.timer);
+      invocation.abort.abort(new ExecutionStoppedError('provider_unavailable'));
+      try {
+        await invocation.lease?.release();
+      } catch (error) {
+        quiescence = undefined;
+        needsRecovery = true;
+        reportError(error);
+      }
+      if (current === invocation) {
+        current = undefined;
+      }
+      // Clear the finished owner before quiescence can deliver the next FIFO job.
+      if (!disposed && quiescence !== undefined) {
+        try {
+          connection.quiesceBrowserProviderJob({
+            ...jobBinding(quiescence),
+            ...(quiescence.approvedTab === undefined
+              ? {}
+              : { tabId: quiescence.approvedTab.tabId }),
+          });
+        } catch {
+          needsRecovery = true;
+        }
+      }
+      if (current === undefined) {
+        publish({
+          message:
+            invocationErrors.get(invocation) ??
+            (needsRecovery
+              ? (coordinator.getSnapshot().blockedReason ??
+                'Retrieve status, close affected tabs, and recover explicitly. Old work will not replay.')
+              : 'CLI tasks are enabled. Keep this panel open.'),
+          phase: restingPhase(),
+        });
+      }
+    }
+  };
+  const onMessage = (input: BrowserProviderInboundMessage): void => {
+    const parsed = browserProviderInboundMessageSchema.safeParse(input);
+    if (!parsed.success || disposed) {
+      return;
+    }
+    const message = parsed.data;
+    if (message.type === 'provider_status_result' || message.type === 'provider_lease_ack') {
+      return;
+    }
+    const binding = message.type === 'provider_job' ? message.job : message;
+    if (binding.providerId !== identity?.providerId || binding.generation !== generation) {
+      return;
+    }
+    if (message.type === 'provider_job_cancel') {
+      if (
+        current?.relay.jobId === message.jobId &&
+        current.relay.invocationId === message.invocationId
+      ) {
+        stopInvocation(message.reason);
+      }
+      return;
+    }
+    if (message.type === 'provider_snapshot') {
+      for (const job of message.jobs) {
+        consumeJob(job);
+      }
+      return;
+    }
+    try {
+      assertLease();
+    } catch {
+      return;
+    }
+    if (store === undefined) {
+      return;
+    }
+    if (
+      current?.relay.invocationId === message.job.invocationId ||
+      jobs.get(message.job.jobId)?.result !== undefined
+    ) {
+      const taskStore = store;
+      void (async () => {
+        try {
+          await taskStore.accept(message);
+          const stored = await taskStore.lookup(message.job.invocationId);
+          publish({ result: jobs.get(message.job.jobId)?.result ?? stored.snapshot.result });
+        } catch (error) {
+          unavailable(failureReason(error));
+          reportError(error);
+        }
+      })();
+      return;
+    }
+    if (current !== undefined) {
+      unavailable('invalid_request');
+      return;
+    }
+    if (needsRecovery || recovering) {
+      unavailable('provider_unavailable');
+      return;
+    }
+    if (
+      message.job.deadlines.approval === undefined ||
+      jobs.get(message.job.jobId)?.status === 'running'
+    ) {
+      unavailable('invalid_request');
+      return;
+    }
+    const invocation: Invocation = {
+      abort: new AbortController(),
+      consent: Promise.withResolvers<Consent | undefined>(),
+      delivery: message,
+      events: [],
+      lease: undefined,
+      permissionChecks: 0,
+      record: undefined,
+      relay: message.job,
+      running: Promise.withResolvers<BrowserJobSnapshot | undefined>(),
+      selected: undefined,
+      started: false,
+      terminal: Promise.withResolvers<BrowserJobSnapshot | undefined>(),
+      timer: undefined,
+      work: undefined,
+    };
+    current = invocation;
+    jobs.set(message.job.jobId, message.job);
+    publish({
+      message: 'Recording the accepted browser task before tab consent.',
+      phase: 'connecting',
+    });
+    const deadline = message.job.deadlines.approval;
+    phaseDeadline(invocation, deadline, 'approval_timeout');
+    invocation.work = runInvocation(invocation);
+  };
+  let heartbeatPending = false;
+  const heartbeat = async (): Promise<void> => {
+    if (heartbeatPending) {
+      return;
+    }
+    heartbeatPending = true;
+    try {
+      const deadline = Date.now() + 30_000;
+      const cursors = new Set<string>();
+      let cursor: string | undefined = undefined;
+      do {
+        assertLease();
+        if (Date.now() >= deadline) {
+          throw new ExecutionStoppedError('provider_unavailable');
+        }
+        // eslint-disable-next-line no-await-in-loop -- Relay pages reconcile the queue; they never dispatch work.
+        const page = await connection.heartbeatBrowserProvider(cursor);
+        onMessage(page);
+        cursor = page.nextCursor;
+        if (cursor !== undefined && cursors.has(cursor)) {
+          throw new ExecutionStoppedError('invalid_request');
+        }
+        if (cursor !== undefined) {
+          cursors.add(cursor);
+        }
+      } while (cursor !== undefined);
+    } catch (error) {
+      if (settings?.enabled === true && !disposed) {
+        needsRecovery ||= current !== undefined;
+        unavailable(failureReason(error), current?.started === true);
+        reportError(error);
+      }
+    } finally {
+      heartbeatPending = false;
+    }
+  };
+  const start = (): Promise<void> => {
+    starting ??= (async () => {
+      try {
+        const admission = await coordinator.acquireProviderOwner();
+        if (!admission.admitted) {
+          const unsupported = coordinator.getSnapshot().delegationUnavailableReason;
+          publish({
+            message:
+              unsupported ??
+              'Another panel owns this browser provider. Use that panel to supervise CLI tasks.',
+            phase: unsupported === undefined ? 'owned_elsewhere' : 'unsupported',
+          });
+          return;
+        }
+        owner = admission.lease;
+        if (disposed) {
+          await owner.release();
+          return;
+        }
+        profile = { auth, owner, storageArea };
+        ({ identity, settings } = await loadBrowserProvider(profile));
+        store = await openBrowserTaskStore(profile);
+        if (disposed) {
+          await owner.release();
+          return;
+        }
+        cleanup.push(
+          connection.onBrowserProviderMessage(onMessage),
+          connection.onBrowserProviderStateChange(onState),
+          connection.retain(),
+          coordinator.subscribe(() => {
+            const execution = coordinator.getSnapshot();
+            const quarantined =
+              execution.quarantinedTabIds.length > 0 ||
+              (execution.delegated === 'idle' && execution.blockedReason !== undefined);
+            // The active runner persists its outcome before withdrawing its own execution.
+            if (
+              !disposed &&
+              settings?.enabled === true &&
+              current?.started !== true &&
+              quarantined
+            ) {
+              needsRecovery = true;
+              if (leaseUntil > Date.now()) {
+                unavailable('effects_uncertain');
+              }
+              publish({
+                message: execution.blockedReason ?? 'Close affected tabs before explicit recovery.',
+                phase: 'recovery',
+              });
+            }
+          })
+        );
+        const revokePermissions = (): void => {
+          if (
+            current !== undefined &&
+            (current.selected !== undefined || approvalRequests.has(current))
+          ) {
+            needsRecovery = true;
+            unavailable('permission_denied', current.started);
+          }
+        };
+        const authChanged = (): void => {
+          unavailable('provider_unavailable', current?.started === true);
+          needsRecovery ||= current !== undefined;
+          if (settings !== undefined) {
+            settings = { ...settings, enabled: false };
+          }
+          publish({
+            message:
+              'The account or organization changed. Browser work stopped; enable new work explicitly.',
+            phase: restingPhase(),
+          });
+        };
+        cleanup.push(
+          storageArea.watch(AUTH_STORAGE_KEY, authChanged),
+          storageArea.watch('local:kiloSelectedOrganizationId', authChanged)
+        );
+        const settingsChanged = (): void => {
+          const invocation = current;
+          const approved = invocation?.selected?.settings;
+          if (
+            invocation !== undefined &&
+            approved === undefined &&
+            approvalRequests.has(invocation)
+          ) {
+            // A settings change invalidates pending consent; never install its stale permissions.
+            revokePermissions();
+            return;
+          }
+          if (invocation === undefined || approved === undefined || settings === undefined) {
+            return;
+          }
+          const selected = settings;
+          invocation.permissionChecks += 1;
+          void (async () => {
+            try {
+              const next = await readBrowserTaskSettings(selected, organizationId, storageArea);
+              if (current !== invocation) {
+                return;
+              }
+              const revoked =
+                (approved.memorySettings.autoApproveMemorySaves &&
+                  !next.memorySettings.autoApproveMemorySaves) ||
+                (approved.workflowSettings.allowWorkflowsInSafeMode &&
+                  !next.workflowSettings.allowWorkflowsInSafeMode) ||
+                (approved.workflowSettings.autoApproveWorkflowChanges &&
+                  !next.workflowSettings.autoApproveWorkflowChanges) ||
+                (approved.workflowSettings.autoApproveWorkflowRuns &&
+                  !next.workflowSettings.autoApproveWorkflowRuns) ||
+                (approved.webMcpSettings.allowWebMcpInSafeMode &&
+                  !next.webMcpSettings.allowWebMcpInSafeMode) ||
+                approved.remoteMcpServers.some(server => {
+                  if (!server.enabled) {
+                    return false;
+                  }
+                  const live = next.remoteMcpServers.find(candidate => candidate.id === server.id);
+                  return (
+                    live === undefined ||
+                    !live.enabled ||
+                    live.url !== server.url ||
+                    live.auth.type !== server.auth.type ||
+                    (server.allowInSafeMode && !live.allowInSafeMode) ||
+                    server.cachedTools.some(
+                      tool => !live.cachedTools.some(candidate => candidate.name === tool.name)
+                    )
+                  );
+                });
+              if (revoked) {
+                revokePermissions();
+              }
+            } catch {
+              if (current === invocation) {
+                revokePermissions();
+              }
+            } finally {
+              invocation.permissionChecks -= 1;
+            }
+          })();
+        };
+        for (const key of [
+          MEMORY_SETTINGS_STORAGE_KEY,
+          WORKFLOW_SETTINGS_STORAGE_KEY,
+          WEB_MCP_SETTINGS_STORAGE_KEY,
+          REMOTE_MCP_STORAGE_KEY,
+        ] as const) {
+          cleanup.push(storageArea.watch(key, settingsChanged));
+        }
+        const tabRemoved = (tabId: number): void => {
+          if (current?.selected?.tab.tabId === tabId) {
+            needsRecovery = true;
+            unavailable('tab_lost', current.started);
+          }
+        };
+        const tabUpdated = (tabId: number, info: { url?: string }): void => {
+          if (
+            current?.selected?.tab.tabId === tabId &&
+            info.url !== undefined &&
+            !/^(?:https?|file):\/\//u.test(info.url)
+          ) {
+            tabRemoved(tabId);
+          }
+        };
+        browser.tabs.onRemoved.addListener(tabRemoved);
+        browser.tabs.onUpdated.addListener(tabUpdated);
+        browser.permissions.onRemoved.addListener(revokePermissions);
+        cleanup.push(() => {
+          browser.tabs.onRemoved.removeListener(tabRemoved);
+          browser.tabs.onUpdated.removeListener(tabUpdated);
+          browser.permissions.onRemoved.removeListener(revokePermissions);
+        });
+        heartbeatTimer = setInterval(() => {
+          if (leaseUntil > Date.now() && settings?.enabled === true) {
+            void heartbeat();
+          }
+        }, 5000);
+        publish({
+          message: settings.enabled
+            ? 'Connecting the enabled browser provider.'
+            : 'CLI tasks are disabled. Select a model and enable them while this panel remains open.',
+          phase: settings.enabled ? 'connecting' : 'disabled',
+        });
+        onState(connection.getBrowserProviderState());
+        await registering;
+      } catch (error) {
+        reportError(error);
+      }
+    })();
+    return starting;
+  };
+  const approvalRequests = new WeakSet<Invocation>();
+  return {
+    approve: async (jobId: string, tabId: number): Promise<void> => {
+      const invocation = current;
+      if (
+        invocation === undefined ||
+        invocation.relay.jobId !== jobId ||
+        invocation.selected !== undefined ||
+        invocation.record === undefined ||
+        settings === undefined ||
+        approvalRequests.has(invocation)
+      ) {
+        return;
+      }
+      approvalRequests.add(invocation);
+      try {
+        guardInvocation(invocation);
+        const captured = await readBrowserTaskSettings(settings, organizationId, storageArea);
+        guardInvocation(invocation);
+        const tabs = await getBrowserTaskTabs();
+        const tab = tabs.find(candidate => candidate.id === tabId);
+        guardInvocation(invocation);
+        if (tab === undefined) {
+          publish({
+            message:
+              'That tab is no longer available. Select an inspectable tab before the deadline.',
+            retryable: true,
+          });
+          return;
+        }
+        const selected: Consent = {
+          settings: captured,
+          supportsImages: options.supportsImages?.(captured.model) === true,
+          tab: { effectiveMode: captured.mode, tabId: tab.id, title: tab.title, url: tab.url },
+        };
+        invocation.selected = selected;
+        invocation.consent.resolve(selected);
+        publish();
+      } catch (error) {
+        // Quiescence can deliver the next job before this approval finishes.
+        if (current === invocation) {
+          reportError(error);
+        }
+      } finally {
+        approvalRequests.delete(invocation);
+      }
+    },
+    cancel: (jobId: string): void => {
+      const job = jobs.get(jobId);
+      if (job === undefined || job.generation !== generation || job.result !== undefined) {
+        return;
+      }
+      if (current?.relay.jobId === jobId) {
+        stopInvocation('cancelled');
+      }
+      try {
+        connection.cancelBrowserProviderJob(jobBinding(job));
+      } catch (error) {
+        unavailable('provider_unavailable', current?.started === true);
+        reportError(error);
+      }
+    },
+    dispose: async (): Promise<void> => {
+      disposed = true;
+      unavailable('provider_unavailable', current?.started === true);
+      clearInterval(heartbeatTimer);
+      clearTimeout(leaseTimer);
+      const draining = current;
+      draining?.terminal.resolve(undefined);
+      if (draining?.started === true && draining.selected !== undefined) {
+        try {
+          await (draining.lease ?? owner)?.quarantine(draining.selected.tab.tabId);
+        } catch {
+          needsRecovery = true;
+        }
+      }
+      for (const unsubscribe of cleanup.splice(0)) {
+        unsubscribe();
+      }
+      await draining?.work;
+      await starting;
+      try {
+        await owner?.release();
+      } catch {
+        /* The coordinator retains failed quarantine releases for explicit recovery. */
+      }
+    },
+    getSnapshot: (): BrowserTaskProviderSnapshot => snapshot,
+    recover: async (): Promise<void> => {
+      if (recovering || disposed || owner === undefined || settings?.enabled !== true) {
+        return;
+      }
+      recovering = true;
+      try {
+        await registering;
+        let fence: BrowserProviderStatusResult['unresolvedFence'];
+        try {
+          fence = await refreshStatus();
+        } catch (error) {
+          if (!(error instanceof BrowserProviderError) || error.code !== 'provider_unavailable') {
+            throw error;
+          }
+          // A normal registration attempt installs the proof for status; it cannot clear a retained fence.
+          const previousStatus = lastStatus;
+          await register();
+          if (lastStatus === undefined || lastStatus === previousStatus) {
+            throw new ExecutionStoppedError('provider_unavailable');
+          }
+          // Registration already retrieved status before withdrawing a locally quarantined profile.
+          ({ fence } = lastStatus);
+        }
+        if (current !== undefined) {
+          publish({
+            message: 'Browser actions are still unwinding. Wait before recovery.',
+            phase: 'recovery',
+          });
+          return;
+        }
+        owner.guard();
+        const recovery = await coordinator.recover(async () => {
+          const tabs = await browser.tabs.query({});
+          owner?.guard();
+          if (disposed || settings?.enabled !== true || current !== undefined) {
+            throw new ExecutionStoppedError('provider_unavailable');
+          }
+          if (fence?.tabId !== undefined && tabs.some(tab => tab.id === fence.tabId)) {
+            throw new ExecutionStoppedError('tab_lost');
+          }
+          // Include every open ID, even if an affected tab navigated to an uninspectable address.
+          return tabs.flatMap(tab => (tab.id === undefined ? [] : [tab.id]));
+        });
+        if (!recovery.recovered) {
+          publish({ message: recovery.reason, phase: 'recovery' });
+          return;
+        }
+        unavailable('provider_unavailable');
+        needsRecovery = false;
+        await register(
+          fence === undefined
+            ? undefined
+            : {
+                invocationId: fence.invocationId,
+                locksDrained: true,
+                tabClosed: true,
+                ...(fence.tabId === undefined ? {} : { tabId: fence.tabId }),
+              }
+        );
+        assertLease();
+        publish({
+          message:
+            'Browser control recovered. Submit a new invocation with fresh tab consent. Old work will not replay.',
+          phase: 'idle',
+        });
+      } catch (error) {
+        needsRecovery = true;
+        if (error instanceof ExecutionStoppedError && error.reason === 'tab_lost') {
+          publish({
+            message:
+              'Close the affected tab before recovery. Status retrieval cannot approve execution.',
+            phase: 'recovery',
+            retryable: true,
+          });
+        } else {
+          reportError(error);
+        }
+      } finally {
+        recovering = false;
+      }
+    },
+    refreshStatus,
+    reject: (jobId: string): void => {
+      if (current?.relay.jobId !== jobId || current.selected !== undefined) {
+        return;
+      }
+      const job = current.relay;
+      stopInvocation('approval_denied');
+      try {
+        connection.approveBrowserProviderJob({
+          ...jobBinding(job),
+          approval: { decision: 'denied', reason: 'approval_denied' },
+        });
+      } catch (error) {
+        unavailable('provider_unavailable');
+        reportError(error);
+      }
+    },
+    retryConnection: (): void => {
+      connection.retryConnection();
+    },
+    setSettings: async (next: BrowserProviderSettings): Promise<void> => {
+      if (profile === undefined || disposed) {
+        return;
+      }
+      if (!next.enabled) {
+        unavailable('provider_unavailable', current?.started === true);
+      }
+      try {
+        settings = await saveBrowserProviderSettings(profile, structuredClone(next));
+        let message =
+          'CLI tasks are disabled. Active and queued tasks stop; issued actions cannot be undone.';
+        if (settings.enabled) {
+          message =
+            current === undefined
+              ? 'CLI tasks are enabled. Keep this panel open.'
+              : snapshot.message;
+        }
+        publish({ message, phase: restingPhase() });
+        if (
+          settings.enabled &&
+          !needsRecovery &&
+          connection.getBrowserProviderState().status !== 'registered'
+        ) {
+          await register();
+        }
+      } catch (error) {
+        reportError(error);
+      }
+    },
+    start,
+    subscribe: (listener: () => void): (() => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+};
+
+export type BrowserTaskProviderRuntime = ReturnType<typeof createBrowserTaskProviderRuntime>;
+const BrowserTaskContext = createContext<BrowserTaskProviderRuntime | undefined>(undefined);
+
+/** A12 supplies the production mount and visible controls; this component does not create a connection. */
+export const BrowserTaskProvider = ({
+  auth,
+  children,
+  connection,
+  organizationId,
+}: {
+  readonly auth: StoredAuth;
+  readonly children: ReactNode;
+  readonly connection: Connection;
+  readonly organizationId: string | undefined;
+}) => {
+  const { modelOptions } = useGatewayModels({ auth, organizationId });
+  const models = useRef(modelOptions);
+  models.current = modelOptions;
+  const { token, userEmail } = auth;
+  const closing = useRef<Promise<void> | undefined>(undefined);
+  const [runtime, setRuntime] = useState<BrowserTaskProviderRuntime>();
+  useEffect(() => {
+    const lifetime = createBrowserTaskProviderRuntime({
+      auth: { token, userEmail },
+      connection,
+      organizationId,
+      supportsImages: model =>
+        models.current.some(option => option.id === model && option.supportsImages === true),
+    });
+    let cancelled = false;
+    setRuntime(lifetime);
+    const previous = closing.current;
+    void (async () => {
+      await previous;
+      if (!cancelled) {
+        await lifetime.start();
+      }
+    })();
+    return () => {
+      cancelled = true;
+      closing.current = lifetime.dispose();
+    };
+  }, [connection, organizationId, token, userEmail]);
+  return runtime === undefined ? null : (
+    <BrowserTaskContext value={runtime}>{children}</BrowserTaskContext>
+  );
+};
+
+export const useBrowserTask = () => {
+  const runtime = useContext(BrowserTaskContext);
+  if (runtime === undefined) {
+    throw new Error('BrowserTaskProvider is required.');
+  }
+  const state = useSyncExternalStore(runtime.subscribe, runtime.getSnapshot);
+  return { ...runtime, state };
+};

--- a/apps/extension/entrypoints/sidepanel/browser-task-provider.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider.tsx
@@ -194,6 +194,7 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
   let store: BrowserTaskStore | undefined = undefined;
   let settings: BrowserProviderSettings | undefined = undefined;
   let disposed = false;
+  let accountChanged = false;
   let needsRecovery = false;
   let generation = 0;
   let revokedGeneration = 0;
@@ -217,7 +218,20 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
     settings: undefined,
     unresolvedFence: undefined,
   };
+  let displayedJob: BrowserJobSnapshot | undefined = undefined;
   const publish = (change: Partial<BrowserTaskProviderSnapshot> = {}): void => {
+    if ('result' in change) {
+      // Keep the displayed outcome's ordering and terminal binding after history expires.
+      const resultJobId = change.result?.jobId;
+      displayedJob =
+        resultJobId === undefined
+          ? undefined
+          : structuredClone(
+              jobs.get(resultJobId) ??
+                (current?.relay.jobId === resultJobId ? current.relay : undefined) ??
+                (displayedJob?.jobId === resultJobId ? displayedJob : undefined)
+            );
+    }
     for (const [id, job] of jobs) {
       if (Date.parse(job.expiresAt) <= Date.now()) {
         jobs.delete(id);
@@ -398,7 +412,8 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
     );
   };
   const consumeJob = (job: BrowserJobSnapshot, acknowledgeRunning = true): void => {
-    const previous = jobs.get(job.jobId);
+    const previous =
+      jobs.get(job.jobId) ?? (displayedJob?.jobId === job.jobId ? displayedJob : undefined);
     if (previous !== undefined && !sameJob(previous, job)) {
       return;
     }
@@ -431,6 +446,19 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
         current.relay = job;
         current.running.resolve(job);
       }
+    } else if (current === undefined && job.result !== undefined) {
+      const displayed = displayedJob;
+      // History pages have no completion order. Use creation time and a stable tie-breaker.
+      if (
+        snapshot.result === undefined ||
+        snapshot.result.jobId === job.jobId ||
+        (displayed !== undefined &&
+          (Date.parse(job.createdAt) > Date.parse(displayed.createdAt) ||
+            (Date.parse(job.createdAt) === Date.parse(displayed.createdAt) &&
+              job.jobId > displayed.jobId)))
+      ) {
+        publish({ result: job.result });
+      }
     }
     publish();
   };
@@ -446,6 +474,7 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
       const guard = (): void => {
         if (
           disposed ||
+          accountChanged ||
           owner !== providerOwner ||
           profile !== providerProfile ||
           identity !== providerIdentity ||
@@ -472,8 +501,25 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           if (Date.now() >= deadline) {
             throw new ExecutionStoppedError('provider_unavailable');
           }
-          // eslint-disable-next-line no-await-in-loop -- Follow bounded history pages without granting execution.
-          const page = await connection.requestBrowserProviderStatus(cursor, providerIdentity);
+          let page: BrowserProviderStatusResult;
+          try {
+            // eslint-disable-next-line no-await-in-loop -- Follow bounded history pages without granting execution.
+            page = await connection.requestBrowserProviderStatus(cursor, providerIdentity);
+          } catch (error) {
+            guard();
+            if (
+              providerSettings?.enabled === false &&
+              providerIdentity !== undefined &&
+              cursor === undefined &&
+              Date.now() < deadline &&
+              error instanceof BrowserProviderError &&
+              error.code === 'not_found'
+            ) {
+              // Only this authenticated request proves an absent provider has no remote fence.
+              break;
+            }
+            throw error;
+          }
           guard();
           if (page.providerId !== providerIdentity?.providerId) {
             throw new ExecutionStoppedError('owner_mismatch');
@@ -517,6 +563,7 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
         // Registration changes its own generation and transport state, not its owning lifetime.
         if (
           disposed ||
+          accountChanged ||
           owner !== providerOwner ||
           profile !== providerProfile ||
           identity !== providerIdentity ||
@@ -1089,6 +1136,7 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           }
         };
         const authChanged = (): void => {
+          accountChanged = true;
           unavailable('provider_unavailable', current?.started === true);
           needsRecovery ||= current !== undefined;
           if (settings !== undefined) {
@@ -1228,6 +1276,8 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
     // Include every open ID, even if an affected tab navigated to an uninspectable address.
     return tabs.flatMap(tab => (tab.id === undefined ? [] : [tab.id]));
   };
+  const disabledRecoveryMessage =
+    'CLI tasks are disabled. A remote browser task still requires recovery. Enable CLI tasks, retrieve status, then recover explicitly.';
   const approvalRequests = new WeakSet<Invocation>();
   return {
     approve: async (jobId: string, tabId: number): Promise<void> => {
@@ -1254,6 +1304,7 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           publish({
             message:
               'That tab is no longer available. Select an inspectable tab before the deadline.',
+            phase: 'awaiting_approval',
             retryable: true,
           });
           return;
@@ -1265,10 +1316,32 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
         };
         invocation.selected = selected;
         invocation.consent.resolve(selected);
-        publish();
+        publish({ retryable: false });
       } catch (error) {
-        // Quiescence can deliver the next job before this approval finishes.
-        if (current === invocation) {
+        // Quiescence or revocation can precede a delayed settings/tab failure.
+        if (current !== invocation || invocation.abort.signal.aborted) {
+          return;
+        }
+        try {
+          guardInvocation(invocation);
+        } catch (lifetimeError) {
+          unavailable(failureReason(lifetimeError));
+          reportError(lifetimeError);
+          return;
+        }
+        const retryable =
+          error instanceof BrowserPersistenceError || error instanceof BrowserProviderError
+            ? error.retryable
+            : !(error instanceof ExecutionStoppedError);
+        if (retryable) {
+          publish({
+            message:
+              'Tab approval could not read settings or tabs. Restore access, then approve this goal again before its deadline.',
+            phase: 'awaiting_approval',
+            retryable: true,
+          });
+        } else {
+          unavailable(failureReason(error));
           reportError(error);
         }
       } finally {
@@ -1328,16 +1401,16 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
             'Recovery requires Web Locks. Restore browser Web Locks support before recovering.'
           );
         }
-        if (disposed || providerOwner === undefined || owner !== providerOwner) {
+        if (disposed || accountChanged || providerOwner === undefined || owner !== providerOwner) {
           throw new BrowserPersistenceError(
             'owner_mismatch',
             'This panel no longer owns the browser provider. Reopen the signed-in panel before checking recovery.'
           );
         }
-        if (settings?.enabled !== true) {
+        if (settings === undefined) {
           throw new BrowserPersistenceError(
             'invalid_request',
-            'Enable CLI tasks in the signed-in panel before checking recovery.'
+            'Wait for the signed-in panel to finish loading before checking recovery.'
           );
         }
         if (current !== undefined) {
@@ -1398,6 +1471,9 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
         guard();
         const fence = await refreshStatus();
         guard();
+        if (providerSettings?.enabled !== true && fence !== undefined) {
+          return { ready: false, reason: disabledRecoveryMessage };
+        }
         reason =
           'Open tabs could not be checked. Restore browser tab access before checking recovery again.';
         // Check remote closure before retrying releases, then enumerate again under the native lock.
@@ -1425,23 +1501,53 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
       }
     },
     recover: async (): Promise<void> => {
-      if (recovering || disposed || owner === undefined || settings?.enabled !== true) {
+      const providerOwner = owner;
+      const providerSettings = settings;
+      const providerProfile = profile;
+      const providerIdentity = identity;
+      if (recovering || disposed || providerOwner === undefined || providerSettings === undefined) {
         return;
       }
+      const guard = (): void => {
+        if (
+          disposed ||
+          accountChanged ||
+          owner !== providerOwner ||
+          settings !== providerSettings ||
+          profile !== providerProfile ||
+          identity !== providerIdentity
+        ) {
+          throw new ExecutionStoppedError('provider_lost');
+        }
+        try {
+          providerOwner.guard();
+        } catch {
+          throw new ExecutionStoppedError('provider_lost');
+        }
+      };
+      let checkRecovery = guard;
       recovering = true;
       recoveryRevision += 1;
       try {
         if ((await registering) === 'cancelled') {
           return;
         }
+        guard();
         let fence: BrowserProviderStatusResult['unresolvedFence'];
         try {
+          await statusRequest;
+          guard();
           fence = await refreshStatus();
         } catch (error) {
-          if (!(error instanceof BrowserProviderError) || error.code !== 'provider_unavailable') {
+          guard();
+          if (
+            !providerSettings.enabled ||
+            !(error instanceof BrowserProviderError) ||
+            error.code !== 'provider_unavailable'
+          ) {
             throw error;
           }
-          // A normal registration attempt installs the proof for status; it cannot clear a retained fence.
+          // Only enabled recovery can register when read-only status is unavailable.
           const previousStatus = lastStatus;
           if ((await register()) === 'cancelled') {
             return;
@@ -1452,6 +1558,7 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           // Registration already retrieved status before withdrawing a locally quarantined profile.
           ({ fence } = lastStatus);
         }
+        guard();
         if (current !== undefined) {
           publish({
             message: 'Browser actions are still unwinding. Wait before recovery.',
@@ -1459,21 +1566,42 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           });
           return;
         }
-        owner.guard();
-        const recovery = await coordinator.recover(() =>
-          getRecoveryTabIds(fence, () => {
-            owner?.guard();
-            if (disposed || settings?.enabled !== true || current !== undefined) {
-              throw new ExecutionStoppedError('provider_unavailable');
-            }
-          })
-        );
+        if (!providerSettings.enabled && fence !== undefined) {
+          needsRecovery = true;
+          publish({ message: disabledRecoveryMessage, phase: 'recovery', retryable: false });
+          return;
+        }
+        const revision = recoveryRevision;
+        const providerGeneration = generation;
+        checkRecovery = () => {
+          guard();
+          if (
+            current !== undefined ||
+            recoveryRevision !== revision ||
+            generation !== providerGeneration
+          ) {
+            throw new ExecutionStoppedError('provider_lost');
+          }
+        };
+        const recovery = await coordinator.recover(() => getRecoveryTabIds(fence, checkRecovery));
+        checkRecovery();
         if (!recovery.recovered) {
           publish({ message: recovery.reason, phase: 'recovery' });
           return;
         }
-        unavailable('provider_unavailable');
         needsRecovery = false;
+        if (!providerSettings.enabled) {
+          publish({
+            message:
+              'Local browser control recovered. CLI tasks remain disabled. Submit local work explicitly; old work will not replay.',
+            phase: 'disabled',
+            retryable: false,
+          });
+          return;
+        }
+        // Registration changes transport state; its completion still belongs to this captured lifetime.
+        checkRecovery = guard;
+        unavailable('provider_unavailable');
         const registration = await register(
           fence === undefined
             ? undefined
@@ -1487,6 +1615,7 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
         if (registration === 'cancelled') {
           return;
         }
+        guard();
         assertLease();
         publish({
           message:
@@ -1494,6 +1623,11 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
           phase: 'idle',
         });
       } catch (error) {
+        try {
+          checkRecovery();
+        } catch {
+          return;
+        }
         if (error instanceof ExecutionStoppedError && error.reason === 'provider_lost') {
           return;
         }
@@ -1505,8 +1639,19 @@ export const createBrowserTaskProviderRuntime = (options: BrowserTaskProviderOpt
             phase: 'recovery',
             retryable: true,
           });
-        } else {
+        } else if (
+          error instanceof BrowserPersistenceError ||
+          error instanceof BrowserProviderError ||
+          error instanceof ExecutionStoppedError
+        ) {
           reportError(error);
+        } else {
+          publish({
+            message:
+              'Recovery could not verify status, storage, or tab access. Restore access, retrieve status, then try recovery again.',
+            phase: 'recovery',
+            retryable: true,
+          });
         }
       } finally {
         recovering = false;

--- a/apps/extension/entrypoints/sidepanel/browser-task-runner.test.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-task-runner.test.ts
@@ -1,0 +1,841 @@
+/* eslint-disable max-lines, import/max-dependencies, import/first, import/no-nodejs-modules, jest/no-hooks, jest/no-untyped-mock-factory, jest/no-conditional-in-test, jest/max-expects, vitest/prefer-import-in-mock, require-await, typescript/require-await, typescript/no-unsafe-assignment, typescript/no-unsafe-type-assertion, unicorn/no-await-expression-member -- Shared-runner scenarios check requests, confirmed results, and absence of later actions together. */
+import { locks as nativeLocks } from 'node:worker_threads';
+import { getDefaultStore } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserJobSnapshot } from '@kilocode/cloud-agent-sdk/schemas';
+import type { BrowserApprovalSettings } from '@/src/shared/browser-provider-settings';
+import type { LlmTurnOutcome } from '@/src/shared/agent-llm-turn-runner-core';
+import type { ToolResultEvent } from '@/src/shared/agent-tool-results';
+import type { RemoteMcpServer } from '@/src/shared/remote-mcp';
+import { loadRemoteMcpStore, REMOTE_MCP_STORAGE_KEY } from '@/src/shared/remote-mcp-storage';
+
+const fixture = vi.hoisted(() => ({
+  actions: [] as number[],
+  dispatch: async (_request: { type: string; tabId?: number }): Promise<unknown> => {
+    throw new Error('Set the browser result.');
+  },
+  removed: new Set<(id: number) => void>(),
+  tabs: [
+    { id: 7, title: 'Approved page', url: 'https://example.test/task' },
+    { id: 8, title: 'Other page', url: 'https://other.test/' },
+  ],
+  values: new Map<string, unknown>(),
+}));
+vi.mock('#imports', () => ({
+  browser: {
+    identity: {
+      getRedirectURL: () => 'https://extension.example.test/remote-mcp',
+    },
+    runtime: {
+      sendMessage: (request: { type: string; tabId?: number }) => fixture.dispatch(request),
+    },
+    tabs: {
+      get: async (id: number) => {
+        const tab = fixture.tabs.find(item => item.id === id);
+        if (tab === undefined) {
+          throw new Error('Tab closed');
+        }
+        return tab;
+      },
+      onRemoved: {
+        addListener: (fn: (id: number) => void) => fixture.removed.add(fn),
+        removeListener: (fn: (id: number) => void) => fixture.removed.delete(fn),
+      },
+      query: async () => structuredClone(fixture.tabs),
+    },
+  },
+  storage: {
+    getItem: (key: string) => structuredClone(fixture.values.get(key)),
+    removeItem: (key: string) => {
+      fixture.values.delete(key);
+    },
+    setItem: (key: string, value: unknown) => {
+      fixture.values.set(key, structuredClone(value));
+    },
+    watch: () => () => {},
+  },
+}));
+import { storage } from '#imports';
+import {
+  createAssistantMessage,
+  createSafeToolCall,
+  createToolResult,
+  createUserMessage,
+} from '@/src/shared/agent-conversation';
+import { ExecutionStoppedError } from '@/src/shared/agent-tool-results';
+import { PAGE_SNAPSHOT_MESSAGE, WEB_MCP_DISCOVER_MESSAGE } from '@/src/shared/tab-debugger';
+import {
+  createBrowserExecutionCoordinator,
+  BROWSER_EXECUTION_SAFETY_KEY,
+} from './browser-execution-lock';
+import type { BrowserExecutionLease } from './browser-execution-lock';
+import { pendingApprovalAtom, pendingLockAtom } from './pending-approval';
+import {
+  readBrowserTaskSettings,
+  runBrowserTask,
+  toBrowserTaskResult,
+} from './browser-task-runner';
+
+const leases: BrowserExecutionLease[] = [];
+const settings = (): BrowserApprovalSettings => ({
+  memorySettings: { autoApproveMemorySaves: false },
+  mode: 'safe',
+  model: 'explicit-model',
+  organizationId: 'org-selected',
+  remoteMcpServers: [],
+  thinkingEffort: 'high',
+  webMcpSettings: { allowWebMcpInSafeMode: false },
+  workflowSettings: {
+    allowWorkflowsInSafeMode: false,
+    autoApproveWorkflowChanges: false,
+    autoApproveWorkflowRuns: false,
+  },
+});
+const job = (): BrowserJobSnapshot => {
+  const now = Date.now();
+  return {
+    approvedTab: {
+      effectiveMode: 'safe',
+      tabId: 7,
+      title: 'Approved page',
+      url: 'https://example.test/task?token=private#fragment',
+    },
+    browserTaskId: `bt_${crypto.randomUUID()}`,
+    createdAt: new Date(now).toISOString(),
+    deadlines: {
+      execution: new Date(now + 600_000).toISOString(),
+      queue: new Date(now + 600_000).toISOString(),
+    },
+    expiresAt: new Date(now + 604_800_000).toISOString(),
+    generation: 1,
+    invocationId: `b1.${now}.${'a'.repeat(64)}`,
+    jobId: `bj_${crypto.randomUUID()}`,
+    payloadFingerprint: 'b'.repeat(64),
+    providerId: `bp_${crypto.randomUUID()}`,
+    status: 'running',
+  };
+};
+const completion = (
+  delta: { content?: string; tool_calls?: unknown[] },
+  finish = 'stop'
+): Response =>
+  new Response(
+    `data: ${JSON.stringify({ choices: [{ delta, finish_reason: finish, index: 0 }] })}\n\ndata: [DONE]\n\n`,
+    { headers: { 'Content-Type': 'text/event-stream' } }
+  );
+const tool = (name: string, args = '{}', index = 0) => ({
+  function: { arguments: args, name },
+  id: `call_${index}`,
+  index,
+  type: 'function',
+});
+const page = () => ({
+  nodes: [],
+  text: 'The page says Ready.',
+  title: 'Observed title',
+  url: 'https://user:secret@example.test/task?token=private#fragment',
+});
+const setup = async (
+  responses: Response[] = [completion({ content: 'The requested answer.' })]
+) => {
+  const coordinator = createBrowserExecutionCoordinator({
+    locks: nativeLocks as LockManager,
+    storageArea: storage,
+  });
+  const provider = await coordinator.acquireProviderOwner();
+  if (!provider.admitted) {
+    throw new Error(provider.reason);
+  }
+  leases.push(provider.lease);
+  const abort = new AbortController();
+  const admitted = await coordinator.acquireDelegated(provider.lease, 'ses_parent_a', abort.signal);
+  if (!admitted.admitted) {
+    throw new Error(admitted.reason);
+  }
+  leases.push(admitted.lease);
+  const requests: { body: string; headers: Headers }[] = [];
+  const input = {
+    abort,
+    apiBaseUrl: 'https://gateway.example.test',
+    events: [createUserMessage('Read this page only.')],
+    executionGuard: () => {},
+    fetch: async (_url: string, init?: RequestInit) => {
+      if (typeof init?.body !== 'string') {
+        throw new TypeError('Expected a serialized model request.');
+      }
+      requests.push({ body: init.body, headers: new Headers(init.headers) });
+      const response = responses.shift();
+      if (response === undefined) {
+        throw new Error('Unexpected model request');
+      }
+      return response;
+    },
+    job: job(),
+    lease: admitted.lease,
+    remoteFetch: globalThis.fetch,
+    settings: settings(),
+    storage,
+    supportsImages: true,
+    token: 'test-token',
+  };
+  return { coordinator, input, requests };
+};
+
+const setupRemoteOAuth = async (responses: Response[]) => {
+  const context = await setup(responses);
+  const server = {
+    allowInSafeMode: true,
+    auth: {
+      oauth: {
+        clientInformation: { client_id: 'test-approved-client' },
+        tokens: {
+          access_token: 'test-approved-account',
+          refresh_token: 'test-approved-refresh',
+          scope: 'read',
+          token_type: 'Bearer',
+        },
+      },
+      type: 'oauth',
+    },
+    cachedTools: [{ inputSchema: { properties: {}, type: 'object' }, name: 'read' }],
+    displayName: 'Approved remote',
+    enabled: true,
+    id: 'remote',
+    slug: 'remote',
+    status: 'connected',
+    url: 'https://mcp.example.test/',
+  } satisfies RemoteMcpServer;
+  fixture.values.set(REMOTE_MCP_STORAGE_KEY, { servers: [server] });
+  context.input.settings = await readBrowserTaskSettings(
+    { enabled: true, mode: 'safe', model: 'explicit-model', thinkingEffort: 'high' },
+    'org-selected',
+    storage
+  );
+  const calls: { authorization: string | null; name: string }[] = [];
+  context.input.remoteFetch = async (_url, init) => {
+    if (init?.method === 'GET') {
+      return new Response(null, { status: 405 });
+    }
+    if (typeof init?.body !== 'string') {
+      throw new TypeError('Expected a serialized MCP request.');
+    }
+    const request = JSON.parse(init.body) as {
+      id: number;
+      method: string;
+      params: { name: string; protocolVersion: string };
+    };
+    if (request.method === 'notifications/initialized') {
+      return new Response(null, { status: 202 });
+    }
+    if (request.method === 'initialize') {
+      return Response.json({
+        id: request.id,
+        jsonrpc: '2.0',
+        result: {
+          capabilities: { tools: {} },
+          protocolVersion: request.params.protocolVersion,
+          serverInfo: { name: 'Test MCP server', version: '1.0.0' },
+        },
+      });
+    }
+    if (request.method === 'tools/call') {
+      calls.push({
+        authorization: new Headers(init.headers).get('Authorization'),
+        name: request.params.name,
+      });
+      return Response.json({
+        id: request.id,
+        jsonrpc: '2.0',
+        result: { content: [{ text: 'The approved remote answer.', type: 'text' }] },
+      });
+    }
+    throw new Error('Unexpected MCP request.');
+  };
+  return { ...context, calls, server };
+};
+
+describe('delegated browser runner adapter', () => {
+  beforeEach(() => {
+    fixture.actions = [];
+    fixture.values.clear();
+    fixture.tabs = [
+      { id: 7, title: 'Approved page', url: 'https://example.test/task' },
+      { id: 8, title: 'Other page', url: 'https://other.test/' },
+    ];
+    fixture.dispatch = async request => {
+      if (request.type === WEB_MCP_DISCOVER_MESSAGE) {
+        return {
+          ok: true,
+          result: { ok: true, value: { documentId: 'doc', tools: [] } },
+          type: request.type,
+        };
+      }
+      if (request.tabId !== undefined) {
+        fixture.actions.push(request.tabId);
+      }
+      return {
+        ok: true,
+        result: { effectsUncertain: false, ok: true, value: page() },
+        type: PAGE_SNAPSHOT_MESSAGE,
+      };
+    };
+    getDefaultStore().set(pendingApprovalAtom, undefined);
+    getDefaultStore().set(pendingLockAtom, false);
+  });
+  afterEach(async () => {
+    await Promise.all(leases.splice(0).map(lease => lease.release()));
+    vi.useRealTimers();
+    fixture.removed.clear();
+  });
+
+  it('treats rejected permission as failure and never starts a later tool or model round', async () => {
+    const { input, requests } = await setup([
+      completion(
+        {
+          tool_calls: [
+            tool('save_memory', '{"text":"Remember this fact"}'),
+            tool('get_page_snapshot', '{}', 1),
+          ],
+        },
+        'tool_calls'
+      ),
+    ]);
+    const running = runBrowserTask(input);
+    await vi.waitFor(() => {
+      expect(getDefaultStore().get(pendingApprovalAtom)?.kind).toBe('memory');
+    });
+    const approval = getDefaultStore().get(pendingApprovalAtom);
+    if (approval === undefined) {
+      throw new Error('Missing approval');
+    }
+    approval.settle({ status: 'rejected' });
+    const result = await running;
+    expect(result.result).toMatchObject({
+      effectsUncertain: false,
+      reason: 'permission_denied',
+      status: 'failed',
+    });
+    expect(fixture.actions).toStrictEqual([]);
+    expect(requests).toHaveLength(1);
+  });
+
+  it('runs the real shared runner on the exact tab with isolated history and confirmed evidence', async () => {
+    const { input, requests } = await setup([
+      completion({ tool_calls: [tool('get_page_snapshot')] }, 'tool_calls'),
+      completion({ content: 'The page says Ready.' }),
+    ]);
+    input.events.unshift(
+      createAssistantMessage('Only this browser conversation is prior context.')
+    );
+    fixture.values.set('local:kiloAgentConversations', { text: 'Foreign parent transcript' });
+    fixture.tabs.reverse();
+    const result = await runBrowserTask(input);
+    expect(result.result).toMatchObject({
+      effectsUncertain: false,
+      evidence: [
+        { text: 'The page says Ready.', title: 'Observed title', url: 'https://example.test/task' },
+      ],
+      reason: 'completed',
+      status: 'succeeded',
+      summary: 'The page says Ready.',
+    });
+    expect(fixture.actions).toStrictEqual([7]);
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.body).toContain('explicit-model');
+    expect(requests[0]?.body).toContain('Only this browser conversation');
+    expect(requests[0]?.body).not.toContain('Foreign parent transcript');
+    expect(requests[0]?.body).not.toContain('token=private');
+    expect(result.events.some(event => event.type === 'tool-result' && event.ok)).toBe(true);
+  });
+
+  it('returns empty evidence rather than turning model claims into observations', async () => {
+    const { input } = await setup();
+    const completed = await runBrowserTask(input);
+    expect(completed.result).toMatchObject({
+      evidence: [],
+      status: 'succeeded',
+      summary: 'The requested answer.',
+    });
+    expect(fixture.actions).toStrictEqual([]);
+  });
+
+  it.each([
+    'model_failure',
+    'retry_exhausted',
+    'context_overflow',
+    'rounds_exhausted',
+    'truncated_response',
+    'empty_response',
+    'incomplete_response',
+    'tool_failure_limit',
+    'unsafe_tool_call',
+  ] as const)('never promotes the typed %s outcome to success', reason => {
+    const result = toBrowserTaskResult(
+      job(),
+      {
+        effectsUncertain: false,
+        reason,
+        status: 'failed',
+        summary: 'Partial work only.',
+        toolResults: [],
+      },
+      []
+    );
+    expect(result).toMatchObject({
+      evidence: [],
+      reason: reason === 'unsafe_tool_call' ? 'permission_denied' : 'runner_failed',
+      status: 'failed',
+    });
+    expect(result.summary).toContain('Work is incomplete');
+    expect(result.summary).toContain('Partial work only.');
+  });
+
+  it.each([
+    ['runner_failed', 'failed'],
+    ['unsupported', 'failed'],
+    ['invalid_request', 'failed'],
+    ['owner_mismatch', 'interrupted'],
+    ['not_found', 'interrupted'],
+    ['invocation_conflict', 'interrupted'],
+    ['conversation_busy', 'interrupted'],
+    ['capacity_exceeded', 'interrupted'],
+    ['cancelled', 'cancelled'],
+    ['tab_lost', 'interrupted'],
+    ['provider_lost', 'interrupted'],
+    ['provider_unavailable', 'interrupted'],
+    ['lease_expired', 'interrupted'],
+    ['effects_uncertain', 'interrupted'],
+    ['queue_timeout', 'timed_out'],
+    ['approval_timeout', 'timed_out'],
+    ['execution_timeout', 'timed_out'],
+    ['invocation_expired', 'timed_out'],
+    ['permission_denied', 'failed'],
+    ['approval_denied', 'failed'],
+  ] as const)('preserves the %s terminal reason', (reason, status) => {
+    const result = toBrowserTaskResult(
+      job(),
+      {
+        effectsUncertain: reason === 'effects_uncertain',
+        reason,
+        status: 'interrupted',
+        summary: '',
+        toolResults: [],
+      },
+      []
+    );
+    expect(result).toMatchObject({
+      effectsUncertain: reason === 'effects_uncertain',
+      reason,
+      status,
+    });
+    expect(result.summary).toContain('Issued actions cannot be undone');
+  });
+
+  it('bounds multibyte evidence and excludes screenshots, failed results, and unconfirmed observations', () => {
+    const call = createSafeToolCall({ name: 'get_page_snapshot', tabId: 7 });
+    const screenshot = createSafeToolCall({ name: 'get_viewport_screenshot', tabId: 7 });
+    const confirmed: ToolResultEvent = {
+      ...createToolResult({
+        ok: true,
+        toolCallId: call.id,
+        value: { ...page(), text: '𐀀'.repeat(20_000), title: '𐀀'.repeat(2000) },
+      }),
+      effectsUncertain: false,
+    };
+    const outcome: LlmTurnOutcome = {
+      effectsUncertain: false,
+      reason: 'completed',
+      status: 'succeeded',
+      summary: '𐀀'.repeat(20_000),
+      toolResults: [
+        confirmed,
+        { ...confirmed, effectsUncertain: true },
+        { ...confirmed, ok: false },
+        {
+          ...confirmed,
+          toolCallId: screenshot.id,
+          value: { dataUrl: 'data:image/png;base64,secret' },
+        },
+      ],
+    };
+    const result = toBrowserTaskResult(job(), outcome, [call, screenshot]);
+    expect(result.evidence).toHaveLength(1);
+    expect(new TextEncoder().encode(JSON.stringify(result)).byteLength).toBeLessThan(64 * 1024);
+    expect(JSON.stringify(result)).not.toContain('secret');
+    expect(JSON.stringify(result)).not.toContain('token=private');
+  });
+
+  it('checks the live lease between issued actions without relying on an abort event', async () => {
+    const { input, requests } = await setup([
+      completion(
+        { tool_calls: [tool('get_page_snapshot'), tool('get_page_snapshot', '{}', 1)] },
+        'tool_calls'
+      ),
+    ]);
+    let live = true;
+    input.executionGuard = () => {
+      if (!live) {
+        throw new ExecutionStoppedError('lease_expired');
+      }
+    };
+    fixture.dispatch = async request => {
+      fixture.actions.push(request.tabId ?? -1);
+      live = false;
+      return {
+        ok: true,
+        result: { effectsUncertain: false, ok: true, value: page() },
+        type: PAGE_SNAPSHOT_MESSAGE,
+      };
+    };
+    const result = await runBrowserTask(input);
+    expect(result.result).toMatchObject({ reason: 'lease_expired', status: 'interrupted' });
+    expect(fixture.actions).toStrictEqual([7]);
+    expect(requests).toHaveLength(1);
+  });
+
+  it('retains bounded recovery for a confirmed retryable tool failure', async () => {
+    const { input, requests } = await setup([
+      completion({ tool_calls: [tool('get_page_snapshot')] }, 'tool_calls'),
+      completion({ tool_calls: [tool('get_page_snapshot')] }, 'tool_calls'),
+      completion({ content: 'The page says Ready.' }),
+    ]);
+    fixture.dispatch = async request => {
+      fixture.actions.push(request.tabId ?? -1);
+      const result =
+        fixture.actions.length === 1
+          ? { effectsUncertain: false, error: 'The page is not ready yet.', ok: false }
+          : { effectsUncertain: false, ok: true, value: page() };
+      return { ok: true, result, type: PAGE_SNAPSHOT_MESSAGE };
+    };
+    const result = await runBrowserTask(input);
+    expect(result.result).toMatchObject({
+      effectsUncertain: false,
+      evidence: [{ text: 'The page says Ready.' }],
+      status: 'succeeded',
+    });
+    expect(fixture.actions).toStrictEqual([7, 7]);
+    expect(requests).toHaveLength(3);
+    expect(fixture.values.has(BROWSER_EXECUTION_SAFETY_KEY)).toBe(false);
+  });
+
+  it.each(['lease_expired', 'provider_lost'] as const)(
+    'checks %s before a model request',
+    async reason => {
+      const { input, requests } = await setup();
+      input.executionGuard = () => {
+        throw new ExecutionStoppedError(reason);
+      };
+      const result = await runBrowserTask(input);
+      expect(result.result).toMatchObject({ reason, status: 'interrupted' });
+      expect(requests).toStrictEqual([]);
+      expect(fixture.actions).toStrictEqual([]);
+    }
+  );
+
+  it('rejects a missing approved tab without falling back to another tab', async () => {
+    const { input, requests } = await setup();
+    fixture.tabs = fixture.tabs.filter(tab => tab.id !== 7);
+    const result = await runBrowserTask(input);
+    expect(result.result).toMatchObject({ reason: 'tab_lost', status: 'interrupted' });
+    expect(requests).toStrictEqual([]);
+    expect(fixture.actions).toStrictEqual([]);
+  });
+
+  it('preserves safe tool restrictions through the real gateway parser', async () => {
+    const { input } = await setup([
+      completion({ tool_calls: [tool('eval', '{"code":"document.body.click()"}')] }, 'tool_calls'),
+    ]);
+    const result = await runBrowserTask(input);
+    expect(result.result).toMatchObject({
+      effectsUncertain: false,
+      reason: 'permission_denied',
+      status: 'failed',
+    });
+    expect(fixture.actions).toStrictEqual([]);
+  });
+
+  it('reports a non-retryable model failure rather than a resolved successful promise', async () => {
+    const { input, requests } = await setup([new Response('Denied', { status: 401 })]);
+    const result = await runBrowserTask(input);
+    expect(result.result).toMatchObject({
+      effectsUncertain: false,
+      reason: 'runner_failed',
+      status: 'failed',
+    });
+    expect(requests).toHaveLength(1);
+    expect(fixture.actions).toStrictEqual([]);
+  });
+
+  it('keeps permission cards despite a later auto-approve increase, and Stop prevents the next tool', async () => {
+    const { input, requests } = await setup([
+      completion(
+        {
+          tool_calls: [
+            tool('save_memory', '{"text":"Remember this fact"}'),
+            tool('get_page_snapshot', '{}', 1),
+          ],
+        },
+        'tool_calls'
+      ),
+    ]);
+    fixture.values.set('local:kiloMemorySettings', { autoApproveMemorySaves: true });
+    const running = runBrowserTask(input);
+    await vi.waitFor(() => {
+      expect(getDefaultStore().get(pendingApprovalAtom)?.kind).toBe('memory');
+    });
+    expect(getDefaultStore().get(pendingApprovalAtom)?.draft.origin).toMatchObject({
+      invocationId: input.job.invocationId,
+      kind: 'delegated',
+    });
+    input.abort.abort(new ExecutionStoppedError('cancelled', 'cancelled'));
+    const result = await running;
+    expect(result.result.status).toBe('cancelled');
+    expect(fixture.actions).toStrictEqual([]);
+    expect(requests).toHaveLength(1);
+    expect(fixture.values.has('local:kiloAgentMemories')).toBe(false);
+    expect(getDefaultStore().get(pendingApprovalAtom)).toBeUndefined();
+  });
+
+  it('awaits an issued action after cancellation and never starts the next action', async () => {
+    const { input, requests } = await setup([
+      completion(
+        { tool_calls: [tool('get_page_snapshot'), tool('get_page_snapshot', '{}', 1)] },
+        'tool_calls'
+      ),
+    ]);
+    const gate = Promise.withResolvers<void>();
+    let finished = false;
+    fixture.dispatch = async request => {
+      fixture.actions.push(request.tabId ?? -1);
+      await gate.promise;
+      return {
+        ok: true,
+        result: { effectsUncertain: false, ok: true, value: page() },
+        type: PAGE_SNAPSHOT_MESSAGE,
+      };
+    };
+    const running = (async () => {
+      const completed = await runBrowserTask(input);
+      finished = true;
+      return completed;
+    })();
+    await vi.waitFor(() => {
+      expect(fixture.actions).toStrictEqual([7]);
+    });
+    input.abort.abort(new ExecutionStoppedError('cancelled', 'cancelled'));
+    expect(finished).toBe(false);
+    gate.resolve();
+    const result = await running;
+    expect(result.result).toMatchObject({
+      effectsUncertain: false,
+      evidence: [{ text: 'The page says Ready.' }],
+      status: 'cancelled',
+    });
+    expect(fixture.actions).toStrictEqual([7]);
+    expect(requests).toHaveLength(1);
+  });
+
+  it('quarantines an uncertain tool result before another action or model retry', async () => {
+    const { coordinator, input, requests } = await setup([
+      completion(
+        { tool_calls: [tool('get_page_snapshot'), tool('get_page_snapshot', '{}', 1)] },
+        'tool_calls'
+      ),
+    ]);
+    fixture.dispatch = async request => {
+      fixture.actions.push(request.tabId ?? -1);
+      return {
+        ok: true,
+        result: { effectsUncertain: true, error: 'Soft timeout', ok: false },
+        type: PAGE_SNAPSHOT_MESSAGE,
+      };
+    };
+    const result = await runBrowserTask(input);
+    expect(result.result).toMatchObject({
+      effectsUncertain: true,
+      evidence: [],
+      reason: 'effects_uncertain',
+      status: 'interrupted',
+    });
+    expect(fixture.actions).toStrictEqual([7]);
+    expect(requests).toHaveLength(1);
+    await input.lease.release();
+    expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+    expect((await coordinator.acquireLocal()).admitted).toBe(false);
+  });
+
+  it('uses approved OAuth credentials for later real MCP tool requests without exposing them in history', async () => {
+    const { calls, input } = await setupRemoteOAuth([
+      completion({ tool_calls: [tool('mcp_remote_read')] }, 'tool_calls'),
+      completion({ tool_calls: [tool('mcp_remote_read')] }, 'tool_calls'),
+      completion({ content: 'The approved remote answer.' }),
+    ]);
+    const result = await runBrowserTask(input);
+    expect(result.result).toMatchObject({
+      effectsUncertain: false,
+      status: 'succeeded',
+      summary: 'The approved remote answer.',
+    });
+    expect(calls).toStrictEqual([
+      { authorization: 'Bearer test-approved-account', name: 'read' },
+      { authorization: 'Bearer test-approved-account', name: 'read' },
+    ]);
+    expect(JSON.stringify(result)).not.toContain('test-approved-account');
+    expect(JSON.stringify(result)).not.toContain('test-approved-refresh');
+  });
+
+  it.each(['account', 'scope', 'client'] as const)(
+    'stops later actions when OAuth %s changes during a credential read after consent',
+    async authority => {
+      const { calls, input, requests, server } = await setupRemoteOAuth([
+        completion({ tool_calls: [tool('mcp_remote_read')] }, 'tool_calls'),
+        completion(
+          { tool_calls: [tool('mcp_remote_read'), tool('get_page_snapshot', '{}', 1)] },
+          'tool_calls'
+        ),
+        completion({ content: 'Must not complete with changed authority.' }),
+      ]);
+      const readStarted = Promise.withResolvers<void>();
+      const resumeRead = Promise.withResolvers<void>();
+      let paused = false;
+      const running = runBrowserTask({
+        ...input,
+        storage: {
+          ...storage,
+          getItem: async key => {
+            if (key === REMOTE_MCP_STORAGE_KEY && requests.length === 2 && !paused) {
+              paused = true;
+              readStarted.resolve();
+              await resumeRead.promise;
+            }
+            return structuredClone(fixture.values.get(key));
+          },
+        },
+      });
+      await readStarted.promise;
+      const changed = structuredClone(server);
+      if (authority === 'account') {
+        changed.auth.oauth.tokens.access_token = 'test-other-account';
+      } else if (authority === 'scope') {
+        changed.auth.oauth.tokens.scope = 'read write';
+      } else {
+        changed.auth.oauth.clientInformation.client_id = 'test-other-client';
+      }
+      fixture.values.set(REMOTE_MCP_STORAGE_KEY, { servers: [changed] });
+      resumeRead.resolve();
+      const result = await running;
+      expect(result.result).toMatchObject({ reason: 'permission_denied', status: 'failed' });
+      expect(calls).toStrictEqual([
+        { authorization: 'Bearer test-approved-account', name: 'read' },
+      ]);
+      expect(fixture.actions).toStrictEqual([]);
+      expect(requests).toHaveLength(2);
+      expect(JSON.stringify(result)).not.toContain('test-other-account');
+      expect(JSON.stringify(result)).not.toContain('test-other-client');
+    }
+  );
+
+  it('preserves live server edits during OAuth refresh and stops before using the new credential', async () => {
+    const { calls, input, server } = await setupRemoteOAuth([
+      completion({ tool_calls: [tool('mcp_remote_read')] }, 'tool_calls'),
+      completion({ content: 'Must not use a refreshed credential without fresh consent.' }),
+    ]);
+    const dispatch = input.remoteFetch;
+    const refreshedTokens = { ...server.auth.oauth.tokens, access_token: 'test-refreshed-account' };
+    const unrelated = {
+      ...server,
+      auth: { type: 'none' },
+      enabled: false,
+      id: 'unrelated',
+      slug: 'unrelated',
+      url: 'https://unrelated.example.test/',
+    } satisfies RemoteMcpServer;
+    const refreshRequests: URLSearchParams[] = [];
+    let challenged = false;
+    input.remoteFetch = async (url, init) => {
+      const address = url instanceof Request ? url.url : url.toString();
+      if (address === 'https://mcp.example.test/.well-known/oauth-protected-resource') {
+        return Response.json({
+          authorization_servers: ['https://auth.example.test/'],
+          resource: server.url,
+        });
+      }
+      if (address === 'https://auth.example.test/.well-known/oauth-authorization-server') {
+        return Response.json({
+          authorization_endpoint: 'https://auth.example.test/authorize',
+          issuer: 'https://auth.example.test/',
+          response_types_supported: ['code'],
+          token_endpoint: 'https://auth.example.test/token',
+          token_endpoint_auth_methods_supported: ['none'],
+        });
+      }
+      if (address === 'https://auth.example.test/token') {
+        refreshRequests.push(new URLSearchParams(await new Response(init?.body).text()));
+        fixture.values.set(REMOTE_MCP_STORAGE_KEY, {
+          servers: [{ ...server, displayName: 'Edited during refresh' }, unrelated],
+        });
+        return Response.json(refreshedTokens);
+      }
+      if (address === server.url && init?.method === 'POST' && !challenged) {
+        challenged = true;
+        return new Response(null, {
+          headers: {
+            'WWW-Authenticate':
+              'Bearer resource_metadata="https://mcp.example.test/.well-known/oauth-protected-resource"',
+          },
+          status: 401,
+        });
+      }
+      return dispatch(url, init);
+    };
+    const result = await runBrowserTask(input);
+    expect(refreshRequests.map(request => Object.fromEntries(request))).toMatchObject([
+      {
+        client_id: 'test-approved-client',
+        grant_type: 'refresh_token',
+        refresh_token: 'test-approved-refresh',
+      },
+    ]);
+    await expect(loadRemoteMcpStore(storage)).resolves.toStrictEqual({
+      servers: [
+        {
+          ...server,
+          auth: { ...server.auth, oauth: { ...server.auth.oauth, tokens: refreshedTokens } },
+          displayName: 'Edited during refresh',
+        },
+        unrelated,
+      ],
+    });
+    expect(result.result).toMatchObject({ reason: 'permission_denied', status: 'failed' });
+    expect(calls).toStrictEqual([]);
+    expect(JSON.stringify(result)).not.toContain('test-refreshed-account');
+  });
+
+  it('keeps Dangerous mode, workflow flags, WebMCP, and approved Remote MCP tools in shared setup', async () => {
+    const { input, requests } = await setup();
+    input.settings.mode = 'dangerous';
+    if (input.job.approvedTab === undefined) {
+      throw new Error('Missing approved tab');
+    }
+    input.job.approvedTab.effectiveMode = 'dangerous';
+    input.settings.remoteMcpServers = [
+      {
+        allowInSafeMode: false,
+        auth: { type: 'none' },
+        cachedTools: [{ inputSchema: { properties: {}, type: 'object' }, name: 'read' }],
+        displayName: 'Approved remote',
+        enabled: true,
+        id: 'remote',
+        slug: 'remote',
+        status: 'connected',
+        url: 'https://mcp.example.test/',
+      },
+    ];
+    const result = await runBrowserTask(input);
+    expect(result.result.status).toBe('succeeded');
+    expect(requests[0]?.body).toContain('"name":"eval"');
+    expect(requests[0]?.body).toContain('run_workflow');
+    expect(requests[0]?.body).toContain('mcp_remote_read');
+    expect(fixture.actions).toStrictEqual([]);
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/browser-task-runner.ts
+++ b/apps/extension/entrypoints/sidepanel/browser-task-runner.ts
@@ -1,0 +1,360 @@
+/* eslint-disable max-lines, import/max-dependencies, typescript/consistent-type-definitions -- The delegated adapter reuses the existing runner and settings contracts. */
+import { browser } from '#imports';
+import { browserFailureReasonSchema, browserResultSchema } from '@kilocode/cloud-agent-sdk/schemas';
+import type { BrowserJobSnapshot, BrowserResult } from '@kilocode/cloud-agent-sdk/schemas';
+import { z } from 'zod';
+import type { AgentConversationEvent } from '@/src/shared/agent-conversation';
+import { loadAgentMemories } from '@/src/shared/agent-memories-storage';
+import {
+  loadMemorySettings,
+  MEMORY_SETTINGS_STORAGE_KEY,
+} from '@/src/shared/agent-memory-settings';
+import type { LlmTurnOutcome } from '@/src/shared/agent-llm-turn-runner-core';
+import { ExecutionStoppedError } from '@/src/shared/agent-tool-results';
+import {
+  loadAgentWorkflows,
+  loadWorkflowSettings,
+  WORKFLOW_SETTINGS_STORAGE_KEY,
+} from '@/src/shared/agent-workflows-storage';
+import { browserApprovalSettingsSchema } from '@/src/shared/browser-provider-settings';
+import type {
+  BrowserApprovalSettings,
+  BrowserProviderSettings,
+} from '@/src/shared/browser-provider-settings';
+import { loadRemoteMcpStore, REMOTE_MCP_STORAGE_KEY } from '@/src/shared/remote-mcp-storage';
+import { listInspectableTabsWithTabsApi } from '@/src/shared/tab-debugger';
+import { loadWebMcpSettings, WEB_MCP_SETTINGS_STORAGE_KEY } from '@/src/shared/web-mcp-settings';
+import { formatSystemEnvironment } from './agent-chat-panel';
+import { runBrowserTurn } from './browser-run-context';
+import type { BrowserRunContext } from './browser-run-context';
+import { requestApproval } from './pending-approval';
+
+export type BrowserTaskStorage = BrowserRunContext['storage'];
+export const getBrowserTaskTabs = () =>
+  listInspectableTabsWithTabsApi({
+    query: async () => {
+      const tabs = await browser.tabs.query({});
+      return tabs.flatMap(tab => {
+        if (tab.id === undefined || tab.url === undefined) {
+          return [];
+        }
+        return [{ id: tab.id, title: tab.title ?? tab.url, url: tab.url }];
+      });
+    },
+  });
+
+/** Only the provider's explicit defaults and current account settings enter consent. */
+export const readBrowserTaskSettings = async (
+  settings: BrowserProviderSettings,
+  organizationId: string | undefined,
+  storageArea: BrowserTaskStorage
+): Promise<BrowserApprovalSettings> => {
+  const selected = { ...settings };
+  const [memorySettings, workflowSettings, webMcpSettings, remote] = await Promise.all([
+    loadMemorySettings(storageArea),
+    loadWorkflowSettings(storageArea),
+    loadWebMcpSettings(storageArea),
+    loadRemoteMcpStore(storageArea),
+  ]);
+  return browserApprovalSettingsSchema.parse({
+    memorySettings,
+    mode: selected.mode,
+    model: selected.model,
+    organizationId: organizationId ?? null,
+    remoteMcpServers: remote.servers,
+    thinkingEffort: selected.thinkingEffort,
+    webMcpSettings,
+    workflowSettings,
+  });
+};
+
+const observationSchema = z.object({ text: z.string(), title: z.string(), url: z.url() });
+const timeoutReasons = new Set([
+  'queue_timeout',
+  'approval_timeout',
+  'execution_timeout',
+  'invocation_expired',
+]);
+const failureStatus = (
+  reason: Exclude<BrowserResult['reason'], 'completed'>
+): Exclude<BrowserResult['status'], 'succeeded'> => {
+  if (timeoutReasons.has(reason)) {
+    return 'timed_out';
+  }
+  if (reason === 'cancelled') {
+    return 'cancelled';
+  }
+  if (
+    reason === 'approval_denied' ||
+    reason === 'permission_denied' ||
+    reason === 'runner_failed' ||
+    reason === 'invalid_request' ||
+    reason === 'unsupported'
+  ) {
+    return 'failed';
+  }
+  return 'interrupted';
+};
+export const browserTaskFailure = (
+  job: BrowserJobSnapshot,
+  reason: Exclude<BrowserResult['reason'], 'completed'>,
+  effectsUncertain = false
+): BrowserResult => ({
+  browserTaskId: job.browserTaskId,
+  effectsUncertain,
+  evidence: [],
+  invocationId: job.invocationId,
+  jobId: job.jobId,
+  providerId: job.providerId,
+  reason,
+  status: failureStatus(reason),
+  summary: `Browser task stopped: ${reason}. Work is incomplete. Issued actions cannot be undone.${effectsUncertain ? ' Effects are uncertain; close affected tabs before explicit recovery.' : ''}`,
+});
+
+/** Evidence is observed page text, not model assertions, arbitrary tool JSON, or screenshot bytes. */
+export const toBrowserTaskResult = (
+  job: BrowserJobSnapshot,
+  outcome: LlmTurnOutcome,
+  events: readonly AgentConversationEvent[]
+): BrowserResult => {
+  const evidence: BrowserResult['evidence'] = outcome.toolResults
+    .filter(
+      result =>
+        result.ok &&
+        !result.effectsUncertain &&
+        events.some(
+          event =>
+            event.type === 'tool-call' &&
+            event.id === result.toolCallId &&
+            event.name === 'get_page_snapshot'
+        )
+    )
+    .flatMap(result => {
+      const observation = observationSchema.safeParse(result.value);
+      if (!observation.success) {
+        return [];
+      }
+      const url = new URL(observation.data.url);
+      url.username = '';
+      url.password = '';
+      url.search = '';
+      url.hash = '';
+      const address = url.toString();
+      const item = {
+        ...(observation.data.text ? { text: observation.data.text.slice(0, 1024) } : {}),
+        ...(observation.data.title ? { title: observation.data.title.slice(0, 128) } : {}),
+        ...(address.length <= 2048 ? { url: address } : {}),
+      };
+      return Object.keys(item).length === 0 ? [] : [item];
+    })
+    .slice(0, 3);
+  const handles = {
+    browserTaskId: job.browserTaskId,
+    invocationId: job.invocationId,
+    jobId: job.jobId,
+    providerId: job.providerId,
+  };
+  if (outcome.status === 'succeeded' && !outcome.effectsUncertain && outcome.summary.trim()) {
+    return browserResultSchema.parse({
+      ...handles,
+      effectsUncertain: false,
+      evidence,
+      reason: 'completed',
+      status: 'succeeded',
+      summary: outcome.summary.slice(0, 4000),
+    });
+  }
+  const parsed = browserFailureReasonSchema.safeParse(outcome.reason);
+  let reason: Exclude<BrowserResult['reason'], 'completed'> = parsed.success
+    ? parsed.data
+    : 'runner_failed';
+  if (outcome.reason === 'unsafe_tool_call') {
+    reason = 'permission_denied';
+  }
+  if (outcome.effectsUncertain && !parsed.success) {
+    reason = 'effects_uncertain';
+  }
+  const failed = browserTaskFailure(job, reason, outcome.effectsUncertain);
+  return browserResultSchema.parse({
+    ...failed,
+    evidence,
+    status: outcome.status === 'failed' && !outcome.effectsUncertain ? 'failed' : failed.status,
+    summary: `${failed.summary}${outcome.summary.trim() ? ` Partial response: ${outcome.summary.slice(0, 4000)}` : ''}`,
+  });
+};
+
+export type BrowserTaskRunInput = {
+  readonly abort: AbortController;
+  readonly apiBaseUrl: string;
+  readonly events: readonly AgentConversationEvent[];
+  readonly executionGuard: BrowserRunContext['executionGuard'];
+  readonly fetch: BrowserRunContext['fetch'];
+  readonly job: BrowserJobSnapshot;
+  readonly lease: BrowserRunContext['lease'];
+  readonly remoteFetch: typeof fetch;
+  readonly settings: BrowserApprovalSettings;
+  readonly storage: BrowserTaskStorage;
+  readonly supportsImages: boolean;
+  readonly token: string;
+};
+
+/** There is one production runner path. Tests inject its inputs, not a runtime bypass. */
+export const runBrowserTask = async (input: BrowserTaskRunInput) => {
+  let events = [...input.events];
+  let entered = false;
+  let ended = false;
+  let outcome: LlmTurnOutcome = {
+    effectsUncertain: false,
+    reason: 'runner_failed',
+    status: 'interrupted',
+    summary: 'Browser execution did not start.',
+    toolResults: [],
+  };
+  const guard = (): void => {
+    input.abort.signal.throwIfAborted();
+    input.lease.guard();
+    input.executionGuard();
+  };
+  const settings = structuredClone(input.settings);
+  const frozenSettings = new Map<string, unknown>([
+    [MEMORY_SETTINGS_STORAGE_KEY, settings.memorySettings],
+    [WORKFLOW_SETTINGS_STORAGE_KEY, settings.workflowSettings],
+    [WEB_MCP_SETTINGS_STORAGE_KEY, settings.webMcpSettings],
+  ]);
+  const invocationStorage: BrowserTaskStorage = {
+    getItem: async key => {
+      if (frozenSettings.has(key)) {
+        return structuredClone(frozenSettings.get(key));
+      }
+      if (key === REMOTE_MCP_STORAGE_KEY) {
+        // Validate the exact OAuth read; a frozen whole store would overwrite unrelated live edits.
+        const remote = await loadRemoteMcpStore(input.storage);
+        guard();
+        const changed = settings.remoteMcpServers.some(
+          server =>
+            server.enabled &&
+            server.auth.type === 'oauth' &&
+            JSON.stringify(remote.servers.find(candidate => candidate.id === server.id)?.auth) !==
+              JSON.stringify(server.auth)
+        );
+        if (changed) {
+          const stopped = new ExecutionStoppedError('permission_denied');
+          input.abort.abort(stopped);
+          throw stopped;
+        }
+        return remote;
+      }
+      return input.storage.getItem(key);
+    },
+    // Matching delegated draft cleanup remains possible after Stop; it cannot grant authority.
+    removeItem: key => input.storage.removeItem(key),
+    setItem: (key, value) => {
+      guard();
+      return input.storage.setItem(key, value);
+    },
+  };
+  try {
+    guard();
+    const tab = input.job.approvedTab;
+    const deadline = input.job.deadlines.execution;
+    if (
+      input.job.status !== 'running' ||
+      tab === undefined ||
+      deadline === undefined ||
+      tab.effectiveMode !== settings.mode
+    ) {
+      throw new ExecutionStoppedError('invalid_request');
+    }
+    const tabs = await getBrowserTaskTabs();
+    if (!tabs.some(candidate => candidate.id === tab.tabId)) {
+      throw new ExecutionStoppedError('tab_lost');
+    }
+    const [memories, workflows] = await Promise.all([
+      loadAgentMemories(invocationStorage),
+      loadAgentWorkflows(invocationStorage),
+    ]);
+    guard();
+    const selectedTab = { id: tab.tabId, title: tab.title, url: tab.url };
+    const last = events.at(-1);
+    if (last?.type !== 'message' || last.role !== 'user') {
+      throw new ExecutionStoppedError('invalid_request');
+    }
+    const systemEnvironment = formatSystemEnvironment({ memories, selectedTab, workflows });
+    events = [
+      ...events.slice(0, -1),
+      { ...last, ...(systemEnvironment === undefined ? {} : { systemEnvironment }) },
+    ];
+    const context: BrowserRunContext = {
+      abort: input.abort,
+      allowTabFallback: false,
+      allowWebMcpInSafeMode: settings.webMcpSettings.allowWebMcpInSafeMode,
+      apiBaseUrl: input.apiBaseUrl,
+      appendEvents: appended => {
+        events = [...events, ...appended];
+      },
+      executionGuard: guard,
+      fetch: input.fetch,
+      lease: input.lease,
+      mode: settings.mode,
+      model: settings.model,
+      onRemoteMcpWarning: () => {},
+      organizationId: settings.organizationId ?? undefined,
+      remoteFetch: input.remoteFetch,
+      remoteMcpServers: settings.remoteMcpServers,
+      requestApproval: async (kind, draft) => {
+        const approval = await requestApproval(invocationStorage, kind, draft, input.abort.signal, {
+          executionGuard: guard,
+          expiresAt: Date.parse(deadline),
+          invocationId: input.job.invocationId,
+          isLive: () => !ended && !input.abort.signal.aborted,
+        });
+        if (approval.status === 'rejected') {
+          input.abort.abort(new ExecutionStoppedError('permission_denied'));
+        }
+        if (approval.status === 'failed') {
+          input.abort.abort(new ExecutionStoppedError('runner_failed'));
+        }
+        guard();
+        return approval;
+      },
+      selectedTab,
+      settings: settings.workflowSettings,
+      storage: invocationStorage,
+      supportsImages: input.supportsImages,
+      thinkingEffort: settings.thinkingEffort,
+      token: input.token,
+      updateAssistantMessage: (eventId, text) => {
+        events = events.map(event =>
+          event.id === eventId && event.type === 'message' ? { ...event, text } : event
+        );
+      },
+      updateThinkingBlock: (eventId, text) => {
+        events = events.map(event =>
+          event.id === eventId && event.type === 'thinking' ? { ...event, text } : event
+        );
+      },
+    };
+    entered = true;
+    outcome = await runBrowserTurn(context, events);
+    // A final model response cannot revive a cancelled or expired invocation.
+    guard();
+  } catch (error) {
+    const stopped = error instanceof ExecutionStoppedError ? error : undefined;
+    outcome = {
+      ...outcome,
+      effectsUncertain: outcome.effectsUncertain || (stopped?.effectsUncertain ?? entered),
+      reason: stopped?.reason ?? 'runner_failed',
+      status: stopped?.status ?? 'interrupted',
+      summary:
+        stopped === undefined
+          ? 'Browser execution was interrupted.'
+          : `Browser execution stopped: ${stopped.reason}.`,
+    };
+  } finally {
+    ended = true;
+  }
+  if (outcome.effectsUncertain && input.job.approvedTab !== undefined) {
+    await input.lease.quarantine(input.job.approvedTab.tabId);
+  }
+  return { events, outcome, result: toBrowserTaskResult(input.job, outcome, events) };
+};


### PR DESCRIPTION
No new behavior — the new browser task support is not yet active in the extension.

---

## Summary

`BrowserTaskProviderRuntime` uses `BrowserTaskProviderOptions` to reuse a signed-in `UserWebConnection`, with exclusive ownership, durable intent, explicit tab consent, and recovery without replay. `BrowserTaskProvider`, `useBrowserTask`, and `BrowserTaskProviderSnapshot` expose supervision without provider proof or remote credentials; production mounting and controls remain deferred. Cancellation uses `provider_cancel`; `provider_quiesced` permits queue progression only after terminal persistence and drained execution, including rejection before tab approval.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/browser-task-provider.tsx` — Source, added, +1,414/−0 lines. Acquires ownership before proof/storage access; competing panels and unsupported Web Locks cannot register. Persists intent before consent and approval before relay acknowledgement; duplicate deliveries and history snapshots never execute. Exposes owner, goal, queue, tab, deadlines, results, and recovery state. Continuations require fresh consent and isolated retained history. Freezes model, mode, thinking, image support, organization, and tool permissions for one inspectable tab. Waits for local work under the approval deadline and requires a matching running acknowledgement. Sends five-second heartbeats, limits leases to fifteen seconds, and clamps phase deadlines to invocation expiry. Checks abort, lease, generation, invocation, and tab binding before actions; all pending permission reads block execution. Permission changes invalidate pending consent; stale approval and validation callbacks cannot affect later jobs. Stops on cancellation, permission/tab loss, disablement, account/organization changes, disconnect, deadlines, and unmount; account changes disable new work. Saves complete history and bounded results before sending terminal updates; relay terminal results remain final, and terminal updates cannot replay across generations. Keeps account-independent quarantine for uncertain effects, blocking both local and delegated execution. Recovery retrieves status, verifies closed tabs and drained locks, then registers a fresh generation without replay. Supplies every open tab identifier for `allTabs` recovery and supports fences without an approved tab. Teardown waits for issued work and lock release; unavailable delivery remains best-effort.
- `apps/extension/entrypoints/sidepanel/browser-task-provider.test.tsx` — Test, added, +1,731/−0 lines. Covers exclusive ownership, persisted consent, first-in-first-out (FIFO) progression, immutable settings, continuation isolation, duplicates, storage failures, and retained terminal results. Exercises stale callbacks, overlapping permission checks, pending approvals, issued-action cancellation, lease/deadline expiry, tab/authentication changes, component lifetime, and explicit recovery.

</details>

`BrowserTaskRunInput` reuses `BrowserRunContext` with isolated browser history, live execution guards, and a consent-time `BrowserApprovalSettings` snapshot instead of local-chat defaults. `BrowserTaskStorage` validates Remote Model Context Protocol (MCP) OAuth reads; changed or refreshed credentials require fresh consent without overwriting unrelated server edits. `LlmTurnOutcome` becomes a bounded `BrowserResult`; only confirmed page observations become evidence, and failures or uncertain effects cannot become success.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/browser-task-runner.ts` — Source, added, +360/−0 lines. Enumerates inspectable tabs and rejects a missing approved tab without active-tab or first-tab fallback. Adds memory/workflow context to the latest browser goal without importing parent or local-chat transcripts. Preserves Safe/Dangerous restrictions, workflow settings, WebMCP, Remote MCP, and existing approval cards. Clones settings, guards writes and approval callbacks, and binds cards to the invocation, deadline, and liveness. Allows matching draft cleanup after Stop without granting execution. Checks enabled OAuth credentials during actual storage reads, including token, scope, and client changes, while preserving unrelated live edits. Rejects failed approvals and rechecks authority after the final model response. Requires a nonempty summary for success; maps typed failures to failed, cancelled, timed-out, or interrupted results and labels partial work. Takes evidence only from confirmed `get_page_snapshot` observations, excluding screenshots, arbitrary tool output, and model claims. Keeps at most three observations, limits text/title/address lengths to 1,024/128/2,048 characters, and limits model summary text to 4,000 characters. Removes address credentials, query strings, and fragments; uncertain actions quarantine the approved tab without retry.
- `apps/extension/entrypoints/sidepanel/browser-task-runner.test.ts` — Test, added, +841/−0 lines. Exercises the real shared runner, gateway parser, and Remote MCP client with mocked external boundaries. Covers exact-tab execution, isolated history, Safe/Dangerous restrictions, approval cancellation, leases, typed terminal reasons, bounded evidence, confirmed retries, and uncertainty. Tests OAuth account/scope/client changes, token refresh, credential exclusion from results/history, and preservation of unrelated server edits.

</details>

Tests: 2 files added (`browser-task-provider.test.tsx`, `browser-task-runner.test.ts`), +2,572/−0 lines.
Generated: 0 files changed.

---

## Verification

No manual test results are available for this level. Production mounting and controls belong to level 12; live browser and model verification remain pending, not skipped or complete. No end-to-end (E2E) report is attached.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Human steps

No human setup steps are required before or after merge for this level. The code requires no new environment value, secret, migration, or manual data conversion.

### Context

- Scope: Cloud level 11, `browser-task-0787-s10...browser-task-0787-s11`; four added files and 4,346 added lines.
- This level supplies the provider runtime and runner adapter for the [command-line interface (CLI) counterpart, Kilo-Org/kilocode #13567](https://github.com/Kilo-Org/kilocode/pull/13567).
- Cloud worktree: `/Users/igor/Projects/.worktrees/browser-task-0787`; branch `browser-task-0787-s11`.
- CLI worktree: `/Users/igor/Projects/.worktrees/browser-task-0787-kilocode`; branch `browser-task-0787-s6`. This level includes no CLI code changes.
- The landing evidence records four passing scoped checks: formatting, both Vitest suites, type-aware lint/type checks, and whitespace validation.

### Notes

Live CLI, extension, relay, and native Chrome/Firefox verification remain pending for the stack tip. This level does not mount the provider in production.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `browser-task-0787` — #5638
2. `browser-task-0787-s2` — #5644
3. `browser-task-0787-s3` — #5648
4. `browser-task-0787-s4` — #5653
7. `browser-task-0787-s7` — #5681
8. `browser-task-0787-s8` — #5694
9. `browser-task-0787-s9` — #5698
10. `browser-task-0787-s10` — #5702
11. `browser-task-0787-s11` — #5716 ← this PR
12. `browser-task-0787-s12` — #5734
13. `browser-task-0787-s13` — #5742 (tip)

