### PR TITLE
feat(extension): expose CLI task consent and supervision

### DIFF
--- a/apps/extension/entrypoints/sidepanel/agents-provider.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-provider.tsx
@@ -3,19 +3,20 @@ import { createContext, useContext, useEffect, useRef } from 'react';
 import type { JSX, ReactNode } from 'react';
 import type { createTRPCClient } from '@trpc/client';
 import { createBrowserLifecycleHooks, createUserWebConnection } from '@kilocode/cloud-agent-sdk';
-import type { SessionManager, UserWebConnection } from '@kilocode/cloud-agent-sdk';
+import type { SessionManager } from '@kilocode/cloud-agent-sdk';
 import type { MobileRouter } from '@kilocode/trpc/mobile';
 import type { StoredAuth } from '@/src/shared/auth';
 import { getKiloApiBaseUrl } from '@/src/shared/auth';
 import { getSessionIngestWsUrl } from '@/src/shared/cloud-agent-config';
 import { createExtensionTrpcClient } from '@/src/shared/extension-trpc-client';
 import { createExtensionAgentSessionManager } from '@/src/shared/extension-agent-session-manager';
+import { BrowserTaskProvider } from './browser-task-provider';
 
 type TrpcClient = ReturnType<typeof createTRPCClient<MobileRouter>>;
 
 export interface ExtensionAgentsContextValue {
   readonly manager: SessionManager;
-  readonly userWebConnection: UserWebConnection;
+  readonly userWebConnection: ReturnType<typeof createUserWebConnection>;
   readonly store: ReturnType<typeof createStore>;
   readonly trpcClient: TrpcClient;
   readonly organizationId: string | null;
@@ -43,15 +44,24 @@ export const ExtensionAgentsProvider = ({
   const apiBaseUrl = getKiloApiBaseUrl();
   const sessionIngestWsUrl = getSessionIngestWsUrl();
 
-  // Create-once via lazy useRef — matching web's CloudAgentProvider pattern.
-  const ref = useRef<ExtensionAgentsContextValue | null>(null);
-  if (ref.current === null) {
+  // Refresh scope-bound resources without remounting BrowserTaskProvider or losing its disposal barrier.
+  const ref = useRef<{
+    auth: StoredAuth;
+    context: ExtensionAgentsContextValue;
+  } | null>(null);
+  if (
+    ref.current === null ||
+    ref.current.auth.token !== auth.token ||
+    ref.current.auth.userEmail !== auth.userEmail ||
+    ref.current.context.organizationId !== organizationId
+  ) {
     const store = createStore();
     const getToken = (): string | undefined => auth.token;
 
     const trpcClient = createExtensionTrpcClient({ apiBaseUrl, getToken });
 
     const userWebConnection = createUserWebConnection({
+      browserProvider: true,
       getAuthToken: async () => {
         const tokenResult = await trpcClient.activeSessions.createWebTicket.mutate();
         return tokenResult.token;
@@ -69,20 +79,30 @@ export const ExtensionAgentsProvider = ({
       userWebConnection,
     });
 
-    ref.current = { manager, organizationId, store, trpcClient, userWebConnection };
+    ref.current = {
+      auth,
+      context: { manager, organizationId, store, trpcClient, userWebConnection },
+    };
   }
 
-  useEffect(() => {
-    const { userWebConnection: uwc } = ref.current!;
-    const release = uwc.retain();
-    return release;
-  }, []);
+  const { context } = ref.current;
+  useEffect(() => context.userWebConnection.retain(), [context]);
 
   return (
-    <JotaiProvider store={ref.current.store}>
-      <ExtensionAgentsContext.Provider value={ref.current}>
+    <ExtensionAgentsContext.Provider value={context}>
+      <BrowserTaskProvider
+        auth={auth}
+        connection={context.userWebConnection}
+        organizationId={organizationId ?? undefined}
+      >
         {children}
-      </ExtensionAgentsContext.Provider>
-    </JotaiProvider>
+      </BrowserTaskProvider>
+    </ExtensionAgentsContext.Provider>
   );
+};
+
+/** Only Agents descendants use the manager's store. Browser producers use getDefaultStore(). */
+export const ExtensionAgentsStore = ({ children }: { children: ReactNode }): JSX.Element => {
+  const { store } = useExtensionAgents();
+  return <JotaiProvider store={store}>{children}</JotaiProvider>;
 };

--- a/apps/extension/entrypoints/sidepanel/auth-shell.tsx
+++ b/apps/extension/entrypoints/sidepanel/auth-shell.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable import/max-dependencies */
+/* eslint-disable import/max-dependencies, max-lines -- Settings keeps delegated supervision inside its existing overlay. */
 import { storage } from '#imports';
 import { useAtom } from 'jotai';
 import { useEffect, useState } from 'react';
@@ -24,6 +24,8 @@ import {
   resolveAnalyticsOptOutIdentity,
   shouldShowFirefoxUsageDataHint,
 } from './analytics-settings-logic';
+import { BrowserTaskSettings } from './browser-task-controls';
+import { BrowserTaskSupervisionSlot } from './browser-task-supervision-slot';
 import { MemorySettings } from './memory-settings';
 import { OrganizationCreditAccountSelect } from './organization-credit-account';
 import { RemoteMcpSettings } from './remote-mcp-settings';
@@ -194,7 +196,12 @@ const HeaderActions = ({
               <X aria-hidden="true" className="size-4" />
             </button>
           </div>
+          <BrowserTaskSupervisionSlot />
           <div className="agent-conversation-scrollbar grid min-h-0 flex-1 content-start gap-4 overflow-y-auto px-4 py-4">
+            <BrowserTaskSettings
+              auth={auth}
+              organizationId={selectedOrganizationId === '' ? undefined : selectedOrganizationId}
+            />
             <div className="min-w-0 rounded-xl border border-border bg-surface-raised p-3">
               <p className="type-label text-foreground-muted">Signed in</p>
               <p className="type-body mt-1 truncate text-foreground">

--- a/apps/extension/entrypoints/sidepanel/auth-views.tsx
+++ b/apps/extension/entrypoints/sidepanel/auth-views.tsx
@@ -9,8 +9,9 @@ import type { SidePanelMode } from '@/src/shared/side-panel-mode';
 import { AgentChatPanel } from './agent-chat-panel';
 import { AgentsMode } from './agents-mode';
 import { AgentsModeSwitch } from './agents-mode-switch';
-import { ExtensionAgentsProvider } from './agents-provider';
+import { ExtensionAgentsProvider, ExtensionAgentsStore } from './agents-provider';
 import { Shell } from './auth-shell';
+import { BrowserTaskControls, BrowserTaskSurface } from './browser-task-controls';
 import { useOrganizationCreditAccount } from './organization-credit-account';
 import { PendingMemorySaveCard } from './pending-memory-save-card';
 import { PendingWorkflowSaveCard } from './pending-workflow-save-card';
@@ -169,36 +170,33 @@ export const SignedInView = ({
   const agentsOrgId = normalizeOrganizationId(selectedOrganizationId);
 
   return (
-    <Shell
-      auth={auth}
-      headerBeforeSettings={mode === 'browser' ? headerBeforeSettings : undefined}
-      onOrganizationChange={selectOrganization}
-      onSignOut={onSignOut}
-      organizationOptions={organizationOptions}
-      selectedOrganizationId={selectedOrganizationId}
-    >
-      <AgentsModeSwitch mode={mode} onModeChange={handleModeChange} />
-      {mode === 'browser' ? (
-        <>
+    <ExtensionAgentsProvider auth={auth} organizationId={agentsOrgId}>
+      <BrowserTaskSurface>
+        <Shell
+          auth={auth}
+          headerBeforeSettings={mode === 'browser' ? headerBeforeSettings : undefined}
+          onOrganizationChange={selectOrganization}
+          onSignOut={onSignOut}
+          organizationOptions={organizationOptions}
+          selectedOrganizationId={selectedOrganizationId}
+        >
+          <AgentsModeSwitch mode={mode} onModeChange={handleModeChange} />
+          <BrowserTaskControls />
           <PendingMemorySaveCard />
           <PendingWorkflowSaveCard />
-        </>
-      ) : null}
-      <AgentChatPanel
-        auth={auth}
-        isVisible={mode === 'browser'}
-        onHeaderBeforeSettingsChange={setHeaderBeforeSettings}
-        organizationId={selectedOrganizationId === '' ? undefined : selectedOrganizationId}
-      />
-      {mode === 'browser' ? null : (
-        <ExtensionAgentsProvider
-          auth={auth}
-          key={`${auth.token}:${selectedOrganizationId}`}
-          organizationId={agentsOrgId}
-        >
-          <AgentsMode />
-        </ExtensionAgentsProvider>
-      )}
-    </Shell>
+          <AgentChatPanel
+            auth={auth}
+            isVisible={mode === 'browser'}
+            onHeaderBeforeSettingsChange={setHeaderBeforeSettings}
+            organizationId={selectedOrganizationId === '' ? undefined : selectedOrganizationId}
+          />
+          {mode === 'browser' ? null : (
+            <ExtensionAgentsStore key={`${auth.token}:${auth.userEmail ?? ''}:${agentsOrgId}`}>
+              <AgentsMode />
+            </ExtensionAgentsStore>
+          )}
+        </Shell>
+      </BrowserTaskSurface>
+    </ExtensionAgentsProvider>
   );
 };

--- a/apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx
@@ -567,7 +567,10 @@ describe('browser task controls', () => {
   ] as const)('announces %s without a stale owner or a loading queue', (phase, label) => {
     fixture.state = { ...fixture.state, phase };
     renderControls();
-    expect(screen.getByRole('status').textContent).toBe(`CLI tasks: ${label}`);
+    expect(screen.getAllByRole('status').map(status => status.textContent)).toStrictEqual([
+      `CLI tasks: ${label}`,
+      '',
+    ]);
     expect(screen.getByText('Queue empty.')).toBeDefined();
     expect(screen.queryByText(/Owner session:/u)).toBeNull();
     expect(screen.queryByRole('button', { name: 'Stop CLI task' })).toBeNull();
@@ -817,6 +820,76 @@ describe('browser task controls', () => {
     expect(screen.queryByRole('button', { name: 'Refresh affected tabs' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Check recovery readiness' })).toBeNull();
   });
+
+  it.each([
+    {
+      label: 'Refresh status',
+      modal: false,
+      operation: 'refreshStatus',
+      pendingText: 'Retrieving status...',
+    },
+    {
+      label: 'Refresh status',
+      modal: true,
+      operation: 'refreshStatus',
+      pendingText: 'Retrieving status...',
+    },
+    {
+      label: 'Check recovery readiness',
+      modal: false,
+      operation: 'prepareRecovery',
+      pendingText: 'Checking recovery readiness...',
+    },
+    {
+      label: 'Check recovery readiness',
+      modal: true,
+      operation: 'prepareRecovery',
+      pendingText: 'Checking recovery readiness...',
+    },
+  ] as const)(
+    'updates a mounted status for the first $operation request (modal=$modal)',
+    async ({ modal, operation, label, pendingText }) => {
+      fixture.state = { ...fixture.state, phase: 'recovery' };
+      const pending = Promise.withResolvers<void>();
+      const action = vi.spyOn(actions, operation).mockImplementation(async () => {
+        await pending.promise;
+        return fixture.readiness;
+      });
+      renderControls(<SettingsOverlay />);
+      // eslint-disable-next-line jest/no-conditional-in-test -- Select the table's supervision surface.
+      const root = modal
+        ? openSettings()
+        : screen.getByRole('region', { name: 'CLI task supervision' });
+      const controls = within(root);
+      const status = controls.getAllByRole('status').find(region => region.textContent === '');
+      try {
+        expect(status).toBeDefined();
+        expect(status?.className).toBe('sr-only');
+        fireEvent.click(controls.getByRole('button', { name: label }));
+        expect(controls.getByText(pendingText)).toBe(status);
+        expect(status?.classList.contains('sr-only')).toBe(false);
+        expect(controls.getByRole('button', { name: label })).toHaveProperty('disabled', true);
+        await act(async () => {
+          pending.resolve();
+          await pending.promise;
+        });
+        expect(controls.getAllByRole('status')).toContain(status);
+        expect(status?.textContent).toBe(
+          // eslint-disable-next-line jest/no-conditional-in-test -- Each operation has a distinct completion notice.
+          operation === 'refreshStatus'
+            ? 'Status retrieved. This does not approve execution or resubmit work.'
+            : ''
+        );
+        expect(controls.getByRole('button', { name: label })).toHaveProperty('disabled', false);
+      } finally {
+        await act(async () => {
+          pending.resolve();
+          await pending.promise;
+        });
+        action.mockRestore();
+      }
+    }
+  );
 
   it('separates status retrieval, preparation, and explicit recovery and invalidates stale readiness', async () => {
     fixture.state = {

--- a/apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx
@@ -1,0 +1,919 @@
+/* eslint-disable max-lines, import/max-dependencies, import/first, jest/no-hooks, jest/no-untyped-mock-factory, jest/max-expects, vitest/prefer-import-in-mock, typescript/consistent-type-definitions, typescript/no-unsafe-type-assertion, require-await, typescript/require-await -- State fixtures exercise the controls; the separate tree suite uses the real provider and stores. */
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { useState, useSyncExternalStore } from 'react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserJobSnapshot, BrowserResult } from '@kilocode/cloud-agent-sdk/schemas';
+import type {
+  BrowserTaskProviderRuntime,
+  BrowserTaskProviderSnapshot,
+} from './browser-task-provider';
+import type { BrowserExecutionSnapshot } from './browser-execution-lock';
+import type { InspectableTab } from '@/src/shared/tab-debugger';
+import type { StoredAgentConversationStore } from '@/src/shared/agent-conversation-tabs';
+import type { BrowserProviderSettings } from '@/src/shared/browser-provider-settings';
+
+const fixture = vi.hoisted(() => ({
+  execution: {} as BrowserExecutionSnapshot,
+  listeners: new Set<() => void>(),
+  readiness: { ready: false, reason: 'Close the affected tab before recovery.' },
+  runtime: undefined as
+    | Pick<BrowserTaskProviderRuntime, 'getSnapshot' | 'setSettings' | 'subscribe'>
+    | undefined,
+  state: {} as BrowserTaskProviderSnapshot,
+  tabs: [] as InspectableTab[],
+}));
+vi.mock('./browser-task-provider', () => ({
+  useBrowserTask: () => {
+    const runtime = fixture.runtime ?? {
+      getSnapshot: () => fixture.state,
+      subscribe: (listener: () => void) => {
+        fixture.listeners.add(listener);
+        return () => {
+          fixture.listeners.delete(listener);
+        };
+      },
+    };
+    return {
+      ...actions,
+      ...runtime,
+      state: useSyncExternalStore(runtime.subscribe, runtime.getSnapshot),
+    };
+  },
+}));
+vi.mock(import('./browser-execution-lock'), async importOriginal => ({
+  ...(await importOriginal()),
+  useBrowserExecutionSnapshot: () => fixture.execution,
+}));
+vi.mock('./browser-task-runner', () => ({ getBrowserTaskTabs: async () => fixture.tabs }));
+vi.mock('./use-model-preferences', () => ({
+  useModelPreferences: () => ({
+    favorites: new Set<string>(),
+    refetch: vi.fn(),
+    status: 'ready',
+    toggleError: false,
+    toggleFavorite: vi.fn(),
+  }),
+}));
+vi.mock('./use-gateway-models', () => ({
+  useGatewayModels: () => ({
+    isLoading: false,
+    modelLoadError: undefined,
+    modelOptions: [
+      {
+        id: 'selected-model',
+        isPreferred: false,
+        name: 'Selected model',
+        variants: ['low', 'high'],
+      },
+      { id: 'other-model', isPreferred: false, name: 'Other model', variants: [] },
+    ],
+    refetchModels: vi.fn(),
+  }),
+}));
+vi.mock('./use-tab-debugger', () => ({
+  useTabDebugger: () => ({
+    inspectableTabs: fixture.tabs,
+    isLoadingTabs: false,
+    selectTab: vi.fn(),
+    selectedTabId: undefined,
+    tabDebuggerError: undefined,
+  }),
+}));
+
+import {
+  BrowserTaskControls,
+  BrowserTaskSettings,
+  BrowserTaskSurface,
+} from './browser-task-controls';
+import { BrowserTaskSupervisionSlot } from './browser-task-supervision-slot';
+import { ModelPicker } from './model-picker';
+import { ConversationHistoryButton } from './conversation-history-button';
+import { WorkflowRunPrompt } from './workflow-run-prompt';
+
+const job = (suffix = 'abcdefgh'): BrowserJobSnapshot => ({
+  browserTaskId: `bt_${suffix}`,
+  createdAt: '2026-08-29T20:00:00.000Z',
+  deadlines: {
+    approval: '2026-08-29T20:02:00.000Z',
+    execution: '2026-08-29T20:10:00.000Z',
+    queue: '2026-08-29T20:10:00.000Z',
+  },
+  expiresAt: '2026-09-05T20:00:00.000Z',
+  generation: 1,
+  invocationId: `invocation-${suffix}`,
+  jobId: `bj_${suffix}`,
+  payloadFingerprint: 'a'.repeat(64),
+  providerId: 'bp_profile',
+  status: 'awaiting_approval',
+});
+const change = (next: Partial<BrowserTaskProviderSnapshot>): void => {
+  fixture.state = { ...fixture.state, ...next };
+  for (const listener of fixture.listeners) {
+    listener();
+  }
+};
+const finish = (
+  reason: Exclude<BrowserResult['reason'], 'completed'>,
+  status: Exclude<BrowserResult['status'], 'succeeded'>
+): void => {
+  const { active } = fixture.state;
+  if (active === undefined) {
+    return;
+  }
+  const result: BrowserResult = {
+    ...active.job,
+    effectsUncertain: false,
+    evidence: [],
+    reason,
+    status,
+    summary: 'The invocation ended without replay.',
+  };
+  change({ active: undefined, jobs: [{ ...active.job, result, status }], phase: 'idle', result });
+};
+const actions = {
+  approve: async (jobId: string, tabId: number) => {
+    const { active, settings } = fixture.state;
+    const tab = fixture.tabs.find(candidate => candidate.id === tabId);
+    if (active?.job.jobId !== jobId || settings === undefined || tab === undefined) {
+      return;
+    }
+    const approvedTab = {
+      effectiveMode: settings.mode,
+      tabId: tab.id,
+      title: tab.title,
+      url: tab.url,
+    };
+    change({
+      active: { ...active, job: { ...active.job, approvedTab, status: 'running' } },
+      phase: 'running',
+    });
+  },
+  cancel: (jobId: string) => {
+    if (fixture.state.active?.job.jobId === jobId) {
+      finish('cancelled', 'cancelled');
+    } else {
+      change({ jobs: fixture.state.jobs.filter(row => row.jobId !== jobId) });
+    }
+  },
+  prepareRecovery: async () => fixture.readiness,
+  recover: async () => {
+    change({ message: 'Recovered; new work requires fresh consent.', phase: 'idle' });
+  },
+  refreshStatus: async () => {
+    change({ message: 'Stored status retrieved without execution.' });
+  },
+  reject: () => {
+    finish('approval_denied', 'failed');
+  },
+  retryConnection: () => {
+    change({ message: 'Connecting without resubmission.', phase: 'connecting' });
+  },
+  setSettings: async (settings: BrowserProviderSettings) => {
+    change({ settings });
+  },
+};
+const clients: QueryClient[] = [];
+const renderControls = (children?: ReactNode) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  clients.push(client);
+  const surface = (content: ReactNode) => (
+    <QueryClientProvider client={client}>
+      <BrowserTaskSurface>
+        <button type="button">Outside</button>
+        <BrowserTaskControls />
+        {content}
+      </BrowserTaskSurface>
+    </QueryClientProvider>
+  );
+  const view = render(surface(children));
+  return {
+    ...view,
+    rerender: (content: ReactNode) => {
+      view.rerender(surface(content));
+    },
+  };
+};
+const auth = { token: 'unit-token', userEmail: 'owner@example.test' };
+const SettingsOverlay = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        onClick={() => {
+          setOpen(true);
+        }}
+        type="button"
+      >
+        Settings
+      </button>
+      {open ? (
+        <div aria-label="Settings panel" aria-modal="true" role="dialog">
+          <button
+            onClick={() => {
+              setOpen(false);
+            }}
+            type="button"
+          >
+            Close settings
+          </button>
+          <BrowserTaskSupervisionSlot />
+          <BrowserTaskSettings auth={auth} organizationId={undefined} />
+        </div>
+      ) : null}
+    </>
+  );
+};
+const openSettings = (): HTMLElement => {
+  fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+  return screen.getByRole('dialog', { name: 'Settings panel' });
+};
+const createSettingsRuntime = (
+  enabled: boolean,
+  persist: (settings: BrowserProviderSettings) => Promise<void>
+) => {
+  let state: BrowserTaskProviderSnapshot = {
+    ...fixture.state,
+    phase: enabled ? 'idle' : 'disabled',
+    settings: { enabled, mode: 'safe', model: 'selected-model', thinkingEffort: 'low' },
+  };
+  const listeners = new Set<() => void>();
+  const writes: { pending: Promise<void> | undefined } = { pending: undefined };
+  return {
+    getSnapshot: () => state,
+    // Match the provider contract: publish settings only after serialized persistence finishes.
+    setSettings: (settings: BrowserProviderSettings) => {
+      const previous = writes.pending;
+      writes.pending = (async () => {
+        await previous;
+        try {
+          await persist(settings);
+          state = { ...state, phase: settings.enabled ? 'idle' : 'disabled', settings };
+        } catch {
+          state = {
+            ...state,
+            message: 'Browser task storage is unavailable. Restore storage access and retry.',
+            phase: 'unavailable',
+            retryable: true,
+          };
+        }
+        for (const listener of listeners) {
+          listener();
+        }
+      })();
+      return writes.pending;
+    },
+    settled: async () => {
+      await writes.pending;
+    },
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+};
+const modelOptions = [
+  { id: 'selected-model', isPreferred: false, name: 'Selected model', variants: [] },
+];
+const emptyConversations: [] = [];
+const emptyStore = {} as StoredAgentConversationStore;
+const noParams: [] = [];
+const ModalExamples = () => {
+  const [workflowOpen, setWorkflowOpen] = useState(false);
+  return (
+    <>
+      <ModelPicker
+        auth={auth}
+        disabled={false}
+        model=""
+        modelOptions={modelOptions}
+        onModelChange={vi.fn()}
+        organizationId={undefined}
+      />
+      <ConversationHistoryButton
+        activeConversationId=""
+        conversations={emptyConversations}
+        conversationStore={emptyStore}
+        onDeleteConversation={vi.fn()}
+        onOpenConversation={vi.fn()}
+      />
+      <button
+        onClick={() => {
+          setWorkflowOpen(true);
+        }}
+        type="button"
+      >
+        Open workflow prompt
+      </button>
+      {workflowOpen ? (
+        <WorkflowRunPrompt
+          name="Example"
+          onCancel={() => {
+            setWorkflowOpen(false);
+          }}
+          onRun={() => {
+            setWorkflowOpen(false);
+          }}
+          params={noParams}
+        />
+      ) : null}
+    </>
+  );
+};
+
+describe('browser task controls', () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    fixture.runtime = undefined;
+    fixture.tabs = [
+      { id: 7, title: 'Requested page', url: 'https://example.test/requested' },
+      { id: 8, title: 'Another page', url: 'https://other.test/' },
+    ];
+    fixture.state = {
+      active: undefined,
+      jobs: [],
+      message: 'Provider status detail.',
+      phase: 'disabled',
+      profile: { label: 'Work browser', providerId: 'bp_profile' },
+      result: undefined,
+      retryable: false,
+      settings: { enabled: false, mode: 'safe', model: 'selected-model', thinkingEffort: '' },
+      unresolvedFence: undefined,
+    };
+    fixture.execution = {
+      blockedReason: undefined,
+      delegated: 'idle',
+      delegationUnavailableReason: undefined,
+      localRuns: 0,
+      owner: undefined,
+      providerOwned: true,
+      quarantinedTabIds: [],
+    };
+    fixture.readiness = { ready: false, reason: 'Close the affected tab before recovery.' };
+  });
+  afterEach(() => {
+    cleanup();
+    for (const client of clients.splice(0)) {
+      client.clear();
+    }
+    fixture.listeners.clear();
+  });
+
+  it.each([
+    {
+      choice: 'Other model',
+      expected: { model: 'other-model' },
+      setting: 'model',
+      trigger: 'Model',
+    },
+    {
+      choice: /^Dangerous/u,
+      expected: { mode: 'dangerous' },
+      setting: 'mode',
+      trigger: /Safe mode:/u,
+    },
+  ])(
+    'keeps confirmed disablement after reopening Settings and attempting a $setting change',
+    async ({ trigger, choice, expected }) => {
+      const write = Promise.withResolvers<void>();
+      const persisted: { settings: BrowserProviderSettings | undefined } = { settings: undefined };
+      const runtime = createSettingsRuntime(true, async settings => {
+        await write.promise;
+        persisted.settings = settings;
+      });
+      fixture.runtime = runtime;
+      renderControls(<SettingsOverlay />);
+      try {
+        openSettings();
+        fireEvent.click(screen.getByRole('switch', { name: 'CLI tasks' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Disable CLI tasks' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Close settings' }));
+        expect(screen.queryByRole('region', { name: 'CLI task settings' })).toBeNull();
+        const reopened = openSettings();
+        const savingVisible = within(reopened).queryByText('Saving CLI task settings...') !== null;
+        const disabledControls = [
+          screen.getByRole<HTMLButtonElement>('switch', { name: 'CLI tasks' }),
+          screen.getByRole<HTMLButtonElement>('button', { name: 'Model' }),
+          screen.getByRole<HTMLButtonElement>('button', { name: /Safe mode:/u }),
+          screen.getByRole<HTMLSelectElement>('combobox', { name: 'Thinking effort' }),
+        ].map(control => control.disabled);
+        fireEvent.click(screen.getByRole('button', { name: trigger }));
+        // Select an option only if the pending save incorrectly lets its picker open.
+        for (const option of screen.queryAllByRole('button', { name: choice })) {
+          fireEvent.click(option);
+        }
+        fireEvent.change(screen.getByRole('combobox', { name: 'Thinking effort' }), {
+          target: { value: 'high' },
+        });
+        await act(async () => {
+          write.resolve();
+          await runtime.settled();
+        });
+        expect(persisted.settings).toStrictEqual({
+          enabled: false,
+          mode: 'safe',
+          model: 'selected-model',
+          thinkingEffort: 'low',
+        });
+        expect(savingVisible).toBe(true);
+        expect(disabledControls).toStrictEqual([true, true, true, true]);
+        expect(screen.getByRole('switch', { name: 'CLI tasks' }).getAttribute('aria-checked')).toBe(
+          'false'
+        );
+        fireEvent.click(screen.getByRole('button', { name: trigger }));
+        fireEvent.click(screen.getByRole('button', { name: choice }));
+        fireEvent.click(screen.getByRole('button', { name: 'Close settings' }));
+        await act(async () => {
+          await runtime.settled();
+        });
+        const saved = openSettings();
+        expect(persisted.settings).toMatchObject({ ...expected, enabled: false });
+        expect(within(saved).getByText('CLI tasks: Disabled')).toBeDefined();
+        expect(within(saved).queryByText('Saving CLI task settings...')).toBeNull();
+      } finally {
+        await act(async () => {
+          write.resolve();
+          await runtime.settled();
+        });
+      }
+    }
+  );
+
+  it('restores settings retry controls after a failed save across overlay closure without enabling', async () => {
+    const write = Promise.withResolvers<void>();
+    const persisted: { settings: BrowserProviderSettings | undefined } = { settings: undefined };
+    const persist = vi
+      .fn(async (settings: BrowserProviderSettings) => {
+        persisted.settings = settings;
+      })
+      .mockReturnValueOnce(write.promise);
+    const runtime = createSettingsRuntime(false, persist);
+    fixture.runtime = runtime;
+    renderControls(<SettingsOverlay />);
+    openSettings();
+    fireEvent.change(screen.getByRole('combobox', { name: 'Thinking effort' }), {
+      target: { value: 'high' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Close settings' }));
+    const reopened = openSettings();
+    await act(async () => {
+      write.reject(new Error('Storage unavailable.'));
+      await runtime.settled();
+    });
+    expect(within(reopened).getByText(/Restore storage access and retry/u)).toBeDefined();
+    expect(within(reopened).queryByText('Saving CLI task settings...')).toBeNull();
+    expect(
+      screen.getByRole<HTMLSelectElement>('combobox', { name: 'Thinking effort' }).disabled
+    ).toBe(false);
+    expect(screen.getByRole('switch', { name: 'CLI tasks' }).getAttribute('aria-checked')).toBe(
+      'false'
+    );
+    expect(persisted.settings).toBeUndefined();
+    fireEvent.change(screen.getByRole('combobox', { name: 'Thinking effort' }), {
+      target: { value: 'high' },
+    });
+    await act(async () => {
+      await runtime.settled();
+    });
+    expect(persisted.settings).toMatchObject({ enabled: false, thinkingEffort: 'high' });
+    expect(within(reopened).getByText('CLI tasks: Disabled')).toBeDefined();
+  });
+
+  it('keeps a replacement runtime save pending when the old runtime save completes', async () => {
+    const oldWrite = Promise.withResolvers<void>();
+    const nextWrite = Promise.withResolvers<void>();
+    const oldRuntime = createSettingsRuntime(true, () => oldWrite.promise);
+    const nextRuntime = createSettingsRuntime(false, () => nextWrite.promise);
+    fixture.runtime = oldRuntime;
+    const view = renderControls(<SettingsOverlay />);
+    try {
+      openSettings();
+      fireEvent.click(screen.getByRole('switch', { name: 'CLI tasks' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Disable CLI tasks' }));
+      fixture.runtime = nextRuntime;
+      view.rerender(<SettingsOverlay />);
+      const mode = screen.getByRole<HTMLButtonElement>('button', { name: /Safe mode:/u });
+      expect(mode.disabled).toBe(false);
+      fireEvent.click(mode);
+      fireEvent.click(screen.getByRole('button', { name: /^Dangerous/u }));
+      await act(async () => {
+        oldWrite.resolve();
+        await oldRuntime.settled();
+      });
+      expect(screen.getByText('Saving CLI task settings...')).toBeDefined();
+      expect(screen.getByRole<HTMLButtonElement>('button', { name: /Safe mode:/u }).disabled).toBe(
+        true
+      );
+      expect(screen.getByRole('switch', { name: 'CLI tasks' }).getAttribute('aria-checked')).toBe(
+        'false'
+      );
+      await act(async () => {
+        nextWrite.resolve();
+        await nextRuntime.settled();
+      });
+      expect(screen.queryByText('Saving CLI task settings...')).toBeNull();
+      expect(
+        screen.getByRole<HTMLButtonElement>('button', { name: /Danger mode:/u }).disabled
+      ).toBe(false);
+      expect(screen.getByRole('switch', { name: 'CLI tasks' }).getAttribute('aria-checked')).toBe(
+        'false'
+      );
+    } finally {
+      await act(async () => {
+        oldWrite.resolve();
+        nextWrite.resolve();
+        await Promise.all([oldRuntime.settled(), nextRuntime.settled()]);
+      });
+    }
+  });
+
+  it.each([
+    ['disabled', 'Disabled'],
+    ['idle', 'Enabled — idle'],
+    ['connecting', 'Connecting'],
+    ['unsupported', 'Unsupported'],
+    ['unavailable', 'Unavailable'],
+    ['owned_elsewhere', 'Owned by another panel'],
+    ['awaiting_approval', 'Tab approval required'],
+    ['waiting', 'Waiting for browser control'],
+    ['running', 'Running'],
+    ['interrupted', 'Interrupted'],
+    ['recovery', 'Recovery required'],
+  ] as const)('announces %s without a stale owner or a loading queue', (phase, label) => {
+    fixture.state = { ...fixture.state, phase };
+    renderControls();
+    expect(screen.getByRole('status').textContent).toBe(`CLI tasks: ${label}`);
+    expect(screen.getByText('Queue empty.')).toBeDefined();
+    expect(screen.queryByText(/Owner session:/u)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Stop CLI task' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Reload panel' })).toBeNull();
+  });
+
+  it('offers a named reload with storage guidance only for retryable initialization failure', () => {
+    fixture.state = {
+      ...fixture.state,
+      phase: 'unavailable',
+      profile: undefined,
+      retryable: true,
+      settings: undefined,
+    };
+    renderControls();
+    expect(screen.getByText(/Restore storage access, then reload this panel/u)).toBeDefined();
+    expect(
+      screen.getByText(/Reload preserves your account, saved settings, and safety records/u)
+    ).toBeDefined();
+    const reload = screen.getByRole<HTMLButtonElement>('button', { name: 'Reload panel' });
+    expect(reload.disabled).toBe(false);
+    reload.focus();
+    expect(document.activeElement).toBe(reload);
+    expect(screen.queryByRole('button', { name: 'Refresh status' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Reconnect' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Check recovery readiness' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+    expect(screen.queryByText(/Retrieve status first/u)).toBeNull();
+    act(() => {
+      change({ retryable: false });
+    });
+    expect(screen.queryByRole('button', { name: 'Reload panel' })).toBeNull();
+    expect(screen.queryByText(/Restore storage access, then reload this panel/u)).toBeNull();
+  });
+
+  it.each([
+    { delegated: 'idle', label: 'local browser work', localRuns: 1 },
+    { delegated: 'running', label: 'delegated execution', localRuns: 0 },
+    { delegated: 'waiting', label: 'pending execution cleanup', localRuns: 0 },
+  ] as const)('blocks initialization reload during $label', ({ delegated, localRuns }) => {
+    fixture.state = {
+      ...fixture.state,
+      phase: 'unavailable',
+      profile: undefined,
+      retryable: true,
+      settings: undefined,
+    };
+    fixture.execution = { ...fixture.execution, delegated, localRuns };
+    renderControls();
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Reload panel' }).disabled).toBe(
+      true
+    );
+    expect(
+      screen.getByText('Stop browser work and wait for cleanup before reloading.')
+    ).toBeDefined();
+    act(() => {
+      fixture.execution = { ...fixture.execution, delegated: 'idle', localRuns: 0 };
+      change({});
+    });
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Reload panel' }).disabled).toBe(
+      false
+    );
+    expect(
+      screen.queryByText('Stop browser work and wait for cleanup before reloading.')
+    ).toBeNull();
+  });
+
+  it('requires an explicit candidate and approval while retaining a long goal after tab loss', async () => {
+    const goal = `Inspect ${'long goal '.repeat(160)}`;
+    fixture.state = {
+      ...fixture.state,
+      active: {
+        approval: undefined,
+        goal,
+        job: job(),
+        ownerLabel: 'ses_same-repository_owner-12345678',
+      },
+      phase: 'awaiting_approval',
+      settings: { enabled: true, mode: 'dangerous', model: 'selected-model', thinkingEffort: '' },
+    };
+    const view = renderControls();
+    await screen.findByRole('option', { name: 'Requested page' });
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Approve tab' }).disabled).toBe(
+      true
+    );
+    fireEvent.change(screen.getByLabelText('Tab to approve'), { target: { value: '7' } });
+    expect(screen.getByText('Address: https://example.test/requested')).toBeDefined();
+    expect(screen.getByText('Mode: Dangerous · Model: selected-model')).toBeDefined();
+    expect(screen.getByText('Bound tab: Not approved')).toBeDefined();
+    fixture.tabs = fixture.tabs.filter(tab => tab.id !== 7);
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh tabs' }));
+    await screen.findByText(/That candidate tab is no longer available/u);
+    expect(view.container.textContent).toContain(goal);
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Approve tab' }).disabled).toBe(
+      true
+    );
+    fireEvent.change(screen.getByLabelText('Tab to approve'), { target: { value: '8' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve tab' }));
+    await screen.findByText('Bound tab: Another page (ID 8)');
+    expect(screen.getByText('CLI tasks: Running')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Stop CLI task' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+  });
+
+  it('keeps the execution deadline for a terminal invocation that is still draining', () => {
+    const bound = {
+      ...job(),
+      approvedTab: {
+        effectiveMode: 'safe' as const,
+        tabId: 7,
+        title: 'Closed tab',
+        url: 'https://example.test/',
+      },
+    };
+    const result: BrowserResult = {
+      ...bound,
+      effectsUncertain: true,
+      evidence: [],
+      reason: 'tab_lost',
+      status: 'interrupted',
+      summary: 'The bound tab closed.',
+    };
+    fixture.state = {
+      ...fixture.state,
+      active: {
+        approval: undefined,
+        goal: 'Inspect the bound page',
+        job: { ...bound, result, status: 'interrupted' },
+        ownerLabel: 'ses_12345678',
+      },
+      phase: 'interrupted',
+      result,
+    };
+    renderControls();
+    expect(screen.getByText(/Execution deadline:/u)).toBeDefined();
+    expect(screen.queryByText(/Approval deadline:/u)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Stop CLI task' })).toBeNull();
+  });
+
+  it('rejects consent without approving a tab or leaving stale actions', async () => {
+    fixture.state = {
+      ...fixture.state,
+      active: { approval: undefined, goal: 'Read only', job: job(), ownerLabel: 'ses_12345678' },
+      phase: 'awaiting_approval',
+    };
+    renderControls();
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    await screen.findByText('Last outcome: failed · approval_denied');
+    expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+    expect(screen.queryByText(/Bound tab:/u)).toBeNull();
+  });
+
+  it('uses authoritative queue ranks and labels and cancels only the selected queued job', () => {
+    fixture.state = {
+      ...fixture.state,
+      jobs: [
+        {
+          ...job('second02'),
+          ownerLabel: 'ses_owner_bbbbbbbb',
+          queuePosition: 2,
+          status: 'queued',
+        },
+        { ...job('legacy00'), status: 'queued' },
+        {
+          ...job('first001'),
+          ownerLabel: 'ses_owner_aaaaaaaa',
+          queuePosition: 1,
+          status: 'queued',
+        },
+      ],
+      phase: 'idle',
+    };
+    renderControls();
+    const list = screen.getByRole('list', { name: 'Queued CLI tasks' });
+    const rows = within(list).getAllByRole('listitem');
+    expect(rows.map(row => row.textContent)).toStrictEqual([
+      expect.stringContaining('Queue position: 1'),
+      expect.stringContaining('Queue position: 2'),
+      expect.stringContaining('Queue position: Unknown'),
+    ]);
+    expect(within(rows[2]!).getByText('Owner session: Unknown')).toBeDefined();
+    expect(within(rows[0]!).getByText(/Queue deadline:/u).textContent).not.toContain('Unknown');
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel queued task second02' }));
+    expect(within(list).getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getByText(/ses_owner_aaaaaaaa/u)).toBeDefined();
+    expect(screen.queryByText(/ses_owner_bbbbbbbb/u)).toBeNull();
+  });
+
+  it('separates status retrieval, preparation, and explicit recovery and invalidates stale readiness', async () => {
+    fixture.state = {
+      ...fixture.state,
+      phase: 'recovery',
+      settings: { enabled: true, mode: 'safe', model: 'selected-model', thinkingEffort: '' },
+    };
+    renderControls();
+    expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh status' }));
+    await screen.findByText('Status retrieved. This does not approve execution or resubmit work.');
+    expect(screen.getByText('CLI tasks: Recovery required')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+    await screen.findByText('Close the affected tab before recovery.');
+    expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+    fixture.readiness = {
+      ready: true,
+      reason: 'Tabs closed and locks drained. Quarantine remains until explicit recovery.',
+    };
+    fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+    await screen.findByRole('button', { name: 'Recover browser control' });
+    expect(screen.getByText('CLI tasks: Recovery required')).toBeDefined();
+    act(() => {
+      change({ message: 'Provider state changed.' });
+    });
+    expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Recover browser control' }));
+    await screen.findByText('CLI tasks: Enabled — idle');
+    expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+  });
+
+  it('shows concrete all-tabs and unsupported-lock instructions without a recovery bypass', () => {
+    fixture.state = { ...fixture.state, phase: 'unsupported' };
+    fixture.execution = {
+      ...fixture.execution,
+      blockedReason:
+        'Close all target tabs before recovery. The affected-tab list is not known to be complete.',
+      delegationUnavailableReason: 'Web Locks unavailable.',
+    };
+    renderControls();
+    expect(
+      screen.getByText(
+        'Recovery requires Web Locks. Restore browser Web Locks support before recovering.'
+      )
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        'Close all target tabs before recovery. The affected-tab list is not known to be complete.'
+      )
+    ).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Reconnect' })).toBeNull();
+  });
+
+  it('offers reconnect only for retryable unavailability and never invents consent from status', async () => {
+    fixture.state = {
+      ...fixture.state,
+      message: 'provider_unavailable',
+      phase: 'unavailable',
+      retryable: true,
+    };
+    renderControls();
+    expect(screen.queryByRole('button', { name: 'Reload panel' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Reconnect' }));
+    await screen.findByText('CLI tasks: Connecting');
+    expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+    act(() => {
+      change({ message: 'owner_mismatch', phase: 'unavailable', retryable: false });
+    });
+    expect(screen.getByText('owner_mismatch')).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Reconnect' })).toBeNull();
+  });
+
+  it.each([
+    [
+      'provider_unavailable',
+      true,
+      'Status unavailable: provider_unavailable. Reconnect and retrieve status again. No work was resubmitted.',
+    ],
+    [
+      'owner_mismatch',
+      false,
+      'Status denied: owner_mismatch. Restore provider access before retrieving status. No work was resubmitted.',
+    ],
+  ] as const)(
+    'keeps the %s status failure distinct without execution approval',
+    async (reason, retryable, message) => {
+      const { BrowserProviderError } =
+        await import('@kilocode/cloud-agent-sdk/user-web-connection');
+      vi.spyOn(actions, 'refreshStatus').mockRejectedValueOnce(
+        new BrowserProviderError(reason, retryable)
+      );
+      fixture.state = { ...fixture.state, phase: 'unavailable', retryable };
+      renderControls();
+      fireEvent.click(screen.getByRole('button', { name: 'Refresh status' }));
+      await screen.findByText(message);
+      expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+    }
+  );
+
+  it.each([
+    {
+      close: 'Close model picker',
+      lastName: 'Search models',
+      lastRole: 'searchbox',
+      name: 'Select model',
+      opener: 'Model',
+    },
+    {
+      close: 'Close history',
+      lastName: 'Refresh status',
+      lastRole: 'button',
+      name: 'Conversation history',
+      opener: 'History',
+    },
+    {
+      close: 'Cancel',
+      lastName: 'Run',
+      lastRole: 'button',
+      name: 'Run workflow "Example"',
+      opener: 'Open workflow prompt',
+    },
+  ])(
+    'keeps Stop, focus containment, and focus restoration inside the $opener overlay',
+    async ({ close, lastName, lastRole, name, opener }) => {
+      fixture.state = {
+        ...fixture.state,
+        active: {
+          approval: undefined,
+          goal: 'Long goal '.repeat(100),
+          job: {
+            ...job(),
+            approvedTab: {
+              effectiveMode: 'safe',
+              tabId: 7,
+              title: 'Long title '.repeat(100),
+              url: `https://example.test/${'long-path/'.repeat(100)}`,
+            },
+            status: 'running',
+          },
+          ownerLabel: 'ses_owner_12345678',
+        },
+        phase: 'running',
+      };
+      renderControls(<ModalExamples />);
+      const trigger = screen.getByRole('button', { name: opener });
+      trigger.focus();
+      fireEvent.click(trigger);
+      const dialog = await screen.findByRole('dialog', { name });
+      const stop = within(dialog).getByRole('button', { name: 'Stop CLI task' });
+      expect(within(dialog).getByText(/Bound tab:/u)).toBeDefined();
+      expect(within(dialog).getByText(/ses_owner_12345678/u)).toBeDefined();
+      const [first] = within(dialog).getAllByRole('button');
+      const last = within(dialog).getByRole(lastRole, { name: lastName });
+      last.focus();
+      fireEvent.keyDown(dialog, { key: 'Tab' });
+      expect(document.activeElement).toBe(first);
+      fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
+      expect(document.activeElement).toBe(last);
+      screen.getByRole('button', { name: 'Outside' }).focus();
+      expect(dialog.contains(document.activeElement)).toBe(true);
+      stop.focus();
+      expect(document.activeElement).toBe(stop);
+      fireEvent.click(within(dialog).getByRole('button', { name: close }));
+      await waitFor(() => {
+        expect(document.activeElement).toBe(trigger);
+      });
+      fireEvent.click(trigger);
+      const reopened = await screen.findByRole('dialog', { name });
+      fireEvent.click(within(reopened).getByRole('button', { name: 'Stop CLI task' }));
+      await waitFor(() => {
+        expect(within(reopened).queryByRole('button', { name: 'Stop CLI task' })).toBeNull();
+      });
+      expect(within(reopened).getByText('Last outcome: cancelled · cancelled')).toBeDefined();
+    }
+  );
+});

--- a/apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx
@@ -723,6 +723,70 @@ describe('browser task controls', () => {
     });
   });
 
+  it.each([
+    {
+      label: 'long tab titles',
+      tabs: [
+        {
+          id: 7,
+          title: 'Requested page with a long title '.repeat(20),
+          url: 'https://example.test/requested',
+        },
+      ],
+    },
+    { label: 'no inspectable tabs', tabs: [] },
+  ])('constrains consent tracks with $label without scrolling Stop', async ({ tabs }) => {
+    fixture.tabs = tabs;
+    fixture.state = {
+      ...fixture.state,
+      active: {
+        approval: undefined,
+        goal: 'Read the page',
+        job: job(),
+        ownerLabel: 'ses_12345678',
+      },
+      phase: 'awaiting_approval',
+    };
+    renderControls();
+    const supervision = screen.getByRole('region', { name: 'CLI task supervision' });
+    const select = within(supervision).getByRole<HTMLSelectElement>('combobox', {
+      name: 'Tab to approve',
+    });
+    await waitFor(() => {
+      expect(select.disabled).toBe(false);
+    });
+    // Compile the rendered utilities, not copied CSS. jsdom checks declarations, not geometry.
+    const { compile } = await import('tailwindcss');
+    const utilities = await compile('@tailwind utilities;');
+    const stylesheet = document.createElement('style');
+    const classes: string[] = [];
+    for (const element of [supervision, ...supervision.querySelectorAll<HTMLElement>('[class]')]) {
+      classes.push(...element.classList);
+    }
+    stylesheet.textContent = utilities.build(classes);
+    document.head.append(stylesheet);
+    try {
+      const tracks = [...supervision.querySelectorAll<HTMLElement>('.grid')];
+      expect(tracks.map(track => getComputedStyle(track).gridTemplateColumns)).toStrictEqual([
+        'repeat(1, minmax(0, 1fr))',
+        'repeat(1, minmax(0, 1fr))',
+        'repeat(1, minmax(0, 1fr))',
+      ]);
+      const details = select.closest('.overflow-y-auto');
+      expect(details?.contains(screen.getByRole('button', { name: 'Reject' }))).toBe(true);
+      expect(details?.contains(screen.getByRole('button', { name: 'Refresh tabs' }))).toBe(true);
+      expect(details?.contains(screen.getByRole('button', { name: 'Stop CLI task' }))).toBe(false);
+      expect(getComputedStyle(supervision).position).toBe('sticky');
+      expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Approve tab' }).disabled).toBe(
+        true
+      );
+      select.focus();
+      expect(document.activeElement).toBe(select);
+    } finally {
+      stylesheet.remove();
+    }
+  });
+
   it('requires an explicit candidate and approval while retaining a long goal after tab loss', async () => {
     const goal = `Inspect ${'long goal '.repeat(160)}`;
     fixture.state = {

--- a/apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx
@@ -326,6 +326,8 @@ const ModalExamples = () => {
       </button>
       {workflowOpen ? (
         <WorkflowRunPrompt
+          admissionPending={false}
+          blocker={undefined}
           name="Example"
           onCancel={() => {
             setWorkflowOpen(false);

--- a/apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx
@@ -6,6 +6,7 @@ import { useState, useSyncExternalStore } from 'react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BrowserJobSnapshot, BrowserResult } from '@kilocode/cloud-agent-sdk/schemas';
+import type { storage as wxtStorage } from '#imports';
 import type {
   BrowserTaskProviderRuntime,
   BrowserTaskProviderSnapshot,
@@ -24,6 +25,20 @@ const fixture = vi.hoisted(() => ({
     | undefined,
   state: {} as BrowserTaskProviderSnapshot,
   tabs: [] as InspectableTab[],
+  tabsUnavailable: false,
+}));
+vi.mock('#imports', async importOriginal => ({
+  ...(await importOriginal<{ storage: typeof wxtStorage }>()),
+  browser: {
+    tabs: {
+      query: async () => {
+        if (fixture.tabsUnavailable) {
+          throw new Error('Tab access unavailable.');
+        }
+        return fixture.tabs;
+      },
+    },
+  },
 }));
 vi.mock('./browser-task-provider', () => ({
   useBrowserTask: () => {
@@ -332,6 +347,7 @@ describe('browser task controls', () => {
       value: vi.fn(),
     });
     fixture.runtime = undefined;
+    fixture.tabsUnavailable = false;
     fixture.tabs = [
       { id: 7, title: 'Requested page', url: 'https://example.test/requested' },
       { id: 8, title: 'Another page', url: 'https://other.test/' },
@@ -699,6 +715,8 @@ describe('browser task controls', () => {
     renderControls();
     fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
     await screen.findByText('Last outcome: failed · approval_denied');
+    expect(screen.getByText('No uncertain effects reported.')).toBeDefined();
+    expect(screen.getByText('No observed evidence.')).toBeDefined();
     expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
     expect(screen.queryByText(/Bound tab:/u)).toBeNull();
   });
@@ -739,6 +757,65 @@ describe('browser task controls', () => {
     expect(screen.queryByText(/ses_owner_bbbbbbbb/u)).toBeNull();
   });
 
+  it('retains affected IDs with current metadata and closure status without retargeting', async () => {
+    fixture.execution = { ...fixture.execution, quarantinedTabIds: [7, 42] };
+    fixture.state = {
+      ...fixture.state,
+      unresolvedFence: { invocationId: 'retained-invocation', tabId: 7 },
+    };
+    fixture.tabs = [
+      { id: 7, title: 'Current settings page', url: 'chrome://settings/' },
+      { id: 8, title: 'Unrelated tab', url: 'https://other.test/' },
+    ];
+    renderControls();
+    const list = screen.getByRole('list', { name: 'Affected tabs' });
+    await within(list).findByText('Title: Current settings page');
+    expect(within(list).getByText('Address: chrome://settings/')).toBeDefined();
+    expect(
+      within(list).getByText('Tab ID 7: Open — close this tab before recovery.')
+    ).toBeDefined();
+    expect(within(list).getByText('Tab ID 42: Closed')).toBeDefined();
+    expect(within(list).getAllByRole('listitem')).toHaveLength(2);
+    fixture.tabs = fixture.tabs.filter(tab => tab.id !== 7);
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh affected tabs' }));
+    await within(list).findByText('Tab ID 7: Closed');
+    expect(within(list).queryByText(/Unrelated tab/u)).toBeNull();
+    expect(within(list).queryByText(/Current settings page/u)).toBeNull();
+    expect(within(list).getAllByRole('listitem')).toHaveLength(2);
+    act(() => {
+      fixture.execution = { ...fixture.execution, quarantinedTabIds: [] };
+      change({ unresolvedFence: undefined });
+    });
+    expect(screen.queryByRole('list', { name: 'Affected tabs' })).toBeNull();
+  });
+
+  it('reports unknown closure after a tab read fails and refreshes without inventing a closed tab', async () => {
+    fixture.execution = { ...fixture.execution, quarantinedTabIds: [7] };
+    renderControls();
+    const list = screen.getByRole('list', { name: 'Affected tabs' });
+    await within(list).findByText('Title: Requested page');
+    fixture.tabsUnavailable = true;
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh affected tabs' }));
+    await screen.findByText('Could not retrieve affected tabs. Restore tab access and refresh.');
+    expect(within(list).getByText('Tab ID 7: Closure unknown')).toBeDefined();
+    expect(within(list).queryByText(/Closed|Requested page/u)).toBeNull();
+    fixture.tabsUnavailable = false;
+    fixture.tabs = [{ id: 7, title: '', url: '' }];
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh affected tabs' }));
+    await within(list).findByText('Tab ID 7: Open — close this tab before recovery.');
+    expect(within(list).queryByText(/Title:|Address:/u)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+  });
+
+  it('does not invent an outcome or an affected identity from the current tabs', () => {
+    renderControls();
+    expect(screen.queryByText(/Last outcome:/u)).toBeNull();
+    expect(screen.queryByText(/Observed evidence|uncertain effects/u)).toBeNull();
+    expect(screen.queryByRole('list', { name: 'Affected tabs' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Refresh affected tabs' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Check recovery readiness' })).toBeNull();
+  });
+
   it('separates status retrieval, preparation, and explicit recovery and invalidates stale readiness', async () => {
     fixture.state = {
       ...fixture.state,
@@ -770,7 +847,7 @@ describe('browser task controls', () => {
     expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
   });
 
-  it('shows concrete all-tabs and unsupported-lock instructions without a recovery bypass', () => {
+  it('shows concrete all-tabs and unsupported-lock instructions without a recovery bypass', async () => {
     fixture.state = { ...fixture.state, phase: 'unsupported' };
     fixture.execution = {
       ...fixture.execution,
@@ -791,6 +868,10 @@ describe('browser task controls', () => {
     ).toBeDefined();
     expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Reconnect' })).toBeNull();
+    fixture.readiness = { ready: false, reason: 'Web Locks must be restored before recovery.' };
+    fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+    await screen.findByText('Web Locks must be restored before recovery.');
+    expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
   });
 
   it('offers reconnect only for retryable unavailability and never invents consent from status', async () => {

--- a/apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx
@@ -558,7 +558,6 @@ describe('browser task controls', () => {
     ['connecting', 'Connecting'],
     ['unsupported', 'Unsupported'],
     ['unavailable', 'Unavailable'],
-    ['owned_elsewhere', 'Owned by another panel'],
     ['awaiting_approval', 'Tab approval required'],
     ['waiting', 'Waiting for browser control'],
     ['running', 'Running'],
@@ -606,36 +605,122 @@ describe('browser task controls', () => {
     expect(screen.queryByText(/Restore storage access, then reload this panel/u)).toBeNull();
   });
 
-  it.each([
-    { delegated: 'idle', label: 'local browser work', localRuns: 1 },
-    { delegated: 'running', label: 'delegated execution', localRuns: 0 },
-    { delegated: 'waiting', label: 'pending execution cleanup', localRuns: 0 },
-  ] as const)('blocks initialization reload during $label', ({ delegated, localRuns }) => {
+  it('offers an ownership retry without claiming that the previous owner is still open', () => {
     fixture.state = {
       ...fixture.state,
-      phase: 'unavailable',
+      message: 'Another panel owns this browser provider. Use that panel to supervise CLI tasks.',
+      phase: 'owned_elsewhere',
       profile: undefined,
-      retryable: true,
       settings: undefined,
     };
-    fixture.execution = { ...fixture.execution, delegated, localRuns };
+    fixture.execution = {
+      ...fixture.execution,
+      blockedReason: 'Browser control remains quarantined.',
+    };
     renderControls();
-    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Reload panel' }).disabled).toBe(
-      true
-    );
+    const reload = screen.getByRole<HTMLButtonElement>('button', { name: 'Reload panel' });
+    expect(reload.disabled).toBe(false);
+    reload.focus();
+    expect(document.activeElement).toBe(reload);
+    expect(screen.getByText('CLI tasks: Ownership not acquired')).toBeDefined();
+    expect(screen.getByText('This panel could not acquire browser ownership.')).toBeDefined();
     expect(
-      screen.getByText('Stop browser work and wait for cleanup before reloading.')
+      screen.getByText(/Close the panel that held ownership, if it is still open/u)
     ).toBeDefined();
+    expect(screen.getByText(/Then reload this panel to retry ownership/u)).toBeDefined();
+    expect(
+      screen.getByText(/Reload preserves your account, saved settings, and safety records/u)
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        /does not enable CLI tasks, clear quarantine, approve execution, or resubmit work/u
+      )
+    ).toBeDefined();
+    expect(screen.queryByText(/Another panel owns this browser provider/u)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Refresh status' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Reconnect' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Check recovery readiness' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+    expect(screen.queryByText(/Retrieve status first/u)).toBeNull();
     act(() => {
-      fixture.execution = { ...fixture.execution, delegated: 'idle', localRuns: 0 };
+      fixture.execution = { ...fixture.execution, providerOwned: false };
       change({});
     });
-    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Reload panel' }).disabled).toBe(
-      false
-    );
-    expect(
-      screen.queryByText('Stop browser work and wait for cleanup before reloading.')
-    ).toBeNull();
+    expect(screen.getByText('This panel could not acquire browser ownership.')).toBeDefined();
+    expect(screen.queryByText(/Another panel owns this browser provider/u)).toBeNull();
+    expect(screen.getByRole('button', { name: 'Reload panel' })).toBe(reload);
+    expect(reload.disabled).toBe(false);
+  });
+
+  it('keeps unsupported ownership separate from reload and quarantine recovery', () => {
+    fixture.state = {
+      ...fixture.state,
+      phase: 'unsupported',
+      profile: undefined,
+      settings: undefined,
+    };
+    fixture.execution = {
+      ...fixture.execution,
+      blockedReason: 'Browser control remains quarantined.',
+      delegationUnavailableReason: 'Web Locks unavailable.',
+      providerOwned: false,
+    };
+    renderControls();
+    expect(screen.getByText('CLI tasks: Unsupported')).toBeDefined();
+    expect(screen.getByText('Browser control remains quarantined.')).toBeDefined();
+    expect(screen.getByText(/Restore browser Web Locks support before recovering/u)).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Reload panel' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Reconnect' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+  });
+
+  describe.each([
+    { label: 'initialization', phase: 'unavailable' },
+    { label: 'ownership', phase: 'owned_elsewhere' },
+  ] as const)('$label reload', ({ phase }) => {
+    it.each([
+      {
+        active: {
+          approval: undefined,
+          goal: 'Read the page',
+          job: job(),
+          ownerLabel: 'ses_12345678',
+        },
+        delegated: 'idle',
+        label: 'an active task',
+        localRuns: 0,
+      },
+      { active: undefined, delegated: 'idle', label: 'local browser work', localRuns: 1 },
+      { active: undefined, delegated: 'running', label: 'delegated execution', localRuns: 0 },
+      { active: undefined, delegated: 'waiting', label: 'pending execution cleanup', localRuns: 0 },
+    ] as const)('blocks reload during $label', ({ active, delegated, localRuns }) => {
+      fixture.state = {
+        ...fixture.state,
+        active,
+        phase,
+        profile: undefined,
+        retryable: phase === 'unavailable',
+        settings: undefined,
+      };
+      fixture.execution = { ...fixture.execution, delegated, localRuns };
+      renderControls();
+      expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Reload panel' }).disabled).toBe(
+        true
+      );
+      expect(
+        screen.getByText('Stop browser work and wait for cleanup before reloading.')
+      ).toBeDefined();
+      act(() => {
+        fixture.execution = { ...fixture.execution, delegated: 'idle', localRuns: 0 };
+        change({ active: undefined });
+      });
+      expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Reload panel' }).disabled).toBe(
+        false
+      );
+      expect(
+        screen.queryByText('Stop browser work and wait for cleanup before reloading.')
+      ).toBeNull();
+    });
   });
 
   it('requires an explicit candidate and approval while retaining a long goal after tab loss', async () => {

--- a/apps/extension/entrypoints/sidepanel/browser-task-controls.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-controls.tsx
@@ -523,9 +523,12 @@ export const BrowserTaskControls = (): JSX.Element => {
             {state.settings?.enabled === false ? ' Local recovery keeps CLI tasks disabled.' : null}
           </p>
         ) : null}
-        {pending === undefined && notice === undefined ? null : (
-          <p role="status">{pending ?? notice}</p>
-        )}
+        <p
+          className={pending === undefined && notice === undefined ? 'sr-only' : undefined}
+          role="status"
+        >
+          {pending ?? notice}
+        </p>
       </div>
     </section>
   );

--- a/apps/extension/entrypoints/sidepanel/browser-task-controls.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-controls.tsx
@@ -1,0 +1,723 @@
+/* eslint-disable max-lines, import/max-dependencies, typescript/consistent-type-definitions -- Consent, settings, and modal supervision share the existing provider, not another runtime. */
+import { useQuery } from '@tanstack/react-query';
+import type { BrowserJobSnapshot } from '@kilocode/cloud-agent-sdk/schemas';
+import { BrowserProviderError } from '@kilocode/cloud-agent-sdk/user-web-connection';
+import { Square } from 'lucide-react';
+import { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import type { JSX, ReactNode } from 'react';
+import { ExecutionStoppedError } from '@/src/shared/agent-tool-results';
+import type { StoredAuth } from '@/src/shared/auth';
+import type { BrowserProviderSettings } from '@/src/shared/browser-provider-settings';
+import { AgentFooterControls } from './agent-footer-controls';
+import { useBrowserExecutionSnapshot } from './browser-execution-lock';
+import type { BrowserRecoveryReadiness } from './browser-execution-lock';
+import { useBrowserTask } from './browser-task-provider';
+import type { BrowserTaskProviderSnapshot } from './browser-task-provider';
+import { getBrowserTaskTabs } from './browser-task-runner';
+import { BrowserTaskSupervisionContext } from './browser-task-supervision-slot';
+import { useGatewayModels } from './use-gateway-models';
+import { useTabDebugger } from './use-tab-debugger';
+import { SettingsToggle } from './workflow-settings';
+
+const actionClass =
+  'type-label min-h-9 max-w-full shrink-0 rounded-md border border-border bg-surface-overlay px-3 py-1 text-foreground-on-secondary outline-none transition hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-brand-primary-ring disabled:cursor-not-allowed disabled:text-foreground-subtle';
+const emptyThinkingOptions: string[] = [];
+const modeLabels = { dangerous: 'Dangerous', safe: 'Safe' };
+const phaseLabels = {
+  awaiting_approval: 'Tab approval required',
+  connecting: 'Connecting',
+  disabled: 'Disabled',
+  idle: 'Enabled — idle',
+  interrupted: 'Interrupted',
+  owned_elsewhere: 'Owned by another panel',
+  recovery: 'Recovery required',
+  running: 'Running',
+  unavailable: 'Unavailable',
+  unsupported: 'Unsupported',
+  waiting: 'Waiting for browser control',
+} satisfies Record<BrowserTaskProviderSnapshot['phase'], string>;
+
+const Owner = ({ label }: { label: string | undefined }): JSX.Element => (
+  <p className="break-words [overflow-wrap:anywhere]">
+    Owner session: {label ?? 'Unknown'}
+    {label === undefined ? null : (
+      <span className="ml-2 font-mono text-foreground-muted" title={label}>
+        (ID {label.slice(-8)})
+      </span>
+    )}
+  </p>
+);
+
+const Deadline = ({ job }: { job: BrowserJobSnapshot }): JSX.Element => {
+  let deadline = job.deadlines.approval;
+  let label = 'Approval';
+  if (job.status === 'queued') {
+    deadline = job.deadlines.queue;
+    label = 'Queue';
+  } else if (job.status === 'running' || job.approvedTab !== undefined) {
+    deadline = job.deadlines.execution;
+    label = 'Execution';
+  }
+  return (
+    <p className="text-foreground-muted">
+      {label} deadline:{' '}
+      {deadline === undefined ? (
+        'Unknown'
+      ) : (
+        <time dateTime={deadline}>{new Date(deadline).toLocaleString()}</time>
+      )}
+    </p>
+  );
+};
+
+const TabConsent = ({
+  active,
+}: {
+  active: NonNullable<BrowserTaskProviderSnapshot['active']>;
+}): JSX.Element => {
+  const task = useBrowserTask();
+  const [tabId, setTabId] = useState<number>();
+  const [approving, setApproving] = useState(false);
+  const tabs = useQuery({
+    queryFn: getBrowserTaskTabs,
+    queryKey: ['browser-task-consent-tabs'],
+    refetchInterval: 2000,
+  });
+  // A candidate is local to this invocation. The Browser target selector never grants consent.
+  const candidate = tabs.isError ? undefined : tabs.data?.find(tab => tab.id === tabId);
+  let tabMessage = 'Choose an inspectable tab. If none are listed, open a page and refresh tabs.';
+  if (tabs.isPending) {
+    tabMessage = 'Loading inspectable tabs...';
+  } else if (tabs.isError) {
+    tabMessage = 'Could not retrieve tabs. Refresh tabs before approval.';
+  } else if (tabId !== undefined) {
+    tabMessage =
+      'That candidate tab is no longer available. The goal is retained. Choose another tab before the deadline.';
+  }
+  const handleApprove = async (): Promise<void> => {
+    if (candidate === undefined || approving) {
+      return;
+    }
+    setApproving(true);
+    try {
+      await task.approve(active.job.jobId, candidate.id);
+    } finally {
+      setApproving(false);
+    }
+  };
+  return (
+    <div className="grid min-w-0 gap-2">
+      <p>
+        The Browser target selector does not approve CLI access. Approve a tab for this invocation
+        only.
+      </p>
+      <label className="grid min-w-0 gap-1">
+        Tab to approve
+        <select
+          className="type-label min-h-9 w-full min-w-0 rounded-md border border-border-strong bg-input-bg px-2 text-foreground focus-visible:ring-2 focus-visible:ring-brand-primary-ring"
+          disabled={approving || tabs.isPending || tabs.isError}
+          onChange={event => {
+            setTabId(
+              event.currentTarget.value === '' ? undefined : Number(event.currentTarget.value)
+            );
+          }}
+          value={tabId ?? ''}
+        >
+          <option value="">Choose a tab</option>
+          {tabId !== undefined && candidate === undefined ? (
+            <option value={tabId}>Candidate tab unavailable</option>
+          ) : null}
+          {tabs.data?.map(tab => (
+            <option key={tab.id} value={tab.id}>
+              {tab.title}
+            </option>
+          ))}
+        </select>
+      </label>
+      {candidate === undefined ? (
+        <p role="status">{tabMessage}</p>
+      ) : (
+        <div className="max-h-28 overflow-y-auto break-words [overflow-wrap:anywhere]">
+          <p>Tab: {candidate.title}</p>
+          <p>Address: {candidate.url}</p>
+        </div>
+      )}
+      <div className="flex flex-wrap gap-2">
+        <button
+          className={actionClass}
+          disabled={
+            candidate === undefined ||
+            approving ||
+            task.state.settings === undefined ||
+            task.state.settings.model === ''
+          }
+          onClick={() => {
+            void handleApprove();
+          }}
+          type="button"
+        >
+          {approving ? 'Approving tab...' : 'Approve tab'}
+        </button>
+        <button
+          className={actionClass}
+          onClick={() => {
+            task.reject(active.job.jobId);
+          }}
+          type="button"
+        >
+          Reject
+        </button>
+        <button
+          className={actionClass}
+          disabled={tabs.isFetching}
+          onClick={() => {
+            void tabs.refetch();
+          }}
+          type="button"
+        >
+          Refresh tabs
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export const BrowserTaskControls = (): JSX.Element => {
+  const task = useBrowserTask();
+  const { state } = task;
+  const execution = useBrowserExecutionSnapshot();
+  const [pending, setPending] = useState<string>();
+  const [notice, setNotice] = useState<string>();
+  const [readiness, setReadiness] = useState<{
+    snapshot: BrowserTaskProviderSnapshot;
+    value: BrowserRecoveryReadiness;
+  }>();
+  const { active } = state;
+  const initializationFailed =
+    state.phase === 'unavailable' &&
+    state.retryable &&
+    state.profile === undefined &&
+    state.settings === undefined;
+  const reloadBlocked =
+    active !== undefined || execution.delegated !== 'idle' || execution.localRuns > 0;
+  const settings = active?.approval?.settings ?? state.settings;
+  const boundTab = active?.approval?.tab ?? active?.job.approvedTab;
+  const modelLabel =
+    settings === undefined || settings.model === '' ? 'Not selected' : settings.model;
+  const queued = state.jobs
+    .filter(job => job.status === 'queued' && job.result === undefined)
+    .toSorted(
+      (left, right) => (left.queuePosition ?? Infinity) - (right.queuePosition ?? Infinity)
+    );
+  const recoverable =
+    state.phase === 'recovery' ||
+    state.phase === 'interrupted' ||
+    state.phase === 'unavailable' ||
+    state.unresolvedFence !== undefined ||
+    (execution.delegated === 'idle' && execution.blockedReason !== undefined);
+  useEffect(() => {
+    setNotice(undefined);
+  }, [active?.job.jobId]);
+  const perform = async (label: string, action: () => Promise<void>): Promise<void> => {
+    if (pending !== undefined) {
+      return;
+    }
+    setPending(label);
+    setNotice(undefined);
+    setReadiness(undefined);
+    try {
+      await action();
+    } catch (error) {
+      if (error instanceof BrowserProviderError) {
+        setNotice(
+          error.retryable
+            ? `Status unavailable: ${error.code}. Reconnect and retrieve status again. No work was resubmitted.`
+            : `Status denied: ${error.code}. Restore provider access before retrieving status. No work was resubmitted.`
+        );
+      } else if (error instanceof ExecutionStoppedError) {
+        setNotice(
+          `Status interrupted: ${error.reason}. Use the owning signed-in panel to retrieve status. No work was resubmitted.`
+        );
+      } else {
+        setNotice(
+          'The request failed. Restore the relay connection and retrieve status. No work was resubmitted.'
+        );
+      }
+    } finally {
+      setPending(undefined);
+    }
+  };
+
+  return (
+    <section
+      aria-label="CLI task supervision"
+      className="sticky top-0 z-10 flex max-h-[45dvh] min-h-0 min-w-0 shrink-0 flex-col border-b border-border bg-surface-raised text-foreground"
+      data-browser-task-supervision=""
+    >
+      <div className="flex shrink-0 items-start justify-between gap-2 px-3 py-2">
+        <p aria-live="polite" className="type-label min-w-0 break-words" role="status">
+          CLI tasks: {phaseLabels[state.phase]}
+        </p>
+        {active !== undefined && active.job.result === undefined ? (
+          <button
+            aria-label="Stop CLI task"
+            className={`${actionClass} flex items-center gap-1`}
+            onClick={() => {
+              task.cancel(active.job.jobId);
+              setNotice(
+                'Stop requested. Issued actions are not undone. Retrieve status to confirm the outcome.'
+              );
+            }}
+            type="button"
+          >
+            <Square aria-hidden="true" className="size-3 shrink-0" />
+            Stop
+          </button>
+        ) : null}
+      </div>
+      <div className="agent-conversation-scrollbar type-label grid min-h-0 min-w-0 gap-2 overflow-y-auto px-3 pb-3 [overflow-wrap:anywhere]">
+        <p aria-live="polite">{state.message}</p>
+        {state.profile === undefined ? null : (
+          <p>
+            Profile: {state.profile.label} ·{' '}
+            <span className="font-mono">{state.profile.providerId}</span>
+          </p>
+        )}
+        {active === undefined ? null : (
+          <>
+            <Owner label={active.ownerLabel} />
+            <p className="font-mono text-foreground-muted">Task ID: {active.job.jobId.slice(-8)}</p>
+            <div className="max-h-24 overflow-y-auto whitespace-pre-wrap break-words">
+              Goal: {active.goal}
+            </div>
+            <p>
+              Mode: {settings === undefined ? 'Unknown' : modeLabels[settings.mode]} · Model:{' '}
+              {modelLabel}
+            </p>
+            {boundTab === undefined ? (
+              <p>Bound tab: Not approved</p>
+            ) : (
+              <div className="max-h-24 overflow-y-auto">
+                <p>
+                  Bound tab: {boundTab.title} (ID {boundTab.tabId})
+                </p>
+                <p>Address: {boundTab.url}</p>
+              </div>
+            )}
+            <Deadline job={active.job} />
+            {state.phase === 'awaiting_approval' &&
+            active.approval === undefined &&
+            active.job.result === undefined ? (
+              <TabConsent active={active} key={active.job.jobId} />
+            ) : null}
+          </>
+        )}
+        {execution.blockedReason === undefined ? null : (
+          <p role="status">{execution.blockedReason}</p>
+        )}
+        {execution.delegationUnavailableReason === undefined ? null : (
+          <p>Recovery requires Web Locks. Restore browser Web Locks support before recovering.</p>
+        )}
+        {queued.length === 0 ? (
+          <p className="text-foreground-muted">Queue empty.</p>
+        ) : (
+          <div>
+            <p aria-live="polite">Queued tasks: {queued.length}</p>
+            <ul aria-label="Queued CLI tasks" className="grid gap-2">
+              {queued.map(job => (
+                <li className="rounded-md border border-border p-2" key={job.jobId}>
+                  <p>Queue position: {job.queuePosition ?? 'Unknown'}</p>
+                  <Owner label={job.ownerLabel} />
+                  <p className="font-mono">Task ID: {job.jobId.slice(-8)}</p>
+                  <Deadline job={job} />
+                  <button
+                    aria-label={`Cancel queued task ${job.jobId.slice(-8)}`}
+                    className={`${actionClass} mt-2`}
+                    onClick={() => {
+                      task.cancel(job.jobId);
+                      setNotice(
+                        'Cancellation requested. Retrieve status to confirm the queued task outcome.'
+                      );
+                    }}
+                    type="button"
+                  >
+                    Cancel queued task
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {state.result === undefined ? null : (
+          <div>
+            <p>
+              Last outcome: {state.result.status} · {state.result.reason}
+            </p>
+            <p>{state.result.summary}</p>
+            {state.result.evidence.length === 0 ? <p>No observed evidence.</p> : null}
+          </div>
+        )}
+        {initializationFailed ? (
+          <div className="grid gap-2">
+            <p role="status">
+              Restore storage access, then reload this panel to retry initialization. Reload
+              preserves your account, saved settings, and safety records. It does not enable CLI
+              tasks, approve execution, or resubmit work.
+            </p>
+            {reloadBlocked ? (
+              <p role="status">Stop browser work and wait for cleanup before reloading.</p>
+            ) : null}
+            <div className="flex flex-wrap gap-2">
+              <button
+                className={actionClass}
+                disabled={reloadBlocked}
+                onClick={() => {
+                  globalThis.location.reload();
+                }}
+                type="button"
+              >
+                Reload panel
+              </button>
+            </div>
+          </div>
+        ) : null}
+        {state.profile === undefined ? null : (
+          <div className="flex flex-wrap gap-2">
+            <button
+              className={actionClass}
+              disabled={pending !== undefined}
+              onClick={() => {
+                void perform('Retrieving status...', async () => {
+                  await task.refreshStatus();
+                  setNotice('Status retrieved. This does not approve execution or resubmit work.');
+                });
+              }}
+              type="button"
+            >
+              Refresh status
+            </button>
+            {state.retryable &&
+            state.phase !== 'idle' &&
+            state.phase !== 'running' &&
+            state.phase !== 'awaiting_approval' ? (
+              <button
+                className={actionClass}
+                onClick={() => {
+                  task.retryConnection();
+                }}
+                type="button"
+              >
+                Reconnect
+              </button>
+            ) : null}
+            {recoverable && state.settings?.enabled === true ? (
+              <button
+                className={actionClass}
+                disabled={pending !== undefined}
+                onClick={() => {
+                  void perform('Checking recovery readiness...', async () => {
+                    const value = await task.prepareRecovery();
+                    setReadiness({ snapshot: task.getSnapshot(), value });
+                  });
+                }}
+                type="button"
+              >
+                Check recovery readiness
+              </button>
+            ) : null}
+            {recoverable && readiness?.value.ready === true && readiness.snapshot === state ? (
+              <button
+                className={actionClass}
+                disabled={pending !== undefined}
+                onClick={() => {
+                  void perform('Recovering browser control...', task.recover);
+                }}
+                type="button"
+              >
+                Recover browser control
+              </button>
+            ) : null}
+          </div>
+        )}
+        {readiness === undefined ? null : (
+          <p role="status">
+            {readiness.value.ready && readiness.snapshot !== state
+              ? 'Provider state changed. Check recovery readiness again.'
+              : readiness.value.reason}
+          </p>
+        )}
+        {recoverable && !initializationFailed ? (
+          <p>
+            Retrieve status first. Close affected tabs and drain execution locks before recovery.
+            Recovery never resumes old work. A new invocation requires fresh tab consent.
+          </p>
+        ) : null}
+        {pending === undefined && notice === undefined ? null : (
+          <p role="status">{pending ?? notice}</p>
+        )}
+      </div>
+    </section>
+  );
+};
+
+const BrowserTaskSettingsContext = createContext<
+  | {
+      saving: boolean;
+      update: (change: Partial<BrowserProviderSettings>) => void;
+    }
+  | undefined
+>(undefined);
+
+export const BrowserTaskSettings = ({
+  auth,
+  organizationId,
+}: {
+  auth: StoredAuth;
+  organizationId: string | undefined;
+}): JSX.Element => {
+  const task = useBrowserTask();
+  const { settings, profile } = task.state;
+  const models = useGatewayModels({ auth, organizationId });
+  const tabs = useTabDebugger();
+  const mutation = useContext(BrowserTaskSettingsContext);
+  const [confirmDisable, setConfirmDisable] = useState(false);
+  const thinkingOptions =
+    models.modelOptions.find(option => option.id === settings?.model)?.variants ??
+    emptyThinkingOptions;
+  if (mutation === undefined) {
+    throw new Error('BrowserTaskSurface is required.');
+  }
+  const { saving, update } = mutation;
+  return (
+    <section
+      aria-label="CLI task settings"
+      className="type-label grid min-w-0 gap-3 rounded-xl border border-border bg-surface-raised p-3 [overflow-wrap:anywhere] [&>div>div]:flex-wrap"
+    >
+      <SettingsToggle
+        checked={settings?.enabled === true}
+        description="Off by default. CLI tasks are available only while this signed-in panel stays open."
+        disabled={settings === undefined || saving || (!settings.enabled && settings.model === '')}
+        label="CLI tasks"
+        onToggle={() => {
+          if (settings?.enabled === true) {
+            setConfirmDisable(true);
+          } else {
+            update({ enabled: true });
+          }
+        }}
+      />
+      <p>Profile: {profile?.label ?? 'Unknown'}</p>
+      <p>
+        Provider ID: <span className="font-mono">{profile?.providerId ?? 'Unknown'}</span>
+      </p>
+      <p>
+        Select the delegated model and mode explicitly. These defaults apply at the next tab
+        approval; approved settings remain frozen.
+      </p>
+      {settings?.model === '' ? <p>Select a model before enabling CLI tasks.</p> : null}
+      <AgentFooterControls
+        auth={auth}
+        inspectableTabs={tabs.inspectableTabs}
+        isConversationStoreLoaded={settings !== undefined}
+        isLoadingTabs={tabs.isLoadingTabs}
+        isModelSelectDisabled={saving || models.modelOptions.length === 0}
+        isRunning={saving}
+        isThinkingSelectDisabled={saving || thinkingOptions.length === 0}
+        mode={settings?.mode ?? 'safe'}
+        model={settings?.model ?? ''}
+        modelLoadError={models.modelLoadError}
+        modelOptions={models.modelOptions}
+        onModeChange={mode => {
+          update({ mode });
+        }}
+        onModelChange={model => {
+          update({ model, thinkingEffort: '' });
+        }}
+        onRetryModels={async () => {
+          await models.refetchModels();
+        }}
+        onSelectedTabChange={tabId => {
+          tabs.selectTab(tabId);
+        }}
+        onThinkingEffortChange={thinkingEffort => {
+          update({ thinkingEffort });
+        }}
+        organizationId={organizationId}
+        selectedTabId={tabs.selectedTabId}
+        tabDebuggerError={tabs.tabDebuggerError}
+        thinkingEffort={settings?.thinkingEffort ?? ''}
+        thinkingOptions={thinkingOptions}
+      />
+      <p>
+        The Target tab selector does not grant consent. Each CLI invocation needs its own Approve
+        tab action.
+      </p>
+      {saving ? <p role="status">Saving CLI task settings...</p> : null}
+      {confirmDisable ? (
+        <div aria-label="Confirm CLI task disablement" className="grid gap-2" role="group">
+          <p>
+            Disabling CLI tasks terminates active and queued jobs. Issued actions are not undone.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <button
+              className={actionClass}
+              disabled={saving}
+              onClick={() => {
+                setConfirmDisable(false);
+                update({ enabled: false });
+              }}
+              type="button"
+            >
+              Disable CLI tasks
+            </button>
+            <button
+              className={actionClass}
+              disabled={saving}
+              onClick={() => {
+                setConfirmDisable(false);
+              }}
+              type="button"
+            >
+              Keep enabled
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+};
+
+const supervision = <BrowserTaskControls />;
+const focusableSelector =
+  'button:not(:disabled), a[href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])';
+
+/** Existing cards use role=dialog. Keep their controls inside the same focus boundary as supervision. */
+export const BrowserTaskSurface = ({ children }: { children: ReactNode }): JSX.Element => {
+  const { getSnapshot, setSettings } = useBrowserTask();
+  const pendingSettings = useRef<{ write: typeof setSettings } | null>(null);
+  const [settingsSave, setSettingsSave] = useState(pendingSettings.current);
+  // The setter identifies its runtime; closing an overlay must not release its pending write.
+  const settingsMutation = useMemo(
+    () => ({
+      saving: settingsSave?.write === setSettings,
+      update: (change: Partial<BrowserProviderSettings>): void => {
+        const { settings } = getSnapshot();
+        if (settings === undefined || pendingSettings.current?.write === setSettings) {
+          return;
+        }
+        const request = { write: setSettings };
+        pendingSettings.current = request;
+        setSettingsSave(request);
+        void (async () => {
+          try {
+            await setSettings({ ...settings, ...change });
+          } finally {
+            if (pendingSettings.current === request) {
+              pendingSettings.current = null;
+              setSettingsSave(null);
+            }
+          }
+        })();
+      },
+    }),
+    [getSnapshot, setSettings, settingsSave]
+  );
+  const rootRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const { current: root } = rootRef;
+    if (root === null) {
+      return;
+    }
+    const returnFocus = new Map<HTMLElement, HTMLElement | null>();
+    let active: HTMLElement | null = null;
+    let lastFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const focusable = (dialog: HTMLElement): HTMLElement[] =>
+      [...dialog.querySelectorAll<HTMLElement>(focusableSelector)].filter(
+        element => !element.closest('[hidden], [inert]')
+      );
+    const synchronize = (): void => {
+      const dialogs = [...root.querySelectorAll<HTMLElement>('[role="dialog"][aria-modal="true"]')];
+      // Settings can cover an older card; a nested model/workflow overlay wins equal layers.
+      const next =
+        dialogs
+          .toSorted(
+            (left, right) =>
+              (Number(getComputedStyle(left).zIndex) || 0) -
+              (Number(getComputedStyle(right).zIndex) || 0)
+          )
+          .at(-1) ?? null;
+      const previous = active === null ? undefined : returnFocus.get(active);
+      if (next !== active) {
+        if (next !== null && !returnFocus.has(next)) {
+          const currentFocus =
+            document.activeElement instanceof HTMLElement ? document.activeElement : null;
+          returnFocus.set(next, next.contains(currentFocus) ? lastFocused : currentFocus);
+        }
+        for (const dialog of returnFocus.keys()) {
+          if (!root.contains(dialog)) {
+            returnFocus.delete(dialog);
+          }
+        }
+        active = next;
+        if (
+          previous !== document.body &&
+          previous?.isConnected === true &&
+          (next === null || next.contains(previous))
+        ) {
+          previous.focus();
+        } else if (next === null) {
+          // Async cards can outlive their approval trigger. Restore a stable supervision control.
+          const fallback =
+            root.querySelector<HTMLElement>('button[aria-label="Stop CLI task"]') ??
+            root.querySelector<HTMLElement>('button[role="tab"][aria-selected="true"]') ??
+            root.querySelector<HTMLElement>(focusableSelector);
+          fallback?.focus();
+        }
+      }
+      if (next !== null && !next.contains(document.activeElement)) {
+        focusable(next)[0]?.focus();
+      }
+      lastFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    };
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Tab' || active === null) {
+        return;
+      }
+      const elements = focusable(active);
+      const index =
+        document.activeElement instanceof HTMLElement
+          ? elements.indexOf(document.activeElement)
+          : -1;
+      const next =
+        elements[(index + (event.shiftKey ? -1 : 1) + elements.length) % elements.length];
+      event.preventDefault();
+      next?.focus();
+    };
+    const observer = new MutationObserver(synchronize);
+    observer.observe(root, { attributeFilter: ['disabled'], childList: true, subtree: true });
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('focusin', synchronize);
+    synchronize();
+    return () => {
+      observer.disconnect();
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('focusin', synchronize);
+      const previous = active === null ? undefined : returnFocus.get(active);
+      if (previous?.isConnected === true) {
+        previous.focus();
+      }
+    };
+  }, []);
+  return (
+    <BrowserTaskSettingsContext value={settingsMutation}>
+      <BrowserTaskSupervisionContext.Provider value={supervision}>
+        <div
+          className="contents [&_[role=dialog]>div:has(>[data-browser-task-supervision])]:max-h-full [&_[role=dialog]>div:has(>[data-browser-task-supervision])]:overflow-y-auto"
+          ref={rootRef}
+        >
+          {children}
+        </div>
+      </BrowserTaskSupervisionContext.Provider>
+    </BrowserTaskSettingsContext>
+  );
+};

--- a/apps/extension/entrypoints/sidepanel/browser-task-controls.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-controls.tsx
@@ -107,12 +107,12 @@ const TabConsent = ({
     }
   };
   return (
-    <div className="grid min-w-0 gap-2">
+    <div className="grid min-w-0 grid-cols-1 gap-2">
       <p>
         The Browser target selector does not approve CLI access. Approve a tab for this invocation
         only.
       </p>
-      <label className="grid min-w-0 gap-1">
+      <label className="grid min-w-0 grid-cols-1 gap-1">
         Tab to approve
         <select
           className="type-label min-h-9 w-full min-w-0 rounded-md border border-border-strong bg-input-bg px-2 text-foreground focus-visible:ring-2 focus-visible:ring-brand-primary-ring"
@@ -290,7 +290,7 @@ export const BrowserTaskControls = (): JSX.Element => {
           </button>
         ) : null}
       </div>
-      <div className="agent-conversation-scrollbar type-label grid min-h-0 min-w-0 gap-2 overflow-y-auto px-3 pb-3 [overflow-wrap:anywhere]">
+      <div className="agent-conversation-scrollbar type-label grid min-h-0 min-w-0 grid-cols-1 gap-2 overflow-y-auto px-3 pb-3 [overflow-wrap:anywhere]">
         <p aria-live="polite">
           {ownershipRejected ? 'This panel could not acquire browser ownership.' : state.message}
         </p>

--- a/apps/extension/entrypoints/sidepanel/browser-task-controls.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-controls.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines, import/max-dependencies, typescript/consistent-type-definitions -- Consent, settings, and modal supervision share the existing provider, not another runtime. */
+import { browser } from '#imports';
 import { useQuery } from '@tanstack/react-query';
 import type { BrowserJobSnapshot } from '@kilocode/cloud-agent-sdk/schemas';
 import { BrowserProviderError } from '@kilocode/cloud-agent-sdk/user-web-connection';
@@ -215,6 +216,19 @@ export const BrowserTaskControls = (): JSX.Element => {
     state.phase === 'unavailable' ||
     state.unresolvedFence !== undefined ||
     (execution.delegated === 'idle' && execution.blockedReason !== undefined);
+  const affectedTabIds = [
+    ...new Set([
+      ...execution.quarantinedTabIds,
+      ...(state.unresolvedFence?.tabId === undefined ? [] : [state.unresolvedFence.tabId]),
+    ]),
+  ];
+  const affectedTabs = useQuery({
+    enabled: affectedTabIds.length > 0,
+    // Recovery includes tabs that navigated to an uninspectable address.
+    queryFn: () => browser.tabs.query({}),
+    queryKey: ['browser-task-affected-tabs'],
+    refetchInterval: 2000,
+  });
   useEffect(() => {
     setNotice(undefined);
   }, [active?.job.jobId]);
@@ -318,6 +332,46 @@ export const BrowserTaskControls = (): JSX.Element => {
         {execution.delegationUnavailableReason === undefined ? null : (
           <p>Recovery requires Web Locks. Restore browser Web Locks support before recovering.</p>
         )}
+        {affectedTabIds.length === 0 ? null : (
+          <div className="grid min-w-0 gap-2">
+            <p>Affected tabs</p>
+            <ul aria-label="Affected tabs" className="grid gap-2">
+              {affectedTabIds.map(tabId => {
+                const tab = affectedTabs.isSuccess
+                  ? affectedTabs.data.find(candidate => candidate.id === tabId)
+                  : undefined;
+                let closure = 'Closure unknown';
+                if (affectedTabs.isSuccess) {
+                  closure = tab === undefined ? 'Closed' : 'Open — close this tab before recovery.';
+                }
+                return (
+                  <li className="rounded-md border border-border p-2" key={tabId}>
+                    <p>
+                      Tab ID {tabId}: {closure}
+                    </p>
+                    {tab?.title !== undefined && tab.title !== '' ? (
+                      <p>Title: {tab.title}</p>
+                    ) : null}
+                    {tab?.url !== undefined && tab.url !== '' ? <p>Address: {tab.url}</p> : null}
+                  </li>
+                );
+              })}
+            </ul>
+            {affectedTabs.isError ? (
+              <p role="status">Could not retrieve affected tabs. Restore tab access and refresh.</p>
+            ) : null}
+            <button
+              className={actionClass}
+              disabled={affectedTabs.isFetching}
+              onClick={() => {
+                void affectedTabs.refetch();
+              }}
+              type="button"
+            >
+              Refresh affected tabs
+            </button>
+          </div>
+        )}
         {queued.length === 0 ? (
           <p className="text-foreground-muted">Queue empty.</p>
         ) : (
@@ -354,7 +408,23 @@ export const BrowserTaskControls = (): JSX.Element => {
               Last outcome: {state.result.status} · {state.result.reason}
             </p>
             <p>{state.result.summary}</p>
-            {state.result.evidence.length === 0 ? <p>No observed evidence.</p> : null}
+            <p>
+              {state.result.effectsUncertain
+                ? 'Effects are uncertain. Close affected tabs before explicit recovery.'
+                : 'No uncertain effects reported.'}
+            </p>
+            {state.result.evidence.length === 0 ? (
+              <p>No observed evidence.</p>
+            ) : (
+              <div>
+                <p>Observed evidence:</p>
+                <p className="whitespace-pre-wrap">
+                  {state.result.evidence
+                    .map(item => [item.title, item.url, item.text].filter(Boolean).join('\n'))
+                    .join('\n\n')}
+                </p>
+              </div>
+            )}
           </div>
         )}
         {initializationFailed ? (
@@ -410,7 +480,7 @@ export const BrowserTaskControls = (): JSX.Element => {
                 Reconnect
               </button>
             ) : null}
-            {recoverable && state.settings?.enabled === true ? (
+            {recoverable ? (
               <button
                 className={actionClass}
                 disabled={pending !== undefined}
@@ -450,6 +520,7 @@ export const BrowserTaskControls = (): JSX.Element => {
           <p>
             Retrieve status first. Close affected tabs and drain execution locks before recovery.
             Recovery never resumes old work. A new invocation requires fresh tab consent.
+            {state.settings?.enabled === false ? ' Local recovery keeps CLI tasks disabled.' : null}
           </p>
         ) : null}
         {pending === undefined && notice === undefined ? null : (

--- a/apps/extension/entrypoints/sidepanel/browser-task-controls.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-controls.tsx
@@ -30,7 +30,7 @@ const phaseLabels = {
   disabled: 'Disabled',
   idle: 'Enabled — idle',
   interrupted: 'Interrupted',
-  owned_elsewhere: 'Owned by another panel',
+  owned_elsewhere: 'Ownership not acquired',
   recovery: 'Recovery required',
   running: 'Running',
   unavailable: 'Unavailable',
@@ -194,6 +194,7 @@ export const BrowserTaskControls = (): JSX.Element => {
     value: BrowserRecoveryReadiness;
   }>();
   const { active } = state;
+  const ownershipRejected = state.phase === 'owned_elsewhere';
   const initializationFailed =
     state.phase === 'unavailable' &&
     state.retryable &&
@@ -290,7 +291,9 @@ export const BrowserTaskControls = (): JSX.Element => {
         ) : null}
       </div>
       <div className="agent-conversation-scrollbar type-label grid min-h-0 min-w-0 gap-2 overflow-y-auto px-3 pb-3 [overflow-wrap:anywhere]">
-        <p aria-live="polite">{state.message}</p>
+        <p aria-live="polite">
+          {ownershipRejected ? 'This panel could not acquire browser ownership.' : state.message}
+        </p>
         {state.profile === undefined ? null : (
           <p>
             Profile: {state.profile.label} ·{' '}
@@ -427,12 +430,14 @@ export const BrowserTaskControls = (): JSX.Element => {
             )}
           </div>
         )}
-        {initializationFailed ? (
+        {initializationFailed || ownershipRejected ? (
           <div className="grid gap-2">
             <p role="status">
-              Restore storage access, then reload this panel to retry initialization. Reload
-              preserves your account, saved settings, and safety records. It does not enable CLI
-              tasks, approve execution, or resubmit work.
+              {ownershipRejected
+                ? 'Close the panel that held ownership, if it is still open. Then reload this panel to retry ownership.'
+                : 'Restore storage access, then reload this panel to retry initialization.'}{' '}
+              Reload preserves your account, saved settings, and safety records. It does not enable
+              CLI tasks, clear quarantine, approve execution, or resubmit work.
             </p>
             {reloadBlocked ? (
               <p role="status">Stop browser work and wait for cleanup before reloading.</p>
@@ -516,7 +521,7 @@ export const BrowserTaskControls = (): JSX.Element => {
               : readiness.value.reason}
           </p>
         )}
-        {recoverable && !initializationFailed ? (
+        {recoverable && !initializationFailed && !ownershipRejected ? (
           <p>
             Retrieve status first. Close affected tabs and drain execution locks before recovery.
             Recovery never resumes old work. A new invocation requires fresh tab consent.

--- a/apps/extension/entrypoints/sidepanel/browser-task-provider-tree.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider-tree.test.tsx
@@ -18,6 +18,7 @@ import type {
 } from '@kilocode/cloud-agent-sdk/schemas';
 import type {
   BrowserProviderState,
+  BrowserProviderStatusResult,
   BrowserProviderRegistration,
   BrowserProviderApprovalInput,
   BrowserProviderCancelInput,
@@ -204,7 +205,8 @@ vi.mock(import('./browser-run-context'), async importOriginal => ({
     }),
 }));
 
-import { storage } from '#imports';
+import { browser, storage } from '#imports';
+import { BrowserProviderError } from '@kilocode/cloud-agent-sdk/user-web-connection';
 import { SignedInView } from './auth-views';
 import { useExtensionAgents } from './agents-provider';
 import { draftAtomFamily, clearPerConversationAtoms } from './agent-chat-atoms';
@@ -300,10 +302,13 @@ const waitForAbort = async (context: BrowserRunContext): Promise<LlmTurnOutcome>
   return outcome();
 };
 type Delivery = Extract<BrowserProviderInboundMessage, { type: 'provider_job' }>;
-const relay = () => {
+const relay = (fence?: BrowserProviderStatusResult['unresolvedFence']) => {
   let state: BrowserProviderState = { status: 'ready' };
   let generation = 0;
   let retained = 0;
+  let registered = false;
+  const authority: string[] = [];
+  const statusProviders: string[] = [];
   // eslint-disable-next-line init-declarations -- Only explicit enablement creates a registration.
   let registration: BrowserProviderRegistration | undefined;
   const rows = new Map<string, BrowserJobSnapshot>();
@@ -362,6 +367,7 @@ const relay = () => {
   };
   const connection = {
     approveBrowserProviderJob: (input: BrowserProviderApprovalInput) => {
+      authority.push('approval');
       const job = rows.get(input.jobId);
       if (job === undefined) {
         throw new Error('Unknown invocation.');
@@ -386,10 +392,12 @@ const relay = () => {
     },
     getBrowserProviderState: () => state,
     heartbeatBrowserProvider: async () => {
+      authority.push('heartbeat');
       renew();
       return snapshot();
     },
     markBrowserProviderUnavailable: (input: BrowserProviderUnavailableInput) => {
+      registered = false;
       setState({ reason: input.reason, retryable: true, status: 'unavailable' });
       for (const job of rows.values()) {
         if (job.result === undefined) {
@@ -410,19 +418,42 @@ const relay = () => {
       };
     },
     quiesceBrowserProviderJob: (_input: BrowserProviderQuiescenceInput) => {
+      authority.push('quiescence');
       publish();
     },
     registerBrowserProvider: async (input: BrowserProviderRegistration) => {
+      authority.push('registration');
       registration = input;
+      registered = true;
       generation += 1;
       return renew();
     },
-    requestBrowserProviderStatus: async () => ({
-      jobs: [...rows.values()],
-      providerId: identity.providerId,
-      requestId: crypto.randomUUID(),
-      type: 'provider_status_result' as const,
-    }),
+    requestBrowserProviderStatus: async (
+      _cursor?: string,
+      provider?: Pick<BrowserProviderRegistration, 'providerId' | 'providerProof'>
+    ) => {
+      const proof = provider ?? (registered ? registration : undefined);
+      if (proof === undefined) {
+        throw new BrowserProviderError('provider_unavailable', true);
+      }
+      if (
+        proof.providerId !== identity.providerId ||
+        proof.providerProof !== identity.providerProof
+      ) {
+        throw new BrowserProviderError('owner_mismatch', false);
+      }
+      statusProviders.push(proof.providerId);
+      if (!registered && rows.size === 0 && fence === undefined) {
+        throw new BrowserProviderError('not_found', false);
+      }
+      return {
+        jobs: [...rows.values()],
+        providerId: identity.providerId,
+        requestId: crypto.randomUUID(),
+        type: 'provider_status_result' as const,
+        unresolvedFence: fence,
+      };
+    },
     retain: () => {
       fixture.retained += 1;
       retained += 1;
@@ -435,6 +466,7 @@ const relay = () => {
       setState({ status: 'ready' });
     },
     sendBrowserProviderResult: (input: BrowserProviderResultInput) => {
+      authority.push('result');
       const job = rows.get(input.jobId);
       if (job === undefined) {
         throw new Error('Unknown invocation.');
@@ -468,6 +500,7 @@ const relay = () => {
     };
   };
   return {
+    authority,
     connection,
     delivery,
     dispatch: (message: Delivery) => {
@@ -478,6 +511,7 @@ const relay = () => {
     registration: () => registration,
     retained: () => retained,
     rows,
+    statusProviders,
   };
 };
 const clients: QueryClient[] = [];
@@ -786,10 +820,6 @@ describe('browser task provider tree', () => {
         expect(replacement.registration()?.providerId).toBe(
           scope === 'account' ? undefined : identity.providerId
         );
-        if (scope === 'account') {
-          await enable('Recovery required');
-        }
-        await screen.findByText('CLI tasks: Recovery required');
         expect(screen.getByRole('region', { name: 'CLI task supervision' })).toBe(supervision);
         expect(screen.queryByText('CLI tasks: Owned by another panel')).toBeNull();
         expect(screen.getByText('Agents scope: unset')).toBeDefined();
@@ -823,7 +853,11 @@ describe('browser task provider tree', () => {
         expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
         expect(effects).toStrictEqual(['issued action']);
         fireEvent.click(recover);
-        await screen.findByText('CLI tasks: Enabled — idle');
+        await screen.findByText(
+          scope === 'account'
+            ? /Local browser control recovered. CLI tasks remain disabled/u
+            : 'CLI tasks: Enabled — idle'
+        );
         expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
           tabIds: [],
           version: 1,
@@ -832,6 +866,9 @@ describe('browser task provider tree', () => {
         expect(transport.rows.get(request.job.jobId)?.status).toBe('interrupted');
         expect(transport.rows.get(queued.jobId)?.status).toBe('interrupted');
         expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+        if (scope === 'account') {
+          await enable();
+        }
         const fresh = Promise.withResolvers<BrowserRunContext>();
         fixture.turn = async context => {
           context.executionGuard();
@@ -906,6 +943,247 @@ describe('browser task provider tree', () => {
       expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
     } finally {
       action.resolve();
+    }
+  });
+
+  it.each(['bootstrap', 'Refresh status'] as const)(
+    'shows an authorized terminal outcome from %s without creating or acknowledging execution',
+    async source => {
+      const transport = relay();
+      fixture.connection = transport.connection;
+      fixture.values.set(BROWSER_PROVIDER_SETTINGS_KEY, {
+        accountKey: await browserAccountKey(auth),
+        settings: { enabled: true, mode: 'safe', model: 'selected-model', thinkingEffort: '' },
+        version: 1,
+      });
+      const { job } = transport.delivery();
+      const result: BrowserResult = {
+        browserTaskId: job.browserTaskId,
+        effectsUncertain: true,
+        evidence: [
+          {
+            text: 'The page showed a pending order.',
+            title: 'Observed checkout',
+            url: 'https://example.test/checkout',
+          },
+        ],
+        invocationId: job.invocationId,
+        jobId: job.jobId,
+        providerId: job.providerId,
+        reason: 'effects_uncertain',
+        status: 'interrupted',
+        summary: 'The page action ended with uncertain effects.',
+      };
+      const terminal: BrowserJobSnapshot = { ...job, result, status: result.status };
+      const effects: string[] = [];
+      fixture.turn = async () => {
+        effects.push('executed');
+        return outcome();
+      };
+      if (source === 'bootstrap') {
+        transport.rows.set(job.jobId, terminal);
+      }
+      renderPanel();
+      await screen.findByText('CLI tasks: Enabled — idle');
+      expect(screen.queryByText(/Last outcome:/u)?.textContent).toBe(
+        source === 'bootstrap' ? 'Last outcome: interrupted · effects_uncertain' : undefined
+      );
+      if (source === 'Refresh status') {
+        transport.rows.set(job.jobId, terminal);
+        fireEvent.click(screen.getByRole('button', { name: 'Refresh status' }));
+      }
+      await screen.findByText('Last outcome: interrupted · effects_uncertain');
+      for (const mode of ['agents', 'browser'] as const) {
+        switchMode(mode);
+        const controls = screen.getByRole('region', { name: 'CLI task supervision' });
+        expect(within(controls).getByText(result.summary)).toBeDefined();
+        expect(
+          within(controls).getByText(
+            'Effects are uncertain. Close affected tabs before explicit recovery.'
+          )
+        ).toBeDefined();
+        expect(controls.textContent).toContain('Observed checkout');
+        expect(controls.textContent).toContain('https://example.test/checkout');
+        expect(controls.textContent).toContain('The page showed a pending order.');
+        expect(within(controls).queryByText('No observed evidence.')).toBeNull();
+        expect(within(controls).queryByText(/Goal:/u)).toBeNull();
+        expect(within(controls).queryByRole('button', { name: 'Approve tab' })).toBeNull();
+        expect(within(controls).queryByRole('button', { name: 'Stop CLI task' })).toBeNull();
+      }
+      expect([...transport.rows.values()]).toStrictEqual([terminal]);
+      expect(transport.authority).toStrictEqual(['registration']);
+      expect(effects).toStrictEqual([]);
+    }
+  );
+
+  it.each(['settings', 'tabs'] as const)(
+    'retains the goal and visible consent controls after a failed %s read and approves only on retry',
+    async source => {
+      const transport = relay();
+      fixture.connection = transport.connection;
+      const effects: string[] = [];
+      fixture.turn = async context => {
+        context.executionGuard();
+        effects.push('executed');
+        return waitForAbort(context);
+      };
+      renderPanel();
+      await enable();
+      switchMode(source === 'settings' ? 'browser' : 'agents');
+      const request = transport.delivery();
+      act(() => {
+        transport.dispatch(request);
+      });
+      await screen.findByRole('button', { name: 'Approve tab' });
+      await screen.findByRole('option', { name: 'Approved tab' });
+      fireEvent.change(screen.getByLabelText('Tab to approve'), { target: { value: '7' } });
+      const storageApi = storage as { getItem: (key: string) => unknown };
+      const { getItem } = storageApi;
+      const read =
+        source === 'tabs'
+          ? vi
+              .spyOn(browser.tabs, 'query')
+              .mockRejectedValueOnce(new Error('Tab access unavailable.'))
+          : vi.spyOn(storageApi, 'getItem').mockImplementation(key => {
+              if (key === 'local:kiloRemoteMcpServers') {
+                throw new Error('Settings unavailable.');
+              }
+              return getItem(key);
+            });
+      try {
+        fireEvent.click(screen.getByRole('button', { name: 'Approve tab' }));
+        await screen.findByText(/approve this goal again before its deadline/u);
+        expect(screen.getByText(`Goal: ${request.goal}`)).toBeDefined();
+        expect(screen.getByText('Bound tab: Not approved')).toBeDefined();
+        for (const name of ['Approve tab', 'Reject', 'Refresh tabs']) {
+          expect(screen.getByRole<HTMLButtonElement>('button', { name }).disabled).toBe(false);
+        }
+        expect(screen.queryByRole('button', { name: 'Reconnect' })).toBeNull();
+        expect(transport.rows.get(request.job.jobId)?.status).toBe('awaiting_approval');
+        expect(transport.authority).toStrictEqual(['registration']);
+        expect(effects).toStrictEqual([]);
+        read.mockRestore();
+        fireEvent.click(screen.getByRole('button', { name: 'Refresh tabs' }));
+        await waitFor(() => {
+          expect(
+            screen.getByRole<HTMLButtonElement>('button', { name: 'Refresh tabs' }).disabled
+          ).toBe(false);
+        });
+        expect(effects).toStrictEqual([]);
+        fireEvent.click(screen.getByRole('button', { name: 'Approve tab' }));
+        await screen.findByText('CLI tasks: Running');
+        expect(screen.getByText('Bound tab: Approved tab (ID 7)')).toBeDefined();
+        expect(transport.rows.get(request.job.jobId)?.approvedTab?.tabId).toBe(7);
+        expect(effects).toStrictEqual(['executed']);
+        switchMode(source === 'settings' ? 'agents' : 'browser');
+        fireEvent.click(screen.getByRole('button', { name: 'Stop CLI task' }));
+        await screen.findByText('Last outcome: cancelled · cancelled');
+        expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Refresh tabs' })).toBeNull();
+      } finally {
+        read.mockRestore();
+      }
+    }
+  );
+
+  it.each([
+    { ending: 'expiry', outcome: /Last outcome: .* · approval_timeout/u },
+    { ending: 'permission denial', outcome: /Last outcome: .* · permission_denied/u },
+  ] as const)(
+    'removes execution retry controls after consent ends through $ending',
+    async ending => {
+      const transport = relay();
+      fixture.connection = transport.connection;
+      const effects: string[] = [];
+      fixture.turn = async () => {
+        effects.push('executed');
+        return outcome();
+      };
+      renderPanel();
+      await enable();
+      const request = transport.delivery();
+      const deadline = Date.now() + 10_000;
+      request.job.deadlines.approval = new Date(deadline).toISOString();
+      act(() => {
+        transport.dispatch(request);
+      });
+      await screen.findByRole('button', { name: 'Approve tab' });
+      await screen.findByRole('option', { name: 'Approved tab' });
+      fireEvent.change(screen.getByLabelText('Tab to approve'), { target: { value: '7' } });
+      const query = vi
+        .spyOn(browser.tabs, 'query')
+        .mockRejectedValueOnce(new Error('Tabs unavailable.'));
+      const clock = vi.spyOn(Date, 'now');
+      try {
+        fireEvent.click(screen.getByRole('button', { name: 'Approve tab' }));
+        await screen.findByText(/approve this goal again before its deadline/u);
+        if (ending.ending === 'expiry') {
+          clock.mockReturnValue(deadline + 1);
+        } else {
+          query.mockRejectedValueOnce(new BrowserProviderError('permission_denied', false));
+        }
+        fireEvent.click(screen.getByRole('button', { name: 'Approve tab' }));
+        await screen.findByText(ending.outcome);
+        expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Reject' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Refresh tabs' })).toBeNull();
+        expect(transport.rows.get(request.job.jobId)?.approvedTab).toBeUndefined();
+        expect(transport.authority).not.toContain('approval');
+        expect(effects).toStrictEqual([]);
+      } finally {
+        clock.mockRestore();
+        query.mockRestore();
+      }
+    }
+  );
+
+  it('does not restore stale consent when a pending tab read fails after visible rejection', async () => {
+    const transport = relay();
+    fixture.connection = transport.connection;
+    const effects: string[] = [];
+    fixture.turn = async () => {
+      effects.push('executed');
+      return outcome();
+    };
+    renderPanel();
+    await enable();
+    const request = transport.delivery();
+    act(() => {
+      transport.dispatch(request);
+    });
+    await screen.findByRole('button', { name: 'Approve tab' });
+    await screen.findByRole('option', { name: 'Approved tab' });
+    fireEvent.change(screen.getByLabelText('Tab to approve'), { target: { value: '7' } });
+    const tabs = await browser.tabs.query({});
+    const tabsApi: {
+      query: (queryInfo: Parameters<typeof browser.tabs.query>[0]) => Promise<typeof tabs>;
+    } = browser.tabs;
+    const entered = Promise.withResolvers<void>();
+    const resume = Promise.withResolvers<void>();
+    const query = vi.spyOn(tabsApi, 'query').mockImplementationOnce(async () => {
+      entered.resolve();
+      await resume.promise;
+      throw new Error('Late tab read failure.');
+    });
+    try {
+      fireEvent.click(screen.getByRole('button', { name: 'Approve tab' }));
+      await entered.promise;
+      fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+      await screen.findByText(/Last outcome: .* · approval_denied/u);
+      const terminal = structuredClone(transport.rows.get(request.job.jobId));
+      await act(async () => {
+        resume.resolve();
+        await resume.promise;
+      });
+      expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Refresh tabs' })).toBeNull();
+      expect(screen.queryByText(/approve this goal again before its deadline/u)).toBeNull();
+      expect(transport.rows.get(request.job.jobId)).toStrictEqual(terminal);
+      expect(terminal?.approvedTab).toBeUndefined();
+      expect(effects).toStrictEqual([]);
+    } finally {
+      resume.resolve();
+      query.mockRestore();
     }
   });
 
@@ -1153,11 +1431,164 @@ describe('browser task provider tree', () => {
     }
   );
 
-  it('prepares real all-tabs recovery without clearing quarantine or replaying work', async () => {
+  it.each(['never-enabled', 'withdrawn'] as const)(
+    'recovers a %s profile only after closure and drainage while delegation stays disabled',
+    async profile => {
+      vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+      const transport = relay();
+      fixture.connection = transport.connection;
+      const effects: string[] = [];
+      fixture.turn = async () => {
+        effects.push('executed');
+        return outcome();
+      };
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const held = nativeLocks.request(BROWSER_EXECUTION_LOCK, { mode: 'shared' }, async () => {
+        entered.resolve();
+        await release.promise;
+      });
+      try {
+        await entered.promise;
+        renderPanel();
+        await screen.findByText('CLI tasks: Disabled');
+        if (profile === 'withdrawn') {
+          await enable();
+          const dialog = await openSettings();
+          fireEvent.click(within(dialog).getByRole('switch', { name: 'CLI tasks' }));
+          fireEvent.click(within(dialog).getByRole('button', { name: 'Disable CLI tasks' }));
+          await within(dialog).findByText('CLI tasks: Disabled');
+          fireEvent.click(within(dialog).getByRole('button', { name: 'Close settings' }));
+        }
+        switchMode('agents');
+        const settings = structuredClone(fixture.values.get(BROWSER_PROVIDER_SETTINGS_KEY));
+        const authority = [...transport.authority];
+        await act(async () => {
+          await storage.setItem(BROWSER_EXECUTION_SAFETY_KEY, { tabIds: [7], version: 1 });
+        });
+        const affected = await screen.findByRole('list', { name: 'Affected tabs' });
+        await within(affected).findByText('Title: Approved tab');
+        fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+        await screen.findByText('Browser actions are still unwinding. Wait before recovery.');
+        expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+        await act(async () => {
+          release.resolve();
+          await held;
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+        await screen.findByText('Close all affected tabs before recovery.');
+        expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+        fixture.tabs = [{ id: 8, title: 'Unrelated tab', url: 'https://other.test/' }];
+        fireEvent.click(screen.getByRole('button', { name: 'Refresh affected tabs' }));
+        await within(affected).findByText('Tab ID 7: Closed');
+        expect(within(affected).queryByText(/Unrelated tab/u)).toBeNull();
+        const statusReads = transport.statusProviders.length;
+        fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+        const recover = await screen.findByRole('button', { name: 'Recover browser control' });
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+          tabIds: [7],
+          version: 1,
+        });
+        expect(screen.getByText('CLI tasks: Disabled')).toBeDefined();
+        fireEvent.click(recover);
+        await screen.findByText(/Local browser control recovered. CLI tasks remain disabled/u);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(5000);
+        });
+        expect(transport.statusProviders.slice(statusReads)).toStrictEqual([
+          identity.providerId,
+          identity.providerId,
+        ]);
+        expect(transport.authority).toStrictEqual(authority);
+        expect(transport.rows.size).toBe(0);
+        expect(effects).toStrictEqual([]);
+        expect(fixture.values.get(BROWSER_PROVIDER_SETTINGS_KEY)).toStrictEqual(settings);
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+          tabIds: [],
+          version: 1,
+        });
+        expect(screen.queryByRole('list', { name: 'Affected tabs' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+        switchMode('browser');
+        expect(screen.getByText('CLI tasks: Disabled')).toBeDefined();
+        const dialog = await openSettings();
+        expect(
+          within(dialog).getByRole('switch', { name: 'CLI tasks' }).getAttribute('aria-checked')
+        ).toBe('false');
+      } finally {
+        release.resolve();
+        await held;
+        vi.useRealTimers();
+      }
+    }
+  );
+
+  it('keeps a disabled remote fence blocked and retains its tab identity without local history', async () => {
+    const transport = relay({ invocationId: `b1.${Date.now()}.${'b'.repeat(64)}`, tabId: 42 });
+    fixture.connection = transport.connection;
+    fixture.tabs = [];
+    renderPanel();
+    await screen.findByText('CLI tasks: Disabled');
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh status' }));
+    await screen.findByText('Tab ID 42: Closed');
+    fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+    await screen.findByText(/A remote browser task still requires recovery/u);
+    expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+    expect(screen.getByText('CLI tasks: Disabled')).toBeDefined();
+    expect(transport.authority).toStrictEqual([]);
+    expect(transport.rows.size).toBe(0);
+    expect(fixture.values.get(BROWSER_PROVIDER_SETTINGS_KEY)).toMatchObject({
+      settings: { enabled: false },
+    });
+  });
+
+  it.each([
+    {
+      message: /Reopen the signed-in panel and retrieve status/u,
+      reason: 'provider_unavailable',
+      retryable: true,
+    },
+    {
+      message: /Restore provider access before checking recovery again/u,
+      reason: 'owner_mismatch',
+      retryable: false,
+    },
+  ] as const)(
+    'keeps disabled local recovery blocked by $reason',
+    async ({ reason, retryable, message }) => {
+      const transport = relay();
+      fixture.connection = transport.connection;
+      fixture.tabs = [];
+      const safety = { tabIds: [7], version: 1 };
+      fixture.values.set(BROWSER_EXECUTION_SAFETY_KEY, safety);
+      const status = vi
+        .spyOn(transport.connection, 'requestBrowserProviderStatus')
+        .mockRejectedValue(new BrowserProviderError(reason, retryable));
+      try {
+        renderPanel();
+        await screen.findByText('CLI tasks: Disabled');
+        fireEvent.click(await screen.findByRole('button', { name: 'Check recovery readiness' }));
+        await screen.findByText(message);
+        expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+        expect(fixture.values.get(BROWSER_PROVIDER_SETTINGS_KEY)).toMatchObject({
+          settings: { enabled: false },
+        });
+        expect(transport.authority).toStrictEqual([]);
+        expect(transport.rows.size).toBe(0);
+      } finally {
+        status.mockRestore();
+      }
+    }
+  );
+
+  it('keeps all-tabs closure guidance until disabled local recovery completes', async () => {
     const transport = relay();
     fixture.connection = transport.connection;
     renderPanel();
-    await enable();
+    await screen.findByText('CLI tasks: Disabled');
     await act(async () => {
       await storage.setItem(BROWSER_EXECUTION_SAFETY_KEY, {
         allTabs: true,
@@ -1165,7 +1596,14 @@ describe('browser task provider tree', () => {
         version: 1,
       });
     });
-    await screen.findByText('CLI tasks: Recovery required');
+    fireEvent.click(await screen.findByRole('button', { name: 'Check recovery readiness' }));
+    await screen.findByText(
+      'Close all target tabs before recovery. The affected-tab list is not known to be complete.'
+    );
+    expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+    fixture.tabs = [{ id: 8, title: 'Another open tab', url: 'https://other.test/' }];
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh affected tabs' }));
+    await screen.findByText('Tab ID 7: Closed');
     fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
     await screen.findByText(
       'Close all target tabs before recovery. The affected-tab list is not known to be complete.'
@@ -1181,20 +1619,26 @@ describe('browser task provider tree', () => {
     });
     expect(transport.rows.size).toBe(0);
     fireEvent.click(recover);
-    await screen.findByText('CLI tasks: Enabled — idle');
+    await screen.findByText(/Local browser control recovered. CLI tasks remain disabled/u);
     expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
       tabIds: [],
       version: 1,
     });
+    expect(screen.queryByText(/affected-tab list is not known to be complete/u)).toBeNull();
+    expect(transport.authority).toStrictEqual([]);
     expect(transport.rows.size).toBe(0);
     expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
   });
 
-  it('confirms disablement before terminating active and queued jobs without clearing quarantine', async () => {
+  it('retains affected tabs through disablement, settlement, and reload until explicit local recovery', async () => {
     const transport = relay();
     fixture.connection = transport.connection;
-    fixture.turn = waitForAbort;
-    renderPanel();
+    const effects: string[] = [];
+    fixture.turn = async context => {
+      effects.push('issued action');
+      return waitForAbort(context);
+    };
+    const panel = renderPanel();
     await enable();
     const request = transport.delivery();
     act(() => {
@@ -1218,17 +1662,62 @@ describe('browser task provider tree', () => {
     expect(transport.rows.get(queued.jobId)?.status).toBe('queued');
     expect(within(dialog).getByRole('button', { name: 'Stop CLI task' })).toBeDefined();
     fireEvent.click(within(settings).getByRole('button', { name: 'Disable CLI tasks' }));
-    await waitFor(() => {
-      expect(within(dialog).getByText('CLI tasks: Disabled')).toBeDefined();
-    });
+    await within(dialog).findByText('CLI tasks: Disabled');
     expect(transport.rows.get(request.job.jobId)?.status).toBe('interrupted');
     expect(transport.rows.get(queued.jobId)?.status).toBe('interrupted');
     expect(fixture.values.get(BROWSER_PROVIDER_SETTINGS_KEY)).toMatchObject({
       settings: { enabled: false },
     });
-    await waitFor(() => {
+    await waitFor(async () => {
       expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+      const locks = await nativeLocks.query();
+      expect(locks.held?.filter(lock => lock.name === BROWSER_EXECUTION_LOCK)).toHaveLength(0);
     });
+    const settled = structuredClone([...transport.rows.values()]);
+    const affected = within(dialog).getByRole('list', { name: 'Affected tabs' });
+    await within(affected).findByText('Title: Approved tab');
+    fixture.tabs = [{ id: 7, title: 'Renamed affected page', url: 'chrome://settings/' }];
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Refresh affected tabs' }));
+    await within(affected).findByText('Title: Renamed affected page');
+    expect(within(affected).getByText('Address: chrome://settings/')).toBeDefined();
     expect(within(dialog).queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Close settings' }));
+    panel.unmount();
+    await waitFor(async () => {
+      const locks = await nativeLocks.query();
+      expect(locks.held?.filter(lock => lock.name === PROVIDER_OWNER_LOCK)).toHaveLength(0);
+      expect(transport.retained()).toBe(0);
+    });
+    renderPanel();
+    await screen.findByText('CLI tasks: Disabled');
+    const reloaded = await screen.findByRole('list', { name: 'Affected tabs' });
+    await within(reloaded).findByText('Title: Renamed affected page');
+    expect(
+      within(reloaded).getByText('Tab ID 7: Open — close this tab before recovery.')
+    ).toBeDefined();
+    expect(within(reloaded).getByText('Address: chrome://settings/')).toBeDefined();
+    const authority = [...transport.authority];
+    fixture.tabs = [{ id: 8, title: 'Unrelated page', url: 'https://other.test/' }];
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh affected tabs' }));
+    await within(reloaded).findByText('Tab ID 7: Closed');
+    expect(within(reloaded).queryByText(/Unrelated page/u)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+    const recover = await screen.findByRole('button', { name: 'Recover browser control' });
+    expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+    expect(screen.getByRole('list', { name: 'Affected tabs' })).toBe(reloaded);
+    fireEvent.click(recover);
+    await screen.findByText(/Local browser control recovered. CLI tasks remain disabled/u);
+    expect(screen.queryByRole('list', { name: 'Affected tabs' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+    expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      tabIds: [],
+      version: 1,
+    });
+    expect(fixture.values.get(BROWSER_PROVIDER_SETTINGS_KEY)).toMatchObject({
+      settings: { enabled: false },
+    });
+    expect([...transport.rows.values()]).toStrictEqual(settled);
+    expect(transport.authority).toStrictEqual(authority);
+    expect(effects).toStrictEqual(['issued action']);
   });
 });

--- a/apps/extension/entrypoints/sidepanel/browser-task-provider-tree.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider-tree.test.tsx
@@ -700,6 +700,125 @@ describe('browser task provider tree', () => {
     }
   );
 
+  it.each([
+    { enabled: true, name: 'enabled profile', phase: 'Enabled — idle', quarantined: false },
+    {
+      enabled: true,
+      name: 'quarantined enabled profile',
+      phase: 'Recovery required',
+      quarantined: true,
+    },
+    { enabled: false, name: 'quarantined disabled profile', phase: 'Disabled', quarantined: true },
+  ] as const)(
+    'retries ownership for a $name only after the native owner closes, without consent or replay',
+    async ({ enabled, phase, quarantined }) => {
+      const transport = relay();
+      fixture.connection = transport.connection;
+      const record = {
+        accountKey: await browserAccountKey(auth),
+        settings: { enabled, mode: 'dangerous', model: 'other-model', thinkingEffort: 'high' },
+        version: 1,
+      };
+      const safety = { tabIds: quarantined ? [7] : [], version: 1 };
+      fixture.values.set(BROWSER_PROVIDER_SETTINGS_KEY, record);
+      fixture.values.set(BROWSER_EXECUTION_SAFETY_KEY, safety);
+      const { job } = transport.delivery();
+      const result: BrowserResult = {
+        browserTaskId: job.browserTaskId,
+        effectsUncertain: quarantined,
+        evidence: [],
+        invocationId: job.invocationId,
+        jobId: job.jobId,
+        providerId: job.providerId,
+        reason: 'provider_unavailable',
+        status: 'interrupted',
+        summary: 'The previous invocation stopped.',
+      };
+      const terminal: BrowserJobSnapshot = { ...job, result, status: result.status };
+      transport.rows.set(job.jobId, terminal);
+      const effects: string[] = [];
+      fixture.turn = async () => {
+        effects.push('executed');
+        return outcome();
+      };
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const held = nativeLocks.request(PROVIDER_OWNER_LOCK, { mode: 'exclusive' }, async () => {
+        entered.resolve();
+        await release.promise;
+      });
+      try {
+        await entered.promise;
+        const locksBeforeRetry = await nativeLocks.query();
+        const ownerLocks = locksBeforeRetry.held?.filter(lock => lock.name === PROVIDER_OWNER_LOCK);
+        let panel = renderPanel();
+        const retry = await screen.findByRole('button', { name: 'Reload panel' });
+        expect(screen.getByText('CLI tasks: Ownership not acquired')).toBeDefined();
+        expect(screen.queryByRole('button', { name: 'Refresh status' })).toBeNull();
+        // Native navigation is unavailable in jsdom. Reload disposes and remounts the real tree.
+        vi.stubGlobal('location', { reload: panel.unmount });
+        fireEvent.click(retry);
+        expect(screen.queryByRole('region', { name: 'CLI task supervision' })).toBeNull();
+        panel = renderPanel();
+        await screen.findByRole('button', { name: 'Reload panel' });
+        expect(screen.getByText('CLI tasks: Ownership not acquired')).toBeDefined();
+        const locksAfterRetry = await nativeLocks.query();
+        expect(
+          locksAfterRetry.held?.filter(lock => lock.name === PROVIDER_OWNER_LOCK)
+        ).toStrictEqual(ownerLocks);
+        expect(transport.registration()).toBeUndefined();
+        expect(transport.authority).toStrictEqual([]);
+        await act(async () => {
+          release.resolve();
+          await held;
+        });
+        const locksAfterClosure = await nativeLocks.query();
+        expect(
+          locksAfterClosure.held?.filter(lock => lock.name === PROVIDER_OWNER_LOCK)
+        ).toHaveLength(0);
+        expect(screen.getByText('This panel could not acquire browser ownership.')).toBeDefined();
+        expect(screen.queryByText(/Another panel owns this browser provider/u)).toBeNull();
+        expect(transport.registration()).toBeUndefined();
+        vi.stubGlobal('location', { reload: panel.unmount });
+        fireEvent.click(screen.getByRole('button', { name: 'Reload panel' }));
+        expect(screen.queryByRole('region', { name: 'CLI task supervision' })).toBeNull();
+        renderPanel();
+        await screen.findByText(`CLI tasks: ${phase}`);
+        const locksAfterReload = await nativeLocks.query();
+        expect(
+          locksAfterReload.held?.filter(lock => lock.name === PROVIDER_OWNER_LOCK)
+        ).toHaveLength(1);
+        expect(fixture.values.get(AUTH_STORAGE_KEY)).toStrictEqual(auth);
+        expect(fixture.values.get(BROWSER_PROVIDER_IDENTITY_KEY)).toStrictEqual(identity);
+        expect(fixture.values.get(BROWSER_PROVIDER_SETTINGS_KEY)).toStrictEqual(record);
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+        expect([...transport.rows.values()]).toStrictEqual([terminal]);
+        expect(effects).toStrictEqual([]);
+        expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Reload panel' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+        if (quarantined) {
+          fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+          await screen.findByText('Close all affected tabs before recovery.');
+        } else {
+          const fresh = transport.delivery();
+          act(() => {
+            transport.dispatch(fresh);
+          });
+          await screen.findByRole('button', { name: 'Approve tab' });
+          await screen.findByText('Bound tab: Not approved');
+        }
+        expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+        expect(transport.authority).toStrictEqual(enabled ? ['registration'] : []);
+        expect(effects).toStrictEqual([]);
+      } finally {
+        release.resolve();
+        await held;
+      }
+    }
+  );
+
   it('stays off by default, preserves Browser drafts, and keeps one transport and a private Agents store', async () => {
     const transport = relay();
     fixture.connection = transport.connection;

--- a/apps/extension/entrypoints/sidepanel/browser-task-provider-tree.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/browser-task-provider-tree.test.tsx
@@ -1,0 +1,1234 @@
+/* eslint-disable max-lines, import/max-dependencies, import/first, import/no-nodejs-modules, jest/no-hooks, jest/no-standalone-expect, jest/no-untyped-mock-factory, jest/no-conditional-in-test, jest/max-expects, vitest/prefer-import-in-mock, typescript/consistent-type-definitions, typescript/no-unsafe-type-assertion, require-await, typescript/require-await -- Browser and relay fixtures surround the real provider, approval storage, and Browser/Agents store boundaries. */
+// @vitest-environment jsdom
+import { webcrypto, createHash } from 'node:crypto';
+import { locks as nativeLocks } from 'node:worker_threads';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { atom, getDefaultStore, useAtom, useAtomValue, useStore } from 'jotai';
+import { useEffect, useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { createUserWebConnection } from '@kilocode/cloud-agent-sdk';
+import type { StoredAuth } from '@/src/shared/auth';
+import type { createExtensionTrpcClient } from '@/src/shared/extension-trpc-client';
+import type { ExtensionAgentsContextValue } from './agents-provider';
+import type {
+  BrowserJobSnapshot,
+  BrowserProviderInboundMessage,
+  BrowserResult,
+} from '@kilocode/cloud-agent-sdk/schemas';
+import type {
+  BrowserProviderState,
+  BrowserProviderRegistration,
+  BrowserProviderApprovalInput,
+  BrowserProviderCancelInput,
+  BrowserProviderUnavailableInput,
+  BrowserProviderQuiescenceInput,
+  BrowserProviderResultInput,
+} from '@kilocode/cloud-agent-sdk/user-web-connection';
+import type { BrowserRunContext } from './browser-run-context';
+import type { BrowserTaskProviderOptions } from './browser-task-provider';
+import type { AgentConversationEvent } from '@/src/shared/agent-conversation';
+import type { LlmTurnOutcome } from '@/src/shared/agent-llm-turn-runner-core';
+
+const fixture = vi.hoisted(() => ({
+  agents: undefined as ExtensionAgentsContextValue | undefined,
+  connection: {} as BrowserTaskProviderOptions['connection'],
+  connectionConfigs: [] as Parameters<typeof createUserWebConnection>[0][],
+  connections: 0,
+  failedReadKey: '',
+  models: [
+    { id: 'selected-model', isPreferred: true, name: 'Selected model', variants: [] as string[] },
+    { id: 'other-model', isPreferred: false, name: 'Other model', variants: [] as string[] },
+  ],
+  organizationId: '',
+  permissions: new Set<() => void>(),
+  removed: new Set<(id: number) => void>(),
+  retained: 0,
+  tabs: [{ id: 7, title: 'Approved tab', url: 'https://example.test/' }],
+  turn: async (
+    _context: BrowserRunContext,
+    _events: AgentConversationEvent[]
+  ): Promise<LlmTurnOutcome> => {
+    throw new Error('Set the turn fixture.');
+  },
+  updated: new Set<(id: number, info: { url?: string }) => void>(),
+  values: new Map<string, unknown>(),
+  waitWrite: undefined as Promise<void> | undefined,
+  waitWriteKey: '',
+  watchers: new Map<string, Set<() => void>>(),
+}));
+vi.mock('#imports', () => ({
+  browser: {
+    permissions: {
+      onRemoved: {
+        addListener: (fn: () => void) => fixture.permissions.add(fn),
+        removeListener: (fn: () => void) => fixture.permissions.delete(fn),
+      },
+    },
+    runtime: {
+      sendMessage: async (request: { type: string }) => {
+        if (request.type === LIST_INSPECTABLE_TABS_MESSAGE) {
+          return { ok: true, tabs: fixture.tabs, type: request.type };
+        }
+        return {
+          ok: true,
+          result: {
+            effectsUncertain: false,
+            ok: true,
+            value: {
+              dryRunActions: [],
+              effectsUncertain: false,
+              ok: true,
+              value: { done: true, result: 'Observed workflow result.' },
+            },
+          },
+          type: request.type,
+        };
+      },
+    },
+    tabs: {
+      get: async (id: number) => {
+        const tab = fixture.tabs.find(candidate => candidate.id === id);
+        if (tab === undefined) {
+          throw new Error('Tab closed.');
+        }
+        return { ...tab, status: 'complete' };
+      },
+      onRemoved: {
+        addListener: (fn: (id: number) => void) => fixture.removed.add(fn),
+        removeListener: (fn: (id: number) => void) => fixture.removed.delete(fn),
+      },
+      onUpdated: {
+        addListener: (fn: (id: number, info: { url?: string }) => void) => fixture.updated.add(fn),
+        removeListener: (fn: (id: number, info: { url?: string }) => void) =>
+          fixture.updated.delete(fn),
+      },
+      query: async () => structuredClone(fixture.tabs),
+    },
+  },
+  storage: {
+    getItem: (key: string) => {
+      if (key === fixture.failedReadKey) {
+        throw new Error('Storage unavailable.');
+      }
+      return structuredClone(fixture.values.get(key));
+    },
+    removeItem: (key: string) => {
+      fixture.values.delete(key);
+      for (const notify of fixture.watchers.get(key) ?? []) {
+        notify();
+      }
+    },
+    setItem: async (key: string, value: unknown) => {
+      if (key === fixture.waitWriteKey) {
+        await fixture.waitWrite;
+      }
+      fixture.values.set(key, structuredClone(value));
+      for (const notify of fixture.watchers.get(key) ?? []) {
+        notify();
+      }
+    },
+    watch: (key: string, fn: () => void) => {
+      const listeners = fixture.watchers.get(key) ?? new Set<() => void>();
+      fixture.watchers.set(key, listeners);
+      listeners.add(fn);
+      return () => {
+        listeners.delete(fn);
+      };
+    },
+  },
+}));
+vi.mock(import('@kilocode/cloud-agent-sdk'), async importOriginal => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    createUserWebConnection: (config: Parameters<typeof createUserWebConnection>[0]) => {
+      fixture.connections += 1;
+      fixture.connectionConfigs.push(config);
+      // Exercise the real SDK opt-in default without starting a socket.
+      const dormant = original.createUserWebConnection(config);
+      const disabled = dormant.getBrowserProviderState().status === 'disabled';
+      dormant.destroy();
+      return {
+        ...dormant,
+        ...fixture.connection,
+        getBrowserProviderState: disabled
+          ? () => ({ status: 'disabled' as const })
+          : fixture.connection.getBrowserProviderState,
+        registerBrowserProvider: disabled
+          ? dormant.registerBrowserProvider
+          : fixture.connection.registerBrowserProvider,
+      };
+    },
+  };
+});
+vi.mock('@/src/shared/extension-trpc-client', () => ({
+  createExtensionTrpcClient: ({ getToken }: Parameters<typeof createExtensionTrpcClient>[0]) => ({
+    activeSessions: {
+      createWebTicket: { mutate: async () => ({ token: `ticket:${getToken()}` }) },
+    },
+  }),
+}));
+vi.mock('./agents-mode', () => ({ AgentsMode: () => <AgentsProbe /> }));
+vi.mock(import('./organization-credit-account'), async importOriginal => ({
+  ...(await importOriginal()),
+  useOrganizationCreditAccount: () => ({
+    organizationOptions: [],
+    selectOrganization: vi.fn(),
+    selectedOrganizationId: fixture.organizationId,
+  }),
+}));
+vi.mock('./use-gateway-models', () => ({
+  useGatewayModels: () => ({
+    isLoading: false,
+    modelLoadError: undefined,
+    modelOptions: fixture.models,
+    refetchModels: vi.fn(),
+  }),
+}));
+vi.mock('./use-model-preferences', () => ({
+  useModelPreferences: () => ({
+    favorites: new Set<string>(),
+    refetch: vi.fn(),
+    status: 'ready',
+    toggleError: false,
+    toggleFavorite: vi.fn(),
+  }),
+}));
+vi.mock(import('./browser-run-context'), async importOriginal => ({
+  ...(await importOriginal()),
+  runBrowserTurn: (context: BrowserRunContext, events: AgentConversationEvent[]) =>
+    context.lease.run(async guard => {
+      guard();
+      return fixture.turn(context, events);
+    }),
+}));
+
+import { storage } from '#imports';
+import { SignedInView } from './auth-views';
+import { useExtensionAgents } from './agents-provider';
+import { draftAtomFamily, clearPerConversationAtoms } from './agent-chat-atoms';
+import { activeConversationIdAtom, settingsDialogOpenAtom } from './settings-dialog-state';
+import { workflowRunRequestAtom } from './workflow-settings-state';
+import { pendingApprovalAtom, pendingLockAtom } from './pending-approval';
+import {
+  PROVIDER_OWNER_LOCK,
+  BROWSER_EXECUTION_LOCK,
+  BROWSER_EXECUTION_SAFETY_KEY,
+} from './browser-execution-lock';
+import { AUTH_STORAGE_KEY, BROWSER_PROVIDER_IDENTITY_KEY } from '@/src/shared/auth';
+import {
+  BROWSER_PROVIDER_SETTINGS_KEY,
+  browserAccountKey,
+} from '@/src/shared/browser-provider-settings';
+import { BROWSER_TASK_STORAGE_KEY } from '@/src/shared/browser-task-store';
+import { AGENT_MEMORIES_STORAGE_KEY, loadAgentMemories } from '@/src/shared/agent-memories-storage';
+import {
+  AGENT_WORKFLOWS_STORAGE_KEY,
+  loadAgentWorkflows,
+} from '@/src/shared/agent-workflows-storage';
+import { createAssistantMessage } from '@/src/shared/agent-conversation';
+import { normalizeStoredConversationStore } from './agent-conversation-storage';
+import { LIST_INSPECTABLE_TABS_MESSAGE } from '@/src/shared/tab-debugger';
+
+const scopeAtom = atom('unset');
+const AgentsProbe = () => {
+  const [scope, setScope] = useAtom(scopeAtom);
+  const [view, setView] = useState('list');
+  const store = useStore();
+  const context = useExtensionAgents();
+  const error = useAtomValue(context.manager.atoms.error);
+  useEffect(() => {
+    fixture.agents = context;
+  }, [context]);
+  return (
+    <div>
+      <p>Agents scope: {scope}</p>
+      <p>Agents view: {view}</p>
+      <p>Agents organization: {context.organizationId ?? 'personal'}</p>
+      <p>Manager store: {store === context.store ? 'matched' : 'mismatched'}</p>
+      <p>Manager error: {error ?? 'none'}</p>
+      <button
+        onClick={() => {
+          setScope('private');
+          setView('session');
+          store.set(context.manager.atoms.error, 'Previous scope error');
+        }}
+        type="button"
+      >
+        Set Agents state
+      </button>
+      <button
+        onClick={() => {
+          context.manager.clearError();
+        }}
+        type="button"
+      >
+        Clear manager error
+      </button>
+    </div>
+  );
+};
+const auth = { token: 'tree-test-token', userEmail: 'tree@example.test' };
+const identity = {
+  label: 'Work profile',
+  providerId: 'bp_11111111-1111-4111-8111-111111111111' as const,
+  providerProof: 'a'.repeat(64),
+  version: 1,
+};
+const outcome = (summary = 'Observed the requested page.'): LlmTurnOutcome => ({
+  effectsUncertain: false,
+  reason: 'completed',
+  status: 'succeeded',
+  summary,
+  toolResults: [],
+});
+const waitForAbort = async (context: BrowserRunContext): Promise<LlmTurnOutcome> => {
+  const stopped = Promise.withResolvers<void>();
+  context.abort.signal.addEventListener(
+    'abort',
+    () => {
+      stopped.resolve();
+    },
+    { once: true }
+  );
+  if (context.abort.signal.aborted) {
+    stopped.resolve();
+  }
+  await stopped.promise;
+  context.executionGuard();
+  return outcome();
+};
+type Delivery = Extract<BrowserProviderInboundMessage, { type: 'provider_job' }>;
+const relay = () => {
+  let state: BrowserProviderState = { status: 'ready' };
+  let generation = 0;
+  let retained = 0;
+  // eslint-disable-next-line init-declarations -- Only explicit enablement creates a registration.
+  let registration: BrowserProviderRegistration | undefined;
+  const rows = new Map<string, BrowserJobSnapshot>();
+  const messages = new Set<(message: BrowserProviderInboundMessage) => void>();
+  const states = new Set<(state: BrowserProviderState) => void>();
+  const send = (message: BrowserProviderInboundMessage): void => {
+    for (const listener of messages) {
+      listener(structuredClone(message));
+    }
+  };
+  const setState = (next: BrowserProviderState): void => {
+    state = next;
+    for (const listener of states) {
+      listener(next);
+    }
+  };
+  const snapshot = () => ({
+    generation,
+    jobs: [...rows.values()].filter(job => job.generation === generation),
+    providerId: identity.providerId,
+    type: 'provider_snapshot' as const,
+  });
+  const publish = (): void => {
+    send(snapshot());
+  };
+  const renew = () => {
+    const lease = {
+      generation,
+      leaseExpiresAt: new Date(Date.now() + 15_000).toISOString(),
+      providerId: identity.providerId,
+      requestId: crypto.randomUUID(),
+      type: 'provider_lease_ack' as const,
+    };
+    setState({ lease, status: 'registered' });
+    return lease;
+  };
+  const settle = (job: BrowserJobSnapshot, result: BrowserResult): void => {
+    rows.set(job.jobId, { ...job, queuePosition: undefined, result, status: result.status });
+    publish();
+  };
+  const stop = (
+    job: BrowserJobSnapshot,
+    reason: Exclude<BrowserResult['reason'], 'completed'>
+  ): void => {
+    settle(job, {
+      browserTaskId: job.browserTaskId,
+      effectsUncertain: false,
+      evidence: [],
+      invocationId: job.invocationId,
+      jobId: job.jobId,
+      providerId: job.providerId,
+      reason,
+      status: reason === 'cancelled' ? 'cancelled' : 'interrupted',
+      summary: `Stopped: ${reason}. Issued actions are not undone.`,
+    });
+  };
+  const connection = {
+    approveBrowserProviderJob: (input: BrowserProviderApprovalInput) => {
+      const job = rows.get(input.jobId);
+      if (job === undefined) {
+        throw new Error('Unknown invocation.');
+      }
+      if (input.approval.decision === 'denied') {
+        stop(job, 'approval_denied');
+        return;
+      }
+      rows.set(job.jobId, {
+        ...job,
+        approvedTab: input.approval.tab,
+        deadlines: { ...job.deadlines, execution: new Date(Date.now() + 600_000).toISOString() },
+        status: 'running',
+      });
+      publish();
+    },
+    cancelBrowserProviderJob: (input: BrowserProviderCancelInput) => {
+      const job = rows.get(input.jobId);
+      if (job !== undefined) {
+        stop(job, 'cancelled');
+      }
+    },
+    getBrowserProviderState: () => state,
+    heartbeatBrowserProvider: async () => {
+      renew();
+      return snapshot();
+    },
+    markBrowserProviderUnavailable: (input: BrowserProviderUnavailableInput) => {
+      setState({ reason: input.reason, retryable: true, status: 'unavailable' });
+      for (const job of rows.values()) {
+        if (job.result === undefined) {
+          stop(job, input.reason);
+        }
+      }
+    },
+    onBrowserProviderMessage: (listener: (message: BrowserProviderInboundMessage) => void) => {
+      messages.add(listener);
+      return () => {
+        messages.delete(listener);
+      };
+    },
+    onBrowserProviderStateChange: (listener: (state: BrowserProviderState) => void) => {
+      states.add(listener);
+      return () => {
+        states.delete(listener);
+      };
+    },
+    quiesceBrowserProviderJob: (_input: BrowserProviderQuiescenceInput) => {
+      publish();
+    },
+    registerBrowserProvider: async (input: BrowserProviderRegistration) => {
+      registration = input;
+      generation += 1;
+      return renew();
+    },
+    requestBrowserProviderStatus: async () => ({
+      jobs: [...rows.values()],
+      providerId: identity.providerId,
+      requestId: crypto.randomUUID(),
+      type: 'provider_status_result' as const,
+    }),
+    retain: () => {
+      fixture.retained += 1;
+      retained += 1;
+      return () => {
+        fixture.retained -= 1;
+        retained -= 1;
+      };
+    },
+    retryConnection: () => {
+      setState({ status: 'ready' });
+    },
+    sendBrowserProviderResult: (input: BrowserProviderResultInput) => {
+      const job = rows.get(input.jobId);
+      if (job === undefined) {
+        throw new Error('Unknown invocation.');
+      }
+      settle(job, input.result);
+    },
+  };
+  const delivery = (): Delivery => {
+    const now = Date.now();
+    return {
+      conversationMode: 'new',
+      goal: 'Inspect the approved page for this parent.',
+      job: {
+        browserTaskId: `bt_${crypto.randomUUID()}`,
+        createdAt: new Date(now).toISOString(),
+        deadlines: {
+          approval: new Date(now + 120_000).toISOString(),
+          queue: new Date(now + 600_000).toISOString(),
+        },
+        expiresAt: new Date(now + 604_800_000).toISOString(),
+        generation,
+        invocationId: `b1.${now}.${'a'.repeat(32)}${crypto.randomUUID().replaceAll('-', '')}`,
+        jobId: `bj_${crypto.randomUUID()}`,
+        ownerLabel: 'ses_parent_12345678',
+        payloadFingerprint: 'a'.repeat(64),
+        providerId: identity.providerId,
+        status: 'awaiting_approval',
+      },
+      ownerLabel: 'ses_parent_12345678',
+      type: 'provider_job',
+    };
+  };
+  return {
+    connection,
+    delivery,
+    dispatch: (message: Delivery) => {
+      rows.set(message.job.jobId, message.job);
+      send(message);
+    },
+    publish,
+    registration: () => registration,
+    retained: () => retained,
+    rows,
+  };
+};
+const clients: QueryClient[] = [];
+const renderPanel = () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  clients.push(client);
+  const panel = (currentAuth: StoredAuth) => (
+    <QueryClientProvider client={client}>
+      <SignedInView auth={currentAuth} onSignOut={vi.fn()} />
+    </QueryClientProvider>
+  );
+  const view = render(panel(auth));
+  return {
+    ...view,
+    rerender: (currentAuth = auth) => {
+      view.rerender(panel(currentAuth));
+    },
+  };
+};
+const openSettings = async () => {
+  const trigger = screen.getByRole('button', { name: 'Settings' });
+  trigger.focus();
+  fireEvent.click(trigger);
+  return screen.findByRole('dialog', { name: 'Settings panel' });
+};
+const enable = async (phase = 'Enabled — idle'): Promise<void> => {
+  await screen.findByText('CLI tasks: Disabled');
+  const dialog = await openSettings();
+  const settings = within(dialog).getByRole('region', { name: 'CLI task settings' });
+  expect(
+    within(settings).getByRole<HTMLButtonElement>('switch', { name: 'CLI tasks' }).disabled
+  ).toBe(true);
+  fireEvent.click(within(settings).getByRole('button', { name: 'Model' }));
+  fireEvent.click(await screen.findByRole('button', { name: 'Selected model' }));
+  await waitFor(() => {
+    expect(
+      within(settings).getByRole<HTMLButtonElement>('switch', { name: 'CLI tasks' }).disabled
+    ).toBe(false);
+  });
+  fireEvent.click(within(settings).getByRole('switch', { name: 'CLI tasks' }));
+  await waitFor(() => {
+    expect(within(dialog).getByText(`CLI tasks: ${phase}`)).toBeDefined();
+  });
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Close settings' }));
+};
+const approve = async (): Promise<void> => {
+  await screen.findByRole('button', { name: 'Approve tab' });
+  await screen.findByRole('option', { name: 'Approved tab' });
+  fireEvent.change(screen.getByLabelText('Tab to approve'), { target: { value: '7' } });
+  const approvalButton = screen.getByRole('button', { name: 'Approve tab' });
+  approvalButton.focus();
+  fireEvent.click(approvalButton);
+  await screen.findByText('CLI tasks: Running');
+};
+const switchMode = (mode: 'agents' | 'browser'): void => {
+  fireEvent.click(screen.getByRole('tab', { name: mode === 'agents' ? 'Agents beta' : 'Browser' }));
+};
+
+describe('browser task provider tree', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'locks', { configurable: true, value: nativeLocks });
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    vi.stubGlobal('crypto', webcrypto);
+    fixture.agents = undefined;
+    fixture.connectionConfigs = [];
+    fixture.connections = 0;
+    fixture.failedReadKey = '';
+    fixture.organizationId = '';
+    fixture.retained = 0;
+    fixture.values.clear();
+    fixture.values.set(AUTH_STORAGE_KEY, auth);
+    fixture.values.set(BROWSER_PROVIDER_IDENTITY_KEY, identity);
+    fixture.tabs = [{ id: 7, title: 'Approved tab', url: 'https://example.test/' }];
+    fixture.waitWrite = undefined;
+    fixture.waitWriteKey = '';
+    fixture.turn = async (context, _events) => {
+      context.executionGuard();
+      context.appendEvents([createAssistantMessage('Observed the requested page.')]);
+      return outcome();
+    };
+    getDefaultStore().set(scopeAtom, 'browser');
+    getDefaultStore().set(settingsDialogOpenAtom, false);
+    getDefaultStore().set(workflowRunRequestAtom, undefined);
+    getDefaultStore().set(pendingApprovalAtom, undefined);
+    getDefaultStore().set(pendingLockAtom, false);
+    clearPerConversationAtoms();
+  });
+  afterEach(async () => {
+    cleanup();
+    for (const client of clients.splice(0)) {
+      client.clear();
+    }
+    await waitFor(async () => {
+      const locks = await nativeLocks.query();
+      expect(
+        locks.held?.filter(
+          lock => lock.name === PROVIDER_OWNER_LOCK || lock.name === BROWSER_EXECUTION_LOCK
+        )
+      ).toHaveLength(0);
+      expect(fixture.retained).toBe(0);
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    { name: 'new profile', savedSettings: undefined },
+    {
+      name: 'saved disabled profile',
+      savedSettings: {
+        enabled: false,
+        mode: 'dangerous',
+        model: 'other-model',
+        thinkingEffort: 'high',
+      },
+    },
+    {
+      name: 'saved enabled profile',
+      savedSettings: {
+        enabled: true,
+        mode: 'safe',
+        model: 'selected-model',
+        thinkingEffort: 'low',
+      },
+    },
+  ] as const)(
+    'reloads a $name after storage initialization fails without changing consent or safety',
+    async ({ savedSettings }) => {
+      const transport = relay();
+      fixture.connection = transport.connection;
+      const expectedSettings = savedSettings ?? {
+        enabled: false,
+        mode: 'safe',
+        model: '',
+        thinkingEffort: '',
+      };
+      const record = {
+        accountKey: await browserAccountKey(auth),
+        settings: expectedSettings,
+        version: 1,
+      };
+      if (savedSettings === undefined) {
+        fixture.values.delete(BROWSER_PROVIDER_IDENTITY_KEY);
+      } else {
+        fixture.values.set(BROWSER_PROVIDER_SETTINGS_KEY, record);
+      }
+      const safety = { allTabs: true, tabIds: [7], version: 1 };
+      fixture.values.set(BROWSER_EXECUTION_SAFETY_KEY, safety);
+      fixture.failedReadKey = BROWSER_PROVIDER_SETTINGS_KEY;
+      const panel = renderPanel();
+      await screen.findByText('CLI tasks: Unavailable');
+      expect(screen.queryByRole('button', { name: 'Refresh status' })).toBeNull();
+      expect(transport.registration()).toBeUndefined();
+      const profile = structuredClone(fixture.values.get(BROWSER_PROVIDER_IDENTITY_KEY));
+      fixture.failedReadKey = '';
+      // Native navigation is unavailable in jsdom. Unmount on reload, then remount after disposal.
+      vi.stubGlobal('location', { reload: panel.unmount });
+      fireEvent.click(screen.getByRole('button', { name: 'Reload panel' }));
+      await waitFor(async () => {
+        expect(screen.queryByRole('region', { name: 'CLI task supervision' })).toBeNull();
+        const locks = await nativeLocks.query();
+        expect(locks.held?.filter(lock => lock.name === PROVIDER_OWNER_LOCK)).toHaveLength(0);
+      });
+      renderPanel();
+      await screen.findByText(
+        expectedSettings.enabled ? 'CLI tasks: Recovery required' : 'CLI tasks: Disabled'
+      );
+      expect(fixture.values.get(AUTH_STORAGE_KEY)).toStrictEqual(auth);
+      expect(fixture.values.get(BROWSER_PROVIDER_IDENTITY_KEY)).toStrictEqual(profile);
+      expect(fixture.values.get(BROWSER_PROVIDER_SETTINGS_KEY)).toStrictEqual(record);
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual(safety);
+      expect(transport.rows.size).toBe(0);
+      expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Reload panel' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+      expect(transport.registration()?.providerId).toBe(
+        expectedSettings.enabled ? identity.providerId : undefined
+      );
+      const dialog = await openSettings();
+      const settings = within(dialog).getByRole('region', { name: 'CLI task settings' });
+      expect(
+        within(settings).getByRole('switch', { name: 'CLI tasks' }).getAttribute('aria-checked')
+      ).toBe(String(expectedSettings.enabled));
+    }
+  );
+
+  it('stays off by default, preserves Browser drafts, and keeps one transport and a private Agents store', async () => {
+    const transport = relay();
+    fixture.connection = transport.connection;
+    renderPanel();
+    await screen.findByText('CLI tasks: Disabled');
+    expect(transport.registration()).toBeUndefined();
+    await enable();
+    const composer = screen.getByRole('textbox', { name: 'Message agent' });
+    fireEvent.change(composer, { target: { value: 'Keep this unsent Browser draft' } });
+    const conversationId = getDefaultStore().get(activeConversationIdAtom);
+    expect(conversationId).toBeDefined();
+    switchMode('agents');
+    await expect(screen.findByText('Agents scope: unset')).resolves.toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Set Agents state' }));
+    expect(screen.getByText('Manager store: matched')).toBeDefined();
+    switchMode('browser');
+    expect(screen.getByRole<HTMLTextAreaElement>('textbox', { name: 'Message agent' }).value).toBe(
+      'Keep this unsent Browser draft'
+    );
+    expect(getDefaultStore().get(scopeAtom)).toBe('browser');
+    expect(getDefaultStore().get(draftAtomFamily(conversationId!))).toBe(
+      'Keep this unsent Browser draft'
+    );
+    switchMode('agents');
+    expect(screen.getByText('Agents scope: private')).toBeDefined();
+    expect(screen.getByText(/Profile: Work profile/u).textContent).toContain(identity.providerId);
+    expect(transport.registration()).toMatchObject({
+      label: identity.label,
+      providerId: identity.providerId,
+    });
+    expect(fixture.connections).toBe(1);
+  });
+
+  it.each(['organization', 'account'] as const)(
+    'waits for %s replacement drainage before recovery in the same panel',
+    async scope => {
+      const transport = relay();
+      fixture.connection = transport.connection;
+      fixture.organizationId = 'organization-before';
+      const entered = Promise.withResolvers<BrowserRunContext>();
+      const action = Promise.withResolvers<void>();
+      const effects: string[] = [];
+      fixture.turn = async context => {
+        context.executionGuard();
+        effects.push('issued action');
+        entered.resolve(context);
+        await action.promise;
+        context.executionGuard();
+        effects.push('stale action');
+        return outcome();
+      };
+      const panel = renderPanel();
+      try {
+        await enable();
+        const supervision = screen.getByRole('region', { name: 'CLI task supervision' });
+        switchMode('agents');
+        fireEvent.click(screen.getByRole('button', { name: 'Set Agents state' }));
+        const previous = fixture.agents;
+        expect(screen.getByText('Agents scope: private')).toBeDefined();
+        expect(screen.getByText('Agents view: session')).toBeDefined();
+        expect(screen.getByText('Manager error: Previous scope error')).toBeDefined();
+        const request = transport.delivery();
+        act(() => {
+          transport.dispatch(request);
+        });
+        await approve();
+        const oldRun = await entered.promise;
+        const queued = transport.delivery().job;
+        act(() => {
+          transport.rows.set(queued.jobId, { ...queued, queuePosition: 1, status: 'queued' });
+          transport.publish();
+        });
+        const replacement = relay();
+        const nextAuth =
+          scope === 'account'
+            ? { token: 'replacement-token', userEmail: 'replacement@example.test' }
+            : auth;
+        fixture.connection = replacement.connection;
+        fixture.organizationId =
+          scope === 'organization' ? 'organization-after' : 'organization-before';
+        await act(async () => {
+          await storage.setItem(
+            scope === 'account' ? AUTH_STORAGE_KEY : 'local:kiloSelectedOrganizationId',
+            scope === 'account' ? nextAuth : fixture.organizationId
+          );
+          panel.rerender(nextAuth);
+        });
+        await waitFor(() => {
+          expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+          expect(transport.retained()).toBe(0);
+        });
+        expect(oldRun.abort.signal.aborted).toBe(true);
+        const locks = await nativeLocks.query();
+        expect(locks.held).toStrictEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ name: PROVIDER_OWNER_LOCK }),
+            expect.objectContaining({ name: BROWSER_EXECUTION_LOCK }),
+          ])
+        );
+        expect(replacement.registration()).toBeUndefined();
+        expect(replacement.retained()).toBe(1);
+        expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+        expect(transport.rows.get(request.job.jobId)?.status).toBe('interrupted');
+        expect(transport.rows.get(queued.jobId)?.status).toBe('interrupted');
+        if (scope === 'organization') {
+          for (const job of transport.rows.values()) {
+            replacement.rows.set(job.jobId, job);
+          }
+        }
+        await act(async () => {
+          action.resolve();
+          await action.promise;
+        });
+        await screen.findByText(
+          scope === 'account' ? 'CLI tasks: Disabled' : 'CLI tasks: Recovery required'
+        );
+        expect(replacement.registration()?.providerId).toBe(
+          scope === 'account' ? undefined : identity.providerId
+        );
+        if (scope === 'account') {
+          await enable('Recovery required');
+        }
+        await screen.findByText('CLI tasks: Recovery required');
+        expect(screen.getByRole('region', { name: 'CLI task supervision' })).toBe(supervision);
+        expect(screen.queryByText('CLI tasks: Owned by another panel')).toBeNull();
+        expect(screen.getByText('Agents scope: unset')).toBeDefined();
+        expect(screen.getByText('Agents view: list')).toBeDefined();
+        expect(screen.getByText(`Agents organization: ${fixture.organizationId}`)).toBeDefined();
+        expect(screen.getByText('Manager store: matched')).toBeDefined();
+        expect(screen.getByText('Manager error: none')).toBeDefined();
+        expect(fixture.agents?.manager).not.toBe(previous?.manager);
+        expect(fixture.agents?.store).not.toBe(previous?.store);
+        expect(fixture.agents?.userWebConnection).not.toBe(previous?.userWebConnection);
+        await expect(fixture.connectionConfigs.at(-1)?.getAuthToken()).resolves.toBe(
+          `ticket:${nextAuth.token}`
+        );
+        await expect(
+          fixture.agents?.trpcClient.activeSessions.createWebTicket.mutate()
+        ).resolves.toStrictEqual({ token: `ticket:${nextAuth.token}` });
+        fireEvent.click(screen.getByRole('button', { name: 'Set Agents state' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Clear manager error' }));
+        expect(screen.getByText('Manager error: none')).toBeDefined();
+        expect(getDefaultStore().get(scopeAtom)).toBe('browser');
+        expect(replacement.retained()).toBe(2);
+        expect(fixture.connections).toBe(2);
+        expect(effects).toStrictEqual(['issued action']);
+        expect(screen.getByText('Queue empty.')).toBeDefined();
+        fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+        await screen.findByText('Close all affected tabs before recovery.');
+        expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+        fixture.tabs = [];
+        fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+        const recover = await screen.findByRole('button', { name: 'Recover browser control' });
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+        expect(effects).toStrictEqual(['issued action']);
+        fireEvent.click(recover);
+        await screen.findByText('CLI tasks: Enabled — idle');
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+          tabIds: [],
+          version: 1,
+        });
+        expect(effects).toStrictEqual(['issued action']);
+        expect(transport.rows.get(request.job.jobId)?.status).toBe('interrupted');
+        expect(transport.rows.get(queued.jobId)?.status).toBe('interrupted');
+        expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+        const fresh = Promise.withResolvers<BrowserRunContext>();
+        fixture.turn = async context => {
+          context.executionGuard();
+          effects.push('new invocation');
+          fresh.resolve(context);
+          return waitForAbort(context);
+        };
+        fixture.tabs = [{ id: 7, title: 'Approved tab', url: 'https://example.test/' }];
+        act(() => {
+          replacement.dispatch(replacement.delivery());
+        });
+        await screen.findByRole('button', { name: 'Approve tab' });
+        expect(effects).toStrictEqual(['issued action']);
+        await approve();
+        const currentRun = await fresh.promise;
+        expect(currentRun.token).toBe(nextAuth.token);
+        expect(currentRun.organizationId).toBe(fixture.organizationId);
+        expect(effects).toStrictEqual(['issued action', 'new invocation']);
+        fireEvent.click(screen.getByRole('button', { name: 'Stop CLI task' }));
+        await screen.findByText('Last outcome: cancelled · cancelled');
+        expect(transport.retained()).toBe(0);
+        expect(fixture.connections).toBe(2);
+      } finally {
+        action.resolve();
+      }
+    }
+  );
+
+  it('retains the first disposal barrier through another scope change during drainage', async () => {
+    const transport = relay();
+    fixture.connection = transport.connection;
+    const entered = Promise.withResolvers<void>();
+    const action = Promise.withResolvers<void>();
+    fixture.turn = async context => {
+      entered.resolve();
+      await action.promise;
+      context.executionGuard();
+      return outcome();
+    };
+    const panel = renderPanel();
+    try {
+      await enable();
+      act(() => {
+        transport.dispatch(transport.delivery());
+      });
+      await approve();
+      await entered.promise;
+      fixture.connection = relay().connection;
+      fixture.organizationId = 'organization-next';
+      await act(async () => {
+        await storage.setItem('local:kiloSelectedOrganizationId', fixture.organizationId);
+        panel.rerender();
+      });
+      await waitFor(() => {
+        expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+        expect(transport.retained()).toBe(0);
+      });
+      fixture.connection = relay().connection;
+      fixture.organizationId = 'organization-latest';
+      await act(async () => {
+        await storage.setItem('local:kiloSelectedOrganizationId', fixture.organizationId);
+        panel.rerender();
+      });
+      await act(async () => {
+        action.resolve();
+        await action.promise;
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/^CLI tasks:/u).textContent).toBe('CLI tasks: Recovery required');
+      });
+      expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+    } finally {
+      action.resolve();
+    }
+  });
+
+  it('keeps a running invocation and frozen settings across modes and settings confirmation', async () => {
+    const transport = relay();
+    fixture.connection = transport.connection;
+    fixture.turn = waitForAbort;
+    renderPanel();
+    await enable();
+    const request = transport.delivery();
+    act(() => {
+      transport.dispatch(request);
+    });
+    switchMode('agents');
+    await approve();
+    const settingsDialog = await openSettings();
+    const settings = within(settingsDialog).getByRole('region', { name: 'CLI task settings' });
+    const settingsWrite = Promise.withResolvers<void>();
+    fixture.waitWriteKey = BROWSER_PROVIDER_SETTINGS_KEY;
+    fixture.waitWrite = settingsWrite.promise;
+    try {
+      fireEvent.click(within(settings).getByRole('button', { name: /Safe mode:/u }));
+      fireEvent.click(within(settings).getByRole('button', { name: /Dangerous/u }));
+      await within(settings).findByText('Saving CLI task settings...');
+      const savingStop = within(settingsDialog).getByRole('button', { name: 'Stop CLI task' });
+      savingStop.focus();
+      expect(document.activeElement).toBe(savingStop);
+    } finally {
+      await act(async () => {
+        settingsWrite.resolve();
+        await settingsWrite.promise;
+      });
+      fixture.waitWriteKey = '';
+    }
+    await waitFor(() => {
+      expect(within(settings).getByRole('button', { name: /Danger mode:/u })).toBeDefined();
+    });
+    expect(within(settingsDialog).getByText('Mode: Safe · Model: selected-model')).toBeDefined();
+    fireEvent.click(within(settings).getByRole('switch', { name: 'CLI tasks' }));
+    expect(
+      within(settings).getByText(
+        'Disabling CLI tasks terminates active and queued jobs. Issued actions are not undone.'
+      )
+    ).toBeDefined();
+    const stop = within(settingsDialog).getByRole('button', { name: 'Stop CLI task' });
+    stop.focus();
+    expect(document.activeElement).toBe(stop);
+    fireEvent.click(within(settings).getByRole('button', { name: 'Keep enabled' }));
+    expect(transport.rows.get(request.job.jobId)?.status).toBe('running');
+    fireEvent.click(within(settingsDialog).getByRole('button', { name: 'Close settings' }));
+    switchMode('browser');
+    expect(screen.getByText('Bound tab: Approved tab (ID 7)')).toBeDefined();
+    expect(fixture.connections).toBe(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Stop CLI task' }));
+    await screen.findByText('Last outcome: cancelled · cancelled');
+    expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+  });
+
+  it.each(['browser', 'agents'] as const)(
+    'settles real memory approval and keeps Stop through saving and confirmation in %s mode',
+    async mode => {
+      const transport = relay();
+      fixture.connection = transport.connection;
+      fixture.turn = async context => {
+        await context.requestApproval('memory', {
+          createdAt: Date.now(),
+          pageTitle: 'Approved tab',
+          pageUrl: 'https://example.test/',
+          text: 'Remember this approved fact.',
+        });
+        return waitForAbort(context);
+      };
+      renderPanel();
+      await enable();
+      switchMode(mode);
+      act(() => {
+        transport.dispatch(transport.delivery());
+      });
+      await approve();
+      const dialog = await screen.findByRole('dialog', { name: 'Add to memory' });
+      const write = Promise.withResolvers<void>();
+      fixture.waitWriteKey = AGENT_MEMORIES_STORAGE_KEY;
+      fixture.waitWrite = write.promise;
+      try {
+        fireEvent.click(within(dialog).getByRole('button', { name: 'Save memory' }));
+        await waitFor(() => {
+          expect(
+            within(dialog).getByRole<HTMLButtonElement>('button', { name: 'Save memory' }).disabled
+          ).toBe(true);
+        });
+        const stop = within(dialog).getByRole('button', { name: 'Stop CLI task' });
+        stop.focus();
+        expect(document.activeElement).toBe(stop);
+        await act(async () => {
+          write.resolve();
+          await write.promise;
+        });
+        await within(dialog).findByText('Saved to memory');
+        await expect(loadAgentMemories(storage)).resolves.toStrictEqual([
+          expect.objectContaining({ text: 'Remember this approved fact.' }),
+        ]);
+        expect(getDefaultStore().get(pendingApprovalAtom)).toBeUndefined();
+        expect(getDefaultStore().get(pendingLockAtom)).toBe(false);
+        fireEvent.click(within(dialog).getByRole('button', { name: 'Stop CLI task' }));
+        await within(dialog).findByText('Last outcome: cancelled · cancelled');
+        fireEvent.click(within(dialog).getByRole('button', { name: 'Done' }));
+        await waitFor(() => {
+          expect(document.activeElement).toBe(
+            screen.getByRole('tab', { name: mode === 'agents' ? 'Agents beta' : 'Browser' })
+          );
+        });
+        switchMode(mode === 'agents' ? 'browser' : 'agents');
+        expect(screen.queryByRole('dialog', { name: 'Add to memory' })).toBeNull();
+      } finally {
+        write.resolve();
+      }
+    }
+  );
+
+  it.each(['browser', 'agents'] as const)(
+    'settles real workflow approval on the default store in %s mode',
+    async mode => {
+      const transport = relay();
+      fixture.connection = transport.connection;
+      fixture.turn = async context => {
+        await context.requestApproval('workflow', {
+          createdAt: Date.now(),
+          description: 'Read a fact',
+          name: 'Approved workflow',
+          scopeOrigin: 'https://example.test',
+          script: 'return { done: true, result: "fact" };',
+        });
+        return waitForAbort(context);
+      };
+      renderPanel();
+      await enable();
+      switchMode(mode);
+      act(() => {
+        transport.dispatch(transport.delivery());
+      });
+      await approve();
+      const dialog = await screen.findByRole('dialog', { name: 'Save workflow' });
+      const write = Promise.withResolvers<void>();
+      fixture.waitWriteKey = AGENT_WORKFLOWS_STORAGE_KEY;
+      fixture.waitWrite = write.promise;
+      try {
+        fireEvent.click(within(dialog).getByRole('button', { name: 'Approve and save' }));
+        await within(dialog).findByRole('button', { name: 'Saving...' });
+        const stop = within(dialog).getByRole('button', { name: 'Stop CLI task' });
+        stop.focus();
+        expect(document.activeElement).toBe(stop);
+        await act(async () => {
+          write.resolve();
+          await write.promise;
+        });
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog', { name: 'Save workflow' })).toBeNull();
+        });
+        const saved = await loadAgentWorkflows(storage);
+        expect(saved).toStrictEqual([
+          expect.objectContaining({
+            approvedScriptHash: createHash('sha256')
+              .update('return { done: true, result: "fact" };')
+              .digest('hex'),
+            name: 'Approved workflow',
+          }),
+        ]);
+        expect(getDefaultStore().get(pendingApprovalAtom)).toBeUndefined();
+        expect(getDefaultStore().get(pendingLockAtom)).toBe(false);
+        fireEvent.click(screen.getByRole('button', { name: 'Stop CLI task' }));
+        await screen.findByText('Last outcome: cancelled · cancelled');
+        switchMode(mode === 'agents' ? 'browser' : 'agents');
+        expect(screen.queryByRole('dialog', { name: 'Save workflow' })).toBeNull();
+      } finally {
+        write.resolve();
+      }
+    }
+  );
+
+  it.each(['browser', 'agents'] as const)(
+    'consumes a settings workflow request in the mounted Browser chat while %s mode is visible',
+    async mode => {
+      const transport = relay();
+      fixture.connection = transport.connection;
+      const script = 'return { done: true, result: input };';
+      fixture.values.set(AGENT_WORKFLOWS_STORAGE_KEY, [
+        {
+          approvedScriptHash: createHash('sha256').update(script).digest('hex'),
+          createdAt: 1,
+          description: 'Read the page',
+          id: 'workflow-1',
+          name: 'Read page',
+          params: [{ description: 'Value to read', name: 'value', required: true }],
+          scopeOrigin: 'https://example.test',
+          script,
+          updatedAt: 1,
+        },
+      ]);
+      fixture.values.set('local:kiloWorkflowSettings', {
+        allowWorkflowsInSafeMode: true,
+        autoApproveWorkflowChanges: false,
+        autoApproveWorkflowRuns: false,
+      });
+      renderPanel();
+      await screen.findByText('CLI tasks: Disabled');
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Model' }).dataset['modelId']).toBe(
+          'selected-model'
+        );
+      });
+      switchMode(mode);
+      const settings = await openSettings();
+      fireEvent.click(
+        await within(settings).findByRole('button', { name: 'Run workflow "Read page"' })
+      );
+      const prompt = await screen.findByRole('dialog', { name: 'Run workflow "Read page"' });
+      fireEvent.change(within(prompt).getByRole('textbox'), {
+        target: { value: 'retained workflow input' },
+      });
+      fireEvent.click(within(prompt).getByRole('button', { name: 'Run' }));
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog', { name: 'Settings panel' })).toBeNull();
+      });
+      await waitFor(() => {
+        const conversations = normalizeStoredConversationStore(
+          fixture.values.get('local:kiloAgentConversations')
+        );
+        expect(
+          conversations?.conversations.flatMap(conversation => conversation.events)
+        ).toStrictEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              arguments: { input: { value: 'retained workflow input' }, workflowId: 'workflow-1' },
+              name: 'run_workflow',
+              type: 'tool-call',
+            }),
+            expect.objectContaining({ text: 'Observed the requested page.', type: 'message' }),
+          ])
+        );
+      });
+      expect(getDefaultStore().get(workflowRunRequestAtom)).toBeUndefined();
+      expect(fixture.values.has(BROWSER_TASK_STORAGE_KEY)).toBe(true);
+      switchMode(mode === 'agents' ? 'browser' : 'agents');
+      expect(getDefaultStore().get(workflowRunRequestAtom)).toBeUndefined();
+    }
+  );
+
+  it('prepares real all-tabs recovery without clearing quarantine or replaying work', async () => {
+    const transport = relay();
+    fixture.connection = transport.connection;
+    renderPanel();
+    await enable();
+    await act(async () => {
+      await storage.setItem(BROWSER_EXECUTION_SAFETY_KEY, {
+        allTabs: true,
+        tabIds: [7],
+        version: 1,
+      });
+    });
+    await screen.findByText('CLI tasks: Recovery required');
+    fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+    await screen.findByText(
+      'Close all target tabs before recovery. The affected-tab list is not known to be complete.'
+    );
+    expect(screen.queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+    fixture.tabs = [];
+    fireEvent.click(screen.getByRole('button', { name: 'Check recovery readiness' }));
+    const recover = await screen.findByRole('button', { name: 'Recover browser control' });
+    expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      allTabs: true,
+      tabIds: [7],
+      version: 1,
+    });
+    expect(transport.rows.size).toBe(0);
+    fireEvent.click(recover);
+    await screen.findByText('CLI tasks: Enabled — idle');
+    expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toStrictEqual({
+      tabIds: [],
+      version: 1,
+    });
+    expect(transport.rows.size).toBe(0);
+    expect(screen.queryByRole('button', { name: 'Approve tab' })).toBeNull();
+  });
+
+  it('confirms disablement before terminating active and queued jobs without clearing quarantine', async () => {
+    const transport = relay();
+    fixture.connection = transport.connection;
+    fixture.turn = waitForAbort;
+    renderPanel();
+    await enable();
+    const request = transport.delivery();
+    act(() => {
+      transport.dispatch(request);
+    });
+    await approve();
+    const queued = transport.delivery().job;
+    act(() => {
+      transport.rows.set(queued.jobId, {
+        ...queued,
+        ownerLabel: 'ses_other_87654321',
+        queuePosition: 1,
+        status: 'queued',
+      });
+      transport.publish();
+    });
+    const dialog = await openSettings();
+    const settings = within(dialog).getByRole('region', { name: 'CLI task settings' });
+    fireEvent.click(within(settings).getByRole('switch', { name: 'CLI tasks' }));
+    expect(transport.rows.get(request.job.jobId)?.status).toBe('running');
+    expect(transport.rows.get(queued.jobId)?.status).toBe('queued');
+    expect(within(dialog).getByRole('button', { name: 'Stop CLI task' })).toBeDefined();
+    fireEvent.click(within(settings).getByRole('button', { name: 'Disable CLI tasks' }));
+    await waitFor(() => {
+      expect(within(dialog).getByText('CLI tasks: Disabled')).toBeDefined();
+    });
+    expect(transport.rows.get(request.job.jobId)?.status).toBe('interrupted');
+    expect(transport.rows.get(queued.jobId)?.status).toBe('interrupted');
+    expect(fixture.values.get(BROWSER_PROVIDER_SETTINGS_KEY)).toMatchObject({
+      settings: { enabled: false },
+    });
+    await waitFor(() => {
+      expect(fixture.values.get(BROWSER_EXECUTION_SAFETY_KEY)).toMatchObject({ tabIds: [7] });
+    });
+    expect(within(dialog).queryByRole('button', { name: 'Recover browser control' })).toBeNull();
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/conversation-history-button.tsx
+++ b/apps/extension/entrypoints/sidepanel/conversation-history-button.tsx
@@ -5,6 +5,7 @@ import type { CSSProperties, JSX } from 'react';
 import { getStoredConversationTitle, isStoredConversationOpen } from './agent-conversation-storage';
 import type { StoredAgentConversation } from './agent-conversation-storage';
 import type { StoredAgentConversationStore } from '@/src/shared/agent-conversation-tabs';
+import { BrowserTaskSupervisionSlot } from './browser-task-supervision-slot';
 
 const historyPageSize = 100;
 
@@ -110,6 +111,9 @@ export const ConversationHistoryButton = ({
             >
               <X aria-hidden="true" className="size-4" />
             </button>
+          </div>
+          <div className="sticky top-14 z-10 shrink-0 bg-surface-raised">
+            <BrowserTaskSupervisionSlot />
           </div>
           <div className="px-3 py-3">
             {conversations.length === 0 ? (

--- a/apps/extension/entrypoints/sidepanel/model-picker.tsx
+++ b/apps/extension/entrypoints/sidepanel/model-picker.tsx
@@ -8,6 +8,7 @@ import {
   isGatewayModelId,
   modelRowDisplayId,
 } from '@/src/shared/model-picker-rows';
+import { BrowserTaskSupervisionSlot } from './browser-task-supervision-slot';
 import { ModelPickerModelRow } from './model-picker-row';
 import { useModelPreferences } from './use-model-preferences';
 
@@ -44,8 +45,9 @@ export const ModelPicker = ({
   const selectedOption = modelOptions.find(option => option.id === model);
   // Always show the conversation's own model: its name when the catalog has it, its raw id
   // While the catalog is missing or stale. 'Loading models...' means no model is stored yet.
+  const emptyLabel = modelOptions.length === 0 ? 'Loading models...' : 'Select model';
   const triggerLabel =
-    selectedOption?.name ?? (model === '' ? 'Loading models...' : modelRowDisplayId(model));
+    selectedOption?.name ?? (model === '' ? emptyLabel : modelRowDisplayId(model));
 
   const rows = useMemo(
     () =>
@@ -119,6 +121,9 @@ export const ModelPicker = ({
             </button>
           </div>
 
+          <div className="sticky top-14 z-10 shrink-0 bg-surface-raised">
+            <BrowserTaskSupervisionSlot />
+          </div>
           <div className="border-b border-border px-3 py-3">
             <input
               aria-label="Search models"

--- a/apps/extension/entrypoints/sidepanel/workflow-run-prompt.tsx
+++ b/apps/extension/entrypoints/sidepanel/workflow-run-prompt.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'react';
 import { useState } from 'react';
 import type { AgentWorkflowParam } from '@/src/shared/agent-workflows';
+import { BrowserTaskSupervisionSlot } from './browser-task-supervision-slot';
 
 const secondaryButtonClass =
   'type-label h-8 rounded-md border border-border bg-surface-overlay px-3 text-foreground-on-secondary transition hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-background';
@@ -48,7 +49,12 @@ export const WorkflowRunPrompt = ({
       role="dialog"
     >
       <div className="flex max-h-full w-full max-w-sm flex-col gap-3 overflow-y-auto rounded-xl border border-border bg-surface-raised p-3 shadow-lg shadow-black/50">
-        <p className="type-body font-semibold text-foreground">Run “{name}”</p>
+        <div className="sticky top-0 z-10 shrink-0 bg-surface-raised">
+          <BrowserTaskSupervisionSlot />
+        </div>
+        <p className="type-body break-words font-semibold text-foreground [overflow-wrap:anywhere]">
+          Run “{name}”
+        </p>
         {params.map(param => (
           <label className="flex flex-col gap-1" key={param.name}>
             <span className="type-label text-foreground-muted">


### PR DESCRIPTION
- The extension now offers optional browser tasks from Kilo's command-line app. Access starts off and requires the signed-in panel to stay open.
- Settings now offers separate model, thinking level, and Safe or Dangerous mode choices for these tasks. Changes apply at the next tab approval.
- Each task asks you to approve or reject a tab, showing the requesting session, goal, page title, address, model, and mode. The usual target selector does not approve access.
- If a chosen tab disappears, the task goal stays visible while you choose another tab. You can refresh the available tabs before approving.
- Browser and Agents modes show the browser profile, task owner, approved tab, deadlines, queue order, and latest outcome. Status messages distinguish waiting, connection problems, interruptions, and control held by another panel.
- You can stop an active task or cancel a queued task without undoing actions already issued.
- Disabling task access asks for confirmation and ends active and queued tasks.
- Approvals for saved memories and workflows now remain available in Agents mode.
- Stop and task details remain inside Settings, model selection, history, and workflow dialogs, including saving and confirmation screens. Keyboard focus stays inside the active dialog and returns when it closes.
- Recovery controls separate status checks from permission to run. Recovery requires affected tabs to close and browser actions to finish; old tasks never resume, and new tasks need fresh approval.
- If startup cannot load saved data, Reload panel retries without clearing your account, settings, or safety records. The button waits until browser work stops.
- When models are available but none is selected, the picker says “Select model” instead of “Loading models...”.

---

## Summary

`ExtensionAgentsProvider` shares one connection across modes with `browserProvider: true`, and `ExtensionAgentsContextValue.userWebConnection` exposes its inferred type. Callers must use `ExtensionAgentsStore` for Agents; Browser chat, command-line interface (CLI) tasks, settings, and approvals keep the default Jotai store. Account or organization changes replace scoped resources without remounting `BrowserTaskProvider`, preserving its cleanup barrier across replacements.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/agents-provider.tsx` — Source, modified, +35/−15 lines. Enables browser capability negotiation and mounts the delegated provider on the shared transport. Replaces the connection, manager, client, and private store when the token, email, or organization changes. Retains and releases each connection with its context, while the delegated provider remains mounted. Exports the separate Agents store boundary.
- `apps/extension/entrypoints/sidepanel/auth-views.tsx` — Source, modified, +28/−30 lines. Mounts the provider, task surface, supervision, and both save cards across Browser and Agents modes. Keeps Browser chat, Settings, approvals, and workflow request consumption on the default store. Keys only the Agents descendants by account and organization.

</details>

`BrowserTaskControls` binds consent to each invocation and displays approved settings plus authoritative `ownerLabel` and `queuePosition`; missing legacy metadata remains unknown. `BrowserTaskSettings` exposes off-by-default `BrowserProviderSettings.enabled` and model/mode/thinking choices; `BrowserTaskSurface` serializes `BrowserTaskSettingsContext` writes across dialog remounts, preventing stale re-enablement. Recovery uses `BrowserRecoveryReadiness` only for the unchanged provider snapshot; status retrieval and initialization reload never approve execution or resubmit work.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/browser-task-controls.tsx` — Source, added, +723/−0 lines. Adds profile, phase, owner, goal, bound-tab, deadline, queue, result, and empty-evidence displays. Refreshes tab choices every two seconds; absent candidates disable approval without discarding the goal. Keeps Stop outside scrolling details and reports cancellation without promising rollback. Separates status refresh, reconnection, readiness preparation, and recovery; provider state changes invalidate readiness. Shows retryable, denied, and interrupted status errors with recovery guidance. Relays closed-tab, drained-lock, unsupported Web Locks, and all-tabs recovery instructions without unsafe clearing. Offers initialization reload only when local and delegated work no longer blocks it, preserving saved data without enabling tasks. Requires a model before enablement, resets thinking effort on model changes, and confirms disablement. Tracks pending settings writes by runtime identity across overlay closure. Supplies live announcements, wrapped content, internal scrolling, and modal focus containment and restoration.

</details>

`BrowserTaskSupervisionContext` supplies `BrowserTaskSupervisionSlot` inside active dialogs, so Stop remains within each dialog's keyboard boundary. `BrowserTaskSurface` selects the top modal, cycles focus, and restores prior focus or a stable control when dialogs close. Settings expose delegated options without hiding supervision; long content scrolls and wraps rather than moving Stop out of reach.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/auth-shell.tsx` — Source, modified, +8/−1 lines. Adds task settings and supervision inside the Settings dialog. Extends the scoped lint exemption for the larger composition.
- `apps/extension/entrypoints/sidepanel/conversation-history-button.tsx` — Source, modified, +4/−0 lines. Pins task supervision below the history header.
- `apps/extension/entrypoints/sidepanel/workflow-run-prompt.tsx` — Source, modified, +7/−1 lines. Pins task supervision inside the workflow prompt and wraps long workflow names.

</details>

`ModelPicker` shows “Select model” when the catalog has entries but no model is selected, rather than implying a pending load. Without a selection, an empty catalog still shows “Loading models...”. Stored model labels remain intact, and the picker keeps task supervision inside its overlay.

<details>
<summary>Files</summary>

- `apps/extension/entrypoints/sidepanel/model-picker.tsx` — Source, modified, +6/−1 lines. Distinguishes an unselected model from an empty catalog and pins supervision above the search field.

</details>

Recorded automation: the handoff reports 47 passing focused controls/composition tests and passing scoped checks.

Tests: 2 files added — `apps/extension/entrypoints/sidepanel/browser-task-controls.test.tsx` (+919/−0 lines), `apps/extension/entrypoints/sidepanel/browser-task-provider-tree.test.tsx` (+1,234/−0 lines); controls and provider composition coverage.
Generated: 0 files changed.

---

## Verification

No manual verification results are available for this level. Browser-only live and visual verification remains pending in the next stack level. No end-to-end report is attached.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Human steps

- **before merge** — The change requires no new environment value, secret, migration, or manual data conversion.
- **after merge** — For optional delegated tasks, select a model and enable “CLI tasks” in Settings.
- **after merge** — Keep the signed-in panel open while delegated tasks run.

### Scope and dependencies

- Scope: Cloud level 12, `browser-task-0787-s11...browser-task-0787-s12`; nine changed files, 2,964 added lines, and 48 removed lines.
- Cloud worktree: `/Users/igor/Projects/.worktrees/browser-task-0787`; branch `browser-task-0787-s12`.
- Command-line interface (CLI) worktree: `/Users/igor/Projects/.worktrees/browser-task-0787-kilocode`; branch `browser-task-0787-s6`. This level includes no CLI changes.
- Runtime prerequisite: [Cloud #5716](https://github.com/Kilo-Org/cloud/pull/5716) supplies the delegated provider and browser runner mounted here.
- Cross-repository dependency: [CLI level 6, #13567](https://github.com/Kilo-Org/kilocode/pull/13567) supplies the command-line caller for delegated browser tasks.
- The completion gate still blocks assignment and reviewer requests.

### Notes

Browser-only live and visual verification remains pending in the next stack level.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `browser-task-0787` — #5638
2. `browser-task-0787-s2` — #5644
3. `browser-task-0787-s3` — #5648
4. `browser-task-0787-s4` — #5653
7. `browser-task-0787-s7` — #5681
8. `browser-task-0787-s8` — #5694
9. `browser-task-0787-s9` — #5698
10. `browser-task-0787-s10` — #5702
11. `browser-task-0787-s11` — #5716
12. `browser-task-0787-s12` — #5734 ← this PR
13. `browser-task-0787-s13` — #5742 (tip)

