### PR TITLE
fix(mobile): repair message actions and navigation UI

### DIFF
--- a/apps/mobile/src/app/(app)/(tabs)/(3_profile)/security-agent/[scope]/_layout.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(3_profile)/security-agent/[scope]/_layout.tsx
@@ -24,7 +24,12 @@ export default function SecurityAgentScopeLayout() {
   return (
     <>
       <SecurityAgentCommandObserver scope={scope} />
-      <Stack screenLayout={privacyScreenLayout} screenOptions={{ headerShown: false }}>
+      {/* Anchored entry needs a valid scope root, not a parameterless dismissal route. */}
+      <Stack
+        initialRouteName="index"
+        screenLayout={privacyScreenLayout}
+        screenOptions={{ headerShown: false }}
+      >
         <Stack.Screen
           name="dismiss/[id]"
           options={{

--- a/apps/mobile/src/components/agents/child-session-card-state.test.ts
+++ b/apps/mobile/src/components/agents/child-session-card-state.test.ts
@@ -346,6 +346,68 @@ describe('getChildSessionCardState', () => {
   });
 });
 
+describe.each(['completed', 'error'] as const)('terminal %s parent activity', status => {
+  const part = makeTaskPart(status, { subagent_type: 'Researcher', description: 'Check spec' });
+  const histories: [string, StoredMessage[]][] = [
+    ['empty history', []],
+    ['incomplete history', [makeAssistantMessage([])]],
+    ['text', [makeAssistantMessage([makeTextPart('The answer')])]],
+    ['reasoning', [makeAssistantMessage([makeReasoningPart('Still thinking')])]],
+    [
+      'snapshot progress',
+      [
+        makeAssistantMessage([
+          {
+            id: 'snapshot',
+            sessionID: 'ses-1',
+            messageID: 'msg-1',
+            type: 'text',
+            text: 'Initializing snapshot…',
+            synthetic: true,
+          },
+        ]),
+      ],
+    ],
+    [
+      'structural part',
+      [
+        makeAssistantMessage([
+          {
+            id: 'step',
+            sessionID: 'ses-1',
+            messageID: 'msg-1',
+            type: 'step-start',
+          },
+        ]),
+      ],
+    ],
+    [
+      'delayed latest parts',
+      [makeAssistantMessage([makeTextPart('Earlier response')]), makeAssistantMessage([], 'msg-2')],
+    ],
+    ...(['pending', 'running', 'completed', 'error'] as const).map(
+      childStatus =>
+        [
+          `${childStatus} child tool`,
+          [
+            makeAssistantMessage([
+              makeToolPart('read', {
+                ...makeTaskPart(childStatus).state,
+                input: { filePath: '/project/spec.md' },
+              }),
+            ]),
+          ],
+        ] satisfies [string, StoredMessage[]]
+    ),
+  ];
+
+  it.each(histories)('omits activity for %s without removing task metadata', (_name, messages) => {
+    const state = getChildSessionCardState(part, messages);
+    expect(state).toEqual({ agentName: 'Researcher', taskName: 'Check spec', latestActivity: '' });
+    expect(getChildSessionActivityLabel(state.latestActivity)).toBe('');
+  });
+});
+
 describe('getChildSessionActivityLabel', () => {
   it('returns the activity string with context when present', () => {
     expect(getChildSessionActivityLabel({ tool: 'read', context: 'spec.md' })).toBe('read spec.md');

--- a/apps/mobile/src/components/agents/child-session-card-state.ts
+++ b/apps/mobile/src/components/agents/child-session-card-state.ts
@@ -91,8 +91,11 @@ export function getChildSessionCardState(
   const taskName =
     description ?? (prompt ? truncateText(prompt, 60) : i18n.t('agentChat.childSession.task'));
 
-  const latestPart = findLatestAssistantPart(childMessages);
   const latestActivity: ChildSessionActivity | string = (() => {
+    if (part.state.status === 'completed' || part.state.status === 'error') {
+      return '';
+    }
+    const latestPart = findLatestAssistantPart(childMessages);
     if (!latestPart) {
       return i18n.t('agentChat.childSession.waitingForActivity');
     }

--- a/apps/mobile/src/components/agents/child-session-message.test.ts
+++ b/apps/mobile/src/components/agents/child-session-message.test.ts
@@ -1,3 +1,7 @@
+/* eslint-disable max-lines -- routing fixtures and mounted completion regression */
+import { QueryClientProvider } from '@tanstack/react-query';
+import { act } from 'react';
+import { renderWithProviders } from '@/test/render-with-providers';
 import {
   type Part,
   type StoredMessage,
@@ -30,6 +34,7 @@ vi.mock('react-i18next', async importOriginal => {
 vi.mock('react-native', () => ({
   Pressable: 'Pressable',
   View: 'View',
+  I18nManager: { isRTL: false },
 }));
 vi.mock('react-native-reanimated', () => ({
   default: { View: 'AnimatedView' },
@@ -236,6 +241,72 @@ describe('ChildSessionMessage routing seam', () => {
     );
     expect(limitTexts).toHaveLength(1);
     expect(renderPart).not.toHaveBeenCalled();
+  });
+});
+
+describe('ChildSessionMessage completion', () => {
+  it('removes activity on a running-to-completed update with unchanged child messages', async () => {
+    const childMessages = [
+      makeMessage([
+        {
+          id: 'step',
+          sessionID: 'child-1',
+          messageID: 'child-message',
+          type: 'step-start',
+        },
+      ]),
+    ];
+    const openedChildren: [string, string][] = [];
+    const props = {
+      depth: 1,
+      getChildMessages: (id: string) => (id === 'child-1' ? childMessages : []),
+      renderPart: () => null,
+      onOpenChildSession: (id: string, title: string) => {
+        openedChildren.push([id, title]);
+      },
+      modelOptions: [modelOption],
+    };
+    const runningPart = makeToolPart('task', {
+      status: 'running',
+      input: taskCompletedState.input,
+      metadata: taskCompletedState.metadata,
+      time: { start: 1 },
+    });
+    const { renderer, queryClient, unmount } = await renderWithProviders(
+      React.createElement(ChildSessionMessage, { ...props, message: makeMessage([runningPart]) })
+    );
+    try {
+      const texts = () =>
+        renderer.root.findAll(node => node.type === 'Text').map(node => node.props.children);
+      const button = () => renderer.root.findByType('Pressable');
+      expect(texts()).toContain('Considering next steps');
+      expect(button().props.accessibilityLabel).toContain('Considering next steps');
+      expect(renderer.root.findAll(node => node.type === 'SpinningIcon')).toHaveLength(1);
+
+      await act(async () => {
+        renderer.update(
+          React.createElement(
+            QueryClientProvider,
+            { client: queryClient },
+            React.createElement(ChildSessionMessage, {
+              ...props,
+              message: makeMessage([makeToolPart('task', taskCompletedState)]),
+            })
+          )
+        );
+        await Promise.resolve();
+      });
+
+      expect(texts()).toEqual(['General', 'child task', 'Test Model', 'completed']);
+      expect(button().props.accessibilityLabel).toContain('completed');
+      expect(button().props.accessibilityLabel).not.toContain('Considering next steps');
+      expect(renderer.root.findAll(node => node.type === 'SpinningIcon')).toHaveLength(0);
+      const { onPress } = button().props as { onPress: () => void };
+      onPress();
+      expect(openedChildren).toEqual([['child-1', 'child task']]);
+    } finally {
+      unmount();
+    }
   });
 });
 

--- a/apps/mobile/src/components/agents/child-session-message.test.ts
+++ b/apps/mobile/src/components/agents/child-session-message.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- routing fixtures and mounted completion regression */
 import { QueryClientProvider } from '@tanstack/react-query';
 import { act } from 'react';
+import { Text } from '@/components/ui/text';
 import { renderWithProviders } from '@/test/render-with-providers';
 import {
   type Part,
@@ -276,8 +277,7 @@ describe('ChildSessionMessage completion', () => {
       React.createElement(ChildSessionMessage, { ...props, message: makeMessage([runningPart]) })
     );
     try {
-      const texts = () =>
-        renderer.root.findAll(node => node.type === 'Text').map(node => node.props.children);
+      const texts = () => renderer.root.findAllByType(Text).map(node => node.props.children);
       const button = () => renderer.root.findByType('Pressable');
       expect(texts()).toContain('Considering next steps');
       expect(button().props.accessibilityLabel).toContain('Considering next steps');

--- a/apps/mobile/src/components/agents/child-session-message.test.ts
+++ b/apps/mobile/src/components/agents/child-session-message.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable max-lines -- routing fixtures and mounted completion regression */
 import { QueryClientProvider } from '@tanstack/react-query';
 import { act } from 'react';
+import { Pressable } from 'react-native';
+import { SpinningIcon } from '@/components/ui/spinning-icon';
 import { Text } from '@/components/ui/text';
 import { renderWithProviders } from '@/test/render-with-providers';
 import {
@@ -238,7 +240,7 @@ describe('ChildSessionMessage routing seam', () => {
 
     const limitTexts = findAll(
       root,
-      el => el.type === 'Text' && textChildren(el) === 'Maximum nesting depth reached.'
+      el => el.type === Text && textChildren(el) === 'Maximum nesting depth reached.'
     );
     expect(limitTexts).toHaveLength(1);
     expect(renderPart).not.toHaveBeenCalled();
@@ -278,10 +280,10 @@ describe('ChildSessionMessage completion', () => {
     );
     try {
       const texts = () => renderer.root.findAllByType(Text).map(node => node.props.children);
-      const button = () => renderer.root.findByType('Pressable');
+      const button = () => renderer.root.findByType(Pressable);
       expect(texts()).toContain('Considering next steps');
       expect(button().props.accessibilityLabel).toContain('Considering next steps');
-      expect(renderer.root.findAll(node => node.type === 'SpinningIcon')).toHaveLength(1);
+      expect(renderer.root.findAllByType(SpinningIcon)).toHaveLength(1);
 
       await act(async () => {
         renderer.update(
@@ -300,7 +302,7 @@ describe('ChildSessionMessage completion', () => {
       expect(texts()).toEqual(['General', 'child task', 'Test Model', 'completed']);
       expect(button().props.accessibilityLabel).toContain('completed');
       expect(button().props.accessibilityLabel).not.toContain('Considering next steps');
-      expect(renderer.root.findAll(node => node.type === 'SpinningIcon')).toHaveLength(0);
+      expect(renderer.root.findAllByType(SpinningIcon)).toHaveLength(0);
       const { onPress } = button().props as { onPress: () => void };
       onPress();
       expect(openedChildren).toEqual([['child-1', 'child task']]);
@@ -344,7 +346,7 @@ describe('ChildSessionSection model label', () => {
     expect(findByType(root, ChildSessionModelLabel)).toHaveLength(0);
     const taskNameTexts = findAll(
       root,
-      el => el.type === 'Text' && textChildren(el) === 'child task'
+      el => el.type === Text && textChildren(el) === 'child task'
     );
     expect(taskNameTexts).toHaveLength(1);
   });

--- a/apps/mobile/src/components/agents/child-session-section.tsx
+++ b/apps/mobile/src/components/agents/child-session-section.tsx
@@ -110,19 +110,21 @@ export function ChildSessionSection({
             {taskName}
           </Text>
           {modelLabel ? <ChildSessionModelLabel modelLabel={modelLabel} /> : null}
-          <Text className="text-xs leading-4 text-muted-foreground" numberOfLines={1}>
-            {
-              // oxlint-disable-next-line anti-slop/no-runtime-typeof -- ChildSessionActivity has no discriminant field to narrow on, and `'tool' in latestActivity` would throw for the string variant.
-              typeof latestActivity === 'string' ? (
-                latestActivity
-              ) : (
-                <>
-                  <Text className="text-xs leading-4 text-agent-sky">{latestActivity.tool}</Text>
-                  {latestActivity.context ? ` ${latestActivity.context}` : ''}
-                </>
-              )
-            }
-          </Text>
+          {latestActivity ? (
+            <Text className="text-xs leading-4 text-muted-foreground" numberOfLines={1}>
+              {
+                // oxlint-disable-next-line anti-slop/no-runtime-typeof -- ChildSessionActivity has no discriminant field to narrow on, and `'tool' in latestActivity` would throw for the string variant.
+                typeof latestActivity === 'string' ? (
+                  latestActivity
+                ) : (
+                  <>
+                    <Text className="text-xs leading-4 text-agent-sky">{latestActivity.tool}</Text>
+                    {latestActivity.context ? ` ${latestActivity.context}` : ''}
+                  </>
+                )
+              }
+            </Text>
+          ) : null}
         </View>
 
         <StatusBadge status={status} />

--- a/apps/mobile/src/components/agents/file-part-renderer.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/file-part-renderer.mounted.test.tsx
@@ -181,11 +181,14 @@ beforeEach(() => {
   );
 });
 
-async function mount(part: FilePart): Promise<TestRenderer.ReactTestRenderer> {
+async function mount(
+  part: FilePart,
+  onLongPress?: () => void
+): Promise<TestRenderer.ReactTestRenderer> {
   const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
   await act(async () => {
     await Promise.resolve();
-    ref.current = TestRenderer.create(createElement(FilePartRenderer, { part }));
+    ref.current = TestRenderer.create(createElement(FilePartRenderer, { part, onLongPress }));
   });
   const renderer = ref.current;
   if (!renderer) {
@@ -284,6 +287,104 @@ async function selectActionSheet(index: number): Promise<void> {
 }
 
 describe('FilePartRenderer mounted', () => {
+  it.each([
+    { mime: 'image/png', filename: 'shot.png', label: 'Open shot.png full screen' },
+    { mime: 'text/markdown', filename: 'readme.md', label: 'Preview readme.md' },
+    { mime: 'application/pdf', filename: 'report.pdf', label: 'Open report.pdf' },
+  ])(
+    'forwards $mime long-press without replacing its normal tap',
+    async ({ mime, filename, label }) => {
+      expoFileSystemMock.fileText.mockResolvedValue('Attachment body');
+      const url = `https://example.test/${filename}`;
+      cacheFilePart('part-1', { url, mime, filename });
+      const part = makeFilePart({ id: 'part-1', mime, filename, url: '' });
+      const selected: string[] = [];
+      const renderer = await mount(part, () => {
+        selected.push(part.messageID);
+      });
+      const button = first(pressableByLabel(renderer.root, label));
+      act(() => {
+        (button.props.onLongPress as () => void)();
+      });
+      expect(selected).toEqual(['message-1']);
+      expect(findByType(renderer.root, 'ImageViewerModal')).toHaveLength(0);
+      expect(findByType(renderer.root, 'Modal')).toHaveLength(0);
+      expect(showActionSheetWithOptions).not.toHaveBeenCalled();
+      await press(button);
+      if (mime === 'image/png') {
+        expect(first(findByType(renderer.root, 'ImageViewerModal')).props.uri).toBe(url);
+      } else if (mime === 'text/markdown') {
+        expect(first(findByType(renderer.root, 'ChatMarkdownText')).props.value).toBe(
+          'Attachment body'
+        );
+      } else {
+        await selectActionSheet(0);
+        expect(texts(renderer.root)).toContain('Attachment body');
+      }
+      expect(selected).toEqual(['message-1']);
+      await unmount(renderer);
+    }
+  );
+
+  it('forwards image-error long-press without retrying until the normal tap', async () => {
+    cacheFilePart('part-1', { url: 'https://x/a.png', mime: 'image/png', filename: 'shot.png' });
+    const selected: string[] = [];
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'image/png', filename: 'shot.png', url: '' }),
+      () => {
+        selected.push('message-1');
+      }
+    );
+    act(() => {
+      (first(findByType(renderer.root, 'Image')).props.onError as () => void)();
+    });
+    const retry = first(pressableByLabel(renderer.root, 'Image unavailable, retry loading'));
+    act(() => {
+      (retry.props.onLongPress as () => void)();
+    });
+    expect(selected).toEqual(['message-1']);
+    expect(findByType(renderer.root, 'Image')).toHaveLength(0);
+    expect(texts(renderer.root)).toContain('Image unavailable');
+    await press(retry);
+    expect(first(findByType(renderer.root, 'Image')).props.source).toEqual({
+      uri: 'https://x/a.png',
+    });
+    expect(selected).toEqual(['message-1']);
+    await unmount(renderer);
+  });
+
+  it('forwards image-presign failure long-press and preserves normal retry recovery', async () => {
+    const uuid = '88888888-8888-4888-8888-888888888888';
+    cacheFilePart('part-1', {
+      url: `file:///tmp/attachments/agent-1/user-1/${uuid}/${uuid}.png`,
+      mime: 'image/png',
+      filename: `${uuid}.png`,
+    });
+    getAttachmentDownloadUrlMutate.mockRejectedValueOnce(new Error('presign failed'));
+    const selected: string[] = [];
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'image/png', filename: `${uuid}.png`, url: '' }),
+      () => {
+        selected.push('message-1');
+      }
+    );
+    await flushAsync();
+    const retry = first(pressableByLabel(renderer.root, 'Image unavailable, retry loading'));
+    act(() => {
+      (retry.props.onLongPress as () => void)();
+    });
+    expect(selected).toEqual(['message-1']);
+    expect(findByType(renderer.root, 'Image')).toHaveLength(0);
+    expect(texts(renderer.root)).toContain('Image unavailable');
+    await press(retry);
+    await flushAsync();
+    expect(first(findByType(renderer.root, 'Image')).props.source).toEqual({
+      uri: 'https://r2.example/signed',
+    });
+    expect(selected).toEqual(['message-1']);
+    await unmount(renderer);
+  });
+
   it('opens the full-screen viewer when an image FilePart is tapped', async () => {
     cacheFilePart('part-1', { url: 'https://x/a.png', mime: 'image/png', filename: 'shot.png' });
     const renderer = await mount(

--- a/apps/mobile/src/components/agents/file-part-renderer.tsx
+++ b/apps/mobile/src/components/agents/file-part-renderer.tsx
@@ -94,11 +94,12 @@ async function shareFilePart(url: string, part: FilePart): Promise<void> {
 
 type FilePartRendererProps = {
   part: FilePart;
+  onLongPress?: () => void;
 };
 
 type PreviewMode = 'markdown' | 'text';
 
-export function FilePartRenderer({ part }: Readonly<FilePartRendererProps>) {
+export function FilePartRenderer({ part, onLongPress }: Readonly<FilePartRendererProps>) {
   const colors = useThemeColors();
   const { t } = useTranslation();
   const { showActionSheetWithOptions } = useActionSheet();
@@ -243,6 +244,7 @@ export function FilePartRenderer({ part }: Readonly<FilePartRendererProps>) {
       if (imageFailed && !viewerVisible) {
         return (
           <Pressable
+            onLongPress={onLongPress}
             onPress={() => {
               if (!resolved.attachmentRef) {
                 setImageFailed(false);
@@ -269,6 +271,7 @@ export function FilePartRenderer({ part }: Readonly<FilePartRendererProps>) {
       return (
         <>
           <Pressable
+            onLongPress={onLongPress}
             onPress={openViewer}
             className="my-1 overflow-hidden rounded-lg active:opacity-80"
             accessibilityRole="button"
@@ -330,6 +333,7 @@ export function FilePartRenderer({ part }: Readonly<FilePartRendererProps>) {
     if (resolved.status === 'error') {
       return (
         <Pressable
+          onLongPress={onLongPress}
           onPress={() => {
             resolved.retry?.();
           }}
@@ -353,6 +357,7 @@ export function FilePartRenderer({ part }: Readonly<FilePartRendererProps>) {
   return (
     <>
       <Pressable
+        onLongPress={onLongPress}
         onPress={handleChipTap}
         disabled={sharing}
         accessibilityState={{ busy: sharing || resolved.status === 'resolving' }}

--- a/apps/mobile/src/components/agents/message-bubble-a11y.test.ts
+++ b/apps/mobile/src/components/agents/message-bubble-a11y.test.ts
@@ -1,122 +1,32 @@
-import { type StoredMessage } from '@kilocode/cloud-agent-sdk';
-import type * as React from 'react';
-import { type AccessibilityActionEvent } from 'react-native';
-import type * as ReactI18next from 'react-i18next';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import '@/i18n';
 import { buildAgentMessageBubbleAccessibilityProps } from './message-bubble-a11y';
-import {
-  assistantMessage,
-  findElementByType,
-  isActionsOverlayProps,
-  userMessage,
-} from './message-bubble-test-utils';
-
-const clipboard = vi.hoisted(() => ({ text: '' }));
-// The direct element harness needs only the copy hook's callback, not a mounted hook dispatcher.
-vi.mock('react', async importOriginal => ({
-  ...(await importOriginal<typeof React>()),
-  useCallback: <T>(fn: T) => fn,
-}));
-vi.mock('react-i18next', async importOriginal => {
-  const actual = await importOriginal<typeof ReactI18next>();
-  return { ...actual, useTranslation: () => ({ t: actual.getI18n().t.bind(actual.getI18n()) }) };
-});
-vi.mock('react-native', () => ({
-  Pressable: 'Pressable',
-  View: 'View',
-  Platform: { OS: 'android' },
-}));
-vi.mock('expo-clipboard', () => ({
-  setStringAsync: (text: string) => {
-    clipboard.text = text;
-  },
-}));
-vi.mock('expo-haptics', () => ({
-  notificationAsync: vi.fn(),
-  NotificationFeedbackType: { Success: 'success' },
-}));
-vi.mock('sonner-native', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
-vi.mock('@/components/ui/icons', () => ({ Clock: 'Clock' }));
-vi.mock('@/lib/hooks/use-theme-colors', () => ({
-  useThemeColors: () => ({ mutedForeground: '#666' }),
-}));
-vi.mock('@/components/ui/bubble', () => ({ Bubble: 'Bubble' }));
-vi.mock('@/components/ui/button', () => ({ Button: 'Button' }));
-vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
-vi.mock('./chat-markdown-text', () => ({ ChatMarkdownText: 'ChatMarkdownText' }));
-vi.mock('./compaction-separator', () => ({ CompactionSeparator: 'CompactionSeparator' }));
-vi.mock('./file-part-renderer', () => ({ FilePartRenderer: 'FilePartRenderer' }));
-vi.mock('./part-renderer', () => ({ PartRenderer: 'PartRenderer' }));
 
 describe.each([
-  { role: 'user', makeMessage: userMessage, label: 'User message' },
-  { role: 'assistant', makeMessage: assistantMessage, label: 'Assistant message' },
-])('message actions for $role messages', ({ makeMessage, label, role }) => {
+  { isUser: true, label: 'User message' },
+  { isUser: false, label: 'Assistant message' },
+])('message accessibility props for $label', ({ isUser, label }) => {
   it.each([
-    { kind: 'text', details: true, actions: ['details', 'copy'], copied: 'hi' },
-    { kind: 'files', details: true, actions: ['details'], copied: 'unchanged' },
-    { kind: 'text', details: false, actions: ['copy'], copied: 'hi' },
-    { kind: 'files', details: false, actions: [], copied: 'unchanged' },
+    { canCopy: true, canOpenDetails: true, actions: ['details', 'copy'] },
+    { canCopy: false, canOpenDetails: true, actions: ['details'] },
+    { canCopy: true, canOpenDetails: false, actions: ['copy'] },
+    { canCopy: false, canOpenDetails: false, actions: [] },
   ])(
-    'executes $kind actions with details callback=$details',
-    async ({ kind, details, actions, copied }) => {
-      const message = makeMessage('message-1');
-      message.parts =
-        kind === 'text'
-          ? userMessage('message-1').parts
-          : [
-              {
-                id: 'file-1',
-                sessionID: 'ses_1',
-                messageID: message.info.id,
-                type: 'file',
-                mime: 'text/plain',
-                url: 'file:///attachment.txt',
-              },
-            ];
-      const selection: { message?: StoredMessage } = {};
-      const props = buildAgentMessageBubbleAccessibilityProps({
-        isUser: role === 'user',
-        canCopy: kind === 'text',
-        canOpenDetails: details,
+    'exposes actions and hints with canCopy=$canCopy canOpenDetails=$canOpenDetails',
+    ({ canCopy, canOpenDetails, actions }) => {
+      expect(
+        buildAgentMessageBubbleAccessibilityProps({ isUser, canCopy, canOpenDetails })
+      ).toEqual({
+        accessible: false,
+        accessibilityRole: 'text',
+        accessibilityLabel: label,
+        accessibilityHint: canOpenDetails ? 'Long press for message details' : '',
+        accessibilityActions: actions.map(name => ({
+          name,
+          label: name === 'details' ? 'Message details' : 'Copy message',
+        })),
       });
-      expect(props.accessibilityActions.map(action => action.name)).toEqual(actions);
-      expect(props.accessibilityLabel).toBe(label);
-      expect(props.accessibilityHint).toBe(details ? 'Long press for message details' : '');
-
-      const { MessageBubble } = await import('./message-bubble');
-      // eslint-disable-next-line new-cap
-      const tree = MessageBubble.type({
-        message,
-        onLongPressDetails: details
-          ? selected => {
-              selection.message = selected;
-            }
-          : undefined,
-      });
-      const wrapper = findElementByType(tree, 'Pressable');
-      expect(wrapper?.props.accessible).toBe(false);
-      expect(wrapper?.props.accessibilityActions).toBeUndefined();
-      const host = findElementByType(tree, 'View', isActionsOverlayProps);
-      if (actions.length === 0) {
-        expect(host).toBeNull();
-        return;
-      }
-      expect(host?.props.accessibilityActions).toEqual(props.accessibilityActions);
-      expect(host?.props.accessibilityRole).toBe('text');
-      const invoke = host?.props.onAccessibilityAction as (
-        event: Pick<AccessibilityActionEvent, 'nativeEvent'>
-      ) => void;
-      clipboard.text = 'unchanged';
-      invoke({ nativeEvent: { actionName: 'details' } });
-      expect(selection.message).toBe(details ? message : undefined);
-      expect(clipboard.text).toBe('unchanged');
-      invoke({ nativeEvent: { actionName: 'copy' } });
-      await Promise.resolve();
-      expect(clipboard.text).toBe(copied);
-      expect(selection.message).toBe(details ? message : undefined);
     }
   );
 });

--- a/apps/mobile/src/components/agents/message-bubble-a11y.test.ts
+++ b/apps/mobile/src/components/agents/message-bubble-a11y.test.ts
@@ -1,60 +1,122 @@
-import { describe, expect, it } from 'vitest';
+import { type StoredMessage } from '@kilocode/cloud-agent-sdk';
+import type * as React from 'react';
+import { type AccessibilityActionEvent } from 'react-native';
+import type * as ReactI18next from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
 
+import '@/i18n';
 import { buildAgentMessageBubbleAccessibilityProps } from './message-bubble-a11y';
+import {
+  assistantMessage,
+  findElementByType,
+  isActionsOverlayProps,
+  userMessage,
+} from './message-bubble-test-utils';
 
-describe('buildAgentMessageBubbleAccessibilityProps', () => {
-  it('marks the wrapping Pressable as non-accessible so the message subtree stays navigable', () => {
-    const props = buildAgentMessageBubbleAccessibilityProps({
-      isUser: true,
-      canCopy: true,
-    });
+const clipboard = vi.hoisted(() => ({ text: '' }));
+// The direct element harness needs only the copy hook's callback, not a mounted hook dispatcher.
+vi.mock('react', async importOriginal => ({
+  ...(await importOriginal<typeof React>()),
+  useCallback: <T>(fn: T) => fn,
+}));
+vi.mock('react-i18next', async importOriginal => {
+  const actual = await importOriginal<typeof ReactI18next>();
+  return { ...actual, useTranslation: () => ({ t: actual.getI18n().t.bind(actual.getI18n()) }) };
+});
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  View: 'View',
+  Platform: { OS: 'android' },
+}));
+vi.mock('expo-clipboard', () => ({
+  setStringAsync: (text: string) => {
+    clipboard.text = text;
+  },
+}));
+vi.mock('expo-haptics', () => ({
+  notificationAsync: vi.fn(),
+  NotificationFeedbackType: { Success: 'success' },
+}));
+vi.mock('sonner-native', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@/components/ui/icons', () => ({ Clock: 'Clock' }));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({ mutedForeground: '#666' }),
+}));
+vi.mock('@/components/ui/bubble', () => ({ Bubble: 'Bubble' }));
+vi.mock('@/components/ui/button', () => ({ Button: 'Button' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('./chat-markdown-text', () => ({ ChatMarkdownText: 'ChatMarkdownText' }));
+vi.mock('./compaction-separator', () => ({ CompactionSeparator: 'CompactionSeparator' }));
+vi.mock('./file-part-renderer', () => ({ FilePartRenderer: 'FilePartRenderer' }));
+vi.mock('./part-renderer', () => ({ PartRenderer: 'PartRenderer' }));
 
-    expect(props.accessible).toBe(false);
-  });
+describe.each([
+  { role: 'user', makeMessage: userMessage, label: 'User message' },
+  { role: 'assistant', makeMessage: assistantMessage, label: 'Assistant message' },
+])('message actions for $role messages', ({ makeMessage, label, role }) => {
+  it.each([
+    { kind: 'text', details: true, actions: ['details', 'copy'], copied: 'hi' },
+    { kind: 'files', details: true, actions: ['details'], copied: 'unchanged' },
+    { kind: 'text', details: false, actions: ['copy'], copied: 'hi' },
+    { kind: 'files', details: false, actions: [], copied: 'unchanged' },
+  ])(
+    'executes $kind actions with details callback=$details',
+    async ({ kind, details, actions, copied }) => {
+      const message = makeMessage('message-1');
+      message.parts =
+        kind === 'text'
+          ? userMessage('message-1').parts
+          : [
+              {
+                id: 'file-1',
+                sessionID: 'ses_1',
+                messageID: message.info.id,
+                type: 'file',
+                mime: 'text/plain',
+                url: 'file:///attachment.txt',
+              },
+            ];
+      const selection: { message?: StoredMessage } = {};
+      const props = buildAgentMessageBubbleAccessibilityProps({
+        isUser: role === 'user',
+        canCopy: kind === 'text',
+        canOpenDetails: details,
+      });
+      expect(props.accessibilityActions.map(action => action.name)).toEqual(actions);
+      expect(props.accessibilityLabel).toBe(label);
+      expect(props.accessibilityHint).toBe(details ? 'Long press for message details' : '');
 
-  it('labels user-authored messages consistently with the previous role/label', () => {
-    const props = buildAgentMessageBubbleAccessibilityProps({
-      isUser: true,
-      canCopy: true,
-    });
-
-    expect(props.accessibilityLabel).toBe('User message');
-  });
-
-  it('labels assistant-authored messages consistently with the previous role/label', () => {
-    const props = buildAgentMessageBubbleAccessibilityProps({
-      isUser: false,
-      canCopy: true,
-    });
-
-    expect(props.accessibilityLabel).toBe('Assistant message');
-  });
-
-  it('keeps the long-press hint and the text role on the inner actions host', () => {
-    const props = buildAgentMessageBubbleAccessibilityProps({
-      isUser: false,
-      canCopy: true,
-    });
-
-    expect(props.accessibilityRole).toBe('text');
-    expect(props.accessibilityHint).toBe('Long press for message details');
-  });
-
-  it('exposes the copy custom action with the same name and label as before', () => {
-    const props = buildAgentMessageBubbleAccessibilityProps({
-      isUser: true,
-      canCopy: true,
-    });
-
-    expect(props.accessibilityActions).toEqual([{ name: 'copy', label: 'Copy message' }]);
-  });
-
-  it('omits the copy action when the caller disables it so the inner host can be left out', () => {
-    const props = buildAgentMessageBubbleAccessibilityProps({
-      isUser: false,
-      canCopy: false,
-    });
-
-    expect(props.accessibilityActions).toEqual([]);
-  });
+      const { MessageBubble } = await import('./message-bubble');
+      // eslint-disable-next-line new-cap
+      const tree = MessageBubble.type({
+        message,
+        onLongPressDetails: details
+          ? selected => {
+              selection.message = selected;
+            }
+          : undefined,
+      });
+      const wrapper = findElementByType(tree, 'Pressable');
+      expect(wrapper?.props.accessible).toBe(false);
+      expect(wrapper?.props.accessibilityActions).toBeUndefined();
+      const host = findElementByType(tree, 'View', isActionsOverlayProps);
+      if (actions.length === 0) {
+        expect(host).toBeNull();
+        return;
+      }
+      expect(host?.props.accessibilityActions).toEqual(props.accessibilityActions);
+      expect(host?.props.accessibilityRole).toBe('text');
+      const invoke = host?.props.onAccessibilityAction as (
+        event: Pick<AccessibilityActionEvent, 'nativeEvent'>
+      ) => void;
+      clipboard.text = 'unchanged';
+      invoke({ nativeEvent: { actionName: 'details' } });
+      expect(selection.message).toBe(details ? message : undefined);
+      expect(clipboard.text).toBe('unchanged');
+      invoke({ nativeEvent: { actionName: 'copy' } });
+      await Promise.resolve();
+      expect(clipboard.text).toBe(copied);
+      expect(selection.message).toBe(details ? message : undefined);
+    }
+  );
 });

--- a/apps/mobile/src/components/agents/message-bubble-a11y.ts
+++ b/apps/mobile/src/components/agents/message-bubble-a11y.ts
@@ -21,8 +21,8 @@ import { i18n } from '@/i18n';
  *   is an inset-matched, non-interactive, focusable `View` with no children,
  *   so it does not swallow the message subtree while still giving the rotor a
  *   target aligned with the bubble's actual bounds. The caller must only render
- *   this host when `accessibilityActions` is non-empty; when the copy action is
- *   not exposed the overlay is omitted so VoiceOver/TalkBack do not stop on an
+ *   this host when `accessibilityActions` is non-empty; when no action is
+ *   exposed the overlay is omitted so VoiceOver/TalkBack do not stop on an
  *   empty focusable node.
  */
 type AgentMessageBubbleAccessibility = {
@@ -43,6 +43,8 @@ type AgentMessageBubbleA11yInput = {
   isUser: boolean;
   /** Whether the copy custom action should be exposed. */
   canCopy: boolean;
+  /** Whether the message-details sheet can open. */
+  canOpenDetails?: boolean;
 };
 
 export function buildAgentMessageBubbleAccessibilityProps(
@@ -51,12 +53,19 @@ export function buildAgentMessageBubbleAccessibilityProps(
   const accessibilityLabel = input.isUser
     ? i18n.t('agentChat.messageBubble.userMessage')
     : i18n.t('agentChat.messageBubble.assistantMessage');
-  // Long-press opens the message-details sheet; copy remains available only
-  // through the rotor custom action below.
-  const accessibilityHint = i18n.t('agentChat.messageBubble.longPressHint');
-  const accessibilityActions: AccessibilityActionInfo[] = input.canCopy
-    ? [{ name: 'copy', label: i18n.t('agentChat.messageDetails.copyMessage') }]
-    : [];
+  const accessibilityHint = input.canOpenDetails
+    ? i18n.t('agentChat.messageBubble.longPressHint')
+    : '';
+  const accessibilityActions: AccessibilityActionInfo[] = [];
+  if (input.canOpenDetails) {
+    accessibilityActions.push({ name: 'details', label: i18n.t('agentChat.messageDetails.title') });
+  }
+  if (input.canCopy) {
+    accessibilityActions.push({
+      name: 'copy',
+      label: i18n.t('agentChat.messageDetails.copyMessage'),
+    });
+  }
 
   return {
     accessible: false,

--- a/apps/mobile/src/components/agents/message-bubble-accessibility.test.ts
+++ b/apps/mobile/src/components/agents/message-bubble-accessibility.test.ts
@@ -53,25 +53,27 @@ describe.each([
   { role: 'assistant', makeMessage: assistantMessage, label: 'Assistant message' },
 ])('MessageBubble accessibility: $role', ({ makeMessage, label }) => {
   it.each([
-    { text: true, callback: true, actions: ['details', 'copy'], copied: 'hi' },
-    { text: false, callback: true, actions: ['details'], copied: 'unchanged' },
-    { text: true, callback: false, actions: ['copy'], copied: 'hi' },
-    { text: false, callback: false, actions: [], copied: 'unchanged' },
+    { kind: 'text', callback: true, actions: ['details', 'copy'], copied: 'hi' },
+    { kind: 'text', callback: false, actions: ['copy'], copied: 'hi' },
+    { kind: 'files', callback: true, actions: ['details'], copied: 'unchanged' },
+    { kind: 'files', callback: false, actions: [], copied: 'unchanged' },
+    { kind: 'text and files', callback: true, actions: ['details', 'copy'], copied: 'hi' },
+    { kind: 'text and files', callback: false, actions: ['copy'], copied: 'hi' },
   ])(
-    'preserves descendants and executes actions with text=$text callback=$callback',
-    async ({ text, callback, actions, copied }) => {
+    'preserves descendants and executes actions with content=$kind callback=$callback',
+    async ({ kind, callback, actions, copied }) => {
       const message = makeMessage('message-1');
-      message.parts = [
-        ...(text ? userMessage('message-1').parts : []),
-        {
+      message.parts = kind === 'files' ? [] : userMessage('message-1').parts;
+      if (kind !== 'text') {
+        message.parts.push({
           id: 'file-1',
           sessionID: 'ses_1',
           messageID: message.info.id,
           type: 'file',
           mime: 'text/plain',
           url: 'file:///attachment.txt',
-        },
-      ];
+        });
+      }
       const selected: StoredMessage[] = [];
       const { MessageBubble } = await import('./message-bubble');
       // eslint-disable-next-line new-cap
@@ -112,11 +114,13 @@ describe.each([
       expect(host?.props.accessibilityLabel).toBe(label);
       expect(host?.props.children).toBeUndefined();
       const exposed = host?.props.accessibilityActions as { name: string; label: string }[];
-      expect(exposed.map(action => action.name)).toEqual(actions);
-      if (callback) {
-        expect(exposed).toContainEqual({ name: 'details', label: 'Message details' });
-        expect(host?.props.accessibilityHint).toBe('Long press for message details');
-      }
+      expect(exposed).toEqual(
+        actions.map(name => ({
+          name,
+          label: name === 'details' ? 'Message details' : 'Copy message',
+        }))
+      );
+      expect(host?.props.accessibilityHint).toBe(callback ? 'Long press for message details' : '');
       const invoke = host?.props.onAccessibilityAction as (
         event: Pick<AccessibilityActionEvent, 'nativeEvent'>
       ) => void;

--- a/apps/mobile/src/components/agents/message-bubble-accessibility.test.ts
+++ b/apps/mobile/src/components/agents/message-bubble-accessibility.test.ts
@@ -1,182 +1,132 @@
+import { type StoredMessage } from '@kilocode/cloud-agent-sdk';
+import type * as React from 'react';
+import { type AccessibilityActionEvent } from 'react-native';
+import type * as ReactI18next from 'react-i18next';
 import { describe, expect, it, vi } from 'vitest';
 
-import { buildAgentMessageBubbleAccessibilityProps } from './message-bubble-a11y';
+import '@/i18n';
 import {
   assistantMessage,
   findElementByType,
   isActionsOverlayProps,
-  pressableProps,
-  renderBubble,
   userMessage,
 } from './message-bubble-test-utils';
 
-import '@/i18n';
-import type * as ReactI18next from 'react-i18next';
-
+const clipboard = vi.hoisted(() => ({ text: '' }));
+vi.mock('react', async importOriginal => ({
+  ...(await importOriginal<typeof React>()),
+  useCallback: <T>(fn: T) => fn,
+}));
 vi.mock('react-i18next', async importOriginal => {
   const actual = await importOriginal<typeof ReactI18next>();
-  return {
-    ...actual,
-    useTranslation: () => {
-      const i18n = actual.getI18n();
-      return { t: i18n.t.bind(i18n), i18n };
-    },
-  };
+  return { ...actual, useTranslation: () => ({ t: actual.getI18n().t.bind(actual.getI18n()) }) };
 });
-
 vi.mock('react-native', () => ({
   Pressable: 'Pressable',
   View: 'View',
   Platform: { OS: 'android' },
 }));
-vi.mock('react-native-reanimated', () => ({
-  default: { View: 'Animated.View' },
-  FadeIn: { duration: vi.fn() },
-  FadeOut: { duration: vi.fn() },
+vi.mock('expo-clipboard', () => ({
+  setStringAsync: (text: string) => {
+    clipboard.text = text;
+  },
 }));
-vi.mock('expo-clipboard', () => ({ setStringAsync: vi.fn() }));
 vi.mock('expo-haptics', () => ({
   notificationAsync: vi.fn(),
   NotificationFeedbackType: { Success: 'success' },
 }));
 vi.mock('sonner-native', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
-vi.mock('@/components/ui/icons', () => ({
-  Clock: () => null,
-}));
+vi.mock('@/components/ui/icons', () => ({ Clock: 'Clock' }));
 vi.mock('@/lib/hooks/use-theme-colors', () => ({
-  useThemeColors: () => ({ mutedForeground: '#6F6A61' }),
+  useThemeColors: () => ({ mutedForeground: '#666' }),
 }));
-vi.mock('@/components/ui/bubble', () => ({
-  Bubble: ({ children }: { children?: unknown }) => children,
-}));
-vi.mock('@/components/ui/text', () => ({
-  Text: ({ children }: { children?: unknown }) => children,
-}));
-vi.mock('./chat-markdown-text', () => ({
-  ChatMarkdownText: () => null,
-}));
-vi.mock('./compaction-separator', () => ({
-  CompactionSeparator: () => null,
-}));
-vi.mock('./file-part-renderer', () => ({
-  FilePartRenderer: () => null,
-}));
-vi.mock('./part-renderer', () => ({
-  PartRenderer: () => null,
-}));
-vi.mock('./part-types', () => ({
-  isFilePart: () => false,
-  isTextPart: () => false,
-  firstHumanText: () => '',
-}));
-vi.mock('./use-message-copy', () => ({
-  useMessageCopy: () => ({ copyMessage: vi.fn() }),
-}));
-vi.mock('./message-bubble-a11y', async () => {
-  const actual = await vi.importActual<{
-    buildAgentMessageBubbleAccessibilityProps: typeof buildAgentMessageBubbleAccessibilityProps;
-  }>('./message-bubble-a11y');
-  return {
-    ...actual,
-    buildAgentMessageBubbleAccessibilityProps: vi.fn(
-      actual.buildAgentMessageBubbleAccessibilityProps
-    ),
-  };
-});
+vi.mock('@/components/ui/bubble', () => ({ Bubble: 'Bubble' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/components/ui/button', () => ({ Button: 'Button' }));
+vi.mock('./chat-markdown-text', () => ({ ChatMarkdownText: 'ChatMarkdownText' }));
+vi.mock('./compaction-separator', () => ({ CompactionSeparator: 'CompactionSeparator' }));
+vi.mock('./file-part-renderer', () => ({ FilePartRenderer: 'FilePartRenderer' }));
+vi.mock('./part-renderer', () => ({ PartRenderer: 'PartRenderer' }));
 
-describe('MessageBubble accessibility', () => {
-  it('renders the wrapping Pressable as non-accessible on a user message so the subtree stays navigable', async () => {
-    const tree = await renderBubble(userMessage('m-user-a11y'));
-    const wrapper = findElementByType(tree, 'Pressable');
-    expect(wrapper).not.toBeNull();
-    expect(wrapper?.props.accessible).toBe(false);
-    // The wrapper must not also be the focusable element; the role/label/hint
-    // would otherwise shadow interactive descendants (permission/question
-    // `Button`s, child-session "open" `Pressable`, file parts).
-    expect(wrapper?.props.accessibilityRole).toBeUndefined();
-    expect(wrapper?.props.accessibilityLabel).toBeUndefined();
-    expect(wrapper?.props.accessibilityHint).toBeUndefined();
-    expect(wrapper?.props.accessibilityActions).toBeUndefined();
-  });
+describe.each([
+  { role: 'user', makeMessage: userMessage, label: 'User message' },
+  { role: 'assistant', makeMessage: assistantMessage, label: 'Assistant message' },
+])('MessageBubble accessibility: $role', ({ makeMessage, label }) => {
+  it.each([
+    { text: true, callback: true, actions: ['details', 'copy'], copied: 'hi' },
+    { text: false, callback: true, actions: ['details'], copied: 'unchanged' },
+    { text: true, callback: false, actions: ['copy'], copied: 'hi' },
+    { text: false, callback: false, actions: [], copied: 'unchanged' },
+  ])(
+    'preserves descendants and executes actions with text=$text callback=$callback',
+    async ({ text, callback, actions, copied }) => {
+      const message = makeMessage('message-1');
+      message.parts = [
+        ...(text ? userMessage('message-1').parts : []),
+        {
+          id: 'file-1',
+          sessionID: 'ses_1',
+          messageID: message.info.id,
+          type: 'file',
+          mime: 'text/plain',
+          url: 'file:///attachment.txt',
+        },
+      ];
+      const selected: StoredMessage[] = [];
+      const { MessageBubble } = await import('./message-bubble');
+      // eslint-disable-next-line new-cap
+      const tree = MessageBubble.type({
+        message,
+        onLongPressDetails: callback
+          ? value => {
+              selected.push(value);
+            }
+          : undefined,
+      });
+      const wrapper = findElementByType(tree, 'Pressable');
+      expect(wrapper?.props.accessible).toBe(false);
+      expect(wrapper?.props.accessibilityRole).toBeUndefined();
+      expect(wrapper?.props.accessibilityLabel).toBeUndefined();
+      expect(wrapper?.props.accessibilityHint).toBeUndefined();
+      expect(wrapper?.props.accessibilityActions).toBeUndefined();
+      expect(wrapper?.props.accessibilityElementsHidden).toBeUndefined();
+      const body = findElementByType(tree, label === 'User message' ? 'Bubble' : 'View', props =>
+        Boolean(props.children)
+      );
+      expect(body).not.toBeNull();
+      expect(body?.props.accessible).not.toBe(true);
+      clipboard.text = 'unchanged';
+      if (!wrapper) {
+        throw new Error('Message wrapper is missing');
+      }
+      (wrapper.props.onLongPress as () => void)();
+      expect(selected).toEqual(callback ? [message] : []);
+      expect(clipboard.text).toBe('unchanged');
 
-  it('hosts the user-message label, role, hint, and copy action on a dedicated inner overlay', async () => {
-    const tree = await renderBubble(userMessage('m-user-overlay'));
-    const host = findElementByType(tree, 'View', isActionsOverlayProps);
-    expect(host).not.toBeNull();
-    expect(host?.props.accessibilityRole).toBe('text');
-    expect(host?.props.accessibilityLabel).toBe('User message');
-    expect(host?.props.accessibilityHint).toBe('Long press for message details');
-    expect(host?.props.accessibilityActions).toEqual([{ name: 'copy', label: 'Copy message' }]);
-    expect(typeof host?.props.onAccessibilityAction).toBe('function');
-  });
-
-  it('renders the wrapping Pressable as non-accessible on an assistant message so the subtree stays navigable', async () => {
-    const tree = await renderBubble(assistantMessage('m-asst-a11y'));
-    const wrapper = findElementByType(tree, 'Pressable');
-    expect(wrapper).not.toBeNull();
-    expect(wrapper?.props.accessible).toBe(false);
-    expect(wrapper?.props.accessibilityRole).toBeUndefined();
-    expect(wrapper?.props.accessibilityLabel).toBeUndefined();
-    expect(wrapper?.props.accessibilityHint).toBeUndefined();
-    expect(wrapper?.props.accessibilityActions).toBeUndefined();
-  });
-
-  it('hosts the assistant-message label, role, hint, and copy action on a dedicated inner overlay', async () => {
-    const tree = await renderBubble(assistantMessage('m-asst-overlay'));
-    const host = findElementByType(tree, 'View', isActionsOverlayProps);
-    expect(host).not.toBeNull();
-    expect(host?.props.accessibilityRole).toBe('text');
-    expect(host?.props.accessibilityLabel).toBe('Assistant message');
-    expect(host?.props.accessibilityHint).toBe('Long press for message details');
-    expect(host?.props.accessibilityActions).toEqual([{ name: 'copy', label: 'Copy message' }]);
-    expect(typeof host?.props.onAccessibilityAction).toBe('function');
-  });
-
-  it('omits the inner accessibility actions host when no custom actions are exposed', async () => {
-    vi.mocked(buildAgentMessageBubbleAccessibilityProps).mockReturnValue({
-      accessible: false,
-      accessibilityLabel: 'Assistant message',
-      accessibilityHint: 'Long press for message details',
-      accessibilityRole: 'text',
-      accessibilityActions: [],
-    });
-
-    const userTree = await renderBubble(userMessage('m-user-no-actions'));
-    expect(findElementByType(userTree, 'View', isActionsOverlayProps)).toBeNull();
-
-    const asstTree = await renderBubble(assistantMessage('m-asst-no-actions'));
-    expect(findElementByType(asstTree, 'View', isActionsOverlayProps)).toBeNull();
-
-    vi.mocked(buildAgentMessageBubbleAccessibilityProps).mockRestore();
-  });
-
-  it('keeps the long-press accelerator wired on the wrapping Pressable for both user and assistant messages', async () => {
-    const userTree = await renderBubble(userMessage('m-user-lp'));
-    const userWrapper = findElementByType(userTree, 'Pressable');
-    expect(typeof userWrapper?.props.onLongPress).toBe('function');
-
-    const asstTree = await renderBubble(assistantMessage('m-asst-lp'));
-    const asstWrapper = findElementByType(asstTree, 'Pressable');
-    expect(typeof asstWrapper?.props.onLongPress).toBe('function');
-  });
-});
-
-describe('MessageBubble long-press details', () => {
-  it('invokes onLongPressDetails on long-press, not copyMessage', async () => {
-    const onLongPressDetails = vi.fn((..._args: unknown[]) => {
-      // void-returning callback matching MessageBubble's prop type
-    });
-    const { MessageBubble } = await import('./message-bubble');
-    const message = userMessage('m-long');
-    // MessageBubble is wrapped in React.memo; invoke its inner component.
-    // eslint-disable-next-line new-cap
-    const tree = MessageBubble.type({ message, onLongPressDetails });
-    const props = pressableProps(tree);
-    expect(props).not.toBeNull();
-    const handler = props === null ? undefined : props.onLongPress;
-    expect(typeof handler).toBe('function');
-    const invoke = handler as (() => void) | undefined;
-    invoke?.();
-    expect(onLongPressDetails).toHaveBeenCalledWith(message);
-  });
+      const host = findElementByType(tree, 'View', isActionsOverlayProps);
+      if (actions.length === 0) {
+        expect(host).toBeNull();
+        return;
+      }
+      expect(host?.props.accessibilityRole).toBe('text');
+      expect(host?.props.accessibilityLabel).toBe(label);
+      expect(host?.props.children).toBeUndefined();
+      const exposed = host?.props.accessibilityActions as { name: string; label: string }[];
+      expect(exposed.map(action => action.name)).toEqual(actions);
+      if (callback) {
+        expect(exposed).toContainEqual({ name: 'details', label: 'Message details' });
+        expect(host?.props.accessibilityHint).toBe('Long press for message details');
+      }
+      const invoke = host?.props.onAccessibilityAction as (
+        event: Pick<AccessibilityActionEvent, 'nativeEvent'>
+      ) => void;
+      invoke({ nativeEvent: { actionName: 'details' } });
+      expect(selected).toEqual(callback ? [message, message] : []);
+      expect(clipboard.text).toBe('unchanged');
+      invoke({ nativeEvent: { actionName: 'copy' } });
+      await Promise.resolve();
+      expect(clipboard.text).toBe(copied);
+      expect(selected).toEqual(callback ? [message, message] : []);
+    }
+  );
 });

--- a/apps/mobile/src/components/agents/message-bubble.test.ts
+++ b/apps/mobile/src/components/agents/message-bubble.test.ts
@@ -187,6 +187,7 @@ async function renderBubbleWithHandlers(
     onRetryMessage?: (m: StoredMessage) => void;
     onCopyToComposer?: (text: string) => void;
     onRestoreQueued?: (m: StoredMessage) => void;
+    onLongPressDetails?: (m: StoredMessage) => void;
   }
 ): Promise<unknown> {
   const { MessageBubble } = await import('./message-bubble');
@@ -375,6 +376,55 @@ describe('MessageBubble queue indicator and restore', () => {
   });
 });
 
+describe('MessageBubble attachment details entry', () => {
+  it.each([false, true])(
+    'selects the whole message from an attachment, with text=%s',
+    async withText => {
+      const actual = await vi.importActual<typeof PartTypes>('./part-types');
+      const { isFilePart, isTextPart } = await import('./part-types');
+      const { FilePartRenderer } = await import('./file-part-renderer');
+      vi.mocked(isFilePart).mockImplementation(actual.isFilePart);
+      vi.mocked(isTextPart).mockImplementation(actual.isTextPart);
+      try {
+        const message = userMessage('attachment-message');
+        const file = {
+          id: 'attachment-part',
+          sessionID: 'ses_1',
+          messageID: message.info.id,
+          type: 'file' as const,
+          mime: 'image/png',
+          url: 'https://example.test/image.png',
+        };
+        message.parts = [...(withText ? message.parts : []), file];
+        const selected: StoredMessage[] = [];
+        const tree = await renderBubbleWithHandlers(message, {
+          deliveryState: { status: 'queued' },
+          onLongPressDetails: value => {
+            selected.push(value);
+          },
+        });
+        const attachment = findElementByTypeFn(tree, FilePartRenderer);
+        if (!attachment) {
+          throw new Error('Attachment control is missing');
+        }
+        expect(attachment.props.part).toBe(file);
+        (attachment.props.onLongPress as () => void)();
+        expect(selected).toEqual([message]);
+        expect(findText(tree, text => text === 'Queued')).toBe(true);
+        expect(findText(tree, text => text === 'Cancel message')).toBe(false);
+
+        const withoutActions = await renderBubbleWithHandlers(message, {});
+        expect(
+          findElementByTypeFn(withoutActions, FilePartRenderer)?.props.onLongPress
+        ).toBeUndefined();
+      } finally {
+        vi.mocked(isFilePart).mockReturnValue(false);
+        vi.mocked(isTextPart).mockReturnValue(false);
+      }
+    }
+  );
+});
+
 describe('MessageBubble copy-to-composer human text', () => {
   it('passes only the first human text part to Copy, not the synthesized notice', async () => {
     const message = userMessage('m-copy-human');
@@ -542,6 +592,15 @@ function findElementByTypeFn(
   node: unknown,
   typeFn: unknown
 ): { type: unknown; props: Record<string, unknown> } | null {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const hit = findElementByTypeFn(child, typeFn);
+      if (hit) {
+        return hit;
+      }
+    }
+    return null;
+  }
   if (node == null || typeof node !== 'object') {
     return null;
   }

--- a/apps/mobile/src/components/agents/message-bubble.test.ts
+++ b/apps/mobile/src/components/agents/message-bubble.test.ts
@@ -186,7 +186,6 @@ async function renderBubbleWithHandlers(
     deliveryState?: MessageDeliveryState;
     onRetryMessage?: (m: StoredMessage) => void;
     onCopyToComposer?: (text: string) => void;
-    onCancelQueued?: (m: StoredMessage) => void;
     onRestoreQueued?: (m: StoredMessage) => void;
   }
 ): Promise<unknown> {
@@ -325,151 +324,54 @@ describe('MessageBubble failure footer', () => {
   });
 });
 
-describe('MessageBubble cancel queued and restore', () => {
-  it('renders the Cancel button when the message is queued and wired', async () => {
-    const tree = await renderBubbleWithHandlers(userMessage('m-cancel'), {
-      deliveryState: { status: 'queued' },
-      onCancelQueued: vi.fn<(message: StoredMessage) => void>(),
-    });
-    expect(findText(tree, t => t === 'Cancel message')).toBe(true);
-    const cancel = findElementByType(
-      tree,
-      'Button',
-      p => p.accessibilityLabel === 'Cancel queued message'
-    );
-    expect(cancel).not.toBeNull();
-    expect(cancel?.props.accessibilityRole).toBe('button');
-  });
-
-  it('omits the Cancel button when no onCancelQueued is wired', async () => {
-    const tree = await renderBubbleWithHandlers(userMessage('m-cancel-nowired'), {
+describe('MessageBubble queue indicator and restore', () => {
+  it('keeps Queued without a standalone cancellation control', async () => {
+    const tree = await renderBubbleWithHandlers(userMessage('m-queued'), {
       deliveryState: { status: 'queued' },
     });
+    expect(findText(tree, text => text === 'Queued')).toBe(true);
+    expect(findText(tree, text => text === 'Cancel message')).toBe(false);
     expect(
-      findElementByType(tree, 'Button', p => p.accessibilityLabel === 'Cancel queued message')
+      findElementByType(
+        tree,
+        'Button',
+        props => props.accessibilityLabel === 'Cancel queued message'
+      )
     ).toBeNull();
   });
 
-  it('omits the Cancel button when the message is dequeued', async () => {
-    const tree = await renderBubbleWithHandlers(userMessage('m-cancel-dequeued'), {
-      onCancelQueued: vi.fn<(message: StoredMessage) => void>(),
-    });
-    expect(
-      findElementByType(tree, 'Button', p => p.accessibilityLabel === 'Cancel queued message')
-    ).toBeNull();
-  });
-
-  it('renders the Restore button when wired and the message is not queued', async () => {
-    const tree = await renderBubbleWithHandlers(userMessage('m-restore'), {
-      onRestoreQueued: vi.fn<(message: StoredMessage) => void>(),
-    });
-    expect(findText(tree, t => t === 'Restore')).toBe(true);
-    const restore = findElementByType(
-      tree,
-      'Button',
-      p => p.accessibilityLabel === 'Restore canceled message to the composer'
-    );
-    expect(restore).not.toBeNull();
-    expect(restore?.props.accessibilityRole).toBe('button');
-  });
-
-  it('sizes the Cancel and Restore controls to the platform minimum touch target', async () => {
-    const cancelTree = await renderBubbleWithHandlers(userMessage('m-size-cancel'), {
-      deliveryState: { status: 'queued' },
-      onCancelQueued: vi.fn<(message: StoredMessage) => void>(),
-    });
-    const cancel = findElementByType(
-      cancelTree,
-      'Button',
-      p => p.accessibilityLabel === 'Cancel queued message'
-    );
-    expect(cancel).not.toBeNull();
-    // The Platform mock reports android, so the controls must reach 48dp.
-    expect(cancel?.props.className).toBe('min-h-12');
-    expect(cancel?.props.size).toBe('sm');
-
-    const restoreTree = await renderBubbleWithHandlers(userMessage('m-size-restore'), {
-      onRestoreQueued: vi.fn<(message: StoredMessage) => void>(),
-    });
-    const restore = findElementByType(
-      restoreTree,
-      'Button',
-      p => p.accessibilityLabel === 'Restore canceled message to the composer'
-    );
-    expect(restore).not.toBeNull();
-    expect(restore?.props.className).toBe('min-h-12');
-    expect(restore?.props.size).toBe('sm');
-  });
-
-  it('sizes the controls to the iOS 44pt minimum touch target', async () => {
-    reactNativeMock.Platform.OS = 'ios';
+  it.each([
+    ['android', 'min-h-12'],
+    ['ios', 'min-h-11'],
+  ])('keeps Restore targeting and the minimum target on %s', async (platform, minHeight) => {
+    reactNativeMock.Platform.OS = platform;
     vi.resetModules();
     try {
-      const cancelTree = await renderBubbleWithHandlers(userMessage('m-size-cancel-ios'), {
-        deliveryState: { status: 'queued' },
-        onCancelQueued: vi.fn<(message: StoredMessage) => void>(),
+      const message = userMessage('m-restore');
+      let restored: StoredMessage | undefined = undefined;
+      const tree = await renderBubbleWithHandlers(message, {
+        onRestoreQueued: selected => {
+          restored = selected;
+        },
       });
-      const cancel = findElementByType(
-        cancelTree,
-        'Button',
-        p => p.accessibilityLabel === 'Cancel queued message'
-      );
-      expect(cancel).not.toBeNull();
-      // The Platform mock reports ios, so the controls reach 44pt.
-      expect(cancel?.props.className).toBe('min-h-11');
-      expect(cancel?.props.size).toBe('sm');
-
-      const restoreTree = await renderBubbleWithHandlers(userMessage('m-size-restore-ios'), {
-        onRestoreQueued: vi.fn<(message: StoredMessage) => void>(),
-      });
+      expect(findText(tree, text => text === 'Restore')).toBe(true);
       const restore = findElementByType(
-        restoreTree,
+        tree,
         'Button',
-        p => p.accessibilityLabel === 'Restore canceled message to the composer'
+        props => props.accessibilityLabel === 'Restore canceled message to the composer'
       );
-      expect(restore).not.toBeNull();
-      expect(restore?.props.className).toBe('min-h-11');
+      expect(restore?.props.accessibilityRole).toBe('button');
+      expect(restore?.props.className).toBe(minHeight);
       expect(restore?.props.size).toBe('sm');
+      if (!restore) {
+        throw new Error('Restore control is missing');
+      }
+      (restore.props.onPress as () => void)();
+      expect(restored).toBe(message);
     } finally {
       reactNativeMock.Platform.OS = 'android';
       vi.resetModules();
     }
-  });
-
-  it('presses Cancel and Restore to call their handlers with the message', async () => {
-    const message = userMessage('m-press-cancel');
-    const onCancelQueued = vi.fn<(message: StoredMessage) => void>();
-    const onRestoreQueued = vi.fn<(message: StoredMessage) => void>();
-
-    const cancelTree = await renderBubbleWithHandlers(message, {
-      deliveryState: { status: 'queued' },
-      onCancelQueued,
-    });
-    const cancel = findElementByType(
-      cancelTree,
-      'Button',
-      p => p.accessibilityLabel === 'Cancel queued message'
-    );
-    expect(cancel).not.toBeNull();
-    if (!cancel) {
-      throw new Error('expected Cancel button');
-    }
-    (cancel.props.onPress as () => void)();
-    expect(onCancelQueued).toHaveBeenCalledWith(message);
-
-    const restoreMessage = userMessage('m-press-restore');
-    const restoreTree = await renderBubbleWithHandlers(restoreMessage, { onRestoreQueued });
-    const restore = findElementByType(
-      restoreTree,
-      'Button',
-      p => p.accessibilityLabel === 'Restore canceled message to the composer'
-    );
-    expect(restore).not.toBeNull();
-    if (!restore) {
-      throw new Error('expected Restore button');
-    }
-    (restore.props.onPress as () => void)();
-    expect(onRestoreQueued).toHaveBeenCalledWith(restoreMessage);
   });
 });
 

--- a/apps/mobile/src/components/agents/message-bubble.tsx
+++ b/apps/mobile/src/components/agents/message-bubble.tsx
@@ -13,6 +13,7 @@ import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 import { InMessageBubbleContext } from './bubble-text-selection-context';
 import { ChatMarkdownText } from './chat-markdown-text';
 import { CompactionSeparator } from './compaction-separator';
+import { collectCopyableText } from './collect-copyable-text';
 import { FilePartRenderer } from './file-part-renderer';
 import { buildAgentMessageBubbleAccessibilityProps } from './message-bubble-a11y';
 import { selectMessageFailure } from './message-failure-state';
@@ -21,11 +22,7 @@ import { firstHumanText, isFilePart, isTextPart } from './part-types';
 import { useMessageCopy } from './use-message-copy';
 import { type OpenChildSession } from './child-session-section';
 
-/**
- * Queued Cancel/Restore controls are compact `size="sm"` buttons (36pt +
- * 4pt hitSlop). The platform minimum touch target is 48dp on Android and
- * 44pt on iOS, so these two controls raise their min-height accordingly.
- */
+/** Restore keeps the platform minimum target despite the compact button size. */
 const QUEUED_CONTROL_MIN_HEIGHT = Platform.OS === 'android' ? 'min-h-12' : 'min-h-11';
 
 type MessageBubbleProps = {
@@ -50,8 +47,6 @@ type MessageBubbleProps = {
   onRetryMessage?: (message: StoredMessage) => void;
   /** Copies a failed user message's text back into the composer. */
   onCopyToComposer?: (text: string) => void;
-  /** Cancels a queued (not yet accepted) user message. Rendered only while queued. */
-  onCancelQueued?: (message: StoredMessage) => void | Promise<void>;
   /** Restores a canceled queued message's prompt back into the composer. */
   onRestoreQueued?: (message: StoredMessage) => void;
 };
@@ -69,29 +64,30 @@ function MessageBubbleImpl({
   holdQueuedSlot,
   onRetryMessage,
   onCopyToComposer,
-  onCancelQueued,
   onRestoreQueued,
 }: Readonly<MessageBubbleProps>) {
   const isUser = message.info.role === 'user';
   const { copyMessage } = useMessageCopy();
   const colors = useThemeColors();
   const { t } = useTranslation();
+  const canCopy = collectCopyableText(message).length > 0;
+  const a11y = buildAgentMessageBubbleAccessibilityProps({
+    isUser,
+    canCopy,
+    canOpenDetails: onLongPressDetails !== undefined,
+  });
 
   const handleLongPress = () => {
     onLongPressDetails?.(message);
   };
 
-  // Long-press opens the details sheet; the VoiceOver/TalkBack rotor "copy"
-  // action stays available so a11y tooling still reaches the existing
-  // ActionSheet copy path. The wrapping `Pressable` is explicitly
-  // `accessible={false}` so iOS does not collapse the message subtree
-  // (permission/question `Button`s, child-session "open" `Pressable`, tool
-  // cards, file parts, markdown link handlers) into a single, unnavigable
-  // node; the role/label/hint/copy action live on a dedicated,
-  // non-interactive focusable overlay so the rotor still has a target.
+  // Keep actions on the separate host so interactive descendants remain reachable.
+  // Accessible Copy retains the existing ActionSheet path; details matches long-press.
   const handleAccessibilityAction = (event: AccessibilityActionEvent) => {
-    if (event.nativeEvent.actionName === 'copy') {
+    if (event.nativeEvent.actionName === 'copy' && canCopy) {
       void copyMessage(message);
+    } else if (event.nativeEvent.actionName === 'details') {
+      handleLongPress();
     }
   };
 
@@ -175,7 +171,6 @@ function MessageBubbleImpl({
     const fileParts = message.parts.filter(isFilePart);
     const isQueued = deliveryState?.status === 'queued';
     const hasBadgeSlot = isQueued || holdQueuedSlot;
-    const a11y = buildAgentMessageBubbleAccessibilityProps({ isUser: true, canCopy: true });
 
     return (
       <>
@@ -214,20 +209,6 @@ function MessageBubbleImpl({
                       {t('agentChat.messageBubble.queued')}
                     </Text>
                   </View>
-                ) : null}
-                {isQueued && onCancelQueued ? (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className={QUEUED_CONTROL_MIN_HEIGHT}
-                    accessibilityRole="button"
-                    accessibilityLabel={t('agentChat.messageBubble.cancelQueuedAccessibility')}
-                    onPress={() => {
-                      void onCancelQueued(message);
-                    }}
-                  >
-                    <Text>{t('agentChat.messageBubble.cancelQueued')}</Text>
-                  </Button>
                 ) : null}
                 {!isQueued && onRestoreQueued ? (
                   <Button
@@ -269,7 +250,6 @@ function MessageBubbleImpl({
   // same value as the gap-2 between parts of one message and the user
   // wrapper's py-1 — every adjacent transcript row pair sits one gap apart.
   const isStreaming = isLastAssistantMessage && isSessionStreaming;
-  const a11y = buildAgentMessageBubbleAccessibilityProps({ isUser: false, canCopy: true });
 
   return (
     <>

--- a/apps/mobile/src/components/agents/message-bubble.tsx
+++ b/apps/mobile/src/components/agents/message-bubble.tsx
@@ -182,7 +182,11 @@ function MessageBubbleImpl({
                   <ChatMarkdownText value={userTextContent} variant="user" selectable={false} />
                 ) : null}
                 {fileParts.map(part => (
-                  <FilePartRenderer key={part.id} part={part} />
+                  <FilePartRenderer
+                    key={part.id}
+                    part={part}
+                    onLongPress={onLongPressDetails ? handleLongPress : undefined}
+                  />
                 ))}
               </InMessageBubbleContext.Provider>
             </Bubble>

--- a/apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- The mounted sheet suite shares native boundaries across actions, selection, and announcements. */
 /* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/test/render-with-providers.tsx) */
 import {
   type AssistantMessage,
@@ -5,16 +6,20 @@ import {
   type StoredMessage,
   type UserMessage,
 } from '@kilocode/cloud-agent-sdk';
-import { createElement, type ReactElement } from 'react';
+import { type ComponentProps, createElement, type ReactElement } from 'react';
+import { Alert } from 'react-native';
 import TestRenderer, { act } from 'react-test-renderer';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageDetailsSheet } from './message-details-sheet';
 
+const native = vi.hoisted(() => ({ clipboard: '', announce: vi.fn() }));
 vi.mock('@/lib/hooks/use-theme-colors', () => ({
-  useThemeColors: () => ({ background: '#000' }),
+  useThemeColors: () => ({ background: '#000', mutedForeground: '#999' }),
 }));
 vi.mock('react-native', () => ({
+  AccessibilityInfo: { announceForAccessibility: native.announce },
+  ActivityIndicator: 'ActivityIndicator',
   Alert: { alert: vi.fn() },
   Modal: 'Modal',
   ScrollView: 'ScrollView',
@@ -24,7 +29,13 @@ vi.mock('react-native', () => ({
   useWindowDimensions: () => ({ width: 390, height: 844 }),
 }));
 vi.mock('@tanstack/react-query', () => ({
-  useMutation: () => ({ mutate: vi.fn() }),
+  useMutation: (options: {
+    onSuccess: (result: { receiptId: string }, input: unknown) => void;
+  }) => ({
+    mutate: (input: unknown) => {
+      options.onSuccess({ receiptId: 'receipt-1' }, input);
+    },
+  }),
 }));
 vi.mock('@/lib/trpc', () => ({
   useTRPC: () => ({
@@ -52,9 +63,22 @@ vi.mock('@/components/ui/text', async () => {
 vi.mock('@/components/ui/selectable-text', () => ({
   SelectableText: 'SelectableText',
 }));
-vi.mock('./message-details-copy', () => ({
-  handleMessageDetailsCopy: vi.fn(),
+vi.mock('expo-clipboard', () => ({
+  setStringAsync: (text: string) => {
+    native.clipboard = text;
+  },
 }));
+vi.mock('expo-haptics', () => ({
+  notificationAsync: vi.fn(),
+  NotificationFeedbackType: { Success: 'success' },
+}));
+vi.mock('sonner-native', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+beforeEach(() => {
+  native.clipboard = '';
+  native.announce.mockClear();
+  vi.mocked(Alert.alert).mockClear();
+});
 
 function userInfo(overrides: Partial<UserMessage> = {}): UserMessage {
   return {
@@ -120,12 +144,15 @@ function storedMessage(info: AssistantMessage | UserMessage, parts: Part[] = [])
   return { info, parts };
 }
 
-function sheetElement(message: StoredMessage | null): ReactElement {
+type SheetOverrides = Partial<ComponentProps<typeof MessageDetailsSheet>>;
+
+function sheetElement(message: StoredMessage | null, overrides: SheetOverrides = {}): ReactElement {
   return createElement(MessageDetailsSheet, {
     visible: true,
     message,
     modelOptions: [],
     onClose: vi.fn<() => void>(),
+    ...overrides,
   });
 }
 
@@ -147,11 +174,14 @@ function press(instance: TestRenderer.ReactTestInstance | undefined): void {
   onPress();
 }
 
-async function mountSheet(message: StoredMessage | null): Promise<TestRenderer.ReactTestRenderer> {
+async function mountSheet(
+  message: StoredMessage | null,
+  overrides: SheetOverrides = {}
+): Promise<TestRenderer.ReactTestRenderer> {
   const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
   await act(async () => {
     await Promise.resolve();
-    ref.current = TestRenderer.create(sheetElement(message));
+    ref.current = TestRenderer.create(sheetElement(message, overrides));
   });
   const renderer = ref.current;
   if (!renderer) {
@@ -168,6 +198,127 @@ async function unmount(renderer: TestRenderer.ReactTestRenderer): Promise<void> 
 }
 
 describe('MessageDetailsSheet mounted', () => {
+  it('presses cancellation and follows eligible, busy, ineligible, empty, and file-only states', async () => {
+    const message = storedMessage(userInfo(), [textPart('queued')]);
+    const selected: StoredMessage[] = [];
+    const onCancelQueued = (value: StoredMessage) => {
+      selected.push(value);
+    };
+    const renderer = await mountSheet(message, { canCancelQueued: true, onCancelQueued });
+    const row = () => findByTestID(renderer.root, 'message-details-cancel-queued')[0];
+    act(() => {
+      press(row());
+    });
+    expect(selected).toEqual([message]);
+    act(() => {
+      renderer.update(
+        sheetElement(message, { canCancelQueued: false, isCancelingQueued: true, onCancelQueued })
+      );
+    });
+    expect(row()?.props.accessibilityState).toEqual({ disabled: true, busy: true });
+    expect(row()?.props.accessibilityLabel).toBe('Cancel queued message');
+    expect(row()?.props.disabled).toBe(true);
+    expect(renderer.root.findAll(node => node.type === 'ActivityIndicator')).toHaveLength(1);
+    act(() => {
+      press(row());
+    });
+    expect(selected).toEqual([message]);
+    act(() => {
+      renderer.update(sheetElement(message, { canCancelQueued: false, onCancelQueued }));
+    });
+    expect(row()).toBeUndefined();
+    act(() => {
+      renderer.update(sheetElement(null, { canCancelQueued: true, onCancelQueued }));
+    });
+    expect(row()).toBeUndefined();
+    const fileOnly = storedMessage(userInfo({ id: 'file-message' }), [
+      {
+        id: 'file-1',
+        sessionID: 'ses-1',
+        messageID: 'file-message',
+        type: 'file',
+        mime: 'text/plain',
+        url: 'file:///attachment.txt',
+      },
+    ]);
+    act(() => {
+      renderer.update(sheetElement(fileOnly, { canCancelQueued: true, onCancelQueued }));
+    });
+    expect(findByTestID(renderer.root, 'message-details-copy')).toHaveLength(0);
+    expect(findByTestID(renderer.root, 'message-details-select-text')).toHaveLength(0);
+    act(() => {
+      press(row());
+    });
+    expect(selected).toEqual([message, fileOnly]);
+    await unmount(renderer);
+  });
+
+  it('announces an identical failure again after a cleared retry, without speech on hiding', async () => {
+    const message = storedMessage(userInfo(), [textPart('queued')]);
+    const failure = 'Could not cancel the queued message.';
+    const renderer = await mountSheet(message, {
+      cancelQueuedFeedback: { message: failure, attempt: 1 },
+    });
+    expect(
+      renderer.root.findAll(node => node.type === 'Text' && node.props.children === failure)
+    ).toHaveLength(1);
+    expect(native.announce.mock.calls).toEqual([[failure]]);
+    act(() => {
+      renderer.update(
+        sheetElement(message, { cancelQueuedFeedback: null, isCancelingQueued: true })
+      );
+    });
+    expect(
+      renderer.root.findAll(node => node.type === 'Text' && node.props.children === failure)
+    ).toHaveLength(0);
+    expect(native.announce.mock.calls).toEqual([[failure]]);
+    act(() => {
+      renderer.update(
+        sheetElement(message, { cancelQueuedFeedback: { message: failure, attempt: 2 } })
+      );
+    });
+    expect(native.announce.mock.calls).toEqual([[failure], [failure]]);
+    act(() => {
+      renderer.update(
+        sheetElement(message, {
+          visible: false,
+          cancelQueuedFeedback: { message: failure, attempt: 2 },
+        })
+      );
+    });
+    expect(native.announce.mock.calls).toEqual([[failure], [failure]]);
+    await unmount(renderer);
+  });
+
+  it('keeps real Copy and confirmed Report outcomes on the details sheet', async () => {
+    const message = storedMessage(assistantInfo(), [textPart('copy this response')]);
+    const renderer = await mountSheet(message);
+    await act(async () => {
+      press(findByTestID(renderer.root, 'message-details-copy')[0]);
+      await Promise.resolve();
+    });
+    expect(native.clipboard).toBe('copy this response');
+    act(() => {
+      press(findByTestID(renderer.root, 'message-details-report')[0]);
+    });
+    expect(findByTestID(renderer.root, 'message-details-report')).toHaveLength(1);
+    const confirm = vi
+      .mocked(Alert.alert)
+      .mock.calls.at(-1)?.[2]
+      ?.find(button => button.style === 'destructive');
+    act(() => confirm?.onPress?.());
+    expect(findByTestID(renderer.root, 'message-details-report')).toHaveLength(0);
+    act(() => {
+      renderer.update(
+        sheetElement(
+          storedMessage(assistantInfo({ id: 'another-response' }), [textPart('another response')])
+        )
+      );
+    });
+    expect(findByTestID(renderer.root, 'message-details-report')).toHaveLength(1);
+    await unmount(renderer);
+  });
+
   it('renders Copy message and Select text for a finished copyable user message', async () => {
     const renderer = await mountSheet(storedMessage(userInfo(), [textPart('hello world')]));
 

--- a/apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx
@@ -290,6 +290,36 @@ describe('MessageDetailsSheet mounted', () => {
     await unmount(renderer);
   });
 
+  it('keeps upgrade guidance readable on reopening without announcing the outcome again', async () => {
+    const message = storedMessage(userInfo(), [textPart('queued')]);
+    const guidance =
+      'Canceling queued messages requires a newer Kilo CLI. Update Kilo CLI and reconnect.';
+    const renderer = await mountSheet(message, {
+      cancelQueuedGuidance: guidance,
+      cancelQueuedFeedback: { message: guidance, attempt: 1 },
+    });
+    const guidanceNodes = () =>
+      renderer.root.findAll(node => node.type === 'Text' && node.props.children === guidance);
+    expect(guidanceNodes()).toHaveLength(1);
+    expect(native.announce.mock.calls).toEqual([[guidance]]);
+    act(() => {
+      renderer.update(sheetElement(message, { visible: false, cancelQueuedGuidance: guidance }));
+    });
+    expect(guidanceNodes()).toHaveLength(0);
+    act(() => {
+      renderer.update(sheetElement(message, { cancelQueuedGuidance: guidance }));
+    });
+    expect(guidanceNodes()).toHaveLength(1);
+    expect(guidanceNodes()[0]?.props.accessibilityLiveRegion).toBeUndefined();
+    expect(native.announce.mock.calls).toEqual([[guidance]]);
+    expect(findByTestID(renderer.root, 'message-details-cancel-queued')).toHaveLength(0);
+    act(() => {
+      renderer.update(sheetElement(null, { cancelQueuedGuidance: guidance }));
+    });
+    expect(guidanceNodes()).toHaveLength(0);
+    await unmount(renderer);
+  });
+
   it('keeps real Copy and confirmed Report outcomes on the details sheet', async () => {
     const message = storedMessage(assistantInfo(), [textPart('copy this response')]);
     const renderer = await mountSheet(message);

--- a/apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx
@@ -7,9 +7,13 @@ import {
   type UserMessage,
 } from '@kilocode/cloud-agent-sdk';
 import { type ComponentProps, createElement, type ReactElement } from 'react';
-import { Alert } from 'react-native';
+import { ActivityIndicator, Alert, Modal, ScrollView } from 'react-native';
 import TestRenderer, { act } from 'react-test-renderer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SheetHeader } from '@/components/sheet-header';
+import { SelectableText } from '@/components/ui/selectable-text';
+import { Text } from '@/components/ui/text';
 
 import { MessageDetailsSheet } from './message-details-sheet';
 
@@ -218,7 +222,7 @@ describe('MessageDetailsSheet mounted', () => {
     expect(row()?.props.accessibilityState).toEqual({ disabled: true, busy: true });
     expect(row()?.props.accessibilityLabel).toBe('Cancel queued message');
     expect(row()?.props.disabled).toBe(true);
-    expect(renderer.root.findAll(node => node.type === 'ActivityIndicator')).toHaveLength(1);
+    expect(renderer.root.findAllByType(ActivityIndicator)).toHaveLength(1);
     act(() => {
       press(row());
     });
@@ -260,7 +264,7 @@ describe('MessageDetailsSheet mounted', () => {
       cancelQueuedFeedback: { message: failure, attempt: 1 },
     });
     expect(
-      renderer.root.findAll(node => node.type === 'Text' && node.props.children === failure)
+      renderer.root.findAll(node => node.type === Text && node.props.children === failure)
     ).toHaveLength(1);
     expect(native.announce.mock.calls).toEqual([[failure]]);
     act(() => {
@@ -269,7 +273,7 @@ describe('MessageDetailsSheet mounted', () => {
       );
     });
     expect(
-      renderer.root.findAll(node => node.type === 'Text' && node.props.children === failure)
+      renderer.root.findAll(node => node.type === Text && node.props.children === failure)
     ).toHaveLength(0);
     expect(native.announce.mock.calls).toEqual([[failure]]);
     act(() => {
@@ -299,7 +303,7 @@ describe('MessageDetailsSheet mounted', () => {
       cancelQueuedFeedback: { message: guidance, attempt: 1 },
     });
     const guidanceNodes = () =>
-      renderer.root.findAll(node => node.type === 'Text' && node.props.children === guidance);
+      renderer.root.findAll(node => node.type === Text && node.props.children === guidance);
     expect(guidanceNodes()).toHaveLength(1);
     expect(native.announce.mock.calls).toEqual([[guidance]]);
     act(() => {
@@ -361,9 +365,7 @@ describe('MessageDetailsSheet mounted', () => {
   it('sizes the details ScrollView to fill the sheet surface with flex-1', async () => {
     const renderer = await mountSheet(storedMessage(userInfo(), [textPart('hello world')]));
 
-    const scrollViews = renderer.root.findAll(
-      node => typeof node.type === 'string' && (node.type as string) === 'ScrollView'
-    );
+    const scrollViews = renderer.root.findAll(node => node.type === ScrollView);
     expect(scrollViews).toHaveLength(1);
     expect(scrollViews[0]?.props.className).toBe('flex-1');
 
@@ -373,13 +375,10 @@ describe('MessageDetailsSheet mounted', () => {
   it('swaps the details Modal content to the select view when Select text is pressed', async () => {
     const renderer = await mountSheet(storedMessage(userInfo(), [textPart('selectable body')]));
 
-    const modals = () =>
-      renderer.root.findAll(
-        node => typeof node.type === 'string' && (node.type as string) === 'Modal'
-      );
+    const modals = () => renderer.root.findAll(node => node.type === Modal);
     const sheetHeaderTitles = () =>
       renderer.root
-        .findAll(node => typeof node.type === 'string' && (node.type as string) === 'SheetHeader')
+        .findAll(node => node.type === SheetHeader)
         .map(node => node.props.title as string | undefined);
 
     // Before press: a single Modal shows the details content.
@@ -396,9 +395,7 @@ describe('MessageDetailsSheet mounted', () => {
     expect(sheetHeaderTitles()).toContain('Select text');
     expect(sheetHeaderTitles()).not.toContain('Message details');
 
-    const selectable = renderer.root.findAll(
-      node => typeof node.type === 'string' && (node.type as string) === 'SelectableText'
-    );
+    const selectable = renderer.root.findAll(node => node.type === SelectableText);
     expect(selectable).toHaveLength(1);
     expect(selectable[0]?.props.children).toBe('selectable body');
 
@@ -409,9 +406,7 @@ describe('MessageDetailsSheet mounted', () => {
     const renderer = await mountSheet(storedMessage(userInfo(), [textPart('selectable body')]));
 
     const modal = () => {
-      const found = renderer.root.findAll(
-        node => typeof node.type === 'string' && (node.type as string) === 'Modal'
-      );
+      const found = renderer.root.findAll(node => node.type === Modal);
       if (!found[0]) {
         throw new Error('Modal not found');
       }
@@ -433,7 +428,7 @@ describe('MessageDetailsSheet mounted', () => {
 
     const sheetHeaderTitles = () =>
       renderer.root
-        .findAll(node => typeof node.type === 'string' && (node.type as string) === 'SheetHeader')
+        .findAll(node => node.type === SheetHeader)
         .map(node => node.props.title as string | undefined);
     expect(sheetHeaderTitles()).toContain('Message details');
     expect(sheetHeaderTitles()).not.toContain('Select text');

--- a/apps/mobile/src/components/agents/message-details-sheet.test.ts
+++ b/apps/mobile/src/components/agents/message-details-sheet.test.ts
@@ -245,12 +245,30 @@ describe('getMessageDetailsContent — empty', () => {
     expect(content.copyableText).toBe('aborted');
   });
 
-  it('hides Copy when there is no copyable text', () => {
-    const message = storedMessage(userInfo(), []);
-    const content = getMessageDetailsContent(message, catalogOptions);
-    expect(content.copyableText).toBeNull();
-    expect(content.roleLabel).toBe('User');
-  });
+  it.each([
+    { name: 'empty', parts: [] },
+    {
+      name: 'file-only',
+      parts: [
+        {
+          id: 'file-1',
+          sessionID: 'ses-1',
+          messageID: 'u-1',
+          type: 'file',
+          mime: 'text/plain',
+          url: 'file:///attachment.txt',
+        },
+      ],
+    },
+  ] satisfies { name: string; parts: Part[] }[])(
+    'keeps user details without Copy for $name parts',
+    ({ parts }) => {
+      const message = storedMessage(userInfo(), parts);
+      const content = getMessageDetailsContent(message, catalogOptions);
+      expect(content.copyableText).toBeNull();
+      expect(content.roleLabel).toBe('User');
+    }
+  );
 
   it('hides Sent when the created timestamp is missing', () => {
     const info = userInfo({

--- a/apps/mobile/src/components/agents/message-details-sheet.tsx
+++ b/apps/mobile/src/components/agents/message-details-sheet.tsx
@@ -35,6 +35,7 @@ type MessageDetailsSheetProps = {
   isCancelingQueued?: boolean;
   onCancelQueued?: (message: StoredMessage) => void | Promise<void>;
   cancelQueuedFeedback?: { message: string; attempt: number } | null;
+  cancelQueuedGuidance?: string | null;
 };
 
 export function MessageDetailsSheet({
@@ -46,6 +47,7 @@ export function MessageDetailsSheet({
   isCancelingQueued = false,
   onCancelQueued,
   cancelQueuedFeedback,
+  cancelQueuedGuidance,
 }: Readonly<MessageDetailsSheetProps>) {
   const insets = useSafeAreaInsets();
   const colors = useThemeColors();
@@ -133,6 +135,13 @@ export function MessageDetailsSheet({
         tone="error"
         className="px-6 pt-4 text-sm"
       />
+      {/* Keep recovery guidance readable without replaying the outcome announcement. */}
+      {visible &&
+      message &&
+      cancelQueuedGuidance &&
+      cancelQueuedFeedback?.message !== cancelQueuedGuidance ? (
+        <Text className="px-6 pt-4 text-sm text-destructive">{cancelQueuedGuidance}</Text>
+      ) : null}
       {selectVisible ? (
         <MessageTextSelectSheet
           text={content?.copyableText ?? ''}

--- a/apps/mobile/src/components/agents/message-details-sheet.tsx
+++ b/apps/mobile/src/components/agents/message-details-sheet.tsx
@@ -1,7 +1,7 @@
 import { type StoredMessage } from '@kilocode/cloud-agent-sdk';
 import { useMutation } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
-import { Alert, Pressable, ScrollView, View } from 'react-native';
+import { ActivityIndicator, Alert, Pressable, ScrollView, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -9,6 +9,8 @@ import { announcingToast } from '@/lib/a11y/announcing-toast';
 import { useTRPC } from '@/lib/trpc';
 import { SheetHeader } from '@/components/sheet-header';
 import { Text } from '@/components/ui/text';
+import { AccessibleStatus } from '@/components/ui/accessible-status';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 
 import { formatExactTokens } from './context-usage-display';
@@ -29,6 +31,10 @@ type MessageDetailsSheetProps = {
   message: StoredMessage | null;
   modelOptions: SessionModelOption[];
   onClose: () => void;
+  canCancelQueued?: boolean;
+  isCancelingQueued?: boolean;
+  onCancelQueued?: (message: StoredMessage) => void | Promise<void>;
+  cancelQueuedFeedback?: { message: string; attempt: number } | null;
 };
 
 export function MessageDetailsSheet({
@@ -36,8 +42,13 @@ export function MessageDetailsSheet({
   message,
   modelOptions,
   onClose,
+  canCancelQueued = false,
+  isCancelingQueued = false,
+  onCancelQueued,
+  cancelQueuedFeedback,
 }: Readonly<MessageDetailsSheetProps>) {
   const insets = useSafeAreaInsets();
+  const colors = useThemeColors();
   const trpc = useTRPC();
   const { t } = useTranslation();
   const [reportedMessageId, setReportedMessageId] = useState<string | null>(null);
@@ -116,6 +127,12 @@ export function MessageDetailsSheet({
           : onClose
       }
     >
+      <AccessibleStatus
+        key={cancelQueuedFeedback?.attempt}
+        message={visible ? (cancelQueuedFeedback?.message ?? null) : null}
+        tone="error"
+        className="px-6 pt-4 text-sm"
+      />
       {selectVisible ? (
         <MessageTextSelectSheet
           text={content?.copyableText ?? ''}
@@ -163,6 +180,32 @@ export function MessageDetailsSheet({
                     </Pressable>
                   ) : null}
                 </View>
+              ) : null}
+
+              {visible && message && onCancelQueued && (canCancelQueued || isCancelingQueued) ? (
+                <Pressable
+                  onPress={() => {
+                    if (canCancelQueued && !isCancelingQueued) {
+                      void onCancelQueued(message);
+                    }
+                  }}
+                  disabled={!canCancelQueued || isCancelingQueued}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('agentChat.messageBubble.cancelQueuedAccessibility')}
+                  accessibilityState={{
+                    disabled: !canCancelQueued || isCancelingQueued,
+                    busy: isCancelingQueued,
+                  }}
+                  className="mb-6 min-h-12 flex-row items-center justify-center gap-2 rounded-md border border-border px-4 py-3 active:opacity-70 disabled:opacity-50"
+                  testID="message-details-cancel-queued"
+                >
+                  {isCancelingQueued ? (
+                    <ActivityIndicator size="small" color={colors.mutedForeground} />
+                  ) : null}
+                  <Text className="text-center text-base font-medium text-foreground">
+                    {t('agentChat.messageBubble.cancelQueued')}
+                  </Text>
+                </Pressable>
               ) : null}
 
               {showReport ? (

--- a/apps/mobile/src/components/agents/platform-filter-modal.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/platform-filter-modal.mounted.test.tsx
@@ -1,0 +1,293 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer mounts the real native component without a DOM. */
+import { type ComponentProps, type ReactElement, useState } from 'react';
+import { Modal, Pressable, ScrollView } from 'react-native';
+import TestRenderer, { act } from 'react-test-renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { i18n } from '@/i18n';
+import { type AgentSessionFilters } from '@/lib/agent-session-filters';
+import { SessionFilterChips, SessionFilterModal } from './platform-filter-modal';
+import { PLATFORM_FILTERS } from './session-list-helpers';
+
+vi.mock('react-native', () => ({
+  Modal: 'Modal',
+  Pressable: 'Pressable',
+  ScrollView: 'ScrollView',
+  View: 'View',
+}));
+vi.mock('@/components/ui/icons', () => ({ Check: 'Check', X: 'X' }));
+vi.mock('@/components/ui/button', () => ({ Button: 'Button' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({ accentSoftForeground: '#1a1a10', primaryForeground: '#1a1a10' }),
+}));
+
+const projects = [
+  { gitUrl: 'https://github.com/iscekic/kilo-workflow.git', displayName: 'ISCEKIC/KILO-WORKFLOW' },
+  { gitUrl: 'https://github.com/Kilo-Org/kilocode.git', displayName: 'KILO-ORG/KILOCODE' },
+  {
+    gitUrl: 'https://github.com/example/a-repository-with-a-very-long-name.git',
+    displayName: 'EXAMPLE/A-REPOSITORY-WITH-A-VERY-LONG-NAME-THAT-MUST-NOT-HIDE-THE-REMOVE-CONTROL',
+  },
+];
+const unavailable = 'https://github.com/unavailable/a-saved-repository-with-a-very-long-name.git';
+const longPlatform = 'a-future-platform-with-a-very-long-display-name';
+const allProjects = projects.map(project => project.gitUrl);
+const allPlatforms = [...PLATFORM_FILTERS, longPlatform];
+
+type FixtureProps = Pick<
+  ComponentProps<typeof SessionFilterChips>,
+  'onRemoveProject' | 'onRemovePlatform'
+> & {
+  initialFilters: AgentSessionFilters;
+  openPicker?: boolean;
+};
+
+function FilterFixture({
+  initialFilters,
+  openPicker = false,
+  onRemoveProject,
+  onRemovePlatform,
+}: Readonly<FixtureProps>) {
+  const [filters, setFilters] = useState(initialFilters);
+  const [picking, setPicking] = useState(openPicker);
+  return (
+    <>
+      <SessionFilterChips
+        {...filters}
+        projectOptions={projects}
+        onRemoveProject={value => {
+          onRemoveProject(value);
+          setFilters(prev => ({
+            ...prev,
+            projectFilter: prev.projectFilter.filter(p => p !== value),
+          }));
+        }}
+        onRemovePlatform={value => {
+          onRemovePlatform(value);
+          setFilters(prev => ({
+            ...prev,
+            platformFilter: prev.platformFilter.filter(p => p !== value),
+          }));
+        }}
+      />
+      {picking && (
+        <SessionFilterModal
+          selectedPlatforms={filters.platformFilter}
+          selectedProjects={filters.projectFilter}
+          projectOptions={projects}
+          onApply={setFilters}
+          onClose={() => {
+            setPicking(false);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+const mounted: TestRenderer.ReactTestRenderer[] = [];
+
+async function render(element: ReactElement) {
+  const ref: { current?: TestRenderer.ReactTestRenderer } = {};
+  await act(async () => {
+    await Promise.resolve();
+    ref.current = TestRenderer.create(element);
+  });
+  if (!ref.current) {
+    throw new Error('renderer was not created');
+  }
+  mounted.push(ref.current);
+  return ref.current;
+}
+
+function pillLabels(renderer: TestRenderer.ReactTestRenderer): string[] {
+  return renderer.root
+    .findAllByType(Pressable)
+    .map(pill => pill.props.accessibilityLabel as string);
+}
+
+describe('SessionFilterChips', () => {
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    act(() => {
+      for (const renderer of mounted) {
+        renderer.unmount();
+      }
+    });
+    mounted.length = 0;
+  });
+
+  it('renders no strip or spacer without selections', async () => {
+    const renderer = await render(
+      <SessionFilterChips
+        projectFilter={[]}
+        platformFilter={[]}
+        projectOptions={projects}
+        onRemoveProject={vi.fn<(value: string) => void>()}
+        onRemovePlatform={vi.fn<(value: string) => void>()}
+      />
+    );
+    expect(renderer.toJSON()).toBeNull();
+  });
+
+  it.each([
+    { name: 'one repository', projectFilter: allProjects.slice(0, 1), platformFilter: [] },
+    { name: 'two repositories', projectFilter: allProjects.slice(0, 2), platformFilter: [] },
+    { name: 'overflowing long labels', projectFilter: allProjects, platformFilter: allPlatforms },
+    { name: 'unavailable repository', projectFilter: [unavailable], platformFilter: ['cli'] },
+    { name: 'platform-only long labels', projectFilter: [], platformFilter: allPlatforms },
+  ])('constrains every pill for $name', async ({ projectFilter, platformFilter }) => {
+    const renderer = await render(
+      <SessionFilterChips
+        projectFilter={projectFilter}
+        platformFilter={platformFilter}
+        projectOptions={projects}
+        onRemoveProject={vi.fn<(value: string) => void>()}
+        onRemovePlatform={vi.fn<(value: string) => void>()}
+      />
+    );
+    const strip = renderer.root.findByType(ScrollView);
+    const stripProps = strip.props as ComponentProps<typeof ScrollView>;
+    expect(stripProps.horizontal).toBe(true);
+    expect(stripProps.className?.split(' ')).toEqual(
+      expect.arrayContaining(['grow-0', 'shrink-0'])
+    );
+    expect(stripProps.contentContainerClassName?.split(' ')).toEqual(
+      expect.arrayContaining(['items-center', 'gap-2', 'px-[22px]', 'py-2'])
+    );
+    expect(stripProps.contentContainerStyle).toBeUndefined();
+    const pills = strip.findAllByType(Pressable);
+    expect(pills).toHaveLength(projectFilter.length + platformFilter.length);
+    for (const pill of pills) {
+      const pillProps = pill.props as ComponentProps<typeof Pressable>;
+      expect(pillProps.accessibilityRole).toBe('button');
+      expect(pillProps.className?.split(' ')).toEqual(
+        expect.arrayContaining([
+          'min-h-[48px]',
+          'min-w-[48px]',
+          'self-center',
+          'shrink-0',
+          'items-center',
+          'rounded-full',
+          'active:opacity-70',
+        ])
+      );
+      const label = pill.findByType(Text);
+      const labelProps = label.props as ComponentProps<typeof Text>;
+      expect(labelProps.numberOfLines).toBe(1);
+      expect(labelProps.className?.split(' ')).toContain('max-w-[220px]');
+      expect(labelProps.allowFontScaling).not.toBe(false);
+      expect(pillProps.accessibilityLabel).toContain(labelProps.children);
+    }
+  });
+
+  it.each(['repository', 'platform'] as const)(
+    'removes exact values, starting with a %s, without clearing the other dimension',
+    async firstDimension => {
+      const onRemoveProject = vi.fn<(value: string) => void>();
+      const onRemovePlatform = vi.fn<(value: string) => void>();
+      const renderer = await render(
+        <FilterFixture
+          initialFilters={{
+            projectFilter: [...allProjects, unavailable],
+            platformFilter: allPlatforms,
+          }}
+          onRemoveProject={onRemoveProject}
+          onRemovePlatform={onRemovePlatform}
+        />
+      );
+      const projectRemovals = [...projects, { gitUrl: unavailable, displayName: unavailable }].map(
+        project => ({
+          value: project.gitUrl,
+          label: i18n.t('agentChat.sessionFilter.removeProjectFilter', {
+            label: project.displayName,
+          }),
+          callback: onRemoveProject,
+          otherCallback: onRemovePlatform,
+        })
+      );
+      const pills = renderer.root.findAllByType(Pressable);
+      expect(
+        pills.slice(0, projectRemovals.length).map(pill => pill.findByType(Text).props.children)
+      ).toEqual([...projects.map(project => project.displayName), unavailable]);
+      const platformPills = pills.slice(projectRemovals.length);
+      const platformRemovals = allPlatforms.map((platform, index) => ({
+        value: platform,
+        label: platformPills[index]?.props.accessibilityLabel as string,
+        callback: onRemovePlatform,
+        otherCallback: onRemoveProject,
+      }));
+      expect(pillLabels(renderer)).toContain(
+        i18n.t('agentChat.sessionFilter.removeProjectFilter', { label: unavailable })
+      );
+      expect(platformPills.at(-1)?.findByType(Text).props.children).toBe(
+        'A-FUTURE-PLATFORM-WITH-A-VERY-LONG-DISPLAY-NAME'
+      );
+      const removals =
+        firstDimension === 'repository'
+          ? [...projectRemovals, ...platformRemovals]
+          : [...platformRemovals, ...projectRemovals];
+      for (const removal of removals) {
+        const before = pillLabels(renderer);
+        const otherCalls = removal.otherCallback.mock.calls.length;
+        act(() => {
+          const pill = renderer.root.findByProps({ accessibilityLabel: removal.label });
+          (pill.props.onPress as () => void)();
+        });
+        expect(removal.callback).toHaveBeenLastCalledWith(removal.value);
+        expect(removal.otherCallback).toHaveBeenCalledTimes(otherCalls);
+        expect(pillLabels(renderer)).toEqual(before.filter(label => label !== removal.label));
+      }
+      expect(onRemoveProject).toHaveBeenCalledTimes(projectRemovals.length);
+      expect(onRemovePlatform).toHaveBeenCalledTimes(platformRemovals.length);
+      expect(renderer.toJSON()).toBeNull();
+    }
+  );
+
+  it('keeps draft selections out of the strip until Apply commits both arrays', async () => {
+    const renderer = await render(
+      <FilterFixture
+        initialFilters={{ projectFilter: [], platformFilter: [] }}
+        openPicker
+        onRemoveProject={vi.fn<(value: string) => void>()}
+        onRemovePlatform={vi.fn<(value: string) => void>()}
+      />
+    );
+    const labels = [
+      projects[0]?.displayName,
+      projects[1]?.displayName,
+      i18n.t('agentChat.sessionFilter.platformCloud'),
+    ];
+    for (const label of labels) {
+      act(() => {
+        const checkbox = renderer.root
+          .findAllByProps({ accessibilityRole: 'checkbox' })
+          .find(row => row.findByType(Text).props.children === label);
+        if (!checkbox) {
+          throw new Error(`missing checkbox: ${label}`);
+        }
+        (checkbox.props.onPress as () => void)();
+      });
+    }
+    expect(renderer.root.findByType(SessionFilterChips).findAllByType(ScrollView)).toHaveLength(0);
+    act(() => {
+      const apply = renderer.root
+        .findAllByType(Button)
+        .find(button => button.findByType(Text).props.children === i18n.t('common.apply'));
+      if (!apply) {
+        throw new Error('missing Apply button');
+      }
+      (apply.props.onPress as () => void)();
+    });
+    expect(renderer.root.findAllByType(Modal)).toHaveLength(0);
+    expect(
+      renderer.root.findAllByType(Pressable).map(pill => pill.findByType(Text).props.children)
+    ).toEqual(labels);
+  });
+});

--- a/apps/mobile/src/components/agents/platform-filter-modal.tsx
+++ b/apps/mobile/src/components/agents/platform-filter-modal.tsx
@@ -18,8 +18,6 @@ import { cn } from '@/lib/utils';
 
 export { type ProjectFilterOption };
 
-const chipScrollContentStyle = { paddingHorizontal: 22, paddingVertical: 8, gap: 8 };
-
 type SessionFilterChipsProps = AgentSessionFilters & {
   projectOptions: ProjectFilterOption[];
   onRemovePlatform: (platform: string) => void;
@@ -117,15 +115,16 @@ export function SessionFilterChips({
   return (
     <ScrollView
       horizontal
+      className="grow-0 shrink-0"
       showsHorizontalScrollIndicator={false}
-      contentContainerStyle={chipScrollContentStyle}
+      contentContainerClassName="items-center gap-2 px-[22px] py-2"
     >
       {projectFilter.map(gitUrl => {
         const label = projectFilterLabel(gitUrl, projectOptions);
         return (
           <Pressable
             key={`project-${gitUrl}`}
-            className="flex-row items-center gap-1.5 rounded-full bg-accent-soft px-3 py-1.5 active:opacity-70"
+            className="min-h-[48px] min-w-[48px] shrink-0 flex-row items-center self-center gap-1.5 rounded-full bg-accent-soft px-3 py-1.5 active:opacity-70"
             onPress={() => {
               onRemoveProject(gitUrl);
             }}
@@ -133,7 +132,7 @@ export function SessionFilterChips({
             accessibilityLabel={t('agentChat.sessionFilter.removeProjectFilter', { label })}
           >
             <Text
-              className="font-mono-medium text-[11px] uppercase tracking-[0.6px] text-accent-soft-foreground"
+              className="max-w-[220px] font-mono-medium text-[11px] uppercase tracking-[0.6px] text-accent-soft-foreground"
               numberOfLines={1}
             >
               {label}
@@ -145,7 +144,7 @@ export function SessionFilterChips({
       {platformFilter.map(platform => (
         <Pressable
           key={`platform-${platform}`}
-          className="flex-row items-center gap-1.5 rounded-full bg-accent-soft px-3 py-1.5 active:opacity-70"
+          className="min-h-[48px] min-w-[48px] shrink-0 flex-row items-center self-center gap-1.5 rounded-full bg-accent-soft px-3 py-1.5 active:opacity-70"
           onPress={() => {
             onRemovePlatform(platform);
           }}
@@ -154,7 +153,10 @@ export function SessionFilterChips({
             label: platformFilterLabel(platform),
           })}
         >
-          <Text className="font-mono-medium text-[11px] uppercase tracking-[0.6px] text-accent-soft-foreground">
+          <Text
+            className="max-w-[220px] font-mono-medium text-[11px] uppercase tracking-[0.6px] text-accent-soft-foreground"
+            numberOfLines={1}
+          >
             {platformFilterLabel(platform)}
           </Text>
           <X size={12} color={colors.accentSoftForeground} />

--- a/apps/mobile/src/components/agents/session-detail-content.test.ts
+++ b/apps/mobile/src/components/agents/session-detail-content.test.ts
@@ -9,27 +9,38 @@ import { type KiloSessionId, type StoredMessage } from '@kilocode/cloud-agent-sd
 import type * as ReactI18next from 'react-i18next';
 
 import { type SessionTranscriptItem } from '@/components/agents/session-transcript';
+import { MessageDetailsSheet } from '@/components/agents/message-details-sheet';
+import { AccessibleStatus } from '@/components/ui/accessible-status';
+import { assistantMessage } from './message-bubble-test-utils';
 import {
   resolveSendAttachmentKind,
   shouldRefuseSilentAttachmentDrop,
 } from '@/components/agents/session-detail-send-attachment';
 
-// The composer and session-list mocks are the only two sub-components the
-// suite drives; everything else is a string host element so the tree renders
-// without pulling in the real native/navigation surface.
-const hoisted = vi.hoisted(() => ({
-  managerRef: { current: null as unknown },
-  chatComposer: {
-    control: {
-      hasContent: vi.fn(() => false),
-      setText: vi.fn(),
-      restoreAttachments: vi.fn(),
+// The screen mounts the real details sheet and AccessibleStatus.
+// Composer and manager fakes expose current state for cancellation tests.
+const hoisted = vi.hoisted(() => {
+  const draft = { text: '', files: [] as unknown[] };
+  return {
+    managerRef: { current: null as unknown },
+    announce: vi.fn(),
+    chatComposer: {
+      draft,
+      control: {
+        hasContent: vi.fn(() => draft.text !== '' || draft.files.length > 0),
+        setText: vi.fn((text: string) => {
+          draft.text = text;
+        }),
+        restoreAttachments: vi.fn((files: unknown[]) => {
+          draft.files = [...files];
+        }),
+      },
+      lastProps: null as null | {
+        onSend?: (text: string, options?: Record<string, unknown>) => Promise<void> | void;
+      },
     },
-    lastProps: null as null | {
-      onSend?: (text: string, options?: Record<string, unknown>) => Promise<void> | void;
-    },
-  },
-}));
+  };
+});
 
 // Mock every RN / Expo / SDK side-effect import that `mobile-session-manager.ts`
 // and `session-detail-content.tsx` pull in transitively before loading either
@@ -75,6 +86,9 @@ vi.mock('@/components/agents/file-part-cache', () => ({
   cacheFilePart: vi.fn(),
 }));
 vi.mock('@/lib/trpc', () => ({
+  useTRPC: () => ({
+    moderation: { reportContent: { mutationOptions: (options: unknown) => options } },
+  }),
   trpcClient: {
     cloudAgentNext: {
       getAttachmentDownloadUrl: { mutate: vi.fn() },
@@ -97,9 +111,25 @@ vi.mock('@/lib/trpc', () => ({
 
 // ── react-native / native bridges ──────────────────────────────────────────
 vi.mock('react-native', () => ({
+  ActivityIndicator: 'ActivityIndicator',
+  Alert: { alert: vi.fn() },
   KeyboardAvoidingView: 'KeyboardAvoidingView',
+  Modal: 'Modal',
   Platform: { OS: 'ios' },
+  Pressable: 'Pressable',
+  ScrollView: 'ScrollView',
   View: 'View',
+}));
+vi.mock('@tanstack/react-query', () => ({ useMutation: () => ({ mutate: vi.fn() }) }));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({ background: '#000', mutedForeground: '#999' }),
+}));
+vi.mock('@/lib/a11y/announcing-toast', () => ({
+  announcingToast: { success: vi.fn(), error: vi.fn() },
+}));
+vi.mock('@/components/sheet-header', () => ({ SheetHeader: 'SheetHeader' }));
+vi.mock('@/components/agents/message-text-select-sheet', () => ({
+  MessageTextSelectSheet: 'MessageTextSelectSheet',
 }));
 vi.mock('expo-router', () => ({
   useFocusEffect: vi.fn(),
@@ -132,12 +162,12 @@ vi.mock('react-i18next', async importOriginal => {
 });
 
 // ── jotai + session provider ───────────────────────────────────────────────
-// Each atom carries its current value on `.value` so `useAtomValue` can read it
-// without a real Jotai store. `useSetAtom` and `useStore` are inert.
+// Hooks and store.get read the same current atom values, including updates before React renders.
+// Writes and subscriptions remain inert because each test controls manager updates.
 vi.mock('jotai', () => ({
   useAtomValue: (atom: { value: unknown }) => atom.value,
   useSetAtom: () => vi.fn(),
-  useStore: () => ({ get: vi.fn(), sub: vi.fn(() => vi.fn()) }),
+  useStore: () => ({ get: (atom: { value: unknown }) => atom.value, sub: vi.fn(() => vi.fn()) }),
 }));
 vi.mock('@/components/agents/session-provider', () => ({
   useSessionManager: () => hoisted.managerRef.current,
@@ -158,6 +188,7 @@ vi.mock('@/lib/analytics/posthog', () => ({
 }));
 vi.mock('@/lib/a11y/announce', () => ({
   moveA11yFocus: () => false,
+  announceForA11y: hoisted.announce,
 }));
 vi.mock('@/lib/persist/drafts', () => ({
   agentComposerDraftKey: (id: string) => `agent-composer:${id}`,
@@ -339,9 +370,7 @@ vi.mock('@/components/agents/message-bubble', () => ({
 vi.mock('@/components/agents/session-message-list', () => ({
   SessionMessageList: 'SessionMessageList',
 }));
-vi.mock('@/components/agents/message-details-sheet', () => ({
-  MessageDetailsSheet: 'MessageDetailsSheet',
-}));
+
 vi.mock('@/components/agents/model-selector', () => ({
   ModelPickerSelectionScopeProvider: 'ModelPickerSelectionScopeProvider',
 }));
@@ -402,9 +431,7 @@ vi.mock('@/components/rename-modal', () => ({
 vi.mock('@/components/screen-header', () => ({
   ScreenHeader: 'ScreenHeader',
 }));
-vi.mock('@/components/ui/accessible-status', () => ({
-  AccessibleStatus: 'AccessibleStatus',
-}));
+
 vi.mock('@/components/ui/blur-bar', () => ({
   BlurBar: 'BlurBar',
 }));
@@ -556,13 +583,71 @@ function bubbleProps(
   return (readBubble(renderer, messageId)?.props ?? {}) as Record<string, unknown>;
 }
 
+function detailsProps(renderer: TestRenderer.ReactTestRenderer) {
+  return renderer.root.findByType(MessageDetailsSheet).props as Parameters<
+    typeof MessageDetailsSheet
+  >[0];
+}
+
+function cancellationRow(renderer: TestRenderer.ReactTestRenderer) {
+  return findByType(renderer, 'Pressable').find(
+    node => node.props.testID === 'message-details-cancel-queued'
+  );
+}
+
+function cancellationPress(renderer: TestRenderer.ReactTestRenderer): () => void {
+  const row = cancellationRow(renderer);
+  if (!row) {
+    throw new Error('Cancellation row is missing');
+  }
+  return row.props.onPress as () => void;
+}
+
+function openDetails(renderer: TestRenderer.ReactTestRenderer, message: StoredMessage): void {
+  const open = bubbleProps(renderer, message.info.id).onLongPressDetails as (
+    message: StoredMessage
+  ) => void;
+  act(() => {
+    open(message);
+  });
+}
+
+function closeDetails(renderer: TestRenderer.ReactTestRenderer): void {
+  const close = findByType(renderer, 'Modal')[0]?.props.onRequestClose as () => void;
+  act(() => {
+    close();
+  });
+}
+
+function updateScreen(renderer: TestRenderer.ReactTestRenderer): void {
+  act(() => {
+    renderer.update(createElement(SessionDetailContent, { sessionId: SESSION_ID }));
+  });
+}
+
+function unmountScreen(renderer: TestRenderer.ReactTestRenderer): void {
+  act(() => {
+    renderer.unmount();
+  });
+}
+
+function statusMessages(renderer: TestRenderer.ReactTestRenderer): string[] {
+  return renderer.root
+    .findAllByType(AccessibleStatus)
+    .map(node => node.props.message as string | null)
+    .filter(message => message !== null);
+}
+
 beforeEach(() => {
   currentManager = makeManager();
   hoisted.managerRef.current = currentManager;
   hoisted.chatComposer.lastProps = null;
-  hoisted.chatComposer.control.hasContent.mockReset().mockReturnValue(false);
-  hoisted.chatComposer.control.setText.mockReset();
-  hoisted.chatComposer.control.restoreAttachments.mockReset();
+  hoisted.chatComposer.draft.text = '';
+  hoisted.chatComposer.draft.files = [];
+  hoisted.chatComposer.control.hasContent.mockClear();
+  hoisted.chatComposer.control.setText.mockClear();
+  hoisted.chatComposer.control.restoreAttachments.mockClear();
+  hoisted.announce.mockClear();
 });
 
 describe('resolveSendAttachmentKind', () => {
@@ -606,111 +691,667 @@ describe('SessionDetailContent cancel/restore', () => {
     currentManager.atoms.pendingMessages.value = new Map([[message.info.id, { status: 'queued' }]]);
   }
 
-  it('keeps the Restore action after canceling a queued message while the composer is occupied', async () => {
+  const failed = 'agentChat.session.cancelQueuedFailed';
+  const restored = 'agentChat.session.cancelQueuedRestored';
+  const restoreAvailable = 'agentChat.session.cancelQueuedRestoreAvailable';
+
+  it('exposes no cancellation without a selected message', () => {
     seedQueuedMessage();
-    currentManager.cancelQueuedMessage.mockResolvedValue({ dropped: true });
-    hoisted.chatComposer.control.hasContent.mockReturnValue(true);
-
     const renderer = mount();
-    const onCancelQueued = bubbleProps(renderer, 'msg-queued-1').onCancelQueued as
-      | ((message: StoredMessage) => Promise<void>)
-      | undefined;
-    expect(onCancelQueued).toBeInstanceOf(Function);
-
-    await act(async () => {
-      await onCancelQueued?.(queuedMessage());
-    });
-
-    // Occupied composer → the row must stay with a Restore action, not be
-    // dropped out of the transcript.
-    expect(bubbleProps(renderer, 'msg-queued-1').onRestoreQueued).toBeInstanceOf(Function);
-
-    act(() => {
-      renderer.unmount();
-    });
+    expect(detailsProps(renderer).visible).toBe(false);
+    expect(detailsProps(renderer).message).toBeNull();
+    expect(cancellationRow(renderer)).toBeUndefined();
+    unmountScreen(renderer);
   });
 
-  it('keeps the queued row and shows a failure status when cancel reports dropped=false', async () => {
-    seedQueuedMessage();
-    currentManager.cancelQueuedMessage.mockResolvedValue({ dropped: false });
-    hoisted.chatComposer.control.hasContent.mockReturnValue(false);
-
-    const renderer = mount();
-    const onCancelQueued = bubbleProps(renderer, 'msg-queued-1').onCancelQueued as
-      | ((message: StoredMessage) => Promise<void>)
-      | undefined;
-    expect(onCancelQueued).toBeInstanceOf(Function);
-
-    await act(async () => {
-      await onCancelQueued?.(queuedMessage());
-    });
-
-    // The queue did not drop the message: the row stays queued (still wired
-    // for Cancel, no Restore) and the prompt is not restored into the composer.
-    expect(bubbleProps(renderer, 'msg-queued-1').onCancelQueued).toBeInstanceOf(Function);
-    expect(bubbleProps(renderer, 'msg-queued-1').onRestoreQueued).toBeUndefined();
-    expect(hoisted.chatComposer.control.setText).not.toHaveBeenCalled();
-    expect(hoisted.chatComposer.control.restoreAttachments).not.toHaveBeenCalled();
-
-    const statuses = findByType(renderer, 'AccessibleStatus');
-    const messages = statuses.map(instance => instance.props.message as string | null);
-    expect(messages).toContain('agentChat.session.cancelQueuedFailed');
-
-    act(() => {
-      renderer.unmount();
-    });
-  });
-
-  it('restores the prompt and file parts into an empty composer after cancel', async () => {
-    const message = queuedMessage([TEXT_PART, FILE_PART]);
+  it.each([
+    'accepted',
+    'running',
+    'canceled',
+    'failed',
+    'missing',
+    'assistant',
+    'untracked',
+    'future',
+  ])('rejects stale activation and updates the open sheet for %s', async state => {
+    const message = queuedMessage();
     seedQueuedMessage(message);
-    currentManager.cancelQueuedMessage.mockResolvedValue({ dropped: true });
-    hoisted.chatComposer.control.hasContent.mockReturnValue(false);
-
     const renderer = mount();
-    const onCancelQueued = bubbleProps(renderer, 'msg-queued-1').onCancelQueued as
-      | ((message: StoredMessage) => Promise<void>)
-      | undefined;
-    expect(onCancelQueued).toBeInstanceOf(Function);
-
+    openDetails(renderer, message);
+    const stalePress = cancellationPress(renderer);
+    expect(detailsProps(renderer).canCancelQueued).toBe(true);
+    if (state === 'missing') {
+      currentManager.atoms.messagesList.value = [];
+    } else if (state === 'assistant') {
+      currentManager.atoms.messagesList.value = [assistantMessage(message.info.id)];
+    } else if (state === 'untracked') {
+      currentManager.atoms.pendingMessages.value = new Map();
+    } else {
+      currentManager.atoms.pendingMessages.value = new Map([[message.info.id, { status: state }]]);
+    }
+    // Deliberately invoke the old row before React receives the manager update.
     await act(async () => {
-      await onCancelQueued?.(message);
+      stalePress();
+      await Promise.resolve();
     });
-
-    expect(hoisted.chatComposer.control.setText).toHaveBeenCalledWith('Queued prompt');
-    expect(hoisted.chatComposer.control.restoreAttachments).toHaveBeenCalledWith([FILE_PART]);
-    // Empty composer → the row is dropped, so the transcript no longer renders it.
-    expect(readBubble(renderer, 'msg-queued-1')).toBeUndefined();
-
-    act(() => {
-      renderer.unmount();
-    });
+    updateScreen(renderer);
+    expect(detailsProps(renderer).canCancelQueued).toBe(false);
+    expect(cancellationRow(renderer)).toBeUndefined();
+    expect(detailsProps(renderer).message).toBe(currentManager.atoms.messagesList.value[0] ?? null);
+    expect(currentManager.cancelQueuedMessage).not.toHaveBeenCalled();
+    expect(hoisted.chatComposer.draft).toEqual({ text: '', files: [] });
+    expect(statusMessages(renderer)).toEqual([]);
+    seedQueuedMessage(message);
+    updateScreen(renderer);
+    expect(detailsProps(renderer).canCancelQueued).toBe(true);
+    expect(cancellationRow(renderer)).toBeDefined();
+    unmountScreen(renderer);
   });
 
-  it('shows the upgrade-required copy when cancel fails with CLI_UPGRADE_REQUIRED', async () => {
-    seedQueuedMessage();
-    currentManager.cancelQueuedMessage.mockRejectedValue(
-      Object.assign(new Error('old cli'), { code: 'CLI_UPGRADE_REQUIRED' })
+  it('uses current message parts rather than the selected snapshot at invocation', async () => {
+    const selected = queuedMessage();
+    seedQueuedMessage(selected);
+    currentManager.cancelQueuedMessage.mockResolvedValue({ dropped: true });
+    const renderer = mount();
+    openDetails(renderer, selected);
+    const press = cancellationPress(renderer);
+    const current = queuedMessage([{ ...TEXT_PART, text: 'Current prompt' }, FILE_PART]);
+    currentManager.atoms.messagesList.value = [current];
+    await act(async () => {
+      press();
+      await Promise.resolve();
+    });
+    expect(hoisted.chatComposer.draft).toEqual({ text: 'Current prompt', files: [FILE_PART] });
+    expect(readBubble(renderer, selected.info.id)).toBeUndefined();
+    expect(statusMessages(renderer)).toEqual([restored]);
+    unmountScreen(renderer);
+  });
+
+  describe.each([false, true])('composer occupied=%s', occupied => {
+    it.each([
+      { name: 'text', parts: [TEXT_PART], text: 'Queued prompt', files: [] },
+      {
+        name: 'text and files',
+        parts: [TEXT_PART, FILE_PART],
+        text: 'Queued prompt',
+        files: [FILE_PART],
+      },
+      { name: 'file-only', parts: [FILE_PART], text: '', files: [FILE_PART] },
+    ])('cancels $name once and preserves its restoration path', async ({ parts, text, files }) => {
+      const message = queuedMessage(parts);
+      seedQueuedMessage(message);
+      const request = Promise.withResolvers<{ dropped: boolean }>();
+      currentManager.cancelQueuedMessage.mockReturnValue(request.promise);
+      const original = {
+        text: occupied ? 'Existing draft' : '',
+        files: occupied ? [{ filename: 'draft.txt' }] : [],
+      };
+      Object.assign(hoisted.chatComposer.draft, original);
+      const renderer = mount();
+      openDetails(renderer, message);
+      const press = cancellationPress(renderer);
+      act(() => {
+        press();
+        press();
+      });
+      expect(currentManager.cancelQueuedMessage.mock.calls).toEqual([[message.info.id]]);
+      expect(detailsProps(renderer).canCancelQueued).toBe(false);
+      expect(detailsProps(renderer).isCancelingQueued).toBe(true);
+      expect(cancellationRow(renderer)?.props.accessibilityState).toEqual({
+        disabled: true,
+        busy: true,
+      });
+      expect(hoisted.chatComposer.draft).toEqual(original);
+      await act(async () => {
+        request.resolve({ dropped: true });
+        await request.promise;
+        // The completed identifier must remain guarded before React commits restoration.
+        press();
+      });
+      expect(currentManager.cancelQueuedMessage.mock.calls).toEqual([[message.info.id]]);
+      expect(detailsProps(renderer).visible).toBe(false);
+      expect(statusMessages(renderer)).toEqual([occupied ? restoreAvailable : restored]);
+      expect(hoisted.announce.mock.calls).toEqual([[occupied ? restoreAvailable : restored]]);
+      if (occupied) {
+        expect(hoisted.chatComposer.draft).toEqual(original);
+        expect(hoisted.chatComposer.control.setText).not.toHaveBeenCalled();
+        expect(hoisted.chatComposer.control.restoreAttachments).not.toHaveBeenCalled();
+        expect(bubbleProps(renderer, message.info.id).deliveryState).toBeUndefined();
+        expect(bubbleProps(renderer, message.info.id).onRestoreQueued).toBeInstanceOf(Function);
+        openDetails(renderer, message);
+        expect(detailsProps(renderer).canCancelQueued).toBe(false);
+        expect(cancellationRow(renderer)).toBeUndefined();
+        closeDetails(renderer);
+        currentManager.atoms.messagesList.value = [];
+        currentManager.atoms.pendingMessages.value = new Map();
+        updateScreen(renderer);
+        const restore = bubbleProps(renderer, message.info.id).onRestoreQueued as (
+          message: StoredMessage
+        ) => void;
+        expect(restore).toBeInstanceOf(Function);
+        act(() => {
+          restore(message);
+        });
+        expect(statusMessages(renderer)).toEqual([restored]);
+        expect(hoisted.announce.mock.calls).toEqual([[restoreAvailable], [restored]]);
+      }
+      expect(hoisted.chatComposer.draft).toEqual({ text: text || original.text, files });
+      expect(hoisted.chatComposer.control.setText).toHaveBeenCalledTimes(text ? 1 : 0);
+      expect(hoisted.chatComposer.control.restoreAttachments).toHaveBeenCalledTimes(1);
+      expect(readBubble(renderer, message.info.id)).toBeUndefined();
+      unmountScreen(renderer);
+    });
+
+    it.each(['false', 'rejection'])(
+      'preserves the message and composer after retryable %s with matching sheet feedback',
+      async outcome => {
+        const message = queuedMessage([TEXT_PART, FILE_PART]);
+        seedQueuedMessage(message);
+        const original = {
+          text: occupied ? 'Keep my draft' : '',
+          files: occupied ? [{ filename: 'draft.txt' }] : [],
+        };
+        Object.assign(hoisted.chatComposer.draft, original);
+        if (outcome === 'false') {
+          currentManager.cancelQueuedMessage.mockResolvedValue({ dropped: false });
+        } else {
+          currentManager.cancelQueuedMessage.mockRejectedValue(
+            Object.assign(new Error(outcome), { code: 'SERVICE_UNAVAILABLE' })
+          );
+        }
+        const renderer = mount();
+        openDetails(renderer, message);
+        await act(async () => {
+          cancellationPress(renderer)();
+          await Promise.resolve();
+        });
+        expect(hoisted.chatComposer.draft).toEqual(original);
+        expect(currentManager.atoms.messagesList.value).toEqual([message]);
+        expect(readBubble(renderer, message.info.id)).toBeDefined();
+        expect(bubbleProps(renderer, message.info.id).onRestoreQueued).toBeUndefined();
+        expect(detailsProps(renderer).canCancelQueued).toBe(true);
+        expect(detailsProps(renderer).isCancelingQueued).toBe(false);
+        expect(detailsProps(renderer).cancelQueuedFeedback?.message).toBe(failed);
+        expect(statusMessages(renderer)).toEqual([failed]);
+        expect(findByType(renderer, 'Text').map(node => node.props.children)).toContain(failed);
+        expect(hoisted.announce.mock.calls).toEqual([[failed]]);
+        expect(currentManager.interrupt).not.toHaveBeenCalled();
+        expect(hoisted.chatComposer.control.restoreAttachments).not.toHaveBeenCalled();
+        unmountScreen(renderer);
+      }
     );
 
-    const renderer = mount();
-    const onCancelQueued = bubbleProps(renderer, 'msg-queued-1').onCancelQueued as
-      | ((message: StoredMessage) => Promise<void>)
-      | undefined;
-    expect(onCancelQueued).toBeInstanceOf(Function);
-
-    await act(async () => {
-      await onCancelQueued?.(queuedMessage());
-    });
-
-    const statuses = findByType(renderer, 'AccessibleStatus');
-    const messages = statuses.map(instance => instance.props.message as string | null);
-    expect(messages).toContain('agentChat.session.cancelQueuedUpgradeRequired');
-
-    act(() => {
-      renderer.unmount();
+    it('retains upgrade guidance and blocks unsupported cancellation across message selections', async () => {
+      const message = queuedMessage([TEXT_PART, FILE_PART]);
+      const second = { ...message, info: { ...message.info, id: 'msg-queued-2' } };
+      currentManager.atoms.messagesList.value = [message, second];
+      currentManager.atoms.pendingMessages.value = new Map(
+        [message, second].map(item => [item.info.id, { status: 'queued' }])
+      );
+      const original = {
+        text: occupied ? 'Keep my draft' : '',
+        files: occupied ? [{ filename: 'draft.txt' }] : [],
+      };
+      Object.assign(hoisted.chatComposer.draft, original);
+      const request = Promise.withResolvers<{ dropped: boolean }>();
+      currentManager.cancelQueuedMessage
+        .mockReturnValueOnce(request.promise)
+        .mockResolvedValue({ dropped: true });
+      const renderer = mount();
+      openDetails(renderer, second);
+      const staleSecondPress = cancellationPress(renderer);
+      openDetails(renderer, message);
+      const stalePress = cancellationPress(renderer);
+      act(() => {
+        stalePress();
+      });
+      await act(async () => {
+        request.reject(
+          Object.assign(new Error('Upgrade required'), { code: 'CLI_UPGRADE_REQUIRED' })
+        );
+        await Promise.resolve();
+        stalePress();
+        staleSecondPress();
+      });
+      const upgrade = 'agentChat.session.cancelQueuedUpgradeRequired';
+      expect(detailsProps(renderer).visible).toBe(true);
+      expect(detailsProps(renderer).canCancelQueued).toBe(false);
+      expect(detailsProps(renderer).isCancelingQueued).toBe(false);
+      expect(cancellationRow(renderer)).toBeUndefined();
+      expect(detailsProps(renderer).cancelQueuedFeedback?.message).toBe(upgrade);
+      expect(statusMessages(renderer)).toEqual([upgrade]);
+      expect(findByType(renderer, 'Text').map(node => node.props.children)).toContain(upgrade);
+      closeDetails(renderer);
+      openDetails(renderer, message);
+      expect(cancellationRow(renderer)).toBeUndefined();
+      openDetails(renderer, second);
+      expect(cancellationRow(renderer)).toBeUndefined();
+      expect(hoisted.chatComposer.draft).toEqual(original);
+      expect(currentManager.atoms.messagesList.value).toEqual([message, second]);
+      expect(readBubble(renderer, message.info.id)).toBeDefined();
+      expect(readBubble(renderer, second.info.id)).toBeDefined();
+      expect(bubbleProps(renderer, message.info.id).onRestoreQueued).toBeUndefined();
+      expect(bubbleProps(renderer, second.info.id).onRestoreQueued).toBeUndefined();
+      expect(currentManager.cancelQueuedMessage.mock.calls).toEqual([[message.info.id]]);
+      expect(currentManager.interrupt).not.toHaveBeenCalled();
+      expect(hoisted.chatComposer.control.restoreAttachments).not.toHaveBeenCalled();
+      expect(hoisted.announce.mock.calls).toEqual([[upgrade]]);
+      unmountScreen(renderer);
     });
   });
+
+  it('keeps the occupied Restore path usable before late delivery events', async () => {
+    const message = queuedMessage([TEXT_PART, FILE_PART]);
+    seedQueuedMessage(message);
+    const request = Promise.withResolvers<{ dropped: boolean }>();
+    currentManager.cancelQueuedMessage.mockReturnValue(request.promise);
+    const renderer = mount();
+    openDetails(renderer, message);
+    act(() => {
+      cancellationPress(renderer)();
+    });
+    const typedDraft = { text: 'Typed while waiting', files: [{ filename: 'draft.txt' }] };
+    Object.assign(hoisted.chatComposer.draft, typedDraft);
+    await act(async () => {
+      request.resolve({ dropped: true });
+      await request.promise;
+    });
+    expect(hoisted.chatComposer.draft).toEqual(typedDraft);
+    expect(bubbleProps(renderer, message.info.id).deliveryState).toBeUndefined();
+    const restore = bubbleProps(renderer, message.info.id).onRestoreQueued as (
+      message: StoredMessage
+    ) => void;
+    act(() => {
+      restore(message);
+    });
+    updateScreen(renderer);
+    expect(hoisted.chatComposer.draft).toEqual({ text: 'Queued prompt', files: [FILE_PART] });
+    expect(readBubble(renderer, message.info.id)).toBeUndefined();
+    expect(currentManager.atoms.messagesList.value).toEqual([message]);
+    expect(hoisted.announce.mock.calls).toEqual([[restoreAvailable], [restored]]);
+    unmountScreen(renderer);
+  });
+
+  it.each(['success', 'upgrade'])(
+    'ignores an old %s outcome in a different session',
+    async outcome => {
+      const message = queuedMessage();
+      seedQueuedMessage(message);
+      const request = Promise.withResolvers<{ dropped: boolean }>();
+      currentManager.cancelQueuedMessage.mockReturnValue(request.promise);
+      const renderer = mount();
+      openDetails(renderer, message);
+      act(() => {
+        cancellationPress(renderer)();
+      });
+      const nextSessionId = 'sess-2' as KiloSessionId;
+      const nextMessage = queuedMessage([{ ...TEXT_PART, text: 'Next session prompt' }]);
+      seedQueuedMessage(nextMessage);
+      currentManager.atoms.fetchedSessionData.value.kiloSessionId = nextSessionId;
+      act(() => {
+        renderer.update(createElement(SessionDetailContent, { sessionId: nextSessionId }));
+      });
+      await act(async () => {
+        if (outcome === 'upgrade') {
+          request.reject(
+            Object.assign(new Error('Upgrade required'), { code: 'CLI_UPGRADE_REQUIRED' })
+          );
+        } else {
+          request.resolve({ dropped: true });
+        }
+        await Promise.resolve();
+      });
+      expect(hoisted.chatComposer.draft).toEqual({ text: '', files: [] });
+      expect(detailsProps(renderer).visible).toBe(false);
+      expect(statusMessages(renderer)).toEqual([]);
+      expect(hoisted.announce).not.toHaveBeenCalled();
+      openDetails(renderer, nextMessage);
+      expect(detailsProps(renderer).canCancelQueued).toBe(true);
+      expect(cancellationRow(renderer)).toBeDefined();
+      unmountScreen(renderer);
+    }
+  );
+
+  it('does not carry known unsupported cancellation into a different session', async () => {
+    const message = queuedMessage();
+    seedQueuedMessage(message);
+    currentManager.cancelQueuedMessage.mockRejectedValueOnce(
+      Object.assign(new Error('Upgrade required'), { code: 'CLI_UPGRADE_REQUIRED' })
+    );
+    const renderer = mount();
+    openDetails(renderer, message);
+    await act(async () => {
+      cancellationPress(renderer)();
+      await Promise.resolve();
+    });
+    expect(cancellationRow(renderer)).toBeUndefined();
+    const nextSessionId = 'sess-2' as KiloSessionId;
+    const nextMessage = queuedMessage([{ ...TEXT_PART, text: 'Next session prompt' }]);
+    seedQueuedMessage(nextMessage);
+    currentManager.atoms.fetchedSessionData.value.kiloSessionId = nextSessionId;
+    act(() => {
+      renderer.update(createElement(SessionDetailContent, { sessionId: nextSessionId }));
+    });
+    openDetails(renderer, nextMessage);
+    expect(statusMessages(renderer)).toEqual([]);
+    currentManager.cancelQueuedMessage.mockResolvedValue({ dropped: true });
+    await act(async () => {
+      cancellationPress(renderer)();
+      await Promise.resolve();
+    });
+    expect(hoisted.chatComposer.draft).toEqual({ text: 'Next session prompt', files: [] });
+    expect(readBubble(renderer, nextMessage.info.id)).toBeUndefined();
+    expect(statusMessages(renderer)).toEqual([restored]);
+    unmountScreen(renderer);
+  });
+
+  it('removes a busy row when the live queue becomes running', async () => {
+    const message = queuedMessage();
+    seedQueuedMessage(message);
+    const request = Promise.withResolvers<{ dropped: boolean }>();
+    currentManager.cancelQueuedMessage.mockReturnValue(request.promise);
+    const renderer = mount();
+    openDetails(renderer, message);
+    const press = cancellationPress(renderer);
+    act(() => {
+      press();
+    });
+    currentManager.atoms.pendingMessages.value = new Map([
+      [message.info.id, { status: 'running' }],
+    ]);
+    updateScreen(renderer);
+    expect(cancellationRow(renderer)).toBeUndefined();
+    expect(detailsProps(renderer).isCancelingQueued).toBe(false);
+    await act(async () => {
+      press();
+      request.resolve({ dropped: false });
+      await request.promise;
+    });
+    expect(currentManager.cancelQueuedMessage.mock.calls).toEqual([[message.info.id]]);
+    expect(cancellationRow(renderer)).toBeUndefined();
+    expect(readBubble(renderer, message.info.id)).toBeDefined();
+    expect(statusMessages(renderer)).toEqual([failed]);
+    expect(hoisted.chatComposer.draft).toEqual({ text: '', files: [] });
+    unmountScreen(renderer);
+  });
+
+  it.each([false, true])(
+    'clears both announcement inputs on retry without replay on dismissal, first dismissed=%s',
+    async dismissed => {
+      const message = queuedMessage();
+      seedQueuedMessage(message);
+      const first = Promise.withResolvers<{ dropped: boolean }>();
+      const retry = Promise.withResolvers<{ dropped: boolean }>();
+      currentManager.cancelQueuedMessage
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(retry.promise);
+      const renderer = mount();
+      openDetails(renderer, message);
+      act(() => {
+        cancellationPress(renderer)();
+      });
+      if (dismissed) {
+        closeDetails(renderer);
+      }
+      await act(async () => {
+        first.reject(new Error('offline'));
+        await Promise.resolve();
+      });
+      expect(statusMessages(renderer)).toEqual([failed]);
+      expect(hoisted.announce.mock.calls).toEqual([[failed]]);
+      if (dismissed) {
+        openDetails(renderer, message);
+      }
+      act(() => {
+        cancellationPress(renderer)();
+      });
+      expect(statusMessages(renderer)).toEqual([]);
+      expect(detailsProps(renderer).cancelQueuedFeedback).toBeNull();
+      expect(findByType(renderer, 'Text').map(node => node.props.children)).not.toContain(failed);
+      expect(hoisted.announce.mock.calls).toEqual([[failed]]);
+      await act(async () => {
+        retry.reject(new Error('offline'));
+        await Promise.resolve();
+      });
+      expect(statusMessages(renderer)).toEqual([failed]);
+      expect(hoisted.announce.mock.calls).toEqual([[failed], [failed]]);
+      closeDetails(renderer);
+      expect(statusMessages(renderer)).toEqual([]);
+      expect(hoisted.announce.mock.calls).toEqual([[failed], [failed]]);
+      openDetails(renderer, message);
+      expect(detailsProps(renderer).cancelQueuedFeedback).toBeNull();
+      expect(hoisted.announce).toHaveBeenCalledTimes(2);
+      unmountScreen(renderer);
+    }
+  );
+
+  it('announces identical immediate failures once per attempt despite React batching', async () => {
+    const message = queuedMessage();
+    seedQueuedMessage(message);
+    currentManager.cancelQueuedMessage.mockResolvedValue({ dropped: false });
+    const renderer = mount();
+    openDetails(renderer, message);
+    await act(async () => {
+      cancellationPress(renderer)();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      cancellationPress(renderer)();
+      await Promise.resolve();
+    });
+    expect(statusMessages(renderer)).toEqual([failed]);
+    expect(hoisted.announce.mock.calls).toEqual([[failed], [failed]]);
+    unmountScreen(renderer);
+  });
+
+  it.each(['success', 'false', 'rejection'])(
+    'announces one outer %s outcome when dismissed while pending',
+    async outcome => {
+      const message = queuedMessage();
+      seedQueuedMessage(message);
+      const request = Promise.withResolvers<{ dropped: boolean }>();
+      currentManager.cancelQueuedMessage.mockReturnValue(request.promise);
+      const renderer = mount();
+      openDetails(renderer, message);
+      act(() => {
+        cancellationPress(renderer)();
+      });
+      closeDetails(renderer);
+      expect(statusMessages(renderer)).toEqual([]);
+      await act(async () => {
+        if (outcome === 'rejection') {
+          request.reject(new Error('offline'));
+        } else {
+          request.resolve({ dropped: outcome === 'success' });
+        }
+        await Promise.resolve();
+      });
+      expect(detailsProps(renderer).visible).toBe(false);
+      expect(detailsProps(renderer).cancelQueuedFeedback).toBeNull();
+      expect(statusMessages(renderer)).toEqual([outcome === 'success' ? restored : failed]);
+      expect(hoisted.announce.mock.calls).toEqual([[outcome === 'success' ? restored : failed]]);
+      expect(hoisted.chatComposer.draft.text).toBe(outcome === 'success' ? 'Queued prompt' : '');
+      closeDetails(renderer);
+      expect(hoisted.announce).toHaveBeenCalledTimes(1);
+      unmountScreen(renderer);
+    }
+  );
+
+  it.each([
+    { outcome: 'success', firstFeedback: restored },
+    { outcome: 'false', firstFeedback: failed },
+    { outcome: 'rejection', firstFeedback: failed },
+    { outcome: 'upgrade', firstFeedback: 'agentChat.session.cancelQueuedUpgradeRequired' },
+  ])(
+    'keeps the selected failure when A completes later with $outcome',
+    async ({ outcome, firstFeedback }) => {
+      const first = queuedMessage([TEXT_PART, FILE_PART]);
+      const second = {
+        ...queuedMessage([{ ...TEXT_PART, text: 'Second prompt' }]),
+        info: { ...first.info, id: 'msg-queued-2' },
+      };
+      currentManager.atoms.messagesList.value = [first, second];
+      currentManager.atoms.pendingMessages.value = new Map(
+        [first, second].map(message => [message.info.id, { status: 'queued' }])
+      );
+      const firstRequest = Promise.withResolvers<{ dropped: boolean }>();
+      const secondRequest = Promise.withResolvers<{ dropped: boolean }>();
+      currentManager.cancelQueuedMessage
+        .mockReturnValueOnce(firstRequest.promise)
+        .mockReturnValueOnce(secondRequest.promise);
+      const renderer = mount();
+      openDetails(renderer, first);
+      act(() => {
+        cancellationPress(renderer)();
+      });
+      closeDetails(renderer);
+      openDetails(renderer, second);
+      act(() => {
+        cancellationPress(renderer)();
+      });
+      await act(async () => {
+        secondRequest.resolve({ dropped: false });
+        await secondRequest.promise;
+      });
+      expect(detailsProps(renderer).cancelQueuedFeedback?.message).toBe(failed);
+      expect(hoisted.announce.mock.calls).toEqual([[failed]]);
+      await act(async () => {
+        if (outcome === 'rejection' || outcome === 'upgrade') {
+          firstRequest.reject(
+            Object.assign(new Error(outcome), {
+              code: outcome === 'upgrade' ? 'CLI_UPGRADE_REQUIRED' : 'SERVICE_UNAVAILABLE',
+            })
+          );
+        } else {
+          firstRequest.resolve({ dropped: outcome === 'success' });
+        }
+        await Promise.resolve();
+      });
+      expect(detailsProps(renderer).visible).toBe(true);
+      expect(detailsProps(renderer).message?.info.id).toBe(second.info.id);
+      expect(detailsProps(renderer).cancelQueuedFeedback?.message).toBe(failed);
+      expect(
+        renderer.root
+          .findByType(MessageDetailsSheet)
+          .findAll(node => node.type === 'Text' && node.props.children === failed)
+      ).toHaveLength(1);
+      expect(detailsProps(renderer).canCancelQueued).toBe(outcome !== 'upgrade');
+      expect(statusMessages(renderer)).toEqual([firstFeedback, failed]);
+      expect(hoisted.announce.mock.calls).toEqual([[failed], [firstFeedback]]);
+      expect(hoisted.chatComposer.draft).toEqual(
+        outcome === 'success'
+          ? { text: 'Queued prompt', files: [FILE_PART] }
+          : { text: '', files: [] }
+      );
+      expect(readBubble(renderer, second.info.id)).toBeDefined();
+      expect(bubbleProps(renderer, second.info.id).onRestoreQueued).toBeUndefined();
+      expect(currentManager.cancelQueuedMessage.mock.calls).toEqual([
+        [first.info.id],
+        [second.info.id],
+      ]);
+      closeDetails(renderer);
+      expect(statusMessages(renderer)).toEqual([firstFeedback]);
+      expect(hoisted.announce.mock.calls).toEqual([[failed], [firstFeedback]]);
+      unmountScreen(renderer);
+    }
+  );
+
+  it('keeps another message’s sheet failure on request start and clears only the matching retry', async () => {
+    const first = queuedMessage();
+    const second = { ...first, info: { ...first.info, id: 'msg-queued-2' } };
+    currentManager.atoms.messagesList.value = [first, second];
+    currentManager.atoms.pendingMessages.value = new Map(
+      [first, second].map(message => [message.info.id, { status: 'queued' }])
+    );
+    const firstRequest = Promise.withResolvers<{ dropped: boolean }>();
+    const secondRequest = Promise.withResolvers<{ dropped: boolean }>();
+    const secondRetry = Promise.withResolvers<{ dropped: boolean }>();
+    currentManager.cancelQueuedMessage
+      .mockReturnValueOnce(secondRequest.promise)
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRetry.promise);
+    const renderer = mount();
+    openDetails(renderer, first);
+    const staleFirstPress = cancellationPress(renderer);
+    openDetails(renderer, second);
+    act(() => {
+      cancellationPress(renderer)();
+    });
+    await act(async () => {
+      secondRequest.resolve({ dropped: false });
+      await secondRequest.promise;
+    });
+    expect(statusMessages(renderer)).toEqual([failed]);
+    act(() => {
+      staleFirstPress();
+    });
+    expect(detailsProps(renderer).message?.info.id).toBe(second.info.id);
+    expect(detailsProps(renderer).cancelQueuedFeedback?.message).toBe(failed);
+    expect(statusMessages(renderer)).toEqual([failed]);
+    expect(hoisted.announce.mock.calls).toEqual([[failed]]);
+    await act(async () => {
+      firstRequest.resolve({ dropped: false });
+      await firstRequest.promise;
+    });
+    expect(statusMessages(renderer)).toEqual([failed, failed]);
+    expect(hoisted.announce.mock.calls).toEqual([[failed], [failed]]);
+    act(() => {
+      cancellationPress(renderer)();
+    });
+    expect(detailsProps(renderer).cancelQueuedFeedback).toBeNull();
+    expect(statusMessages(renderer)).toEqual([failed]);
+    expect(hoisted.announce.mock.calls).toEqual([[failed], [failed]]);
+    await act(async () => {
+      secondRetry.resolve({ dropped: false });
+      await secondRetry.promise;
+    });
+    expect(detailsProps(renderer).cancelQueuedFeedback?.message).toBe(failed);
+    expect(statusMessages(renderer)).toEqual([failed, failed]);
+    expect(hoisted.announce.mock.calls).toEqual([[failed], [failed], [failed]]);
+    expect(hoisted.chatComposer.draft).toEqual({ text: '', files: [] });
+    expect(readBubble(renderer, first.info.id)).toBeDefined();
+    expect(readBubble(renderer, second.info.id)).toBeDefined();
+    closeDetails(renderer);
+    expect(statusMessages(renderer)).toEqual([failed]);
+    expect(hoisted.announce.mock.calls).toEqual([[failed], [failed], [failed]]);
+    unmountScreen(renderer);
+  });
+
+  it.each([true, false])(
+    'binds an old request outcome to its message, dropped=%s',
+    async dropped => {
+      const first = queuedMessage();
+      const second = {
+        ...queuedMessage([{ ...TEXT_PART, text: 'Second prompt' }]),
+        info: { ...first.info, id: 'msg-queued-2' },
+      };
+      currentManager.atoms.messagesList.value = [first, second];
+      currentManager.atoms.pendingMessages.value = new Map(
+        [first, second].map(message => [message.info.id, { status: 'queued' }])
+      );
+      const request = Promise.withResolvers<{ dropped: boolean }>();
+      currentManager.cancelQueuedMessage.mockReturnValue(request.promise);
+      const renderer = mount();
+      openDetails(renderer, first);
+      act(() => {
+        cancellationPress(renderer)();
+      });
+      openDetails(renderer, second);
+      await act(async () => {
+        request.resolve({ dropped });
+        await request.promise;
+      });
+      expect(currentManager.cancelQueuedMessage.mock.calls).toEqual([[first.info.id]]);
+      expect(detailsProps(renderer).visible).toBe(true);
+      expect(detailsProps(renderer).message?.info.id).toBe(second.info.id);
+      expect(detailsProps(renderer).canCancelQueued).toBe(true);
+      expect(detailsProps(renderer).cancelQueuedFeedback).toBeNull();
+      expect(statusMessages(renderer)).toEqual([dropped ? restored : failed]);
+      expect(hoisted.announce.mock.calls).toEqual([[dropped ? restored : failed]]);
+      expect(hoisted.chatComposer.draft.text).toBe(dropped ? 'Queued prompt' : '');
+      unmountScreen(renderer);
+    }
+  );
 });
 
 describe('SessionDetailContent send failure', () => {

--- a/apps/mobile/src/components/agents/session-detail-content.test.ts
+++ b/apps/mobile/src/components/agents/session-detail-content.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable max-lines -- the session test renders the full SessionDetailContent and mocks its RN/expo/SDK surface, so the wiring is long. */
 /* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (node env, no jsdom); see src/app/(app)/agent-chat/[session-id].mounted.test.tsx. */
 /* eslint-disable require-await, @typescript-eslint/require-await -- mock factories settle without await because they resolve immediately */
-import { createElement, type ReactElement } from 'react';
+import { createElement, type ElementType, type ReactElement } from 'react';
+import { Modal, Pressable } from 'react-native';
 import TestRenderer, { act } from 'react-test-renderer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -9,8 +10,10 @@ import { type KiloSessionId, type StoredMessage } from '@kilocode/cloud-agent-sd
 import type * as ReactI18next from 'react-i18next';
 
 import { type SessionTranscriptItem } from '@/components/agents/session-transcript';
+import { SessionMessageList } from '@/components/agents/session-message-list';
 import { MessageDetailsSheet } from '@/components/agents/message-details-sheet';
 import { AccessibleStatus } from '@/components/ui/accessible-status';
+import { Text } from '@/components/ui/text';
 import { assistantMessage } from './message-bubble-test-utils';
 import {
   resolveSendAttachmentKind,
@@ -552,9 +555,9 @@ function mount(): TestRenderer.ReactTestRenderer {
 
 function findByType(
   renderer: TestRenderer.ReactTestRenderer,
-  type: string
+  type: ElementType
 ): TestRenderer.ReactTestInstance[] {
-  return renderer.root.findAll(node => node.type === type);
+  return renderer.root.findAllByType(type);
 }
 
 /** Reads the MessageBubble element the current transcript renders for `messageId`. */
@@ -562,7 +565,7 @@ function readBubble(
   renderer: TestRenderer.ReactTestRenderer,
   messageId: string
 ): ReactElement | undefined {
-  const lists = findByType(renderer, 'SessionMessageList');
+  const lists = findByType(renderer, SessionMessageList);
   const listProps = lists[0]?.props as
     | {
         items?: SessionTranscriptItem[];
@@ -592,7 +595,7 @@ function detailsProps(renderer: TestRenderer.ReactTestRenderer) {
 }
 
 function cancellationRow(renderer: TestRenderer.ReactTestRenderer) {
-  return findByType(renderer, 'Pressable').find(
+  return findByType(renderer, Pressable).find(
     node => node.props.testID === 'message-details-cancel-queued'
   );
 }
@@ -615,7 +618,7 @@ function openDetails(renderer: TestRenderer.ReactTestRenderer, message: StoredMe
 }
 
 function closeDetails(renderer: TestRenderer.ReactTestRenderer): void {
-  const close = findByType(renderer, 'Modal')[0]?.props.onRequestClose as () => void;
+  const close = findByType(renderer, Modal)[0]?.props.onRequestClose as () => void;
   act(() => {
     close();
   });
@@ -875,7 +878,7 @@ describe('SessionDetailContent cancel/restore', () => {
         expect(detailsProps(renderer).isCancelingQueued).toBe(false);
         expect(detailsProps(renderer).cancelQueuedFeedback?.message).toBe(failed);
         expect(statusMessages(renderer)).toEqual([failed]);
-        expect(findByType(renderer, 'Text').map(node => node.props.children)).toContain(failed);
+        expect(findByType(renderer, Text).map(node => node.props.children)).toContain(failed);
         expect(hoisted.announce.mock.calls).toEqual([[failed]]);
         expect(currentManager.interrupt).not.toHaveBeenCalled();
         expect(hoisted.chatComposer.control.restoreAttachments).not.toHaveBeenCalled();
@@ -922,15 +925,15 @@ describe('SessionDetailContent cancel/restore', () => {
       expect(cancellationRow(renderer)).toBeUndefined();
       expect(detailsProps(renderer).cancelQueuedFeedback?.message).toBe(upgrade);
       expect(statusMessages(renderer)).toEqual([upgrade]);
-      expect(findByType(renderer, 'Text').map(node => node.props.children)).toContain(upgrade);
+      expect(findByType(renderer, Text).map(node => node.props.children)).toContain(upgrade);
       closeDetails(renderer);
       openDetails(renderer, message);
       expect(cancellationRow(renderer)).toBeUndefined();
-      expect(findByType(renderer, 'Text').map(node => node.props.children)).toContain(upgrade);
+      expect(findByType(renderer, Text).map(node => node.props.children)).toContain(upgrade);
       expect(statusMessages(renderer)).toEqual([]);
       openDetails(renderer, second);
       expect(cancellationRow(renderer)).toBeUndefined();
-      expect(findByType(renderer, 'Text').map(node => node.props.children)).toContain(upgrade);
+      expect(findByType(renderer, Text).map(node => node.props.children)).toContain(upgrade);
       expect(statusMessages(renderer)).toEqual([]);
       expect(hoisted.chatComposer.draft).toEqual(original);
       expect(currentManager.atoms.messagesList.value).toEqual([message, second]);
@@ -968,7 +971,7 @@ describe('SessionDetailContent cancel/restore', () => {
       if (closed) {
         closeDetails(renderer);
         openDetails(renderer, message);
-        expect(findByType(renderer, 'Text').map(node => node.props.children)).toContain(upgrade);
+        expect(findByType(renderer, Text).map(node => node.props.children)).toContain(upgrade);
         expect(statusMessages(renderer)).toEqual([]);
       }
 
@@ -986,7 +989,7 @@ describe('SessionDetailContent cancel/restore', () => {
           stalePress();
         });
         expect(cancellationRow(renderer)).toBeUndefined();
-        expect(findByType(renderer, 'Text').map(node => node.props.children)).toContain(upgrade);
+        expect(findByType(renderer, Text).map(node => node.props.children)).toContain(upgrade);
         expect(currentManager.cancelQueuedMessage.mock.calls).toEqual([[message.info.id]]);
         expect(hoisted.chatComposer.draft).toEqual({ text: '', files: [] });
       }
@@ -1005,7 +1008,7 @@ describe('SessionDetailContent cancel/restore', () => {
       expect(cancellationRow(renderer)).toBeDefined();
       expect(detailsProps(renderer).canCancelQueued).toBe(true);
       expect(detailsProps(renderer).cancelQueuedFeedback).toBeNull();
-      expect(findByType(renderer, 'Text').map(node => node.props.children)).not.toContain(upgrade);
+      expect(findByType(renderer, Text).map(node => node.props.children)).not.toContain(upgrade);
       expect(hoisted.announce.mock.calls).toEqual([[upgrade]]);
       currentManager.cancelQueuedMessage.mockResolvedValue({ dropped: true });
       await act(async () => {
@@ -1055,7 +1058,7 @@ describe('SessionDetailContent cancel/restore', () => {
       );
       expect(detailsProps(renderer).cancelQueuedGuidance).toBeNull();
       expect(statusMessages(renderer)).toEqual([failed]);
-      const visibleText = findByType(renderer, 'Text').map(node => node.props.children);
+      const visibleText = findByType(renderer, Text).map(node => node.props.children);
       expect(visibleText.filter(text => text === failed)).toHaveLength(1);
       expect(visibleText).not.toContain('agentChat.session.cancelQueuedUpgradeRequired');
       expect(hoisted.announce.mock.calls).toEqual([[failed]]);
@@ -1251,7 +1254,7 @@ describe('SessionDetailContent cancel/restore', () => {
       });
       expect(statusMessages(renderer)).toEqual([]);
       expect(detailsProps(renderer).cancelQueuedFeedback).toBeNull();
-      expect(findByType(renderer, 'Text').map(node => node.props.children)).not.toContain(failed);
+      expect(findByType(renderer, Text).map(node => node.props.children)).not.toContain(failed);
       expect(hoisted.announce.mock.calls).toEqual([[failed]]);
       await act(async () => {
         retry.reject(new Error('offline'));
@@ -1377,7 +1380,7 @@ describe('SessionDetailContent cancel/restore', () => {
       expect(
         renderer.root
           .findByType(MessageDetailsSheet)
-          .findAll(node => node.type === 'Text' && node.props.children === failed)
+          .findAll(node => node.type === Text && node.props.children === failed)
       ).toHaveLength(1);
       expect(detailsProps(renderer).canCancelQueued).toBe(outcome !== 'upgrade');
       expect(statusMessages(renderer)).toEqual([firstFeedback, failed]);

--- a/apps/mobile/src/components/agents/session-detail-content.test.ts
+++ b/apps/mobile/src/components/agents/session-detail-content.test.ts
@@ -486,7 +486,9 @@ function makeManager() {
       childSessionError: { value: () => null },
       pendingMessages: { value: new Map<string, { status: string }>() },
       activeSessionType: { value: null },
-      remoteModelState: { value: { catalog: null, ownerConnectionId: null, protocol: 'v1' } },
+      remoteModelState: {
+        value: { catalog: null, ownerConnectionId: null as string | null, protocol: 'v1' },
+      },
       observedModel: { value: null },
       remoteModelOverride: { value: null },
       cloudAgentModelOverride: { value: null },
@@ -924,8 +926,12 @@ describe('SessionDetailContent cancel/restore', () => {
       closeDetails(renderer);
       openDetails(renderer, message);
       expect(cancellationRow(renderer)).toBeUndefined();
+      expect(findByType(renderer, 'Text').map(node => node.props.children)).toContain(upgrade);
+      expect(statusMessages(renderer)).toEqual([]);
       openDetails(renderer, second);
       expect(cancellationRow(renderer)).toBeUndefined();
+      expect(findByType(renderer, 'Text').map(node => node.props.children)).toContain(upgrade);
+      expect(statusMessages(renderer)).toEqual([]);
       expect(hoisted.chatComposer.draft).toEqual(original);
       expect(currentManager.atoms.messagesList.value).toEqual([message, second]);
       expect(readBubble(renderer, message.info.id)).toBeDefined();
@@ -939,6 +945,144 @@ describe('SessionDetailContent cancel/restore', () => {
       unmountScreen(renderer);
     });
   });
+
+  it.each([false, true])(
+    'restores cancellation only for a replacement CLI connection, sheet closed=%s',
+    async closed => {
+      const message = queuedMessage([TEXT_PART, FILE_PART]);
+      seedQueuedMessage(message);
+      currentManager.atoms.remoteModelState.value.ownerConnectionId = 'cli-1';
+      currentManager.cancelQueuedMessage.mockRejectedValueOnce(
+        Object.assign(new Error('Upgrade required'), { code: 'CLI_UPGRADE_REQUIRED' })
+      );
+      const renderer = mount();
+      openDetails(renderer, message);
+      const stalePress = cancellationPress(renderer);
+      await act(async () => {
+        stalePress();
+        await Promise.resolve();
+      });
+      const upgrade = 'agentChat.session.cancelQueuedUpgradeRequired';
+      expect(cancellationRow(renderer)).toBeUndefined();
+      expect(hoisted.chatComposer.draft).toEqual({ text: '', files: [] });
+      if (closed) {
+        closeDetails(renderer);
+        openDetails(renderer, message);
+        expect(findByType(renderer, 'Text').map(node => node.props.children)).toContain(upgrade);
+        expect(statusMessages(renderer)).toEqual([]);
+      }
+
+      for (const ownerConnectionId of ['cli-1', null, 'cli-1']) {
+        currentManager.atoms.remoteModelState.value = {
+          ...currentManager.atoms.remoteModelState.value,
+          ownerConnectionId,
+        };
+        currentManager.atoms.agentStatus.value = {
+          type: ownerConnectionId === null ? 'disconnected' : 'connected',
+        };
+        currentManager.atoms.supportsAttachments.value = ownerConnectionId !== null;
+        updateScreen(renderer);
+        act(() => {
+          stalePress();
+        });
+        expect(cancellationRow(renderer)).toBeUndefined();
+        expect(findByType(renderer, 'Text').map(node => node.props.children)).toContain(upgrade);
+        expect(currentManager.cancelQueuedMessage.mock.calls).toEqual([[message.info.id]]);
+        expect(hoisted.chatComposer.draft).toEqual({ text: '', files: [] });
+      }
+      if (closed) {
+        closeDetails(renderer);
+      }
+      currentManager.atoms.remoteModelState.value = {
+        ...currentManager.atoms.remoteModelState.value,
+        ownerConnectionId: 'cli-2',
+      };
+      updateScreen(renderer);
+      if (closed) {
+        openDetails(renderer, message);
+      }
+      expect(detailsProps(renderer).message).toBe(message);
+      expect(cancellationRow(renderer)).toBeDefined();
+      expect(detailsProps(renderer).canCancelQueued).toBe(true);
+      expect(detailsProps(renderer).cancelQueuedFeedback).toBeNull();
+      expect(findByType(renderer, 'Text').map(node => node.props.children)).not.toContain(upgrade);
+      expect(hoisted.announce.mock.calls).toEqual([[upgrade]]);
+      currentManager.cancelQueuedMessage.mockResolvedValue({ dropped: true });
+      await act(async () => {
+        cancellationPress(renderer)();
+        await Promise.resolve();
+      });
+      expect(hoisted.chatComposer.draft).toEqual({ text: 'Queued prompt', files: [FILE_PART] });
+      expect(readBubble(renderer, message.info.id)).toBeUndefined();
+      expect(detailsProps(renderer).visible).toBe(false);
+      expect(statusMessages(renderer)).toEqual([restored]);
+      expect(hoisted.announce.mock.calls).toEqual([[upgrade], [restored]]);
+      unmountScreen(renderer);
+    }
+  );
+
+  it.each([false, true])(
+    'reports a late upgrade failure once without disabling the replacement, sheet dismissed=%s',
+    async dismissed => {
+      const message = queuedMessage();
+      seedQueuedMessage(message);
+      currentManager.atoms.remoteModelState.value.ownerConnectionId = 'cli-1';
+      const request = Promise.withResolvers<{ dropped: boolean }>();
+      currentManager.cancelQueuedMessage.mockReturnValueOnce(request.promise);
+      const renderer = mount();
+      openDetails(renderer, message);
+      act(() => {
+        cancellationPress(renderer)();
+      });
+      if (dismissed) {
+        closeDetails(renderer);
+      }
+      currentManager.atoms.remoteModelState.value = {
+        ...currentManager.atoms.remoteModelState.value,
+        ownerConnectionId: 'cli-2',
+      };
+      updateScreen(renderer);
+      await act(async () => {
+        request.reject(
+          Object.assign(new Error('Upgrade required'), { code: 'CLI_UPGRADE_REQUIRED' })
+        );
+        await Promise.resolve();
+      });
+      expect(detailsProps(renderer).visible).toBe(!dismissed);
+      expect(detailsProps(renderer).isCancelingQueued).toBe(false);
+      expect(detailsProps(renderer).cancelQueuedFeedback?.message ?? null).toBe(
+        dismissed ? null : failed
+      );
+      expect(detailsProps(renderer).cancelQueuedGuidance).toBeNull();
+      expect(statusMessages(renderer)).toEqual([failed]);
+      const visibleText = findByType(renderer, 'Text').map(node => node.props.children);
+      expect(visibleText.filter(text => text === failed)).toHaveLength(1);
+      expect(visibleText).not.toContain('agentChat.session.cancelQueuedUpgradeRequired');
+      expect(hoisted.announce.mock.calls).toEqual([[failed]]);
+      expect(hoisted.chatComposer.draft).toEqual({ text: '', files: [] });
+      expect(readBubble(renderer, message.info.id)).toBeDefined();
+      if (dismissed) {
+        openDetails(renderer, message);
+      }
+      expect(detailsProps(renderer).canCancelQueued).toBe(true);
+      expect(cancellationRow(renderer)?.props.accessibilityState).toEqual({
+        disabled: false,
+        busy: false,
+      });
+      expect(hoisted.announce.mock.calls).toEqual([[failed]]);
+      currentManager.cancelQueuedMessage.mockResolvedValue({ dropped: true });
+      await act(async () => {
+        cancellationPress(renderer)();
+        await Promise.resolve();
+      });
+      expect(hoisted.chatComposer.draft).toEqual({ text: 'Queued prompt', files: [] });
+      expect(readBubble(renderer, message.info.id)).toBeUndefined();
+      expect(detailsProps(renderer).visible).toBe(false);
+      expect(statusMessages(renderer)).toEqual([restored]);
+      expect(hoisted.announce.mock.calls).toEqual([[failed], [restored]]);
+      unmountScreen(renderer);
+    }
+  );
 
   it('keeps the occupied Restore path usable before late delivery events', async () => {
     const message = queuedMessage([TEXT_PART, FILE_PART]);

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -694,20 +694,48 @@ export function SessionDetailContent({
   const [cancelingQueuedIds, setCancelingQueuedIds] = useState<ReadonlySet<string>>(EMPTY_IDS);
   // Successful drops stay guarded before React commits and after Restore removes a retained row.
   const canceledQueuedIdsRef = useRef(new Set<string>());
-  // Dismissing feedback must not enable another request to the same unsupported session.
-  const cancelQueuedUpgradeRequiredRef = useRef(false);
+  // The SDK owner ID changes when a replacement CLI connection takes over.
+  // Catalog refreshes and temporary owner loss do not prove recovery.
+  const cancelQueuedUpgradeRequiredRef = useRef<{
+    ownerConnectionId: string | null;
+    attempt: number;
+  } | null>(null);
+  const isQueuedCancellationUnsupported = useCallback(() => {
+    const unsupported = cancelQueuedUpgradeRequiredRef.current;
+    const ownerConnectionId = store.get(manager.atoms.remoteModelState).ownerConnectionId;
+    return (
+      unsupported !== null &&
+      (ownerConnectionId === null || ownerConnectionId === unsupported.ownerConnectionId)
+    );
+  }, [manager, store]);
+
+  useEffect(() => {
+    const unsupported = cancelQueuedUpgradeRequiredRef.current;
+    if (
+      unsupported !== null &&
+      remoteModelState.ownerConnectionId !== null &&
+      remoteModelState.ownerConnectionId !== unsupported.ownerConnectionId
+    ) {
+      cancelQueuedUpgradeRequiredRef.current = null;
+      setCancelQueuedStatus(current => (current?.attempt === unsupported.attempt ? null : current));
+      setCancelQueuedSheetStatus(current =>
+        current?.attempt === unsupported.attempt ? null : current
+      );
+    }
+  }, [remoteModelState.ownerConnectionId]);
+
   const isQueuedCancellationEligible = useCallback(
     (
       message: StoredMessage | undefined,
       delivery: MessageDeliveryState | undefined,
       busy: boolean
     ) =>
-      !cancelQueuedUpgradeRequiredRef.current &&
+      !isQueuedCancellationUnsupported() &&
       message?.info.role === 'user' &&
       delivery?.status === 'queued' &&
       !canceledQueuedIdsRef.current.has(message.info.id) &&
       !busy,
-    []
+    [isQueuedCancellationUnsupported]
   );
 
   const handleOpenDetails = useCallback((message: StoredMessage) => {
@@ -785,7 +813,7 @@ export function SessionDetailContent({
     cancelingQueuedIdsRef.current = new Set();
     setCancelingQueuedIds(EMPTY_IDS);
     canceledQueuedIdsRef.current = new Set();
-    cancelQueuedUpgradeRequiredRef.current = false;
+    cancelQueuedUpgradeRequiredRef.current = null;
   } else {
     const next = nextHeldQueuedIds(heldQueuedIds, pendingMessages, isStreaming);
     if (next !== heldQueuedIds) {
@@ -939,12 +967,13 @@ export function SessionDetailContent({
       // The attempt also resets announcement identity if React batches an immediate retry failure.
       cancelQueuedAttemptRef.current += 1;
       const attempt = cancelQueuedAttemptRef.current;
+      const ownerConnectionId = store.get(manager.atoms.remoteModelState).ownerConnectionId;
       const reportFailure = (feedback: string, upgradeRequired = false) => {
         if (inFlight !== cancelingQueuedIdsRef.current) {
           return;
         }
         if (upgradeRequired) {
-          cancelQueuedUpgradeRequiredRef.current = true;
+          cancelQueuedUpgradeRequiredRef.current = { ownerConnectionId, attempt };
         }
         const setStatus =
           detailsMessageIdRef.current === messageId
@@ -965,7 +994,10 @@ export function SessionDetailContent({
         } catch (cancelError) {
           // Old CLI versions without queue drop require an upgrade. Remove only when all
           // supported CLI versions implement queue drop; never fall back to interrupt.
-          const upgrade = isCancelQueuedUpgradeRequired(cancelError);
+          const currentOwner = store.get(manager.atoms.remoteModelState).ownerConnectionId;
+          const upgrade =
+            isCancelQueuedUpgradeRequired(cancelError) &&
+            (currentOwner === null || currentOwner === ownerConnectionId);
           reportFailure(
             upgrade
               ? t('agentChat.session.cancelQueuedUpgradeRequired')
@@ -1475,6 +1507,13 @@ export function SessionDetailContent({
           onCancelQueued={handleCancelQueued}
           cancelQueuedFeedback={
             cancelQueuedSheetStatus?.messageId === detailsMessageId ? cancelQueuedSheetStatus : null
+          }
+          cancelQueuedGuidance={
+            isQueuedCancellationUnsupported() &&
+            detailsMessage?.info.role === 'user' &&
+            detailsDelivery?.status === 'queued'
+              ? t('agentChat.session.cancelQueuedUpgradeRequired')
+              : null
           }
         />
 

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -1,5 +1,9 @@
 /* eslint-disable max-lines -- Session orchestration and its render paths are kept together. */
-import { type KiloSessionId, type StoredMessage } from '@kilocode/cloud-agent-sdk';
+import {
+  type KiloSessionId,
+  type MessageDeliveryState,
+  type StoredMessage,
+} from '@kilocode/cloud-agent-sdk';
 import { type Href, useFocusEffect, useIsFocused, useRouter } from 'expo-router';
 import { useAtomValue, useSetAtom, useStore } from 'jotai';
 import { MessageSquare } from '@/components/ui/icons';
@@ -159,6 +163,13 @@ type SessionDetailContentProps = {
   cachedTitle?: string;
 };
 
+type CancelQueuedStatus = {
+  messageId: string;
+  tone: 'status' | 'error';
+  message: string;
+  attempt: number;
+};
+
 const EMPTY_IDS: ReadonlySet<string> = new Set();
 
 export function SessionDetailContent({
@@ -227,7 +238,8 @@ export function SessionDetailContent({
   const olderMessagesOmittedItemCount = useAtomValue(manager.atoms.olderMessagesOmittedItemCount);
   const [openContextSheetIdentity, setOpenContextSheetIdentity] =
     useState<ContextSheetIdentity | null>(null);
-  const [detailsMessage, setDetailsMessage] = useState<StoredMessage | null>(null);
+  const [detailsMessageId, setDetailsMessageId] = useState<string | null>(null);
+  const detailsMessageIdRef = useRef<string | null>(null);
 
   const { bottom } = useSafeAreaInsets();
 
@@ -667,16 +679,50 @@ export function SessionDetailContent({
   // row out of the transcript before merge; `canceledQueuedMessages` keeps the
   // full row with a Restore action when the composer was occupied (the SDK
   // deletes the row on cloud.message.canceled, so the local copy re-inserts it).
-  // `cancelQueuedStatus` surfaces the outcome through `AccessibleStatus`. All
-  // three reset on switch.
+  // Sheet and screen outcomes have separate slots so one cannot erase the other.
+  // The rows and feedback reset on session switch.
   const EMPTY_CANCELED: ReadonlyMap<string, StoredMessage> = new Map();
   const [droppedQueuedIds, setDroppedQueuedIds] = useState<ReadonlySet<string>>(EMPTY_IDS);
   const [canceledQueuedMessages, setCanceledQueuedMessages] =
     useState<ReadonlyMap<string, StoredMessage>>(EMPTY_CANCELED);
-  const [cancelQueuedStatus, setCancelQueuedStatus] = useState<{
-    tone: 'status' | 'error';
-    message: string;
-  } | null>(null);
+  const [cancelQueuedStatus, setCancelQueuedStatus] = useState<CancelQueuedStatus | null>(null);
+  const [cancelQueuedSheetStatus, setCancelQueuedSheetStatus] = useState<CancelQueuedStatus | null>(
+    null
+  );
+  const cancelQueuedAttemptRef = useRef(0);
+  const cancelingQueuedIdsRef = useRef(new Set<string>());
+  const [cancelingQueuedIds, setCancelingQueuedIds] = useState<ReadonlySet<string>>(EMPTY_IDS);
+  // Successful drops stay guarded before React commits and after Restore removes a retained row.
+  const canceledQueuedIdsRef = useRef(new Set<string>());
+  // Dismissing feedback must not enable another request to the same unsupported session.
+  const cancelQueuedUpgradeRequiredRef = useRef(false);
+  const isQueuedCancellationEligible = useCallback(
+    (
+      message: StoredMessage | undefined,
+      delivery: MessageDeliveryState | undefined,
+      busy: boolean
+    ) =>
+      !cancelQueuedUpgradeRequiredRef.current &&
+      message?.info.role === 'user' &&
+      delivery?.status === 'queued' &&
+      !canceledQueuedIdsRef.current.has(message.info.id) &&
+      !busy,
+    []
+  );
+
+  const handleOpenDetails = useCallback((message: StoredMessage) => {
+    detailsMessageIdRef.current = message.info.id;
+    setDetailsMessageId(message.info.id);
+    setCancelQueuedSheetStatus(null);
+  }, []);
+
+  const handleCloseDetails = useCallback(() => {
+    const messageId = detailsMessageIdRef.current;
+    detailsMessageIdRef.current = null;
+    setDetailsMessageId(null);
+    // A presented sheet failure must not become a second, outer announcement on dismissal.
+    setCancelQueuedSheetStatus(current => (current?.messageId === messageId ? null : current));
+  }, []);
 
   const visibleMessages = useMemo(() => {
     const base =
@@ -705,6 +751,18 @@ export function SessionDetailContent({
     });
   }, [messages, droppedQueuedIds, canceledQueuedMessages]);
 
+  const detailsMessage = visibleMessages.find(message => message.info.id === detailsMessageId);
+  const detailsDelivery =
+    detailsMessageId === null ? undefined : pendingMessages.get(detailsMessageId);
+  const detailsBusy = detailsMessageId !== null && cancelingQueuedIds.has(detailsMessageId);
+  const canCancelSelected = isQueuedCancellationEligible(
+    detailsMessage,
+    detailsDelivery,
+    detailsBusy
+  );
+  const isCancelingSelected =
+    detailsBusy && isQueuedCancellationEligible(detailsMessage, detailsDelivery, false);
+
   const transcript = useMemo(
     () => mergeSessionTranscript(visibleMessages, preparationAttempts),
     [visibleMessages, preparationAttempts]
@@ -721,6 +779,13 @@ export function SessionDetailContent({
     setDroppedQueuedIds(EMPTY_IDS);
     setCanceledQueuedMessages(EMPTY_CANCELED);
     setCancelQueuedStatus(null);
+    setCancelQueuedSheetStatus(null);
+    detailsMessageIdRef.current = null;
+    setDetailsMessageId(null);
+    cancelingQueuedIdsRef.current = new Set();
+    setCancelingQueuedIds(EMPTY_IDS);
+    canceledQueuedIdsRef.current = new Set();
+    cancelQueuedUpgradeRequiredRef.current = false;
   } else {
     const next = nextHeldQueuedIds(heldQueuedIds, pendingMessages, isStreaming);
     if (next !== heldQueuedIds) {
@@ -851,55 +916,104 @@ export function SessionDetailContent({
   );
 
   const handleCancelQueued = useCallback(
-    async (message: StoredMessage) => {
-      let dropped = false;
-      try {
-        ({ dropped } = await manager.cancelQueuedMessage(message.info.id));
-      } catch (cancelError) {
-        const upgrade = isCancelQueuedUpgradeRequired(cancelError);
-        setCancelQueuedStatus({
-          tone: 'error',
-          message: upgrade
-            ? t('agentChat.session.cancelQueuedUpgradeRequired')
-            : t('agentChat.session.cancelQueuedFailed'),
-        });
-        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+    async (selectedMessage: StoredMessage) => {
+      const messageId = selectedMessage.info.id;
+      const message = store
+        .get(manager.atoms.messagesList)
+        .find(item => item.info.id === messageId);
+      const inFlight = cancelingQueuedIdsRef.current;
+      if (
+        !message ||
+        !isQueuedCancellationEligible(
+          message,
+          store.get(manager.atoms.pendingMessages).get(messageId),
+          inFlight.has(messageId)
+        )
+      ) {
         return;
       }
-      if (!dropped) {
-        // The queue did not drop the message (missing id or already-accepted
-        // current turn). Keep the row and surface the failure — never restore,
-        // hide, or drop it, or the user could send again on top of a hidden
-        // running turn.
-        setCancelQueuedStatus({
-          tone: 'error',
-          message: t('agentChat.session.cancelQueuedFailed'),
-        });
-        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
-        return;
-      }
-      const composerHasContent = composerControlRef.current?.hasContent() ?? false;
-      const prompt = firstHumanText(message.parts);
-      if (!composerHasContent) {
-        if (prompt !== '') {
-          composerControlRef.current?.setText(prompt);
+      inFlight.add(messageId);
+      setCancelingQueuedIds(new Set(inFlight));
+      setCancelQueuedStatus(current => (current?.messageId === messageId ? null : current));
+      setCancelQueuedSheetStatus(current => (current?.messageId === messageId ? null : current));
+      // The attempt also resets announcement identity if React batches an immediate retry failure.
+      cancelQueuedAttemptRef.current += 1;
+      const attempt = cancelQueuedAttemptRef.current;
+      const reportFailure = (feedback: string, upgradeRequired = false) => {
+        if (inFlight !== cancelingQueuedIdsRef.current) {
+          return;
         }
-        composerControlRef.current?.restoreAttachments(message.parts.filter(isFilePart));
-        setDroppedQueuedIds(prev => new Set(prev).add(message.info.id));
-        setCancelQueuedStatus({
-          tone: 'status',
-          message: t('agentChat.session.cancelQueuedRestored'),
+        if (upgradeRequired) {
+          cancelQueuedUpgradeRequiredRef.current = true;
+        }
+        const setStatus =
+          detailsMessageIdRef.current === messageId
+            ? setCancelQueuedSheetStatus
+            : setCancelQueuedStatus;
+        setStatus({
+          messageId,
+          tone: 'error',
+          message: feedback,
+          attempt,
         });
-      } else {
-        setCanceledQueuedMessages(prev => new Map(prev).set(message.info.id, message));
+        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+      };
+      try {
+        let dropped = false;
+        try {
+          ({ dropped } = await manager.cancelQueuedMessage(messageId));
+        } catch (cancelError) {
+          // Old CLI versions without queue drop require an upgrade. Remove only when all
+          // supported CLI versions implement queue drop; never fall back to interrupt.
+          const upgrade = isCancelQueuedUpgradeRequired(cancelError);
+          reportFailure(
+            upgrade
+              ? t('agentChat.session.cancelQueuedUpgradeRequired')
+              : t('agentChat.session.cancelQueuedFailed'),
+            upgrade
+          );
+          return;
+        }
+        if (inFlight !== cancelingQueuedIdsRef.current) {
+          return;
+        }
+        if (!dropped) {
+          // An accepted or missing queue entry must not be hidden or restored as an unsent draft.
+          reportFailure(t('agentChat.session.cancelQueuedFailed'));
+          return;
+        }
+        canceledQueuedIdsRef.current.add(messageId);
+        const composerHasContent = composerControlRef.current?.hasContent() ?? false;
+        const prompt = firstHumanText(message.parts);
+        if (!composerHasContent) {
+          if (prompt !== '') {
+            composerControlRef.current?.setText(prompt);
+          }
+          composerControlRef.current?.restoreAttachments(message.parts.filter(isFilePart));
+          setDroppedQueuedIds(prev => new Set(prev).add(messageId));
+        } else {
+          setCanceledQueuedMessages(prev => new Map(prev).set(messageId, message));
+        }
+        if (detailsMessageIdRef.current === messageId) {
+          handleCloseDetails();
+        }
         setCancelQueuedStatus({
+          messageId,
           tone: 'status',
-          message: t('agentChat.session.cancelQueuedRestoreAvailable'),
+          message: composerHasContent
+            ? t('agentChat.session.cancelQueuedRestoreAvailable')
+            : t('agentChat.session.cancelQueuedRestored'),
+          attempt,
         });
+        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      } finally {
+        inFlight.delete(messageId);
+        if (inFlight === cancelingQueuedIdsRef.current) {
+          setCancelingQueuedIds(new Set(inFlight));
+        }
       }
-      void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     },
-    [manager, t]
+    [manager, store, isQueuedCancellationEligible, handleCloseDetails, t]
   );
 
   const handleRestoreQueued = useCallback(
@@ -910,14 +1024,18 @@ export function SessionDetailContent({
         composerControlRef.current?.setText(prompt);
       }
       composerControlRef.current?.restoreAttachments(stored.parts.filter(isFilePart));
+      setDroppedQueuedIds(prev => new Set(prev).add(message.info.id));
       setCanceledQueuedMessages(prev => {
         const next = new Map(prev);
         next.delete(message.info.id);
         return next;
       });
+      cancelQueuedAttemptRef.current += 1;
       setCancelQueuedStatus({
+        messageId: message.info.id,
         tone: 'status',
         message: t('agentChat.session.cancelQueuedRestored'),
+        attempt: cancelQueuedAttemptRef.current,
       });
       void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     },
@@ -932,12 +1050,11 @@ export function SessionDetailContent({
       if (item.type === 'time') {
         return <TranscriptTimeMarker created={item.created} dayChanged={item.dayChanged} />;
       }
-      // Look up delivery state by message id. The map is keyed by user-message
-      // id and may briefly contain an entry before the bubble has rendered
-      // (ServiceEvents can be applied while chat events are still buffered),
-      // so a plain lookup is enough — no render-order guard.
+      // Delivery events can lag a successful drop. The retained row must expose Restore immediately.
       const deliveryState =
-        item.message.info.role === 'user' ? pendingMessages.get(item.message.info.id) : undefined;
+        item.message.info.role === 'user' && !canceledQueuedMessages.has(item.message.info.id)
+          ? pendingMessages.get(item.message.info.id)
+          : undefined;
       // Suppress Retry on an assistant failure with no preceding user row.
       const retryPrompt = resolveRetryPrompt(item.message, messages);
       return (
@@ -950,11 +1067,10 @@ export function SessionDetailContent({
           defaultReasoningExpanded={reasoningDefaultExpanded}
           onOpenChildSession={handleOpenChildSession}
           deliveryState={deliveryState}
-          onLongPressDetails={setDetailsMessage}
+          onLongPressDetails={handleOpenDetails}
           holdQueuedSlot={isStreaming && heldQueuedIds.has(item.message.info.id)}
           onRetryMessage={retryPrompt !== null ? handleRetryMessage : undefined}
           onCopyToComposer={handleCopyToComposer}
-          onCancelQueued={deliveryState?.status === 'queued' ? handleCancelQueued : undefined}
           onRestoreQueued={
             canceledQueuedMessages.has(item.message.info.id) ? handleRestoreQueued : undefined
           }
@@ -973,7 +1089,7 @@ export function SessionDetailContent({
       messages,
       handleRetryMessage,
       handleCopyToComposer,
-      handleCancelQueued,
+      handleOpenDetails,
       handleRestoreQueued,
       canceledQueuedMessages,
     ]
@@ -1350,12 +1466,16 @@ export function SessionDetailContent({
         ) : null}
 
         <MessageDetailsSheet
-          visible={detailsMessage !== null}
-          message={detailsMessage}
+          visible={detailsMessageId !== null}
+          message={detailsMessage ?? null}
           modelOptions={modelOptions}
-          onClose={() => {
-            setDetailsMessage(null);
-          }}
+          onClose={handleCloseDetails}
+          canCancelQueued={canCancelSelected}
+          isCancelingQueued={isCancelingSelected}
+          onCancelQueued={handleCancelQueued}
+          cancelQueuedFeedback={
+            cancelQueuedSheetStatus?.messageId === detailsMessageId ? cancelQueuedSheetStatus : null
+          }
         />
 
         {childSessionSheet.sheet ? (
@@ -1419,6 +1539,7 @@ export function SessionDetailContent({
         </View>
 
         <AccessibleStatus
+          key={cancelQueuedStatus?.attempt}
           message={cancelQueuedStatus?.message ?? null}
           tone={cancelQueuedStatus?.tone ?? 'status'}
           className="px-4 text-center text-sm"
@@ -1590,7 +1711,7 @@ export function SessionDetailContent({
     if (shouldBlockMessages) {
       return <SessionSkeletonMessages sessionId={sessionId} />;
     }
-    if (messages.length === 0) {
+    if (visibleMessages.length === 0) {
       return (
         <View className="flex-1 items-center justify-center px-6">
           {statusIndicator ? <SessionStatusIndicator indicator={statusIndicator} /> : null}

--- a/apps/mobile/src/components/agents/session-history-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/session-history-screen.mounted.test.tsx
@@ -4,11 +4,17 @@ import TestRenderer, { act } from 'react-test-renderer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { i18n } from '@/i18n';
+import { type StoredSession, type useAgentSessions } from '@/lib/hooks/use-agent-sessions';
+import type * as PlatformFilterModule from './platform-filter-modal';
 import { SessionHistoryScreen } from './session-history-screen';
 
+type MockStoredSession = Pick<StoredSession, 'session_id' | 'organization_id'> &
+  Partial<Pick<StoredSession, 'git_url' | 'created_on_platform'>>;
+
 const listState = vi.hoisted(() => ({
-  storedSessions: [] as { session_id: string; organization_id: string | null }[],
+  storedSessions: [] as MockStoredSession[],
   isSearching: false,
+  isError: false,
 }));
 
 const appState = vi.hoisted(() => {
@@ -33,18 +39,28 @@ const appState = vi.hoisted(() => {
 
 const focusState = vi.hoisted(() => ({ current: true as boolean }));
 const focusCallbacks = vi.hoisted(() => ({
-  current: [] as (() => void)[],
+  current: new Set<() => void>(),
 }));
 const handleRefetchSpy = vi.hoisted(() => vi.fn());
+const readFilterRecord = vi.hoisted(() => vi.fn<(storageKey: string) => Promise<string | null>>());
 
 vi.mock('react-native', () => ({
   View: 'View',
+  Modal: 'Modal',
+  Pressable: 'Pressable',
+  ScrollView: 'ScrollView',
   AppState: { addEventListener: appState.addEventListener },
+}));
+vi.mock('@/components/ui/icons', () => ({ Check: 'Check', X: 'X' }));
+vi.mock('@/components/ui/button', () => ({ Button: 'Button' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({ accentSoftForeground: '#1a1a10' }),
 }));
 vi.mock('expo-router', () => ({
   useNavigation: () => ({ isFocused: () => focusState.current }),
   useFocusEffect: (effect: () => void) => {
-    focusCallbacks.current.push(effect);
+    focusCallbacks.current.add(effect);
   },
 }));
 vi.mock('@/components/agents/session-list-content', () => ({
@@ -56,8 +72,8 @@ vi.mock('@/components/agents/session-list-header-actions', () => ({
 vi.mock('@/components/agents/session-list-search-header', () => ({
   SessionListSearchHeader: 'SessionListSearchHeader',
 }));
-vi.mock('@/components/agents/platform-filter-modal', () => ({
-  SessionFilterChips: 'SessionFilterChips',
+vi.mock('@/components/agents/platform-filter-modal', async importOriginal => ({
+  ...(await importOriginal<typeof PlatformFilterModule>()),
   SessionFilterModal: 'SessionFilterModal',
 }));
 vi.mock('@/components/agents/active-now-section', () => ({
@@ -68,56 +84,72 @@ vi.mock('@/components/screen-header', () => ({
 }));
 vi.mock('@/components/agents/use-session-search-input', () => ({
   useSessionSearchInput: () => ({
-    searchQuery: '',
+    searchQuery: listState.isSearching ? 'no matching sessions' : '',
     searchInputRef: { current: null },
-    hasText: false,
+    hasText: listState.isSearching,
     awaitingCommit: false,
     searchInputKey: 'session-search-empty',
     searchDefaultValue: undefined,
     handleSearchInputChange: vi.fn(),
     handleClearSearchInput: vi.fn(),
-    clearSearchInput: vi.fn(),
+    clearSearchInput: () => {
+      listState.isSearching = false;
+    },
     searchController: { clearSearchOnly: vi.fn() },
   }),
 }));
 vi.mock('@/components/agents/use-agent-session-navigator', () => ({
   useAgentSessionNavigator: () => vi.fn(),
 }));
-vi.mock('@/components/agents/use-agent-session-list-data', () => ({
-  useAgentSessionListData: () => ({
-    storedSessions: listState.storedSessions,
-    activeSessions: [],
-    isLoading: false,
-    storedIsFetching: false,
-    storedLoadedPageCount: 1,
-    paging: {
+// Keep query construction and persisted filters real. Only the server response
+// is modeled here, so dropped query dimensions change the resulting rows.
+vi.mock('@/lib/hooks/use-agent-sessions', () => ({
+  useAgentSessions: ({
+    gitUrl,
+    createdOnPlatform,
+  }: Parameters<typeof useAgentSessions>[0] = {}) => {
+    const storedSessions = listState.storedSessions.filter(
+      session =>
+        (!gitUrl || gitUrl.includes(session.git_url ?? '')) &&
+        (!createdOnPlatform || createdOnPlatform.includes(session.created_on_platform ?? ''))
+    );
+    return {
+      storedSessions,
+      dateGroups: storedSessions.length > 0 ? [{ label: 'Today', sessions: storedSessions }] : [],
+      activeIsError: false,
+      storedIsError: listState.isError,
+      storedIsFetching: false,
+      storedLoadedPageCount: 1,
       hasNextPage: false,
       isFetchingNextPage: false,
-      isPlaceholderData: false,
       fetchNextPage: vi.fn(),
+      refetch: handleRefetchSpy,
+    };
+  },
+  useAgentSessionSearch: () => ({
+    dateGroups: [],
+    isError: listState.isError,
+    isFetching: false,
+    isPending: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    isPlaceholderData: false,
+    fetchNextPage: vi.fn(),
+    refetch: handleRefetchSpy,
+  }),
+  useRecentAgentRepositories: () => ({
+    data: {
+      repositories: listState.storedSessions.flatMap(session =>
+        session.git_url ? [{ gitUrl: session.git_url }] : []
+      ),
     },
-    refetch: vi.fn(),
-    handleRetry: vi.fn(),
-    handleRefetch: handleRefetchSpy,
-    isSearching: listState.isSearching,
-    search: { isFetching: false, isPending: false },
-    projectOptions: [],
-    contentIsError: false,
-    pinnedActive: [],
-    sections: [],
   }),
 }));
-vi.mock('@/lib/hooks/use-persisted-agent-session-filters', () => ({
-  usePersistedAgentSessionFilters: () => ({
-    platformFilter: [],
-    projectFilter: [],
-    sortBy: 'updated',
-    hasLoaded: true,
-    setFilters: vi.fn(),
-    setPlatformFilter: vi.fn(),
-    setProjectFilter: vi.fn(),
-  }),
+vi.mock('expo-secure-store', () => ({ getItemAsync: readFilterRecord }));
+vi.mock('@/lib/auth/account-metadata-write', () => ({
+  setAccountMetadata: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock('sonner-native', () => ({ toast: { error: vi.fn() } }));
 vi.mock('@/lib/hooks/use-current-user-id', () => ({
   useCurrentUserId: () => ({ userId: 'u1', isLoading: false }),
 }));
@@ -147,6 +179,38 @@ function findNodeByType(
   return renderer.root.find(node => typeof node.type === 'string' && node.type === type);
 }
 
+function historyHeaderActions(renderer: TestRenderer.ReactTestRenderer) {
+  const header = findNodeByType(renderer, 'ScreenHeader');
+  return (
+    header.props.headerRight as ReactElement<{
+      activeFilterCount: number;
+      onOpenFilters: () => void;
+    }>
+  ).props;
+}
+
+function applyFilters(
+  renderer: TestRenderer.ReactTestRenderer,
+  projectFilter: string[],
+  platformFilter: string[]
+) {
+  act(() => {
+    historyHeaderActions(renderer).onOpenFilters();
+  });
+  const modal = findNodeByType(renderer, 'SessionFilterModal');
+  act(() => {
+    (modal.props.onApply as (filters: unknown) => void)({ projectFilter, platformFilter });
+    (modal.props.onClose as () => void)();
+  });
+}
+
+function storedSessionIds(renderer: TestRenderer.ReactTestRenderer) {
+  const sections = findNodeByType(renderer, 'AgentSessionListContent').props.sections as {
+    data: MockStoredSession[];
+  }[];
+  return sections.flatMap(section => section.data.map(session => session.session_id));
+}
+
 function fireFocus(): void {
   for (const effect of focusCallbacks.current) {
     effect();
@@ -174,8 +238,11 @@ describe('SessionHistoryScreen', () => {
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     listState.storedSessions = [];
     listState.isSearching = false;
+    listState.isError = false;
+    readFilterRecord.mockReset();
+    readFilterRecord.mockResolvedValue(null);
     focusState.current = true;
-    focusCallbacks.current = [];
+    focusCallbacks.current = new Set();
     handleRefetchSpy.mockClear();
     handleRefetchSpy.mockResolvedValue(undefined);
   });
@@ -189,6 +256,171 @@ describe('SessionHistoryScreen', () => {
     mountedRenderers.length = 0;
     appState.listeners.clear();
     vi.restoreAllMocks();
+  });
+
+  const workflow = 'https://github.com/iscekic/kilo-workflow.git';
+  const code = 'https://github.com/Kilo-Org/kilocode.git';
+  const sessions: MockStoredSession[] = [
+    {
+      session_id: 'workflow',
+      organization_id: null,
+      git_url: workflow,
+      created_on_platform: 'cloud-agent-web',
+    },
+    {
+      session_id: 'code-cloud',
+      organization_id: null,
+      git_url: code,
+      created_on_platform: 'cloud-agent',
+    },
+    { session_id: 'code-cli', organization_id: null, git_url: code, created_on_platform: 'cli' },
+    {
+      session_id: 'other',
+      organization_id: null,
+      git_url: 'https://github.com/example/other.git',
+      created_on_platform: 'cloud-agent',
+    },
+  ];
+
+  it('keeps real pills, counts, query results, and search placement in sync through removal', async () => {
+    listState.storedSessions = sessions;
+    const renderer = await renderScreen();
+    expect(findNodesByType(renderer, 'ScrollView')).toHaveLength(0);
+    applyFilters(renderer, [workflow, code], ['cloud-agent']);
+    expect(storedSessionIds(renderer)).toEqual(['workflow', 'code-cloud']);
+    expect(historyHeaderActions(renderer).activeFilterCount).toBe(3);
+    const strip = findNodeByType(renderer, 'ScrollView');
+    expect((strip.props.className as string | undefined)?.split(' ')).toEqual(
+      expect.arrayContaining(['grow-0', 'shrink-0'])
+    );
+    const selectedTree = renderer.toJSON() as TestRenderer.ReactTestRendererJSON;
+    expect(
+      selectedTree.children
+        ?.slice(0, 3)
+        .map(child => (typeof child === 'string' ? child : child.type))
+    ).toEqual(['ScreenHeader', 'ScrollView', 'SessionListSearchHeader']);
+
+    for (const step of [
+      {
+        label: i18n.t('agentChat.sessionFilter.removeProjectFilter', {
+          label: 'iscekic/kilo-workflow',
+        }),
+        count: 2,
+        ids: ['code-cloud'],
+      },
+      {
+        label: i18n.t('agentChat.sessionFilter.removePlatformFilter', {
+          label: i18n.t('agentChat.sessionFilter.platformCloud'),
+        }),
+        count: 1,
+        ids: ['code-cloud', 'code-cli'],
+      },
+      {
+        label: i18n.t('agentChat.sessionFilter.removeProjectFilter', {
+          label: 'Kilo-Org/kilocode',
+        }),
+        count: 0,
+        ids: ['workflow', 'code-cloud', 'code-cli', 'other'],
+      },
+    ]) {
+      act(() => {
+        const pill = renderer.root.findByProps({ accessibilityLabel: step.label });
+        (pill.props.onPress as () => void)();
+      });
+      expect(historyHeaderActions(renderer).activeFilterCount).toBe(step.count);
+      expect(storedSessionIds(renderer)).toEqual(step.ids);
+    }
+    expect(findNodesByType(renderer, 'ScrollView')).toHaveLength(0);
+    const clearedTree = renderer.toJSON() as TestRenderer.ReactTestRendererJSON;
+    expect(
+      clearedTree.children
+        ?.slice(0, 3)
+        .map(child => (typeof child === 'string' ? child : child.type))
+    ).toEqual(['ScreenHeader', 'SessionListSearchHeader', 'View']);
+  });
+
+  it('keeps saved repository and platform selections after a successful history retry', async () => {
+    readFilterRecord.mockImplementation(async storageKey => {
+      await Promise.resolve();
+      return storageKey === 'agent-session-filters'
+        ? JSON.stringify({ projectFilter: [code], platformFilter: ['cloud-agent'] })
+        : null;
+    });
+    listState.isError = true;
+    const renderer = await renderScreen();
+    const content = findNodeByType(renderer, 'AgentSessionListContent');
+    expect(content.props.isError).toBe(true);
+    expect(historyHeaderActions(renderer).activeFilterCount).toBe(2);
+    handleRefetchSpy.mockImplementationOnce(async () => {
+      await Promise.resolve();
+      listState.isError = false;
+      listState.storedSessions = sessions;
+    });
+    await act(async () => {
+      (content.props.onRetry as () => void)();
+      await Promise.resolve();
+      renderer.update(createElement(SessionHistoryScreen));
+    });
+    expect(findNodeByType(renderer, 'AgentSessionListContent').props.isError).toBe(false);
+    expect(storedSessionIds(renderer)).toEqual(['code-cloud']);
+    expect(historyHeaderActions(renderer).activeFilterCount).toBe(2);
+    expect(
+      findNodeByType(renderer, 'ScrollView').findAll(
+        node => typeof node.type === 'string' && (node.type as string) === 'Pressable'
+      )
+    ).toHaveLength(2);
+  });
+
+  it('clears no-result filters without a strip gap and keeps platform-only filtering usable', async () => {
+    listState.storedSessions = sessions;
+    const renderer = await renderScreen();
+    applyFilters(renderer, [workflow], ['slack']);
+    const content = findNodeByType(renderer, 'AgentSessionListContent');
+    expect(content.props.hasActiveQuery).toBe(true);
+    expect(content.props.isSearching).toBe(false);
+    expect(storedSessionIds(renderer)).toEqual([]);
+    expect(historyHeaderActions(renderer).activeFilterCount).toBe(2);
+    act(() => {
+      (content.props.onClearQuery as () => void)();
+    });
+    expect(storedSessionIds(renderer)).toEqual(['workflow', 'code-cloud', 'code-cli', 'other']);
+    expect(historyHeaderActions(renderer).activeFilterCount).toBe(0);
+    expect(findNodesByType(renderer, 'ScrollView')).toHaveLength(0);
+
+    applyFilters(renderer, [], ['cloud-agent']);
+    expect(storedSessionIds(renderer)).toEqual(['workflow', 'code-cloud', 'other']);
+    expect(historyHeaderActions(renderer).activeFilterCount).toBe(1);
+    act(() => {
+      const pill = renderer.root.findByProps({
+        accessibilityLabel: i18n.t('agentChat.sessionFilter.removePlatformFilter', {
+          label: i18n.t('agentChat.sessionFilter.platformCloud'),
+        }),
+      });
+      (pill.props.onPress as () => void)();
+    });
+    expect(storedSessionIds(renderer)).toEqual(['workflow', 'code-cloud', 'code-cli', 'other']);
+    expect(historyHeaderActions(renderer).activeFilterCount).toBe(0);
+    expect(findNodesByType(renderer, 'ScrollView')).toHaveLength(0);
+  });
+
+  it('clears only the search when no-result recovery says Clear search', async () => {
+    readFilterRecord.mockResolvedValue(
+      JSON.stringify({ projectFilter: [code], platformFilter: ['cloud-agent'] })
+    );
+    listState.storedSessions = sessions;
+    listState.isSearching = true;
+    const renderer = await renderScreen();
+    const content = findNodeByType(renderer, 'AgentSessionListContent');
+    expect(content.props.isSearching).toBe(true);
+    expect(storedSessionIds(renderer)).toEqual([]);
+    act(() => {
+      (content.props.onClearQuery as () => void)();
+      renderer.update(createElement(SessionHistoryScreen));
+    });
+    expect(findNodeByType(renderer, 'AgentSessionListContent').props.isSearching).toBe(false);
+    expect(storedSessionIds(renderer)).toEqual(['code-cloud']);
+    expect(historyHeaderActions(renderer).activeFilterCount).toBe(2);
+    expect(findNodesByType(renderer, 'ScrollView')).toHaveLength(1);
   });
 
   it('renders the agents title with a back button and default header size', async () => {

--- a/apps/mobile/src/components/agents/session-list-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/session-list-screen.mounted.test.tsx
@@ -3,6 +3,7 @@ import { createElement } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type * as PlatformFilterModule from './platform-filter-modal';
 import { AgentSessionListScreen } from './session-list-screen';
 
 type MountedRenderer = TestRenderer.ReactTestRenderer;
@@ -58,8 +59,10 @@ vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
   AppState: { addEventListener: appState.addEventListener },
   FlatList: 'FlatList',
+  Modal: 'Modal',
   Pressable: 'Pressable',
   RefreshControl: 'RefreshControl',
+  ScrollView: 'ScrollView',
   View: 'View',
   useWindowDimensions: () => ({ fontScale: 1 }),
 }));
@@ -83,15 +86,17 @@ vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({ invalidateQueries }),
 }));
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, options?: { label: string }) => (options ? `${key}: ${options.label}` : key),
+  }),
 }));
 vi.mock('@/i18n', () => ({
   i18n: { t: (key: string) => key, language: 'en' },
 }));
 // The real persisted-filters hook runs; only its native edges are stubbed, so
 // the apply/clear transitions below exercise the actual filter state. The
-// stored record resolves through `filterRecord` so a test can hold it pending.
-const readFilterRecord = vi.hoisted(() => vi.fn<() => Promise<string | null>>());
+// stored record resolves through `readFilterRecord` so a test can hold it pending.
+const readFilterRecord = vi.hoisted(() => vi.fn<(storageKey: string) => Promise<string | null>>());
 vi.mock('expo-secure-store', () => ({
   getItemAsync: readFilterRecord,
 }));
@@ -107,6 +112,8 @@ vi.mock('sonner-native', () => ({
 vi.mock('@/components/ui/icons', () => ({
   Plus: 'Plus',
   Bot: 'Bot',
+  Check: 'Check',
+  X: 'X',
   SlidersHorizontal: 'SlidersHorizontal',
 }));
 vi.mock('@/components/empty-state', () => ({
@@ -126,8 +133,8 @@ vi.mock('@/components/agents/session-list-content', () => ({
 vi.mock('@/components/agents/session-list-search-header', () => ({
   SessionListSearchHeader: 'SessionListSearchHeader',
 }));
-vi.mock('@/components/agents/platform-filter-modal', () => ({
-  SessionFilterChips: 'SessionFilterChips',
+vi.mock('@/components/agents/platform-filter-modal', async importOriginal => ({
+  ...(await importOriginal<typeof PlatformFilterModule>()),
   SessionFilterModal: 'SessionFilterModal',
 }));
 vi.mock('@/components/agents/active-now-section', () => ({
@@ -436,6 +443,145 @@ describe('AgentSessionListScreen live tab', () => {
     expect(filterButton.props.activeCount).toBe(0);
   });
 
+  it('keeps real pills, counts, results, and search placement in sync through removal', async () => {
+    const workflow = 'https://github.com/iscekic/kilo-workflow.git';
+    const code = 'https://github.com/Kilo-Org/kilocode.git';
+    sessionListState.activeSessions = [
+      {
+        id: 'workflow',
+        organizationId: null,
+        gitUrl: workflow,
+        createdOnPlatform: 'cloud-agent-web',
+      },
+      { id: 'code-cloud', organizationId: null, gitUrl: code, createdOnPlatform: 'cloud-agent' },
+      { id: 'code-cli', organizationId: null, gitUrl: code, createdOnPlatform: 'cli' },
+      {
+        id: 'other',
+        organizationId: null,
+        gitUrl: 'https://github.com/example/other.git',
+        createdOnPlatform: 'cloud-agent',
+      },
+    ];
+    const renderer = await renderScreen();
+    expect(findTypeCount(renderer, 'ScrollView')).toBe(0);
+    act(() => {
+      (requireHeaderAction(renderer, 'agents-open-filters').props.onPress as () => void)();
+    });
+    const modal = renderer.root.find(
+      node => typeof node.type === 'string' && (node.type as string) === 'SessionFilterModal'
+    );
+    act(() => {
+      (modal.props.onApply as (filters: unknown) => void)({
+        projectFilter: [workflow, code],
+        platformFilter: ['cloud-agent'],
+      });
+      (modal.props.onClose as () => void)();
+    });
+    const visibleIds = () => {
+      const rows = renderer.root.find(
+        node => typeof node.type === 'string' && (node.type as string) === 'FlatList'
+      ).props.data as MockActiveSession[];
+      return rows.map(row => row.id);
+    };
+    expect(visibleIds()).toEqual(['workflow', 'code-cloud']);
+    expect(requireHeaderAction(renderer, 'agents-open-filters').props.activeCount).toBe(3);
+    const strip = renderer.root.find(
+      node => typeof node.type === 'string' && (node.type as string) === 'ScrollView'
+    );
+    expect((strip.props.className as string | undefined)?.split(' ')).toEqual(
+      expect.arrayContaining(['grow-0', 'shrink-0'])
+    );
+    const selectedTree = renderer.toJSON() as TestRenderer.ReactTestRendererJSON;
+    expect(
+      selectedTree.children
+        ?.slice(0, 3)
+        .map(child => (typeof child === 'string' ? child : child.type))
+    ).toEqual(['ScreenHeader', 'SessionListSearchHeader', 'ScrollView']);
+
+    for (const step of [
+      {
+        label: 'agentChat.sessionFilter.removeProjectFilter: iscekic/kilo-workflow',
+        count: 2,
+        ids: ['code-cloud'],
+      },
+      {
+        label:
+          'agentChat.sessionFilter.removePlatformFilter: agentChat.sessionFilter.platformCloud',
+        count: 1,
+        ids: ['code-cloud', 'code-cli'],
+      },
+      {
+        label: 'agentChat.sessionFilter.removeProjectFilter: Kilo-Org/kilocode',
+        count: 0,
+        ids: ['workflow', 'code-cloud', 'code-cli', 'other'],
+      },
+    ]) {
+      act(() => {
+        const pill = renderer.root.findByProps({ accessibilityLabel: step.label });
+        (pill.props.onPress as () => void)();
+      });
+      expect(requireHeaderAction(renderer, 'agents-open-filters').props.activeCount).toBe(
+        step.count
+      );
+      expect(visibleIds()).toEqual(step.ids);
+    }
+    expect(findTypeCount(renderer, 'ScrollView')).toBe(0);
+    const clearedTree = renderer.toJSON() as TestRenderer.ReactTestRendererJSON;
+    expect(
+      clearedTree.children
+        ?.slice(0, 3)
+        .map(child => (typeof child === 'string' ? child : child.type))
+    ).toEqual(['ScreenHeader', 'SessionListSearchHeader', 'FlatList']);
+  });
+
+  it('keeps saved repository and platform selections after a successful list retry', async () => {
+    const gitUrl = 'https://github.com/example/a-long-saved-repository-name.git';
+    readFilterRecord.mockImplementation(async storageKey => {
+      await Promise.resolve();
+      return storageKey === 'live-session-filters'
+        ? JSON.stringify({ projectFilter: [gitUrl], platformFilter: ['cloud-agent'] })
+        : null;
+    });
+    sessionListState.isError = true;
+    const renderer = await renderScreen();
+    const error = renderer.root.find(
+      node => typeof node.type === 'string' && (node.type as string) === 'QueryError'
+    );
+    expect(error.props.message).toBe('agents.sessionList.couldNotLoadActive');
+    expect(requireHeaderAction(renderer, 'agents-open-filters').props.activeCount).toBe(2);
+    refetchSpy.mockImplementationOnce(async () => {
+      await Promise.resolve();
+      sessionListState.isError = false;
+      sessionListState.activeSessions = [
+        { id: 'matching', organizationId: null, gitUrl, createdOnPlatform: 'cloud-agent-web' },
+        { id: 'wrong-platform', organizationId: null, gitUrl, createdOnPlatform: 'cli' },
+        {
+          id: 'wrong-repository',
+          organizationId: null,
+          gitUrl: 'https://github.com/example/other.git',
+          createdOnPlatform: 'cloud-agent',
+        },
+      ];
+      return true;
+    });
+    await act(async () => {
+      (error.props.onRetry as () => void)();
+      await Promise.resolve();
+      renderer.update(createElement(AgentSessionListScreen));
+    });
+    expect(findTypeCount(renderer, 'QueryError')).toBe(0);
+    const rows = renderer.root.find(
+      node => typeof node.type === 'string' && (node.type as string) === 'FlatList'
+    ).props.data as MockActiveSession[];
+    expect(rows.map(row => row.id)).toEqual(['matching']);
+    expect(requireHeaderAction(renderer, 'agents-open-filters').props.activeCount).toBe(2);
+    expect(
+      renderer.root
+        .find(node => typeof node.type === 'string' && (node.type as string) === 'ScrollView')
+        .findAll(node => typeof node.type === 'string' && (node.type as string) === 'Pressable')
+    ).toHaveLength(2);
+  });
+
   it('filters the live list down to the applied repository', async () => {
     sessionListState.activeSessions = [
       { id: 'a1', organizationId: null, gitUrl: 'https://github.com/kilo/cloud.git' },
@@ -490,12 +636,16 @@ describe('AgentSessionListScreen live tab', () => {
       node => typeof node.type === 'string' && (node.type as string) === 'EmptyState'
     );
     expect(emptyState.props.title).toBe('agents.sessionList.noMatches');
+    expect(requireHeaderAction(renderer, 'agents-open-filters').props.activeCount).toBe(1);
+    expect(findTypeCount(renderer, 'ScrollView')).toBe(1);
 
     const clearAction = emptyState.props.action as { props: { onPress: () => void } };
     act(() => {
       clearAction.props.onPress();
     });
     expect(findTypeCount(renderer, 'FlatList')).toBe(1);
+    expect(requireHeaderAction(renderer, 'agents-open-filters').props.activeCount).toBe(0);
+    expect(findTypeCount(renderer, 'ScrollView')).toBe(0);
   });
 
   it('hides the FAB when there are no live rows', async () => {

--- a/apps/mobile/src/components/agents/tool-part-renderer.test.ts
+++ b/apps/mobile/src/components/agents/tool-part-renderer.test.ts
@@ -1,8 +1,13 @@
-import { type StoredMessage, type ToolPart } from '@kilocode/cloud-agent-sdk';
+/* eslint-disable max-lines -- routing fixtures and the shared status/part matrix cover both card entry points */
+import { type Part, type StoredMessage, type ToolPart } from '@kilocode/cloud-agent-sdk';
 import * as React from 'react';
+import { type ReactTestInstance } from 'react-test-renderer';
 import { describe, expect, it, vi } from 'vitest';
 
 import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
+import { renderWithProviders } from '@/test/render-with-providers';
+
+import '@/i18n';
 
 import {
   BashToolCard,
@@ -19,26 +24,21 @@ import {
   WriteToolCard,
 } from './tool-cards';
 import { SuggestToolCard } from './suggest-tool-card';
-import { ChildSessionSection } from './child-session-section';
+import { ChildSessionMessage, ChildSessionSection } from './child-session-section';
+import { getChildSessionActivityLabel, getChildSessionCardState } from './child-session-card-state';
 import { ToolPartRenderer } from './tool-part-renderer';
 
-// The seam test must not pull in React Native, so the child-session section is
-// mocked entirely. getTaskToolSessionId mirrors child-session-card-state so the
-// task-with-handlers route resolves a session id; the real extraction logic has
-// its own coverage in child-session-card-state.test.ts.
-vi.mock('./child-session-section', () => ({
-  ChildSessionSection: 'ChildSessionSection',
-  getTaskToolSessionId: (part: ToolPart) => {
-    if (part.tool !== 'task') {
-      return undefined;
-    }
-    const { state } = part;
-    if (state.status === 'running' || state.status === 'completed' || state.status === 'error') {
-      return state.metadata?.sessionId as string | undefined;
-    }
-    return undefined;
-  },
+vi.mock('react-native', () => ({ Pressable: 'Pressable', View: 'View' }));
+vi.mock('react-native-reanimated', () => ({
+  default: { View: 'AnimatedView' },
+  LinearTransition: { duration: () => ({}) },
 }));
+vi.mock('@/components/ui/icons', () => ({ Bot: 'Bot', Loader2: 'Loader2' }));
+vi.mock('@/components/ui/directional-icons', () => ({ DirectionalChevronRight: 'ChevronRight' }));
+vi.mock('@/components/ui/spinning-icon', () => ({ SpinningIcon: 'SpinningIcon' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({ useThemeColors: () => ({}) }));
+vi.mock('./message-error-boundary', () => ({ MessageErrorBoundary: 'MessageErrorBoundary' }));
 vi.mock('./suggest-tool-card', () => ({
   SuggestToolCard: 'SuggestToolCard',
 }));
@@ -87,7 +87,7 @@ function makeToolPart(tool: string, state: ToolPart['state']): ToolPart {
   };
 }
 
-function makeStoredMessage(): StoredMessage {
+function makeStoredMessage(parts: Part[] = []): StoredMessage {
   return {
     info: {
       id: 'm1',
@@ -103,7 +103,7 @@ function makeStoredMessage(): StoredMessage {
       cost: 0,
       tokens: { total: 0, input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
     },
-    parts: [],
+    parts,
   };
 }
 
@@ -168,6 +168,173 @@ const routingTable: [string, React.ElementType][] = [
   ['task', TaskToolCard],
   ['suggest', SuggestToolCard],
 ];
+
+function makeTaskState(status: ToolPart['state']['status']): ToolPart['state'] {
+  const input = taskCompletedState.input;
+  const metadata = taskCompletedState.metadata;
+  if (status === 'pending') {
+    return { status, input, raw: '' };
+  }
+  if (status === 'running') {
+    return { status, input, metadata, time: { start: 1 } };
+  }
+  if (status === 'error') {
+    return { status, input, metadata, error: 'failed', time: { start: 1, end: 2 } };
+  }
+  return taskCompletedState;
+}
+
+// eslint-disable-next-line typescript-eslint/no-deprecated -- the existing harness uses this DOM-free React renderer
+function textContent(node: ReactTestInstance | string): string {
+  return typeof node === 'string' ? node : node.children.map(textContent).join('');
+}
+
+const childPartBase = { id: 'activity', sessionID: 'child-1', messageID: 'child-message' };
+const textPart: Part = { ...childPartBase, type: 'text', text: 'The answer' };
+const activityParts: [string, Part, string][] = [
+  ['text', textPart, 'Writing response'],
+  [
+    'reasoning',
+    { ...childPartBase, type: 'reasoning', text: 'Thinking', time: { start: 1 } },
+    'Thinking',
+  ],
+  [
+    'snapshot progress',
+    { ...childPartBase, type: 'text', text: 'Initializing snapshot…', synthetic: true },
+    'Initializing snapshot…',
+  ],
+  ['step start', { ...childPartBase, type: 'step-start' }, 'Considering next steps'],
+  [
+    'step finish',
+    {
+      ...childPartBase,
+      type: 'step-finish',
+      reason: 'stop',
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    'Considering next steps',
+  ],
+];
+const toolActivities: [string, Record<string, unknown>, string][] = [
+  ['read', { filePath: '/project/spec.md' }, 'read spec.md'],
+  ['edit', { filePath: '/project/spec.md' }, 'edit spec.md'],
+  ['write', { filePath: '/project/spec.md' }, 'write spec.md'],
+  ['bash', { command: 'pnpm test' }, 'bash pnpm'],
+  ['glob', { pattern: '**/*.ts' }, 'glob **/*.ts'],
+  ['grep', { pattern: 'handler' }, 'grep handler'],
+  ['task', { description: 'Nested work' }, 'task Nested work'],
+  ...[
+    'list',
+    'patch',
+    'apply_patch',
+    'websearch',
+    'webfetch',
+    'codesearch',
+    'todoread',
+    'todowrite',
+    'question',
+    'suggest',
+    'plan_enter',
+    'plan_exit',
+    'unknown-tool',
+  ].map(tool => [tool, {}, tool] satisfies [string, Record<string, unknown>, string]),
+];
+const activityHistories: [string, StoredMessage[], string][] = [
+  ['empty history', [], 'Waiting for activity'],
+  ['incomplete history', [makeStoredMessage()], 'Waiting for activity'],
+  [
+    'delayed latest parts',
+    [makeStoredMessage([textPart]), makeStoredMessage()],
+    'Writing response',
+  ],
+  ...activityParts.map(
+    ([name, part, activity]) =>
+      [name, [makeStoredMessage([part])], activity] satisfies [string, StoredMessage[], string]
+  ),
+  ...toolActivities.flatMap(([tool, input, activity]) =>
+    (['pending', 'running', 'completed', 'error'] as const).map(
+      status =>
+        [
+          `${status} ${tool}`,
+          [makeStoredMessage([makeToolPart(tool, { ...makeTaskState(status), input })])],
+          activity,
+        ] satisfies [string, StoredMessage[], string]
+    )
+  ),
+];
+
+// One executable matrix checks the projection and both production entry points.
+describe.each(['top-level', 'nested'] as const)('%s child-card initial history', entry => {
+  describe.each([
+    { status: 'pending', active: true, canOpen: false },
+    { status: 'running', active: true, canOpen: true },
+    { status: 'completed', active: false, canOpen: true },
+    { status: 'error', active: false, canOpen: true },
+  ] as const)('$status parent', ({ status, active, canOpen }) => {
+    it.each(activityHistories)(
+      'keeps activity and child access consistent for %s',
+      async (_name, messages, activity) => {
+        const part = makeToolPart('task', makeTaskState(status));
+        const childMessages = canOpen ? messages : [];
+        const activeActivity = canOpen ? activity : 'Waiting for activity';
+        const expectedActivity = active ? activeActivity : '';
+        const modelLabel = childMessages.length > 0 ? 'Test Model' : '';
+        const projected = getChildSessionCardState(part, childMessages);
+        expect(getChildSessionActivityLabel(projected.latestActivity)).toBe(expectedActivity);
+
+        const openedChildren: [string, string][] = [];
+        const props = {
+          getChildMessages: (id: string) => (id === 'child-1' ? messages : []),
+          renderPart: () => null,
+          onOpenChildSession: (id: string, title: string) => {
+            openedChildren.push([id, title]);
+          },
+          modelOptions,
+        };
+        const element =
+          entry === 'top-level'
+            ? React.createElement(ToolPartRenderer, { ...props, part })
+            : React.createElement(ChildSessionMessage, {
+                ...props,
+                message: makeStoredMessage([part]),
+                depth: 1,
+              });
+        const { renderer, unmount } = await renderWithProviders(element);
+        try {
+          expect(textContent(renderer.root)).toBe(
+            `Generalchild task${modelLabel}${expectedActivity}${status}`
+          );
+          expect(renderer.root.findAll(node => node.type === 'SpinningIcon')).toHaveLength(
+            active ? 1 : 0
+          );
+          const button = renderer.root.findByType('Pressable');
+          expect(button.props.accessibilityRole).toBe('button');
+          expect(button.props.accessibilityLabel).toContain('General, child task');
+          expect(button.props.accessibilityLabel).toContain(status);
+          if (modelLabel) {
+            expect(button.props.accessibilityLabel).toContain(modelLabel);
+          }
+          if (active) {
+            expect(button.props.accessibilityLabel).toContain(expectedActivity);
+          } else {
+            expect(button.props.accessibilityLabel).not.toContain(activity);
+            expect(renderer.root.findAll(node => node.type === 'Text')).toHaveLength(
+              modelLabel ? 4 : 3
+            );
+          }
+          expect(button.props.disabled).toBe(!canOpen);
+          expect(button.props.accessibilityState).toEqual({ disabled: !canOpen });
+          const { onPress } = button.props as { onPress: () => void };
+          onPress();
+          expect(openedChildren).toEqual(canOpen ? [['child-1', 'child task']] : []);
+        } finally {
+          unmount();
+        }
+      }
+    );
+  });
+});
 
 describe('ToolPartRenderer routing', () => {
   it.each(routingTable)('routes tool %s to its card', (tool, card) => {

--- a/apps/mobile/src/components/agents/tool-part-renderer.test.ts
+++ b/apps/mobile/src/components/agents/tool-part-renderer.test.ts
@@ -1,9 +1,12 @@
 /* eslint-disable max-lines -- routing fixtures and the shared status/part matrix cover both card entry points */
 import { type Part, type StoredMessage, type ToolPart } from '@kilocode/cloud-agent-sdk';
 import * as React from 'react';
+import { Pressable } from 'react-native';
 import { type ReactTestInstance } from 'react-test-renderer';
 import { describe, expect, it, vi } from 'vitest';
 
+import { SpinningIcon } from '@/components/ui/spinning-icon';
+import { Text } from '@/components/ui/text';
 import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 import { renderWithProviders } from '@/test/render-with-providers';
 
@@ -305,10 +308,8 @@ describe.each(['top-level', 'nested'] as const)('%s child-card initial history',
           expect(textContent(renderer.root)).toBe(
             `Generalchild task${modelLabel}${expectedActivity}${status}`
           );
-          expect(renderer.root.findAll(node => node.type === 'SpinningIcon')).toHaveLength(
-            active ? 1 : 0
-          );
-          const button = renderer.root.findByType('Pressable');
+          expect(renderer.root.findAllByType(SpinningIcon)).toHaveLength(active ? 1 : 0);
+          const button = renderer.root.findByType(Pressable);
           expect(button.props.accessibilityRole).toBe('button');
           expect(button.props.accessibilityLabel).toContain('General, child task');
           expect(button.props.accessibilityLabel).toContain(status);
@@ -319,9 +320,7 @@ describe.each(['top-level', 'nested'] as const)('%s child-card initial history',
             expect(button.props.accessibilityLabel).toContain(expectedActivity);
           } else {
             expect(button.props.accessibilityLabel).not.toContain(activity);
-            expect(renderer.root.findAll(node => node.type === 'Text')).toHaveLength(
-              modelLabel ? 4 : 3
-            );
+            expect(renderer.root.findAllByType(Text)).toHaveLength(modelLabel ? 4 : 3);
           }
           expect(button.props.disabled).toBe(!canOpen);
           expect(button.props.accessibilityState).toEqual({ disabled: !canOpen });

--- a/apps/mobile/src/components/security-agent/finding-detail-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/security-agent/finding-detail-screen.mounted.test.tsx
@@ -1,16 +1,15 @@
 /* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer for RN trees under vitest (node env, no jsdom). */
 
-// Finding-detail dismiss retry-card contract: the card shows only when the
-// stored draft carries a non-null `lastError` (a pre-accept failure no command
-// observer will reconcile). A retryable failure offers Retry, a non-retryable
-// one hides it, and a cleared/absent draft (accept or empty) shows no card.
-// The screen stays mounted while the dismiss sheet is open, so it re-reads the
-// draft on focus.
+// Finding-detail load/back states and dismiss retry cards. The screen stays
+// mounted while the dismiss sheet is open, so it re-reads the draft on focus.
 
 import { createElement } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { QueryError } from '@/components/query-error';
+import { Skeleton } from '@/components/ui/skeleton';
+import { type SecurityFinding } from '@/lib/security-agent';
 import { FindingDetailScreen } from './finding-detail-screen';
 
 type Draft = {
@@ -32,7 +31,7 @@ const finding = vi.hoisted(() => ({
   isLoading: false,
   isError: false,
   error: null as unknown,
-  data: { status: 'open', repo_full_name: 'org/repo' },
+  data: undefined as Pick<SecurityFinding, 'status' | 'repo_full_name'> | undefined,
   refetch: vi.fn(),
 }));
 
@@ -50,9 +49,8 @@ const capability = vi.hoisted(() => ({
   refetch: vi.fn(),
 }));
 
-const trackInteraction = vi.hoisted(() => ({
-  mutate: vi.fn(),
-}));
+const trackInteraction = vi.hoisted(() => ({ mutate: vi.fn() }));
+const navigation = vi.hoisted(() => ({ history: [] as string[] }));
 
 // Captures the useFocusEffect callback so a test can simulate a focus event.
 const focusEffect = vi.hoisted(() => ({
@@ -72,14 +70,33 @@ const retryCards = vi.hoisted(() => ({
 vi.mock('react-native', () => ({
   View: 'View',
   Pressable: 'Pressable',
+  I18nManager: { isRTL: false },
+  Platform: { OS: 'ios' },
 }));
 vi.mock('@/components/ui/icons', () => ({
   Ban: 'Ban',
   ShieldOff: 'ShieldOff',
+  ChevronDown: 'ChevronDown',
+  AlertCircle: 'AlertCircle',
+  Lock: 'Lock',
+  SearchX: 'SearchX',
+  ServerCrash: 'ServerCrash',
+  WifiOff: 'WifiOff',
 }));
+vi.mock('@/components/ui/directional-icons', () => ({ DirectionalChevronLeft: 'ChevronLeft' }));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('expo-router', () => ({
-  useRouter: () => ({ push: vi.fn(), back: vi.fn(), replace: vi.fn() }),
-  useNavigation: () => ({ getState: vi.fn(() => ({})) }),
+  useRouter: () => ({
+    push: (href: string) => navigation.history.push(href),
+    back: () => navigation.history.pop(),
+    replace: (href: string) => navigation.history.splice(-1, 1, href),
+    // Parent history must not override the detail Stack's own history signal.
+    canGoBack: () => true,
+  }),
+  useNavigation: () => ({ getState: () => ({ index: navigation.history.length - 1 }) }),
   useFocusEffect: (effect: () => void) => {
     focusEffect.effect = effect;
   },
@@ -109,11 +126,11 @@ vi.mock('@/components/security-agent/security-command-retry-card', () => ({
     return null;
   },
 }));
-vi.mock('@/components/screen-header', () => ({ ScreenHeader: () => null }));
-vi.mock('@/components/empty-state', () => ({ EmptyState: () => null }));
-vi.mock('@/components/query-error', () => ({ QueryError: () => null }));
-vi.mock('@/components/ui/skeleton', () => ({ Skeleton: () => null }));
+vi.mock('@/components/ui/skeleton', () => ({ Skeleton: 'Skeleton' }));
 vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/components/ui/eyebrow', () => ({ Eyebrow: 'Text' }));
+vi.mock('@/components/ui/button', () => ({ Button: 'Pressable' }));
+vi.mock('@/lib/a11y/status-announcement', () => ({ useStatusAnnouncement: vi.fn() }));
 vi.mock('@/components/tab-screen', () => ({
   TabScreenScrollView: (props: { children?: unknown }) => props.children,
   useTabBarBottomPadding: () => 0,
@@ -127,56 +144,62 @@ vi.mock('@/components/security-agent/finding-details-panel', () => ({
 vi.mock('@/components/security-agent/finding-remediation-panel', () => ({
   FindingRemediationPanel: () => null,
 }));
-vi.mock('@/lib/finding-detail-back', () => ({
-  findingDetailBackTarget: vi.fn(() => ({ kind: 'pop' })),
-  findingDetailHasLocalHistory: vi.fn(() => false),
-}));
-vi.mock('@/lib/security-agent', () => ({
-  getSecurityAgentPath: (scope: string, section: string) => `/security/${scope}/${section}`,
-}));
 vi.mock('@/lib/utils', () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
 }));
 
 type R = TestRenderer.ReactTestRenderer;
+let renderer: R | undefined = undefined;
+const scopeRoot = '/(app)/(tabs)/(3_profile)/security-agent/personal';
+const detailPath = `${scopeRoot}/findings/finding-1`;
 
 function renderScreen(): R {
-  const ref: { current: R | undefined } = { current: undefined };
   act(() => {
-    ref.current = TestRenderer.create(
+    renderer = TestRenderer.create(
       createElement(FindingDetailScreen, { scope: 'personal', findingId: 'finding-1' })
     );
   });
-  const r = ref.current;
-  if (!r) {
+  if (!renderer) {
     throw new Error('renderer was not created');
   }
-  return r;
+  return renderer;
 }
 
-describe('FindingDetailScreen dismiss retry card states', () => {
-  beforeEach(() => {
-    dismissDraft.draft = null;
-    dismissDraft.hydrated = true;
-    dismissDraft.persist.mockClear();
-    dismissDraft.clear.mockClear();
-    dismissDraft.refresh.mockClear();
-    finding.isLoading = false;
-    finding.isError = false;
-    finding.data = { status: 'open', repo_full_name: 'org/repo' };
-    analysis.isLoading = false;
-    analysis.isError = false;
-    analysis.data = undefined;
-    capability.canManage = true;
-    capability.isLoading = false;
-    capability.isError = false;
-    trackInteraction.mutate.mockClear();
-    retryCards.cards = [];
-    focusEffect.effect = undefined;
-  });
+function press(tree: R, accessibilityLabel: string) {
+  const { onPress } = tree.root.findByProps({ accessibilityLabel }).props as {
+    onPress: () => void;
+  };
+  act(onPress);
+}
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  dismissDraft.draft = null;
+  dismissDraft.hydrated = true;
+  finding.isLoading = false;
+  finding.isError = false;
+  finding.error = null;
+  finding.data = { status: 'open', repo_full_name: 'org/repo' };
+  finding.refetch.mockReset();
+  analysis.isLoading = false;
+  analysis.isError = false;
+  analysis.data = undefined;
+  capability.canManage = true;
+  capability.isLoading = false;
+  capability.isError = false;
+  retryCards.cards = [];
+  focusEffect.effect = undefined;
+  navigation.history = [detailPath];
+});
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = undefined;
+  vi.unstubAllGlobals();
+});
+
+describe('FindingDetailScreen dismiss retry card states', () => {
   it('renders no retry card when there is no draft (empty)', () => {
-    dismissDraft.draft = null;
     renderScreen();
 
     expect(retryCards.cards).toHaveLength(0);
@@ -242,5 +265,83 @@ describe('FindingDetailScreen dismiss retry card states', () => {
     });
 
     expect(dismissDraft.refresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe.each([true, false])('finding load states with local history=%s', hasLocalHistory => {
+  beforeEach(() => {
+    navigation.history = hasLocalHistory ? [scopeRoot, detailPath] : [detailPath];
+  });
+
+  function expectSafeBack(tree: R) {
+    press(tree, 'screenHeader.goBack');
+    expect(navigation.history).toEqual(
+      hasLocalHistory ? [scopeRoot] : ['/(app)/(tabs)/(3_profile)']
+    );
+  }
+
+  it('keeps Back available during loading without offering Retry', () => {
+    finding.isLoading = true;
+    finding.data = undefined;
+    const tree = renderScreen();
+
+    expect(tree.root.findAllByType(Skeleton)).toHaveLength(4);
+    expect(tree.root.findAllByType(QueryError)).toHaveLength(0);
+    expect(tree.root.findAllByProps({ accessibilityLabel: 'common.retry' })).toHaveLength(0);
+    expectSafeBack(tree);
+  });
+
+  it('keeps Back safe while a transient load failure remains visible', () => {
+    finding.isError = true;
+    finding.error = { data: { code: 'INTERNAL_SERVER_ERROR' } };
+    finding.data = undefined;
+    const tree = renderScreen();
+
+    expect(tree.root.findAllByType(QueryError)).toHaveLength(1);
+    expectSafeBack(tree);
+  });
+
+  it('recovers the finding through Retry after a transient load failure', () => {
+    finding.isError = true;
+    finding.error = { data: { code: 'INTERNAL_SERVER_ERROR' } };
+    finding.data = undefined;
+    finding.refetch.mockImplementationOnce(() => {
+      finding.isError = false;
+      finding.error = null;
+      finding.data = { status: 'open', repo_full_name: 'org/recovered' };
+    });
+    const tree = renderScreen();
+    expect(
+      tree.root.findAllByProps({ children: 'securityAgent.findingDetail.couldNotLoad' })
+    ).toHaveLength(1);
+
+    press(tree, 'common.retry');
+    act(() => {
+      tree.update(
+        createElement(FindingDetailScreen, { scope: 'personal', findingId: 'finding-1' })
+      );
+    });
+
+    expect(tree.root.findAllByProps({ children: 'org/recovered' })).toHaveLength(1);
+    expect(tree.root.findAllByType(QueryError)).toHaveLength(0);
+    expect(tree.root.findAllByProps({ accessibilityLabel: 'common.retry' })).toHaveLength(0);
+    expectSafeBack(tree);
+  });
+
+  it.each(['NOT_FOUND', 'FORBIDDEN'])('shows unavailable guidance and safe Back for %s', code => {
+    finding.isError = true;
+    finding.error = { data: { code } };
+    finding.data = undefined;
+    const tree = renderScreen();
+
+    expect(
+      tree.root.findAllByProps({ children: 'securityAgent.findingDetail.notFound' })
+    ).toHaveLength(1);
+    expect(
+      tree.root.findAllByProps({ children: 'securityAgent.findingDetail.notFoundDescription' })
+    ).toHaveLength(1);
+    expect(tree.root.findAllByProps({ accessibilityLabel: 'common.retry' })).toHaveLength(0);
+    expect(tree.root.findAllByType(QueryError)).toHaveLength(0);
+    expectSafeBack(tree);
   });
 });

--- a/apps/mobile/src/lib/notifications.test.ts
+++ b/apps/mobile/src/lib/notifications.test.ts
@@ -1,22 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => {
-  const platform = { OS: 'android' as string };
-  return {
-    platform,
-    setNotificationChannelAsync: vi.fn(),
-    getPermissionsAsync: vi.fn(),
-    requestPermissionsAsync: vi.fn(),
-    getExpoPushTokenAsync: vi.fn(),
-    captureException: vi.fn(),
-    addNotificationResponseReceivedListener: vi.fn(),
-    clearLastNotificationResponse: vi.fn(),
-    notificationPathForData: vi.fn(),
-    setPendingDeepLink: vi.fn(),
-    safeParse: vi.fn(),
-    captureEvent: vi.fn(),
-  };
-});
+import type * as Notifications from '@kilocode/notifications';
+
+type Response = { notification: { request: { content: { data: unknown } } } };
+type ResponseListener = (response: Response) => void;
+
+const mocks = vi.hoisted(() => ({
+  platform: { OS: 'android' as string },
+  setNotificationChannelAsync: vi.fn(),
+  getPermissionsAsync: vi.fn(),
+  requestPermissionsAsync: vi.fn(),
+  getExpoPushTokenAsync: vi.fn(),
+  captureException: vi.fn(),
+  lastResponse: null as Response | null,
+  listeners: new Set<ResponseListener>(),
+  clearLastNotificationResponse: vi.fn(),
+  captureEvent: vi.fn(),
+}));
 
 vi.mock('react-native', () => ({
   Platform: mocks.platform,
@@ -28,8 +28,11 @@ vi.mock('expo-notifications', () => ({
   requestPermissionsAsync: mocks.requestPermissionsAsync,
   getExpoPushTokenAsync: mocks.getExpoPushTokenAsync,
   setNotificationHandler: vi.fn(),
-  addNotificationResponseReceivedListener: mocks.addNotificationResponseReceivedListener,
-  getLastNotificationResponse: vi.fn(),
+  addNotificationResponseReceivedListener: (listener: ResponseListener) => {
+    mocks.listeners.add(listener);
+    return { remove: () => mocks.listeners.delete(listener) };
+  },
+  getLastNotificationResponse: () => mocks.lastResponse,
   clearLastNotificationResponse: mocks.clearLastNotificationResponse,
   AndroidImportance: { HIGH: 4, DEFAULT: 3 },
   PermissionStatus: { GRANTED: 'granted', DENIED: 'denied', UNDETERMINED: 'undetermined' },
@@ -43,33 +46,30 @@ vi.mock('expo-constants', () => ({
   default: { expoConfig: { extra: { eas: { projectId: 'proj-1' } } } },
 }));
 
-vi.mock('@kilocode/notifications', () => ({
+vi.mock('@kilocode/notifications', async importOriginal => ({
+  ...(await importOriginal<typeof Notifications>()),
   ANDROID_NOTIFICATION_CHANNELS: [
     { id: 'agent', name: 'Agent sessions', importance: 'high' },
     { id: 'chat', name: 'Chat messages', importance: 'high' },
     { id: 'balance', name: 'Balance alerts', importance: 'default' },
   ],
-  pushDataSchema: { safeParse: mocks.safeParse },
-}));
-
-vi.mock('@/lib/deep-link-launch', () => ({
-  setPendingDeepLink: mocks.setPendingDeepLink,
-}));
-
-vi.mock('@/lib/notification-path', () => ({
-  notificationPathForData: mocks.notificationPathForData,
 }));
 
 vi.mock('@/lib/analytics/posthog', () => ({
   captureEvent: mocks.captureEvent,
 }));
 
-// Each test re-imports the module so the module-level single-flight promise
-// (`androidChannelsPromise`) starts fresh.
+// Each test starts with fresh channel and pending-link state. Only native
+// storage is replaced; payload parsing, mapping, and the pending slot are real.
 async function loadNotifications() {
   vi.resetModules();
-  const mod = await import('./notifications');
-  return mod;
+  const pending = await import('./deep-link-launch');
+  pending._setSecureStoreForTests({
+    setItemAsync: vi.fn().mockResolvedValue(undefined),
+    deleteItemAsync: vi.fn().mockResolvedValue(undefined),
+    getItemAsync: vi.fn().mockResolvedValue(null),
+  });
+  return { ...(await import('./notifications')), pending };
 }
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {
@@ -98,8 +98,11 @@ beforeEach(() => {
   mocks.getPermissionsAsync.mockResolvedValue({ status: 'denied' });
   mocks.requestPermissionsAsync.mockResolvedValue({ status: 'denied' });
   mocks.getExpoPushTokenAsync.mockResolvedValue({ data: 'expo-token' });
-  mocks.safeParse.mockReturnValue({ success: false });
-  mocks.addNotificationResponseReceivedListener.mockReset();
+  mocks.lastResponse = null;
+  mocks.listeners.clear();
+  mocks.clearLastNotificationResponse.mockImplementation(() => {
+    mocks.lastResponse = null;
+  });
 });
 
 describe('ensureAndroidNotificationChannels', () => {
@@ -198,51 +201,102 @@ describe('channel creation ordering', () => {
   });
 });
 
-describe('setupNotificationResponseHandler', () => {
-  type ResponseListener = (response: {
-    notification: { request: { content: { data: unknown } } };
-  }) => void;
+const securityResponses = ['personal', 'org-example'].flatMap(scope =>
+  (
+    [
+      { type: 'security_finding' },
+      { type: 'security_lifecycle', event: 'analysis_completed' },
+    ] as const
+  ).map(payload => ({
+    data: { ...payload, scope, findingId: 'finding-123' } satisfies Notifications.PushData,
+    path: `/(app)/(tabs)/(3_profile)/security-agent/${scope}/findings/finding-123?via=push`,
+  }))
+);
+const responseCases = [
+  {
+    data: { type: 'chat.message', sandboxId: 's1', conversationId: 'c1', messageId: 'm1' },
+    path: '/(app)/(tabs)/(1_kiloclaw)/chat/s1/c1?via=push',
+  },
+  ...securityResponses,
+];
 
-  it('stashes the destination and does not navigate', async () => {
-    mocks.safeParse.mockReturnValue({ success: true, data: { type: 'chat.message' } });
-    mocks.notificationPathForData.mockReturnValue('/(app)/(tabs)/(1_kiloclaw)/chat/s1/c1?via=push');
-    mocks.addNotificationResponseReceivedListener.mockImplementation(
-      (listener: ResponseListener) => {
-        listener({
-          notification: { request: { content: { data: { type: 'chat.message' } } } },
-        });
-        return { remove: vi.fn() };
+function deliverWarmResponse(response: Response) {
+  for (const listener of mocks.listeners) {
+    listener(response);
+  }
+}
+
+describe.each(['cold', 'warm'])('%s notification responses', mode => {
+  it.each(responseCases)(
+    'stashes $data.type at $path once and removes the listener',
+    async ({ data, path }) => {
+      const { setupNotificationResponseHandler, checkInitialNotification, pending } =
+        await loadNotifications();
+      const response = { notification: { request: { content: { data } } } };
+      mocks.lastResponse = response;
+      const subscription = setupNotificationResponseHandler();
+
+      if (mode === 'cold') {
+        checkInitialNotification();
+      } else {
+        deliverWarmResponse(response);
       }
-    );
 
-    const { setupNotificationResponseHandler } = await loadNotifications();
-    setupNotificationResponseHandler();
+      expect(pending.getPendingDeepLinkSnapshot()).toBe(path);
+      expect(mocks.lastResponse).toBeNull();
+      expect(pending.getPendingDeepLink()).toBe(path);
+      checkInitialNotification();
+      expect(pending.getPendingDeepLinkSnapshot()).toBeNull();
 
-    expect(mocks.setPendingDeepLink).toHaveBeenCalledWith(
-      '/(app)/(tabs)/(1_kiloclaw)/chat/s1/c1?via=push',
-      'notification'
-    );
-    expect(mocks.clearLastNotificationResponse).toHaveBeenCalled();
-  });
+      subscription.remove();
+      deliverWarmResponse(response);
+      expect(pending.getPendingDeepLinkSnapshot()).toBeNull();
+    }
+  );
 
-  it('ignores a response with unparseable data', async () => {
-    mocks.safeParse.mockReturnValue({ success: false });
-    mocks.addNotificationResponseReceivedListener.mockImplementation(
-      (listener: ResponseListener) => {
-        listener({
-          notification: { request: { content: { data: { type: 'chat.message' } } } },
-        });
-        return { remove: vi.fn() };
-      }
-    );
+  it.each([
+    null,
+    { type: 'security_finding', scope: 'personal' },
+    { type: 'security_finding', scope: [], findingId: 'finding-invalid' },
+    {
+      type: 'security_lifecycle',
+      event: 'unknown',
+      scope: 'org-example',
+      findingId: 'finding-invalid',
+    },
+  ])('preserves the pending destination for malformed data %j', async data => {
+    const { setupNotificationResponseHandler, checkInitialNotification, pending } =
+      await loadNotifications();
+    const existing = '/(app)/(tabs)/(3_profile)';
+    pending.setPendingDeepLink(existing, 'notification');
+    const response = { notification: { request: { content: { data } } } };
+    mocks.lastResponse = response;
+    const subscription = setupNotificationResponseHandler();
 
-    const { setupNotificationResponseHandler } = await loadNotifications();
-    setupNotificationResponseHandler();
+    if (mode === 'cold') {
+      checkInitialNotification();
+    } else {
+      deliverWarmResponse(response);
+    }
 
-    expect(mocks.setPendingDeepLink).not.toHaveBeenCalled();
-    expect(mocks.clearLastNotificationResponse).not.toHaveBeenCalled();
+    expect(pending.getPendingDeepLinkSnapshot()).toBe(existing);
+    expect(mocks.lastResponse).toBe(mode === 'cold' ? null : response);
+    subscription.remove();
   });
 });
+
+it.each([null, '/(app)/(tabs)/(3_profile)'])(
+  'leaves pending destination %s unchanged without a last response',
+  async destination => {
+    const { checkInitialNotification, pending } = await loadNotifications();
+    if (destination) {
+      pending.setPendingDeepLink(destination, 'universal-link');
+    }
+    checkInitialNotification();
+    expect(pending.getPendingDeepLinkSnapshot()).toBe(destination);
+    expect(mocks.clearLastNotificationResponse).not.toHaveBeenCalled();
+  }
+);
 
 describe('notification permission and token events', () => {
   it('emits granted when a live permission request is granted', async () => {

--- a/apps/mobile/src/lib/security-notification-navigation.mounted.test.tsx
+++ b/apps/mobile/src/lib/security-notification-navigation.mounted.test.tsx
@@ -1,0 +1,173 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer mounts native trees without a DOM. */
+
+// eslint-disable-next-line import/no-nodejs-modules -- Load the installed router without the native Expo entry.
+import { createRequire } from 'node:module';
+import type * as StackRouterModule from 'expo-router/build/react-navigation/routers/StackRouter.js';
+import { Children, createElement, isValidElement, type ReactNode } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type PushData } from '@kilocode/notifications';
+
+import SecurityAgentScopeLayout from '@/app/(app)/(tabs)/(3_profile)/security-agent/[scope]/_layout';
+import { InvalidRouteState } from '@/components/invalid-route-state';
+import { notificationPathForData } from './notification-path';
+
+const loadRouter = createRequire(import.meta.url);
+const { StackActions, StackRouter: createStackRouter } = loadRouter(
+  'expo-router/build/react-navigation/routers/StackRouter.js'
+) as typeof StackRouterModule;
+type RouterAction = Parameters<ReturnType<typeof createStackRouter>['getStateForAction']>[1];
+type StackProps = { initialRouteName?: string; children?: ReactNode };
+
+const captured = vi.hoisted(() => ({
+  scope: 'personal' as string | string[] | undefined,
+  stack: undefined as StackProps | undefined,
+}));
+
+vi.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ scope: captured.scope }),
+  Stack: Object.assign(
+    (props: StackProps): ReactNode => {
+      captured.stack = props;
+      return props.children;
+    },
+    { Screen: () => null }
+  ),
+}));
+vi.mock('@/components/invalid-route-state', () => ({ InvalidRouteState: 'InvalidRouteState' }));
+vi.mock('@/components/security-agent/security-agent-command-observer', () => ({
+  SecurityAgentCommandObserver: 'SecurityAgentCommandObserver',
+}));
+vi.mock('@/components/privacy-cover-overlay', () => ({
+  privacyScreenLayout: ({ children }: { children: ReactNode }): ReactNode => children,
+}));
+vi.mock('@/lib/form-sheet', () => ({ useFormSheetDetents: () => ({ fullSheetDetent: 1 }) }));
+
+let renderer: TestRenderer.ReactTestRenderer | undefined = undefined;
+
+beforeEach(() => {
+  captured.stack = undefined;
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+});
+afterEach(() => {
+  act(() => renderer?.unmount());
+  renderer = undefined;
+  vi.unstubAllGlobals();
+});
+
+function mountScope(scope: string | string[] | undefined) {
+  captured.scope = scope;
+  act(() => {
+    renderer = TestRenderer.create(createElement(SecurityAgentScopeLayout));
+  });
+  if (!renderer) {
+    throw new Error('Scope layout did not mount');
+  }
+  return renderer;
+}
+
+function initializeScope(scope: string) {
+  mountScope(scope);
+  const stack = captured.stack;
+  if (!stack) {
+    throw new Error('Scope layout did not render a Stack');
+  }
+  // eslint-disable-next-line react/no-react-children -- Read the actual Stack.Screen declarations for this layout regression.
+  const declaredNames = Children.toArray(stack.children).map(child => {
+    if (!isValidElement<{ name: string }>(child)) {
+      throw new Error('Expected a Stack.Screen declaration');
+    }
+    return child.props.name;
+  });
+  // Expo Router puts explicit declarations before the remaining file routes.
+  const options = {
+    routeNames: [...declaredNames, 'index', 'findings/index', 'findings/[id]'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  const router = createStackRouter({ initialRouteName: stack.initialRouteName });
+  let state = router.getInitialState(options);
+  return {
+    initialState: state,
+    apply: (action: RouterAction) => {
+      const next = router.getStateForAction(state, action, options);
+      if (!next) {
+        throw new Error(`Router rejected ${action.type}`);
+      }
+      state = next;
+      return state;
+    },
+  };
+}
+
+// Router-model POP is not evidence for a native gesture or the response handlers.
+describe.each(['personal', 'org-example'])('security notification history (%s)', scope => {
+  it.each([
+    { type: 'security_finding' },
+    { type: 'security_lifecycle', event: 'analysis_completed' },
+  ] as const)('initializes index beneath a $type entry without a duplicate loop', payload => {
+    const { initialState, apply } = initializeScope(scope);
+    expect(initialState.routeNames).toEqual([
+      'dismiss/[id]',
+      'filter',
+      'index',
+      'findings/index',
+      'findings/[id]',
+    ]);
+    expect(initialState.routes.map(route => route.name)).toEqual(['index']);
+    expect(initialState.routes[0]?.params).toBeUndefined();
+
+    const data = { ...payload, scope, findingId: 'finding-123' } satisfies PushData;
+    const path = notificationPathForData(data);
+    expect(path).toBe(
+      `/(app)/(tabs)/(3_profile)/security-agent/${scope}/findings/finding-123?via=push`
+    );
+    const url = new URL(path, 'https://example.test');
+    const segments = url.pathname.split('/');
+    const action = {
+      type: 'NAVIGATE',
+      payload: {
+        name: 'findings/[id]',
+        params: {
+          scope: segments.at(-3),
+          id: segments.at(-1),
+          via: url.searchParams.get('via'),
+        },
+      },
+    } as const;
+    const opened = apply(action);
+    expect(opened.routes.map(({ name, params }) => ({ name, params }))).toEqual([
+      { name: 'index', params: undefined },
+      { name: 'findings/[id]', params: { scope, id: 'finding-123', via: 'push' } },
+    ]);
+    expect(apply(action)).toEqual(opened);
+    expect(apply(StackActions.pop())).toEqual(initialState);
+  });
+
+  it('returns from an ordinary detail push to the same filtered findings list', () => {
+    const { apply } = initializeScope(scope);
+    const list = apply(
+      StackActions.push('findings/index', {
+        scope,
+        repoFullName: 'org/repo',
+        status: 'open',
+        severity: 'critical',
+        sortBy: 'sla_due_at_asc',
+      })
+    );
+    apply(StackActions.push('findings/[id]', { scope, id: 'finding-ordinary' }));
+    expect(apply(StackActions.pop())).toEqual(list);
+  });
+});
+
+it.each([{ scope: undefined }, { scope: '' }, { scope: ['personal', 'org-example'] }])(
+  'rejects invalid scope $scope before mounting the Stack',
+  ({ scope }) => {
+    const tree = mountScope(scope);
+    expect(tree.root.findByType(InvalidRouteState).props).toMatchObject({
+      backTo: '/(app)/(tabs)/(3_profile)/security-agent',
+    });
+    expect(captured.stack).toBeUndefined();
+  }
+);

--- a/apps/mobile/src/lib/security-notification-navigation.mounted.test.tsx
+++ b/apps/mobile/src/lib/security-notification-navigation.mounted.test.tsx
@@ -159,7 +159,10 @@ describe.each(['personal', 'org-example'])('security notification history (%s)',
     apply(StackActions.push('findings/[id]', { scope, id: 'finding-ordinary' }));
     expect(apply(StackActions.pop())).toEqual(list);
 
-    const reset = apply({ type: 'RESET', payload: { routes: list.routes } });
+    const reset = apply({
+      type: 'RESET',
+      payload: { routes: list.routes.map(({ key, name, params }) => ({ key, name, params })) },
+    });
     expect(reset.routes).toEqual(list.routes);
     apply(StackActions.push('findings/[id]', { scope, id: 'finding-ordinary' }));
     expect(apply(StackActions.pop())).toEqual(reset);

--- a/apps/mobile/src/lib/security-notification-navigation.mounted.test.tsx
+++ b/apps/mobile/src/lib/security-notification-navigation.mounted.test.tsx
@@ -95,7 +95,7 @@ function initializeScope(scope: string) {
       if (!next) {
         throw new Error(`Router rejected ${action.type}`);
       }
-      state = next;
+      state = router.getRehydratedState(next, options);
       return state;
     },
   };
@@ -145,7 +145,7 @@ describe.each(['personal', 'org-example'])('security notification history (%s)',
     expect(apply(StackActions.pop())).toEqual(initialState);
   });
 
-  it('returns from an ordinary detail push to the same filtered findings list', () => {
+  it('returns to the same filtered findings list before and after a partial reset', () => {
     const { apply } = initializeScope(scope);
     const list = apply(
       StackActions.push('findings/index', {
@@ -158,6 +158,11 @@ describe.each(['personal', 'org-example'])('security notification history (%s)',
     );
     apply(StackActions.push('findings/[id]', { scope, id: 'finding-ordinary' }));
     expect(apply(StackActions.pop())).toEqual(list);
+
+    const reset = apply({ type: 'RESET', payload: { routes: list.routes } });
+    expect(reset.routes).toEqual(list.routes);
+    apply(StackActions.push('findings/[id]', { scope, id: 'finding-ordinary' }));
+    expect(apply(StackActions.pop())).toEqual(reset);
   });
 });
 


### PR DESCRIPTION
## Summary

- Queued messages now offer Cancel in message details, not beside the message. The action shows progress and prevents repeat cancellation taps.
- Cancellation errors appear in the open message details. Update guidance remains available when you reopen the message.
- Canceled messages offer Restore immediately when you already have a draft. Restore keeps the text and attachments and removes the canceled message.
- Press and hold an attachment to open message details. Taps still open previews, file actions, or retries.
- Screen readers offer message details and offer Copy only when there is text to copy. Links and other controls remain reachable.
- Opening a Security Agent notification no longer adds a dismissal screen that has no finding selected.
- Cards for completed or failed child agents no longer show active-work text. Their names, models, statuses, and conversations remain available.
- Repository and platform filters stay in a compact horizontal row on Live Agents and History. Long labels stay on one line, with usable remove controls.

---

### Maintainer changelog

`CancelQueuedStatus` separates sheet and screen feedback by message and attempt; live delivery checks and synchronous guards reject stale or duplicate cancellations.
Successful cancellation restores text and files only into an empty composer; an occupied composer keeps its draft and offers Restore on the retained row.
Session changes discard late results; older command-line interface (CLI) connections retain upgrade guidance until a different `ownerConnectionId` arrives, without an interrupt fallback.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/session-detail-content.tsx` — Source; M (modified); 282 changed lines. Resolves selection from live state, guards duplicate requests, and leaves failed or refused drops untouched. Separates announcements, handles replacement connections, preserves Restore through delayed delivery updates, and uses visible rows for the empty state.
- `apps/mobile/src/components/agents/session-detail-content.test.ts` — Test; M (modified); 1,034 changed lines. Updates cancellation and restoration regression tests.

</details>

`MessageDetailsSheetProps` adds optional `canCancelQueued`, `isCancelingQueued`, `onCancelQueued`, `cancelQueuedFeedback`, and `cancelQueuedGuidance` controls; callers that omit them keep existing behavior.
The cancellation action uses a 48-point minimum height and exposes disabled and busy states while the request runs.
Failures remain readable inside the sheet; attempt identity supports repeated failure announcements, while persistent upgrade guidance does not repeat an outcome announcement.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/message-details-sheet.tsx` — Source; M (modified); 54 changed lines. Adds the guarded cancellation action, progress indicator, accessible feedback, and separate persistent guidance without changing Copy, Select Text, or Report.
- `apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx` — Test; M (modified); 224 changed lines. Updates the mounted sheet regression tests.
- `apps/mobile/src/components/agents/message-details-sheet.test.ts` — Test; M (modified); 30 changed lines. Updates the message details regression tests.

</details>

`MessageBubbleProps` removes `onCancelQueued`; callers must use the details sheet, while the queued badge and Restore action remain.
Optional `AgentMessageBubbleA11yInput.canOpenDetails` enables the `details` accessibility action; `copy` appears only for copyable content, and interactive descendants remain reachable.
Optional `FilePartRendererProps.onLongPress` forwards attachment holds to message details without changing image previews, file actions, or retry taps.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/message-bubble.tsx` — Source; M (modified); 52 changed lines. Removes inline Cancel, derives Copy availability, dispatches details and Copy actions, and forwards attachment holds. Omits the host when neither action exists; Restore keeps its platform minimum height.
- `apps/mobile/src/components/agents/message-bubble-a11y.ts` — Source; M (modified); 25 changed lines. Adds conditional details actions and hints alongside Copy, retaining the separate action host contract.
- `apps/mobile/src/components/agents/file-part-renderer.tsx` — Source; M (modified); 7 changed lines. Forwards holds from image, file, and retry controls while retaining their tap handlers.
- `apps/mobile/src/components/agents/message-bubble-a11y.test.ts` — Test; M (modified); 170 changed lines. Updates the message accessibility contract tests.
- `apps/mobile/src/components/agents/message-bubble-accessibility.test.ts` — Test; M (modified); 258 changed lines. Updates the message accessibility regression tests.
- `apps/mobile/src/components/agents/message-bubble.test.ts` — Test; M (modified); 213 changed lines. Updates the message action regression tests.
- `apps/mobile/src/components/agents/file-part-renderer.mounted.test.tsx` — Test; M (modified); 105 changed lines. Updates the mounted attachment regression tests.

</details>

Scoped Security Agent navigation sets `Stack.initialRouteName` to `index`, preventing anchored notifications from starting on a dismissal screen without a finding identifier.
Notification payloads, authentication, scope validation, dismissal sheets, and existing Back behavior stay unchanged.
Router-model tests cover personal and organization entries, repeated notifications, filtered-list returns, partial resets, and invalid scopes; they do not prove native gestures.

<details>
<summary>Files</summary>

- `apps/mobile/src/app/(app)/(tabs)/(3_profile)/security-agent/[scope]/_layout.tsx` — Source; M (modified); 7 changed lines. Selects the scoped dashboard as the initial screen while preserving the command observer and sheet options.
- `apps/mobile/src/lib/security-notification-navigation.mounted.test.tsx` — Test; A (added); 181 changed lines. Exercises the mounted scope layout with the installed stack router and notification destinations.
- `apps/mobile/src/lib/notifications.test.ts` — Test; M (modified); 196 changed lines. Updates the notification entry regression tests.
- `apps/mobile/src/components/security-agent/finding-detail-screen.mounted.test.tsx` — Test; M (modified); 201 changed lines. Updates the finding detail navigation regression tests.

</details>

`ChildSessionCardState.latestActivity` returns an empty string for `completed` or `error` task states, so terminal cards stop showing active-work or waiting text.
The display omits the activity row and its accessible text, while keeping the agent, task, model, status, and child access.
Pending and running tasks keep their activity display; historical terminal messages receive the same presentation without a data migration.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/child-session-card-state.ts` — Source; M (modified); 5 changed lines. Stops activity lookup for terminal task states and returns an empty activity label.
- `apps/mobile/src/components/agents/child-session-section.tsx` — Source; M (modified); 28 changed lines. Renders the activity row only when activity exists, retaining metadata, status styling, and child navigation.
- `apps/mobile/src/components/agents/child-session-card-state.test.ts` — Test; M (modified); 62 changed lines. Updates the child activity state regression tests.
- `apps/mobile/src/components/agents/child-session-message.test.ts` — Test; M (modified); 77 changed lines. Updates the child message regression tests.
- `apps/mobile/src/components/agents/tool-part-renderer.test.ts` — Test; M (modified); 206 changed lines. Updates the tool rendering regression tests.

</details>

`SessionFilterChips` keeps the scroll row at its content height, with centered, nonshrinking controls shared by Live Agents and History.
Labels stay on one line within 220 points, and each remove control keeps a minimum size of 48 by 48 points.
`AgentSessionFilters`, saved selections, application, and removal callbacks keep their existing contracts.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/platform-filter-modal.tsx` — Source; M (modified); 16 changed lines. Replaces inline spacing with classes, prevents row growth, limits label widths, and sets minimum touch targets.
- `apps/mobile/src/components/agents/platform-filter-modal.mounted.test.tsx` — Test; A (added); 293 changed lines. Adds mounted filter control regression tests.
- `apps/mobile/src/components/agents/session-history-screen.mounted.test.tsx` — Test; M (modified); 306 changed lines. Updates the History regression tests.
- `apps/mobile/src/components/agents/session-list-screen.mounted.test.tsx` — Test; M (modified); 160 changed lines. Updates the Live Agents regression tests.

</details>

Tests: 16 changed files (14 modified; 2 added): `child-session-card-state.test.ts`, `child-session-message.test.ts`, `file-part-renderer.mounted.test.tsx`, `message-bubble-a11y.test.ts`, `message-bubble-accessibility.test.ts`, `message-bubble.test.ts`, `message-details-sheet.mounted.test.tsx`, `message-details-sheet.test.ts`, `platform-filter-modal.mounted.test.tsx`, `session-detail-content.test.ts`, `session-history-screen.mounted.test.tsx`, `session-list-screen.mounted.test.tsx`, `tool-part-renderer.test.ts`, `finding-detail-screen.mounted.test.tsx`, `notifications.test.ts`, `security-notification-navigation.mounted.test.tsx`. The tests account for 3,716 changed lines.
Generated: 0 files changed.

---

## Verification

No full native pass or reporter/upload task exists.
Further native work is skipped because the owner ended device verification and authorized delivery with the recorded limitations.
The native verifier reports these passed paths on iOS:

- Two genuine warm personal finding notifications opened the intended finding and repository through native banners.
- Native edge-back exited the repeated finding. Visible Back reached Profile, and Home opened a usable task screen without a duplicate finding loop.
- The Profile tab reopened its root without retaining the finding.

The organization scope remains unproved after the Security Agent load error recurred.
The remaining notification matrix, live cancellation, child transitions and history, filter sizing, and accessibility checks remain incomplete.

## Visual Changes

Visual Changes: N/A

Native before/after screenshots and recordings are not attached.

## Reviewer Notes

### Human steps

- **Before merge: Attach the retained native demo and stills.** The dispatcher must not upload them or claim attachment.
- After merge: Add secure per-procedure tRPC error reporting in a separate change; it does not block this PR.
- No extra setup, secret, migration, feature-flag, or deploy-order steps are required before or after merge.

### Check status

- The handoff reports passing changed-file tests, lint, format, and whitespace checks.
- No local package-wide typecheck or build ran.
- The handoff reports passing current-head mobile and root continuous integration (CI), including the repository-wide typecheck.
- The final navigation suite passed nine tests.
- Native workflow `33269785718` succeeded by reusing matching iOS and Android artifacts; it did not compile fresh native builds.
- Later changes affect JavaScript and tests only; no native inputs changed.
- No English keys were added; no translation pass was needed.
- The current mechanical gate returned ALL GATES OK (1 PRs) on the unchanged review head.

### Review scope

- Repository: `Kilo-Org/cloud`.
- Worktree: `/Users/igor/Projects/.worktrees/mobile-ui-repairs-63e7`.
- Base: `origin/main` (`79026ffcdc2d`).
- Head: `mobile-ui-repairs-63e7-s1` (`c0b42f212c5d`).
- Diff size: 25 changed files, 3,391 insertions, and 801 deletions.

### Notes

Native verification is incomplete. Repeated genuine notification entry, native edge-back, safe exit to Home, and Profile root passed.

The organization Security Agent scope screen remains unproved. Its load error recurred once; no product defect was established.

Nothing in the harness reports which procedure inside a tRPC batch failed. HTTP 207 is routine batch status, not the failure diagnosis.

The remaining notification matrix, live queue cancellation/restoration, child transition/history, filter sizing, and accessibility checks remain unproved.

Matching native artifacts were reused; no fresh native compilation is claimed. Deterministic tests do not prove native server-error reproduction.

Deterministic fault tests do not prove native server-error reproduction.

The organization Security Agent scope screen remains unproved. The owner explicitly waived native proof for that screen for this section only.

The investigation eliminated three named hypotheses: missing fixture data, denied organization permission, and missing mandatory preconditions. The finding exists, middleware granted access, and all four handlers tolerate absent optional rows.

The harness cannot identify the failing procedure. `apps/web/src/app/api/trpc/[trpc]/route.ts` configures `fetchRequestHandler` without an `onError` hook, leaving no per-procedure error evidence. The owner requested a separate follow-up for secure per-procedure error reporting; that product change is outside PR 5725.

Two genuine warm personal notification entries, native edge-back, visible Back, safe Home exit, and Profile root passed independently. The organization screen did not pass.

The remaining notification matrix, live queue cancellation/restoration, child transition/history, filter sizing, and accessibility checks remain unproved. Further native work is skipped because the owner ended device verification and authorized delivery with the recorded limitations.

No full native pass or evidence upload is claimed. The owner authorizes readiness under the recorded waiver and stop decision, not a broader claim of runtime coverage.

Merge remains the owner's decision; this task does not merge.
