### PR TITLE
feat(pr-review): evaluate evidenced merge policies

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-dtos.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-dtos.test.ts
@@ -123,6 +123,20 @@ const fullContext = {
   revision,
   observedAt,
   evaluatedShas: ['head'],
+  evaluationSources: {
+    mergeable: source,
+    testMerge: source,
+    comparison: source,
+    canBypassClassic: source,
+    requiredApprovingReviewCount: source,
+    requiredStatusCheckContexts: source,
+    requiresConversationResolution: source,
+    threads: source,
+    eligibleReviews: source,
+    reviewDecisions: source,
+    reviewActivity: source,
+    deployments: source,
+  },
   labels: complete([{ id: 'L_1', name: 'bug', color: null }]),
   assignees: complete([identity]),
   reviewRequests: complete([
@@ -629,6 +643,67 @@ test('preserves strict comment-author and legacy aggregate checks contracts', ()
     GitHubPrReviewChecksResultSchema.safeParse({
       ...checks,
       checkRuns: [{ ...checks.checkRuns[0], requiredness: 'required' }],
+    }).success
+  ).toBe(false);
+});
+
+test.each([undefined, {}])(
+  'normalizes missing evaluation sources (%j) without rewriting old evidence',
+  evaluationSources => {
+    const { evaluationSources: knownSources, ...legacyContext } = fullContext;
+    const { context } = NormalizedGitHubPrReviewOverviewSchema.parse({
+      ...oldOverview,
+      context: { ...legacyContext, evaluationSources },
+    });
+    const { evaluationSources: normalized, ...preserved } = context;
+    expect(preserved).toStrictEqual(legacyContext);
+    for (const key of Object.keys(knownSources))
+      expect(normalized).toHaveProperty(key, {
+        availability: 'unavailable',
+        retryable: false,
+        reason: 'source-state-not-recorded',
+        provenance: [],
+        observedAt: null,
+      });
+  }
+);
+
+test.each([
+  { availability: 'unavailable', retryable: true, reason: 'transient' },
+  { availability: 'denied', retryable: false, reason: 'permission' },
+])('retains structured $availability recovery without provenance', failure => {
+  const failed = { ...source, ...failure, provenance: [] };
+  const input = {
+    ...fullContext,
+    evaluationSources: { ...fullContext.evaluationSources, comparison: failed },
+  };
+  expect(
+    NormalizedGitHubPrReviewOverviewSchema.parse({ ...oldOverview, context: input }).context
+  ).toStrictEqual(input);
+  const partial = GitHubPrReviewContextSchema.parse({
+    revision,
+    evaluationSources: { comparison: failed },
+    labels: complete([]),
+  });
+  expect(partial.evaluationSources.comparison).toStrictEqual(failed);
+  expect(partial.evaluationSources.threads).toMatchObject({
+    availability: 'unavailable',
+    retryable: false,
+    reason: 'source-state-not-recorded',
+  });
+  expect(partial.labels).toStrictEqual(complete([]));
+});
+
+test.each([
+  ['availability', { availability: 'unknown' }],
+  ['retryability', { retryable: 'true' }],
+  ['reason', { reason: 403 }],
+  ['provenance', { provenance: [''] }],
+])('rejects invalid evaluation source %s instead of supplying a fallback', (_name, invalid) => {
+  expect(
+    GitHubPrReviewContextSchema.safeParse({
+      revision,
+      evaluationSources: { comparison: { ...source, ...invalid } },
     }).success
   ).toBe(false);
 });

--- a/apps/web/src/lib/github-pr-review/context-dtos.ts
+++ b/apps/web/src/lib/github-pr-review/context-dtos.ts
@@ -269,6 +269,27 @@ export const GitHubPrReviewQueueSchema = z
   })
   .strict();
 
+const evaluationSourceSchema = GitHubPrReviewSourceSchema.default(() => ({
+  ...unavailablePrReviewSource(),
+  reason: 'source-state-not-recorded',
+}));
+const evaluationSourcesSchema = z
+  .object({
+    mergeable: evaluationSourceSchema,
+    testMerge: evaluationSourceSchema,
+    comparison: evaluationSourceSchema,
+    canBypassClassic: evaluationSourceSchema,
+    requiredApprovingReviewCount: evaluationSourceSchema,
+    requiredStatusCheckContexts: evaluationSourceSchema,
+    requiresConversationResolution: evaluationSourceSchema,
+    threads: evaluationSourceSchema,
+    eligibleReviews: evaluationSourceSchema,
+    reviewDecisions: evaluationSourceSchema,
+    reviewActivity: evaluationSourceSchema,
+    deployments: evaluationSourceSchema,
+  })
+  .strict();
+
 // Old context payloads omit sources. Retain defaults until all old clients, servers, and records are gone.
 // Missing sources never establish an empty collection.
 export const GitHubPrReviewContextSchema = z
