### PR TITLE
feat(pr-review): evaluate evidenced check requirements

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-requirements.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-requirements.test.ts
@@ -1,0 +1,440 @@
+import {
+  GitHubPrReviewContextSchema,
+  type GitHubPrReviewContext,
+  type GitHubPrReviewRevision,
+  type GitHubPrReviewSource,
+} from './context-dtos';
+import { normalizeContextPolicies } from './context-rules';
+import {
+  contextCheckSchema,
+  evaluateContextRequirements,
+  type RequirementCollection,
+  type RequirementFacts,
+  type RequirementObservations,
+} from './context-requirements';
+
+type Check = GitHubPrReviewContext['checks']['items'][number];
+const revision: GitHubPrReviewRevision = {
+  prNodeId: 'PR',
+  number: 1,
+  headSha: 'head',
+  baseRepoFullName: 'o/r',
+  baseRef: 'release',
+  baseSha: 'base',
+};
+const source: GitHubPrReviewSource = {
+  availability: 'available',
+  retryable: false,
+  reason: null,
+  provenance: ['graphql.observation'],
+  observedAt: '2026-08-29T00:00:00Z',
+};
+const collection = <T>(
+  items: T[],
+  patch: Partial<RequirementCollection<T>> = {}
+): RequirementCollection<T> => ({
+  items,
+  source,
+  completeness: 'complete',
+  knownCount: items.length,
+  totalCount: items.length,
+  hasNextPage: false,
+  endCursor: null,
+  ...patch,
+});
+const field = <T>(data: T) => ({ data, source });
+const checkPolicy = (app_id: number | null = -1, strict = false) => ({
+  required_status_checks: { strict, contexts: ['ci'], checks: [{ context: 'ci', app_id }] },
+});
+const reviewPolicy = {
+  required_pull_request_reviews: {
+    required_approving_review_count: 2,
+    dismiss_stale_reviews: false,
+    require_code_owner_reviews: false,
+    require_last_push_approval: false,
+  },
+};
+function setup(classic: unknown = checkPolicy(), rules: unknown[] = []) {
+  const context = GitHubPrReviewContextSchema.parse({ revision });
+  context.requirements = normalizeContextPolicies(
+    revision,
+    collection(classic === null ? [] : [classic], {
+      source: { ...source, provenance: ['rest.branchProtection'] },
+    }),
+    collection(rules, { source: { ...source, provenance: ['rest.branchRules'] } })
+  );
+  context.reviewDecisions = collection([]);
+  context.reviewActivity = collection([]);
+  const configured = classic as Partial<
+    ReturnType<typeof checkPolicy> &
+      typeof reviewPolicy & {
+        required_conversation_resolution: { enabled: boolean };
+      }
+  > | null;
+  const facts: RequirementFacts = {
+    mergeable: field('MERGEABLE'),
+    testMerge: field(null),
+    canBypassClassic: field(false),
+    comparison: field({ behindBy: 0, baseTarget: { oid: 'base' }, headTarget: { oid: 'head' } }),
+    viewerRule: {
+      requiredApprovingReviewCount: field(
+        configured?.required_pull_request_reviews?.required_approving_review_count ?? 0
+      ),
+      requiredStatusCheckContexts: field(configured?.required_status_checks?.contexts ?? []),
+      requiresConversationResolution: field(
+        configured?.required_conversation_resolution?.enabled ?? false
+      ),
+    },
+  };
+  const observations: RequirementObservations = {
+    head: collection([]),
+    merge: null,
+    threads: collection([]),
+    eligibleReviews: collection([]),
+    deployments: collection([]),
+  };
+  return { context, facts, observations };
+}
+type Scenario = ReturnType<typeof setup>;
+const evaluate = ({ context, facts, observations }: Scenario) =>
+  evaluateContextRequirements(context, facts, observations);
+const requirements = (scenario: Scenario, kind: string) =>
+  evaluate(scenario).requirements.items.filter(row => row.kind === kind);
+function run(id: string, app = 7, patch: Record<string, unknown> = {}) {
+  return {
+    __typename: 'CheckRun',
+    id,
+    name: 'ci',
+    status: 'COMPLETED',
+    conclusion: 'SUCCESS',
+    isRequired: true,
+    detailsUrl: null,
+    checkSuite: {
+      app: { id: `APP_${app}`, databaseId: app, slug: `app-${app}`, name: 'Same display name' },
+      commit: { oid: 'head' },
+    },
+    ...patch,
+  };
+}
+function status(id: string, patch: Record<string, unknown> = {}) {
+  return {
+    __typename: 'StatusContext',
+    id,
+    context: 'ci',
+    state: 'SUCCESS',
+    targetUrl: null,
+    isRequired: true,
+    commit: { oid: 'head' },
+    ...patch,
+  };
+}
+function check(raw: unknown): Check {
+  const result = contextCheckSchema.parse(raw);
+  result.evidence = [
+    {
+      source: 'graphql.checks.isRequired',
+      policyId: null,
+      observation: `isRequired:${result.requiredness}`,
+      headSha: 'head',
+      baseSha: 'base',
+      evaluatedSha: result.evaluatedSha,
+      observedAt: source.observedAt,
+    },
+    {
+      source: 'graphql.checks',
+      policyId: null,
+      observation: `check:${result.id}:${result.outcome}`,
+      headSha: 'head',
+      baseSha: 'base',
+      evaluatedSha: result.evaluatedSha,
+      observedAt: source.observedAt,
+    },
+  ];
+  return result;
+}
+
+it('preserves both required run and status outcomes under an explicit wildcard', () => {
+  const scenario = setup();
+  scenario.observations.head = collection([
+    check(run('RUN')),
+    check(status('STATUS', { state: 'FAILURE' })),
+  ]);
+  expect(requirements(scenario, 'status-check')).toMatchObject([
+    { state: 'met', check: { kind: 'check-run', application: { kind: 'any' } } },
+    { state: 'unmet', check: { kind: 'status', application: { kind: 'any' } } },
+  ]);
+});
+
+it.each(['failure', 'missing'] as const)(
+  'retains current proof for a required check %s',
+  outcome => {
+    const scenario = setup(checkPolicy(7));
+    if (outcome === 'failure')
+      scenario.observations.head = collection([check(run('FAILED', 7, { conclusion: 'FAILURE' }))]);
+    const [row] = requirements(scenario, 'status-check');
+    expect(row).toMatchObject({
+      state: 'unmet',
+      check: { name: 'ci', application: { kind: 'app', appId: 7 } },
+      policy: {
+        enforcement: 'active',
+        base: { baseRepoFullName: 'o/r', baseRef: 'release', baseSha: 'base' },
+        viewerEnforcement: 'enforced',
+        viewerBypass: 'never',
+      },
+    });
+    for (const entry of row.evidence)
+      expect(entry).toMatchObject({
+        policyId: row.policy?.id,
+        headSha: 'head',
+        baseSha: 'base',
+        observedAt: source.observedAt,
+      });
+    expect(
+      row.evidence.map(entry => [entry.source, entry.observation, entry.evaluatedSha])
+    ).toEqual([
+      ['rest.branchProtection', 'policy-configuration', null],
+      ...(outcome === 'failure'
+        ? [
+            ['graphql.checks.isRequired', 'isRequired:required', 'head'],
+            ['graphql.checks', 'check:FAILED:failure', 'head'],
+          ]
+        : [
+            [
+              'graphql.observation',
+              'required-check-missing:complete-policy-and-observations',
+              'head',
+            ],
+          ]),
+    ]);
+  }
+);
+
+it.each(['graphql.checks', 'graphql.checks.isRequired'])(
+  'does not report a required failure without %s evidence',
+  missingSource => {
+    const scenario = setup();
+    const observed = check(run('FAILED', 7, { conclusion: 'FAILURE' }));
+    observed.evidence = observed.evidence.filter(entry => entry.source !== missingSource);
+    scenario.observations.head = collection([observed]);
+    expect(requirements(scenario, 'status-check')).toMatchObject([{ state: 'unavailable' }]);
+  }
+);
+
+it('does not use stale evidence for a check that names the current commit', () => {
+  const scenario = setup();
+  const observed = check(run('FAILED', 7, { conclusion: 'FAILURE' }));
+  observed.evidence = observed.evidence.map(entry => ({ ...entry, headSha: 'old-head' }));
+  scenario.observations.head = collection([observed]);
+  expect(requirements(scenario, 'status-check')).toMatchObject([{ state: 'unavailable' }]);
+});
+
+it('retains an optional failure without making it a requirement blocker', () => {
+  const scenario = setup();
+  scenario.observations.head = collection([
+    check(run('REQUIRED')),
+    check(run('OPTIONAL', 7, { name: 'lint', conclusion: 'FAILURE', isRequired: false })),
+  ]);
+  const result = evaluate(scenario);
+  expect(result.checks.items).toMatchObject([
+    { id: 'REQUIRED', requiredness: 'required', outcome: 'success' },
+    { id: 'OPTIONAL', requiredness: 'optional', outcome: 'failure' },
+  ]);
+  expect(result.requirements.items).toMatchObject([{ title: 'ci', state: 'met' }]);
+});
+
+it('keeps non-check policies unavailable without enforcement evidence', () => {
+  const scenario = setup({
+    ...checkPolicy(-1, true),
+    ...reviewPolicy,
+    required_conversation_resolution: { enabled: true },
+    required_deployments: { required_deployment_environments: ['production'] },
+    required_signatures: { enabled: true },
+  });
+  scenario.facts.canBypassClassic = {
+    data: null,
+    source: { ...source, availability: 'unavailable', reason: 'permission' },
+  };
+  const rows = evaluate(scenario).requirements.items.filter(row => !row.check);
+  expect(rows.map(row => [row.kind, row.state])).toEqual([
+    ['branch-freshness', 'unavailable'],
+    ['approving-reviews', 'unavailable'],
+    ['conversation-resolution', 'unavailable'],
+    ['deployment', 'unavailable'],
+    ['commit-signatures', 'unavailable'],
+  ]);
+});
+
+it('retains a retryable partial failure without inventing an unobserved check', () => {
+  const policy = checkPolicy();
+  policy.required_status_checks.contexts.push('build');
+  policy.required_status_checks.checks.push({ context: 'build', app_id: -1 });
+  const scenario = setup(policy);
+  scenario.observations.head = collection([check(run('FAILED', 7, { conclusion: 'FAILURE' }))], {
+    source: { ...source, availability: 'partial', retryable: true, reason: 'deadline' },
+    completeness: 'partial',
+    totalCount: null,
+    hasNextPage: true,
+    endCursor: 'NEXT',
+  });
+  const result = evaluate(scenario);
+  expect(result.checks).toMatchObject({
+    items: [{ id: 'FAILED', observation: 'observed', outcome: 'failure' }],
+    source: { availability: 'partial', retryable: true, reason: 'deadline' },
+    completeness: 'partial',
+    totalCount: null,
+    hasNextPage: true,
+    endCursor: 'NEXT',
+  });
+  expect(
+    result.requirements.items.filter(row => row.check).map(row => [row.title, row.state])
+  ).toEqual([
+    ['ci', 'unmet'],
+    ['build', 'unavailable'],
+  ]);
+});
+
+it('keeps denied check details unavailable without a retry or missing-check claim', () => {
+  const scenario = setup();
+  scenario.observations.head = collection([], {
+    source: { ...source, availability: 'denied', reason: 'permission' },
+    completeness: 'unknown',
+    totalCount: null,
+  });
+  const result = evaluate(scenario);
+  expect(result.checks).toMatchObject({
+    items: [],
+    source: { availability: 'denied', retryable: false, reason: 'permission' },
+    completeness: 'unknown',
+    totalCount: null,
+  });
+  expect(result.requirements.items.map(row => [row.kind, row.state])).toEqual([
+    ['status-check', 'unavailable'],
+    ['check-evaluation', 'unavailable'],
+  ]);
+});
+
+it.each([null, { required_status_checks: { strict: true, contexts: [], checks: [] } }])(
+  'reports confirmed empty requirements only from complete policy sources %j',
+  policy => {
+    const result = evaluate(setup(policy));
+    expect(result.requirements).toMatchObject({
+      items: [],
+      source: { availability: 'available', retryable: false },
+      completeness: 'complete',
+      knownCount: 0,
+      totalCount: 0,
+    });
+    expect(result.checks).toMatchObject({ items: [], completeness: 'complete', totalCount: 0 });
+  }
+);
+
+it('does not create a requirement from a non-selected head check', () => {
+  const scenario = setup();
+  scenario.facts.testMerge = field({
+    oid: 'merge',
+    parents: { totalCount: 2, nodes: [{ oid: 'base' }, { oid: 'head' }] },
+  });
+  const headCheck = check(run('HEAD', 7, { conclusion: 'FAILURE' }));
+  const mergeCheck = check(status('MERGE', { commit: { oid: 'merge' } }));
+  scenario.observations.head = collection([headCheck]);
+  scenario.observations.merge = collection([mergeCheck]);
+
+  const result = evaluate(scenario);
+  expect(result.requirements.items).toMatchObject([
+    {
+      state: 'met',
+      check: { name: 'ci', kind: 'status', application: { kind: 'any' } },
+      evidence: expect.arrayContaining([
+        expect.objectContaining({
+          source: 'graphql.checks',
+          observation: 'check:MERGE:success',
+          evaluatedSha: 'merge',
+        }),
+      ]),
+    },
+  ]);
+  const selectionEvidence = expect.objectContaining({
+    observation: 'head:head;test-merge:merge;selected:merge',
+    evaluatedSha: 'merge',
+  });
+  expect(result.checks.items).toEqual([
+    { ...headCheck, evidence: [...headCheck.evidence, selectionEvidence] },
+    { ...mergeCheck, evidence: [...mergeCheck.evidence, selectionEvidence] },
+  ]);
+  expect(result.evaluatedShas).toEqual(['head', 'merge']);
+});
+
+it.each(['head', 'merge'] as const)(
+  'retains unmatched required checks from the selected %s commit',
+  sha => {
+    const scenario = setup();
+    const selectedChecks = collection([
+      check(status('CURRENT', { commit: { oid: sha } })),
+      check(status('UNMATCHED', { context: 'build', state: 'FAILURE', commit: { oid: sha } })),
+    ]);
+    if (sha === 'head') {
+      scenario.observations.head = selectedChecks;
+    } else {
+      scenario.facts.testMerge = field({
+        oid: 'merge',
+        parents: { totalCount: 2, nodes: [{ oid: 'base' }, { oid: 'head' }] },
+      });
+      scenario.observations.merge = selectedChecks;
+    }
+
+    expect(evaluate(scenario).requirements.items).toMatchObject([
+      { title: 'ci', state: 'met' },
+      {
+        id: 'github:isRequired:UNMATCHED',
+        title: 'build',
+        state: 'unavailable',
+        evidence: expect.arrayContaining([
+          expect.objectContaining({
+            source: 'graphql.checks',
+            policyId: 'github:isRequired:UNMATCHED',
+            observation: 'check:UNMATCHED:failure',
+            headSha: 'head',
+            baseSha: 'base',
+            evaluatedSha: sha,
+          }),
+        ]),
+      },
+    ]);
+  }
+);
+
+it('keeps required observations unavailable when check-run-only merge selection is ambiguous', () => {
+  const scenario = setup();
+  scenario.facts.testMerge = field({
+    oid: 'merge',
+    parents: { totalCount: 2, nodes: [{ oid: 'base' }, { oid: 'head' }] },
+  });
+  const mergeRun = run('MERGE');
+  mergeRun.checkSuite.commit.oid = 'merge';
+  scenario.observations.head = collection([check(run('HEAD'))]);
+  scenario.observations.merge = collection([check(mergeRun)]);
+
+  const result = evaluate(scenario);
+  expect(result.requirements.items).toMatchObject([
+    { kind: 'status-check', state: 'unavailable' },
+    { id: 'github:isRequired:HEAD', state: 'unavailable' },
+    { id: 'github:isRequired:MERGE', state: 'unavailable' },
+    { id: 'github:check-evaluation', state: 'unavailable' },
+  ]);
+  expect(result.checks).toMatchObject({
+    items: [
+      { id: 'HEAD', evaluatedSha: 'head' },
+      { id: 'MERGE', evaluatedSha: 'merge' },
+    ],
+    source: { availability: 'partial', retryable: false, reason: 'check-source-ambiguous' },
+    completeness: 'partial',
+    totalCount: null,
+  });
+  for (const observed of result.checks.items)
+    expect(observed.evidence).toContainEqual(
+      expect.objectContaining({
+        observation: 'head:head;test-merge:merge;selected:unavailable',
+        evaluatedSha: null,
+      })
+    );
+});

