### PR TITLE
feat(pr-review): define requirement observation contracts

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-requirements-schema.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-requirements-schema.test.ts
@@ -1,0 +1,177 @@
+import {
+  contextCheckSchema,
+  contextComparisonSchema,
+  contextDeploymentSchema,
+  contextTestMergeSchema,
+  contextThreadSchema,
+} from './context-requirements';
+
+const app = { databaseId: 41, id: 'APP', slug: 'ci', name: 'Shared CI' };
+const run = {
+  __typename: 'CheckRun',
+  id: 'RUN',
+  name: 'ci',
+  checkSuite: { app, commit: { oid: 'head' } },
+};
+const status = {
+  __typename: 'StatusContext',
+  id: 'STATUS',
+  context: 'ci',
+  commit: { oid: 'merge' },
+};
+
+it('keeps same-name run/status identities and application IDs separate', () => {
+  const otherApp = { ...app, databaseId: 52, id: 'OTHER_APP' };
+  const other = { ...run, id: 'OTHER_RUN', checkSuite: { ...run.checkSuite, app: otherApp } };
+  const checks = [run, status, other].map(node => contextCheckSchema.parse(node));
+  expect(checks.map(({ id, name, kind, evaluatedSha }) => [id, name, kind, evaluatedSha])).toEqual([
+    ['RUN', 'ci', 'check-run', 'head'],
+    ['STATUS', 'ci', 'status', 'merge'],
+    ['OTHER_RUN', 'ci', 'check-run', 'head'],
+  ]);
+  expect(checks.map(check => check.application)).toEqual([
+    { id: 41, nodeId: 'APP', slug: 'ci', name: 'Shared CI' },
+    null,
+    { id: 52, nodeId: 'OTHER_APP', slug: 'ci', name: 'Shared CI' },
+  ]);
+});
+
+describe.each([run, status])('$__typename fields', node => {
+  it.each([
+    [true, 'required'],
+    [false, 'optional'],
+    [null, 'unknown'],
+    [undefined, 'unknown'],
+    ['false', 'unknown'],
+    [0, 'unknown'],
+  ])('maps isRequired %p to %s independently of failure', (isRequired, requiredness) => {
+    const check = contextCheckSchema.parse({
+      ...node,
+      isRequired,
+      status: 'COMPLETED',
+      conclusion: 'FAILURE',
+      state: 'FAILURE',
+    });
+    expect([check.requiredness, check.outcome]).toEqual([requiredness, 'failure']);
+  });
+  it.each([null, undefined, 7])('keeps unavailable optional fields %p null', value => {
+    const check = contextCheckSchema.parse({
+      ...node,
+      checkSuite: value,
+      commit: value,
+      detailsUrl: value,
+      targetUrl: value,
+    });
+    expect([
+      check.id,
+      check.application,
+      check.evaluatedSha,
+      check.detailsUrl,
+      check.outcome,
+    ]).toEqual([node.id, null, null, null, 'unknown']);
+  });
+  it.each([null, undefined, '', 7])('rejects malformed source identity %p', value => {
+    expect(contextCheckSchema.safeParse({ ...node, id: value }).success).toBe(false);
+    expect(contextCheckSchema.safeParse({ ...node, name: value, context: value }).success).toBe(
+      false
+    );
+  });
+});
+
+it.each([null, undefined, 0, -1, 1.5, '41'])(
+  'does not infer application ID from %p',
+  databaseId => {
+    const check = contextCheckSchema.parse({
+      ...run,
+      checkSuite: { ...run.checkSuite, app: { ...app, databaseId } },
+    });
+    expect(check.application).toEqual({ id: null, nodeId: 'APP', slug: 'ci', name: 'Shared CI' });
+  }
+);
+
+it.each([
+  ['run', 'COMPLETED', 'SUCCESS', 'success'],
+  ['run', 'COMPLETED', 'NEUTRAL', 'skipped'],
+  ['run', 'COMPLETED', 'SKIPPED', 'skipped'],
+  ['run', 'COMPLETED', 'FAILURE', 'failure'],
+  ['run', 'COMPLETED', null, 'unknown'],
+  ['run', 'IN_PROGRESS', 'FAILURE', 'pending'],
+  ['run', 'FUTURE_STATUS', 'SUCCESS', 'unknown'],
+  ['status', 'SUCCESS', null, 'success'],
+  ['status', 'FAILURE', null, 'failure'],
+  ['status', 'ERROR', null, 'failure'],
+  ['status', 'PENDING', null, 'pending'],
+  ['status', 'EXPECTED', null, 'pending'],
+  ['status', 'FUTURE_STATE', null, 'unknown'],
+])('maps %s %p/%p to %s', (kind, state, conclusion, outcome) => {
+  const check = contextCheckSchema.parse({
+    ...(kind === 'run' ? run : status),
+    status: state,
+    state,
+    conclusion,
+  });
+  expect(check.outcome).toBe(outcome);
+});
+
+it.each([
+  [
+    'test-merge',
+    contextTestMergeSchema,
+    {
+      oid: 'merge',
+      parents: { totalCount: 2, nodes: [{ oid: 'base' }, { oid: 'head' }] },
+    },
+  ],
+  [
+    'comparison',
+    contextComparisonSchema,
+    {
+      behindBy: 0,
+      baseTarget: { oid: 'base' },
+      headTarget: { oid: 'head' },
+    },
+  ],
+  ['thread', contextThreadSchema, { id: 'THREAD', isResolved: false }],
+  [
+    'deployment',
+    contextDeploymentSchema,
+    {
+      id: 'DEPLOYMENT',
+      commitOid: 'merge',
+      environment: 'production',
+      latestStatus: { state: 'FAILURE' },
+    },
+  ],
+] as const)('preserves %s identity and rejects missing fields', (_kind, schema, input) => {
+  expect(schema.parse(input)).toEqual(input);
+  expect(schema.safeParse({}).success).toBe(false);
+});
+
+it('retains unavailable fact fields without inventing their values', () => {
+  expect(contextTestMergeSchema.parse(null)).toBeNull();
+  expect(contextComparisonSchema.parse(null)).toBeNull();
+  expect(
+    contextTestMergeSchema.parse({ oid: 'merge', parents: { totalCount: 1, nodes: [] } })
+  ).toEqual({ oid: 'merge', parents: null });
+  expect(contextThreadSchema.parse({ id: 'THREAD', isResolved: 'false' })).toEqual({
+    id: 'THREAD',
+    isResolved: null,
+  });
+  const deployment = {
+    id: 'DEPLOYMENT',
+    commitOid: 'merge',
+    environment: null,
+    latestStatus: null,
+  };
+  expect(contextDeploymentSchema.parse(deployment)).toEqual(deployment);
+});
+
+it.each([-1, 0.5])('rejects invalid comparison lag %p', behindBy => {
+  expect(
+    contextComparisonSchema.safeParse({
+      behindBy,
+      baseTarget: { oid: 'base' },
+      headTarget: { oid: 'head' },
+    }).success
+  ).toBe(false);
+});