@@ -306,6 +327,8 @@ export const GitHubPrReviewContextSchema = z
     // Completeness covers supported PR-side sources, not every outgoing or inaccessible link.
     issueCoverage: z.literal('supported-pr-sources').default('supported-pr-sources'),
     requirements: githubPrReviewCollectionSchema(GitHubPrReviewRequirementSchema),
+    // Old evidence has no recovery metadata. Retain defaults until all old clients, servers, and records are gone.
+    evaluationSources: evaluationSourcesSchema.default(() => evaluationSourcesSchema.parse({})),
     checks: githubPrReviewCollectionSchema(GitHubPrReviewContextCheckSchema),
     queue: GitHubPrReviewQueueSchema.default(() => ({
       membership: { source: unavailablePrReviewSource(), state: 'unknown' as const, entryId: null },

--- a/apps/web/src/lib/github-pr-review/context-requirements.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-requirements.test.ts
@@ -152,6 +152,57 @@ function check(raw: unknown): Check {
   ];
   return result;
 }
+function review(
+  id = 'REVIEW',
+  actor = 'USER'
+): GitHubPrReviewContext['reviewDecisions']['items'][number] {
+  return {
+    id,
+    state: 'APPROVED',
+    submittedAt: source.observedAt,
+    commitSha: 'head',
+    actor: {
+      id: actor,
+      kind: 'User',
+      login: actor,
+      name: null,
+      avatarUrl: null,
+      url: null,
+      teamSlug: null,
+    },
+    onBehalfOf: collection([]),
+  };
+}
+function reviewed() {
+  const scenario = setup(reviewPolicy);
+  scenario.observations.eligibleReviews = collection([review()]);
+  scenario.context.reviewDecisions = collection([review()]);
+  scenario.context.reviewActivity = collection([review()]);
+  return scenario;
+}
+function deployed() {
+  const scenario = setup(null, [
+    {
+      type: 'required_deployments',
+      parameters: { required_deployment_environments: ['production'] },
+    },
+  ]);
+  // Explicit normalized enforcement is an input, not proof of provider bypass semantics.
+  for (const row of scenario.context.requirements.items)
+    if (row.policy) {
+      row.policy.viewerEnforcement = 'enforced';
+      row.policy.viewerBypass = 'never';
+    }
+  scenario.observations.deployments = collection([
+    {
+      id: 'DEPLOY',
+      commitOid: 'head',
+      environment: 'production',
+      latestStatus: { state: 'FAILURE' },
+    },
+  ]);
+  return scenario;
+}
 
 it('preserves both required run and status outcomes under an explicit wildcard', () => {
   const scenario = setup();
@@ -163,6 +214,90 @@ it('preserves both required run and status outcomes under an explicit wildcard',
     { state: 'met', check: { kind: 'check-run', application: { kind: 'any' } } },
     { state: 'unmet', check: { kind: 'status', application: { kind: 'any' } } },
   ]);
+});
+
+it.each([
+  'known',
+  'enough',
+  'unknown-actor',
+  'old-commit',
+  'partial',
+  'inconsistent',
+  'code-owner',
+  'dismissal',
+  'last-push',
+  'unknown-flags',
+  'unknown-enforcement',
+] as const)('counts only current eligible and enforced reviews: %s', condition => {
+  const scenario = reviewed();
+  if (condition === 'enough') {
+    scenario.observations.eligibleReviews = collection([review(), review('SECOND', 'USER_2')]);
+    scenario.context.reviewDecisions = collection([review(), review('SECOND', 'USER_2')]);
+    scenario.context.reviewActivity = collection([review(), review('SECOND', 'USER_2')]);
+  }
+  if (condition === 'unknown-actor') scenario.observations.eligibleReviews.items[0]!.actor = null;
+  if (condition === 'old-commit') scenario.observations.eligibleReviews.items[0]!.commitSha = 'old';
+  if (condition === 'partial') scenario.observations.eligibleReviews.completeness = 'partial';
+  if (condition === 'inconsistent') scenario.context.reviewDecisions.items[0]!.state = 'DISMISSED';
+  const parametersByCondition: Record<string, string> = {
+    'code-owner': 'require_code_owner_reviews',
+    dismissal: 'dismiss_stale_reviews',
+    'last-push': 'require_last_push_approval',
+    'unknown-flags': 'dismiss_stale_reviews',
+  };
+  const parameter = parametersByCondition[condition];
+  if (parameter) {
+    for (const row of scenario.context.requirements.items) {
+      const parameters = row.policy?.parameters?.required_pull_request_reviews as Record<
+        string,
+        unknown
+      >;
+      parameters[parameter] = condition === 'unknown-flags' ? null : true;
+    }
+  }
+  if (condition === 'unknown-enforcement')
+    scenario.facts.viewerRule.requiredApprovingReviewCount = {
+      data: null,
+      source: { ...source, availability: 'denied' },
+    };
+  expect(requirements(scenario, 'approving-reviews')[0]?.state).toBe(
+    condition === 'known' ? 'unmet' : condition === 'enough' ? 'met' : 'unavailable'
+  );
+});
+
+it.each([
+  'failed',
+  'successful',
+  'other-environment',
+  'other-commit',
+  'partial',
+  'unknown-bypass',
+  'multiple',
+] as const)('matches deployments to the required environment and commit: %s', condition => {
+  const scenario = deployed();
+  const deployment = scenario.observations.deployments.items[0]!;
+  if (condition === 'successful') deployment.latestStatus = { state: 'SUCCESS' };
+  if (condition === 'other-environment') deployment.environment = 'preview';
+  if (condition === 'other-commit') deployment.commitOid = 'old';
+  if (condition === 'partial') scenario.observations.deployments.completeness = 'partial';
+  if (condition === 'multiple')
+    scenario.observations.deployments = collection([deployment, { ...deployment, id: 'OTHER' }]);
+  if (condition === 'unknown-bypass')
+    scenario.context.requirements.items[0]!.policy!.viewerBypass = 'unknown';
+  const row = requirements(scenario, 'deployment')[0];
+  expect(row?.state).toBe(
+    condition === 'failed' ? 'unmet' : condition === 'successful' ? 'met' : 'unavailable'
+  );
+  if (condition.startsWith('other'))
+    expect(row?.evidence.some(entry => entry.observation.includes('DEPLOY'))).toBe(false);
+  if (condition === 'multiple')
+    expect(
+      row?.evidence.some(
+        entry =>
+          entry.observation.includes('deployment:DEPLOY;') &&
+          entry.observation.includes('deployment:OTHER;')
+      )
+    ).toBe(true);
 });
 
 it.each(['failure', 'missing'] as const)(
@@ -437,4 +572,274 @@ it('keeps required observations unavailable when check-run-only merge selection 
         evaluatedSha: null,
       })
     );