--- a/apps/web/src/lib/github-pr-review/context-requirements.ts
+++ b/apps/web/src/lib/github-pr-review/context-requirements.ts
@@ -1,15 +1,17 @@
 import 'server-only';
 
 import { z } from 'zod';
-import type {
-  GitHubPrReviewContext,
-  GitHubPrReviewRevision,
-  GitHubPrReviewSource,
+import {
+  GitHubPrReviewPolicySchema,
+  type GitHubPrReviewContext,
+  type GitHubPrReviewRevision,
+  type GitHubPrReviewSource,
 } from './context-dtos';
 import type { ContextReadResult } from './context-reader';
 
 type Check = GitHubPrReviewContext['checks']['items'][number];
 type Requirement = GitHubPrReviewContext['requirements']['items'][number];
+type Policy = NonNullable<Requirement['policy']>;
 export type RequirementCollection<T> = Omit<GitHubPrReviewContext['checks'], 'items'> & {
   items: T[];
 };
@@ -245,6 +247,13 @@ export type RequirementObservations = {
   deployments: RequirementCollection<z.output<typeof contextDeploymentSchema>>;
 };
 
+const complete = <T>(collection: RequirementCollection<T>) =>
+  collection.source.availability === 'available' &&
+  collection.completeness === 'complete' &&
+  collection.hasNextPage === false &&
+  collection.knownCount === collection.items.length &&
+  collection.totalCount === collection.items.length;
+const available = <T>(field: ContextReadResult<T>) => field.source.availability === 'available';
 const objectSchema = z.record(z.string(), z.json());
 const object = (value: unknown): z.output<typeof objectSchema> =>
   objectSchema.safeParse(value).data ?? {};
@@ -420,4 +429,346 @@ export function expandPolicy(item: Requirement): Requirement[] {
   }
   // Check descriptions are separate rows; do not keep an unevaluated umbrella for them.
   return rows.length || supportedStatus ? rows : [item];
+}
+
+export function evaluateContextRequirements(
+  context: GitHubPrReviewContext,
+  facts: RequirementFacts,
+  observations: RequirementObservations
+): Pick<GitHubPrReviewContext, 'checks' | 'requirements' | 'evaluatedShas'> {
+  const { revision } = context;
+  const { head, merge } = observations;
+  const testMerge = facts.testMerge.data;
+  const validMerge =
+    available(facts.testMerge) &&
+    (!testMerge ||
+      (testMerge.parents?.nodes.some(parent => parent.oid === revision.headSha) &&
+        testMerge.parents?.nodes.some(parent => parent.oid === revision.baseSha)));
+  // GitHub documents status-based selection, not check-run-only or per-context fallback.
+  const selected = !validMerge
+    ? null
+    : !testMerge
+      ? head
+      : merge?.items.some(
+            check =>
+              check.kind === 'status' &&
+              check.evaluatedSha === testMerge.oid &&
+              check.observation === 'observed'
+          )
+        ? merge
+        : merge && complete(merge) && merge.items.length === 0
+          ? head
+          : null;
+  const selectedSha =
+    selected === head ? revision.headSha : selected ? (testMerge?.oid ?? null) : null;
+  const collections = [head, ...(merge ? [merge] : [])];
+  const allChecks = collections.flatMap(collection => collection.items);
+  const currentPolicy = (policy: Policy | null): policy is Policy =>
+    Boolean(
+      policy &&
+      policy.enforcement === 'active' &&
+      policy.base?.baseRepoFullName === revision.baseRepoFullName &&
+      policy.base?.baseRef === revision.baseRef &&
+      policy.base?.baseSha === revision.baseSha
+    );
+  const classicEnforced =
+    available(facts.canBypassClassic) && facts.canBypassClassic.data === false;
+  const enforced = (policy: Policy, checkName?: string) =>
+    currentPolicy(policy) &&
+    ((policy.viewerEnforcement === 'enforced' && policy.viewerBypass === 'never') ||
+      (policy.source === 'classic' && classicEnforced)) &&
+    (!checkName ||
+      policy.source !== 'classic' ||
+      (available(facts.viewerRule.requiredStatusCheckContexts) &&
+        facts.viewerRule.requiredStatusCheckContexts.data?.includes(checkName) === true));
+  const evidence = (
+    source: GitHubPrReviewSource,
+    observation: string,
+    sha = revision.headSha,
+    policyId: string | null = null
+  ) => contextRequirementEvidence(revision, source, observation, sha, policyId);
+  const githubPolicy = (id: string, ruleType: string) =>
+    GitHubPrReviewPolicySchema.parse({
+      id,
+      source: 'github',
+      enforcement: 'active',
+      ruleType,
+      base: {
+        baseRepoFullName: revision.baseRepoFullName,
+        baseRef: revision.baseRef,
+        baseSha: revision.baseSha,
+      },
+      viewerEnforcement: 'enforced',
+      viewerBypass: 'never',
+    });
+  const items: Requirement[] = [];
+  const record = (
+    row: Requirement,
+    state: Requirement['state'],
+    source: GitHubPrReviewSource,
+    observation: string,
+    sha = revision.headSha
+  ) => {
+    const policy = row.policy;
+    return {
+      ...row,
+      state: currentPolicy(policy) ? state : ('unavailable' as const),
+      policy:
+        policy && enforced(policy)
+          ? { ...policy, viewerEnforcement: 'enforced' as const, viewerBypass: 'never' as const }
+          : policy,
+      evidence: [...row.evidence, ...evidence(source, observation, sha, policy?.id ?? null)],
+    };
+  };
+  const sameCheckSource = (left: Check, right: Check) => {
+    if (left.name !== right.name || left.kind !== right.kind) return false;
+    const numeric = left.application?.id != null && right.application?.id != null;
+    const node = left.application?.nodeId != null && right.application?.nodeId != null;
+    return (
+      (numeric && left.application?.id === right.application?.id) ||
+      (node && left.application?.nodeId === right.application?.nodeId) ||
+      (!numeric && !node)
+    );
+  };
+  const checkState = (check: Check): Requirement['state'] => {
+    const currentEvidence = check.evidence.filter(
+      entry =>
+        entry.headSha === revision.headSha &&
+        entry.baseSha === revision.baseSha &&
+        entry.evaluatedSha === selectedSha &&
+        entry.observedAt !== null
+    );
+    if (
+      !selected ||
+      !['available', 'partial'].includes(selected.source.availability) ||
+      check.evaluatedSha !== selectedSha ||
+      check.kind === 'unknown' ||
+      check.observation !== 'observed' ||
+      check.requiredness !== 'required' ||
+      !currentEvidence.some(
+        entry =>
+          entry.source === 'graphql.checks.isRequired' &&
+          entry.observation === 'isRequired:required'
+      ) ||
+      !currentEvidence.some(
+        entry =>
+          entry.source === 'graphql.checks' &&
+          entry.observation.startsWith(`check:${check.id}:${check.outcome}`)
+      ) ||
+      selected.items.filter(other => sameCheckSource(check, other)).length !== 1
+    )
+      return 'unavailable';
+    return check.outcome === 'success' || check.outcome === 'skipped'
+      ? 'met'
+      : check.outcome === 'failure' || check.outcome === 'pending'
+        ? 'unmet'
+        : 'unavailable';
+  };
+  const covered = new Set<Check>();
+  for (const row of context.requirements.items.flatMap(expandPolicy)) {
+    const policy = row.policy;
+    if (!currentPolicy(policy)) {
+      items.push({ ...row, state: 'unavailable' });
+      continue;
+    }
+    if (row.check) {
+      const binding = row.check.application;
+      const named = selected?.items.filter(check => check.name === row.check?.name) ?? [];
+      const matching = named.filter(
+        check =>
+          binding.kind === 'any' ||
+          (binding.kind === 'app' && check.application?.id === binding.appId)
+      );
+      if (matching.length) {
+        for (const check of matching) {
+          covered.add(check);
+          items.push({
+            ...record(
+              {
+                ...row,
+                id: `${row.id}:${check.kind}:${check.id}`,
+                check: { ...row.check, kind: check.kind },
+              },
+              enforced(policy, row.check.name) ? checkState(check) : 'unavailable',
+              selected?.source ?? head.source,
+              `check:${check.id}:${check.outcome}`,
+              check.evaluatedSha ?? revision.headSha
+            ),
+            evidence: [
+              ...row.evidence,
+              ...check.evidence.map(entry => ({ ...entry, policyId: policy.id })),
+            ],
+          });
+        }
+      } else {
+        const headFallback =
+          selected === merge && head.items.some(check => check.name === row.check?.name);
+        const unresolvedIdentity = named.some(
+          check => check.kind === 'status' || check.application?.id == null
+        );
+        const missing =
+          binding.kind !== 'unknown' &&
+          !headFallback &&
+          !unresolvedIdentity &&
+          enforced(policy, row.check.name) &&
+          complete(context.requirements) &&
+          complete(head) &&
+          Boolean(selected && complete(selected)) &&
+          (!testMerge || Boolean(merge && complete(merge)));
+        items.push(
+          record(
+            row,
+            missing ? 'unmet' : 'unavailable',
+            selected?.source ?? head.source,
+            missing
+              ? 'required-check-missing:complete-policy-and-observations'
+              : 'check-source-or-application-unavailable',
+            selectedSha ?? revision.headSha
+          )
+        );
+        if (missing)
+          allChecks.push({
+            id: null,
+            name: row.check.name,
+            kind: row.check.kind,
+            application:
+              binding.kind === 'app'
+                ? { id: binding.appId, nodeId: null, slug: null, name: null }
+                : null,
+            outcome: 'pending',
+            status: null,
+            conclusion: null,
+            requiredness: 'required',
+            observation: 'missing',
+            evaluatedSha: selectedSha,
+            detailsUrl: null,
+            evidence: items[items.length - 1]?.evidence ?? [],
+          });
+      }
+      continue;
+    }
+    items.push({ ...row, state: 'unavailable' });
+  }
+  for (const check of (selected?.items ?? allChecks).filter(
+    check =>
+      check.requiredness === 'required' && check.observation === 'observed' && !covered.has(check)
+  )) {
+    const id = `github:isRequired:${check.id}`;
+    items.push({
+      id,
+      kind: 'status-check',
+      title: check.name,
+      // isRequired identifies requiredness, not the binding or the viewer's bypass rights.
+      state: 'unavailable',
+      policy: {
+        ...githubPolicy(id, 'required_status_checks'),
+        viewerEnforcement: 'unknown',
+        viewerBypass: 'unknown',
+      },
+      check: {
+        name: check.name,
+        kind: check.kind,
+        application: check.application?.id
+          ? { kind: 'app', appId: check.application.id }
+          : { kind: 'unknown' },
+      },
+      evidence: check.evidence.map(entry => ({ ...entry, policyId: id })),
+    });
+  }
+  if (
+    !selected ||
+    !complete(selected) ||
+    selected.items.some(
+      check => check.requiredness === 'unknown' || check.observation === 'unknown'
+    )
+  ) {
+    items.push({
+      id: 'github:check-evaluation',
+      kind: 'check-evaluation',
+      title: 'Required check evaluation',
+      state: 'unavailable',
+      policy: null,
+      check: null,
+      evidence: evidence(
+        selected?.source ?? facts.testMerge.source,
+        `check-source-unavailable;head:${revision.headSha};test-merge:${testMerge?.oid ?? 'unknown'}`,
+        selectedSha ?? revision.headSha
+      ),
+    });
+  }
+  if (!available(facts.mergeable) || facts.mergeable.data !== 'MERGEABLE') {
+    const id = 'github:merge-conflicts';
+    items.push({
+      id,
+      kind: 'merge-conflicts',
+      title: 'Merge conflicts',
+      state:
+        available(facts.mergeable) && facts.mergeable.data === 'CONFLICTING'
+          ? 'unmet'
+          : 'unavailable',
+      policy: githubPolicy(id, 'mergeability'),
+      check: null,
+      evidence: evidence(
+        facts.mergeable.source,
+        `mergeable:${facts.mergeable.data ?? 'unavailable'}`,
+        revision.headSha,
+        id
+      ),
+    });
+  }
+  const checksComplete = Boolean(selected) && collections.every(complete);
+  const failed =
+    collections.find(collection => !complete(collection))?.source ?? facts.testMerge.source;
+  const selectionEvidence = contextRequirementEvidence(
+    revision,
+    facts.testMerge.source,
+    `head:${revision.headSha};test-merge:${testMerge?.oid ?? (available(facts.testMerge) ? 'none' : 'unavailable')};selected:${selectedSha ?? 'unavailable'}`,
+    selectedSha
+  );
+  return {
+    evaluatedShas: [
+      ...new Set([
+        revision.headSha,
+        ...(testMerge ? [testMerge.oid] : []),
+        ...allChecks.flatMap(check => (check.evaluatedSha ? [check.evaluatedSha] : [])),
+      ]),
+    ],
+    checks: {
+      ...head,
+      items: allChecks.map(check => ({
+        ...check,
+        evidence: [...check.evidence, ...selectionEvidence],
+      })),
+      knownCount: allChecks.length,
+      totalCount: checksComplete ? allChecks.length : null,
+      completeness: checksComplete ? 'complete' : allChecks.length ? 'partial' : 'unknown',
+      hasNextPage: collections.some(collection => collection.hasNextPage === true)
+        ? true
+        : collections.every(collection => collection.hasNextPage === false)
+          ? false
+          : null,
+      source: {
+        ...failed,
+        provenance: [...new Set(collections.flatMap(collection => collection.source.provenance))],
+        availability: checksComplete
+          ? 'available'
+          : allChecks.length
+            ? 'partial'
+            : failed.availability === 'denied'
+              ? 'denied'
+              : 'unavailable',
+        reason: checksComplete ? null : (failed.reason ?? 'check-source-ambiguous'),
+        retryable: checksComplete
+          ? false
+          : collections.some(collection => collection.source.retryable) ||
+            facts.testMerge.source.retryable,
+      },
+    },
+    requirements: {
+      ...context.requirements,
+      items,
+      knownCount: items.length,
+      totalCount: context.requirements.completeness === 'complete' ? items.length : null,
+    },
+  };
 }


