### PR TITLE
test(pr-review): complete requirement reader coverage

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-rules-integration.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-rules-integration.test.ts
@@ -550,6 +550,130 @@ it('does not use an errored revision field to invalidate independent context', a
   expect(context.labels.completeness).toBe('complete');
 });
 
+const writerReview = {
+  id: 'REVIEW',
+  state: 'APPROVED',
+  submittedAt: '2026-08-29T00:00:00Z',
+  commit: { oid: 'head' },
+  author: {
+    __typename: 'User',
+    id: 'USER',
+    login: 'writer',
+    name: null,
+    avatarUrl: null,
+    url: null,
+  },
+  onBehalfOf: empty,
+};
+const approvalPolicy = {
+  required_pull_request_reviews: {
+    required_approving_review_count: 2,
+    dismiss_stale_reviews: false,
+    require_code_owner_reviews: false,
+    require_last_push_approval: false,
+  },
+};
+
+it('uses the writer-only API filter for approval shortfalls', async () => {
+  const otherReview = {
+    ...writerReview,
+    id: 'OTHER_REVIEW',
+    author: { ...writerReview.author, id: 'OTHER_USER', login: 'reader' },
+  };
+  const { context } = await run((url, options) => {
+    if (decodeURIComponent(url.pathname) === protectionPath) return Response.json(approvalPolicy);
+    if (url.pathname !== '/graphql') return;
+    const { query } = JSON.parse(String(options.body));
+    const field = Object.entries({
+      ...PR_CONTEXT_REVIEW_QUERIES,
+      eligibleReviews: PR_CONTEXT_REQUIREMENT_QUERIES.eligibleReviews,
+    }).find(([, document]) => document === query)?.[0];
+    if (!field) return;
+    const nodes = query.includes('writersOnly: true')
+      ? [writerReview]
+      : [writerReview, otherReview];
+    return Response.json({
+      data: {
+        repository: { pullRequest: { [field]: { ...empty, nodes, totalCount: nodes.length } } },
+      },
+    });
+  });
+  expect(context.reviewDecisions.items).toHaveLength(2);
+  expect(context.requirements.items.find(item => item.kind === 'approving-reviews')).toMatchObject({
+    state: 'unmet',
+    evidence: expect.arrayContaining([
+      expect.objectContaining({ observation: 'eligible-approvals:1/2;ids:REVIEW' }),
+    ]),
+  });
+});
+
+it('rejects conflicting eligible review pages without changing independent review decisions', async () => {
+  const { context } = await run((url, options) => {
+    if (decodeURIComponent(url.pathname) === protectionPath) return Response.json(approvalPolicy);
+    if (url.pathname !== '/graphql') return;
+    const { query, variables } = JSON.parse(String(options.body));
+    if (query === PR_CONTEXT_REQUIREMENT_QUERIES.eligibleReviews)
+      return Response.json({
+        data: {
+          repository: {
+            pullRequest: {
+              eligibleReviews: {
+                nodes: [
+                  { ...writerReview, state: variables.after ? 'APPROVED' : 'CHANGES_REQUESTED' },
+                ],
+                totalCount: 1,
+                pageInfo: variables.after
+                  ? empty.pageInfo
+                  : { hasNextPage: true, endCursor: 'next' },
+              },
+            },
+          },
+        },
+      });
+    const field = Object.entries(PR_CONTEXT_REVIEW_QUERIES).find(
+      ([, document]) => document === query
+    )?.[0];
+    if (field)
+      return Response.json({
+        data: {
+          repository: {
+            pullRequest: { [field]: { ...empty, nodes: [writerReview], totalCount: 1 } },
+          },
+        },
+      });
+  });
+  expect(context.requirements.items.find(item => item.kind === 'approving-reviews')?.state).toBe(
+    'unavailable'
+  );
+  expect(context.reviewDecisions).toMatchObject({
+    completeness: 'complete',
+    items: [{ id: 'REVIEW', state: 'APPROVED' }],
+  });
+});
+
+it('keeps conflicting check pages unavailable instead of accepting their last outcome', async () => {
+  const { context } = await run((url, options) => {
+    if (url.pathname !== '/graphql') return;
+    const { query, variables } = JSON.parse(String(options.body));
+    if (query !== PR_CONTEXT_REQUIREMENT_QUERIES.checks) return;
+    return checkPage(
+      [{ ...observedRun, conclusion: variables.after ? 'SUCCESS' : 'FAILURE' }],
+      variables.after ? empty.pageInfo : { hasNextPage: true, endCursor: 'next' },
+      1
+    );
+  });
+  expect(context.checks.items[0]).toMatchObject({
+    id: 'RUN',
+    requiredness: 'unknown',
+    observation: 'unknown',
+  });
+  expect(
+    context.requirements.items
+      .filter(item => item.check)
+      .every(item => item.state === 'unavailable')
+  ).toBe(true);
+});
+
 const observedRun = {
   __typename: 'CheckRun',
   id: 'RUN',
@@ -690,6 +814,99 @@ it.each([true, false])('does not trust an errored isRequired value of %s', async
   ).toBe(true);
   expect(context.labels.completeness).toBe('complete');
 });