+});
+
+it.each(['current', 'base', 'head', 'viewer', 'retryable', 'denied'] as const)(
+  'requires matching comparison and viewer enforcement for freshness: %s',
+  condition => {
+    const scenario = setup(checkPolicy(-1, true));
+    if (condition === 'base') scenario.facts.comparison.data!.baseTarget.oid = 'old-base';
+    if (condition === 'head') scenario.facts.comparison.data!.headTarget.oid = 'old-head';
+    if (condition === 'viewer') scenario.facts.viewerRule.requiredStatusCheckContexts = field([]);
+    if (condition === 'retryable' || condition === 'denied')
+      scenario.facts.comparison.source = {
+        ...source,
+        availability: condition === 'retryable' ? 'unavailable' : 'denied',
+        retryable: condition === 'retryable',
+        reason: condition === 'retryable' ? 'transient' : 'permission',
+      };
+    expect(requirements(scenario, 'branch-freshness')).toMatchObject([
+      { state: condition === 'current' ? 'met' : 'unavailable' },
+    ]);
+  }
+);
+
+it.each([
+  [false, false, 'unmet', 'observed-unresolved-thread-ids:THREAD'],
+  [false, true, 'unmet', 'unresolved-threads:1;ids:THREAD'],
+  [true, false, 'unavailable', 'conversation-observations-incomplete'],
+  [true, true, 'met', 'unresolved-threads:0;ids:'],
+  [null, true, 'unavailable', 'conversation-observations-incomplete'],
+] as const)(
+  'retains thread evidence for resolution %s with complete pages %s',
+  (isResolved, completePages, state, observation) => {
+    const scenario = setup({ required_conversation_resolution: { enabled: true } });
+    scenario.observations.threads = collection(
+      isResolved === true ? [] : [{ id: 'THREAD', isResolved }],
+      completePages
+        ? {}
+        : {
+            completeness: 'partial',
+            hasNextPage: true,
+            totalCount: null,
+            source: { ...source, availability: 'partial', retryable: true, reason: 'deadline' },
+          }
+    );
+    expect(requirements(scenario, 'conversation-resolution')).toMatchObject([
+      { state, evidence: expect.arrayContaining([expect.objectContaining({ observation })]) },
+    ]);
+  }
+);
+
+it('retains current policy and direct evidence for each non-check failure', () => {
+  const scenario = setup({
+    ...checkPolicy(-1, true),
+    ...reviewPolicy,
+    required_conversation_resolution: { enabled: true },
+    required_deployments: { required_deployment_environments: ['production'] },
+  });
+  scenario.observations.head = collection([check(run('PASS'))]);
+  scenario.facts.comparison.data!.behindBy = 2;
+  scenario.observations.threads = collection([{ id: 'THREAD', isResolved: false }]);
+  scenario.observations.eligibleReviews = collection([review()]);
+  scenario.context.reviewDecisions = collection([review()]);
+  scenario.context.reviewActivity = collection([review()]);
+  scenario.observations.deployments = deployed().observations.deployments;
+  const unmet = evaluate(scenario).requirements.items.filter(row => row.state === 'unmet');
+  expect(unmet.map(row => row.kind)).toEqual([
+    'branch-freshness',
+    'approving-reviews',
+    'conversation-resolution',
+    'deployment',
+  ]);
+  for (const [index, observation] of [
+    'branch-behind:2',
+    'eligible-approvals:1/2;ids:REVIEW',
+    'unresolved-threads:1;ids:THREAD',
+    'deployment:DEPLOY;environment:production;state:FAILURE',
+  ].entries()) {
+    const row = unmet[index]!;
+    expect(row.policy).toMatchObject({
+      enforcement: 'active',
+      base: { baseRepoFullName: 'o/r', baseRef: 'release', baseSha: 'base' },
+      viewerEnforcement: 'enforced',
+      viewerBypass: 'never',
+    });
+    expect(row.evidence).toContainEqual(
+      expect.objectContaining({
+        source: 'graphql.observation',
+        policyId: row.policy!.id,
+        observation,
+        headSha: 'head',
+        baseSha: 'base',
+        evaluatedSha: 'head',
+        observedAt: source.observedAt,
+      })
+    );
+  }
+});
+
+it('retains every viewer-policy contradiction instead of confirming no requirements', () => {
+  const scenario = setup(null);
+  scenario.facts.viewerRule.requiredStatusCheckContexts = field(['ci']);
+  scenario.facts.viewerRule.requiredApprovingReviewCount = field(2);
+  scenario.facts.viewerRule.requiresConversationResolution = field(true);
+  const rows = evaluate(scenario).requirements.items;
+  expect(rows).toMatchObject([{ kind: 'policy-evaluation', state: 'unavailable' }]);
+  expect(rows[0]?.evidence.map(entry => entry.observation)).toEqual([
+    'policy-source-conflict:status-checks',
+    'policy-source-conflict:approving-reviews',
+    'policy-source-conflict:conversations',
+  ]);
+});
+
+function allNonCheckRequirements() {
+  const scenario = setup({
+    ...checkPolicy(-1, true),
+    ...reviewPolicy,
+    required_conversation_resolution: { enabled: true },
+    required_deployments: { required_deployment_environments: ['production'] },
+  });
+  scenario.observations.head = collection([check(run('PASS'))]);
+  scenario.observations.deployments = deployed().observations.deployments;
+  return scenario;
+}
+
+describe.each([
+  { availability: 'unavailable', retryable: true, reason: 'transient' },
+  { availability: 'denied', retryable: false, reason: 'permission' },
+] as const)('source recovery for $availability', failure => {
+  it.each([
+    ['comparison', 'branch-freshness'],
+    ['threads', 'conversation-resolution'],
+    ['eligibleReviews', 'approving-reviews'],
+    ['deployments', 'deployment'],
+  ] as const)('retains %s metadata and successful siblings', (key, kind) => {
+    for (const provenance of [[`graphql.${key}`], []]) {
+      const scenario = allNonCheckRequirements();
+      const before = evaluate(scenario);
+      const failed = { ...source, ...failure, provenance };
+      const inputs = {
+        comparison: scenario.facts.comparison,
+        threads: scenario.observations.threads,
+        eligibleReviews: scenario.observations.eligibleReviews,
+        deployments: scenario.observations.deployments,
+      };
+      inputs[key].source = failed;
+      const result = evaluate(scenario);
+      expect(result.evaluationSources[key]).toStrictEqual(failed);
+      expect(result.requirements.items.filter(row => row.kind === kind)).toMatchObject([
+        { state: 'unavailable' },
+      ]);
+      expect(result.requirements.items.filter(row => row.kind !== kind)).toStrictEqual(
+        before.requirements.items.filter(row => row.kind !== kind)
+      );
+      expect(result.requirements.source).toStrictEqual(before.requirements.source);
+    }
+  });
+
+  it.each([
+    [
+      'canBypassClassic',
+      [
+        'branch-freshness',
+        'approving-reviews',
+        'conversation-resolution',
+        'deployment',
+        'status-check',
+      ],
+    ],
+    ['requiredStatusCheckContexts', ['branch-freshness', 'status-check']],
+    ['requiredApprovingReviewCount', ['approving-reviews']],
+    ['requiresConversationResolution', ['conversation-resolution']],
+    ['reviewDecisions', ['approving-reviews']],
+    ['reviewActivity', ['approving-reviews']],
+  ] as const)('retains the failed %s dependency without hiding siblings', (key, kinds) => {
+    for (const provenance of [[`graphql.${key}`], []]) {
+      const scenario = allNonCheckRequirements();
+      const before = evaluate(scenario);
+      const failed = { ...source, ...failure, provenance };
+      const inputs = {
+        canBypassClassic: scenario.facts.canBypassClassic,
+        ...scenario.facts.viewerRule,
+        reviewDecisions: scenario.context.reviewDecisions,
+        reviewActivity: scenario.context.reviewActivity,
+      };
+      inputs[key].source = failed;
+      const result = evaluate(scenario);
+      expect(result.evaluationSources[key]).toStrictEqual(failed);
+      const affected = result.requirements.items.filter(row =>
+        kinds.some(kind => kind === row.kind)
+      );
+      expect(affected.map(row => [row.kind, row.state])).toEqual(
+        expect.arrayContaining(kinds.map(kind => [kind, 'unavailable']))
+      );
+      expect(
+        result.requirements.items.filter(row => !kinds.some(kind => kind === row.kind))
+      ).toStrictEqual(
+        before.requirements.items.filter(row => !kinds.some(kind => kind === row.kind))
+      );
+    }
+  });
+
+  it('retains unavailable mergeability without discarding non-check policy results', () => {
+    const scenario = allNonCheckRequirements();
+    const before = evaluate(scenario);
+    const failed = { ...source, ...failure, provenance: [] };
+    scenario.facts.mergeable = { data: null, source: failed };
+    const result = evaluate(scenario);
+    expect(result.evaluationSources.mergeable).toStrictEqual(failed);
+    expect(result.requirements.items.filter(row => row.kind === 'merge-conflicts')).toMatchObject([
+      { state: 'unavailable' },
+    ]);
+    expect(result.requirements.items.filter(row => row.kind !== 'merge-conflicts')).toStrictEqual(
+      before.requirements.items
+    );
+  });
+});
+
+it('retains simultaneous transient and denied evaluation sources independently', () => {
+  const scenario = allNonCheckRequirements();
+  scenario.facts.comparison.source = {
+    ...source,
+    availability: 'unavailable',
+    retryable: true,
+    reason: 'transient',
+    provenance: [],
+  };
+  scenario.observations.threads.source = {
+    ...source,
+    availability: 'denied',
+    reason: 'permission',
+    provenance: [],
+  };
+  const result = evaluate(scenario);
+  expect(result.evaluationSources).toMatchObject({
+    comparison: { availability: 'unavailable', retryable: true, reason: 'transient' },
+    threads: { availability: 'denied', retryable: false, reason: 'permission' },
+    deployments: { availability: 'available', retryable: false, reason: null },
+  });
+  expect(result.requirements.items.map(row => [row.kind, row.state])).toEqual([
+    ['branch-freshness', 'unavailable'],
+    ['approving-reviews', 'unmet'],
+    ['conversation-resolution', 'unavailable'],
+    ['deployment', 'unmet'],
+    ['status-check', 'met'],
+  ]);
+});
+
+it('retains retry metadata beside a directly observed unresolved thread', () => {
+  const scenario = allNonCheckRequirements();
+  const partial = {
+    ...source,
+    availability: 'partial' as const,
+    retryable: true,
+    reason: 'deadline',
+  };
+  scenario.observations.threads = collection([{ id: 'THREAD', isResolved: false }], {
+    source: partial,
+    completeness: 'partial',
+    totalCount: null,
+    hasNextPage: true,
+  });
+  const result = evaluate(scenario);
+  expect(result.evaluationSources.threads).toStrictEqual(partial);
+  expect(
+    result.requirements.items.find(row => row.kind === 'conversation-resolution')
+  ).toMatchObject({
+    state: 'unmet',
+    evidence: expect.arrayContaining([
+      expect.objectContaining({ observation: 'observed-unresolved-thread-ids:THREAD' }),
+    ]),
+  });
 });

