### PR TITLE
feat(pr-review): preserve queue membership and position

### DIFF
--- a/apps/web/src/lib/github-pr-review/context-queue.test.ts
+++ b/apps/web/src/lib/github-pr-review/context-queue.test.ts
@@ -1,0 +1,354 @@
+import { Octokit } from '@octokit/rest';
+import {
+  createContextReadBudget,
+  PR_CONTEXT_REVISION_QUERY,
+  readPullRequestContext,
+} from './context-reader';
+import { PR_CONTEXT_QUEUE_QUERIES } from './context-queue';
+import { GitHubPrReviewContextSchema } from './context-dtos';
+import type { PullRequestRestData } from './mappers';
+
+const revision = {
+  prNodeId: 'PR_1',
+  number: 1,
+  headSha: 'head',
+  baseRepoFullName: 'o/r',
+  baseRef: 'main',
+  baseSha: 'base',
+};
+const pr: PullRequestRestData = {
+  node_id: 'PR_1',
+  number: 1,
+  title: 'PR',
+  body: null,
+  user: null,
+  state: 'open',
+  head: { ref: 'feature', sha: 'head' },
+  base: { ref: 'main', sha: 'base', repo: { full_name: 'o/r' } },
+  commits: 1,
+  changed_files: 1,
+  additions: 1,
+  deletions: 0,
+  mergeable: null,
+};
+const entry = {
+  __typename: 'MergeQueueEntry',
+  id: 'ENTRY_1',
+  pullRequest: { id: 'PR_1' },
+  position: 17,
+  state: 'QUEUED',
+  enqueuedAt: '2026-08-28T12:00:00Z',
+};
+const envelope = (data: unknown, errors?: unknown[]) => ({ data: { data, errors } });
+const membership = (value: unknown = { id: 'ENTRY_1' }, id = 'PR_1', errors?: unknown[]) =>
+  envelope({ repository: { pullRequest: { id, membership: value } } }, errors);
+const failure = (status: number) => Object.assign(new Error('provider-only'), { status });
+const denied = [{ type: 'FORBIDDEN', path: ['repository', 'pullRequest', 'membership'] }];
+let budget: ReturnType<typeof createContextReadBudget>;
+beforeEach(() => {
+  jest.useFakeTimers();
+  budget = createContextReadBudget();
+});
+afterEach(() => {
+  budget.close();
+  jest.useRealTimers();
+});
+
+async function run(
+  members: unknown[] = [membership()],
+  details: unknown = envelope({ node: entry }),
+  finalRevision?: unknown
+) {
+  const requests: string[] = [];
+  const client = new Octokit();
+  const deny = async () => {
+    throw failure(403);
+  };
+  const octokit = {
+    pulls: { get: async () => ({ data: pr }) },
+    repos: {
+      getBranchProtection: deny,
+      getBranchRules: Object.assign(deny, client.repos.getBranchRules),
+    },
+    paginate: client.paginate,
+    request: async (_route: string, body: { query: string; variables: { entryId?: string } }) => {
+      let response: unknown;
+      if (body.query === PR_CONTEXT_QUEUE_QUERIES.queueMembership) {
+        requests.push('membership');
+        response = members.shift();
+      } else if (body.query === PR_CONTEXT_QUEUE_QUERIES.queueEntry) {
+        requests.push(`entry:${body.variables.entryId}`);
+        response = details;
+      } else if (body.query === PR_CONTEXT_REVISION_QUERY && finalRevision !== undefined) {
+        response = finalRevision;
+      } else
+        return envelope({
+          repository: {
+            pullRequest: {
+              id: 'PR_1',
+              number: 1,
+              headRefOid: 'head',
+              baseRefName: 'main',
+              baseRefOid: 'base',
+              baseRepository: { nameWithOwner: 'o/r' },
+            },
+          },
+        });
+      if (response instanceof Error) throw response;
+      return response;
+    },
+  } as unknown as Octokit;
+  const context = GitHubPrReviewContextSchema.parse(
+    await readPullRequestContext(
+      octokit,
+      { owner: 'o', repo: 'r', number: 1, expectedRevision: revision },
+      budget
+    )
+  );
+  return { queue: context.queue, requests };
+}
+
+it.each(['AWAITING_CHECKS', 'LOCKED', 'MERGEABLE', 'QUEUED', 'UNMERGEABLE'])(
+  'preserves authoritative %s details after membership',
+  async state => {
+    const { queue, requests } = await run([membership()], envelope({ node: { ...entry, state } }));
+    expect(queue.membership).toMatchObject({
+      state: 'queued',
+      entryId: 'ENTRY_1',
+      source: { availability: 'available' },
+    });
+    expect(queue.position).toMatchObject({
+      value: 17,
+      state,
+      enqueuedAt: entry.enqueuedAt,
+      entryId: 'ENTRY_1',
+      prNodeId: 'PR_1',
+      source: { availability: 'available' },
+    });
+    expect(requests).toEqual(['membership', 'entry:ENTRY_1']);
+  }
+);
+
+it.each([
+  ['unproved null', membership(null), 'unavailable', false],
+  ['missing entry', envelope({ repository: { pullRequest: { id: 'PR_1' } } }), 'unavailable', true],
+  ['wrong PR', membership({ id: 'ENTRY_1' }, 'OTHER'), 'unavailable', true],
+  ['invalid entry ID', membership({ id: '' }), 'unavailable', true],
+  ['null ancestor', envelope({ repository: null }), 'unavailable', true],
+  ['denied field', membership(null, 'PR_1', denied), 'denied', false],
+  ['pathless error', membership(null, 'PR_1', [{ type: 'INTERNAL' }]), 'unavailable', true],
+  ['HTTP 403', failure(403), 'denied', false],
+  ['optional HTTP 401', failure(401), 'denied', false],
+  ['HTTP 503', failure(503), 'unavailable', true],
+])('does not infer membership from %s', async (_name, response, availability, retryable) => {
+  const { queue, requests } = await run([response]);
+  expect(queue.membership).toMatchObject({
+    state: 'unknown',
+    entryId: null,
+    source: { availability, retryable },
+  });
+  expect(queue.position).toMatchObject({ value: null, state: null, enqueuedAt: null });
+  expect(requests).toEqual(['membership']);
+});
+
+it.each([
+  ['HTTP 503', failure(503), 'unavailable', true],
+  ['HTTP 403', failure(403), 'denied', false],
+  ['optional HTTP 401', failure(401), 'denied', false],
+  [
+    'null propagation',
+    envelope({ node: null }, [{ type: 'INTERNAL', path: ['node', 'position'] }]),
+    'unavailable',
+    true,
+  ],
+  [
+    'denied position',
+    envelope({ node: null }, [{ type: 'FORBIDDEN', path: ['node', 'position'] }]),
+    'denied',
+    false,
+  ],
+  [
+    'errored value',
+    envelope({ node: entry }, [{ type: 'INTERNAL', path: ['node', 'position'] }]),
+    'unavailable',
+    true,
+  ],
+  ['invalid position', envelope({ node: { ...entry, position: -1 } }), 'unavailable', true],
+  ['invalid state', envelope({ node: { ...entry, state: 'UNKNOWN' } }), 'unavailable', true],
+  [
+    'invalid timestamp',
+    envelope({ node: { ...entry, enqueuedAt: 'yesterday' } }),
+    'unavailable',
+    true,
+  ],
+])('retains membership through %s', async (_name, response, availability, retryable) => {
+  const { queue, requests } = await run([membership()], response);
+  expect(queue.membership).toMatchObject({
+    state: 'queued',
+    entryId: 'ENTRY_1',
+    source: { availability: 'available' },
+  });
+  expect(queue.position).toMatchObject({
+    value: null,
+    state: null,
+    enqueuedAt: null,
+    entryId: null,
+    prNodeId: null,
+    source: { availability, retryable },
+  });
+  expect(requests).toEqual(['membership', 'entry:ENTRY_1']);
+});
+
+it.each([
+  ['disappearance', envelope({ node: null })],
+  ['wrong entry', envelope({ node: { ...entry, id: 'ENTRY_2' } })],
+  ['wrong PR', envelope({ node: { ...entry, pullRequest: { id: 'OTHER' } } })],
+  ['wrong node type', envelope({ node: { ...entry, __typename: 'PullRequest' } })],
+  [
+    'movement with a denied old position',
+    envelope({ node: { ...entry, id: 'ENTRY_2' } }, [
+      { type: 'FORBIDDEN', path: ['node', 'position'] },
+    ]),
+  ],
+  [
+    'movement with detail errors',
+    envelope({ node: { ...entry, id: 'ENTRY_2' } }, [
+      { type: 'INTERNAL', path: ['node', 'position'] },
+    ]),
+  ],
+])('refreshes membership once after %s without reusing details', async (_name, response) => {
+  const { queue, requests } = await run([membership(), membership({ id: 'ENTRY_2' })], response);
+  expect(queue.membership).toMatchObject({
+    state: 'queued',
+    entryId: 'ENTRY_2',
+    source: { availability: 'available' },
+  });
+  expect(queue.position).toMatchObject({
+    value: null,
+    state: null,
+    enqueuedAt: null,
+    source: { availability: 'unavailable', retryable: true },
+  });
+  expect(requests).toEqual(['membership', 'entry:ENTRY_1', 'membership']);
+});
+
+it.each([membership(null), membership(null, 'PR_1', denied)])(
+  'keeps an inconclusive refresh unknown',
+  async refresh => {
+    const { queue, requests } = await run([membership(), refresh], envelope({ node: null }));
+    expect(queue.membership).toMatchObject({
+      state: 'unknown',
+      entryId: null,
+      source: { retryable: false },
+    });
+    expect(queue.membership.source.availability).not.toBe('available');
+    expect(queue.position).toMatchObject({ value: null, source: { retryable: false } });
+    expect(requests).toEqual(['membership', 'entry:ENTRY_1', 'membership']);
+  }
+);
+
+describe.each(['deadline', 'revision-mismatch'])('after %s', revisionFailure => {
+  it.each([
+    ['unproved null', membership(null), envelope({ node: entry })],
+    ['denied membership', membership(null, 'PR_1', denied), envelope({ node: entry })],
+    ['denied position', membership(), failure(403)],
+    ['transient position failure', membership(), failure(503)],
+    ['successful queue', membership(), envelope({ node: entry })],
+  ])(
+    'preserves permanent failures and revision recovery for %s',
+    async (_name, member, details) => {
+      const before = (await run([member], details)).queue;
+      const finalRevision =
+        revisionFailure === 'deadline'
+          ? new Promise(() => undefined)
+          : envelope({
+              repository: {
+                pullRequest: {
+                  id: 'PR_1',
+                  number: 1,
+                  headRefOid: 'new-head',
+                  baseRefName: 'main',
+                  baseRefOid: 'base',
+                  baseRepository: { nameWithOwner: 'o/r' },
+                },
+              },
+            });
+      const pending = run([member], details, finalRevision);
+      if (revisionFailure === 'deadline') await jest.advanceTimersByTimeAsync(10_000);
+      const { queue } = await pending;
+      for (const field of ['membership', 'position'] as const) {
+        if (before[field].source.availability === 'available' || before[field].source.retryable) {
+          expect(queue[field].source).toMatchObject({
+            availability: revisionFailure === 'deadline' ? 'unavailable' : 'stale',
+            retryable: true,
+            reason: revisionFailure,
+          });
+        } else {
+          expect(queue[field].source).toEqual(before[field].source);
+        }
+      }
+      expect(queue.membership.state).toBe(before.membership.state);
+      expect(queue.position.value).toBe(before.position.value);
+    }
+  );
+});
+
+it('keeps the observed entry when the shared deadline prevents detail and revision completion', async () => {
+  const pending = run([membership()], new Promise(() => undefined));
+  await jest.advanceTimersByTimeAsync(10_000);
+  const { queue, requests } = await pending;
+  expect(queue.membership).toMatchObject({
+    state: 'queued',
+    entryId: 'ENTRY_1',
+    source: { availability: 'unavailable', retryable: true, reason: 'deadline' },
+  });
+  expect(queue.position).toMatchObject({
+    value: null,
+    state: null,
+    source: { reason: 'deadline' },
+  });
+  expect(requests).toEqual(['membership', 'entry:ENTRY_1']);
+});
+
+it.each([
+  { name: 'HTTP 503', response: failure(503), reason: 'bad_gateway' },
+  { name: 'rate limiting', response: failure(429), reason: 'too_many_requests' },
+  { name: 'deadline', response: new Promise(() => undefined), reason: 'deadline' },
+])(
+  'marks both unattempted queue sources retryable after initial core $name',
+  async ({ response, reason }) => {
+    const octokit = {
+      pulls: {
+        get: async () => {
+          if (response instanceof Error) throw response;
+          return response;
+        },
+      },
+    } as unknown as Octokit;
+    const pending = readPullRequestContext(
+      octokit,
+      { owner: 'o', repo: 'r', number: 1, expectedRevision: revision },
+      budget
+    );
+    if (reason === 'deadline') await jest.advanceTimersByTimeAsync(10_000);
+    const { queue } = GitHubPrReviewContextSchema.parse(await pending);
+    const source = {
+      availability: 'unavailable',
+      retryable: true,
+      reason,
+      provenance: ['rest.pullRequest'],
+      observedAt: expect.any(String),
+    };
+    expect(queue).toMatchObject({
+      membership: { state: 'unknown', entryId: null, source },
+      position: {
+        entryId: null,
+        prNodeId: null,
+        value: null,
+        state: null,
+        enqueuedAt: null,
+        source,
+      },
+    });
+  }
+);

