### PR TITLE
feat(pr-review): expand named policy requirements

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-requirements-policy.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-requirements-policy.test.ts
@@ -1,0 +1,307 @@
+import { GitHubPrReviewRequirementSchema } from './context-dtos';
+import { expandPolicy } from './context-requirements';
+
+const requirement = (source: 'classic' | 'ruleset', ruleType: string, parameters: unknown) =>
+  GitHubPrReviewRequirementSchema.parse({
+    id: 'policy',
+    kind: ruleType,
+    title: ruleType,
+    state: 'unavailable',
+    check: null,
+    policy: {
+      id: 'policy',
+      source,
+      enforcement: 'active',
+      ruleType,
+      parameters,
+      base: { baseRepoFullName: 'kilo/upstream', baseRef: 'release/1', baseSha: 'base' },
+      ruleset: source === 'ruleset' ? { id: 12, source: 'kilo', sourceType: 'Organization' } : null,
+    },
+    evidence: [
+      {
+        source: source === 'classic' ? 'rest.branchProtection' : 'rest.branchRules',
+        policyId: 'policy',
+        observation: 'policy-configuration',
+        headSha: 'head',
+        baseSha: 'base',
+        evaluatedSha: null,
+        observedAt: '2026-08-29T12:00:00Z',
+      },
+    ],
+  });
+
+function expectKinds(item: ReturnType<typeof requirement>, kinds: string[]) {
+  const rows = expandPolicy(item);
+  expect(rows.map(row => row.kind)).toEqual(kinds);
+  for (const row of rows) {
+    expect(row.state).toBe('unavailable');
+    expect(row.policy).toEqual(item.policy);
+    expect(row.evidence).toEqual(item.evidence);
+  }
+  return rows;
+}
+
+it('names each classic requirement and retains its exact configuration evidence', () => {
+  const item = requirement('classic', 'branch_protection', {
+    required_status_checks: {
+      strict: true,
+      checks: [{ context: 'ci', app_id: 7 }],
+      contexts: ['ci'],
+    },
+    required_pull_request_reviews: {
+      required_approving_review_count: 2,
+      require_code_owner_reviews: true,
+      require_last_push_approval: true,
+      dismiss_stale_reviews: true,
+    },
+    required_conversation_resolution: { enabled: true },
+    required_deployments: {
+      required_deployment_environments: ['preview', 'production', 'preview'],
+    },
+    required_signatures: { enabled: true },
+    required_linear_history: true,
+    lock_branch: { enabled: true },
+    block_creations: true,
+    restrictions: { users: [], teams: [], apps: [] },
+    future_rule: { nested: [null, { limit: 3 }] },
+  });
+  const rows = expectKinds(item, [
+    'branch-freshness',
+    'approving-reviews',
+    'code-owner-reviews',
+    'last-push-approval',
+    'stale-review-dismissal',
+    'conversation-resolution',
+    'deployment',
+    'deployment',
+    'commit-signatures',
+    'linear-history',
+    'locked-branch',
+    'branch-creation',
+    'push-restrictions',
+    'future_rule',
+  ]);
+  expect(rows.map(row => row.title)).toEqual([
+    'Branch must be up to date',
+    'Required approving reviews',
+    'Code owner reviews',
+    'Approval of the last push',
+    'Stale review dismissal',
+    'Resolved review conversations',
+    'preview',
+    'production',
+    'Signed commits',
+    'Linear history',
+    'Unlocked branch',
+    'Branch creation restrictions',
+    'Push restrictions',
+    'future_rule',
+  ]);
+  expect(new Set(rows.map(row => row.id)).size).toBe(rows.length);
+});
+
+it.each([
+  [
+    'required_status_checks',
+    {
+      required_status_checks: [],
+      strict_required_status_checks_policy: true,
+      do_not_enforce_on_create: false,
+    },
+    [],
+  ],
+  [
+    'pull_request',
+    {
+      required_approving_review_count: 3,
+      require_code_owner_review: true,
+      require_last_push_approval: true,
+      dismiss_stale_reviews_on_push: true,
+      required_review_thread_resolution: true,
+      allowed_merge_methods: ['squash'],
+      future_parameter: { nested: ['unknown'] },
+    },
+    [
+      'approving-reviews',
+      'code-owner-reviews',
+      'last-push-approval',
+      'stale-review-dismissal',
+      'conversation-resolution',
+      'allowed-merge-methods',
+    ],
+  ],
+  [
+    'required_deployments',
+    { required_deployment_environments: ['production', 'staging'] },
+    ['deployment', 'deployment'],
+  ],
+] as const)(
+  'expands inherited %s without losing parameters or provenance',
+  (kind, parameters, kinds) => {
+    const item = requirement('ruleset', kind, parameters);
+    const rows = expectKinds(item, [...kinds]);
+    if (kind === 'required_deployments')
+      expect(rows.map(row => row.title)).toEqual(['production', 'staging']);
+  }
+);
+
+it.each([
+  { kind: 'app', appId: 7 },
+  { kind: 'app', appId: 8 },
+  { kind: 'any' },
+  { kind: 'unknown' },
+] as const)('preserves the named check and its exact binding %j', application => {
+  const item = {
+    ...requirement('classic', 'branch_protection', { required_status_checks: { strict: true } }),
+    kind: 'status-check',
+    title: 'ci',
+    check: { name: 'ci', kind: 'unknown' as const, application },
+  };
+  expect(expandPolicy(item)).toEqual([item]);
+});
+
+it.each(['required_signatures', 'workflows', 'code_scanning', 'future_rule'])(
+  'keeps unsupported %s named and unavailable',
+  kind => {
+    const item = requirement('ruleset', kind, { opaque: [{ value: null, enabled: true }] });
+    expect(expandPolicy(item)).toEqual([item]);
+  }
+);
+
+it('retains malformed classic configuration as named unavailable requirements', () => {
+  const item = requirement('classic', 'branch_protection', {
+    required_status_checks: 'invalid',
+    required_pull_request_reviews: {
+      required_approving_review_count: '2',
+      require_code_owner_reviews: null,
+    },
+    required_deployments: { required_deployment_environments: ['production', null] },
+    required_signatures: null,
+  });
+  expectKinds(item, [
+    'status-policy',
+    'approving-reviews',
+    'review-policy',
+    'deployment-policy',
+    'commit-signatures',
+  ]);
+});
+
+it.each(['2', -1, 0.5, null])('does not treat invalid approval count %p as zero', count => {
+  expectKinds(
+    requirement('ruleset', 'pull_request', {
+      required_approving_review_count: count,
+      require_code_owner_review: false,
+      require_last_push_approval: false,
+      dismiss_stale_reviews_on_push: false,
+    }),
+    ['approving-reviews']
+  );
+});
+
+it.each([
+  ['required_status_checks', 'status-policy'],
+  ['pull_request', 'approving-reviews'],
+  ['required_deployments', 'required_deployments'],
+])('does not turn missing %s parameters into an empty result', (kind, expected) => {
+  expectKinds(requirement('ruleset', kind, null), [expected]);
+});
+
+it.each([
+  ['classic', false],
+  ['classic', true],
+  ['ruleset', false],
+  ['ruleset', true],
+] as const)('accepts supported empty %s checks with strict %p', (source, strict) => {
+  const item =
+    source === 'classic'
+      ? requirement(source, 'branch_protection', {
+          required_status_checks: { strict, checks: [], contexts: [] },
+          required_pull_request_reviews: {
+            required_approving_review_count: 0,
+            require_code_owner_reviews: false,
+            require_last_push_approval: false,
+            dismiss_stale_reviews: false,
+          },
+          required_conversation_resolution: { enabled: false },
+          required_deployments: { required_deployment_environments: [] },
+          required_signatures: { enabled: false },
+          required_linear_history: false,
+          lock_branch: { enabled: false },
+          block_creations: false,
+        })
+      : requirement(source, 'required_status_checks', {
+          required_status_checks: [],
+          strict_required_status_checks_policy: strict,
+        });
+  expect(expandPolicy(item)).toEqual([]);
+});
+
+it('retains strict freshness for a configured ruleset check', () => {
+  expectKinds(
+    requirement('ruleset', 'required_status_checks', {
+      required_status_checks: [{ context: 'ci', integration_id: 7 }],
+      strict_required_status_checks_policy: true,
+      do_not_enforce_on_create: false,
+    }),
+    ['branch-freshness']
+  );
+});
+
+it.each([{ enabled: 'invalid' }, 'invalid', {}, null])(
+  'retains malformed classic conversations %j beside supported empty checks',
+  conversation => {
+    const item = requirement('classic', 'branch_protection', {
+      required_status_checks: { strict: false, checks: [], contexts: [] },
+      required_conversation_resolution: conversation,
+    });
+    expectKinds(item, ['conversation-resolution']);
+  }
+);
+
+it.each([false, true])(
+  'retains unknown ruleset status parameters beside empty checks with strict %p',
+  strict => {
+    const item = requirement('ruleset', 'required_status_checks', {
+      required_status_checks: [],
+      strict_required_status_checks_policy: strict,
+      future_parameter: { nested: ['unknown'] },
+    });
+    expectKinds(item, ['status-policy']);
+  }
+);
+
+it.each([
+  ['classic', { strict: false, checks: [null], contexts: [] }, ['status-policy']],
+  ['classic', { strict: true, checks: [], contexts: null }, ['branch-freshness', 'status-policy']],
+  [
+    'ruleset',
+    { strict_required_status_checks_policy: true },
+    ['branch-freshness', 'status-policy'],
+  ],
+  [
+    'ruleset',
+    { strict_required_status_checks_policy: false, required_status_checks: [{ context: '' }] },
+    ['status-policy'],
+  ],
+  [
+    'ruleset',
+    {
+      strict_required_status_checks_policy: false,
+      required_status_checks: [],
+      do_not_enforce_on_create: 'invalid',
+    },
+    ['status-policy'],
+  ],
+] as const)('retains uncertain %s status configuration %j', (source, parameters, kinds) => {
+  const item =
+    source === 'classic'
+      ? requirement(source, 'branch_protection', { required_status_checks: parameters })
+      : requirement(source, 'required_status_checks', parameters);
+  expectKinds(item, [...kinds]);
+});
+
+it('preserves a requirement when its policy is unavailable', () => {
+  const item = { ...requirement('ruleset', 'future_rule', null), policy: null };
+  expect(expandPolicy(item)).toEqual([item]);
+});

