### PR TITLE
feat(pr-review): integrate requirement observation reads

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-reader.ts
+++ b/apps/web/src/lib/github-pr-review/context-reader.ts
@@ -33,11 +33,25 @@ import {
   resolveContextIssues,
 } from './context-issues';
 import { normalizeContextPolicies } from './context-rules';
+import {
+  PR_CONTEXT_EVALUATION_QUERY,
+  PR_CONTEXT_REQUIREMENT_QUERIES,
+  contextCheckSchema,
+  contextCheckOutcome,
+  contextComparisonSchema,
+  contextDeploymentSchema,
+  contextRequirementEvidence,
+  contextTestMergeSchema,
+  contextThreadSchema,
+  evaluateContextRequirements,
+  type RequirementFacts,
+} from './context-requirements';
 
 const collectionQueries = {
   ...PR_CONTEXT_PEOPLE_QUERIES,
   ...PR_CONTEXT_REVIEW_QUERIES,
   ...PR_CONTEXT_ISSUE_QUERIES,
+  ...PR_CONTEXT_REQUIREMENT_QUERIES,
 };
 const deadlineError = new Error('PR context deadline');
 type PrInput = { owner: string; repo: string; number: number };
@@ -246,6 +260,21 @@ function invalidateRevision(context: GitHubPrReviewContext, source: GitHubPrRevi
     collection.source = source;
     collection.completeness = 'unknown';
   }
+  for (const requirement of context.requirements.items) requirement.state = 'unavailable';
+  for (const check of context.checks.items) {
+    check.requiredness = 'unknown';
+    check.observation = 'unknown';
+  }
+  // Keep failed sources' recovery metadata; invalidate only previously successful observations.
+  for (const [key, evaluationSource] of Object.entries(context.evaluationSources)) {
+    if (evaluationSource.availability !== 'available') continue;
+    Object.assign(context.evaluationSources, {
+      [key]: {
+        ...source,
+        provenance: [...new Set([...evaluationSource.provenance, ...source.provenance])],
+      },
+    });
+  }
   context.queue.membership.source = source;
   context.queue.position.source = source;
   return context;
@@ -280,7 +309,12 @@ export async function readPullRequestContext(
     fallback: Collection<T>,
     merge: (known: T, current: T) => T,
     matches = (known: T, current: T) => known?.id != null && known.id === current?.id,
-    normalize: (item: T, result: ContextReadResult<unknown>, index: number) => T = item => item
+    normalize: (item: T, result: ContextReadResult<unknown>, index: number) => T = item => item,
+    options: {
+      path?: ReadonlyArray<string | number>;
+      variables?: Record<string, string>;
+      validPage?: (result: ContextReadResult<unknown>) => boolean;
+    } = {}
   ): Promise<Collection<T>> {
     const schema = z.object({
       nodes: z.array(node.nullable().catch(null)).nullish().catch(null),
@@ -318,14 +352,20 @@ export async function readPullRequestContext(
             name: input.repo,
             number: input.number,
             after: collection.endCursor,
+            ...options.variables,
           },
           request: { signal },
         });
         return response.data;
       });
-      const page = decodeContextGraphQlSource(result, ['repository', 'pullRequest', field], schema);
+      const page = decodeContextGraphQlSource(
+        result,
+        options.path ?? ['repository', 'pullRequest', field],
+        schema
+      );
       collection.source = page.source;