--- a/apps/web/src/lib/github-pr-review/context-queue.ts
+++ b/apps/web/src/lib/github-pr-review/context-queue.ts
@@ -1,0 +1,31 @@
+import 'server-only';
+
+import { z } from 'zod';
+import { GitHubPrReviewQueueSchema, GitHubPrReviewTimestampSchema } from './context-dtos';
+
+export const PR_CONTEXT_QUEUE_QUERIES = {
+  queueMembership: /* GraphQL */ `
+    query PrReviewContextQueueMembership($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) { id membership: mergeQueueEntry { id } }
+      }
+    }
+  `,
+  queueEntry: /* GraphQL */ `
+    query PrReviewContextQueueEntry($entryId: ID!) {
+      node(id: $entryId) {
+        __typename
+        ... on MergeQueueEntry { id position state enqueuedAt pullRequest { id } }
+      }
+    }
+  `,
+};
+
+export const contextQueueEntrySchema = z.object({
+  __typename: z.literal('MergeQueueEntry'),
+  id: z.string().min(1),
+  pullRequest: z.object({ id: z.string().min(1) }),
+  position: z.number().int().nonnegative(),
+  state: GitHubPrReviewQueueSchema.shape.position.shape.state.unwrap(),
+  enqueuedAt: GitHubPrReviewTimestampSchema,
+});

