### PR TITLE
test(pr-review): preserve check evaluation coverage

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-requirements.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-requirements.test.ts
@@ -204,6 +204,96 @@ function deployed() {
   return scenario;
 }
 
+it.each([
+  [true, 'FAILURE', 'required', 'failure', 'unmet'],
+  [false, 'FAILURE', 'optional', 'failure', 'unavailable'],
+  [undefined, 'FAILURE', 'unknown', 'failure', 'unavailable'],
+  [null, 'SUCCESS', 'unknown', 'success', 'unavailable'],
+  [true, 'NEUTRAL', 'required', 'skipped', 'met'],
+  [true, 'SKIPPED', 'required', 'skipped', 'met'],
+  [true, 'NEW_CONCLUSION', 'required', 'unknown', 'unavailable'],
+] as const)(
+  'keeps requiredness %s separate from conclusion %s',
+  (isRequired, conclusion, requiredness, outcome, state) => {
+    const scenario = setup();
+    scenario.observations.head = collection([check(run('RUN', 7, { isRequired, conclusion }))]);
+    const result = evaluate(scenario);
+    expect(result.checks.items[0]).toMatchObject({ requiredness, outcome, kind: 'check-run' });
+    expect(result.requirements.items.find(row => row.check)?.state).toBe(state);
+  }
+);
+
+it.each(['bypass', 'denied-bypass', 'unknown-context', 'no-policy'] as const)(
+  'keeps known required failures unavailable without established enforcement: %s',
+  condition => {
+    const scenario = setup(condition === 'no-policy' ? null : checkPolicy());
+    scenario.observations.head = collection([check(run('RUN', 7, { conclusion: 'FAILURE' }))]);
+    if (condition === 'bypass') scenario.facts.canBypassClassic = field(true);
+    if (condition === 'denied-bypass')
+      scenario.facts.canBypassClassic = {
+        data: null,
+        source: { ...source, availability: 'denied' },
+      };
+    if (condition === 'unknown-context')
+      scenario.facts.viewerRule.requiredStatusCheckContexts = field(null);
+    const result = evaluate(scenario);
+    expect(result.checks.items[0]).toMatchObject({ requiredness: 'required', outcome: 'failure' });
+    expect(result.requirements.items.filter(row => row.check)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ state: 'unavailable' })])
+    );
+    expect(result.requirements.items.some(row => row.state === 'unmet')).toBe(false);
+  }
+);
+
+it.each([
+  ['EXPECTED', 'pending', 'unmet'],
+  ['PENDING', 'pending', 'unmet'],
+  ['ERROR', 'failure', 'unmet'],
+  ['SUCCESS', 'success', 'met'],
+  ['NEW_STATE', 'unknown', 'unavailable'],
+] as const)('preserves the observed status state %s', (state, outcome, requirementState) => {
+  const scenario = setup();
+  scenario.observations.head = collection([check(status('STATUS', { state }))]);
+  const result = evaluate(scenario);
+  expect(result.checks.items[0]).toMatchObject({ kind: 'status', status: state, outcome });
+  expect(result.requirements.items[0]?.state).toBe(requirementState);
+});
+
+it('matches application IDs instead of equal display names and retains optional failures', () => {
+  const scenario = setup(checkPolicy(7));
+  scenario.observations.head = collection([
+    check(run('OTHER', 8, { isRequired: false, conclusion: 'FAILURE' })),
+    check(run('BOUND', 7)),
+  ]);
+  const result = evaluate(scenario);
+  expect(result.checks.items).toMatchObject([
+    {
+      id: 'OTHER',
+      application: { id: 8, name: 'Same display name' },
+      outcome: 'failure',
+      requiredness: 'optional',
+    },
+    { id: 'BOUND', application: { id: 7, name: 'Same display name' } },
+  ]);
+  expect(result.requirements.items.filter(row => row.check)).toMatchObject([
+    { state: 'met', check: { application: { kind: 'app', appId: 7 } } },
+  ]);
+  expect(result.requirements.items.some(row => row.state === 'unmet')).toBe(false);
+});
+
+it.each([null, 0])(
+  'does not normalize the undocumented application binding %s to a wildcard',
+  app_id => {
+    const scenario = setup(checkPolicy(app_id));
+    scenario.observations.head = collection([check(run('RUN'))]);
+    expect(
+      evaluate(scenario).requirements.items.find(
+        row => row.policy?.source === 'classic' && row.check
+      )
+    ).toMatchObject({ state: 'unavailable', check: { application: { kind: 'unknown' } } });
+  }
+);
+
 it('preserves both required run and status outcomes under an explicit wildcard', () => {
   const scenario = setup();
   scenario.observations.head = collection([
@@ -214,6 +304,163 @@ it('preserves both required run and status outcomes under an explicit wildcard',
     { state: 'met', check: { kind: 'check-run', application: { kind: 'any' } } },
     { state: 'unmet', check: { kind: 'status', application: { kind: 'any' } } },
   ]);
+});
+
+it('does not use a status creator or an inaccessible app to satisfy an application-bound policy', () => {
+  const scenario = setup(checkPolicy(7));
+  scenario.observations.head = collection([
+    check(status('STATUS', { creator: { id: 7, login: 'app-7' } })),
+    check(run('RUN', 7, { checkSuite: { app: null, commit: { oid: 'head' } } })),
+  ]);
+  const result = evaluate(scenario);
+  expect(
+    result.requirements.items.find(row => row.policy?.source === 'classic' && row.check)?.state
+  ).toBe('unavailable');
+  expect(result.checks.items.every(item => item.application === null)).toBe(true);
+  expect(result.checks.items.some(item => item.observation === 'missing')).toBe(false);
+});
+
+it.each([7, 8])(
+  'preserves duplicate names from app %s without guessing the latest run',
+  secondApp => {
+    const scenario = setup();
+    scenario.observations.head = collection([
+      check(run('FIRST', 7)),
+      check(run('SECOND', secondApp, { conclusion: 'FAILURE' })),
+    ]);
+    expect(requirements(scenario, 'status-check').map(row => row.state)).toEqual(
+      secondApp === 7 ? ['unavailable', 'unavailable'] : ['met', 'unmet']
+    );
+  }
+);
+
+it.each([
+  'complete',
+  'policy-partial',
+  'checks-partial',
+  'next-page',
+  'denied',
+  'unknown-bypass',
+] as const)(
+  'reports missing observations only with complete applicable evidence: %s',
+  condition => {
+    const scenario = setup();
+    if (condition === 'policy-partial') scenario.context.requirements.completeness = 'partial';
+    if (condition === 'checks-partial') scenario.observations.head.completeness = 'partial';
+    if (condition === 'next-page') scenario.observations.head.hasNextPage = true;
+    if (condition === 'denied')
+      scenario.observations.head.source = { ...source, availability: 'denied', retryable: false };
+    if (condition === 'unknown-bypass')
+      scenario.facts.canBypassClassic = {
+        data: null,
+        source: { ...source, availability: 'unavailable' },
+      };
+    const result = evaluate(scenario);
+    expect(result.checks.items.filter(item => item.observation === 'missing')).toHaveLength(
+      condition === 'complete' ? 1 : 0
+    );
+    expect(result.requirements.items.find(row => row.check)?.state).toBe(
+      condition === 'complete' ? 'unmet' : 'unavailable'
+    );
+  }
+);
+
+it('retains a directly observed failure when a later check page is unavailable', () => {
+  const scenario = setup();
+  scenario.observations.head = collection([check(run('RUN', 7, { conclusion: 'FAILURE' }))], {
+    completeness: 'partial',
+    totalCount: 2,
+    hasNextPage: true,
+    source: { ...source, availability: 'partial', retryable: true, reason: 'bad_gateway' },
+  });
+  const result = evaluate(scenario);
+  expect(result.checks.source).toMatchObject({ availability: 'partial', retryable: true });
+  expect(result.requirements.items).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ kind: 'status-check', state: 'unmet' }),
+      expect.objectContaining({ kind: 'check-evaluation', state: 'unavailable' }),
+    ])
+  );
+});
+
+it.each(['status', 'empty', 'run-only', 'partial', 'wrong-parents', 'head-only-context'] as const)(
+  'uses documented commit selection without inventing fallback: %s',
+  condition => {
+    const scenario = setup();
+    scenario.facts.testMerge = field({
+      oid: 'merge',
+      parents: {
+        totalCount: 2,
+        nodes: [{ oid: 'head' }, { oid: condition === 'wrong-parents' ? 'old-base' : 'base' }],
+      },
+    });
+    scenario.observations.head = collection([check(run('HEAD', 7, { conclusion: 'FAILURE' }))]);
+    const mergeCheck =
+      condition === 'run-only'
+        ? check(run('MERGE', 7, { checkSuite: { app: null, commit: { oid: 'merge' } } }))
+        : check(
+            status('MERGE', {
+              context: condition === 'head-only-context' ? 'other' : 'ci',
+              commit: { oid: 'merge' },
+              isRequired: condition !== 'head-only-context',
+            })
+          );
+    scenario.observations.merge = collection(condition === 'empty' ? [] : [mergeCheck]);
+    if (condition === 'partial') {
+      scenario.observations.merge = collection([], { completeness: 'partial', totalCount: null });
+    }
+    const result = evaluate(scenario);
+    expect(result.evaluatedShas).toEqual(['head', 'merge']);
+    expect(result.checks.items[0]?.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          observation: expect.stringContaining('head:head;test-merge:merge;selected:'),
+        }),
+      ])
+    );
+    const bound = result.requirements.items.filter(
+      row => row.policy?.source === 'classic' && row.check
+    );
+    expect(bound[0]?.state).toBe(
+      condition === 'status' ? 'met' : condition === 'empty' ? 'unmet' : 'unavailable'
+    );
+    if (condition !== 'empty')
+      expect(result.requirements.items.some(row => row.state === 'unmet')).toBe(false);
+    if (condition === 'head-only-context')
+      expect(result.checks.items.some(item => item.observation === 'missing')).toBe(false);
+  }
+);
+
+it.each(['missing', 'old-head', 'old-base', 'missing-time'] as const)(
+  'rejects incomplete or stale direct check evidence: %s',
+  condition => {
+    const scenario = setup();
+    const observed = check(run('RUN', 7, { conclusion: 'FAILURE' }));
+    if (condition === 'missing') observed.evidence = [];
+    for (const entry of observed.evidence) {
+      if (condition === 'old-head') entry.headSha = 'old-head';
+      if (condition === 'old-base') entry.baseSha = 'old-base';
+      if (condition === 'missing-time') entry.observedAt = null;
+    }
+    scenario.observations.head = collection([observed]);
+    expect(requirements(scenario, 'status-check')[0]?.state).toBe('unavailable');
+  }
+);
+
+it('does not satisfy a policy with an observation of unknown kind', () => {
+  const scenario = setup();
+  const observed = check(run('RUN'));
+  observed.kind = 'unknown';
+  scenario.observations.head = collection([observed]);
+  expect(requirements(scenario, 'status-check')[0]?.state).toBe('unavailable');
+});
+
+it('does not use an old check commit as current failure evidence', () => {
+  const scenario = setup();
+  scenario.observations.head = collection([
+    check(status('OLD', { state: 'FAILURE', commit: { oid: 'old-head' } })),
+  ]);
+  expect(requirements(scenario, 'status-check')[0]?.state).toBe('unavailable');
 });
 
 it.each([


### PR DESCRIPTION
No new behavior — this level adds regression tests without changing product code.

---

## Summary

Restored check regression tests exercise `contextCheckSchema`, `normalizeContextPolicies`, and `evaluateContextRequirements` directly, so the scenarios use the production contracts.
They separate check outcomes from enforcement, validate application bindings and commit selection, and keep uncertain evidence unavailable.
Production contracts, saved data, and existing callers remain unchanged; the added cases establish automated coverage, not live provider behavior.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-requirements.test.ts` — adds requiredness and conclusion cases: neutral and skipped required runs are `met`; optional or unknown requiredness and unknown outcomes remain `unavailable`. Covers `EXPECTED`, `PENDING`, and `ERROR` as `unmet`, `SUCCESS` as `met`, and unknown status states as `unavailable`. Tests bypass rights, denied bypass access, unknown viewer contexts, and missing policies without inventing blockers from observed failures. Matches `appId` rather than display names, retains optional failures, and leaves null or zero bindings unknown rather than wildcard. Rejects status creators and inaccessible applications as binding evidence without reporting missing checks. Keeps duplicate runs from one application `unavailable`; different applications retain independent outcomes under a wildcard. Reports missing checks as `unmet` only with complete applicable policies, complete observations, and established enforcement. Partial collections, pagination, denied access, and unknown bypass rights cannot establish missing checks. Retains an observed `unmet` failure when a later page fails, alongside partial retryable source metadata and an `unavailable` evaluation row. Selects a valid test-merge commit with status observations, and falls back to the head only for complete empty merge observations. Leaves run-only results, partial merge reads, wrong parents, and head-only contexts `unavailable`, without inventing blockers; head-only contexts do not create missing observations. Asserts `evaluatedShas` and selection evidence. Rejects missing evidence, old head or base revisions, missing timestamps, unknown check kinds, and checks tied to an old commit.

</details>

Tests: 1 modified test file, `apps/web/src/lib/github-pr-review/context-requirements.test.ts` (M; +247/-0 lines).
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual verification: skipped because this level changes tests only. The handoff includes no end-to-end report.

## Reviewer Notes

- Repository: `Kilo-Org/cloud`.
- Worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- Review scope: level 21 only, from `mobile-pr-review-context-5458-s20` to `mobile-pr-review-context-5458-s21`.
- These added tests do not establish live provider or repository-wide verification.

### Human steps

This level requires no human steps before merge or after merge.

### Notes

This level changes tests only. Live backend and iOS verification remains pending on the completed stack tip.







<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730 ← this PR
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