--- a/apps/web/src/lib/github-pr-review/context-requirements.ts
+++ b/apps/web/src/lib/github-pr-review/context-requirements.ts
@@ -245,6 +245,10 @@ export type RequirementObservations = {
   deployments: RequirementCollection<z.output<typeof contextDeploymentSchema>>;
 };
 
+const objectSchema = z.record(z.string(), z.json());
+const object = (value: unknown): z.output<typeof objectSchema> =>
+  objectSchema.safeParse(value).data ?? {};
+
 export function contextRequirementEvidence(
   revision: GitHubPrReviewRevision,
   source: GitHubPrReviewSource,
@@ -261,4 +265,159 @@ export function contextRequirementEvidence(
     evaluatedSha,
     observedAt: source.observedAt,
   }));
+}
+
+const reviewFlags = [
+  [
+    'require_code_owner_reviews',
+    'require_code_owner_review',
+    'code-owner-reviews',
+    'Code owner reviews',
+  ],
+  [
+    'require_last_push_approval',
+    'require_last_push_approval',
+    'last-push-approval',
+    'Approval of the last push',
+  ],
+  [
+    'dismiss_stale_reviews',
+    'dismiss_stale_reviews_on_push',
+    'stale-review-dismissal',
+    'Stale review dismissal',
+  ],
+] as const;
+
+export function expandPolicy(item: Requirement): Requirement[] {
+  if (item.check || !item.policy) return [item];
+  const { policy } = item;
+  const parameters: z.output<typeof objectSchema> = policy.parameters ?? {};
+  const classic = policy.source === 'classic';
+  const rows: Requirement[] = [];
+  const add = (kind: string, title: string) =>
+    rows.push({ ...item, id: `${item.id}:${kind}:${title}`, kind, title });
+  const status: z.output<typeof objectSchema> = classic
+    ? object(parameters.required_status_checks)
+    : policy.ruleType === 'required_status_checks'
+      ? parameters
+      : {};
+  const checkListSchema = z.array(z.object({ context: z.string().min(1) }));
+  const supportedStatus = (
+    classic
+      ? z
+          .object({
+            strict: z.boolean(),
+            checks: checkListSchema,
+            contexts: z.array(z.string().min(1)),
+            url: z.string().optional(),
+            contexts_url: z.string().optional(),
+            enforcement_level: z.string().optional(),
+          })
+          .strict()
+      : z
+          .object({
+            strict_required_status_checks_policy: z.boolean(),
+            required_status_checks: checkListSchema,
+            do_not_enforce_on_create: z.boolean().optional(),
+          })
+          .strict()
+  ).safeParse(status).success;
+  const checks = classic ? status.checks : status.required_status_checks;
+  const emptyChecks =
+    Array.isArray(checks) &&
+    checks.length === 0 &&
+    (!classic || (Array.isArray(status.contexts) && status.contexts.length === 0));
+  const strict = classic ? status.strict : status.strict_required_status_checks_policy;
+  if (strict === true && !emptyChecks) add('branch-freshness', 'Branch must be up to date');
+  if (
+    (classic
+      ? parameters.required_status_checks != null
+      : policy.ruleType === 'required_status_checks') &&
+    !supportedStatus
+  )
+    add('status-policy', 'Required status check policy');
+  const reviews: z.output<typeof objectSchema> = classic
+    ? object(parameters.required_pull_request_reviews)
+    : policy.ruleType === 'pull_request'
+      ? parameters
+      : {};
+  const reviewCount = z
+    .number()
+    .int()
+    .nonnegative()
+    .safeParse(reviews.required_approving_review_count);
+  if (
+    (classic
+      ? parameters.required_pull_request_reviews != null
+      : policy.ruleType === 'pull_request') &&
+    (!reviewCount.success || reviewCount.data > 0)
+  )
+    add('approving-reviews', 'Required approving reviews');
+  for (const [classicField, rulesetField, kind, title] of reviewFlags)
+    if (reviews[classic ? classicField : rulesetField] === true) add(kind, title);
+  if (
+    Object.keys(reviews).length &&
+    reviewFlags.some(
+      ([classicField, rulesetField]) =>
+        typeof reviews[classic ? classicField : rulesetField] !== 'boolean'
+    )
+  )
+    add('review-policy', 'Review requirements');
+  if (
+    (classic &&
+      Object.hasOwn(parameters, 'required_conversation_resolution') &&
+      parameters.required_conversation_resolution !== false &&
+      object(parameters.required_conversation_resolution).enabled !== false) ||
+    reviews.required_review_thread_resolution === true
+  )
+    add('conversation-resolution', 'Resolved review conversations');
+  if (!classic && policy.ruleType === 'pull_request' && parameters.allowed_merge_methods != null)
+    add('allowed-merge-methods', 'Allowed merge methods');
+  const environments = classic
+    ? object(parameters.required_deployments).required_deployment_environments
+    : policy.ruleType === 'required_deployments'
+      ? parameters.required_deployment_environments
+      : undefined;
+  const parsedEnvironments = z.array(z.string().min(1)).safeParse(environments);
+  if (parsedEnvironments.success) {
+    for (const environment of new Set(parsedEnvironments.data)) add('deployment', environment);
+  } else if (classic && parameters.required_deployments != null) {
+    add('deployment-policy', 'Required deployment policy');
+  }
+  if (classic) {
+    for (const [field, kind, title] of [
+      ['required_signatures', 'commit-signatures', 'Signed commits'],
+      ['required_linear_history', 'linear-history', 'Linear history'],
+      ['lock_branch', 'locked-branch', 'Unlocked branch'],
+      ['block_creations', 'branch-creation', 'Branch creation restrictions'],
+    ] as const)
+      if (
+        Object.hasOwn(parameters, field) &&
+        parameters[field] !== false &&
+        object(parameters[field]).enabled !== false
+      )
+        add(kind, title);
+    if (parameters.restrictions != null) add('push-restrictions', 'Push restrictions');
+    const known = new Set([
+      'url',
+      'name',
+      'protection_url',
+      'required_status_checks',
+      'required_pull_request_reviews',
+      'required_conversation_resolution',
+      'required_deployments',
+      'required_signatures',
+      'required_linear_history',
+      'lock_branch',
+      'block_creations',
+      'restrictions',
+      'enforce_admins',
+      'allow_force_pushes',
+      'allow_deletions',
+      'allow_fork_syncing',
+    ]);
+    for (const key of Object.keys(parameters)) if (!known.has(key)) add(key, key);
+  }
+  // Check descriptions are separate rows; do not keep an unevaluated umbrella for them.
+  return rows.length || supportedStatus ? rows : [item];
 }