--- a/apps/web/src/lib/github-pr-review/context-requirements.ts
+++ b/apps/web/src/lib/github-pr-review/context-requirements.ts
@@ -231,8 +231,8 @@ export type RequirementFacts = {
   testMerge: ContextReadResult<z.output<typeof contextTestMergeSchema>>;
   comparison: ContextReadResult<z.output<typeof contextComparisonSchema>>;
   viewerRule: {
-    requiredApprovingReviewCount: ContextReadResult<number>;
-    requiredStatusCheckContexts: ContextReadResult<Array<string | null>>;
+    requiredApprovingReviewCount: ContextReadResult<number | null>;
+    requiredStatusCheckContexts: ContextReadResult<Array<string | null> | null>;
     requiresConversationResolution: ContextReadResult<boolean>;
   };
   canBypassClassic: ContextReadResult<boolean>;

--- a/apps/web/src/lib/github-pr-review/context-requirements.ts
+++ b/apps/web/src/lib/github-pr-review/context-requirements.ts
@@ -1,0 +1,264 @@
+import 'server-only';
+
+import { z } from 'zod';
+import type {
+  GitHubPrReviewContext,
+  GitHubPrReviewRevision,
+  GitHubPrReviewSource,
+} from './context-dtos';
+import type { ContextReadResult } from './context-reader';
+
+type Check = GitHubPrReviewContext['checks']['items'][number];
+type Requirement = GitHubPrReviewContext['requirements']['items'][number];
+export type RequirementCollection<T> = Omit<GitHubPrReviewContext['checks'], 'items'> & {
+  items: T[];
+};
+
+export const PR_CONTEXT_EVALUATION_QUERY = /* GraphQL */ `
+  query PrReviewContextEvaluation($owner: String!, $name: String!, $number: Int!, $head: String!) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        id number headRefOid baseRefName baseRefOid baseRepository { nameWithOwner }
+        mergeable
+        viewerCanMergeAsAdmin
+        potentialMergeCommit { oid parents(first: 2) { totalCount nodes { oid } } }
+        baseRef {
+          refUpdateRule { requiredApprovingReviewCount requiredStatusCheckContexts requiresConversationResolution }
+          compare(headRef: $head) { behindBy baseTarget { oid } headTarget { oid } }
+        }
+      }
+    }
+  }
+`;
+
+export const PR_CONTEXT_REQUIREMENT_QUERIES = {
+  checks: /* GraphQL */ `
+    query PrReviewContextChecks($owner: String!, $name: String!, $oid: String!, $pr: ID!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        object(expression: $oid) {
+          ... on Commit {
+            oid
+            statusCheckRollup {
+              contexts(first: 100, after: $after) {
+                totalCount pageInfo { hasNextPage endCursor }
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    id name status conclusion detailsUrl isRequired(pullRequestId: $pr)
+                    checkSuite { commit { oid } app { databaseId id slug name } }
+                  }
+                  ... on StatusContext {
+                    id context state targetUrl isRequired(pullRequestId: $pr) commit { oid }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+  reviewThreads: /* GraphQL */ `
+    query PrReviewContextThreads($owner: String!, $name: String!, $number: Int!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100, after: $after) {
+            totalCount pageInfo { hasNextPage endCursor } nodes { id isResolved }
+          }
+        }
+      }
+    }
+  `,
+  eligibleReviews: /* GraphQL */ `
+    query PrReviewContextEligibleReviews($owner: String!, $name: String!, $number: Int!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          eligibleReviews: latestOpinionatedReviews(first: 100, after: $after, writersOnly: true) {
+            totalCount pageInfo { hasNextPage endCursor }
+            nodes {
+              id state submittedAt commit { oid }
+              author {
+                __typename
+                ... on User { id login name avatarUrl url }
+                ... on Bot { id login avatarUrl url }
+                ... on Mannequin { id login avatarUrl url }
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+  deployments: /* GraphQL */ `
+    query PrReviewContextDeployments($owner: String!, $name: String!, $oid: String!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        object(expression: $oid) {
+          ... on Commit {
+            oid
+            deployments(first: 100, after: $after) {
+              totalCount pageInfo { hasNextPage endCursor }
+              nodes { id commitOid environment latestStatus { state } }
+            }
+          }
+        }
+      }
+    }
+  `,
+};
+
+const oidSchema = z.object({ oid: z.string().min(1) });
+export const contextTestMergeSchema = oidSchema
+  .extend({
+    parents: z
+      .object({ totalCount: z.literal(2), nodes: z.array(oidSchema).length(2) })
+      .nullable()
+      .catch(null),
+  })
+  .nullable();
+export const contextComparisonSchema = z
+  .object({
+    behindBy: z.number().int().nonnegative(),
+    baseTarget: oidSchema,
+    headTarget: oidSchema,
+  })
+  .nullable();
+export const contextThreadSchema = z.object({
+  id: z.string().min(1),
+  isResolved: z.boolean().nullable().catch(null),
+});
+export const contextDeploymentSchema = z.object({
+  id: z.string().min(1),
+  commitOid: z.string().min(1),
+  environment: z.string().nullable(),
+  latestStatus: z.object({ state: z.string() }).nullable(),
+});
+const applicationSchema = z
+  .object({
+    databaseId: z.number().int().positive().nullable().catch(null),
+    id: z.string().min(1).nullable().catch(null),
+    slug: z.string().nullable().catch(null),
+    name: z.string().nullable().catch(null),
+  })
+  .nullable()
+  .catch(null);
+const checkFields = {
+  id: z.string().min(1),
+  isRequired: z.boolean().nullable().catch(null),
+};
+export const contextCheckSchema = z
+  .discriminatedUnion('__typename', [
+    z.object({
+      ...checkFields,
+      __typename: z.literal('CheckRun'),
+      name: z.string().min(1),
+      status: z.string().nullable().catch(null),
+      conclusion: z.string().nullable().catch(null),
+      detailsUrl: z.string().url().nullable().catch(null),
+      checkSuite: z
+        .object({
+          app: applicationSchema,
+          commit: oidSchema.nullable().catch(null),
+        })
+        .nullable()
+        .catch(null),
+    }),
+    z.object({
+      ...checkFields,
+      __typename: z.literal('StatusContext'),
+      context: z.string().min(1),
+      state: z.string().nullable().catch(null),
+      targetUrl: z.string().url().nullable().catch(null),
+      commit: oidSchema.nullable().catch(null),
+    }),
+  ])
+  .transform((node): Check => {
+    const run = node.__typename === 'CheckRun';
+    const app = run ? node.checkSuite?.app : null;
+    const kind = run ? 'check-run' : 'status';
+    const status = run ? node.status : node.state;
+    const conclusion = run ? node.conclusion : null;
+    return {
+      id: node.id,
+      name: run ? node.name : node.context,
+      kind,
+      application: app
+        ? { id: app.databaseId, nodeId: app.id, slug: app.slug, name: app.name }
+        : null,
+      outcome: contextCheckOutcome(kind, status, conclusion),
+      status,
+      conclusion,
+      requiredness:
+        node.isRequired === true ? 'required' : node.isRequired === false ? 'optional' : 'unknown',
+      observation: 'observed',
+      evaluatedSha: (run ? node.checkSuite?.commit?.oid : node.commit?.oid) ?? null,
+      detailsUrl: run ? node.detailsUrl : node.targetUrl,
+      evidence: [],
+    };
+  });
+
+export function contextCheckOutcome(
+  kind: Check['kind'],
+  status: string | null,
+  conclusion: string | null
+): Check['outcome'] {
+  if (kind === 'status') {
+    return status === 'SUCCESS'
+      ? 'success'
+      : status === 'FAILURE' || status === 'ERROR'
+        ? 'failure'
+        : status === 'PENDING' || status === 'EXPECTED'
+          ? 'pending'
+          : 'unknown';
+  }
+  if (status === 'COMPLETED') {
+    if (conclusion === 'SUCCESS') return 'success';
+    if (conclusion === 'SKIPPED' || conclusion === 'NEUTRAL') return 'skipped';
+    if (
+      ['ACTION_REQUIRED', 'CANCELLED', 'FAILURE', 'STARTUP_FAILURE', 'TIMED_OUT'].includes(
+        conclusion ?? ''
+      )
+    )
+      return 'failure';
+    return 'unknown';
+  }
+  return ['QUEUED', 'IN_PROGRESS', 'REQUESTED', 'WAITING', 'PENDING'].includes(status ?? '')
+    ? 'pending'
+    : 'unknown';
+}
+
+export type RequirementFacts = {
+  mergeable: ContextReadResult<'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'>;
+  testMerge: ContextReadResult<z.output<typeof contextTestMergeSchema>>;
+  comparison: ContextReadResult<z.output<typeof contextComparisonSchema>>;
+  viewerRule: {
+    requiredApprovingReviewCount: ContextReadResult<number>;
+    requiredStatusCheckContexts: ContextReadResult<Array<string | null>>;
+    requiresConversationResolution: ContextReadResult<boolean>;
+  };
+  canBypassClassic: ContextReadResult<boolean>;
+};
+export type RequirementObservations = {
+  head: GitHubPrReviewContext['checks'];
+  merge: GitHubPrReviewContext['checks'] | null;
+  threads: RequirementCollection<z.output<typeof contextThreadSchema>>;
+  eligibleReviews: GitHubPrReviewContext['reviewDecisions'];
+  deployments: RequirementCollection<z.output<typeof contextDeploymentSchema>>;
+};
+
+export function contextRequirementEvidence(
+  revision: GitHubPrReviewRevision,
+  source: GitHubPrReviewSource,
+  observation: string,
+  evaluatedSha: string | null,
+  policyId: string | null = null
+): Requirement['evidence'] {
+  return source.provenance.map(provenance => ({
+    source: provenance,
+    policyId,
+    observation,
+    headSha: revision.headSha,
+    baseSha: revision.baseSha,
+    evaluatedSha,
+    observedAt: source.observedAt,
+  }));
+}

--- a/apps/web/src/routers/github-pr-review-graphql-schema.test.ts
+++ b/apps/web/src/routers/github-pr-review-graphql-schema.test.ts
@@ -42,8 +42,8 @@ const introspection = JSON.parse(readFileSync(introspectionPath, 'utf8'));
 const githubSchema = buildClientSchema(introspection);
 
 describe('github-pr-review-router GraphQL documents', () => {
-  test('exports exactly 19 documents (sanity guard for the export record)', () => {
-    expect(Object.keys(PR_REVIEW_GRAPHQL_DOCUMENTS)).toHaveLength(19);
+  test('exports exactly 24 documents (sanity guard for the export record)', () => {
+    expect(Object.keys(PR_REVIEW_GRAPHQL_DOCUMENTS)).toHaveLength(24);
   });
 
   test.each(Object.entries(PR_REVIEW_GRAPHQL_DOCUMENTS))(

--- a/apps/web/src/routers/github-pr-review-router.ts
+++ b/apps/web/src/routers/github-pr-review-router.ts
@@ -50,6 +50,10 @@ import {
 import { PR_CONTEXT_PEOPLE_QUERIES } from '@/lib/github-pr-review/context-people';
 import { PR_CONTEXT_REVIEW_QUERIES } from '@/lib/github-pr-review/context-reviews';
 import { PR_CONTEXT_ISSUE_QUERIES } from '@/lib/github-pr-review/context-issues';
+import {
+  PR_CONTEXT_EVALUATION_QUERY,
+  PR_CONTEXT_REQUIREMENT_QUERIES,
+} from '@/lib/github-pr-review/context-requirements';
 import { getGitHubUserAccessToken } from '@/lib/integrations/platforms/github/user-token-client';
 import {
   AutoMergeMethodSchema,
@@ -544,6 +548,8 @@ export const CONVERSATION_COMMENTS_QUERY_FOR_TEST = CONVERSATION_COMMENTS_QUERY;
 export const PR_REVIEW_GRAPHQL_DOCUMENTS = {
   PULL_REQUEST_FRAGMENT_QUERY,
   PR_CONTEXT_REVISION_QUERY,
+  PR_CONTEXT_EVALUATION_QUERY,
+  ...PR_CONTEXT_REQUIREMENT_QUERIES,
   ...PR_CONTEXT_PEOPLE_QUERIES,
   ...PR_CONTEXT_REVIEW_QUERIES,
   ...PR_CONTEXT_ISSUE_QUERIES,


### PR DESCRIPTION
No new behavior — mobile users keep the same pull request review experience; this change does not add live requirement checks.

---

## Summary

The `RequirementFacts` rule inputs preserve nullable `ContextReadResult` values: `requiredApprovingReviewCount` uses `number | null`, and `requiredStatusCheckContexts` uses `Array<string | null> | null`.
`PR_CONTEXT_EVALUATION_QUERY` and `PR_CONTEXT_REQUIREMENT_QUERIES` define five documents; `RequirementObservations` and `RequirementCollection<T>` separate observation collections without dropping their metadata.
`contextTestMergeSchema`, `contextComparisonSchema`, `contextThreadSchema`, and `contextDeploymentSchema` validate facts; `contextCheckSchema`, `contextCheckOutcome`, and `contextRequirementEvidence` retain check distinctions and provenance for later evaluation.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-requirements.ts` — added (+264 lines); adds an evaluation document for mergeability, administrator bypass, branch rules, candidate merge parents, and commit comparison. Four collection documents request 100 checks, threads, writer-only opinionated reviews, or deployments per cursor page, including totals and continuation metadata. Eligible reviews include author identity, submission time, state, and commit. Merge parent observations require exactly two parents; malformed parent lists and thread resolution values become null. Comparisons require nonnegative integer lag and nonempty commit identities; deployments retain commit, environment, and latest status. Normalized checks retain separate run/status and application identities, raw status and conclusion, evaluated commit, and valid details links. Core check identities must be nonempty; malformed optional fields become null. Missing or invalid requiredness remains unknown, independent of the outcome. Outcomes distinguish success, failure, pending, skipped, and unknown; completed neutral or skipped runs remain skipped. Recognized incomplete runs stay pending even with a failure conclusion; unrecognized states remain unknown. The observation types distinguish head checks from nullable candidate-merge checks and retain collection metadata. The two nullable rule arguments preserve absent approval counts, absent status-context lists, and null list entries for callers. Normalized checks start with empty evidence. The evidence helper binds each provenance source to the observation, head, base, evaluated commit, timestamp, and optional policy.
- `apps/web/src/lib/github-pr-review/context-requirements-schema.test.ts` — added (+177 lines); covers distinct check, application, and commit identities, independent requiredness, outcome normalization, nullable fields, and malformed input rejection. A readonly case table exercises merge-parent, comparison, thread, and deployment contracts; additional cases reject invalid comparison lag.

</details>

`PR_REVIEW_GRAPHQL_DOCUMENTS` now exposes five additional documents to GitHub schema validation, and its count guard rises from 19 to 24.
No new request invokes these documents, so existing callers receive the same runtime behavior.
The explicit count guard requires an update whenever the registered document set changes.

<details>
<summary>Files</summary>

- `apps/web/src/routers/github-pr-review-router.ts` — modified (+6 lines); imports the requirement documents and adds them to the exported validation registry without adding a runtime request.
- `apps/web/src/routers/github-pr-review-graphql-schema.test.ts` — modified (+2/-2 lines); updates the guard title and expected document count from 19 to 24.

</details>

Tests: 2 files — `context-requirements-schema.test.ts` added and `github-pr-review-graphql-schema.test.ts` modified; +179/-2 lines in total.
Generated: 0 files.

---

## Visual Changes

Visual Changes: N/A

## Verification

No manual tests ran for this level. The changes add observation contracts without attaching them to live context reads or completing the evaluator.

## Reviewer Notes

### Scope

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- This description covers level 17, from `mobile-pr-review-context-5458-s16` to `mobile-pr-review-context-5458-s17`, not the cumulative branch.
- The saved review refs define this level; the frozen source checkout and uncommitted changes do not supply the reviewed code.
- All 27 pull requests (PRs) remain part of one incomplete stack.

### Historical automated proof

- The owning level-17 snapshot passed 87 cases; its cumulative snapshot passed 360 cases.
- Both contract-root type projects and formatting passed before the level-17 publication.
- These results come from the supplied history, not new checks during this refresh.
- Later inherited repairs change review hashes without adding inherited files to this level's diff.
- Current-head continuous integration (CI), bot review, thread handling, and the final description gate each remain independently required.

### Human steps

No deployment, migration, or configuration step is known for these level-specific diffs.
The owner retains product merge authority.

- **before merge:** When the owner permits runtime verification, verify live backend and iOS features on the completed stack tip.
- **before merge:** Do not ask for review or merge before the complete-stack human-ready gate.
- **after merge:** No additional step is known for this level.

### Notes

Live backend and iOS verification remains pending on the completed stack tip.

Live backend and iOS feature verification remains required on the completed stack tip.

The owner currently prohibits new E2E slots and bundles; this hold does not waive runtime verification.

Levels 24 and 25 have prepared repairs and partial proof, but publication remains pending a workflow operation for an unpublished propagated baseline.

Their required three-root type checks have not passed; no failed publication proof is applied.

The owner descoped large-text/font-scaling, theme variants, contrast rendering, scaled-text layout, and screen-reader presentation.

Functional accessibility labels, roles, identifiers, selectors, default appearance flows, and all non-visual criteria remain required.

This is an interim description refresh; the complete-stack readiness gate remains open.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720 ← this PR
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)