+
+it('does not use an errored application binding for a bound policy', async () => {
+  const { context } = await run((url, options) => {
+    if (
+      url.pathname !== '/graphql' ||
+      JSON.parse(String(options.body)).query !== PR_CONTEXT_REQUIREMENT_QUERIES.checks
+    )
+      return;
+    return checkPage([observedRun], empty.pageInfo, 1, [
+      {
+        type: 'FORBIDDEN',
+        path: [
+          'repository',
+          'object',
+          'statusCheckRollup',
+          'contexts',
+          'nodes',
+          0,
+          'checkSuite',
+          'app',
+        ],
+      },
+    ]);
+  });
+  expect(context.checks.items[0]).toMatchObject({
+    application: null,
+    requiredness: 'required',
+    outcome: 'failure',
+  });
+  expect(
+    context.requirements.items.find(item => item.check?.application.kind === 'app')?.state
+  ).toBe('unavailable');
+  expect(
+    context.requirements.items.find(item => item.check?.application.kind === 'any')?.state
+  ).toBe('unmet');
+});
+
+it('retains check pages after a transient failure without inventing missing checks', async () => {
+  const { context } = await run((url, options) => {
+    if (decodeURIComponent(url.pathname) === protectionPath)
+      return Response.json({
+        required_status_checks: {
+          strict: false,
+          contexts: ['ci', 'absent'],
+          checks: [
+            { context: 'ci', app_id: -1 },
+            { context: 'absent', app_id: -1 },
+          ],
+        },
+      });
+    if (url.pathname !== '/graphql') return;
+    const { query, variables } = JSON.parse(String(options.body));
+    if (query !== PR_CONTEXT_REQUIREMENT_QUERIES.checks) return;
+    return variables.after
+      ? failure(503)
+      : checkPage([observedRun], { hasNextPage: true, endCursor: 'next' }, 2);
+  });
+  expect(context.checks).toMatchObject({
+    source: { availability: 'partial', retryable: true },
+    items: [{ id: 'RUN', outcome: 'failure' }],
+  });
+  expect(context.requirements.items.find(item => item.check?.name === 'ci')?.state).toBe('unmet');
+  expect(context.requirements.items.find(item => item.check?.name === 'absent')?.state).toBe(
+    'unavailable'
+  );
+  expect(context.checks.items.some(item => item.observation === 'missing')).toBe(false);
+});
+
+it.each([null, { contexts: null }])(
+  'does not turn a null check source %j into missing requirements',
+  async statusCheckRollup => {
+    const { context } = await run((url, options) => {
+      if (
+        url.pathname !== '/graphql' ||
+        JSON.parse(String(options.body)).query !== PR_CONTEXT_REQUIREMENT_QUERIES.checks
+      )
+        return;
+      return Response.json({
+        data: { repository: { object: { oid: 'head', statusCheckRollup } } },
+      });
+    });
+    expect(context.checks).toMatchObject({
+      items: [],
+      completeness: 'unknown',
+      source: { availability: 'unavailable' },
+    });
+    expect(
+      context.requirements.items
+        .filter(item => item.check)
+        .every(item => item.state === 'unavailable')
+    ).toBe(true);
+  }
+);
 
 it.each(['head', 'base'])(
   'invalidates observed failures when the final %s revision changes',


### PR DESCRIPTION
No new behavior — the change adds regression coverage without changing production code.

---

## Summary

Requirement-reader regressions enforce `writersOnly: true`; conflicting `eligibleReviews` must leave approval requirements `unavailable` and independent `reviewDecisions` complete.
The `checks` coverage rejects conflicting pages, retains failures through interrupted pagination, and treats null `statusCheckRollup` or `contexts` as unavailable evidence.
Tests for errored `checkSuite.app` retain required failures but clear `application`; app-bound requirements stay `unavailable`, while any-application requirements stay `unmet`.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-rules-integration.test.ts` — Test; modified (`M`), +217/-0 lines. Adds shared review and policy fixtures, then checks a one-of-two eligible approval shortfall while retaining both reviews. Conflicting checks require unknown `requiredness` and `observation`, with unavailable requirements. A 503 response keeps checks partial and retryable: observed requirements stay `unmet`, unseen requirements stay `unavailable`, and no missing checks appear. Null sources require empty checks, unknown completeness, and unavailable requirements.

</details>

Tests: 1 modified integration test file, `context-rules-integration.test.ts`, with 217 insertions and no deletions.
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual tests: not run for this test-only level; live backend and iOS verification remains pending on the completed stack tip.
- Runtime verification has not run; backend and iOS verification remain required before complete-stack readiness.

## Reviewer Notes

- Review refs: `mobile-pr-review-context-5458-s24` (base) and `mobile-pr-review-context-5458-s25` (head); this description covers level 25 only.
- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.

### Retained verification claims

- Automated verification (handoff): 122 integration tests passed; scoped lint, formatting, and whitespace checks passed.
- Preservation verification (handoff): seven file hashes matched the preservation record.

### Human steps

This change needs no human steps before merge or after merge.

### Notes

Live backend and iOS verification remains pending on the completed stack tip.

- Levels 24 and 25 are prepared and proved but unpublished, pending a workflow operation that applies an owning repair to an unpublished propagated baseline.
- This note concerns the prepared repairs, not the existing feature commits.
- Owning and cumulative tests and scoped formatting pass for the prepared repair snapshots; type and publication gates remain incomplete.
- Owner-descoped: large text/font scaling, theme variants, contrast rendering, scaled-text layout, and screen-reader presentation checks.
- Functional accessibility labels, roles, identifiers, selectors, default appearance, and all non-visual criteria remain required.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739 ← this PR
26. `mobile-pr-review-context-5458-s26` — #5741
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