### PR DESCRIPTION
No new behavior — this change prepares more detailed review information without changing what the app shows.

---

## Summary

`expandPolicy` names classic branch protection and ruleset requirements for checks, freshness, reviews, conversations, deployments, signatures, merge methods, branch restrictions, and unsupported rules.
Rows retain policy identity, structured parameters, provenance, and state; unavailable inputs stay unavailable because this contract does not evaluate results.
Supported empty checks omit freshness and redundant status rows; malformed classic conversation settings and unsupported status settings remain named.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-requirements.ts` — modified (M), +159/-0 lines. Reads nested objects safely, validates status shapes, and derives row identifiers from the original identifier, kind, and title. Expands approval counts, code-owner reviews, last-push approval, stale-review dismissal, allowed merge methods, and distinct deployment environments. Adds classic rows for signatures, linear history, branch locks, branch creation, push restrictions, and unrecognized fields. Existing checks retain exact application bindings; requirements without a policy and unsupported ruleset types pass through unchanged. Invalid or missing approval counts remain requirements; invalid review or deployment settings keep fallback rows. Configured zero approvals and false review flags add no corresponding rows. Classic toggles respect both plain false and disabled objects. If strict checking is enabled, nonempty or incomplete check lists retain a freshness row.

</details>

Tests: 1 test file added — `apps/web/src/lib/github-pr-review/context-requirements-policy.test.ts` (A, +307/-0 lines). Covers named rows, preserved identity and provenance, exact check bindings, unsupported rules, missing parameters, malformed settings, and empty-check handling.
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

No manual tests ran for this level. The change does not attach live reads or complete the evaluator, so it has no current user-facing behavior to test.

## Reviewer Notes

### Scope

- Repository: `Kilo-Org/cloud`.
- Worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- This description covers level 18 only: `mobile-pr-review-context-5458-s17...mobile-pr-review-context-5458-s18`, not the cumulative branch.

### Automated evidence from the handoff

- All 90 scoped policy/schema tests passed.
- Scoped lint, formatting, whitespace, and guarded repair-delta checks passed.

### Human steps

This change requires no human steps before merge or after merge.

### Notes

Live backend and iOS verification remains pending on the completed stack tip.









<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723 ← this PR
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