-      if (page.source.availability !== 'available') incomplete = markIncomplete();
+      if (page.source.availability !== 'available' || options.validPage?.(result) === false)
+        incomplete = markIncomplete();
       if (!page.data) break;
       const { nodes, totalCount, pageInfo } = page.data;
       if (
@@ -387,11 +427,13 @@ export async function readPullRequestContext(
   const reviewEvidence = {
     latestOpinionatedReviews: new Map<string, z.output<typeof contextReviewSchema>>(),
     latestReviews: new Map<string, z.output<typeof contextReviewSchema>>(),
+    eligibleReviews: new Map<string, z.output<typeof contextReviewSchema>>(),
   };
   const conflictingReviewIds = new Set<string>();
   const collectReviews = (
-    field: keyof typeof PR_CONTEXT_REVIEW_QUERIES,
-    fallback: GitHubPrReviewContext['reviewDecisions']
+    field: keyof typeof reviewEvidence,
+    fallback: GitHubPrReviewContext['reviewDecisions'],
+    conflicts = conflictingReviewIds
   ) => {
     const evidence = reviewEvidence[field];
     const pageConflicts = new Set<string>();
@@ -441,7 +483,7 @@ export async function readPullRequestContext(
         };
         if (previous && contextReviewEvidenceConflicts(previous, current)) {
           pageConflicts.add(review.id);
-          conflictingReviewIds.add(review.id);
+          conflicts.add(review.id);
         }
         // Missing observations cannot erase comparison evidence or supply public field values.
         evidence.set(review.id, {
@@ -551,6 +593,198 @@ export async function readPullRequestContext(
     ]);
     return normalizeContextPolicies(context.revision, classic, rules);
   }
+  async function collectEvaluation() {
+    const result = await read('graphql.requirements', async (signal): Promise<unknown> => {
+      const response = await octokit.request('POST /graphql', {
+        query: PR_CONTEXT_EVALUATION_QUERY,
+        variables: {
+          owner: input.owner,
+          name: input.repo,
+          number: input.number,
+          head: context.revision.headSha,
+        },
+        request: { signal },
+      });
+      return response.data;
+    });
+    const path = ['repository', 'pullRequest'];
+    const revision = decodeContextGraphQlSource(result, path, graphQlRevisionSchema);
+    const identity = (
+      [
+        ['prNodeId', ['id'], z.string().min(1)],
+        ['number', ['number'], z.number().int().positive()],
+        ['headSha', ['headRefOid'], z.string().min(1)],
+        ['baseRef', ['baseRefName'], z.string().min(1)],
+        ['baseSha', ['baseRefOid'], z.string().min(1)],
+        ['baseRepoFullName', ['baseRepository', 'nameWithOwner'], z.string().min(1)],
+      ] as const
+    ).map(([field, parts, schema]) => ({
+      field,
+      ...decodeContextGraphQlSource(result, [...path, ...parts], schema),
+    }));
+    // Matching outer reads cannot supply missing evaluation identity.
+    const identified = identity.every(field => field.source.availability === 'available');
+    function fact<T extends z.ZodTypeAny>(
+      fields: string[],
+      schema: T
+    ): ContextReadResult<z.output<T>> {
+      const decoded = decodeContextGraphQlSource(result, [...path, ...fields], schema);
+      return identified
+        ? decoded
+        : {
+            data: null,
+            source: {
+              ...revision.source,
+              availability: revision.source.availability === 'denied' ? 'denied' : 'unavailable',
+              reason: revision.source.reason ?? 'evaluation-identity-unavailable',
+            },
+          };
+    }
+    const facts: RequirementFacts = {
+      mergeable: fact(['mergeable'], z.enum(['MERGEABLE', 'CONFLICTING', 'UNKNOWN'])),
+      testMerge: fact(['potentialMergeCommit'], contextTestMergeSchema),
+      canBypassClassic: fact(['viewerCanMergeAsAdmin'], z.boolean()),
+      viewerRule: {
+        requiredApprovingReviewCount: fact(
+          ['baseRef', 'refUpdateRule', 'requiredApprovingReviewCount'],
+          z.number().int().nonnegative().nullable()
+        ),
+        requiredStatusCheckContexts: fact(
+          ['baseRef', 'refUpdateRule', 'requiredStatusCheckContexts'],
+          z.array(z.string().nullable()).nullable()
+        ),
+        requiresConversationResolution: fact(
+          ['baseRef', 'refUpdateRule', 'requiresConversationResolution'],
+          z.boolean()
+        ),
+      },
+      comparison: fact(['baseRef', 'compare'], contextComparisonSchema),
+    };
+    const commitMatches = (page: ContextReadResult<unknown>, oid: string) =>
+      decodeContextGraphQlSource(page, ['repository', 'object', 'oid'], z.literal(oid)).source
+        .availability === 'available';
+    const collectChecks = (oid: string) => {
+      const checkPath = ['repository', 'object', 'statusCheckRollup', 'contexts'];
+      const seen = new Map<string, z.output<typeof contextCheckSchema>>();
+      const conflicts = new Set<string>();
+      return collect(
+        'checks',
+        contextCheckSchema,
+        context.checks,
+        (_known, current) => current,
+        undefined,
+        (item, page, index) => {
+          const nodePath = [...checkPath, 'nodes', index];
+          const run = item.kind === 'check-run';
+          const field = <T extends z.ZodTypeAny>(parts: string[], schema: T) =>
+            decodeContextGraphQlSource(page, [...nodePath, ...parts], schema);
+          const required = field(['isRequired'], z.boolean());
+          const status = field([run ? 'status' : 'state'], z.string());
+          const conclusion = run ? field(['conclusion'], z.string().nullable()) : null;
+          const application = run ? field(['checkSuite', 'app'], z.unknown()) : null;
+          const commit = field(
+            run ? ['checkSuite', 'commit', 'oid'] : ['commit', 'oid'],
+            z.literal(oid)
+          );
+          const identity = field(['id'], z.literal(item.id));
+          const name = field([run ? 'name' : 'context'], z.literal(item.name));
+          const current = {
+            ...item,
+            status: status.source.availability === 'available' ? status.data : null,
+            conclusion: conclusion?.source.availability === 'available' ? conclusion.data : null,
+            application: application?.source.availability === 'available' ? item.application : null,
+            requiredness:
+              required.source.availability !== 'available'
+                ? ('unknown' as const)
+                : required.data
+                  ? ('required' as const)
+                  : ('optional' as const),
+          };
+          current.outcome = contextCheckOutcome(current.kind, current.status, current.conclusion);
+          if (
+            !commitMatches(page, oid) ||
+            [commit, identity, name].some(value => value.source.availability !== 'available')
+          ) {
+            current.observation = 'unknown';
+            current.requiredness = 'unknown';
+          }
+          if (current.id) {
+            const previous = seen.get(current.id);
+            if (previous && JSON.stringify(previous) !== JSON.stringify(current))
+              conflicts.add(current.id);
+            seen.set(current.id, { ...current });
+            if (conflicts.has(current.id)) {
+              current.observation = 'unknown';
+              current.requiredness = 'unknown';
+            }
+          }
+          current.evidence = [
+            ...contextRequirementEvidence(
+              context.revision,
+              { ...required.source, provenance: ['graphql.checks.isRequired'] },
+              `isRequired:${current.requiredness}`,
+              current.evaluatedSha
+            ),
+            ...contextRequirementEvidence(
+              context.revision,
+              { ...page.source, provenance: ['graphql.checks'] },
+              `check:${current.id}:${current.outcome};status:${current.status};conclusion:${current.conclusion}`,
+              current.evaluatedSha
+            ),
+          ];
+          return current;
+        },
+        {
+          path: checkPath,
+          variables: { oid, pr: context.revision.prNodeId },
+          validPage: page => commitMatches(page, oid),
+        }
+      );
+    };
+    const [head, merge, threads, eligibleReviews, deployments] = await Promise.all([
+      collectChecks(context.revision.headSha),
+      facts.testMerge.data ? collectChecks(facts.testMerge.data.oid) : Promise.resolve(null),
+      collect(
+        'reviewThreads',
+        contextThreadSchema,
+        { ...context.checks, items: [] },
+        (_known, current) => current,
+        undefined,
+        (thread, page, index) => ({
+          ...thread,
+          isResolved:
+            decodeContextGraphQlSource(
+              page,
+              [...path, 'reviewThreads', 'nodes', index, 'isResolved'],
+              z.boolean()
+            ).source.availability === 'available'
+              ? thread.isResolved
+              : null,
+        })
+      ),
+      collectReviews('eligibleReviews', { ...context.reviewDecisions, items: [] }, new Set()),
+      collect(
+        'deployments',
+        contextDeploymentSchema,
+        { ...context.checks, items: [] },
+        (_known, current) => current,
+        undefined,
+        undefined,
+        {
+          path: ['repository', 'object', 'deployments'],
+          variables: { oid: context.revision.headSha },
+          validPage: page => commitMatches(page, context.revision.headSha),
+        }
+      ),
+    ]);
+    return {
+      // Incomplete identity cannot prove a verdict, but reliable fields can still prove a mismatch.
+      identity,
+      facts,
+      observations: { head, merge, threads, eligibleReviews, deployments },
+    };
+  }
+  let evaluation: Awaited<ReturnType<typeof collectEvaluation>>;
   [
     context.labels,
     context.assignees,
@@ -559,6 +793,7 @@ export async function readPullRequestContext(
     context.reviewActivity,
     context.issues,
     context.requirements,
+    evaluation,
   ] = await Promise.all([
     collect('labels', contextLabelSchema, context.labels, (known, current) => ({
       ...current,
@@ -587,6 +822,7 @@ export async function readPullRequestContext(
     collectReviews('latestReviews', context.reviewActivity),
     collectIssues(),
     collectPolicies(),
+    collectEvaluation(),
   ]);
   // Final null fields can hide contradictions between the two connections.
   for (const review of context.reviewDecisions.items) {
@@ -601,6 +837,10 @@ export async function readPullRequestContext(
     context.reviewDecisions,
     context.reviewActivity,
     conflictingReviewIds
+  );
+  Object.assign(
+    context,
+    evaluateContextRequirements(context, evaluation.facts, evaluation.observations)
   );
   const final = decodeContextGraphQlSource(
     await read('graphql.revision', async (signal): Promise<unknown> => {
@@ -628,9 +868,12 @@ export async function readPullRequestContext(
     fields.some(
       field =>
         new Set(
-          observations
-            .map(revision => revision?.[field])
-            .filter(value => value != null && value !== '')
+          [
+            ...observations.map(revision => revision?.[field]),
+            evaluation.identity.find(
+              identity => identity.field === field && identity.source.availability === 'available'
+            )?.data,
+          ].filter(value => value != null && value !== '')
         ).size > 1
     );
   if (mismatch) {

--- a/apps/web/src/lib/github-pr-review/context-reader.ts
+++ b/apps/web/src/lib/github-pr-review/context-reader.ts
@@ -44,6 +44,7 @@ import {
   contextTestMergeSchema,
   contextThreadSchema,
   evaluateContextRequirements,
+  type ContextReadResult,
   type RequirementFacts,
 } from './context-requirements';
 
@@ -55,7 +56,7 @@ const collectionQueries = {
 };
 const deadlineError = new Error('PR context deadline');
 type PrInput = { owner: string; repo: string; number: number };
-export type ContextReadResult<T> = { data: T | null; source: GitHubPrReviewSource };
+export type { ContextReadResult } from './context-requirements';
 
 export function createContextReadBudget() {
   const deadline = Date.now() + 10_000;

--- a/apps/web/src/lib/github-pr-review/context-requirements.ts
+++ b/apps/web/src/lib/github-pr-review/context-requirements.ts
@@ -8,8 +8,9 @@ import {
   type GitHubPrReviewRevision,
   type GitHubPrReviewSource,
 } from './context-dtos';
-import type { ContextReadResult } from './context-reader';
 import { contextReviewsAgree } from './context-reviews';
+
+export type ContextReadResult<T> = { data: T | null; source: GitHubPrReviewSource };
 
 type Check = GitHubPrReviewContext['checks']['items'][number];
 type Requirement = GitHubPrReviewContext['requirements']['items'][number];

--- a/apps/web/src/lib/github-pr-review/context-rules-integration.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-rules-integration.test.ts
@@ -8,6 +8,10 @@ import { GitHubPrReviewContextSchema } from './context-dtos';
 import { PR_CONTEXT_PEOPLE_QUERIES } from './context-people';
 import { PR_CONTEXT_REVIEW_QUERIES } from './context-reviews';
 import { PR_CONTEXT_ISSUE_QUERIES } from './context-issues';
+import {
+  PR_CONTEXT_EVALUATION_QUERY,
+  PR_CONTEXT_REQUIREMENT_QUERIES,
+} from './context-requirements';
 
 const revision = {
   prNodeId: 'PR',
@@ -53,6 +57,26 @@ const collections = {
   ...PR_CONTEXT_PEOPLE_QUERIES,
   ...PR_CONTEXT_REVIEW_QUERIES,
   ...PR_CONTEXT_ISSUE_QUERIES,
+  ...PR_CONTEXT_REQUIREMENT_QUERIES,
+};
+const evaluationPr = {
+  id: 'PR',
+  number: 1,
+  headRefOid: 'head',
+  baseRefName: 'release/1',
+  baseRefOid: 'base',
+  baseRepository: { nameWithOwner: 'upstream/policies' },
+  mergeable: 'MERGEABLE',
+  viewerCanMergeAsAdmin: false,
+  potentialMergeCommit: null,
+  baseRef: {
+    refUpdateRule: {
+      requiredApprovingReviewCount: 2,
+      requiredStatusCheckContexts: ['ci'],
+      requiresConversationResolution: true,
+    },
+    compare: { behindBy: 0, baseTarget: { oid: 'base' }, headTarget: { oid: 'head' } },
+  },
 };
 const empty = { nodes: [], totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null } };
 const failure = (status: number) => Response.json({ message: 'provider-only' }, { status });
@@ -110,22 +134,24 @@ async function run(
           if (path === protectionPath) return Response.json(protection);
           if (path === branchPath) return Response.json(unprotected);
           if (path === rulesPath) return Response.json([rule]);
-          const { query } = JSON.parse(String(options.body));
-          if (query === PR_CONTEXT_REVISION_QUERY)
+          const { query, variables } = JSON.parse(String(options.body));
+          if (
+            query === PR_CONTEXT_REQUIREMENT_QUERIES.checks ||
+            query === PR_CONTEXT_REQUIREMENT_QUERIES.deployments
+          )
             return Response.json({
               data: {
                 repository: {
-                  pullRequest: {
-                    id: 'PR',
-                    number: 1,
-                    headRefOid: 'head',
-                    baseRefName: 'release/1',
-                    baseRefOid: 'base',
-                    baseRepository: { nameWithOwner: 'upstream/policies' },
+                  object: {
+                    oid: variables.oid,
+                    statusCheckRollup: { contexts: empty },
+                    deployments: empty,
                   },
                 },
               },
             });
+          if (query === PR_CONTEXT_REVISION_QUERY || query === PR_CONTEXT_EVALUATION_QUERY)
+            return Response.json({ data: { repository: { pullRequest: evaluationPr } } });
           const field = Object.entries(collections).find(([, document]) => document === query)?.[0];
           if (!field) throw new Error('Unexpected request');
           return Response.json({ data: { repository: { pullRequest: { [field]: empty } } } });
@@ -145,7 +171,7 @@ async function run(
   return { context, requests, peak };
 }
 
-it('reads exact-base classic and inherited active policies without evaluating them', async () => {
+it('retains exact-base policy evidence while adding named evaluation requirements', async () => {
   const { context, requests } = await run(url =>
     decodeURIComponent(url.pathname) === rulesPath
       ? Response.json([
@@ -156,32 +182,44 @@ it('reads exact-base classic and inherited active policies without evaluating th
   );
   expect(context.requirements).toMatchObject({
     completeness: 'complete',
-    knownCount: 6,
+    knownCount: 12,
     source: { availability: 'available' },
   });
   const policies = context.requirements.items.filter(item => item.check === null);
-  expect(policies.map(item => item.kind)).toEqual([
-    'branch_protection',
-    'required_deployments',
-    'future_rule',
+  expect(policies.map(item => [item.kind, item.state])).toEqual([
+    ['branch-freshness', 'met'],
+    ['approving-reviews', 'unavailable'],
+    ['code-owner-reviews', 'unavailable'],
+    ['last-push-approval', 'unavailable'],
+    ['stale-review-dismissal', 'unavailable'],
+    ['conversation-resolution', 'met'],
+    ['commit-signatures', 'unavailable'],
+    ['deployment', 'unavailable'],
+    ['future_rule', 'unavailable'],
   ]);
   expect(policies[0]?.policy?.parameters).toEqual(protection);
-  expect(policies[1]?.policy).toMatchObject({
+  expect(policies.find(item => item.kind === 'deployment')?.policy).toMatchObject({
     parameters: rule.parameters,
     ruleset: { id: 7, source: 'upstream', sourceType: 'Organization' },
+    viewerBypass: 'unknown',
+    viewerEnforcement: 'unknown',
   });
   for (const item of context.requirements.items) {
-    expect(item).toMatchObject({
-      state: 'unavailable',
-      policy: {
-        enforcement: 'active',
-        viewerBypass: 'unknown',
-        viewerEnforcement: 'unknown',
-        bypassActors: null,
-        base: { baseRepoFullName: 'upstream/policies', baseRef: 'release/1', baseSha: 'base' },
-      },
-      evidence: [expect.objectContaining({ headSha: 'head', baseSha: 'base', evaluatedSha: null })],
+    expect(item.policy).toMatchObject({
+      enforcement: 'active',
+      bypassActors: null,
+      base: { baseRepoFullName: 'upstream/policies', baseRef: 'release/1', baseSha: 'base' },
     });
+    expect(item.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          observation: 'policy-configuration',
+          headSha: 'head',
+          baseSha: 'base',
+          evaluatedSha: null,
+        }),
+      ])
+    );
   }
   expect(context.requirements.items.flatMap(item => (item.check ? [item.check] : []))).toEqual([
     { name: 'ci', kind: 'unknown', application: { kind: 'app', appId: 7 } },
@@ -254,9 +292,23 @@ it.each([protectionPath, rulesPath])(
 );
 
 it('confirms empty policies only after explicit exact-ref absence and empty active rules', async () => {
-  const { context } = await run(url => {
+  const { context } = await run((url, options) => {
     if (decodeURIComponent(url.pathname) === protectionPath) return failure(404);
     if (decodeURIComponent(url.pathname) === rulesPath) return Response.json([]);
+    if (
+      url.pathname === '/graphql' &&
+      JSON.parse(String(options.body)).query === PR_CONTEXT_EVALUATION_QUERY
+    )
+      return Response.json({
+        data: {
+          repository: {
+            pullRequest: {
+              ...evaluationPr,
+              baseRef: { ...evaluationPr.baseRef, refUpdateRule: null },
+            },
+          },
+        },
+      });
   });
   expect(context.requirements).toMatchObject({
     items: [],
@@ -359,4 +411,588 @@ it('shares four request slots and aborts late policy pages at the ten-second dea
   expect(aborted).toBe(true);
   expect(peak).toBe(4);
   expect(requests.filter(path => path.startsWith(rulesPath))).toHaveLength(2);
+});
+
+const observedRun = {
+  __typename: 'CheckRun',
+  id: 'RUN',
+  name: 'ci',
+  status: 'COMPLETED',
+  conclusion: 'FAILURE',
+  isRequired: true,
+  detailsUrl: null,
+  checkSuite: {
+    commit: { oid: 'head' },
+    app: { databaseId: 7, id: 'APP_7', slug: 'ci-app', name: 'CI' },
+  },
+};
+function checkPage(
+  nodes: unknown[],
+  pageInfo: { hasNextPage: boolean; endCursor: string | null } = empty.pageInfo,
+  totalCount = nodes.length,
+  errors: unknown[] = []
+) {
+  return Response.json({
+    data: {
+      repository: {
+        object: { oid: 'head', statusCheckRollup: { contexts: { nodes, totalCount, pageInfo } } },
+      },
+    },
+    errors,
+  });
+}
+
+it('paginates PR-scoped checks while retaining application, kind, and optional failures', async () => {
+  const { context, peak } = await run((url, options) => {
+    if (url.pathname !== '/graphql') return;
+    const { query, variables } = JSON.parse(String(options.body));
+    if (query !== PR_CONTEXT_REQUIREMENT_QUERIES.checks) return;
+    if (variables.pr !== 'PR' || variables.oid !== 'head') throw new Error('Wrong check identity');
+    if (!variables.after)
+      return checkPage([observedRun], { hasNextPage: true, endCursor: 'next' }, 3);
+    if (variables.after !== 'next') throw new Error('Wrong check cursor');
+    return checkPage(
+      [
+        { ...observedRun, id: 'OPTIONAL', name: 'optional', isRequired: false },
+        {
+          __typename: 'StatusContext',
+          id: 'STATUS',
+          context: 'ci',
+          state: 'SUCCESS',
+          isRequired: true,
+          targetUrl: null,
+          commit: { oid: 'head' },
+        },
+      ],
+      empty.pageInfo,
+      3
+    );
+  });
+  expect(context.checks).toMatchObject({
+    completeness: 'complete',
+    items: [
+      {
+        id: 'RUN',
+        kind: 'check-run',
+        application: { id: 7, nodeId: 'APP_7' },
+        requiredness: 'required',
+        outcome: 'failure',
+        evaluatedSha: 'head',
+      },
+      { id: 'OPTIONAL', requiredness: 'optional', outcome: 'failure' },
+      {
+        id: 'STATUS',
+        kind: 'status',
+        application: null,
+        requiredness: 'required',
+        outcome: 'success',
+      },
+    ],
+  });
+  expect(context.requirements.items).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        state: 'unmet',
+        check: { name: 'ci', kind: 'check-run', application: { kind: 'app', appId: 7 } },
+      }),
+      expect.objectContaining({
+        state: 'met',
+        check: { name: 'ci', kind: 'status', application: { kind: 'any' } },
+      }),
+    ])
+  );
+  for (const row of context.requirements.items.filter(item => item.state === 'unmet')) {
+    expect(row.policy?.base).toEqual({
+      baseRepoFullName: 'upstream/policies',
+      baseRef: 'release/1',
+      baseSha: 'base',
+    });
+    expect(row.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          policyId: row.policy?.id,
+          headSha: 'head',
+          baseSha: 'base',
+          evaluatedSha: 'head',
+          observation: 'isRequired:required',
+        }),
+        expect.objectContaining({
+          policyId: row.policy?.id,
+          observation: 'check:RUN:failure;status:COMPLETED;conclusion:FAILURE',
+        }),
+      ])
+    );
+    expect(row.evidence.some(entry => entry.observation.includes('OPTIONAL'))).toBe(false);
+  }
+  expect(peak).toBeLessThanOrEqual(4);
+  expect(context.labels.completeness).toBe('complete');
+});
+
+it.each([true, false])('does not trust an errored isRequired value of %s', async isRequired => {
+  const { context } = await run((url, options) => {
+    if (
+      url.pathname !== '/graphql' ||
+      JSON.parse(String(options.body)).query !== PR_CONTEXT_REQUIREMENT_QUERIES.checks
+    )
+      return;
+    return checkPage([{ ...observedRun, isRequired }], empty.pageInfo, 1, [
+      {
+        type: 'FORBIDDEN',
+        path: ['repository', 'object', 'statusCheckRollup', 'contexts', 'nodes', 0, 'isRequired'],
+      },
+    ]);
+  });
+  expect(context.checks).toMatchObject({
+    source: { availability: 'partial', retryable: false },
+    items: [{ requiredness: 'unknown', outcome: 'failure' }],
+  });
+  expect(
+    context.requirements.items
+      .filter(item => item.check)
+      .every(item => item.state === 'unavailable')
+  ).toBe(true);
+  expect(context.labels.completeness).toBe('complete');
+});
+
+it.each(['head', 'base'])(
+  'invalidates observed failures when the final %s revision changes',
+  async changed => {
+    const { context } = await run((url, options) => {
+      if (url.pathname !== '/graphql') return;
+      const { query } = JSON.parse(String(options.body));
+      if (query === PR_CONTEXT_REQUIREMENT_QUERIES.checks) return checkPage([observedRun]);
+      if (query === PR_CONTEXT_REVISION_QUERY)
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                id: 'PR',
+                number: 1,
+                headRefOid: changed === 'head' ? 'new-head' : 'head',
+                baseRefName: 'release/1',
+                baseRefOid: changed === 'base' ? 'new-base' : 'base',
+                baseRepository: { nameWithOwner: 'upstream/policies' },
+              },
+            },
+          },
+        });
+    });
+    expect(context.checks).toMatchObject({
+      source: { availability: 'stale', retryable: true },
+      items: [{ id: 'RUN', outcome: 'failure', requiredness: 'unknown', observation: 'unknown' }],
+    });
+    expect(context.requirements.items.every(item => item.state === 'unavailable')).toBe(true);
+    expect(context.labels.completeness).toBe('complete');
+  }
+);
+
+it('returns available evaluation sources instead of compatibility defaults', async () => {
+  const { context } = await run();
+  for (const source of Object.values(context.evaluationSources)) {
+    expect(source).toMatchObject({
+      availability: 'available',
+      retryable: false,
+      reason: null,
+      provenance: expect.arrayContaining([expect.stringMatching(/^graphql\./)]),
+    });
+  }
+});
+
+describe.each([403, 503])('evaluation source recovery for HTTP %s', status => {
+  it.each([
+    ['current', 'available', false, null],
+    ['head', 'stale', true, 'revision-mismatch'],
+    ['base', 'stale', true, 'revision-mismatch'],
+    ['denied', 'denied', false, 'forbidden'],
+    ['unavailable', 'unavailable', true, 'bad_gateway'],
+  ] as const)(
+    'preserves failed sources while fencing successful sources for final revision %s',
+    async (finalRevision, availability, retryable, reason) => {
+      const { context } = await run((url, options) => {
+        if (url.pathname !== '/graphql') return;
+        const { query } = JSON.parse(String(options.body));
+        if (query === PR_CONTEXT_REQUIREMENT_QUERIES.checks) return checkPage([observedRun]);
+        if (
+          [
+            PR_CONTEXT_REQUIREMENT_QUERIES.reviewThreads,
+            PR_CONTEXT_REQUIREMENT_QUERIES.eligibleReviews,
+            PR_CONTEXT_REQUIREMENT_QUERIES.deployments,
+          ].includes(query)
+        )
+          return failure(status);
+        if (query === PR_CONTEXT_EVALUATION_QUERY)
+          return Response.json({
+            data: { repository: { pullRequest: evaluationPr } },
+            errors: [
+              {
+                type: status === 403 ? 'FORBIDDEN' : 'INTERNAL',
+                path: ['repository', 'pullRequest', 'baseRef', 'compare'],
+              },
+            ],
+          });
+        if (query === PR_CONTEXT_REVISION_QUERY) {
+          if (finalRevision === 'denied') return failure(403);
+          if (finalRevision === 'unavailable') return failure(503);
+          return Response.json({
+            data: {
+              repository: {
+                pullRequest: {
+                  ...evaluationPr,
+                  headRefOid: finalRevision === 'head' ? 'new-head' : 'head',
+                  baseRefOid: finalRevision === 'base' ? 'new-base' : 'base',
+                },
+              },
+            },
+          });
+        }
+      });
+      expect(context.evaluationSources.comparison).toMatchObject({
+        availability: 'partial',
+        retryable: status === 503,
+        reason: status === 403 ? 'graphql-denied' : 'graphql-incomplete',
+        provenance: ['graphql.requirements'],
+      });
+      for (const [key, field] of [
+        ['threads', 'reviewThreads'],
+        ['eligibleReviews', 'eligibleReviews'],
+        ['deployments', 'deployments'],
+      ] as const) {
+        expect(context.evaluationSources[key]).toMatchObject({
+          availability: status === 403 ? 'denied' : 'unavailable',
+          retryable: status === 503,
+          reason: status === 403 ? 'forbidden' : 'bad_gateway',
+          provenance: [`graphql.${field}`],
+        });
+      }
+      for (const [key, source] of Object.entries(context.evaluationSources)) {
+        if (['comparison', 'threads', 'eligibleReviews', 'deployments'].includes(key)) continue;
+        expect(source).toMatchObject({
+          availability,
+          retryable,
+          reason,
+          provenance: expect.arrayContaining([expect.stringMatching(/^graphql\./)]),
+        });
+      }
+      expect(context.requirements.items.some(item => item.state === 'unmet')).toBe(
+        finalRevision === 'current'
+      );
+      expect(context.checks).toMatchObject({
+        source: { availability, retryable, reason },
+        items: [{ id: 'RUN', outcome: 'failure' }],
+      });
+      expect(context.reviewActivity).toMatchObject({
+        completeness: 'complete',
+        source: { availability: 'available', retryable: false, reason: null },
+      });
+      expect(context.labels.completeness).toBe('complete');
+    }
+  );
+});
+
+describe('evaluation identity', () => {
+  const fields = ['id', 'number', 'headRefOid', 'baseRefName', 'baseRefOid', 'baseRepository'];
+  const review = {
+    id: 'IDENTITY_REVIEW',
+    state: 'APPROVED',
+    submittedAt: '2026-08-29T00:00:00Z',
+    commit: { oid: 'head' },
+    author: null,
+    onBehalfOf: empty,
+  };
+
+  function readIdentity(patch: Record<string, unknown>, errors: unknown[] = []) {
+    return run((url, options) => {
+      if (url.pathname !== '/graphql') return;
+      const { query } = JSON.parse(String(options.body));
+      if (query === PR_CONTEXT_EVALUATION_QUERY)
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: { ...evaluationPr, mergeable: 'CONFLICTING', ...patch },
+            },
+          },
+          errors,
+        });
+      if (query === PR_CONTEXT_REQUIREMENT_QUERIES.checks) return checkPage([observedRun]);
+      const field = Object.entries(PR_CONTEXT_REVIEW_QUERIES).find(
+        ([, document]) => query === document
+      )?.[0];
+      if (field)
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: { [field]: { ...empty, nodes: [review], totalCount: 1 } },
+            },
+          },
+        });
+    });
+  }
+
+  it.each([
+    ...fields.flatMap(field => [null, undefined, '', {}].map(value => [field, value] as const)),
+    ...[null, undefined, '', {}].map(
+      value => ['baseRepository', { nameWithOwner: value }] as const
+    ),
+  ])('rejects evaluation %s=%p without borrowing outer identity', async (field, value) => {
+    const { context } = await readIdentity({ [field]: value });
+    expect(context.revision).toEqual(revision);
+    expect(context.requirements.items.find(item => item.kind === 'merge-conflicts')).toMatchObject({
+      state: 'unavailable',
+      evidence: [expect.objectContaining({ observation: 'mergeable:unavailable' })],
+    });
+    expect(context.requirements).toMatchObject({
+      completeness: 'complete',
+      source: { availability: 'available', retryable: false, reason: null },
+    });
+    for (const key of [
+      'mergeable',
+      'testMerge',
+      'comparison',
+      'canBypassClassic',
+      'requiredApprovingReviewCount',
+      'requiredStatusCheckContexts',
+      'requiresConversationResolution',
+    ] as const) {
+      expect(context.evaluationSources[key].availability).toBe('unavailable');
+    }
+    expect(context.checks).toMatchObject({
+      completeness: 'partial',
+      knownCount: 1,
+      source: { availability: 'partial' },
+      items: [{ id: 'RUN', outcome: 'failure', requiredness: 'required', observation: 'observed' }],
+    });
+    for (const collection of [context.reviewDecisions, context.reviewActivity]) {
+      expect(collection).toMatchObject({
+        items: [{ id: 'IDENTITY_REVIEW', state: 'APPROVED', submittedAt: review.submittedAt }],
+        completeness: 'complete',
+        source: { availability: 'available', retryable: false, reason: null },
+      });
+    }
+    for (const key of [
+      'threads',
+      'eligibleReviews',
+      'deployments',
+      'reviewDecisions',
+      'reviewActivity',
+    ] as const) {
+      expect(context.evaluationSources[key]).toMatchObject({
+        availability: 'available',
+        retryable: false,
+        reason: null,
+      });
+    }
+    expect(context.labels.completeness).toBe('complete');
+  });
+
+  it.each(
+    [...fields, 'baseRepository.nameWithOwner'].flatMap(field =>
+      ['FORBIDDEN', 'INTERNAL'].map(type => [field, type] as const)
+    )
+  )('retains %s identity failure metadata for %s', async (field, type) => {
+    const { context } = await readIdentity({}, [
+      { type, path: ['repository', 'pullRequest', ...field.split('.')] },
+    ]);
+    expect(context.requirements.items.find(item => item.kind === 'merge-conflicts')).toMatchObject({
+      state: 'unavailable',
+      evidence: [expect.objectContaining({ observation: 'mergeable:unavailable' })],
+    });
+    for (const key of ['mergeable', 'testMerge', 'comparison', 'canBypassClassic'] as const) {
+      expect(context.evaluationSources[key]).toMatchObject({
+        availability: 'unavailable',
+        retryable: type === 'INTERNAL',
+        reason: type === 'FORBIDDEN' ? 'graphql-denied' : 'graphql-incomplete',
+        provenance: ['graphql.requirements'],
+      });
+    }
+    expect(context.reviewDecisions).toMatchObject({
+      items: [{ id: 'IDENTITY_REVIEW', state: 'APPROVED' }],
+      source: { availability: 'available' },
+    });
+    expect(context.checks.items).toMatchObject([{ id: 'RUN', outcome: 'failure' }]);
+    expect(context.requirements.source.availability).toBe('available');
+  });
+
+  it.each([
+    ['CONFLICTING', 'unmet'],
+    ['UNKNOWN', 'unavailable'],
+    ['MERGEABLE', null],
+  ] as const)('accepts complete matching identity for %s', async (mergeable, state) => {
+    const { context } = await readIdentity({ mergeable });
+    const conflicts = context.requirements.items.filter(item => item.kind === 'merge-conflicts');
+    if (state === null) expect(conflicts).toEqual([]);
+    else
+      expect(conflicts).toMatchObject([
+        {
+          state,
+          evidence: [
+            expect.objectContaining({
+              source: 'graphql.requirements',
+              policyId: 'github:merge-conflicts',
+              headSha: 'head',
+              baseSha: 'base',
+              evaluatedSha: 'head',
+              observedAt: expect.any(String),
+            }),
+          ],
+        },
+      ]);
+    expect(context.evaluationSources.mergeable).toMatchObject({
+      availability: 'available',
+      retryable: false,
+      reason: null,
+    });
+    expect(context.checks).toMatchObject({
+      completeness: 'complete',
+      items: [{ id: 'RUN', outcome: 'failure', requiredness: 'required' }],
+    });
+  });
+
+  it.each([
+    { headRefOid: 'other-head', baseRepository: null },
+    { headRefOid: 'other-head', baseRefOid: null },
+    { headRefOid: 'other-head', baseRefName: '' },
+    { baseRefOid: 'other-base', baseRepository: null },
+  ])('preserves known mismatches in incomplete evaluation identity: %p', async patch => {
+    const { context } = await readIdentity(patch);
+    expect(context.requirements.source).toMatchObject({
+      availability: 'stale',
+      retryable: true,
+      reason: 'revision-mismatch',
+    });
+    expect(context.requirements.items.every(item => item.state === 'unavailable')).toBe(true);
+    expect(context.checks.items).toMatchObject([
+      { id: 'RUN', requiredness: 'unknown', observation: 'unknown' },
+    ]);
+    expect(context.reviewDecisions.source.availability).toBe('stale');
+    expect(context.reviewActivity.source.availability).toBe('available');
+    expect(context.evaluationSources.mergeable.availability).toBe('unavailable');
+    expect(context.labels.completeness).toBe('complete');
+  });
+
+  it('does not fence context with an errored mismatching evaluation identity', async () => {
+    const { context } = await readIdentity({ headRefOid: 'other-head', baseRepository: null }, [
+      { type: 'FORBIDDEN', path: ['repository', 'pullRequest', 'headRefOid'] },
+    ]);
+    expect(context.requirements.source.availability).toBe('available');
+    expect(context.checks.items).toMatchObject([
+      { id: 'RUN', requiredness: 'required', observation: 'observed' },
+    ]);
+    expect(context.reviewDecisions.source.availability).toBe('available');
+    expect(context.evaluationSources.mergeable.availability).toBe('unavailable');
+  });
+
+  it.each([
+    [
+      'denied base repository',
+      { headRefOid: 'other-head', baseRepository: null },
+      ['baseRepository'],
+    ],
+    [
+      'errored base repository name',
+      { headRefOid: 'other-head', baseRepository: { nameWithOwner: 'other/policies' } },
+      ['baseRepository', 'nameWithOwner'],
+    ],
+    ['omitted base repository', { headRefOid: 'other-head', baseRepository: undefined }, null],
+    [
+      'invalid base repository',
+      { headRefOid: 'other-head', baseRepository: { nameWithOwner: 42 } },
+      null,
+    ],
+    ['omitted base oid', { headRefOid: 'other-head', baseRefOid: undefined }, null],
+    ['invalid base ref', { headRefOid: 'other-head', baseRefName: {} }, null],
+    ['errored head', { headRefOid: 'other-head', baseRefOid: 'other-base' }, ['headRefOid']],
+    ['omitted head', { headRefOid: undefined, baseRefOid: 'other-base' }, null],
+    ['invalid head', { headRefOid: {}, baseRefOid: 'other-base' }, null],
+    [
+      'omitted base oid beside a changed repository',
+      { baseRefOid: undefined, baseRepository: { nameWithOwner: 'other/policies' } },
+      null,
+    ],
+  ] as const)(
+    'fences reliable evaluation mismatches beside %s',
+    async (_label, patch, errorPath) => {
+      const { context } = await readIdentity(
+        patch,
+        errorPath ? [{ type: 'FORBIDDEN', path: ['repository', 'pullRequest', ...errorPath] }] : []
+      );
+      expect(context.revision).toEqual(revision);
+      for (const collection of [context.requirements, context.checks, context.reviewDecisions]) {
+        expect(collection).toMatchObject({
+          completeness: 'unknown',
+          source: { availability: 'stale', retryable: true, reason: 'revision-mismatch' },
+        });
+      }
+      expect(context.requirements.items.every(item => item.state === 'unavailable')).toBe(true);
+      expect(context.checks.items).toMatchObject([
+        { id: 'RUN', outcome: 'failure', requiredness: 'unknown', observation: 'unknown' },
+      ]);
+      expect(context.evaluationSources.mergeable.availability).toBe('unavailable');
+      expect(context.evaluationSources.threads).toMatchObject({
+        availability: 'stale',
+        retryable: true,
+        reason: 'revision-mismatch',
+      });
+      expect(context.reviewActivity).toMatchObject({
+        items: [{ id: 'IDENTITY_REVIEW', state: 'APPROVED' }],
+        completeness: 'complete',
+        source: { availability: 'available' },
+      });
+      expect(context.labels.completeness).toBe('complete');
+    }
+  );
+
+  it.each([
+    ['baseRefOid', { headRefOid: undefined, baseRefOid: 'other-base' }],
+    [
+      'baseRepository.nameWithOwner',
+      { baseRefOid: undefined, baseRepository: { nameWithOwner: 'other/policies' } },
+    ],
+  ] as const)(
+    'ignores an errored %s mismatch beside unavailable identity',
+    async (field, patch) => {
+      const { context } = await readIdentity(patch, [
+        { type: 'FORBIDDEN', path: ['repository', 'pullRequest', ...field.split('.')] },
+      ]);
+      expect(context.requirements.source.availability).toBe('available');
+      expect(context.checks.items).toMatchObject([
+        { id: 'RUN', requiredness: 'required', observation: 'observed' },
+      ]);
+      expect(context.reviewDecisions).toMatchObject({
+        items: [{ id: 'IDENTITY_REVIEW', state: 'APPROVED' }],
+        source: { availability: 'available' },
+      });
+      expect(context.evaluationSources.mergeable).toMatchObject({
+        availability: 'denied',
+        retryable: false,
+        reason: 'graphql-denied',
+      });
+    }
+  );
+
+  it.each([
+    { id: 'OTHER_PR' },
+    { number: 2 },
+    { headRefOid: 'other-head' },
+    { baseRefName: 'main' },
+    { baseRefOid: 'other-base' },
+    { baseRepository: { nameWithOwner: 'other/policies' } },
+  ])('fences a complete mismatching evaluation identity: %p', async patch => {
+    const { context } = await readIdentity(patch);
+    expect(context.requirements.items.find(item => item.kind === 'merge-conflicts')).toMatchObject({
+      state: 'unavailable',
+    });
+    expect(context.requirements.source).toMatchObject({
+      availability: 'stale',
+      retryable: true,
+      reason: 'revision-mismatch',
+    });
+    expect(context.evaluationSources.mergeable.availability).toBe('stale');
+    expect(context.checks.items).toMatchObject([
+      { id: 'RUN', outcome: 'failure', requiredness: 'unknown', observation: 'unknown' },
+    ]);
+    expect(context.reviewActivity).toMatchObject({
+      items: [{ id: 'IDENTITY_REVIEW', state: 'APPROVED' }],
+      source: { availability: 'available' },
+    });
+  });
 });

--- a/apps/web/src/routers/github-pr-review-router.test.ts
+++ b/apps/web/src/routers/github-pr-review-router.test.ts
@@ -1314,6 +1314,23 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
               pullRequest: {
                 id: identity.prNodeId,
                 number: identity.number,
+                mergeable: 'MERGEABLE',
+                viewerCanMergeAsAdmin: false,
+                potentialMergeCommit: null,
+                baseRef: {
+                  refUpdateRule: {
+                    requiredApprovingReviewCount: 0,
+                    requiredStatusCheckContexts: [],
+                    requiresConversationResolution: false,
+                  },
+                  compare: {
+                    behindBy: 0,
+                    baseTarget: { oid: identity.baseSha },
+                    headTarget: { oid: identity.headSha },
+                  },
+                },
+                reviewThreads: empty,
+                eligibleReviews: empty,
                 headRefOid: identity.headSha,
                 baseRefName: identity.baseRef,
                 baseRefOid: identity.baseSha,
@@ -1332,6 +1349,11 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
                 closingIssuesReferences: empty,
                 timelineItems: empty,
                 privatePayload: 'provider-only',
+              },
+              object: {
+                oid: identity.headSha,
+                statusCheckRollup: { contexts: empty },
+                deployments: empty,
               },
             },
           },
@@ -1376,16 +1398,16 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
         });
       }
       expect(result.requirements).toMatchObject({
-        items: [{ kind: 'branch_protection', state: 'unavailable' }],
+        items: [{ kind: 'linear-history', state: 'unavailable' }],
         completeness: 'complete',
         source: { availability: 'available' },
       });
       expect(result.checks).toMatchObject({
         items: [],
-        completeness: 'unknown',
-        totalCount: null,
-        hasNextPage: null,
-        source: { availability: 'unavailable', reason: 'not-requested' },
+        completeness: 'complete',
+        totalCount: 0,
+        hasNextPage: false,
+        source: { availability: 'available', reason: null },
       });
       expect(result.queue).toMatchObject({
         membership: { state: 'unknown', source: { availability: 'unavailable' } },
@@ -1559,7 +1581,7 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
         const result = await caller.getPullRequestContext(contextInput);
         expect(result.labels.items[0]?.name).toBe('rotated');
         expect(result.requirements).toMatchObject({
-          items: [{ kind: 'branch_protection', state: 'unavailable' }],
+          items: [{ kind: 'linear-history', state: 'unavailable' }],
           source: { availability: 'available', reason: null },
         });
         expect(getGitHubUserAccessToken).toHaveBeenNthCalledWith(2, 'user-1', {


### PR DESCRIPTION
The optional backend endpoint now returns evaluated requirements and checks; mobile integration remains pending.

---

## Summary

`getPullRequestContext` now evaluates named `requirements` and fills `checks`, `evaluatedShas`, and `evaluationSources` from `RequirementFacts` and `RequirementObservations`, replacing unrequested evaluation defaults. All observations share the existing ten-second deadline, four-request limit, and credential probe, so optional failures stay isolated. Complete evaluation identity gates facts; reliable mismatches against `expectedRevision` and outer reads invalidate verdicts, `requiredness`, and `observation`, preserving failed-source recovery metadata.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-reader.ts` — connects evaluation facts, head/test-merge checks, review threads, eligible reviews, and deployments to the shared reader. Adds collection paths, variables, and page validation; decodes check fields independently and records revision-bound evidence. Retains check applications and kinds, marks conflicting duplicate observations unknown, and isolates eligible-review conflicts from review decisions. Evaluates after review resolution, preserves unavailable states for unproved requirements, and imports and re-exports `ContextReadResult`.
- `apps/web/src/lib/github-pr-review/context-rules-integration.test.ts` — adds paginated checks, application bindings, optional failures, field-error handling, and evaluated policy expectations. Covers incomplete, conflicting, denied, and stale identities plus source-specific recovery without losing labels or review activity.
- `apps/web/src/routers/github-pr-review-router.test.ts` — provides complete evaluation fixtures and expects named requirements plus confirmed empty checks. Keeps legacy inputs, credential rotation, deadlines, and queue defaults covered.

</details>

A single `ContextReadResult<T>` declaration removes the type-only dependency cycle between the reader and requirement evaluation. The shape remains `{ data: T | null; source: GitHubPrReviewSource }`; the reader's public re-export and nullable `RequirementFacts` arguments remain unchanged. This relocation changes no schemas, fact values, source metadata, or runtime statements.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-requirements.ts` — owns the unchanged generic declaration and removes the reverse type import from the reader.

</details>

Tests: 2 files modified — `context-rules-integration.test.ts` (693 changed lines) and `github-pr-review-router.test.ts` (34 changed lines).
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual testing: Not run for this description. This level covers the optional backend reader; mobile integration lands later. The handoff includes no end-to-end report and leaves live backend and iOS verification pending until the completed stack tip.

## Reviewer Notes

- Repository: `Kilo-Org/cloud`.
- Worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- Review scope: level 23 only, from `mobile-pr-review-context-5458-s22` to `mobile-pr-review-context-5458-s23`.
- Review head: `9293124762296beb3f614efa2cb365260a46644f`.
- Change totals: 4 modified files, 950 insertions, and 44 deletions.
- The reported checks do not establish repository-wide or live verification.

### Recorded automated checks

- The supplied isolated repair report records 346 passing cases across four suites: requirement schema, requirement policy, requirement evaluation, and rules integration.
- Both exact publication snapshots passed all five checks: Madge, the four affected suites, scoped production types, lint, and formatting.
- The type-only repair preserves the emitted JavaScript fingerprints for both source files.
- At capture, cloud and mobile continuous integration (CI) remained pending for `9293124762296beb3f614efa2cb365260a46644f`; Secret Scanning passed.
- Automated checks do not prove manual runtime or provider semantics.

### Human steps

This change requires no human steps before merge or after merge.

### Notes

Live backend and iOS verification remains pending on the completed stack tip.

No manual runtime verification ran. Backend and iOS verification remain required before complete-stack readiness.

Owner-descoped visual checks: large text/font scaling, theme variants, contrast rendering, scaled-text layout, and screen-reader presentation. Functional accessibility labels, roles, identifiers, selectors, default-size behavior, and all non-visual criteria remain required.

Levels 24 and 25 are prepared and proved but unpublished, pending a workflow operation that applies an owning repair to an unpublished propagated baseline.

The pending higher-level repairs pass owning/cumulative tests and formatting, but their required type and publication gates remain incomplete. The already-published feature commits are distinct from these pending repairs.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735 ← this PR
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