--- a/apps/web/src/lib/github-pr-review/context-reader.ts
+++ b/apps/web/src/lib/github-pr-review/context-reader.ts
@@ -33,6 +33,7 @@ import {
   resolveContextIssues,
 } from './context-issues';
 import { normalizeContextPolicies } from './context-rules';
+import { PR_CONTEXT_QUEUE_QUERIES, contextQueueEntrySchema } from './context-queue';
 import {
   PR_CONTEXT_EVALUATION_QUERY,
   PR_CONTEXT_REQUIREMENT_QUERIES,
@@ -275,8 +276,15 @@ function invalidateRevision(context: GitHubPrReviewContext, source: GitHubPrRevi
       },
     });
   }
-  context.queue.membership.source = source;
-  context.queue.position.source = source;
+  // Observed permanent queue failures retain their recovery policy across revision failures.
+  for (const field of [context.queue.membership, context.queue.position]) {
+    if (
+      field.source.availability === 'available' ||
+      field.source.retryable ||
+      field.source.reason === 'not-requested'
+    )
+      field.source = source;
+  }
   return context;
 }
 
@@ -593,6 +601,110 @@ export async function readPullRequestContext(
     ]);
     return normalizeContextPolicies(context.revision, classic, rules);
   }
+  async function collectQueue() {
+    const queue = context.queue;
+    const request = (
+      field: keyof typeof PR_CONTEXT_QUEUE_QUERIES,
+      variables: Record<string, unknown>
+    ) =>
+      read(`graphql.${field}`, async (signal): Promise<unknown> => {
+        const response = await octokit.request('POST /graphql', {
+          query: PR_CONTEXT_QUEUE_QUERIES[field],
+          variables,
+          request: { signal },
+        });
+        return response.data;
+      });
+    const membership = async () => {
+      const result = await request('queueMembership', {
+        owner: input.owner,
+        name: input.repo,
+        number: input.number,
+      });
+      const identity = decodeContextGraphQlSource(
+        result,
+        ['repository', 'pullRequest', 'id'],
+        z.literal(context.revision.prNodeId)
+      );
+      const member = decodeContextGraphQlSource(
+        result,
+        ['repository', 'pullRequest', 'membership'],
+        z.object({ id: z.string().min(1) }).nullable()
+      );
+      const { data, source } =
+        identity.source.availability === 'available'
+          ? member
+          : { data: null, source: identity.source };
+      queue.membership =
+        data && source.availability === 'available'
+          ? { source, state: 'queued', entryId: data.id }
+          : {
+              state: 'unknown',
+              entryId: null,
+              source: {
+                ...source,
+                availability: source.availability === 'denied' ? 'denied' : 'unavailable',
+                // PR access and an error-free null do not prove queue-read capability.
+                reason: source.reason ?? 'queue-read-capability-unproved',
+              },
+            };
+    };
+    await membership();
+    const entryId = queue.membership.entryId;
+    if (!entryId) {
+      queue.position.source = queue.membership.source;
+      return queue;
+    }
+    const result = await request('queueEntry', { entryId });
+    const { data, source } = decodeContextGraphQlSource(result, ['node'], contextQueueEntrySchema);
+    if (
+      data &&
+      source.availability === 'available' &&
+      data.id === entryId &&
+      data.pullRequest.id === context.revision.prNodeId
+    ) {
+      queue.position = {
+        source,
+        entryId,
+        prNodeId: data.pullRequest.id,
+        value: data.position,
+        state: data.state,
+        enqueuedAt: data.enqueuedAt,
+      };
+    } else {
+      queue.position.source = {
+        ...source,
+        availability: source.availability === 'denied' ? 'denied' : 'unavailable',
+        retryable: source.availability === 'available' || source.retryable,
+        reason: source.reason ?? 'queue-entry-changed',
+      };
+      const changed = (
+        [
+          [['node', '__typename'], 'MergeQueueEntry'],
+          [['node', 'id'], entryId],
+          [['node', 'pullRequest', 'id'], context.revision.prNodeId],
+        ] as const
+      ).some(([path, expected]) => {
+        const field = decodeContextGraphQlSource(result, path, z.string());
+        return field.source.availability === 'available' && field.data !== expected;
+      });
+      const disappeared =
+        decodeContextGraphQlSource(result, ['node'], z.null()).source.availability === 'available';
+      // Refresh membership once after movement; never reuse details from the old observation.
+      if (changed || disappeared) {
+        await membership();
+        queue.position.source = queue.membership.entryId
+          ? {
+              ...source,
+              availability: 'unavailable',
+              retryable: true,
+              reason: 'queue-entry-changed',
+            }
+          : queue.membership.source;
+      }
+    }
+    return queue;
+  }
   async function collectEvaluation() {
     const result = await read('graphql.requirements', async (signal): Promise<unknown> => {
       const response = await octokit.request('POST /graphql', {
@@ -794,6 +906,7 @@ export async function readPullRequestContext(
     context.issues,
     context.requirements,
     evaluation,
+    context.queue,
   ] = await Promise.all([
     collect('labels', contextLabelSchema, context.labels, (known, current) => ({
       ...current,
@@ -823,6 +936,7 @@ export async function readPullRequestContext(
     collectIssues(),
     collectPolicies(),
     collectEvaluation(),
+    collectQueue(),
   ]);
   // Final null fields can hide contradictions between the two connections.
   for (const review of context.reviewDecisions.items) {

--- a/apps/web/src/routers/github-pr-review-graphql-schema.test.ts
+++ b/apps/web/src/routers/github-pr-review-graphql-schema.test.ts
@@ -42,8 +42,8 @@ const introspection = JSON.parse(readFileSync(introspectionPath, 'utf8'));
 const githubSchema = buildClientSchema(introspection);
 
 describe('github-pr-review-router GraphQL documents', () => {
-  test('exports exactly 24 documents (sanity guard for the export record)', () => {
-    expect(Object.keys(PR_REVIEW_GRAPHQL_DOCUMENTS)).toHaveLength(24);
+  test('exports exactly 26 documents (sanity guard for the export record)', () => {
+    expect(Object.keys(PR_REVIEW_GRAPHQL_DOCUMENTS)).toHaveLength(26);
   });
 
   test.each(Object.entries(PR_REVIEW_GRAPHQL_DOCUMENTS))(

--- a/apps/web/src/routers/github-pr-review-router.test.ts
+++ b/apps/web/src/routers/github-pr-review-router.test.ts
@@ -1305,7 +1305,11 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
         privatePayload: 'provider-only',
       };
     }
-    function contextEnvelope(identity = revision, labelName = 'known') {
+    function contextEnvelope(
+      identity = revision,
+      labelName = 'known',
+      membership: { id: string } | null = { id: 'QUEUE_1' }
+    ) {
       const empty = { nodes: [], totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null } };
       return {
         data: {
@@ -1348,6 +1352,7 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
                 latestReviews: empty,
                 closingIssuesReferences: empty,
                 timelineItems: empty,
+                membership,
                 privatePayload: 'provider-only',
               },
               object: {
@@ -1355,6 +1360,14 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
                 statusCheckRollup: { contexts: empty },
                 deployments: empty,
               },
+            },
+            node: {
+              __typename: 'MergeQueueEntry',
+              id: 'QUEUE_1',
+              pullRequest: { id: identity.prNodeId },
+              position: 7,
+              state: 'AWAITING_CHECKS',
+              enqueuedAt: '2026-08-28T12:00:00Z',
             },
           },
         },
@@ -1375,7 +1388,7 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
       jest.restoreAllMocks();
     });
 
-    it('enriches people, reviews, issues, and policies without claiming unattached readers are empty', async () => {
+    it('enriches people, reviews, issues, policies, and independent queue evidence', async () => {
       const result = await caller.getPullRequestContext(contextInput);
       expect(result.revision).toEqual(revision);
       expect(result.labels).toMatchObject({
@@ -1410,10 +1423,33 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
         source: { availability: 'available', reason: null },
       });
       expect(result.queue).toMatchObject({
-        membership: { state: 'unknown', source: { availability: 'unavailable' } },
-        position: { value: null, source: { availability: 'unavailable' } },
+        membership: { state: 'queued', entryId: 'QUEUE_1', source: { availability: 'available' } },
+        position: { value: 7, state: 'AWAITING_CHECKS', source: { availability: 'available' } },
       });
     });
+
+    it.each([null, { merge_method: 'squash' }])(
+      'keeps auto-merge %p separate from unproved queue membership',
+      async auto_merge => {
+        const octokit = buildOctokit('t1');
+        octokit.pulls.get.mockResolvedValue({ data: { ...contextPr(), auto_merge } });
+        octokit.request.mockResolvedValue(contextEnvelope(revision, 'known', null));
+        const core = await caller.getPullRequest(prInput);
+        expect(core.autoMerge).toEqual(auto_merge ? { method: 'squash' } : null);
+        const result = await caller.getPullRequestContext(contextInput);
+        expect(result.queue).toMatchObject({
+          membership: {
+            state: 'unknown',
+            source: {
+              availability: 'unavailable',
+              retryable: false,
+              reason: 'queue-read-capability-unproved',
+            },
+          },
+          position: { value: null, state: null },
+        });
+      }
+    );
 
     it('accepts old PR payloads without inventing missing context or base identity', async () => {
       buildOctokit('t1').pulls.get.mockResolvedValue({ data: overviewPrData });

--- a/apps/web/src/routers/github-pr-review-router.ts
+++ b/apps/web/src/routers/github-pr-review-router.ts
@@ -50,6 +50,7 @@ import {
 import { PR_CONTEXT_PEOPLE_QUERIES } from '@/lib/github-pr-review/context-people';
 import { PR_CONTEXT_REVIEW_QUERIES } from '@/lib/github-pr-review/context-reviews';
 import { PR_CONTEXT_ISSUE_QUERIES } from '@/lib/github-pr-review/context-issues';
+import { PR_CONTEXT_QUEUE_QUERIES } from '@/lib/github-pr-review/context-queue';
 import {
   PR_CONTEXT_EVALUATION_QUERY,
   PR_CONTEXT_REQUIREMENT_QUERIES,
@@ -553,6 +554,7 @@ export const PR_REVIEW_GRAPHQL_DOCUMENTS = {
   ...PR_CONTEXT_PEOPLE_QUERIES,
   ...PR_CONTEXT_REVIEW_QUERIES,
   ...PR_CONTEXT_ISSUE_QUERIES,
+  ...PR_CONTEXT_QUEUE_QUERIES,
   REVIEW_THREADS_QUERY,
   REVIEW_THREAD_COMMENTS_FOLLOWUP_QUERY,
   CONVERSATION_COMMENTS_QUERY,


### PR DESCRIPTION
- Data for pull request reviews now includes merge queue membership, position, status, and entry time when GitHub confirms them.

---

## Summary

`getPullRequestContext` populates existing `GitHubPrReviewContext.queue` fields, validates both identities, and keeps confirmed membership when details fail, without changing the request or response shapes.
Error-free nulls leave membership unavailable with `queue-read-capability-unproved`, never `not-queued`; entry movement triggers one membership refresh without reusing details.
Revision failures invalidate available or retryable observations, preserve permanent queue failures, and retain retryability after transient initial core failures.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-reader.ts` — Source, modified (`M`, +116/-2 lines). Adds membership, detail, and single-refresh reads within the existing ten-second budget and four-request limit. Reports `queue-entry-changed` when refreshed membership remains confirmed; does not fetch replacement details.
- `apps/web/src/lib/github-pr-review/context-queue.test.ts` — Test, added (`A`, +354/-0 lines). Covers provider states, unproved membership, malformed details, movement, authorization, deadlines, revision failures, and initial core recovery.
- `apps/web/src/routers/github-pr-review-router.test.ts` — Test, modified (`M`, +40/-4 lines). Updates queue fixtures and authenticated route assertions, including null membership with auto-merge enabled or disabled.

</details>

`PR_CONTEXT_QUEUE_QUERIES` separates `PrReviewContextQueueMembership` from `PrReviewContextQueueEntry`; `PR_REVIEW_GRAPHQL_DOCUMENTS` includes both in the existing schema checks.
`contextQueueEntrySchema` requires `MergeQueueEntry`, nonempty identities, a nonnegative integer position, a supported GitHub state, and a valid enqueue time.
Valid positions and states retain GitHub's values; `autoMerge` does not establish queue membership.

<details>
<summary>Files</summary>

- `apps/web/src/lib/github-pr-review/context-queue.ts` — Source, added (`A`, +31/-0 lines). Defines separate membership and entry queries and validates the entry payload against the existing state and timestamp contracts.
- `apps/web/src/routers/github-pr-review-router.ts` — Source, modified (`M`, +2/-0 lines). Adds both queue queries to the exported document registry for schema validation.
- `apps/web/src/routers/github-pr-review-graphql-schema.test.ts` — Test, modified (`M`, +2/-2 lines). Raises the document-count guard from 24 to 26.

</details>

Tests: 3 files changed — `context-queue.test.ts` added; `github-pr-review-router.test.ts` and `github-pr-review-graphql-schema.test.ts` updated (+396/-6 lines).
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

- Manual verification did not run for this level; live backend and iOS checks wait for the completed stack tip.
- The dispatcher still owns the missing authorized provider inputs and control identities.

## Reviewer Notes

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/mobile-pr-review-context-5458`.
- Scope: level 26 only, from `mobile-pr-review-context-5458-s25` to `mobile-pr-review-context-5458-s26`.
- Automated checks reported by the handoff: 341 targeted tests passed across five suites; scoped lint, formatting, and whitespace checks passed.
- This level changes backend responses only; mobile presentation belongs to later levels.

### Human steps

No human setup, migration, or deployment step is currently identified.

The dispatcher must complete provider comparisons and live backend/iOS verification before the stack receives the `human-ready` label.

### Notes

Live backend and iOS verification remains pending on the completed stack tip. Actual integration-account comparisons remain required before queue-null fixture authority or final queue acceptance.


<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-pr-review-context-5458-s1` — #5679
2. `mobile-pr-review-context-5458-s2` — #5682
3. `mobile-pr-review-context-5458-s3` — #5684
4. `mobile-pr-review-context-5458-s4` — #5687
5. `mobile-pr-review-context-5458-s5` — #5690
6. `mobile-pr-review-context-5458-s6` — #5691
7. `mobile-pr-review-context-5458-s7` — #5695
8. `mobile-pr-review-context-5458-s8` — #5696
9. `mobile-pr-review-context-5458-s9` — #5699
10. `mobile-pr-review-context-5458-s10` — #5703
11. `mobile-pr-review-context-5458-s11` — #5706
12. `mobile-pr-review-context-5458-s12` — #5707
13. `mobile-pr-review-context-5458-s13` — #5708
14. `mobile-pr-review-context-5458-s14` — #5709
15. `mobile-pr-review-context-5458-s15` — #5712
16. `mobile-pr-review-context-5458-s16` — #5713
17. `mobile-pr-review-context-5458-s17` — #5720
18. `mobile-pr-review-context-5458-s18` — #5723
19. `mobile-pr-review-context-5458-s19` — #5727
20. `mobile-pr-review-context-5458-s20` — #5728
21. `mobile-pr-review-context-5458-s21` — #5730
22. `mobile-pr-review-context-5458-s22` — #5732
23. `mobile-pr-review-context-5458-s23` — #5735
24. `mobile-pr-review-context-5458-s24` — #5736
25. `mobile-pr-review-context-5458-s25` — #5739
26. `mobile-pr-review-context-5458-s26` — #5741 ← this PR
27. `mobile-pr-review-context-5458-s27` — #5744 (tip)
