### PR TITLE
test(pr-review): preserve policy evaluation coverage

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-requirements.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-requirements.test.ts
@@ -463,6 +463,53 @@ it('does not use an old check commit as current failure evidence', () => {
   expect(requirements(scenario, 'status-check')[0]?.state).toBe('unavailable');
 });
 
+it.each([true, false])('requires freshness enforcement before reporting branch lag: %s', strict => {
+  const scenario = setup(checkPolicy(-1, strict));
+  scenario.facts.comparison = field({
+    behindBy: 3,
+    baseTarget: { oid: 'base' },
+    headTarget: { oid: 'head' },
+  });
+  expect(requirements(scenario, 'branch-freshness')).toMatchObject(
+    strict ? [{ state: 'unmet' }] : []
+  );
+});
+
+it.each([
+  'partial-unresolved',
+  'partial-empty',
+  'complete-empty',
+  'unknown-field',
+  'unknown-enforcement',
+] as const)('keeps conversation evidence exact: %s', condition => {
+  const scenario = setup({ required_conversation_resolution: { enabled: true } });
+  scenario.observations.threads = collection(
+    condition === 'partial-unresolved'
+      ? [{ id: 'THREAD', isResolved: false }]
+      : condition === 'unknown-field'
+        ? [{ id: 'THREAD', isResolved: null }]
+        : []
+  );
+  if (condition.startsWith('partial')) scenario.observations.threads.completeness = 'partial';
+  if (condition === 'unknown-enforcement')
+    scenario.facts.canBypassClassic = { data: null, source: { ...source, availability: 'denied' } };
+  const row = requirements(scenario, 'conversation-resolution')[0];
+  expect(row?.state).toBe(
+    condition === 'partial-unresolved'
+      ? 'unmet'
+      : condition === 'complete-empty'
+        ? 'met'
+        : 'unavailable'
+  );
+  if (condition.startsWith('partial')) {
+    expect(row?.evidence.some(entry => entry.observation.startsWith('unresolved-threads:'))).toBe(
+      false
+    );
+    if (condition === 'partial-unresolved')
+      expect(row?.evidence.some(entry => entry.observation.includes('THREAD'))).toBe(true);
+  }
+});
+
 it.each([
   'known',
   'enough',
@@ -546,6 +593,201 @@ it.each([
       )
     ).toBe(true);
 });