--- a/apps/web/src/lib/github-pr-review/context-requirements.ts
+++ b/apps/web/src/lib/github-pr-review/context-requirements.ts
@@ -3,11 +3,13 @@ import 'server-only';
 import { z } from 'zod';
 import {
   GitHubPrReviewPolicySchema,
+  GitHubPrReviewTimestampSchema,
   type GitHubPrReviewContext,
   type GitHubPrReviewRevision,
   type GitHubPrReviewSource,
 } from './context-dtos';
 import type { ContextReadResult } from './context-reader';
+import { contextReviewsAgree } from './context-reviews';
 
 type Check = GitHubPrReviewContext['checks']['items'][number];
 type Requirement = GitHubPrReviewContext['requirements']['items'][number];
@@ -435,9 +437,9 @@ export function evaluateContextRequirements(
   context: GitHubPrReviewContext,
   facts: RequirementFacts,
   observations: RequirementObservations
-): Pick<GitHubPrReviewContext, 'checks' | 'requirements' | 'evaluatedShas'> {
+): Pick<GitHubPrReviewContext, 'checks' | 'requirements' | 'evaluatedShas' | 'evaluationSources'> {
   const { revision } = context;
-  const { head, merge } = observations;
+  const { head, merge, threads, eligibleReviews, deployments } = observations;
   const testMerge = facts.testMerge.data;
   const validMerge =
     available(facts.testMerge) &&
@@ -647,8 +649,178 @@ export function evaluateContextRequirements(
       }
       continue;
     }
