### PR TITLE
test(pr-review): preserve requirement source coverage

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-rules-integration.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-rules-integration.test.ts
@@ -413,6 +413,143 @@ it('shares four request slots and aborts late policy pages at the ten-second dea
   expect(requests.filter(path => path.startsWith(rulesPath))).toHaveLength(2);
 });
 
+it('isolates an unavailable check policy field from conversation enforcement', async () => {
+  const { context } = await run((url, options) => {
+    if (
+      url.pathname !== '/graphql' ||
+      JSON.parse(String(options.body)).query !== PR_CONTEXT_EVALUATION_QUERY
+    )
+      return;
+    return Response.json({
+      data: { repository: { pullRequest: evaluationPr } },
+      errors: [
+        {
+          type: 'FORBIDDEN',
+          path: [
+            'repository',
+            'pullRequest',
+            'baseRef',
+            'refUpdateRule',
+            'requiredStatusCheckContexts',
+          ],
+        },
+      ],
+    });
+  });
+  expect(
+    context.requirements.items.find(item => item.kind === 'conversation-resolution')?.state
+  ).toBe('met');
+  expect(context.requirements.items.find(item => item.kind === 'branch-freshness')?.state).toBe(
+    'unavailable'
+  );
+  expect(
+    context.requirements.items
+      .filter(item => item.check)
+      .every(item => item.state === 'unavailable')
+  ).toBe(true);
+  expect(context.labels.completeness).toBe('complete');
+});
+
+it.each([true, false])(
+  'does not turn an errored thread resolution %s into a verdict or count',
+  async isResolved => {
+    const { context } = await run((url, options) => {
+      if (
+        url.pathname !== '/graphql' ||
+        JSON.parse(String(options.body)).query !== PR_CONTEXT_REQUIREMENT_QUERIES.reviewThreads
+      )
+        return;
+      return Response.json({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                nodes: [{ id: 'THREAD', isResolved }],
+                totalCount: 1,
+                pageInfo: empty.pageInfo,
+              },
+            },
+          },
+        },
+        errors: [
+          {
+            type: 'FORBIDDEN',
+            path: ['repository', 'pullRequest', 'reviewThreads', 'nodes', 0, 'isResolved'],
+          },
+        ],
+      });
+    });
+    const row = context.requirements.items.find(item => item.kind === 'conversation-resolution');
+    expect(row?.state).toBe('unavailable');
+    expect(row?.evidence.some(entry => entry.observation.startsWith('unresolved-threads:'))).toBe(
+      false
+    );
+  }
+);
+
+it.each(['BLOCKED', 'UNSTABLE'])(
+  'does not expand generic %s into invented requirements',
+  async mergeStateStatus => {
+    const { context } = await run((url, options) => {
+      const path = decodeURIComponent(url.pathname);
+      if (path === protectionPath) return failure(404);
+      if (path === rulesPath) return Response.json([]);
+      if (
+        path === '/graphql' &&
+        JSON.parse(String(options.body)).query === PR_CONTEXT_EVALUATION_QUERY
+      )
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                ...evaluationPr,
+                mergeStateStatus,
+                baseRef: { ...evaluationPr.baseRef, refUpdateRule: null },
+              },
+            },
+          },
+        });
+    });
+    expect(context.requirements).toMatchObject({ items: [], completeness: 'complete' });
+  }
+);
+
+it('rejects a mismatching evaluation revision even when both outer revisions agree', async () => {
+  const { context } = await run((url, options) => {
+    if (url.pathname !== '/graphql') return;
+    const { query } = JSON.parse(String(options.body));
+    if (query === PR_CONTEXT_EVALUATION_QUERY)
+      return Response.json({
+        data: { repository: { pullRequest: { ...evaluationPr, headRefOid: 'other-head' } } },
+      });
+    if (query === PR_CONTEXT_REQUIREMENT_QUERIES.checks) return checkPage([observedRun]);
+  });
+  expect(context.requirements.source).toMatchObject({
+    availability: 'stale',
+    reason: 'revision-mismatch',
+  });
+  expect(context.requirements.items.every(item => item.state === 'unavailable')).toBe(true);
+  expect(context.labels.completeness).toBe('complete');
+});
+
+it('does not use an errored revision field to invalidate independent context', async () => {
+  const { context } = await run((url, options) => {
+    if (url.pathname !== '/graphql') return;
+    const { query } = JSON.parse(String(options.body));
+    if (query === PR_CONTEXT_REQUIREMENT_QUERIES.checks) return checkPage([observedRun]);
+    if (query === PR_CONTEXT_EVALUATION_QUERY)
+      return Response.json({
+        data: { repository: { pullRequest: { ...evaluationPr, headRefOid: 'untrusted-head' } } },
+        errors: [{ type: 'FORBIDDEN', path: ['repository', 'pullRequest', 'headRefOid'] }],
+      });
+  });
+  expect(context.requirements.source.availability).not.toBe('stale');
+  expect(context.requirements.items.every(item => item.state === 'unavailable')).toBe(true);
+  expect(context.checks.source).toMatchObject({ availability: 'partial', retryable: false });
+  expect(context.reviewDecisions.source.availability).toBe('available');
+  expect(context.labels.completeness).toBe('complete');
+});
+
 const observedRun = {
   __typename: 'CheckRun',
   id: 'RUN',


### PR DESCRIPTION
No new behavior — this change adds tests for existing review behavior.

---

## Summary

`readPullRequestContext` gains regression coverage for evidence boundaries without changing its runtime contract. The tests isolate errors on `requiredStatusCheckContexts` and `isResolved`, reject requirements inferred from `mergeStateStatus`, and distinguish trustworthy `headRefOid` mismatches from field errors. Only trustworthy evaluation mismatches mark requirements `stale` with `revision-mismatch`; errored revision fields cannot invalidate independent review context.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-rules-integration.test.ts` — adds checks for policy, thread, merge-state, and revision evidence. Denied check policies keep conversation resolution met and labels complete; branch freshness and check requirements become unavailable. Both errored thread states make conversation resolution unavailable without an unresolved-thread count. Confirmed policy absence stays empty and complete for `BLOCKED` and `UNSTABLE`. A trustworthy evaluation mismatch invalidates all requirements despite matching outer revision reads. An errored revision leaves requirements unavailable without staleness, checks partial and non-retryable, review decisions available, and labels complete.

</details>

Tests: 1 test file modified (M), `context-rules-integration.test.ts`: 137 insertions, 0 deletions; 41,571 bytes at the review head.
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual testing: not run for this description; this level restores tests without changing production behavior.

## Reviewer Notes

- Review scope: level 24, from `mobile-pr-review-context-5458-s23` to `mobile-pr-review-context-5458-s24`.
- Repository: Kilo-Org/cloud. Worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- This update does not rerun product tests; the previous handoff supplies the automated result.
- Automated verification (handoff): All 115 integration tests, scoped lint, formatting, and whitespace checks passed.

### Human steps

This change requires no human steps before merge or after merge.

### Notes

Live backend and iOS verification remains pending on the completed stack tip.

- Levels 24 and 25 are prepared and proved but unpublished, pending a workflow operation that applies an owning repair to an unpublished propagated baseline.
- This note concerns the prepared repairs, not the existing feature commits.
- Owning and cumulative tests and scoped formatting pass for the prepared repair snapshots; type and publication gates remain incomplete.
- Runtime verification has not run; backend and iOS verification remain required before complete-stack readiness.
- Owner-descoped: large text/font scaling, theme variants, contrast rendering, scaled-text layout, and screen-reader presentation checks.
- Functional accessibility labels, roles, identifiers, selectors, default appearance, and all non-visual criteria remain required.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736 ← this PR
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