+
+it('keeps ruleset review restrictions named with their installed REST field names', () => {
+  const scenario = setup(null, [
+    {
+      type: 'pull_request',
+      parameters: {
+        required_approving_review_count: 2,
+        dismiss_stale_reviews_on_push: true,
+        require_code_owner_review: true,
+        require_last_push_approval: true,
+        required_review_thread_resolution: true,
+        allowed_merge_methods: ['squash'],
+      },
+    },
+  ]);
+  expect(evaluate(scenario).requirements.items.map(row => [row.kind, row.state])).toEqual([
+    ['approving-reviews', 'unavailable'],
+    ['code-owner-reviews', 'unavailable'],
+    ['last-push-approval', 'unavailable'],
+    ['stale-review-dismissal', 'unavailable'],
+    ['conversation-resolution', 'unavailable'],
+    ['allowed-merge-methods', 'unavailable'],
+  ]);
+});
+
+it.each(['checks', 'reviews', 'conversations'] as const)(
+  'does not claim no policy when viewer enforcement contradicts it: %s',
+  field => {
+    const scenario = setup(null);
+    if (field === 'checks')
+      scenario.facts.viewerRule.requiredStatusCheckContexts = { data: ['ci'], source };
+    if (field === 'reviews')
+      scenario.facts.viewerRule.requiredApprovingReviewCount = { data: 2, source };
+    if (field === 'conversations')
+      scenario.facts.viewerRule.requiresConversationResolution = { data: true, source };
+    expect(evaluate(scenario).requirements.items).toMatchObject([
+      { kind: 'policy-evaluation', state: 'unavailable' },
+    ]);
+  }
+);
+
+it('preserves named unsupported rules without expanding generic merge states into failures', () => {
+  const scenario = setup({ required_signatures: { enabled: true } }, [
+    { type: 'workflows', parameters: { workflows: [] } },
+    { type: 'code_scanning', parameters: {} },
+    { type: 'future_rule', parameters: { required_conversation_resolution: { enabled: true } } },
+  ]);
+  expect(evaluate(scenario).requirements.items.map(row => [row.kind, row.state])).toEqual([
+    ['commit-signatures', 'unavailable'],
+    ['workflows', 'unavailable'],
+    ['code_scanning', 'unavailable'],
+    ['future_rule', 'unavailable'],
+  ]);
+});
+
+it.each([null, 'unknown'])('keeps an invalid signature flag %s named and unavailable', enabled => {
+  const scenario = setup({ ...checkPolicy(), required_signatures: { enabled } });
+  scenario.observations.head = collection([check(run('RUN'))]);
+  expect(evaluate(scenario).requirements.items).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ kind: 'commit-signatures', state: 'unavailable' }),
+    ])
+  );
+});
+
+it('keeps missing freshness configuration unavailable even when every observed check passes', () => {
+  const policy = checkPolicy();
+  const scenario = setup({
+    required_status_checks: {
+      contexts: policy.required_status_checks.contexts,
+      checks: policy.required_status_checks.checks,
+    },
+  });
+  scenario.observations.head = collection([check(run('RUN'))]);
+  expect(evaluate(scenario).requirements.items).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ kind: 'status-policy', state: 'unavailable' }),
+    ])
+  );
+});
+
+it('does not retain a generic unknown row after a fully supported check policy passes', () => {
+  const scenario = setup();
+  scenario.observations.head = collection([check(run('RUN'))]);
+  expect(evaluate(scenario).requirements.items).toMatchObject([
+    { kind: 'status-check', state: 'met' },
+  ]);
+});
+
+it.each(['complete', 'denied-policy', 'denied-checks'])(
+  'distinguishes no requirements from unavailable evidence: %s',
+  condition => {
+    const scenario = setup(null);
+    if (condition === 'denied-policy')
+      scenario.context.requirements = collection([], {
+        completeness: 'unknown',
+        totalCount: null,
+        source: { ...source, availability: 'denied', retryable: false },
+      });
+    if (condition === 'denied-checks')
+      scenario.observations.head = collection([], {
+        completeness: 'unknown',
+        totalCount: null,
+        source: { ...source, availability: 'denied', retryable: false },
+      });
+    const result = evaluate(scenario);
+    if (condition === 'complete')
+      expect(result.requirements).toMatchObject({
+        items: [],
+        completeness: 'complete',
+        source: { availability: 'available' },
+      });
+    if (condition === 'denied-policy')
+      expect(result.requirements.source).toMatchObject({
+        availability: 'denied',
+        retryable: false,
+      });
+    if (condition === 'denied-checks')
+      expect(result.requirements.items).toMatchObject([
+        { kind: 'check-evaluation', state: 'unavailable' },
+      ]);
+  }
+);
+
+it.each([
+  [
+    'check',
+    () => {
+      const scenario = setup();
+      scenario.observations.head = collection([check(run('FAILED', 7, { conclusion: 'FAILURE' }))]);
+      return scenario;
+    },
+    /^check:FAILED:failure$/,
+  ],
+  ['missing', () => setup(), /^required-check-missing:/],
+  [
+    'freshness',
+    () => {
+      const scenario = setup(checkPolicy(-1, true));
+      scenario.observations.head = collection([check(run('PASS'))]);
+      scenario.facts.comparison = field({
+        behindBy: 2,
+        baseTarget: { oid: 'base' },
+        headTarget: { oid: 'head' },
+      });
+      return scenario;
+    },
+    /^branch-behind:2$/,
+  ],
+  [
+    'conversation',
+    () => {
+      const scenario = setup({ required_conversation_resolution: { enabled: true } });
+      scenario.observations.threads = collection([{ id: 'UNRESOLVED', isResolved: false }]);
+      return scenario;
+    },
+    /^unresolved-threads:1;ids:UNRESOLVED$/,
+  ],
+  ['review', reviewed, /^eligible-approvals:1\/2;ids:REVIEW$/],
+  ['deployment', deployed, /^deployment:DEPLOY;environment:production;state:FAILURE$/],
+  [
+    'conflict',
+    () => {
+      const scenario = setup(null);
+      scenario.facts.mergeable = field('CONFLICTING');
+      return scenario;
+    },
+    /^mergeable:CONFLICTING$/,
+  ],
+] as const)(
+  'requires policy, current revision, and direct observation for every unmet %s row',
+  (_name, create, failure) => {
+    const result = evaluate(create());
+    const unmet = result.requirements.items.filter(row => row.state === 'unmet');
+    expect(unmet.length).toBeGreaterThan(0);
+    for (const row of unmet) {
+      expect(row.policy).toMatchObject({
+        enforcement: 'active',
+        base: { baseRepoFullName: 'o/r', baseRef: 'release', baseSha: 'base' },
+      });
+      expect(row.evidence).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            policyId: row.policy?.id,
+            headSha: 'head',
+            baseSha: 'base',
+            evaluatedSha: 'head',
+            observedAt: source.observedAt,
+            observation: expect.stringMatching(failure),
+          }),
+        ])
+      );
+    }
+  }
+);
 
 it.each(['failure', 'missing'] as const)(
   'retains current proof for a required check %s',


### PR DESCRIPTION
No new behavior — this change adds automated tests only.

---

## Summary

New `evaluateContextRequirements` regressions protect non-check policies and the evidence required for every `unmet` requirement across seven families.
They distinguish confirmed failures from unavailable evidence and confirmed absence of requirements, while retaining named unsupported rules.
These tests use the existing production contracts; runtime behavior, stored data, and callers do not change.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-requirements.test.ts` — adds the invariant for failed checks, missing required checks, branch lag, unresolved conversations, insufficient eligible approvals, failed deployments, and merge conflicts. Each fixture must produce an unmet row. Every unmet row must link its active policy to the base repository and branch, current head and base revisions, evaluated revision, timestamp, and direct observation. Strict mode produces an unmet freshness requirement for branch lag; disabling it produces no freshness requirement. Missing `strict` retains unavailable `status-policy` despite passing checks; a supported passing policy returns only a met `status-check`, without an extra unknown row. Partial unresolved threads remain unmet; partial empty results, unknown resolution fields, and unknown enforcement remain unavailable. Complete empty threads are met, while partial evidence names observed threads without asserting a complete count. Installed `pull_request` fields retain unavailable approving reviews, code-owner reviews, last-push approval, stale-review dismissal, conversation resolution, and allowed merge methods. Unsupported signatures, workflows, code scanning, and future rules stay named and unavailable; future rules do not expand nested conversation settings. Null and invalid signature flags also stay named and unavailable. Complete empty evidence yields no requirements; denied policies retain non-retryable denial, and denied checks add unavailable `check-evaluation`. Viewer check, approval-count, and conversation contradictions add unavailable `policy-evaluation` rather than claiming no policy.

</details>

Tests: 1 modified test file, `apps/web/src/lib/github-pr-review/context-requirements.test.ts` (M; +242/-0 lines).
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual verification was not run for this description because this level changes tests only. The handoff includes no end-to-end report.

## Reviewer Notes

- Repository: `Kilo-Org/cloud`.
- Worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- Review scope: level 22 only, from `mobile-pr-review-context-5458-s21` to `mobile-pr-review-context-5458-s22`.
- These tests do not establish live provider or repository-wide verification.

### Human steps

This test-only change requires no human steps before merge or after merge.

### Notes

This level changes tests only. Live backend and iOS verification remains pending on the completed stack tip.






<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732 ← this PR
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