-    items.push({ ...row, state: 'unavailable' });
+    const parameters: z.output<typeof objectSchema> = policy.parameters ?? {};
+    const reviewParameters =
+      policy.source === 'classic' ? object(parameters.required_pull_request_reviews) : parameters;
+    const viewerRule = {
+      requiredApprovingReviewCount: available(facts.viewerRule.requiredApprovingReviewCount)
+        ? facts.viewerRule.requiredApprovingReviewCount.data
+        : null,
+      requiresConversationResolution: available(facts.viewerRule.requiresConversationResolution)
+        ? facts.viewerRule.requiresConversationResolution.data
+        : null,
+    };
+    if (row.kind === 'branch-freshness') {
+      const comparison = facts.comparison.data;
+      const names = context.requirements.items.flatMap(item =>
+        item.policy?.id === policy.id && item.check ? [item.check.name] : []
+      );
+      const known =
+        names.length > 0 &&
+        names.every(name => enforced(policy, name)) &&
+        available(facts.comparison) &&
+        comparison !== null &&
+        comparison.baseTarget.oid === revision.baseSha &&
+        comparison.headTarget.oid === revision.headSha;
+      items.push(
+        record(
+          row,
+          known ? (comparison.behindBy > 0 ? 'unmet' : 'met') : 'unavailable',
+          facts.comparison.source,
+          known ? `branch-behind:${comparison.behindBy}` : 'freshness-evaluation-unavailable'
+        )
+      );
+    } else if (row.kind === 'conversation-resolution') {
+      const unresolved = threads.items.filter(thread => thread.isResolved === false);
+      const completeThreads =
+        complete(threads) && threads.items.every(thread => thread.isResolved !== null);
+      const known =
+        enforced(policy) &&
+        (policy.source !== 'classic' || viewerRule?.requiresConversationResolution === true);
+      items.push(
+        record(
+          row,
+          known && unresolved.length ? 'unmet' : known && completeThreads ? 'met' : 'unavailable',
+          threads.source,
+          completeThreads
+            ? `unresolved-threads:${unresolved.length};ids:${unresolved.map(thread => thread.id).join(',')}`
+            : unresolved.length
+              ? `observed-unresolved-thread-ids:${unresolved.map(thread => thread.id).join(',')}`
+              : 'conversation-observations-incomplete'
+        )
+      );
+    } else if (row.kind === 'approving-reviews') {
+      const count = reviewParameters.required_approving_review_count;
+      const consistent =
+        complete(eligibleReviews) &&
+        complete(context.reviewDecisions) &&
+        complete(context.reviewActivity) &&
+        new Set(eligibleReviews.items.map(review => review.actor?.id)).size ===
+          eligibleReviews.items.length &&
+        eligibleReviews.items.every(
+          review =>
+            review.actor?.kind === 'User' &&
+            review.actor.id &&
+            review.commitSha === revision.headSha &&
+            GitHubPrReviewTimestampSchema.safeParse(review.submittedAt).success &&
+            ['APPROVED', 'CHANGES_REQUESTED'].includes(review.state) &&
+            context.reviewDecisions.items.some(current => contextReviewsAgree(review, current))
+        );
+      const known =
+        enforced(policy) &&
+        consistent &&
+        typeof count === 'number' &&
+        Number.isInteger(count) &&
+        count > 0 &&
+        (policy.source !== 'classic' || viewerRule?.requiredApprovingReviewCount === count) &&
+        reviewFlags.every(
+          ([classicField, rulesetField]) =>
+            reviewParameters[policy.source === 'classic' ? classicField : rulesetField] === false
+        );
+      const approved = eligibleReviews.items.filter(review => review.state === 'APPROVED');
+      items.push(
+        record(
+          row,
+          known ? (approved.length < count ? 'unmet' : 'met') : 'unavailable',
+          eligibleReviews.source,
+          known
+            ? `eligible-approvals:${approved.length}/${count};ids:${approved.map(review => review.id).join(',')}`
+            : 'review-eligibility-or-enforcement-unavailable'
+        )
+      );
+    } else if (row.kind === 'deployment') {
+      const matching = deployments.items.filter(
+        deployment =>
+          deployment.environment === row.title && deployment.commitOid === revision.headSha
+      );
+      const deployment = matching.length === 1 ? matching[0] : undefined;
+      const state = deployment?.latestStatus?.state;
+      const known = enforced(policy) && complete(deployments) && deployment;
+      items.push(
+        record(
+          row,
+          known && state === 'SUCCESS'
+            ? 'met'
+            : known && (state === 'FAILURE' || state === 'ERROR')
+              ? 'unmet'
+              : 'unavailable',
+          deployments.source,
+          matching.length
+            ? matching
+                .map(
+                  observed =>
+                    `deployment:${observed.id};environment:${row.title};state:${observed.latestStatus?.state ?? 'unknown'}`
+                )
+                .join('|')
+            : 'matching-deployment-unavailable'
+        )
+      );
+    } else {
+      items.push({ ...row, state: 'unavailable' });
+    }
   }