### PR DESCRIPTION
No new behavior — this change prepares check results that the app does not yet use.

---

## Summary

`evaluateContextRequirements` adds a pure evaluator that returns `checks`, `requirements`, and `evaluatedShas` from `GitHubPrReviewContext`, `RequirementFacts`, and `RequirementObservations`.
It uses current policy, revision, viewer enforcement, and direct observations to distinguish unmet required checks from unavailable evidence without treating optional failures as blockers.
Existing callers remain unchanged because no live caller uses the evaluator; non-check requirements stay unavailable except confirmed merge conflicts.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-requirements.ts` — modified (M), +355/-4 lines. Validates the test merge against both current parents. Selects an observed test-merge status; otherwise uses the head only for an absent test merge or a complete empty merge collection. Check-run-only merge data cannot select a commit, and selection never falls back per check name. Retains observations from both commits, including optional failures, but does not create extra current requirements from non-selected head observations. Matches exact check names and any-application or numeric application bindings; separates runs from statuses and rejects duplicate sources. Requires active policy for the current base repository, branch, and commit, plus viewer enforcement. Classic checks also need the viewer's required-context list; confirmed absence of classic bypass rights can establish enforcement. Accepts available or partial observations only with timestamped, matching revision evidence for requiredness and outcome. Proven success or skipped checks become met; failure or pending checks become unmet; uncertain checks remain unavailable. Missing checks require complete policy and observation collections, resolved application identity, and no same-name head observation after merge selection. Adds explicit missing-check evidence and synthetic required pending details. Unmatched required observations retain unknown viewer rights; incomplete selections or unknown requiredness or observation values add unavailable evaluation requirements. Expands policies but leaves non-check requirements unavailable. Conflicts become unmet only from available `CONFLICTING` evidence; unknown mergeability remains unavailable, and `MERGEABLE` adds no conflict requirement. Preserves policy-linked evidence, appends commit-selection evidence, and deduplicates the head, test merge, and observed commits. Complete check metadata requires a valid selection and complete collections with available sources, exhausted pages, and exact counts. Recalculates check and requirement counts; combines check pagination and provenance, with null check totals until the inputs are complete. Derives check availability, failure reasons, and retryability from the input sources.

</details>

Tests: 1 evaluator test file added — `apps/web/src/lib/github-pr-review/context-requirements.test.ts` (A, +440/-0 lines).
Generated: 0 files.

---

## Visual Changes

Visual Changes: N/A

## Verification

No manual tests ran for this level because the evaluator has no live caller and changes no current user-visible behavior.

## Reviewer Notes

### Scope

- Repository: `Kilo-Org/cloud`.
- Worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- This description covers level 19 only: `mobile-pr-review-context-5458-s18...mobile-pr-review-context-5458-s19`, not the cumulative branch.

### Automated evidence from the handoff

- The handoff reports 16 passing core evaluator tests.
- The handoff reports passing scoped lint, formatting, and whitespace checks.

### Human steps

This change requires no human steps before merge or after merge.

### Notes

Live backend and iOS verification remains pending on the completed stack tip.









<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727 ← this PR
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