+  // Names compare source coverage here; only the check matcher can establish an application binding.
+  const viewer = facts.viewerRule;
+  const conflicts = [
+    {
+      field: 'status-checks',
+      source: viewer.requiredStatusCheckContexts.source,
+      conflict:
+        available(viewer.requiredStatusCheckContexts) &&
+        viewer.requiredStatusCheckContexts.data?.some(
+          name =>
+            name === null ||
+            !items.some(row => currentPolicy(row.policy) && row.check?.name === name)
+        ),
+    },
+    {
+      field: 'approving-reviews',
+      source: viewer.requiredApprovingReviewCount.source,
+      conflict:
+        available(viewer.requiredApprovingReviewCount) &&
+        (viewer.requiredApprovingReviewCount.data ?? 0) > 0 &&
+        !items.some(row => {
+          if (row.kind !== 'approving-reviews' || !currentPolicy(row.policy)) return false;
+          const parameters =
+            row.policy.source === 'classic'
+              ? object(row.policy.parameters?.required_pull_request_reviews)
+              : row.policy.parameters;
+          return (
+            parameters?.required_approving_review_count === viewer.requiredApprovingReviewCount.data
+          );
+        }),
+    },
+    {
+      field: 'conversations',
+      source: viewer.requiresConversationResolution.source,
+      conflict:
+        available(viewer.requiresConversationResolution) &&
+        viewer.requiresConversationResolution.data === true &&
+        !items.some(row => currentPolicy(row.policy) && row.kind === 'conversation-resolution'),
+    },
+  ].filter(result => result.conflict);
+  if (complete(context.requirements) && conflicts.length)
+    items.push({
+      id: 'github:policy-evaluation',
+      kind: 'policy-evaluation',
+      title: 'Policy evaluation',
+      state: 'unavailable',
+      policy: null,
+      check: null,
+      evidence: conflicts.flatMap(result =>
+        evidence(result.source, `policy-source-conflict:${result.field}`)
+      ),
+    });
   for (const check of (selected?.items ?? allChecks).filter(
     check =>
       check.requiredness === 'required' && check.observation === 'observed' && !covered.has(check)
@@ -726,6 +898,20 @@ export function evaluateContextRequirements(
     selectedSha
   );
   return {
+    evaluationSources: {
+      mergeable: facts.mergeable.source,
+      testMerge: facts.testMerge.source,
+      comparison: facts.comparison.source,
+      canBypassClassic: facts.canBypassClassic.source,
+      requiredApprovingReviewCount: facts.viewerRule.requiredApprovingReviewCount.source,
+      requiredStatusCheckContexts: facts.viewerRule.requiredStatusCheckContexts.source,
+      requiresConversationResolution: facts.viewerRule.requiresConversationResolution.source,
+      threads: threads.source,
+      eligibleReviews: eligibleReviews.source,
+      reviewDecisions: context.reviewDecisions.source,
+      reviewActivity: context.reviewActivity.source,
+      deployments: deployments.source,
+    },
     evaluatedShas: [
       ...new Set([
         revision.headSha,


### PR DESCRIPTION
No new behavior — the mobile app does not use the new pull request results yet.

---

## Summary

`evaluateContextRequirements` now assigns outcomes to `branch-freshness`, `conversation-resolution`, `approving-reviews`, and `deployment`, instead of always leaving these requirements `unavailable`.
Current enforcement and direct evidence control each result; uncertain cases remain `unavailable`, but an observed unresolved thread can establish `unmet` without complete pagination.
If complete policy coverage cannot explain viewer requirements, an unavailable `policy-evaluation` row records the mismatch.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-requirements.ts` — Modified source (M), +189/-3 lines. Requires enforced check names and an exact head/base comparison for freshness; a positive behind count yields `unmet`, and zero yields `met`. Marks conversations `met` only when all threads are known and resolved. Approval counts require complete eligible reviews, decisions, and activity. Each eligible review needs a unique user, the current head, a valid timestamp, and a matching decision. Compares approvals with a positive required count. Code-owner review, last-push approval, or stale-review dismissal keeps approval counts `unavailable`. Classic conversation and approval rules must match the viewer's requirements. Evaluates one current-head deployment per required environment from complete observations: `SUCCESS` becomes `met`, while `FAILURE` or `ERROR` becomes `unmet`. Missing, duplicate, pending, and unknown deployments remain `unavailable`. Preserves revision-bound evidence and viewer-policy conflicts for check names, approval counts, and conversations; returns all 12 evaluation sources.

</details>

`GitHubPrReviewContextSchema` and `evaluateContextRequirements` now expose `evaluationSources`, retaining availability, retryability, provenance, reasons, and observation times for 12 inputs.
`evaluationSourcesSchema` validates those records; `evaluationSourceSchema` defaults missing entries to unavailable, non-retryable records with reason `source-state-not-recorded`, empty provenance, and no observation time.
Old payloads remain valid, but absent source state never proves success or an empty collection.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-dtos.ts` — Modified source (M), +23/-0 lines. Adds strict source records for `mergeable`, `testMerge`, `comparison`, `canBypassClassic`, `requiredApprovingReviewCount`, `requiredStatusCheckContexts`, and `requiresConversationResolution`. Also records `threads`, `eligibleReviews`, `reviewDecisions`, `reviewActivity`, and `deployments`, with defaults for an omitted object or omitted individual entries.

</details>

Tests: 2 modified files extend evaluator and contract coverage — `apps/web/src/lib/github-pr-review/context-requirements.test.ts` (M, +405/-0 lines) and `apps/web/src/lib/github-pr-review/context-dtos.test.ts` (M, +75/-0 lines); 480 added lines.
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

The handoff includes no manual test results for this level. The reader and mobile integration remain in later levels.

## Reviewer Notes

### Scope

- Repository: `Kilo-Org/cloud`.
- Worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- Scope: level 20 only, from `mobile-pr-review-context-5458-s19` to `mobile-pr-review-context-5458-s20`.

### Automated evidence

- The handoff reports 132 passing targeted cases for the evaluator and data transfer objects, plus passing scoped lint, formatting, and whitespace checks.
- This evidence does not establish live or repository-wide verification.

### Human steps

This change requires no human steps before merge or after merge.

### Notes

Live backend and iOS verification remains pending on the completed stack tip.








<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728 ← this PR
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
