### PR TITLE
test(browser-task): verify delegated jobs and recovery

### DIFF
--- a/apps/extension/tests/e2e/agents-mode-live.test.ts
+++ b/apps/extension/tests/e2e/agents-mode-live.test.ts
@@ -1,8 +1,9 @@
 /* eslint-disable import/no-nodejs-modules, jest/no-conditional-in-test, max-lines, no-await-in-loop, promise/avoid-new */
 import { expect, test } from '@playwright/test';
-import type { BrowserContext, Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import { rm } from 'node:fs/promises';
 import { launchExtensionContext, startFixtureServer } from './extension-context-fixture';
+import { signInWithLocalDeviceAuth } from './local-device-auth-helpers';
 
 const runLive = process.env['EXTENSION_LOCAL_BACKEND_E2E'] === '1';
 test.skip(!runLive, 'local backend only');
@@ -11,75 +12,6 @@ test.setTimeout(150_000);
 
 const localBackendUrl = process.env['LOCAL_BACKEND_ORIGIN'] ?? 'http://localhost:3000';
 const localUserEmail = process.env['LOCAL_USER_EMAIL'] ?? 'fl@fl.fl';
-
-// ---------------------------------------------------------------------------
-// Sign-in helper (adapted from local-backend-live.test.ts)
-// ---------------------------------------------------------------------------
-
-const signInWithLocalDeviceAuth = async ({
-  context,
-  extensionId,
-  sidePanel,
-}: {
-  context: BrowserContext;
-  extensionId: string;
-  sidePanel: Page;
-}): Promise<void> => {
-  await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
-  const codeLocator = sidePanel.getByText(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/u).first();
-  let codeText: string | null = null;
-
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    await sidePanel.getByRole('button', { name: 'Sign in' }).click();
-
-    const didShowCode = await codeLocator
-      .waitFor({ state: 'visible', timeout: 20_000 })
-      .then(() => true)
-      .catch(() => false);
-
-    if (didShowCode) {
-      codeText = await codeLocator.textContent();
-      break;
-    }
-
-    await expect(sidePanel.getByText('Failed to start sign in. Try again.')).toBeVisible();
-  }
-
-  const code = codeText?.trim();
-
-  if (code === undefined || code === '') {
-    throw new Error('Device auth code was not visible.');
-  }
-
-  const authPage = await context.newPage();
-  const callbackPath = `/device-auth?code=${encodeURIComponent(code)}&app=1`;
-  let authOrigin = localBackendUrl;
-
-  try {
-    const probe = await context.request.get(`${localBackendUrl}/users/after-sign-in`, {
-      maxRedirects: 0,
-    });
-    const { location } = probe.headers();
-
-    if (
-      probe.status() >= 300 &&
-      probe.status() < 400 &&
-      location !== undefined &&
-      location !== ''
-    ) {
-      authOrigin = new URL(location).origin;
-    }
-  } catch {
-    // Fall back to localBackendUrl
-  }
-
-  await authPage.goto(
-    `${authOrigin}/users/sign_in?fakeUser=${encodeURIComponent(localUserEmail)}&callbackPath=${encodeURIComponent(callbackPath)}`
-  );
-  await authPage.getByRole('button', { name: 'Authorize' }).click({ timeout: 60_000 });
-  await expect(sidePanel.getByLabel('Message agent')).toBeVisible({ timeout: 30_000 });
-  await authPage.close();
-};
 
 // ---------------------------------------------------------------------------
 // Shared phase helpers
@@ -441,7 +373,13 @@ test('live local backend: remote CLI agent covers start, reopen, queue, and stop
     await targetPage.goto(fixture.url);
 
     const sidePanel = await context.newPage();
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Message agent')).toBeVisible({ timeout: 15_000 });
 
     await sidePanel.getByRole('tab', { name: 'Agents' }).click();
@@ -490,7 +428,13 @@ test('live local backend: cloud agent covers start, reopen, queue, and stop', as
     await targetPage.goto(fixture.url);
 
     const sidePanel = await context.newPage();
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Message agent')).toBeVisible({ timeout: 15_000 });
 
     await sidePanel.getByRole('tab', { name: 'Agents' }).click();

--- a/apps/extension/tests/e2e/browser-task-live.test.ts
+++ b/apps/extension/tests/e2e/browser-task-live.test.ts
@@ -473,7 +473,10 @@ const enableProvider = async (panel: Page) => {
     .locator(`button[data-model-id="${model}"]`)
     .click();
   await settings.getByRole('button', { name: /Safe mode/u }).click();
-  await settings.getByRole('button', { exact: true, name: 'Dangerous' }).click();
+  await settings
+    .getByRole('button', { exact: true, name: 'Dangerous Arbitrary webpage control' })
+    .click();
+  await expect(settings.getByRole('button', { name: /Danger mode/u })).toBeVisible();
   await settings.getByRole('switch', { exact: true, name: 'CLI tasks' }).click();
   await expect(settings.getByRole('switch', { exact: true, name: 'CLI tasks' })).toHaveAttribute(
     'aria-checked',

--- a/apps/extension/tests/e2e/browser-task-live.test.ts
+++ b/apps/extension/tests/e2e/browser-task-live.test.ts
@@ -1,0 +1,1162 @@
+/* eslint-disable import/no-nodejs-modules, import/max-dependencies, max-lines, no-await-in-loop, jest/prefer-each, jest/no-conditional-in-test, jest/no-conditional-expect, jest/max-expects, promise/avoid-new, init-declarations, typescript/consistent-type-definitions -- Deferred resources have explicit cleanup; live success always uses real CLI tools. */
+import { expect, test } from '@playwright/test';
+import type { Page, WebSocketRoute } from '@playwright/test';
+import { execFileSync, spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { once } from 'node:events';
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { join, resolve } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { z } from 'zod';
+import {
+  browserJobIdSchema,
+  browserProviderDescriptorSchema,
+  browserProviderIdSchema,
+  browserProviderInboundMessageSchema,
+  browserTaskArgumentsSchema,
+  browserTaskIdSchema,
+} from '@kilocode/cloud-agent-sdk/schemas';
+import type {
+  BrowserProviderInboundMessage,
+  BrowserTaskArguments,
+} from '@kilocode/cloud-agent-sdk/schemas';
+import { launchExtensionContext } from './extension-context-fixture';
+import { signInWithLocalDeviceAuth } from './local-device-auth-helpers';
+import { selectModelById } from './model-picker-e2e-helpers';
+
+// Preparation belongs to the orchestrator: inspect dev:status; start only missing nextjs and
+// Cloudflare-session-ingest with KILO_PORT_OFFSET=auto; inspect dev:seed without arguments;
+// Seed one account and credits; privately supply its token; build the unpacked local artifact.
+// Run this file explicitly with EXTENSION_LOCAL_BACKEND_E2E=1. Discovery is not live proof.
+test.skip(
+  process.env['EXTENSION_LOCAL_BACKEND_E2E'] !== '1',
+  'requires the prepared local CLI, extension, and relay stack'
+);
+test.use({ screenshot: 'off', trace: 'off', video: 'off' });
+test.setTimeout(15 * 60_000);
+
+const cloudRoot = resolve(import.meta.dirname, '../../../..');
+const model = 'deepseek/deepseek-v4-flash-0731';
+const cliModel = { modelID: model, providerID: 'kilo' };
+const terminal = new Set(['succeeded', 'failed', 'cancelled', 'interrupted', 'timed_out']);
+const required = (name: string): string =>
+  z.string().min(1, `Prepare ${name} before live acceptance.`).parse(process.env[name]);
+const portSchema = z.coerce.number().int().min(1).max(65_535);
+const statusSchema = z.object({
+  services: z.array(z.object({ name: z.string(), port: portSchema, status: z.string() })),
+});
+const remoteSchema = z.object({ connected: z.boolean(), enabled: z.boolean() });
+const sessionSchema = z.object({ id: z.string().startsWith('ses_') });
+const permissionSchema = z.array(
+  z.object({
+    id: z.string(),
+    patterns: z.array(z.string()),
+    permission: z.string(),
+    sessionID: z.string(),
+  })
+);
+const messagesSchema = z.array(
+  z.object({ info: z.object({ id: z.string() }), parts: z.array(z.unknown()) })
+);
+const toolPartSchema = z.object({
+  id: z.string(),
+  state: z.object({ input: z.unknown(), output: z.string().optional(), status: z.string() }),
+  tool: z.literal('browser_task'),
+  type: z.literal('tool'),
+});
+const outputFields = {
+  browser_task_id: browserTaskIdSchema.optional(),
+  effectsUncertain: z.boolean(),
+  evidence: z.array(
+    z.object({
+      text: z.string().optional(),
+      title: z.string().optional(),
+      url: z.string().optional(),
+    })
+  ),
+  invocation_id: z.string().optional(),
+  job_id: browserJobIdSchema.optional(),
+  provider_id: browserProviderIdSchema.optional(),
+  reason: z.string(),
+  status: z.string(),
+  summary: z.string(),
+};
+const outputSchema = z.object({
+  ...outputFields,
+  jobs: z.array(z.object(outputFields)).optional(),
+  providers: z.array(browserProviderDescriptorSchema).optional(),
+});
+const gatewayRequestSchema = z.object({ messages: z.array(z.unknown()), model: z.string() });
+const modelCatalogSchema = z.object({ data: z.array(z.object({ id: z.string() })) });
+const proxyStatsSchema = z.object({
+  droppedReplies: z.number(),
+  invocations: z.number(),
+  lastInvocationId: z.string().optional(),
+  probe: z.object({ code: z.string().optional(), kind: z.string() }).optional(),
+});
+type ProbeTarget = { parent: string; provider: string; task: string };
+type Output = z.infer<typeof outputSchema>;
+type Delivery = Extract<BrowserProviderInboundMessage, { type: 'provider_job' }>;
+
+type Evidence = {
+  checks: string[];
+  clock: 'production deadlines';
+  model: string;
+  scenarios: string[];
+  screenshots: string[];
+};
+const readJson = async <Value>(
+  url: URL,
+  schema: z.ZodType<Value>,
+  init: RequestInit = {}
+): Promise<Value> => {
+  const headers = new Headers(init.headers);
+  headers.set('accept', 'application/json');
+  const response = await fetch(url, {
+    ...init,
+    headers,
+    signal: init.signal ?? AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} from ${url.pathname}; no response body was logged.`);
+  }
+  if (response.headers.get('content-type')?.includes('application/json') !== true) {
+    throw new Error(`Expected JSON Content-Type from ${url.pathname}.`);
+  }
+  const parsed = schema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error(`Invalid JSON structure from ${url.pathname}.`);
+  }
+  return parsed.data;
+};
+const freePort = (): number =>
+  portSchema.parse(
+    execFileSync(join(required('KILO_WORKFLOW'), 'free-port.sh'), { encoding: 'utf8' }).trim()
+  );
+const stopChild = async (
+  child: ChildProcess,
+  signal: 'SIGTERM' | 'SIGKILL' = 'SIGTERM'
+): Promise<void> => {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  const exited = once(child, 'exit');
+  const force = setTimeout(() => {
+    child.kill('SIGKILL');
+  }, 5000);
+  child.kill(signal);
+  try {
+    await exited;
+  } finally {
+    clearTimeout(force);
+  }
+};
+
+// A transparent test-only fault proxy. Bun owns WebSocket framing. The real relay still
+// Authenticates, negotiates, deduplicates, queues, authorizes, and persists every browser job.
+// Never return or log the captured invocation: it contains the parent's private proof.
+const faultProxySource = `
+const state = { dropBefore: false, dropReplies: false, droppedReplies: 0, invocations: 0 };
+const sockets = new Set();
+const owners = new Map();
+const probes = new Map();
+let invocation;
+let invocationSocket;
+const stats = probe => ({ droppedReplies: state.droppedReplies, invocations: state.invocations, lastInvocationId: invocation?.invocationId, ...(probe ? { probe } : {}) });
+Bun.serve({
+  hostname: '127.0.0.1', port: Number(process.env.PORT),
+  async fetch(request, server) {
+    const url = new URL(request.url);
+    if (url.pathname === '/control') {
+      if (request.headers.get('x-kilo-e2e-control') !== process.env.CONTROL_KEY) return new Response(null, { status: 403 });
+      const command = await request.json();
+      const { operation } = command;
+      if (operation.startsWith('probe-')) {
+        const authority = owners.get(command.parent);
+        if (!authority || authority.remote.readyState !== WebSocket.OPEN) return new Response(null, { status: 409 });
+        const requestId = crypto.randomUUID();
+        const action = operation.slice(6);
+        const nonce = crypto.randomUUID().replaceAll('-', '') + crypto.randomUUID().replaceAll('-', '');
+        const reply = Promise.withResolvers();
+        const timer = setTimeout(() => reply.resolve({ kind: 'timeout' }), 10000);
+        probes.set(requestId, reply.resolve);
+        authority.remote.send(JSON.stringify({ type: 'browser_request', requestId, operation: action, owner: authority.owner, browserTaskId: command.task, ...(action === 'invoke' ? { providerId: command.provider, goal: 'This foreign continuation must be denied.', invocationId: 'b1.' + Date.now() + '.' + nonce } : {}) }));
+        try {
+          const result = await reply.promise;
+          return Response.json(stats({ kind: result.kind, ...(result.code ? { code: result.code } : {}) }));
+        } finally { clearTimeout(timer); probes.delete(requestId); }
+      }
+      if (operation === 'drop-before') state.dropBefore = true;
+      if (operation === 'drop-acceptance') state.dropReplies = true;
+      if (operation === 'restore') { state.dropBefore = false; state.dropReplies = false; }
+      if (operation === 'repeat') {
+        if (!invocation || !invocationSocket || invocationSocket.readyState !== WebSocket.OPEN) return new Response(null, { status: 409 });
+        invocationSocket.send(JSON.stringify(invocation));
+      }
+      if (operation === 'disconnect') for (const socket of sockets) { socket.data.remote?.close(); socket.close(); }
+      return Response.json(stats());
+    }
+    const upstream = new URL(url.pathname + url.search, process.env.RELAY);
+    if (request.headers.get('upgrade')?.toLowerCase() === 'websocket') {
+      upstream.protocol = upstream.protocol === 'https:' ? 'wss:' : 'ws:';
+      const authorization = request.headers.get('authorization');
+      if (server.upgrade(request, { data: { upstream: upstream.href, authorization, pending: [] } })) return;
+      return new Response(null, { status: 400 });
+    }
+    return fetch(new Request(upstream, request));
+  },
+  websocket: {
+    open(socket) {
+      sockets.add(socket);
+      const remote = new WebSocket(socket.data.upstream, { headers: socket.data.authorization ? { authorization: socket.data.authorization } : {} });
+      socket.data.remote = remote;
+      remote.onopen = () => { for (const message of socket.data.pending) remote.send(message); socket.data.pending = []; };
+      remote.onmessage = event => {
+        const value = JSON.parse(String(event.data));
+        if (value.type === 'browser_response' && probes.has(value.requestId)) { probes.get(value.requestId)(value.response); return; }
+        if (state.dropReplies && (value.type === 'browser_response' || value.type === 'browser_event')) { state.droppedReplies++; return; }
+        socket.send(event.data);
+      };
+      remote.onclose = () => socket.close();
+      remote.onerror = () => socket.close();
+    },
+    message(socket, raw) {
+      const text = typeof raw === 'string' ? raw : Buffer.from(raw).toString();
+      const value = JSON.parse(text);
+      if (value.type === 'browser_request' && value.owner) owners.set(value.owner.parentSessionId, { owner: value.owner, remote: socket.data.remote });
+      if (value.type === 'browser_request' && value.operation === 'invoke') {
+        state.invocations++;
+        invocation = value;
+        invocationSocket = socket.data.remote;
+        if (state.dropBefore) return;
+      }
+      if (socket.data.remote?.readyState === WebSocket.OPEN) socket.data.remote.send(text);
+      else if (socket.data.pending.length < 100) socket.data.pending.push(text);
+      else socket.close();
+    },
+    close(socket) { sockets.delete(socket); socket.data.remote?.close(); }
+  }
+});
+`;
+
+const startCli = async (input: {
+  api: string;
+  relay: string;
+  root: string;
+  cliRoot: string;
+  token: string;
+}) => {
+  const password = randomBytes(24).toString('hex');
+  const directory = join(input.root, 'project');
+  await mkdir(directory, { mode: 0o700, recursive: true });
+  let origin = '';
+  let child: ChildProcess | undefined;
+  const request = <Value>(path: string, schema: z.ZodType<Value>, init: RequestInit = {}) => {
+    const url = new URL(path, origin);
+    url.searchParams.set('directory', directory);
+    const headers = new Headers(init.headers);
+    headers.set('authorization', `Basic ${Buffer.from(`kilo:${password}`).toString('base64')}`);
+    headers.set('content-type', 'application/json');
+    headers.set('x-kilo-directory', directory);
+    return readJson(url, schema, { ...init, headers });
+  };
+  const start = async (): Promise<void> => {
+    const port = freePort();
+    origin = `http://127.0.0.1:${port}`;
+    child = spawn(
+      'bun',
+      [
+        '--no-env-file',
+        'run',
+        '--conditions=browser',
+        'src/index.ts',
+        'serve',
+        '--hostname',
+        '127.0.0.1',
+        '--port',
+        String(port),
+      ],
+      {
+        cwd: join(input.cliRoot, 'packages/opencode'),
+        env: {
+          HOME: process.env['HOME'],
+          KILO_API_KEY: input.token,
+          KILO_API_URL: input.api,
+          KILO_CLIENT: 'cli',
+          KILO_SERVER_PASSWORD: password,
+          KILO_SESSION_INGEST_URL: input.relay,
+          PATH: process.env['PATH'],
+          TMPDIR: process.env['TMPDIR'],
+          XDG_CACHE_HOME: join(input.root, 'cache'),
+          XDG_CONFIG_HOME: join(input.root, 'config'),
+          XDG_DATA_HOME: join(input.root, 'data'),
+          XDG_STATE_HOME: join(input.root, 'state'),
+        },
+        stdio: 'ignore',
+      }
+    );
+    await once(child, 'spawn');
+    await expect
+      .poll(
+        async () => {
+          try {
+            return await request('/global/health', z.object({ healthy: z.boolean() }));
+          } catch {
+            return null;
+          }
+        },
+        { message: 'The source CLI did not become healthy.', timeout: 60_000 }
+      )
+      .toMatchObject({ healthy: true });
+    await request('/remote/enable', remoteSchema, { method: 'POST' });
+    await expect
+      .poll(() => request('/remote/status', remoteSchema), { timeout: 30_000 })
+      .toMatchObject({ connected: true, enabled: true });
+  };
+  const stop = async (signal: 'SIGTERM' | 'SIGKILL' = 'SIGTERM'): Promise<void> => {
+    if (child !== undefined) {
+      await stopChild(child, signal);
+    }
+  };
+  try {
+    await start();
+  } catch (error) {
+    await stop();
+    throw error;
+  }
+  return {
+    createParent: (title: string) =>
+      request('/session', sessionSchema, { body: JSON.stringify({ title }), method: 'POST' }),
+    directory,
+    request,
+    restart: async () => {
+      await stop('SIGKILL');
+      await start();
+    },
+    running: () => child?.exitCode === null && child.signalCode === null,
+    sendPrompt: async (sessionID: string, text: string): Promise<void> => {
+      const url = new URL(`/session/${sessionID}/prompt_async`, origin);
+      url.searchParams.set('directory', directory);
+      const response = await fetch(url, {
+        body: JSON.stringify({ model: cliModel, parts: [{ text, type: 'text' }] }),
+        headers: {
+          accept: 'application/json',
+          authorization: `Basic ${Buffer.from(`kilo:${password}`).toString('base64')}`,
+          'content-type': 'application/json',
+          'x-kilo-directory': directory,
+        },
+        method: 'POST',
+      });
+      if (response.status !== 204 || (await response.text()) !== '') {
+        throw new Error('CLI prompt submission did not return empty HTTP 204.');
+      }
+    },
+    stop,
+  };
+};
+type Cli = Awaited<ReturnType<typeof startCli>>;
+type Parent = { cli: Cli; id: string };
+
+const callTool = async (
+  parent: Parent,
+  args: BrowserTaskArguments,
+  parentOnly = ''
+): Promise<Output> => {
+  const before = await parent.cli.request(`/session/${parent.id}/message`, messagesSchema);
+  const known = new Set(
+    before
+      .flatMap(message => message.parts)
+      .flatMap(part => {
+        const parsed = toolPartSchema.safeParse(part);
+        return parsed.success ? [parsed.data.id] : [];
+      })
+  );
+  await parent.cli.sendPrompt(
+    parent.id,
+    `${parentOnly}\nCall browser_task exactly once with these exact arguments: ${JSON.stringify(args)}. Do not use another tool. Do not copy parent-only text into the goal. Return the tool result.`
+  );
+  const deadline = Date.now() + 12 * 60_000;
+  while (Date.now() < deadline) {
+    if (!parent.cli.running()) {
+      throw new Error('The owning CLI stopped during this tool call.');
+    }
+    const permissions = await parent.cli.request('/permission', permissionSchema);
+    for (const permission of permissions.filter(item => item.sessionID === parent.id)) {
+      if (permission.permission !== 'browser_task') {
+        throw new Error(
+          `Unexpected CLI permission: ${permission.permission}. No permission was granted.`
+        );
+      }
+      await parent.cli.request(`/permission/${permission.id}/reply`, z.boolean(), {
+        body: JSON.stringify({ reply: 'once' }),
+        method: 'POST',
+      });
+    }
+    const messages = await parent.cli.request(`/session/${parent.id}/message`, messagesSchema);
+    const calls = messages
+      .flatMap(message => message.parts)
+      .flatMap(part => {
+        const parsed = toolPartSchema.safeParse(part);
+        return parsed.success && !known.has(parsed.data.id) ? [parsed.data] : [];
+      });
+    for (const part of calls) {
+      if (part.state.status === 'error') {
+        throw new Error('The real browser_task tool returned a tool error.');
+      }
+      // A pending part can still contain streamed, incomplete arguments.
+      if (part.state.status === 'running' || part.state.status === 'completed') {
+        expect(browserTaskArgumentsSchema.parse(part.state.input)).toEqual(args);
+      }
+      if (part.state.status === 'completed') {
+        const { output } = part.state;
+        if (output === undefined) {
+          throw new Error('The completed browser_task has no output.');
+        }
+        const result = outputSchema.parse(JSON.parse(output));
+        await expect
+          .poll(
+            async () => {
+              const states = await parent.cli.request(
+                '/session/status',
+                z.record(z.string(), z.object({ type: z.string() }))
+              );
+              return states[parent.id]?.type ?? 'idle';
+            },
+            { intervals: [1000], timeout: 30_000 }
+          )
+          .toBe('idle');
+        return result;
+      }
+    }
+    await delay(1000);
+  }
+  throw new Error('The real browser_task exceeded its finite acceptance deadline.');
+};
+
+const controls = (panel: Page) => panel.getByRole('region', { name: 'CLI task supervision' });
+const approveTab = async (panel: Page, title = 'Browser acceptance A'): Promise<void> => {
+  await expect(
+    controls(panel).getByRole('button', { exact: true, name: 'Approve tab' })
+  ).toBeDisabled();
+  await controls(panel).getByLabel('Tab to approve').selectOption({ label: title });
+  await controls(panel).getByRole('button', { exact: true, name: 'Approve tab' }).click();
+};
+const enableProvider = async (panel: Page) => {
+  await selectModelById(panel, model);
+  await panel.getByLabel('Settings', { exact: true }).click();
+  const settings = panel.getByRole('region', { name: 'CLI task settings' });
+  const text = await settings.getByText(/Provider ID:/u).textContent();
+  const providerId = browserProviderIdSchema.parse(text?.match(/bp_[a-f0-9-]{36}/u)?.[0]);
+  await settings.getByLabel('Model', { exact: true }).click();
+  await panel
+    .getByRole('dialog', { name: 'Select model' })
+    .locator(`button[data-model-id="${model}"]`)
+    .click();
+  await settings.getByRole('button', { name: /Safe mode/u }).click();
+  await settings.getByRole('button', { exact: true, name: 'Dangerous' }).click();
+  await settings.getByRole('switch', { exact: true, name: 'CLI tasks' }).click();
+  await expect(settings.getByRole('switch', { exact: true, name: 'CLI tasks' })).toHaveAttribute(
+    'aria-checked',
+    'true'
+  );
+  await panel.getByLabel('Close settings').click();
+  await expect(controls(panel)).toContainText('Enabled — idle');
+  return providerId;
+};
+
+const withLive = async (
+  run: (live: {
+    a1: Parent;
+    a2: Parent;
+    b1: Parent;
+    panel: Page;
+    target: Page;
+    other: Page;
+    deliveries: Delivery[];
+    modelRequests: z.infer<typeof gatewayRequestSchema>[];
+    capture: (name: string) => Promise<void>;
+    evidence: Evidence;
+    proxy: (operation: string, target?: ProbeTarget) => Promise<z.infer<typeof proxyStatsSchema>>;
+    loseProvider: () => Promise<void>;
+    closeBrowser: () => Promise<void>;
+  }) => Promise<void>
+): Promise<void> => {
+  const scratch = required('SCRATCH');
+  const cliRoot = required('KILO_CLI_WORKTREE');
+  const email = required('LOCAL_USER_EMAIL');
+  const token = required('KILO_API_KEY');
+  await access(scratch);
+  await access(join(cliRoot, 'packages/opencode/src/index.ts'));
+  const statusText = execFileSync('pnpm', ['-s', 'dev:status', '--json'], {
+    cwd: cloudRoot,
+    encoding: 'utf8',
+  });
+  const status = statusSchema.parse(JSON.parse(statusText));
+  const service = (name: string) => {
+    const value = status.services.find(item => item.name === name && item.status === 'up');
+    if (value === undefined) {
+      throw new Error(`Prepare ${name} with KILO_PORT_OFFSET=auto before live acceptance.`);
+    }
+    return value;
+  };
+  const api = `http://localhost:${service('nextjs').port}`;
+  const relay = `http://localhost:${service('cloudflare-session-ingest').port}`;
+  // Reuse the repository resolver, but reject missing services instead of using its fallback ports.
+  const exports = execFileSync(
+    process.execPath,
+    [join(cloudRoot, 'apps/extension/scripts/resolve-e2e-ports.mjs')],
+    {
+      encoding: 'utf8',
+      env: {
+        PATH: process.env['PATH'],
+        VITE_CLOUD_AGENT_WS_URL: '',
+        VITE_KILO_API_BASE_URL: '',
+        VITE_SESSION_INGEST_WS_URL: '',
+      },
+      input: statusText,
+    }
+  );
+  const relayWs = exports.match(/VITE_SESSION_INGEST_WS_URL=(ws:\/\/localhost:[0-9]+)/u)?.[1];
+  if (relayWs !== relay.replace('http:', 'ws:')) {
+    throw new Error('The resolver and live service status disagree.');
+  }
+  const catalog = await readJson(new URL('/api/gateway/models', api), modelCatalogSchema, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!catalog.data.some(item => item.id === model)) {
+    throw new Error(
+      `Verification blocked: required model ${model} is unavailable. No model was substituted.`
+    );
+  }
+  const root = await mkdtemp(join(scratch, 'browser-task-live-'));
+  const evidence: Evidence = {
+    checks: [
+      'gateway catalog: Content-Type application/json',
+      'gateway catalog: parsed data[].id',
+      'dev:status: parsed running service names and ports',
+      'resolve-e2e-ports: relay origin matches status',
+    ],
+    clock: 'production deadlines',
+    model: `kilo/${model}`,
+    scenarios: [],
+    screenshots: [],
+  };
+  const clis: Cli[] = [];
+  const controlKey = randomBytes(24).toString('hex');
+  const proxyPort = freePort();
+  const targetPort = freePort();
+  const proxyProcess = spawn('bun', ['--no-env-file', '--eval', faultProxySource], {
+    cwd: root,
+    env: {
+      CONTROL_KEY: controlKey,
+      PATH: process.env['PATH'],
+      PORT: String(proxyPort),
+      RELAY: relay,
+    },
+    stdio: 'ignore',
+  });
+  const proxy = (operation: string, target?: ProbeTarget) =>
+    readJson(new URL(`http://127.0.0.1:${proxyPort}/control`), proxyStatsSchema, {
+      body: JSON.stringify({ operation, ...target }),
+      headers: { 'content-type': 'application/json', 'x-kilo-e2e-control': controlKey },
+      method: 'POST',
+    });
+  const targetServer = createServer((request, response) => {
+    const label = request.url === '/b' ? 'B' : 'A';
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    response.end(
+      `<!doctype html><title>Browser acceptance ${label}</title><h1>Browser acceptance ${label}</h1><p>Observed evidence ${label} only.</p><button id="effect" onclick="document.querySelector('#count').textContent = String(Number(document.querySelector('#count').textContent) + 1)">Apply once</button><output id="count">0</output>`
+    );
+  });
+  let launched: Awaited<ReturnType<typeof launchExtensionContext>> | undefined;
+  let browserClosed = false;
+  try {
+    await once(proxyProcess, 'spawn');
+    await expect
+      .poll(
+        async () => {
+          try {
+            return await proxy('stats');
+          } catch {
+            return null;
+          }
+        },
+        { timeout: 15_000 }
+      )
+      .toMatchObject({ invocations: 0 });
+    targetServer.listen(targetPort, '127.0.0.1');
+    await once(targetServer, 'listening');
+    for (const label of ['A', 'B']) {
+      clis.push(
+        await startCli({
+          api,
+          cliRoot,
+          relay: label === 'A' ? `http://127.0.0.1:${proxyPort}` : relay,
+          root: join(root, `cli-${label}`),
+          token,
+        })
+      );
+    }
+    const [cliA, cliB] = clis;
+    if (cliA === undefined || cliB === undefined) {
+      throw new Error('Both source CLI processes are required.');
+    }
+    const a1 = { cli: cliA, ...(await cliA.createParent('Browser acceptance parent A1')) };
+    const a2 = { cli: cliA, ...(await cliA.createParent('Browser acceptance parent A2')) };
+    const b1 = { cli: cliB, ...(await cliB.createParent('Browser acceptance parent B1')) };
+    launched = await launchExtensionContext();
+    const { context, extensionId } = launched;
+    const deliveries: Delivery[] = [];
+    const modelRequests: z.infer<typeof gatewayRequestSchema>[] = [];
+    const providerSockets: WebSocketRoute[] = [];
+    await context.route('https://app.kilo.ai/**', route => route.abort());
+    await context.routeWebSocket(`${relayWs}/api/user/web**`, route => {
+      const server = route.connectToServer();
+      providerSockets.push(server);
+      server.onMessage(raw => {
+        const parsed = browserProviderInboundMessageSchema.safeParse(JSON.parse(String(raw)));
+        if (parsed.success && parsed.data.type === 'provider_job') {
+          deliveries.push(parsed.data);
+        }
+        route.send(raw);
+      });
+    });
+    context.on('request', request => {
+      if (request.url() === `${api}/api/gateway/v1/chat/completions`) {
+        modelRequests.push(gatewayRequestSchema.parse(request.postDataJSON()));
+      }
+    });
+    const target = await context.newPage();
+    const other = await context.newPage();
+    for (const [page, path, label] of [
+      [target, '/a', 'A'],
+      [other, '/b', 'B'],
+    ] as const) {
+      const navigation = await page.goto(`http://127.0.0.1:${targetPort}${path}`);
+      expect(navigation?.headers()['content-type']).toContain('text/html');
+      await expect(page.locator('h1')).toHaveText(`Browser acceptance ${label}`);
+    }
+    evidence.checks.push(
+      'target pages: Content-Type text/html',
+      'target pages: required heading and deterministic controls'
+    );
+    const panel = await context.newPage();
+    await panel.setViewportSize({ height: 720, width: 320 });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl: api,
+      localUserEmail: email,
+      sidePanel: panel,
+    });
+    const capture = async (name: string): Promise<void> => {
+      const path = join(root, `${name}.png`);
+      await panel.screenshot({ path });
+      evidence.screenshots.push(path);
+      await test.info().attach(name, { contentType: 'image/png', path });
+    };
+    await run({
+      a1,
+      a2,
+      b1,
+      capture,
+      closeBrowser: async () => {
+        await context.close();
+        browserClosed = true;
+      },
+      deliveries,
+      evidence,
+      loseProvider: async () => {
+        for (const socket of providerSockets) {
+          await socket.close({ code: 1011, reason: 'Acceptance connection loss' });
+        }
+      },
+      modelRequests,
+      other,
+      panel,
+      proxy,
+      target,
+    });
+    evidence.checks.push(
+      'CLI JSON responses: Content-Type checked before parsing',
+      'CLI JSON responses: endpoint schemas validated',
+      'provider deliveries: shared wire schema validated'
+    );
+  } finally {
+    await Promise.all(clis.map(cli => cli.stop()));
+    await stopChild(proxyProcess);
+    if (launched !== undefined) {
+      if (!browserClosed) {
+        await launched.context.close();
+      }
+      await rm(launched.userDataDir, { force: true, recursive: true });
+    }
+    targetServer.closeAllConnections();
+    if (targetServer.listening) {
+      const closed = once(targetServer, 'close');
+      targetServer.close();
+      await closed;
+    }
+    await Promise.all(
+      ['A', 'B'].map(label => rm(join(root, `cli-${label}`), { force: true, recursive: true }))
+    );
+    const path = join(root, 'evidence.json');
+    await writeFile(path, JSON.stringify(evidence, null, 2));
+    await test
+      .info()
+      .attach('sanitized browser acceptance', { contentType: 'application/json', path });
+  }
+};
+
+const heldGoal =
+  'Use get_page_snapshot to read the approved page. Then call save_memory with text "Live browser acceptance A1" and wait for its approval. After approval, use eval to click #effect exactly once. Read #count and report the title, observed text, and count.';
+const approveMemory = async (panel: Page): Promise<void> => {
+  const dialog = panel.getByRole('dialog', { name: 'Add to memory' });
+  await dialog.getByRole('button', { name: 'Save memory' }).click();
+  await expect(dialog).toContainText('Saved to memory');
+  await dialog.getByRole('button', { exact: true, name: 'Done' }).click();
+};
+
+test('real CLI parents route queued results and continue only their owned browser history', async () => {
+  await withLive(async live => {
+    const { a1, a2, b1, panel, target, other, deliveries, evidence } = live;
+    const empty = await callTool(a1, { operation: 'list' });
+    expect(empty.status).toBe('empty');
+    expect(empty.providers).toEqual([]);
+    await live.capture('disabled-empty-discovery');
+    const provider = await enableProvider(panel);
+    const discovery = await callTool(a1, { operation: 'list' });
+    expect(discovery.providers).toContainEqual(
+      expect.objectContaining({ availability: 'available', providerId: provider })
+    );
+    const resultA = callTool(
+      a1,
+      { goal: heldGoal, operation: 'run', provider_id: provider },
+      'PARENT_ONLY_A1_CANARY'
+    );
+    await expect(controls(panel)).toContainText(a1.id, { timeout: 90_000 });
+    await approveTab(panel);
+    await expect(panel.getByRole('dialog', { name: 'Add to memory' })).toBeVisible({
+      timeout: 90_000,
+    });
+    // Change the active tab after approval, while the real runner waits for memory consent.
+    await other.bringToFront();
+    await panel.bringToFront();
+    const resultB = callTool(
+      b1,
+      {
+        goal: 'BROWSER_HISTORY_B1_CANARY. Use only get_page_snapshot to read this approved page. Report its title and observed evidence. Do not change it.',
+        operation: 'run',
+        provider_id: provider,
+      },
+      'PARENT_ONLY_B1_CANARY'
+    );
+    await expect(
+      panel
+        .getByRole('dialog', { name: 'Add to memory' })
+        .getByRole('list', { name: 'Queued CLI tasks' })
+    ).toContainText(b1.id, { timeout: 90_000 });
+    await live.capture('running-A1-queued-B1-memory-approval');
+    await live.proxy('repeat');
+    await approveMemory(panel);
+    const outputA = await resultA;
+    expect(outputA.status).toBe('succeeded');
+    expect(outputA.effectsUncertain).toBe(false);
+    expect(outputA.summary.length).toBeGreaterThan(15);
+    await expect(target.locator('#count')).toHaveText('1');
+    const taskA = browserTaskIdSchema.parse(outputA.browser_task_id);
+    const originalJob = browserJobIdSchema.parse(outputA.job_id);
+    await expect(controls(panel)).toContainText(b1.id, { timeout: 30_000 });
+    await approveTab(panel, 'Browser acceptance B');
+    const outputB = await resultB;
+    const taskB = browserTaskIdSchema.parse(outputB.browser_task_id);
+    expect(outputB.status).toBe('succeeded');
+    expect(taskB).not.toBe(taskA);
+    expect(outputA.evidence.some(item => item.url === target.url())).toBe(true);
+    expect(outputB.evidence.some(item => item.url === other.url())).toBe(true);
+    await expect(other.locator('#count')).toHaveText('0');
+    const resultA2 = callTool(
+      a2,
+      {
+        goal: 'BROWSER_HISTORY_A2_CANARY. Use only get_page_snapshot to read this page. Do not save a memory or change the page.',
+        operation: 'run',
+        provider_id: provider,
+      },
+      'PARENT_ONLY_A2_CANARY'
+    );
+    await expect(controls(panel)).toContainText(a2.id, { timeout: 90_000 });
+    await approveTab(panel, 'Browser acceptance B');
+    const outputA2 = await resultA2;
+    expect(outputA2.status).toBe('succeeded');
+    const taskA2 = browserTaskIdSchema.parse(outputA2.browser_task_id);
+    expect([taskA, taskB]).not.toContain(taskA2);
+    expect(deliveries.find(delivery => delivery.job.browserTaskId === taskA)?.ownerLabel).toBe(
+      a1.id
+    );
+    expect(deliveries.find(delivery => delivery.job.browserTaskId === taskA2)?.ownerLabel).toBe(
+      a2.id
+    );
+    const requestsBefore = live.modelRequests.length;
+    const continuation = callTool(a1, {
+      browser_task_id: taskA,
+      goal: 'Read the current count and report it as "Current count: <value>". Quote the prior observed page text from this browser conversation. Do not click again.',
+      operation: 'run',
+      provider_id: provider,
+    });
+    await expect(controls(panel)).toContainText('Tab approval required', { timeout: 90_000 });
+    expect(live.modelRequests).toHaveLength(requestsBefore);
+    await approveTab(panel);
+    const continued = await continuation;
+    expect(continued.status).toBe('succeeded');
+    expect(continued.effectsUncertain).toBe(false);
+    expect(continued.summary).toContain('Current count: 1');
+    expect(continued.summary).toContain('Observed evidence A only.');
+    expect(continued.browser_task_id).toBe(taskA);
+    expect(continued.job_id).not.toBe(originalJob);
+    const continuationRequests = live.modelRequests.slice(requestsBefore);
+    const userTurn = z.object({ content: z.string(), role: z.literal('user') });
+    expect(
+      continuationRequests.some(request =>
+        request.messages.some(message => {
+          const parsed = userTurn.safeParse(message);
+          return parsed.success && parsed.data.content.includes(heldGoal);
+        })
+      )
+    ).toBe(true);
+    const requestText = JSON.stringify(continuationRequests);
+    // Boolean assertions cannot dump real request bodies into a failing test's report.
+    for (const marker of [
+      'PARENT_ONLY_A1_CANARY',
+      'PARENT_ONLY_A2_CANARY',
+      'PARENT_ONLY_B1_CANARY',
+      'BROWSER_HISTORY_A2_CANARY',
+      'BROWSER_HISTORY_B1_CANARY',
+      'Observed evidence B only.',
+    ]) {
+      expect(requestText.includes(marker)).toBe(false);
+    }
+    expect(live.modelRequests.every(request => request.model === model)).toBe(true);
+    const countBeforeForeign = deliveries.length;
+    for (const args of [
+      { browser_task_id: taskA, operation: 'status' },
+      { browser_task_id: taskA, operation: 'cancel' },
+      { browser_task_id: taskA, goal: 'Read the count.', operation: 'run', provider_id: provider },
+    ] satisfies BrowserTaskArguments[]) {
+      const rejected = await callTool(a2, args);
+      expect(rejected.status).toBe('rejected');
+      expect(rejected.reason).toMatch(/^(?:owner_mismatch|not_found)$/u);
+    }
+    // Use A2's actual captured proof on its authenticated CLI socket. A random invalid proof
+    // Would test authentication only, not isolation between two valid parents in one process.
+    for (const operation of ['status', 'cancel', 'invoke']) {
+      const denial = await live.proxy(`probe-${operation}`, {
+        parent: a2.id,
+        provider,
+        task: taskA,
+      });
+      expect(denial.probe).toMatchObject({
+        code: expect.stringMatching(/^(?:owner_mismatch|not_found)$/u),
+        kind: 'error',
+      });
+    }
+    expect(deliveries).toHaveLength(countBeforeForeign);
+    await expect(target.locator('#count')).toHaveText('1');
+    const original = await callTool(a1, {
+      browser_task_id: taskA,
+      job_id: originalJob,
+      operation: 'status',
+    });
+    expect(original).toEqual(outputA);
+    const beforeRestart = await callTool(a1, { browser_task_id: taskA, operation: 'status' });
+    await a1.cli.restart();
+    const afterRestart = await callTool(a1, { browser_task_id: taskA, operation: 'status' });
+    expect(afterRestart).toEqual(beforeRestart);
+    await panel.reload();
+    await expect(controls(panel)).toContainText('Enabled — idle', { timeout: 30_000 });
+    await expect(panel.getByRole('button', { exact: true, name: 'Approve tab' })).toHaveCount(0);
+    await expect(target.locator('#count')).toHaveText('1');
+    evidence.scenarios.push(
+      `A1 ${taskA}: ${outputA.status}/${outputA.reason}; effects=1; evidence=${outputA.evidence.length}`,
+      `B1 ${taskB}: ${outputB.status}/${outputB.reason}; effects=0`,
+      `A2 ${taskA2}: ${outputA2.status}/${outputA2.reason}; effects=0`,
+      'empty discovery',
+      'two real CLI processes',
+      'distinct owned conversations in process A',
+      'named provider',
+      'FIFO queue',
+      'useful owned results',
+      'duplicate invocation without replay',
+      'fresh continuation consent',
+      'isolated browser history',
+      'foreign tool and relay denial',
+      'real process restart',
+      'immutable original and latest results',
+      'reload without execution'
+    );
+    await live.capture('completed-owned-results');
+  });
+});
+
+for (const loss of ['before acceptance', 'entire acceptance response'] as const) {
+  test(`real process restart recovers after loss of ${loss} without a fresh invocation`, async () => {
+    await withLive(async live => {
+      const provider = await enableProvider(live.panel);
+      await live.proxy(loss === 'before acceptance' ? 'drop-before' : 'drop-acceptance');
+      const outstanding = callTool(live.a1, {
+        goal: heldGoal,
+        operation: 'run',
+        provider_id: provider,
+      }).then(
+        value => ({ value }),
+        () => ({ value: undefined })
+      );
+      await expect
+        .poll(
+          async () => {
+            const stats = await live.proxy('stats');
+            return stats.invocations;
+          },
+          { intervals: [1000], timeout: 90_000 }
+        )
+        .toBeGreaterThan(0);
+      if (loss === 'entire acceptance response') {
+        await expect(controls(live.panel)).toContainText('Tab approval required', {
+          timeout: 30_000,
+        });
+        await expect
+          .poll(async () => {
+            const stats = await live.proxy('stats');
+            return stats.droppedReplies;
+          })
+          .toBeGreaterThan(0);
+      }
+      const [accepted] = live.deliveries;
+      const beforeCrash = await live.proxy('stats');
+      await live.a1.cli.stop('SIGKILL');
+      const lost = await outstanding;
+      expect(lost.value?.browser_task_id).toBeUndefined();
+      await live.proxy('restore');
+      await live.a1.cli.restart();
+      const recovered = await callTool(live.a1, { operation: 'recover' });
+      if (loss === 'entire acceptance response') {
+        if (accepted === undefined) {
+          throw new Error('No real accepted dispatch was observed.');
+        }
+        const original = recovered.jobs?.find(job => job.job_id === accepted.job.jobId);
+        expect(original).toMatchObject({
+          browser_task_id: accepted.job.browserTaskId,
+          invocation_id: accepted.job.invocationId,
+          job_id: accepted.job.jobId,
+        });
+        if (original?.status === 'awaiting_approval') {
+          await expect(controls(live.panel)).toContainText('Tab approval required');
+          await approveTab(live.panel);
+          await expect(live.panel.getByRole('dialog', { name: 'Add to memory' })).toBeVisible({
+            timeout: 90_000,
+          });
+          await approveMemory(live.panel);
+          await expect(live.target.locator('#count')).toHaveText('1', { timeout: 90_000 });
+          await expect(controls(live.panel)).toContainText('Last outcome: succeeded', {
+            timeout: 90_000,
+          });
+          const status = await callTool(live.a1, {
+            browser_task_id: accepted.job.browserTaskId,
+            operation: 'status',
+          });
+          expect(status.status).toBe('succeeded');
+          expect(status.job_id).toBe(accepted.job.jobId);
+        } else {
+          // A slow real restart can consume the production approval deadline. Recovery must
+          // Still return the original terminal record, never create another invocation.
+          expect(original?.status).toBe('timed_out');
+          expect(original?.reason).toBe('approval_timeout');
+          await expect(live.target.locator('#count')).toHaveText('0');
+        }
+        expect(live.deliveries).toHaveLength(1);
+      } else {
+        expect(recovered.jobs?.some(job => job.status === 'not_found')).toBe(true);
+        expect(live.deliveries).toHaveLength(0);
+        await expect(live.target.locator('#count')).toHaveText('0');
+      }
+      const afterRecovery = await live.proxy('stats');
+      expect(afterRecovery.invocations).toBe(beforeCrash.invocations);
+      live.evidence.scenarios.push(
+        `restart after ${loss}: ${recovered.status}/${recovered.reason}`,
+        'durable outgoing intent',
+        'lookup-only recovery',
+        'original handles or authoritative not-found',
+        'no automatic replay'
+      );
+      await live.capture('recovered-original-intent');
+    });
+  });
+}
+
+for (const loss of ['after dispatch', 'before completion'] as const) {
+  test(`real connection loss ${loss} recovers the existing result with one browser side effect`, async () => {
+    await withLive(async live => {
+      const provider = await enableProvider(live.panel);
+      const running = callTool(live.a1, {
+        goal: heldGoal,
+        operation: 'run',
+        provider_id: provider,
+      });
+      await expect(controls(live.panel)).toContainText('Tab approval required', {
+        timeout: 90_000,
+      });
+      await approveTab(live.panel);
+      await expect(live.panel.getByRole('dialog', { name: 'Add to memory' })).toBeVisible({
+        timeout: 90_000,
+      });
+      const [accepted] = live.deliveries;
+      if (accepted === undefined) {
+        throw new Error('The real relay did not dispatch the CLI invocation.');
+      }
+      await live.proxy('repeat');
+      await live.proxy(loss === 'after dispatch' ? 'disconnect' : 'drop-acceptance');
+      await approveMemory(live.panel);
+      await expect(live.target.locator('#count')).toHaveText('1', { timeout: 90_000 });
+      await expect(controls(live.panel)).toContainText('Last outcome: succeeded', {
+        timeout: 90_000,
+      });
+      if (loss === 'before completion') {
+        const stats = await live.proxy('stats');
+        expect(stats.droppedReplies).toBeGreaterThan(0);
+        await live.proxy('disconnect');
+        await live.proxy('restore');
+      }
+      const delivered = await running;
+      if (delivered.status !== 'succeeded') {
+        expect(delivered.reason).toBe('delivery_interrupted');
+      }
+      const status = await callTool(live.a1, {
+        browser_task_id: accepted.job.browserTaskId,
+        operation: 'status',
+      });
+      expect(status).toMatchObject({
+        browser_task_id: accepted.job.browserTaskId,
+        invocation_id: accepted.job.invocationId,
+        job_id: accepted.job.jobId,
+        reason: 'completed',
+        status: 'succeeded',
+      });
+      expect(live.deliveries).toHaveLength(1);
+      await expect(live.target.locator('#count')).toHaveText('1');
+      live.evidence.scenarios.push(
+        `${loss}: ${status.browser_task_id}; ${status.status}/${status.reason}; effects=1`,
+        'same invocation across reconnection'
+      );
+      await live.capture(`${loss.replaceAll(' ', '-')}-recovered`);
+    });
+  });
+}
+
+for (const [failure, reasons] of [
+  ['Stop', ['cancelled']],
+  ['tab loss', ['tab_lost']],
+  ['provider socket loss', ['provider_lost', 'lease_expired', 'provider_unavailable']],
+  ['panel close', ['provider_lost', 'lease_expired', 'provider_unavailable']],
+  ['panel reload', ['provider_lost', 'lease_expired', 'provider_unavailable']],
+  ['disablement', ['provider_unavailable']],
+  ['extension shutdown', ['provider_lost', 'lease_expired', 'provider_unavailable']],
+  ['execution timeout', ['execution_timeout']],
+] as const) {
+  test(`real delegated ${failure} settles active and queued parents with finite outcomes`, async () => {
+    await withLive(async live => {
+      const provider = await enableProvider(live.panel);
+      const active = callTool(live.a1, { goal: heldGoal, operation: 'run', provider_id: provider });
+      await expect(controls(live.panel)).toContainText('Tab approval required', {
+        timeout: 90_000,
+      });
+      await approveTab(live.panel);
+      const card = live.panel.getByRole('dialog', { name: 'Add to memory' });
+      await expect(card).toBeVisible({ timeout: 90_000 });
+      const beforeCount = await live.target.locator('#count').textContent();
+      const queued = callTool(live.b1, {
+        goal: 'Read the page only after new tab approval.',
+        operation: 'run',
+        provider_id: provider,
+      });
+      await expect(card.getByRole('list', { name: 'Queued CLI tasks' })).toContainText(live.b1.id, {
+        timeout: 90_000,
+      });
+      await live.capture(`${failure.replaceAll(' ', '-')}-before`);
+      if (failure === 'Stop') {
+        await card.getByRole('button', { name: 'Stop CLI task' }).click();
+      }
+      if (failure === 'tab loss') {
+        await live.target.close();
+      }
+      if (failure === 'provider socket loss') {
+        await live.loseProvider();
+      }
+      if (failure === 'panel close') {
+        await live.panel.close();
+      }
+      if (failure === 'panel reload') {
+        await live.panel.reload();
+      }
+      if (failure === 'extension shutdown') {
+        await live.closeBrowser();
+      }
+      if (failure === 'disablement') {
+        // Hold the next real request, rather than racing the runner after dismissing its card.
+        const gate = Promise.withResolvers<void>();
+        await live.panel.context().route('**/api/gateway/v1/chat/completions', async route => {
+          await gate.promise;
+          await route.continue();
+        });
+        try {
+          await card.getByRole('button', { exact: true, name: 'Cancel' }).click();
+          await live.panel.getByLabel('Settings', { exact: true }).click();
+          const settings = live.panel.getByRole('dialog', { name: 'Settings panel' });
+          await settings.getByRole('switch', { exact: true, name: 'CLI tasks' }).click();
+          await expect(
+            settings.getByRole('group', { name: 'Confirm CLI task disablement' })
+          ).toContainText('Issued actions are not undone');
+          await settings.getByRole('button', { name: 'Disable CLI tasks' }).click();
+          await expect(
+            settings.getByRole('region', { name: 'CLI task supervision' })
+          ).toContainText('CLI tasks: Disabled');
+        } finally {
+          gate.resolve();
+        }
+      }
+      // The timeout case keeps memory consent open for the production ten-minute deadline.
+      // No fake clock, shortened deadline, or substitute model enters this live path.
+      const [result, queuedResult] = await Promise.all([active, queued]);
+      expect(terminal.has(result.status)).toBe(true);
+      expect(result.status).not.toBe('succeeded');
+      expect(reasons).toContain(result.reason);
+      expect(terminal.has(queuedResult.status)).toBe(true);
+      expect(queuedResult.reason).toBe('provider_unavailable');
+      const task = browserTaskIdSchema.parse(result.browser_task_id);
+      const stored = await callTool(live.a1, { browser_task_id: task, operation: 'status' });
+      expect(stored).toEqual(result);
+      if (failure !== 'tab loss' && failure !== 'extension shutdown') {
+        await expect(live.target.locator('#count')).toHaveText(beforeCount ?? '0');
+      }
+      if (failure !== 'extension shutdown') {
+        await expect(live.other.locator('#count')).toHaveText('0');
+      }
+      if (failure === 'panel reload') {
+        await expect(
+          live.panel.getByRole('button', { exact: true, name: 'Approve tab' })
+        ).toHaveCount(0);
+        expect(
+          live.deliveries.filter(delivery => delivery.job.browserTaskId === task)
+        ).toHaveLength(1);
+        await live.capture('reloaded-without-execution');
+      }
+      live.evidence.scenarios.push(
+        `${failure}: ${task}; ${result.status}/${result.reason}`,
+        `queued: ${queuedResult.status}/${queuedResult.reason}`,
+        'finite outcomes',
+        'immutable persisted terminal result',
+        'no subsequent browser action'
+      );
+    });
+  });
+}

--- a/apps/extension/tests/e2e/browser-task-live.test.ts
+++ b/apps/extension/tests/e2e/browser-task-live.test.ts
@@ -22,7 +22,8 @@ import type {
   BrowserProviderInboundMessage,
   BrowserTaskArguments,
 } from '@kilocode/cloud-agent-sdk/schemas';
-import { launchExtensionContext } from './extension-context-fixture';
+import { conversationEventsSchema } from '../../entrypoints/sidepanel/agent-conversation-schemas';
+import { launchExtensionContext, readExtensionLocalStorage } from './extension-context-fixture';
 import { signInWithLocalDeviceAuth } from './local-device-auth-helpers';
 import { selectModelById } from './model-picker-e2e-helpers';
 
@@ -89,6 +90,23 @@ const outputSchema = z.object({
   providers: z.array(browserProviderDescriptorSchema).optional(),
 });
 const gatewayRequestSchema = z.object({ messages: z.array(z.unknown()), model: z.string() });
+const replayMessageSchema = z.object({
+  content: z.unknown().optional(),
+  role: z.enum(['system', 'user', 'assistant', 'tool']),
+  tool_call_id: z.string().optional(),
+  tool_calls: z.array(z.object({ id: z.string() })).optional(),
+});
+const toolProjectionSchema = z.object({
+  effectsUncertain: z.boolean().optional(),
+  error: z.string().optional(),
+  ok: z.boolean(),
+  value: z.unknown().optional(),
+});
+const browserHistorySchema = z.object({
+  histories: z.array(
+    z.object({ browserTaskId: browserTaskIdSchema, events: conversationEventsSchema })
+  ),
+});
 const modelCatalogSchema = z.object({ data: z.array(z.object({ id: z.string() })) });
 const proxyStatsSchema = z.object({
   droppedReplies: z.number(),
@@ -899,6 +917,232 @@ test('real CLI parents route queued results and continue only their owned browse
   });
 });
 
+test('real CLI continuation pairs an interrupted multi-call batch without replay', async () => {
+  await withLive(async live => {
+    const { a1, panel, target, other } = live;
+    const provider = await enableProvider(panel);
+    const memoriesBefore = await readExtensionLocalStorage(panel, 'kiloAgentMemories');
+    const interruptedGoal = `Return one batch of exactly three tool calls in this order: ${JSON.stringify(
+      [
+        { arguments: {}, name: 'get_page_snapshot' },
+        { arguments: { text: 'Interrupted batch memory' }, name: 'save_memory' },
+        {
+          arguments: {
+            code: 'document.querySelector("#effect").click(); return document.querySelector("#count").textContent;',
+          },
+          name: 'eval',
+        },
+      ]
+    )}. Put all three calls in the same assistant response, not separate responses. The memory call waits for user approval before the page action can run.`;
+    const running = callTool(a1, {
+      goal: interruptedGoal,
+      operation: 'run',
+      provider_id: provider,
+    });
+    await expect(controls(panel)).toContainText('Tab approval required', { timeout: 90_000 });
+    await approveTab(panel);
+    const card = panel.getByRole('dialog', { name: 'Add to memory' });
+    await expect(card).toBeVisible({ timeout: 90_000 });
+    await expect(target.locator('#count')).toHaveText('0');
+    await live.capture('interrupted-batch-before-stop');
+    await card.getByRole('button', { name: 'Stop CLI task' }).click();
+    const stopped = await running;
+    expect(stopped.status).toBe('cancelled');
+    expect(stopped.reason).toBe('cancelled');
+    expect(stopped.effectsUncertain).toBe(true);
+    const task = browserTaskIdSchema.parse(stopped.browser_task_id);
+    const originalJob = browserJobIdSchema.parse(stopped.job_id);
+    const readHistory = async () => {
+      const parsed = browserHistorySchema.safeParse(
+        await readExtensionLocalStorage(panel, 'kiloBrowserTasks')
+      );
+      if (!parsed.success) {
+        throw new Error('The persisted browser history has an invalid structure.');
+      }
+      return parsed.data.histories.find(history => history.browserTaskId === task)?.events;
+    };
+    await expect
+      .poll(async () => {
+        const storedHistory = await readHistory();
+        return storedHistory?.some(event => event.type === 'tool-call') === true;
+      })
+      .toBe(true);
+    const history = await readHistory();
+    if (history === undefined) {
+      throw new Error('The interrupted browser history is missing.');
+    }
+    const batchStart = history.findIndex(event => event.type === 'tool-call');
+    const batch = history
+      .slice(batchStart, batchStart + 3)
+      .filter(event => event.type === 'tool-call');
+    expect(batch.map(call => call.name)).toEqual(['get_page_snapshot', 'save_memory', 'eval']);
+    const [snapshotCall, memoryCall, skippedCall] = batch;
+    if (snapshotCall === undefined || memoryCall === undefined || skippedCall === undefined) {
+      throw new Error('The required model did not produce the requested multi-call batch.');
+    }
+    const confirmed = history.find(
+      event => event.type === 'tool-result' && event.toolCallId === snapshotCall.id
+    );
+    if (confirmed?.type !== 'tool-result' || !confirmed.ok) {
+      throw new Error('The interrupted batch has no confirmed snapshot result.');
+    }
+    expect(JSON.stringify(confirmed.value).includes('Observed evidence A only.')).toBe(true);
+    for (const call of [memoryCall, skippedCall]) {
+      expect(
+        history.some(event => event.type === 'tool-result' && event.toolCallId === call.id)
+      ).toBe(false);
+    }
+    await expect(card).toBeHidden();
+    await expect(target.locator('#count')).toHaveText('0');
+    const requestsAfterStop = live.modelRequests.length;
+    await expect(controls(panel)).toContainText('Recovery required');
+    await expect
+      .poll(() =>
+        panel.evaluate(async () => {
+          const locks = await navigator.locks.query();
+          return (locks.held ?? []).filter(lock => lock.name === 'kilo:browser-execution').length;
+        })
+      )
+      .toBe(0);
+    await controls(panel).getByRole('button', { name: 'Check recovery readiness' }).click();
+    await expect(panel.getByRole('button', { name: 'Recover browser control' })).toHaveCount(0);
+    await target.close();
+    await controls(panel).getByRole('button', { name: 'Check recovery readiness' }).click();
+    await panel.getByRole('button', { name: 'Recover browser control' }).click();
+    await expect(controls(panel)).toContainText('Enabled — idle', { timeout: 30_000 });
+    expect(live.modelRequests).toHaveLength(requestsAfterStop);
+
+    const responses: { contentType: string | undefined; status: number }[] = [];
+    panel.context().on('response', response => {
+      if (response.url().endsWith('/api/gateway/v1/chat/completions')) {
+        responses.push({
+          contentType: response.headers()['content-type'],
+          status: response.status(),
+        });
+      }
+    });
+    const continuation = callTool(a1, {
+      browser_task_id: task,
+      goal: 'Use only get_page_snapshot to read the newly approved page. Report its observed text and "Current count: <value>". Quote the prior confirmed page text from this browser history. Do not repeat the skipped memory save or eval action; no click or memory save is authorized.',
+      operation: 'run',
+      provider_id: provider,
+    });
+    await expect(controls(panel)).toContainText('Tab approval required', { timeout: 90_000 });
+    expect(live.modelRequests).toHaveLength(requestsAfterStop);
+    await expect(other.locator('#count')).toHaveText('0');
+    await live.capture('interrupted-batch-fresh-consent');
+    await approveTab(panel, 'Browser acceptance B');
+    const continued = await continuation;
+    expect(continued.status).toBe('succeeded');
+    expect(continued.reason).toBe('completed');
+    expect(continued.effectsUncertain).toBe(false);
+    expect(continued.browser_task_id).toBe(task);
+    expect(continued.job_id).not.toBe(originalJob);
+    expect(continued.summary).toContain('Current count: 0');
+    expect(continued.summary).toContain('Observed evidence A only.');
+    expect(continued.summary).toContain('Observed evidence B only.');
+    expect(continued.evidence.some(item => item.url === other.url())).toBe(true);
+    await expect(other.locator('#count')).toHaveText('0');
+    expect(
+      JSON.stringify(await readExtensionLocalStorage(panel, 'kiloAgentMemories')) ===
+        JSON.stringify(memoriesBefore)
+    ).toBe(true);
+    expect(responses.length).toBeGreaterThan(0);
+    expect(responses.every(response => response.status === 200)).toBe(true);
+    expect(
+      responses.every(response => response.contentType?.includes('text/event-stream') === true)
+    ).toBe(true);
+
+    const continuationRequests = live.modelRequests.slice(requestsAfterStop);
+    expect(continuationRequests.length).toBeGreaterThan(0);
+    const batchIds = batch.map(call => call.providerToolCallId ?? call.id);
+    for (const request of continuationRequests) {
+      expect(request.model).toBe(model);
+      const parsed = z.array(replayMessageSchema).safeParse(request.messages);
+      if (!parsed.success) {
+        throw new Error('The continuation gateway messages have an invalid structure.');
+      }
+      const { data: messages } = parsed;
+      const pending = new Set<string>();
+      for (const message of messages) {
+        if (message.role === 'tool') {
+          expect(message.tool_calls).toBeUndefined();
+          expect(message.tool_call_id !== undefined && pending.delete(message.tool_call_id)).toBe(
+            true
+          );
+        } else {
+          expect(pending.size).toBe(0);
+          expect(message.tool_call_id).toBeUndefined();
+          for (const call of message.tool_calls ?? []) {
+            expect(message.role).toBe('assistant');
+            expect(pending.has(call.id)).toBe(false);
+            pending.add(call.id);
+          }
+        }
+      }
+      expect(pending.size).toBe(0);
+      const replayedBatch = messages.find(
+        message => message.tool_calls?.some(call => call.id === batchIds[0]) === true
+      );
+      expect(replayedBatch?.tool_calls?.map(call => call.id)).toEqual(batchIds);
+      for (const [index, id] of batchIds.entries()) {
+        const reply = messages.find(
+          message => message.role === 'tool' && message.tool_call_id === id
+        );
+        let projection: z.infer<typeof toolProjectionSchema>;
+        try {
+          projection = toolProjectionSchema.parse(JSON.parse(z.string().parse(reply?.content)));
+        } catch {
+          throw new Error('The continuation contains an invalid tool result projection.');
+        }
+        if (index === 0) {
+          expect(projection.ok).toBe(true);
+          expect(projection.effectsUncertain === true).toBe(false);
+          expect(JSON.stringify(projection.value) === JSON.stringify(confirmed.value)).toBe(true);
+        } else {
+          expect(projection.ok).toBe(false);
+          expect(projection.effectsUncertain).toBe(true);
+          expect(projection.value).toBeUndefined();
+          expect(projection.error?.includes('No result was recorded')).toBe(true);
+          expect(projection.error?.includes('Execution and effects are unknown')).toBe(true);
+          expect(projection.error?.includes('Do not automatically retry')).toBe(true);
+        }
+      }
+    }
+    const continuedHistory = await readHistory();
+    expect(
+      JSON.stringify(continuedHistory?.slice(0, history.length)) === JSON.stringify(history)
+    ).toBe(true);
+    for (const call of [memoryCall, skippedCall]) {
+      expect(
+        continuedHistory?.some(
+          event => event.type === 'tool-result' && event.toolCallId === call.id
+        )
+      ).toBe(false);
+    }
+    const original = await callTool(a1, {
+      browser_task_id: task,
+      job_id: originalJob,
+      operation: 'status',
+    });
+    expect(original).toEqual(stopped);
+    live.evidence.checks.push(
+      'continuation responses: HTTP 200 and Content-Type text/event-stream',
+      'continuation requests: parsed roles, unique call IDs, exactly paired results',
+      'confirmed snapshot retained; missing results stay uncertain and never enter stored history'
+    );
+    live.evidence.scenarios.push(
+      `interrupted multi-call continuation: ${stopped.status}/${stopped.reason} -> ${continued.status}/${continued.reason}`,
+      'fresh consent after explicit recovery',
+      'required real model accepts paired history',
+      'useful prior and current observations',
+      'skipped eval and memory save not replayed; effects=0',
+      'immutable original cancellation'
+    );
+    await live.capture('interrupted-batch-useful-continuation');
+  });
+});
+
 for (const loss of ['before acceptance', 'entire acceptance response'] as const) {
   test(`real process restart recovers after loss of ${loss} without a fresh invocation`, async () => {
     await withLive(async live => {
@@ -1066,7 +1310,11 @@ for (const [failure, reasons] of [
   test(`real delegated ${failure} settles active and queued parents with finite outcomes`, async () => {
     await withLive(async live => {
       const provider = await enableProvider(live.panel);
-      const active = callTool(live.a1, { goal: heldGoal, operation: 'run', provider_id: provider });
+      const goal =
+        failure === 'disablement'
+          ? 'Use get_page_snapshot to read the approved page, then call save_memory with text "Live disablement observation" and wait for approval. After approval, report the observed title and text. Do not use eval, click, or change the page.'
+          : heldGoal;
+      const active = callTool(live.a1, { goal, operation: 'run', provider_id: provider });
       await expect(controls(live.panel)).toContainText('Tab approval required', {
         timeout: 90_000,
       });
@@ -1102,24 +1350,37 @@ for (const [failure, reasons] of [
         await live.closeBrowser();
       }
       if (failure === 'disablement') {
-        // Hold the next real request, rather than racing the runner after dismissing its card.
+        // Approve, never reject, the memory card. Hold the next real request until disablement.
         const gate = Promise.withResolvers<void>();
+        let requestHeld = false;
         await live.panel.context().route('**/api/gateway/v1/chat/completions', async route => {
+          requestHeld = true;
           await gate.promise;
           await route.continue();
         });
         try {
-          await card.getByRole('button', { exact: true, name: 'Cancel' }).click();
+          await approveMemory(live.panel);
+          await expect.poll(() => requestHeld, { timeout: 30_000 }).toBe(true);
           await live.panel.getByLabel('Settings', { exact: true }).click();
           const settings = live.panel.getByRole('dialog', { name: 'Settings panel' });
-          await settings.getByRole('switch', { exact: true, name: 'CLI tasks' }).click();
+          const toggle = settings.getByRole('switch', { exact: true, name: 'CLI tasks' });
+          await toggle.click();
           await expect(
             settings.getByRole('group', { name: 'Confirm CLI task disablement' })
           ).toContainText('Issued actions are not undone');
+          await expect(toggle).toHaveAttribute('aria-checked', 'true');
+          const supervision = settings.getByRole('region', { name: 'CLI task supervision' });
+          await expect(supervision).toContainText('CLI tasks: Running');
+          await expect(supervision).toContainText(live.a1.id);
+          await expect(supervision.getByRole('button', { name: 'Stop CLI task' })).toBeEnabled();
+          await expect(supervision.getByRole('list', { name: 'Queued CLI tasks' })).toContainText(
+            live.b1.id
+          );
+          await expect(live.target.locator('#count')).toHaveText(beforeCount ?? '0');
+          await live.capture('disablement-confirmation-active-and-queued');
           await settings.getByRole('button', { name: 'Disable CLI tasks' }).click();
-          await expect(
-            settings.getByRole('region', { name: 'CLI task supervision' })
-          ).toContainText('CLI tasks: Disabled');
+          await expect(toggle).toHaveAttribute('aria-checked', 'false');
+          await expect(supervision).toContainText('CLI tasks: Disabled');
         } finally {
           gate.resolve();
         }
@@ -1132,9 +1393,25 @@ for (const [failure, reasons] of [
       expect(reasons).toContain(result.reason);
       expect(terminal.has(queuedResult.status)).toBe(true);
       expect(queuedResult.reason).toBe('provider_unavailable');
+      if (failure === 'disablement') {
+        for (const outcome of [result, queuedResult]) {
+          expect(outcome.status).toBe('interrupted');
+          expect(outcome.reason).toBe('provider_unavailable');
+        }
+      }
       const task = browserTaskIdSchema.parse(result.browser_task_id);
-      const stored = await callTool(live.a1, { browser_task_id: task, operation: 'status' });
+      const stored = await callTool(live.a1, {
+        browser_task_id: task,
+        job_id: browserJobIdSchema.parse(result.job_id),
+        operation: 'status',
+      });
       expect(stored).toEqual(result);
+      const storedQueued = await callTool(live.b1, {
+        browser_task_id: browserTaskIdSchema.parse(queuedResult.browser_task_id),
+        job_id: browserJobIdSchema.parse(queuedResult.job_id),
+        operation: 'status',
+      });
+      expect(storedQueued).toEqual(queuedResult);
       if (failure !== 'tab loss' && failure !== 'extension shutdown') {
         await expect(live.target.locator('#count')).toHaveText(beforeCount ?? '0');
       }

--- a/apps/extension/tests/e2e/browser-task.test.ts
+++ b/apps/extension/tests/e2e/browser-task.test.ts
@@ -2,7 +2,7 @@
 import { expect, test } from '@playwright/test';
 import type { BrowserContext, Locator, Page, WebSocketRoute } from '@playwright/test';
 import { createHash, randomUUID } from 'node:crypto';
-import { rm } from 'node:fs/promises';
+import { rm, writeFile } from 'node:fs/promises';
 import {
   browserProviderInboundMessageSchema,
   webOutboundWithBrowserMessageSchema,
@@ -358,7 +358,7 @@ const withHarness = async (
     await other.goto(`${fixture.url}/other`);
     const openPanel = async (): Promise<Page> => {
       const page = await context.newPage();
-      await page.setViewportSize({ height: 720, width: 320 });
+      expect(page.viewportSize()).toEqual({ height: 720, width: 320 });
       await page.goto(`chrome-extension://${extensionId}/sidepanel.html`);
       return page;
     };
@@ -435,7 +435,7 @@ const approve = async (root: Page | Locator): Promise<void> => {
   await controls.getByRole('button', { exact: true, name: 'Approve tab' }).click();
 };
 const capture = async (panel: Page, name: string): Promise<void> => {
-  await panel.setViewportSize({ height: 720, width: 320 });
+  expect(panel.viewportSize()).toEqual({ height: 720, width: 320 });
   const dialogs = panel.getByRole('dialog');
   const root = (await dialogs.count()) > 0 ? dialogs.last() : panel;
   const stop = supervision(root).getByRole('button', { name: 'Stop CLI task' });
@@ -738,9 +738,11 @@ for (const profile of ['enabled', 'quarantined'] as const) {
               warning: rectangle(warning),
             };
           });
+          const geometryPath = test.info().outputPath(`${name}-geometry.json`);
+          await writeFile(geometryPath, JSON.stringify(geometry, null, 2), 'utf8');
           await test.info().attach(`${name}-geometry`, {
-            body: JSON.stringify(geometry, null, 2),
             contentType: 'application/json',
+            path: geometryPath,
           });
           expect(
             Math.max(geometry.paintedConversationBottom, geometry.paintedGreetingBottom),

--- a/apps/extension/tests/e2e/browser-task.test.ts
+++ b/apps/extension/tests/e2e/browser-task.test.ts
@@ -1505,14 +1505,20 @@ const expectNativeSendPending = async (panel: Page, draft: string): Promise<void
   await expect(panel.getByRole('button', { exact: true, name: 'Send message' })).toBeDisabled();
 };
 
-// Each installation belongs to one Send or Resume action. Restore simultaneous gates in reverse order.
+const nativeWorkflowName = 'Admission fixture';
+// Each installation belongs to one action. Restore simultaneous gates in reverse order.
 const holdNativeSendBoundary = async (
   panel: Page,
-  boundary: 'safety' | 'tab',
-  action: 'send' | 'resume' = 'send'
+  boundary: 'safety' | 'locked-safety' | 'tab',
+  action: 'send' | 'resume' | 'workflow-row' | 'workflow-form' = 'send'
 ) => {
-  const options = { activation: action, kind: boundary };
-  const handle = await panel.evaluateHandle(({ kind, activation }) => {
+  const options = {
+    activation: action,
+    kind: boundary,
+    lockName: executionLock,
+    workflowLabel: `Run workflow "${nativeWorkflowName}"`,
+  };
+  const handle = await panel.evaluateHandle(({ kind, activation, lockName, workflowLabel }) => {
     const scope = globalThis as typeof globalThis & {
       chrome: typeof browser;
     };
@@ -1521,7 +1527,11 @@ const holdNativeSendBoundary = async (
     // eslint-disable-next-line typescript/unbound-method -- Restore the original API; apply below preserves its receiver.
     const originalStorageGet = storage.get;
     const originalTabGet = tabs.get;
+    const { locks } = navigator;
+    // eslint-disable-next-line typescript/unbound-method -- Restore the native method; apply below preserves its receiver.
+    const originalLockRequest = locks.request;
     const gate = Promise.withResolvers<void>();
+    let nativeCallbackEntered = false;
     let rejectRead = false;
     let restored = false;
     const state = {
@@ -1543,7 +1553,10 @@ const holdNativeSendBoundary = async (
         gate.resolve();
         document.removeEventListener('keydown', arm, true);
         document.removeEventListener('click', arm, true);
-        if (kind === 'safety') {
+        if (kind === 'locked-safety') {
+          locks.request = originalLockRequest;
+        }
+        if (kind === 'safety' || kind === 'locked-safety') {
           storage.get = originalStorageGet;
         } else {
           tabs.get = originalTabGet;
@@ -1554,20 +1567,38 @@ const holdNativeSendBoundary = async (
     };
     const arm = (event: Event): void => {
       const input = document.querySelector('#agent-message');
-      if (!(input instanceof HTMLTextAreaElement)) {
+      const workflow = activation === 'workflow-row' || activation === 'workflow-form';
+      if (!workflow && !(input instanceof HTMLTextAreaElement)) {
         return;
       }
-      const control =
-        activation === 'resume'
-          ? [...document.querySelectorAll('button')].find(
-              button => button.textContent?.trim() === 'Resume queued message'
-            )
-          : input.form?.querySelector('button[type="submit"]');
+      let control: Element | null | undefined;
+      if (activation === 'workflow-row') {
+        control = [...document.querySelectorAll('button')].find(
+          button => button.getAttribute('aria-label') === workflowLabel
+        );
+      } else if (activation === 'workflow-form') {
+        const dialog = [...document.querySelectorAll('[role="dialog"]')].find(
+          element => element.getAttribute('aria-label') === workflowLabel
+        );
+        control = [...(dialog?.querySelectorAll('button') ?? [])].find(
+          button => button.textContent?.trim() === 'Run'
+        );
+      } else if (activation === 'resume') {
+        control = [...document.querySelectorAll('button')].find(
+          button => button.textContent?.trim() === 'Resume queued message'
+        );
+      } else if (input instanceof HTMLTextAreaElement) {
+        control = input.form?.querySelector('button[type="submit"]');
+      }
+      const workflowField =
+        activation === 'workflow-form' &&
+        event.target instanceof HTMLInputElement &&
+        event.target.closest('[role="dialog"]')?.getAttribute('aria-label') === workflowLabel;
       const enter =
         event instanceof KeyboardEvent &&
         event.key === 'Enter' &&
         !event.shiftKey &&
-        event.target === (activation === 'resume' ? control : input);
+        (event.target === (activation === 'send' ? input : control) || workflowField);
       const click =
         event.type === 'click' &&
         event.target instanceof Node &&
@@ -1575,12 +1606,14 @@ const holdNativeSendBoundary = async (
       if (!enter && !click) {
         return;
       }
-      const target = document.querySelector('[aria-label="Target tab"]');
-      if (!(target instanceof HTMLSelectElement)) {
-        throw new Error('Send must have a target selector.');
+      if (!workflow) {
+        const target = document.querySelector('[aria-label="Target tab"]');
+        if (!(target instanceof HTMLSelectElement)) {
+          throw new Error('Send must have a target selector.');
+        }
+        state.submittedTabId = Number(target.value);
       }
       state.activated = true;
-      state.submittedTabId = Number(target.value);
       document.removeEventListener('keydown', arm, true);
       document.removeEventListener('click', arm, true);
     };
@@ -1599,7 +1632,32 @@ const holdNativeSendBoundary = async (
         state.settled = true;
       }
     };
-    if (kind === 'safety') {
+    if (kind === 'locked-safety') {
+      locks.request = ((...args: unknown[]) => {
+        const [name, requestOptions, callback] = args;
+        if (
+          state.activated &&
+          name === lockName &&
+          requestOptions !== null &&
+          typeof requestOptions === 'object' &&
+          'mode' in requestOptions &&
+          requestOptions.mode === 'shared' &&
+          typeof callback === 'function'
+        ) {
+          // Observe entry only. The native manager still grants and releases the unchanged lock.
+          const entered: LockGrantedCallback<unknown> = lock => {
+            if (lock !== null) {
+              nativeCallbackEntered = true;
+            }
+            // eslint-disable-next-line promise/prefer-await-to-callbacks -- Preserve the native callback's exact result and scheduling.
+            return (callback as LockGrantedCallback<unknown>)(lock);
+          };
+          args[2] = entered;
+        }
+        return (originalLockRequest as (...nativeArgs: unknown[]) => unknown).apply(locks, args);
+      }) as typeof originalLockRequest;
+    }
+    if (kind === 'safety' || kind === 'locked-safety') {
       storage.get = ((...args: unknown[]) => {
         const [keys, callback] = args;
         // Forward every native overload unchanged, including callback-only callers.
@@ -1613,6 +1671,10 @@ const holdNativeSendBoundary = async (
             Object.hasOwn(keys, 'kiloBrowserExecutionSafety'));
         // Preserve callback callers. The runtime safety read uses the Promise overload.
         if (!state.activated || !includesSafety || callback !== undefined) {
+          return read();
+        }
+        // A pre-callback background read must pass even if the lock becomes held before it resolves.
+        if (kind === 'locked-safety' && !nativeCallbackEntered) {
           return read();
         }
         // A background refresh can share this read; only the UI status proves pending Send.
@@ -1639,6 +1701,7 @@ const holdNativeSendBoundary = async (
     return state;
   }, options);
   return {
+    activated: () => handle.evaluate(state => state.activated),
     dispose: async () => {
       try {
         await handle.evaluate(state => {
@@ -2654,6 +2717,528 @@ for (const outcome of ['success', 'failure'] as const) {
         }
       },
       { gateway: nativeQueueGateway(seenChatBodies, completion.promise) }
+    );
+  });
+}
+
+type NativeWorkflowInput = { name: string; note?: string };
+const nativeWorkflowResult = 'Native workflow admission result';
+const nativeWorkflowStorageBlocker =
+  'Browser safety state is unavailable. No browser work can start. Restore storage access before recovery.';
+const nativeWorkflowForm = (panel: Page) =>
+  panel.getByRole('dialog', { exact: true, name: `Run workflow "${nativeWorkflowName}"` });
+const nativeWorkflowRoot = (panel: Page, parameters: boolean) =>
+  parameters
+    ? nativeWorkflowForm(panel)
+    : panel.getByRole('dialog', { exact: true, name: 'Settings panel' });
+const nativeWorkflowRun = (panel: Page, parameters: boolean) =>
+  parameters
+    ? nativeWorkflowForm(panel).getByRole('button', { exact: true, name: 'Run' })
+    : panel.getByRole('button', { exact: true, name: `Run workflow "${nativeWorkflowName}"` });
+const nativeWorkflowPending = (root: Locator) =>
+  root.getByRole('status').filter({
+    hasText: 'Checking browser control… Your workflow has not started.',
+  });
+const fillNativeWorkflow = async (panel: Page, input: NativeWorkflowInput): Promise<void> => {
+  const form = nativeWorkflowForm(panel);
+  await form.getByRole('textbox', { exact: true, name: 'name — A name' }).fill(input.name);
+  await form
+    .getByRole('textbox', { exact: true, name: 'note (optional) — A note' })
+    .fill(input.note ?? '');
+};
+const prepareNativeWorkflow = async (
+  { panel, target }: Harness,
+  input?: NativeWorkflowInput
+): Promise<void> => {
+  await prepareNativeSend(panel, ['Settings admission']);
+  const script = `await page.click("#effect"); return { done: true, result: { input, marker: "${nativeWorkflowResult}" } };`;
+  await setExtensionStorage(panel, {
+    kiloAgentWorkflows: [
+      {
+        approvedScriptHash: createHash('sha256').update(script).digest('hex'),
+        createdAt: Date.now(),
+        description: 'One native action with the supplied input.',
+        id: randomUUID(),
+        name: nativeWorkflowName,
+        params:
+          input === undefined
+            ? []
+            : [
+                { description: 'A name', name: 'name', required: true },
+                { description: 'A note', name: 'note', required: false },
+              ],
+        scopeOrigin: new URL(target.url()).origin,
+        script,
+        updatedAt: Date.now(),
+      },
+    ],
+    kiloWorkflowSettings: {
+      allowWorkflowsInSafeMode: true,
+      autoApproveWorkflowChanges: false,
+      autoApproveWorkflowRuns: false,
+    },
+  });
+  await panel.getByLabel('Settings', { exact: true }).click();
+  await expect(nativeWorkflowRun(panel, false)).toBeEnabled();
+  if (input !== undefined) {
+    await nativeWorkflowRun(panel, false).click();
+    await fillNativeWorkflow(panel, input);
+  }
+};
+const expectNativeWorkflowFields = async (
+  panel: Page,
+  input: NativeWorkflowInput,
+  readOnly: boolean
+): Promise<void> => {
+  for (const [name, value] of [
+    ['name — A name', input.name],
+    ['note (optional) — A note', input.note ?? ''],
+  ] as const) {
+    const field = nativeWorkflowForm(panel).getByRole('textbox', { exact: true, name });
+    await expect(field).toHaveValue(value);
+    await expect(field).toHaveJSProperty('readOnly', readOnly);
+    await expect(field).toBeEnabled();
+    if (!readOnly) {
+      await expect(field).toBeEditable();
+    }
+  }
+};
+const expectNativeWorkflowPending = async (
+  panel: Page,
+  input?: NativeWorkflowInput
+): Promise<void> => {
+  const root = nativeWorkflowRoot(panel, input !== undefined);
+  const pending = nativeWorkflowPending(root);
+  await expect(root).toBeVisible();
+  await expect(pending).toHaveCount(1);
+  await expect(pending).toBeVisible();
+  await expect(pending).toHaveText('Checking browser control… Your workflow has not started.');
+  await expect(nativeWorkflowRun(panel, input !== undefined)).toBeDisabled();
+  await expect(nativeWorkflowRun(panel, input !== undefined)).toHaveAttribute('aria-busy', 'true');
+  if (input !== undefined) {
+    await expectNativeWorkflowFields(panel, input, true);
+  }
+};
+const expectNativeWorkflowRetained = async (
+  panel: Page,
+  input?: NativeWorkflowInput
+): Promise<void> => {
+  await expect(nativeWorkflowRoot(panel, false)).toBeVisible();
+  await expect(nativeWorkflowRoot(panel, input !== undefined)).toBeVisible();
+  await expect(nativeWorkflowPending(nativeWorkflowRoot(panel, input !== undefined))).toHaveCount(
+    0
+  );
+  await expect(nativeWorkflowRun(panel, input !== undefined)).toBeEnabled();
+  await expect(nativeWorkflowRun(panel, input !== undefined)).toHaveAttribute('aria-busy', 'false');
+  if (input !== undefined) {
+    await expectNativeWorkflowFields(panel, input, false);
+  }
+};
+const expectNativeWorkflowUnpublished = async (
+  { panel, target, other }: Harness,
+  seenChatBodies: unknown[]
+): Promise<void> => {
+  await expect(
+    panel.getByRole('button', { exact: true, includeHidden: true, name: 'Resume workflow' })
+  ).toHaveCount(0);
+  // A published workflow must not add a turn to the seeded conversation before admission.
+  expect(await readExtensionLocalStorage(panel, 'kiloAgentConversations')).toMatchObject({
+    conversations: [
+      {
+        events: [
+          expect.objectContaining({
+            role: 'user',
+            text: 'Prior Settings admission',
+            type: 'message',
+          }),
+        ],
+      },
+    ],
+  });
+  await expect(target.locator('#count')).toHaveText('0');
+  await expect(other.locator('#count')).toHaveText('0');
+  expect(seenChatBodies).toHaveLength(0);
+};
+const expectNativeWorkflowCompletion = async (
+  harness: Harness,
+  input?: NativeWorkflowInput
+): Promise<void> => {
+  const { panel } = harness;
+  await expect(nativeWorkflowRoot(panel, false)).toBeHidden();
+  await expect(nativeWorkflowForm(panel)).toBeHidden();
+  const workflow = panel
+    .getByRole('region', { name: 'Agent conversation' })
+    .locator('details')
+    .filter({ hasText: nativeWorkflowResult });
+  const summary = workflow.locator('summary');
+  await expect(summary).toContainText('completed');
+  await summary.click();
+  const result = workflow.getByText(nativeWorkflowResult, { exact: false });
+  await expect(result).toHaveCount(1);
+  await expect(result).toBeVisible();
+  await (input === undefined
+    ? expect(result).not.toContainText('"name"')
+    : expect(result).toContainText(`"input": ${JSON.stringify(input, null, 2)}`));
+  if (input?.note === undefined) {
+    await expect(result).not.toContainText('"note"');
+  }
+  await expect(panel.getByRole('button', { exact: true, name: 'Resume workflow' })).toHaveCount(0);
+  await expectNativeQueueDrained(harness, 1);
+};
+const closeNativeWorkflowSettings = async (panel: Page): Promise<void> => {
+  const cancel = nativeWorkflowForm(panel).getByRole('button', { exact: true, name: 'Cancel' });
+  if (await cancel.isVisible()) {
+    await cancel.click();
+  }
+  const close = panel.getByRole('button', { exact: true, name: 'Close settings' });
+  if (await close.isVisible()) {
+    await close.click();
+  }
+};
+
+for (const parameters of [false, true]) {
+  for (const outcome of [
+    'success',
+    'native contention',
+    'storage failure',
+    'cancellation',
+  ] as const) {
+    test(`native gap A4: ${parameters ? 'parameters' : 'no parameters'} ${outcome} settles Settings admission`, async () => {
+      const seenChatBodies: unknown[] = [];
+      await withHarness(
+        async harness => {
+          const { panel, openPanel } = harness;
+          const input = parameters
+            ? { name: 'Original A name', note: 'Original A note' }
+            : undefined;
+          if (outcome === 'storage failure') {
+            await enable(panel);
+          }
+          await prepareNativeWorkflow(harness, input);
+          const run = nativeWorkflowRun(panel, parameters);
+          const root = nativeWorkflowRoot(panel, parameters);
+          const gate = await holdNativeSendBoundary(
+            panel,
+            outcome === 'cancellation' ? 'locked-safety' : 'safety',
+            parameters ? 'workflow-form' : 'workflow-row'
+          );
+          let effects = 0;
+          try {
+            await run.click();
+            await expect(run).toBeFocused();
+            await expectNativeWorkflowPending(panel, input);
+            await gate.wait();
+            await expect
+              .poll(() => heldExecutionModes(panel))
+              .toEqual(outcome === 'cancellation' ? ['shared'] : []);
+            await panel.keyboard.press('Enter');
+            await expect(run).toBeFocused();
+            await expectNativeWorkflowPending(panel, input);
+            if (input !== undefined) {
+              for (const name of ['name — A name', 'note (optional) — A note']) {
+                const field = root.getByRole('textbox', { exact: true, name });
+                await field.click();
+                await field.press('End');
+                await panel.keyboard.type(' overwritten while pending');
+              }
+              await expectNativeWorkflowFields(panel, input, true);
+              const cancel = root.getByRole('button', { exact: true, name: 'Cancel' });
+              await keyboardReach(panel, cancel, root);
+              await expect(cancel).toBeFocused();
+              await expect(cancel).toBeEnabled();
+            }
+            await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+
+            if (outcome === 'success') {
+              effects = 1;
+              await gate.release();
+              await expect.poll(gate.outcome).toEqual({ failed: false, settled: true });
+              await gate.restore();
+              await expectNativeWorkflowCompletion(harness, input);
+            } else if (outcome === 'native contention') {
+              const second = await openPanel();
+              try {
+                const contender = await holdNativeQueueContender(second);
+                try {
+                  await expect.poll(() => heldExecutionModes(panel)).toEqual(['exclusive']);
+                  await gate.release();
+                  await expectNativeWorkflowRetained(panel, input);
+                  await expect(root.getByText(/owns browser control/u).first()).toBeVisible();
+                  await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+                  await gate.restore();
+                  await contender.evaluate(held => held.release());
+                  await expectNativeQueueDrained(harness, 0);
+                  await expect(
+                    root.getByText(/Workflow input is retained\./u).first()
+                  ).toBeVisible();
+                  await expectNativeWorkflowRetained(panel, input);
+                  await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+
+                  effects = 1;
+                  await run.click();
+                  await expectNativeWorkflowCompletion(harness, input);
+                } finally {
+                  await contender.evaluate(held => held.release());
+                  await contender.dispose();
+                }
+              } finally {
+                await second.close();
+              }
+            } else if (outcome === 'storage failure') {
+              await gate.reject();
+              await expectNativeWorkflowRetained(panel, input);
+              await expect(
+                root.getByText(nativeWorkflowStorageBlocker, { exact: true }).first()
+              ).toBeVisible();
+              await expect.poll(gate.outcome).toEqual({ failed: true, settled: true });
+              await expectNativeQueueDrained(harness, 0);
+              await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+              await gate.restore();
+              await expectNativeWorkflowRetained(panel, input);
+              await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+
+              const controls = supervision(root);
+              await controls.getByRole('button', { name: 'Check recovery readiness' }).click();
+              const recover = controls.getByRole('button', { name: 'Recover browser control' });
+              await expect(recover).toBeEnabled();
+              await expectNativeWorkflowRetained(panel, input);
+              await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+              await recover.click();
+              await expect(controls).toContainText('Enabled — idle');
+              await expectNativeWorkflowRetained(panel, input);
+              await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+
+              effects = 1;
+              await run.click();
+              await expectNativeWorkflowCompletion(harness, input);
+            } else {
+              if (parameters) {
+                await panel.keyboard.press('Enter');
+                await expect(nativeWorkflowForm(panel)).toBeHidden();
+                await expect(nativeWorkflowRun(panel, false)).toBeEnabled();
+                await expect(nativeWorkflowRun(panel, false)).toHaveAttribute('aria-busy', 'false');
+              } else {
+                await panel.getByRole('button', { exact: true, name: 'Close settings' }).click();
+                await expect(root).toBeHidden();
+              }
+              await expect(nativeWorkflowPending(root)).toHaveCount(0);
+              await gate.release();
+              await expect.poll(gate.outcome).toEqual({ failed: false, settled: true });
+              await gate.restore();
+              // Observe the cancelled continuation's lock release before checking for late work.
+              await expectNativeQueueDrained(harness, 0);
+              await expect(nativeWorkflowForm(panel)).toBeHidden();
+              await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+            }
+          } finally {
+            try {
+              await closeNativeWorkflowSettings(panel);
+            } finally {
+              try {
+                await gate.dispose();
+              } finally {
+                await expectNativeQueueDrained(harness, effects);
+              }
+            }
+          }
+        },
+        { gateway: { seenChatBodies } }
+      );
+    });
+  }
+}
+
+test('native gap A4: blank required name disables Run without admission', async () => {
+  const seenChatBodies: unknown[] = [];
+  await withHarness(
+    async harness => {
+      const { panel } = harness;
+      const input = { name: '', note: 'Retain the optional note without a required name.' };
+      await prepareNativeWorkflow(harness, input);
+      const form = nativeWorkflowForm(panel);
+      const run = nativeWorkflowRun(panel, true);
+      const gate = await holdNativeSendBoundary(panel, 'safety', 'workflow-form');
+      try {
+        for (const name of ['', '   ']) {
+          const field = form.getByRole('textbox', { exact: true, name: 'name — A name' });
+          await field.fill(name);
+          await expect(run).toBeDisabled();
+          await expect(run).toHaveAttribute('aria-busy', 'false');
+          await field.press('Enter');
+          expect(await gate.activated()).toBe(true);
+          // Periodic safety reads can enter without a submission. Observe the armed boundary and UI.
+          await gate.wait();
+          await expect(nativeWorkflowPending(form)).toHaveCount(0);
+          await expect(run).toBeDisabled();
+          await expect(run).toHaveAttribute('aria-busy', 'false');
+          await expectNativeWorkflowFields(panel, { ...input, name }, false);
+          await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+          const cancel = form.getByRole('button', { exact: true, name: 'Cancel' });
+          await keyboardReach(panel, cancel, form);
+          await expect(cancel).toBeFocused();
+          await expect(cancel).toBeEnabled();
+          await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+        }
+        await panel.keyboard.press('Enter');
+        await expect(form).toBeHidden();
+        await expect(nativeWorkflowRun(panel, false)).toBeEnabled();
+        await gate.restore();
+        await expectNativeQueueDrained(harness, 0);
+        await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+      } finally {
+        try {
+          await closeNativeWorkflowSettings(panel);
+        } finally {
+          try {
+            await gate.dispose();
+          } finally {
+            await expectNativeQueueDrained(harness, 0);
+          }
+        }
+      }
+    },
+    { gateway: { seenChatBodies } }
+  );
+});
+
+test('native gap A4: blank optional note stays absent from the returned input', async () => {
+  const seenChatBodies: unknown[] = [];
+  await withHarness(
+    async harness => {
+      const { panel } = harness;
+      const input = { name: 'Required name only' };
+      await prepareNativeWorkflow(harness, input);
+      const gate = await holdNativeSendBoundary(panel, 'safety', 'workflow-form');
+      try {
+        const run = nativeWorkflowRun(panel, true);
+        await run.click();
+        await expect(run).toBeFocused();
+        await expectNativeWorkflowPending(panel, input);
+        await gate.wait();
+        await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+        await gate.release();
+        await expect.poll(gate.outcome).toEqual({ failed: false, settled: true });
+        await gate.restore();
+        await expectNativeWorkflowCompletion(harness, input);
+      } finally {
+        try {
+          await closeNativeWorkflowSettings(panel);
+        } finally {
+          try {
+            await gate.dispose();
+          } finally {
+            await expectNativeQueueDrained(harness, 1);
+          }
+        }
+      }
+    },
+    { gateway: { seenChatBodies } }
+  );
+});
+
+for (const outcome of ['success', 'storage failure'] as const) {
+  test(`native gap A5 Parameters: cancelled A cannot clear B ${outcome}`, async () => {
+    const seenChatBodies: unknown[] = [];
+    await withHarness(
+      async harness => {
+        const { panel } = harness;
+        const oldInput = { name: 'Cancelled A name', note: 'Cancelled A note' };
+        const newInput = { name: 'Current B name', note: 'Current B note' };
+        await prepareNativeWorkflow(harness, oldInput);
+        const older = await holdNativeSendBoundary(panel, 'locked-safety', 'workflow-form');
+        let effects = 0;
+        try {
+          await nativeWorkflowRun(panel, true).click();
+          await expectNativeWorkflowPending(panel, oldInput);
+          await older.wait();
+          await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+          await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+          const form = nativeWorkflowForm(panel);
+          const cancel = form.getByRole('button', { exact: true, name: 'Cancel' });
+          await keyboardReach(panel, cancel, form);
+          await panel.keyboard.press('Enter');
+          await expect(form).toBeHidden();
+          await expect(nativeWorkflowRun(panel, false)).toBeEnabled();
+          await expect(nativeWorkflowRun(panel, false)).toHaveAttribute('aria-busy', 'false');
+          await nativeWorkflowRun(panel, false).click();
+          await fillNativeWorkflow(panel, newInput);
+          const sharedRefresh = await holdNativeSendBoundary(panel, 'safety', 'workflow-form');
+          let newer: Awaited<ReturnType<typeof holdNativeSendBoundary>> | undefined;
+          try {
+            const run = nativeWorkflowRun(panel, true);
+            await run.click();
+            await expect(run).toBeFocused();
+            await expectNativeWorkflowPending(panel, newInput);
+            await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+            await older.release();
+            await expect.poll(older.outcome).toEqual({ failed: false, settled: true });
+            await sharedRefresh.wait();
+            // A has released its native lock; its release tail still shares B's first refresh.
+            await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+            await expectNativeWorkflowPending(panel, newInput);
+            await expect(run).toBeFocused();
+
+            newer = await holdNativeSendBoundary(panel, 'safety', 'workflow-form');
+            // Arm the next read with the still-focused Run, without submitting another attempt.
+            await panel.keyboard.press('Enter');
+            expect(await newer.activated()).toBe(true);
+            await sharedRefresh.release();
+            await expect.poll(sharedRefresh.outcome).toEqual({ failed: false, settled: true });
+            await newer.wait();
+            // The shared refresh lets A finish before B's native callback requests its own refresh.
+            await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+            await expectNativeWorkflowPending(panel, newInput);
+            await expect(run).toBeFocused();
+            expect(await newer.outcome()).toEqual({ failed: false, settled: false });
+            await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+
+            if (outcome === 'success') {
+              effects = 1;
+              await newer.release();
+              await expect.poll(newer.outcome).toEqual({ failed: false, settled: true });
+              await newer.restore();
+              await sharedRefresh.restore();
+              await older.restore();
+              await expectNativeWorkflowCompletion(harness, newInput);
+            } else {
+              await newer.reject();
+              await expectNativeWorkflowRetained(panel, newInput);
+              await expect(
+                form.getByRole('alert').filter({ hasText: nativeWorkflowStorageBlocker })
+              ).toBeVisible();
+              await expect.poll(newer.outcome).toEqual({ failed: true, settled: true });
+              await expectNativeQueueDrained(harness, 0);
+              await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+              await newer.restore();
+              await sharedRefresh.restore();
+              await older.restore();
+              await expectNativeWorkflowRetained(panel, newInput);
+              await expectNativeWorkflowUnpublished(harness, seenChatBodies);
+            }
+          } finally {
+            try {
+              await closeNativeWorkflowSettings(panel);
+            } finally {
+              try {
+                await newer?.dispose();
+              } finally {
+                await sharedRefresh.dispose();
+              }
+            }
+          }
+        } finally {
+          try {
+            await closeNativeWorkflowSettings(panel);
+          } finally {
+            try {
+              await older.dispose();
+            } finally {
+              await expectNativeQueueDrained(harness, effects);
+            }
+          }
+        }
+      },
+      { gateway: { seenChatBodies } }
     );
   });
 }

--- a/apps/extension/tests/e2e/browser-task.test.ts
+++ b/apps/extension/tests/e2e/browser-task.test.ts
@@ -620,6 +620,117 @@ test('two panels share local locks, drain before delegation, and retain a blocke
   });
 });
 
+for (const loss of ['close', 'reload'] as const) {
+  test(`native local owner ${loss} blocks local and delegated work until explicit recovery`, async () => {
+    const issueAction = Promise.withResolvers<void>();
+    const recoveredText = 'Explicitly submitted browser work completed.';
+    await withHarness(
+      async ({ panel, openPanel, context, relay, target, other }) => {
+        let requests = 0;
+        context.on('request', request => {
+          if (request.url().endsWith('/api/gateway/v1/chat/completions')) {
+            requests += 1;
+          }
+        });
+        await enable(panel, true);
+        const localOwner = await openPanel();
+        await selectModelById(localOwner, model);
+        await localOwner
+          .getByLabel('Target tab')
+          .selectOption({ label: 'Approved browser task tab' });
+        await localOwner.getByRole('button', { name: /(?:Safe|Dangerous) mode/u }).click();
+        await localOwner.getByRole('button', { exact: true, name: 'Dangerous' }).click();
+        await localOwner.getByLabel('Message agent').fill('Issue the local page action and wait.');
+        await localOwner.getByLabel('Message agent').press('Enter');
+        await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+        const delivery = relay.submit('Do not run until local work safely drains.');
+        await approve(panel);
+        await expect(supervision(panel)).toContainText('Waiting for browser control');
+        await expect.poll(() => requests).toBe(1);
+
+        // Queue delegation first, so owner destruction follows the issued action before its eval timeout.
+        issueAction.resolve();
+        await expect(target.locator('#count')).toHaveText('1');
+        await (loss === 'close' ? localOwner.close() : localOwner.reload());
+        await target.evaluate(() => {
+          document.dispatchEvent(new Event('finish-local-action'));
+        });
+        await expect(target.locator('html')).toHaveAttribute('data-local-action', 'finished');
+        await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+        await expect(supervision(panel)).toContainText('Recovery required');
+        // An orphaned local record, not a prior timeout quarantine, must retain exclusion.
+        expect(await readExtensionLocalStorage(panel, 'kiloBrowserExecutionSafety')).toEqual(
+          expect.objectContaining({
+            localRuns: [expect.objectContaining({ tabId: expect.any(Number) })],
+            tabIds: [],
+          })
+        );
+        const draft = 'Keep this draft until explicit recovery.';
+        await panel.getByLabel('Message agent').fill(draft);
+        await panel.getByLabel('Message agent').press('Enter');
+        await expect(panel.getByLabel('Message agent')).toHaveValue(draft);
+        await expect(supervision(panel)).toContainText('an action may still be running');
+        await expect(supervision(panel).getByRole('list', { name: 'Affected tabs' })).toContainText(
+          'Approved browser task tab'
+        );
+        await supervision(panel).getByRole('button', { name: 'Check recovery readiness' }).click();
+        await expect(supervision(panel)).toContainText('Close all affected tabs before recovery.');
+        await expect(panel.getByRole('button', { name: 'Recover browser control' })).toHaveCount(0);
+        relay.send(delivery);
+        await expect(panel.getByRole('button', { exact: true, name: 'Approve tab' })).toHaveCount(
+          0
+        );
+        await expect(target.locator('#count')).toHaveText('1');
+        await expect(other.locator('#count')).toHaveText('0');
+        expect(requests).toBe(1);
+        await capture(panel, `native-local-owner-${loss}-blocked`);
+
+        await target.close();
+        await supervision(panel).getByRole('button', { name: 'Check recovery readiness' }).click();
+        const recover = panel.getByRole('button', { name: 'Recover browser control' });
+        await expect(recover).toBeVisible();
+        await panel.getByLabel('Message agent').press('Enter');
+        await expect(panel.getByLabel('Message agent')).toHaveValue(draft);
+        expect(requests).toBe(1);
+        await recover.click();
+        await expect(supervision(panel)).toContainText('Enabled — idle');
+        await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+        expect(requests).toBe(1);
+        await expect(panel.getByLabel('Message agent')).toHaveValue(draft);
+        await panel.getByLabel('Target tab').selectOption({ label: 'Unapproved tab' });
+        await panel.getByRole('button', { name: /(?:Safe|Dangerous) mode/u }).click();
+        await panel.getByRole('button', { exact: true, name: 'Dangerous' }).click();
+        await panel.getByLabel('Message agent').press('Enter');
+        await expect(panel.getByText(recoveredText, { exact: true })).toBeVisible();
+        await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+        expect(requests).toBe(2);
+        relay.submit('Run only this new explicitly approved invocation.');
+        await expect(supervision(panel)).toContainText('Tab approval required');
+        expect(requests).toBe(2);
+        await supervision(panel)
+          .getByLabel('Tab to approve')
+          .selectOption({ label: 'Unapproved tab' });
+        await supervision(panel).getByRole('button', { exact: true, name: 'Approve tab' }).click();
+        await expect(supervision(panel)).toContainText('Last outcome: succeeded');
+        expect(requests).toBe(3);
+        await expect(other.locator('#count')).toHaveText('0');
+        await capture(panel, `native-local-owner-${loss}-explicit-recovery`);
+      },
+      {
+        gateway: {
+          beforeFirstCompletion: () => issueAction.promise,
+          firstCompletionEvents: toolCall('eval', {
+            code: 'document.querySelector("#effect").click(); await new Promise(resolve => document.addEventListener("finish-local-action", resolve, { once: true })); document.documentElement.setAttribute("data-local-action", "finished"); return "finished";',
+          }),
+          secondCompletionEvents: content(recoveredText),
+          thirdCompletionEvents: content(recoveredText),
+          toolNames: dangerousToolNames,
+        },
+      }
+    );
+  });
+}
+
 for (const mode of ['Browser', 'Agents'] as const) {
   test(`${mode}: memory saving, retry, and confirmation retain keyboard-accessible supervision`, async () => {
     const finish = Promise.withResolvers<void>();

--- a/apps/extension/tests/e2e/browser-task.test.ts
+++ b/apps/extension/tests/e2e/browser-task.test.ts
@@ -1,0 +1,1033 @@
+/* eslint-disable import/no-nodejs-modules, import/max-dependencies, max-lines, no-await-in-loop, jest/no-conditional-in-test, jest/no-conditional-expect, jest/max-expects, jest/prefer-each, init-declarations, typescript/consistent-type-definitions, typescript/no-unsafe-type-assertion -- Playwright has no test.each; fixture casts describe injected page APIs, not product authority. */
+import { expect, test } from '@playwright/test';
+import type { BrowserContext, Locator, Page, WebSocketRoute } from '@playwright/test';
+import { createHash, randomUUID } from 'node:crypto';
+import { rm } from 'node:fs/promises';
+import {
+  browserProviderInboundMessageSchema,
+  webOutboundWithBrowserMessageSchema,
+} from '@kilocode/cloud-agent-sdk/schemas';
+import type {
+  BrowserJobSnapshot,
+  BrowserProviderInboundMessage,
+  BrowserResult,
+} from '@kilocode/cloud-agent-sdk/schemas';
+import { mockAgentsApi } from './agents-fixture';
+import {
+  launchExtensionContext,
+  readExtensionLocalStorage,
+  seedExtensionAuth,
+  setExtensionStorage,
+  startFixtureServer,
+} from './extension-context-fixture';
+import { dangerousToolNames, mockKiloApi, safeToolNames } from './kilo-api-fixture';
+import { selectModelById } from './model-picker-e2e-helpers';
+
+const model = 'deepseek/deepseek-v4-flash-0731';
+const owner = `ses_parent_A1_${'long_owner_'.repeat(6)}`;
+const executionLock = 'kilo:browser-execution';
+const resultText = 'The approved page reports one completed action.';
+const content = (text: string) => [{ choices: [{ delta: { content: text } }] }];
+const toolCall = (name: string, args: Record<string, unknown>) => [
+  {
+    choices: [
+      {
+        delta: {
+          tool_calls: [
+            {
+              function: { arguments: JSON.stringify(args), name },
+              id: randomUUID(),
+              index: 0,
+              type: 'function',
+            },
+          ],
+        },
+      },
+    ],
+  },
+];
+const binding = (job: BrowserJobSnapshot) => ({
+  browserTaskId: job.browserTaskId,
+  generation: job.generation,
+  invocationId: job.invocationId,
+  jobId: job.jobId,
+  providerId: job.providerId,
+});
+
+type Delivery = Extract<BrowserProviderInboundMessage, { type: 'provider_job' }>;
+type Failure = Exclude<BrowserResult['reason'], 'completed'>;
+
+// This peer supplies wire inputs, not runtime proof of the real relay or CLI.
+const mockBrowserRelay = async (
+  context: BrowserContext,
+  input: {
+    supported?: boolean;
+    registrationError?: boolean;
+    silent?: boolean;
+    now?: () => number;
+  } = {}
+) => {
+  const options = { registrationError: false, silent: false, supported: true, ...input };
+  let socket: WebSocketRoute | undefined;
+  let providerId: BrowserJobSnapshot['providerId'] | undefined;
+  let generation = 0;
+  let fence: { invocationId: string; tabId?: number } | undefined;
+  const jobs = new Map<string, BrowserJobSnapshot>();
+  const deliveries = new Map<string, Delivery>();
+  const results: BrowserResult[] = [];
+  const cancellations: string[] = [];
+  const send = (message: BrowserProviderInboundMessage): void => {
+    if (socket === undefined) {
+      throw new Error('The provider has not registered.');
+    }
+    socket.send(JSON.stringify(browserProviderInboundMessageSchema.parse(message)));
+  };
+  const snapshot = (): void => {
+    if (providerId !== undefined) {
+      send({
+        generation,
+        jobs: [...jobs.values()].filter(job => job.generation === generation),
+        providerId,
+        type: 'provider_snapshot',
+      });
+    }
+  };
+  const settle = (job: BrowserJobSnapshot, result: BrowserResult): void => {
+    if (jobs.get(job.jobId)?.result !== undefined) {
+      return;
+    }
+    jobs.set(job.jobId, { ...job, queuePosition: undefined, result, status: result.status });
+    snapshot();
+  };
+  const fail = (job: BrowserJobSnapshot, reason: Failure, uncertain = false): void => {
+    let status: Exclude<BrowserResult['status'], 'succeeded'> = 'interrupted';
+    if (reason.endsWith('_timeout')) {
+      status = 'timed_out';
+    } else if (reason === 'cancelled') {
+      status = 'cancelled';
+    } else if (reason === 'approval_denied') {
+      status = 'failed';
+    }
+    settle(job, {
+      browserTaskId: job.browserTaskId,
+      effectsUncertain: uncertain,
+      evidence: [],
+      invocationId: job.invocationId,
+      jobId: job.jobId,
+      providerId: job.providerId,
+      reason,
+      status,
+      summary: `The relay settled this invocation: ${reason}. Issued actions are not undone.`,
+    });
+  };
+  const dispatch = (delivery: Delivery): void => {
+    const job = { ...delivery.job, queuePosition: undefined, status: 'awaiting_approval' as const };
+    jobs.set(job.jobId, job);
+    fence = { invocationId: job.invocationId };
+    send({ ...delivery, job });
+  };
+  await context.routeWebSocket('wss://ingest.kilosessions.ai/api/user/web**', route => {
+    route.send(JSON.stringify({ data: {}, event: 'connected', type: 'system' }));
+    route.onMessage(raw => {
+      const message = webOutboundWithBrowserMessageSchema.parse(JSON.parse(String(raw)));
+      if (message.type === 'ping') {
+        if (!options.silent) {
+          route.send(
+            JSON.stringify({
+              capabilities: { browserJobsV1: options.supported },
+              nonce: message.nonce,
+              type: 'pong',
+            })
+          );
+        }
+        return;
+      }
+      if (message.type === 'provider_register') {
+        socket = route;
+        ({ providerId } = message);
+        if (
+          options.registrationError ||
+          (fence !== undefined && message.recovery?.invocationId !== fence.invocationId)
+        ) {
+          route.send(
+            JSON.stringify({
+              error: {
+                code: 'provider_unavailable',
+                message: 'Retrieve status before recovery.',
+                retryable: true,
+              },
+              id: message.requestId,
+              type: 'response',
+            })
+          );
+          return;
+        }
+        generation = Math.max(generation, message.generation) + 1;
+        fence = undefined;
+        send({
+          generation,
+          leaseExpiresAt: new Date((input.now ?? Date.now)() + 15_000).toISOString(),
+          providerId,
+          requestId: message.requestId,
+          type: 'provider_lease_ack',
+        });
+      } else if (message.type === 'provider_heartbeat') {
+        send({
+          generation,
+          leaseExpiresAt: new Date((input.now ?? Date.now)() + 15_000).toISOString(),
+          providerId: message.providerId,
+          requestId: message.requestId,
+          type: 'provider_lease_ack',
+        });
+        send({
+          generation,
+          jobs: [...jobs.values()].filter(job => job.generation === generation),
+          providerId: message.providerId,
+          requestId: message.requestId,
+          type: 'provider_snapshot',
+        });
+      } else if (message.type === 'provider_status') {
+        route.send(
+          JSON.stringify(
+            browserProviderInboundMessageSchema.parse({
+              jobs: [...jobs.values()],
+              providerId: message.providerId,
+              requestId: message.requestId,
+              type: 'provider_status_result',
+              unresolvedFence: fence,
+            })
+          )
+        );
+      } else if (message.type === 'provider_approval') {
+        const job = jobs.get(message.jobId);
+        if (job === undefined) {
+          throw new Error('Approval names an unknown job.');
+        }
+        if (message.approval.decision === 'denied') {
+          fail(job, 'approval_denied');
+        } else {
+          fence = { invocationId: job.invocationId, tabId: message.approval.tab.tabId };
+          jobs.set(job.jobId, {
+            ...job,
+            approvedTab: message.approval.tab,
+            deadlines: {
+              ...job.deadlines,
+              execution: new Date(Date.now() + 600_000).toISOString(),
+            },
+            status: 'running',
+          });
+          snapshot();
+        }
+      } else if (message.type === 'provider_result') {
+        const job = jobs.get(message.jobId);
+        if (job === undefined) {
+          throw new Error('Result names an unknown job.');
+        }
+        results.push(message.result);
+        settle(job, message.result);
+      } else if (message.type === 'provider_cancel') {
+        const job = jobs.get(message.jobId);
+        if (job === undefined) {
+          throw new Error('Cancellation names an unknown job.');
+        }
+        cancellations.push(job.jobId);
+        send({ ...binding(job), reason: 'cancelled', type: 'provider_job_cancel' });
+        fail(job, 'cancelled');
+      } else if (message.type === 'provider_unavailable') {
+        for (const job of jobs.values()) {
+          if (job.result === undefined) {
+            fail(job, message.reason, message.effectsUncertain);
+          }
+        }
+      } else if (message.type === 'provider_quiesced') {
+        if (fence?.invocationId === message.invocationId) {
+          fence = undefined;
+        }
+        const next = [...jobs.values()].find(job => job.status === 'queued');
+        const delivery = next === undefined ? undefined : deliveries.get(next.jobId);
+        if (delivery !== undefined) {
+          dispatch(delivery);
+        }
+      }
+    });
+  });
+  return {
+    cancellations,
+    dispatch,
+    expireResults: () => {
+      jobs.clear();
+    },
+    interrupt: (job: BrowserJobSnapshot, reason: Failure) => {
+      send({ ...binding(job), reason, type: 'provider_job_cancel' });
+      fail(jobs.get(job.jobId) ?? job, reason, true);
+    },
+    jobs,
+    results,
+    send,
+    submit: (goal = 'Inspect the approved tab.', ownerLabel = owner, queued = false) => {
+      if (providerId === undefined) {
+        throw new Error('Enable the provider before submitting work.');
+      }
+      const now = Date.now();
+      const job: BrowserJobSnapshot = {
+        browserTaskId: `bt_${randomUUID()}`,
+        createdAt: new Date(now).toISOString(),
+        deadlines: {
+          approval: new Date(now + 120_000).toISOString(),
+          queue: new Date(now + 600_000).toISOString(),
+        },
+        expiresAt: new Date(now + 7 * 86_400_000).toISOString(),
+        generation,
+        invocationId: `b1.${now}.${createHash('sha256').update(randomUUID()).digest('hex')}`,
+        jobId: `bj_${randomUUID()}`,
+        ownerLabel,
+        payloadFingerprint: createHash('sha256').update(goal).digest('hex'),
+        providerId,
+        ...(queued
+          ? { queuePosition: [...jobs.values()].filter(row => row.status === 'queued').length + 1 }
+          : {}),
+        status: queued ? 'queued' : 'awaiting_approval',
+      };
+      const delivery: Delivery = {
+        conversationMode: 'new',
+        goal,
+        job,
+        ownerLabel,
+        type: 'provider_job',
+      };
+      jobs.set(job.jobId, job);
+      deliveries.set(job.jobId, delivery);
+      if (queued) {
+        snapshot();
+      } else {
+        dispatch(delivery);
+      }
+      return delivery;
+    },
+  };
+};
+
+type Harness = {
+  context: BrowserContext;
+  panel: Page;
+  target: Page;
+  other: Page;
+  relay: Awaited<ReturnType<typeof mockBrowserRelay>>;
+  openPanel: () => Promise<Page>;
+};
+const withHarness = async (
+  run: (harness: Harness) => Promise<void>,
+  options: {
+    gateway?: Parameters<typeof mockKiloApi>[1];
+    relay?: Parameters<typeof mockBrowserRelay>[1];
+    init?: (context: BrowserContext) => Promise<void>;
+  } = {}
+): Promise<void> => {
+  const fixture = await startFixtureServer({
+    bodyHtml:
+      '<button id="effect" onclick="document.querySelector(\'#count\').textContent = String(Number(document.querySelector(\'#count\').textContent) + 1)">Apply once</button><output id="count">0</output><p>Approved evidence A1.</p>',
+    pathHtml: {
+      '/other':
+        '<!doctype html><title>Unapproved tab</title><output id="count">0</output><p>Foreign evidence B1.</p>',
+    },
+    title: 'Approved browser task tab',
+  });
+  const launched = await launchExtensionContext();
+  const { context, extensionId } = launched;
+  try {
+    await options.init?.(context);
+    await mockAgentsApi(context, { activeSessions: [], historySessions: [] });
+    await mockKiloApi(context, {
+      firstCompletionEvents: content('Observed the requested page.'),
+      models: [{ id: model, name: 'DeepSeek V4 Flash' }],
+      ...options.gateway,
+    });
+    const relay = await mockBrowserRelay(context, options.relay);
+    const target = await context.newPage();
+    await target.goto(fixture.url);
+    const other = await context.newPage();
+    await other.goto(`${fixture.url}/other`);
+    const openPanel = async (): Promise<Page> => {
+      const page = await context.newPage();
+      await page.setViewportSize({ height: 720, width: 320 });
+      await page.goto(`chrome-extension://${extensionId}/sidepanel.html`);
+      return page;
+    };
+    const panel = await openPanel();
+    await seedExtensionAuth(panel);
+    await panel.reload();
+    await expect(panel.getByLabel('Message agent')).toBeVisible();
+    await run({ context, openPanel, other, panel, relay, target });
+  } finally {
+    await context.close();
+    await fixture.close();
+    await rm(launched.userDataDir, { force: true, recursive: true });
+  }
+};
+const supervision = (root: Page | Locator) =>
+  root.getByRole('region', { name: 'CLI task supervision' });
+const enable = async (
+  panel: Page,
+  dangerous = false,
+  expected = 'Enabled — idle'
+): Promise<void> => {
+  await selectModelById(panel, model);
+  await panel.getByLabel('Settings', { exact: true }).click();
+  const settings = panel.getByRole('region', { name: 'CLI task settings' });
+  await expect(settings.getByRole('switch', { exact: true, name: 'CLI tasks' })).toHaveAttribute(
+    'aria-checked',
+    'false'
+  );
+  await expect(settings.getByRole('switch', { exact: true, name: 'CLI tasks' })).toBeDisabled();
+  // The existing model helper targets the local composer. Delegated settings have their own model trigger.
+  await settings.getByLabel('Model', { exact: true }).click();
+  await panel
+    .getByRole('dialog', { name: 'Select model' })
+    .locator(`button[data-model-id="${model}"]`)
+    .click();
+  await expect(settings.getByLabel('Model', { exact: true })).toHaveAttribute(
+    'data-model-id',
+    model
+  );
+  if (dangerous) {
+    await settings.getByRole('button', { name: /Safe mode/u }).click();
+    await settings.getByRole('button', { exact: true, name: 'Dangerous' }).click();
+  }
+  await settings.getByRole('switch', { exact: true, name: 'CLI tasks' }).click();
+  await expect(settings.getByRole('switch', { exact: true, name: 'CLI tasks' })).toHaveAttribute(
+    'aria-checked',
+    'true'
+  );
+  await panel.getByLabel('Close settings').click();
+  await expect(supervision(panel)).toContainText(`CLI tasks: ${expected}`);
+};
+const approve = async (root: Page | Locator): Promise<void> => {
+  const controls = supervision(root);
+  await expect(controls.getByRole('button', { exact: true, name: 'Approve tab' })).toBeDisabled();
+  await controls.getByLabel('Tab to approve').selectOption({ label: 'Approved browser task tab' });
+  await controls.getByRole('button', { exact: true, name: 'Approve tab' }).click();
+};
+const capture = async (panel: Page, name: string): Promise<void> => {
+  await panel.setViewportSize({ height: 720, width: 320 });
+  await panel.evaluate(() => {
+    document.documentElement.style.fontSize = '200%';
+  });
+  const dialogs = panel.getByRole('dialog');
+  const root = (await dialogs.count()) > 0 ? dialogs.last() : panel;
+  const stop = supervision(root).getByRole('button', { name: 'Stop CLI task' });
+  if ((await stop.count()) > 0) {
+    await expect(stop).toBeInViewport({ ratio: 1 });
+    const box = await stop.boundingBox();
+    expect(box?.height).toBeGreaterThanOrEqual(32);
+    expect(box?.width).toBeGreaterThanOrEqual(32);
+  }
+  expect(
+    await panel.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth
+    )
+  ).toBe(true);
+  const path = test.info().outputPath(`${name}.png`);
+  await panel.screenshot({ path });
+  await test.info().attach(name, { contentType: 'image/png', path });
+};
+const keyboardReach = async (panel: Page, control: Locator, dialog?: Locator): Promise<void> => {
+  for (let step = 0; step < 100; step += 1) {
+    if (await control.evaluate(element => element === document.activeElement)) {
+      return;
+    }
+    await panel.keyboard.press('Tab');
+    if (dialog !== undefined) {
+      expect(await dialog.evaluate(element => element.contains(document.activeElement))).toBe(true);
+    }
+  }
+  await expect(control).toBeFocused();
+};
+const assertSupervision = async (root: Page | Locator): Promise<void> => {
+  const controls = supervision(root);
+  await expect(controls.getByText(`Owner session: ${owner}`, { exact: false })).toBeVisible();
+  await expect(controls.getByText(/Bound tab: Approved browser task tab/u)).toBeVisible();
+  await expect(controls.getByRole('button', { name: 'Stop CLI task' })).toBeVisible();
+};
+
+test.setTimeout(90_000);
+for (const mode of ['Browser', 'Agents'] as const) {
+  test(`${mode}: disabled, idle, consent, queue, bound tab, and one execution after duplicate delivery`, async () => {
+    const completion = Promise.withResolvers<void>();
+    await withHarness(
+      async ({ panel, target, other, relay }) => {
+        await target.goto(`${target.url()}?detail=${'long-path-segment-'.repeat(80)}`);
+        await expect(supervision(panel)).toContainText('CLI tasks: Disabled');
+        await capture(panel, `${mode}-disabled`);
+        await enable(panel, true);
+        await panel.getByRole('tab', { exact: true, name: mode }).click();
+        await expect(supervision(panel)).toContainText('Enabled — idle');
+        await expect(supervision(panel)).toContainText('Queue empty.');
+        await expect(supervision(panel)).not.toContainText('Owner session:');
+        await capture(panel, `${mode}-idle`);
+        const delivery = relay.submit(
+          `Read the approved page and apply exactly one action. ${'Long goal with a long URL https://example.test/path/'.repeat(24)}`
+        );
+        await expect(supervision(panel)).toContainText('Tab approval required');
+        await expect(target.locator('#count')).toHaveText('0');
+        await panel.evaluate(() => {
+          document.documentElement.style.fontSize = '200%';
+        });
+        await capture(panel, `${mode}-approval-320px-200percent`);
+        await approve(panel);
+        await expect(supervision(panel)).toContainText('CLI tasks: Running');
+        await other.bringToFront();
+        await panel.bringToFront();
+        relay.send(delivery);
+        const queued = relay.submit(
+          'Foreign goal B1 must not enter A1 history.',
+          'ses_parent_B1_distinct_owner',
+          true
+        );
+        await expect(panel.getByRole('list', { name: 'Queued CLI tasks' })).toContainText(
+          'Queue position: 1'
+        );
+        await expect(panel.getByRole('list', { name: 'Queued CLI tasks' })).toContainText(
+          'ses_parent_B1'
+        );
+        await expect(panel.getByRole('list', { name: 'Queued CLI tasks' })).toContainText(
+          'Queue deadline:'
+        );
+        await capture(panel, `${mode}-running-queued-320px-200percent`);
+        await panel
+          .getByRole('button', { name: `Cancel queued task ${queued.job.jobId.slice(-8)}` })
+          .click();
+        await expect(supervision(panel)).toContainText('Queue empty.');
+        completion.resolve();
+        await expect(target.locator('#count')).toHaveText('1');
+        await expect(other.locator('#count')).toHaveText('0');
+        await expect(supervision(panel)).toContainText(resultText);
+        await expect(supervision(panel)).toContainText('Last outcome: succeeded');
+        await expect(supervision(panel).getByRole('button', { name: 'Stop CLI task' })).toHaveCount(
+          0
+        );
+        await panel.reload();
+        await expect(supervision(panel)).toContainText(resultText);
+        await expect(target.locator('#count')).toHaveText('1');
+        await expect(
+          supervision(panel).getByRole('button', { exact: true, name: 'Approve tab' })
+        ).toHaveCount(0);
+      },
+      {
+        gateway: {
+          beforeFirstCompletion: () => completion.promise,
+          firstCompletionEvents: toolCall('eval', {
+            code: 'document.querySelector("#effect").click(); return document.querySelector("#count").textContent;',
+          }),
+          secondCompletionEvents: content(resultText),
+          toolNames: dangerousToolNames,
+        },
+      }
+    );
+  });
+
+  test(`${mode}: Reject leaves the target untouched and removes consent after reload`, async () => {
+    await withHarness(async ({ panel, target, relay }) => {
+      await enable(panel);
+      await panel.getByRole('tab', { exact: true, name: mode }).click();
+      relay.submit();
+      await supervision(panel).getByRole('button', { exact: true, name: 'Reject' }).click();
+      await expect(supervision(panel)).toContainText('approval_denied');
+      await expect(supervision(panel)).toContainText('No observed evidence.');
+      await expect(target.locator('#count')).toHaveText('0');
+      await panel.reload();
+      await expect(supervision(panel)).toContainText('approval_denied');
+      await expect(panel.getByRole('button', { exact: true, name: 'Approve tab' })).toHaveCount(0);
+      await capture(panel, `${mode}-denied-empty-evidence`);
+    });
+  });
+
+  test(`${mode}: Stop invalidates an open delegated workflow approval, including persisted reload`, async () => {
+    await withHarness(
+      async ({ panel, target, relay }) => {
+        await enable(panel);
+        await panel.getByRole('tab', { exact: true, name: mode }).click();
+        relay.submit('Save the proposed workflow only after explicit approval.');
+        await approve(panel);
+        const dialog = panel.getByRole('dialog', { name: 'Save workflow' });
+        await expect(dialog).toBeVisible();
+        await assertSupervision(dialog);
+        await keyboardReach(panel, dialog.getByRole('button', { name: 'Stop CLI task' }), dialog);
+        await capture(panel, `${mode}-workflow-approval`);
+        await panel.keyboard.press('Enter');
+        await expect(dialog).toBeHidden();
+        await expect(supervision(panel)).toContainText('cancelled');
+        await panel.reload();
+        await expect(panel.getByLabel('Message agent')).toBeAttached();
+        await expect(dialog).toHaveCount(0);
+        await expect(panel.getByRole('button', { name: 'Approve and save' })).toHaveCount(0);
+        expect(await readExtensionLocalStorage(panel, 'kiloAgentWorkflows')).toBeUndefined();
+        await expect(target.locator('#count')).toHaveText('0');
+      },
+      {
+        gateway: {
+          firstCompletionEvents: toolCall('save_workflow', {
+            description: 'Read an approved page.',
+            name: 'Delegated workflow',
+            scopeOrigin: 'https://example.test',
+            script: 'return { done: true, result: await page.text("h1") };',
+          }),
+          toolNames: safeToolNames,
+        },
+      }
+    );
+  });
+}
+
+const heldExecutionModes = (panel: Page): Promise<(LockMode | undefined)[]> =>
+  panel.evaluate(async name => {
+    const state = await navigator.locks.query();
+    return (state.held ?? []).filter(lock => lock.name === name).map(lock => lock.mode);
+  }, executionLock);
+
+test('two panels share local locks, drain before delegation, and retain a blocked local draft', async () => {
+  const localCompletions = Promise.withResolvers<void>();
+  await withHarness(async ({ panel, openPanel, context, relay }) => {
+    await enable(panel);
+    const second = await openPanel();
+    await expect(supervision(second)).toContainText('Owned by another panel');
+    await context.route('**/api/gateway/v1/chat/completions', async route => {
+      await localCompletions.promise;
+      await route.abort();
+    });
+    for (const page of [panel, second]) {
+      await page.getByLabel('Message agent').fill('Keep this local run open.');
+      await page.getByLabel('Message agent').press('Enter');
+      await expect(page.getByRole('button', { exact: true, name: 'Stop' })).toBeVisible();
+    }
+    await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared', 'shared']);
+    relay.submit();
+    await approve(panel);
+    await expect(supervision(panel)).toContainText('Waiting for browser control');
+    for (const page of [panel, second]) {
+      await page.getByRole('button', { exact: true, name: 'Stop' }).click();
+    }
+    await expect(supervision(panel)).toContainText('CLI tasks: Running');
+    await expect.poll(() => heldExecutionModes(panel)).toEqual(['exclusive']);
+    await second.getByLabel('Message agent').fill('Preserve my unsent local draft.');
+    await second.getByLabel('Message agent').press('Enter');
+    await expect(second.getByLabel('Message agent')).toHaveValue('Preserve my unsent local draft.');
+    await expect(second.getByText(/owns browser control/u).first()).toBeVisible();
+    await supervision(panel).getByRole('button', { name: 'Stop CLI task' }).click();
+    await expect(supervision(panel)).toContainText('cancelled');
+    localCompletions.resolve();
+    await expect(second.getByLabel('Message agent')).toHaveValue('Preserve my unsent local draft.');
+    await expect(second.getByRole('button', { name: 'Send message' })).toBeVisible();
+  });
+});
+
+for (const mode of ['Browser', 'Agents'] as const) {
+  test(`${mode}: memory saving, retry, and confirmation retain keyboard-accessible supervision`, async () => {
+    const finish = Promise.withResolvers<void>();
+    await withHarness(
+      async ({ panel, context, relay }) => {
+        await enable(panel);
+        await panel.getByRole('tab', { exact: true, name: mode }).click();
+        let requests = 0;
+        await context.route('**/api/gateway/v1/chat/completions', async route => {
+          requests += 1;
+          if (requests > 1) {
+            await finish.promise;
+          }
+          await route.fallback();
+        });
+        await panel.evaluate(() => {
+          const scope = globalThis as typeof globalThis & {
+            chrome: {
+              storage: { local: { set: (items: Record<string, unknown>) => Promise<void> } };
+            };
+            releaseMemoryWrite?: () => void;
+          };
+          const storage = scope.chrome.storage.local;
+          const original = storage.set.bind(storage);
+          const gate = Promise.withResolvers<void>();
+          let failOnce = true;
+          scope.releaseMemoryWrite = () => {
+            gate.resolve();
+          };
+          storage.set = async items => {
+            if (Object.hasOwn(items, 'kiloAgentMemories')) {
+              await gate.promise;
+              if (failOnce) {
+                failOnce = false;
+                throw new Error('The test storage rejects the first memory write.');
+              }
+            }
+            await original(items);
+          };
+        });
+        relay.submit('Save the proposed observation only after consent.');
+        await approve(panel);
+        const dialog = panel.getByRole('dialog', { name: 'Add to memory' });
+        await expect(dialog).toBeVisible();
+        await assertSupervision(dialog);
+        await keyboardReach(panel, dialog.getByRole('button', { name: 'Save memory' }), dialog);
+        await panel.keyboard.press('Enter');
+        await expect(dialog.getByRole('button', { name: 'Save memory' })).toBeDisabled();
+        await assertSupervision(dialog);
+        await keyboardReach(panel, dialog.getByRole('button', { name: 'Stop CLI task' }), dialog);
+        await capture(panel, `${mode}-memory-saving`);
+        await panel.evaluate(() => {
+          const scope = globalThis as typeof globalThis & { releaseMemoryWrite: () => void };
+          scope.releaseMemoryWrite();
+        });
+        await expect(dialog).toContainText("Couldn't save memory. Try again.");
+        await assertSupervision(dialog);
+        await capture(panel, `${mode}-memory-retryable-error`);
+        await dialog.getByRole('button', { exact: true, name: 'Retry' }).click();
+        await expect(dialog).toContainText('Saved to memory');
+        expect(await readExtensionLocalStorage(panel, 'kiloAgentMemories')).toEqual(
+          expect.arrayContaining([expect.objectContaining({ text: 'Delegated observation A1.' })])
+        );
+        await assertSupervision(dialog);
+        await keyboardReach(panel, dialog.getByRole('button', { name: 'Stop CLI task' }), dialog);
+        await capture(panel, `${mode}-memory-confirmation`);
+        await panel.keyboard.press('Enter');
+        await expect(supervision(dialog)).toContainText('cancelled');
+        finish.resolve();
+        await dialog.getByRole('button', { exact: true, name: 'Done' }).click();
+        await panel.reload();
+        await expect(dialog).toHaveCount(0);
+        expect(await readExtensionLocalStorage(panel, 'kiloAgentMemories')).toEqual(
+          expect.arrayContaining([expect.objectContaining({ text: 'Delegated observation A1.' })])
+        );
+      },
+      {
+        gateway: {
+          firstCompletionEvents: toolCall('save_memory', { text: 'Delegated observation A1.' }),
+          secondCompletionEvents: content('The memory was saved.'),
+          toolNames: safeToolNames,
+        },
+      }
+    );
+  });
+
+  test(`${mode}: an expired result fence still requires tab closure and drained native locks`, async () => {
+    const completion = Promise.withResolvers<void>();
+    let clockOffset = 0;
+    await withHarness(
+      async ({ panel, target, openPanel, relay }) => {
+        await enable(panel);
+        await panel.getByRole('tab', { exact: true, name: mode }).click();
+        const delivery = relay.submit();
+        await approve(panel);
+        await expect(supervision(panel)).toContainText('CLI tasks: Running');
+        relay.interrupt(delivery.job, 'provider_lost');
+        await expect(supervision(panel)).toContainText('Recovery required');
+        await capture(panel, `${mode}-interrupted`);
+        await expect
+          .poll(() => readExtensionLocalStorage(panel, 'kiloBrowserExecutionSafety'))
+          .toEqual(
+            expect.objectContaining({ tabIds: expect.arrayContaining([expect.any(Number)]) })
+          );
+        // Only this deterministic browser case advances time. The peer supplies post-expiry history;
+        // Reloading also expires the real extension's persisted results, not its safety record.
+        clockOffset = 7 * 86_400_000 + 1000;
+        relay.expireResults();
+        completion.resolve();
+        await panel.clock.install({ time: new Date(Date.now() + clockOffset) });
+        await panel.reload();
+        await supervision(panel).getByRole('button', { name: 'Refresh status' }).click();
+        await supervision(panel).getByRole('button', { name: 'Check recovery readiness' }).click();
+        await expect(panel.getByRole('button', { name: 'Recover browser control' })).toHaveCount(0);
+        await expect(supervision(panel)).toContainText('Close');
+        await target.close();
+        const second = await openPanel();
+        await second.evaluate(() => {
+          const gate = Promise.withResolvers<void>();
+          Object.assign(globalThis, {
+            releaseRecoveryLock: () => {
+              gate.resolve();
+            },
+          });
+          void navigator.locks.request(
+            'kilo:browser-execution',
+            { mode: 'shared' },
+            () => gate.promise
+          );
+        });
+        await expect.poll(() => heldExecutionModes(panel)).toContain('shared');
+        await supervision(panel).getByRole('button', { name: 'Check recovery readiness' }).click();
+        await expect(panel.getByRole('button', { name: 'Recover browser control' })).toHaveCount(0);
+        await capture(panel, `${mode}-recovery-blocked`);
+        await second.evaluate(() => {
+          const scope = globalThis as typeof globalThis & { releaseRecoveryLock: () => void };
+          scope.releaseRecoveryLock();
+        });
+        await second.close();
+        await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+        await supervision(panel).getByRole('button', { name: 'Check recovery readiness' }).click();
+        await panel.getByRole('button', { name: 'Recover browser control' }).click();
+        await expect(supervision(panel)).toContainText('Enabled — idle');
+        await expect(panel.getByRole('button', { exact: true, name: 'Approve tab' })).toHaveCount(
+          0
+        );
+        await expect(panel.getByRole('button', { name: 'Stop CLI task' })).toHaveCount(0);
+        await capture(panel, `${mode}-recovered-without-replay`);
+      },
+      {
+        gateway: { beforeFirstCompletion: () => completion.promise },
+        relay: { now: () => Date.now() + clockOffset },
+      }
+    );
+  });
+}
+
+for (const reason of ['approval_timeout', 'execution_timeout', 'permission_denied'] as const) {
+  test(`${reason} has a finite non-success outcome and no execution after late dispatch`, async () => {
+    const completion = Promise.withResolvers<void>();
+    await withHarness(
+      async ({ panel, target, relay }) => {
+        await enable(panel);
+        const delivery = relay.submit();
+        await expect(supervision(panel)).toContainText('Tab approval required');
+        if (reason === 'execution_timeout') {
+          await approve(panel);
+          await expect(supervision(panel)).toContainText('CLI tasks: Running');
+        }
+        relay.interrupt(delivery.job, reason);
+        await expect(supervision(panel)).toContainText(reason);
+        relay.send(delivery);
+        await panel.reload();
+        completion.resolve();
+        await expect(supervision(panel)).toContainText(reason);
+        await expect(panel.getByRole('button', { exact: true, name: 'Approve tab' })).toHaveCount(
+          0
+        );
+        await expect(target.locator('#count')).toHaveText('0');
+      },
+      { gateway: { beforeFirstCompletion: () => completion.promise } }
+    );
+  });
+}
+
+test('provider cancellation wins over a delayed queued dispatch without replacing the active owner', async () => {
+  await withHarness(async ({ panel, relay, target }) => {
+    await enable(panel);
+    relay.submit('Retain the active A1 consent.');
+    await expect(supervision(panel)).toContainText('Retain the active A1 consent.');
+    const queued = relay.submit('Never execute the cancelled B1 goal.', 'ses_parent_B1', true);
+    await panel
+      .getByRole('button', { name: `Cancel queued task ${queued.job.jobId.slice(-8)}` })
+      .click();
+    await expect(panel.getByRole('list', { name: 'Queued CLI tasks' })).toHaveCount(0);
+    relay.send({
+      ...queued,
+      job: { ...queued.job, queuePosition: undefined, status: 'awaiting_approval' },
+    });
+    await expect(supervision(panel)).toContainText('Retain the active A1 consent.');
+    await expect(supervision(panel)).not.toContainText('Never execute the cancelled B1 goal.');
+    await expect(supervision(panel)).toContainText('Tab approval required');
+    await expect(target.locator('#count')).toHaveText('0');
+    await supervision(panel).getByRole('button', { exact: true, name: 'Reject' }).click();
+  });
+});
+
+test('a vanished consent candidate retains the goal and never selects another tab', async () => {
+  await withHarness(async ({ panel, relay, target, other }) => {
+    await enable(panel);
+    relay.submit('Keep this goal when its candidate closes.');
+    await supervision(panel)
+      .getByLabel('Tab to approve')
+      .selectOption({ label: 'Approved browser task tab' });
+    await target.close();
+    await expect(supervision(panel)).toContainText('The goal is retained.');
+    await expect(supervision(panel)).toContainText('Keep this goal when its candidate closes.');
+    await expect(
+      supervision(panel).getByRole('button', { exact: true, name: 'Approve tab' })
+    ).toBeDisabled();
+    await expect(other.locator('#count')).toHaveText('0');
+  });
+});
+
+test('sign-out during quarantine preserves safety and provider identity after account history disappears', async () => {
+  const completion = Promise.withResolvers<void>();
+  await withHarness(
+    async ({ panel, relay, target }) => {
+      await enable(panel);
+      const profile = await supervision(panel)
+        .getByText(/^Profile:/u)
+        .textContent();
+      const delivery = relay.submit();
+      await approve(panel);
+      await expect(supervision(panel)).toContainText('CLI tasks: Running');
+      relay.interrupt(delivery.job, 'provider_lost');
+      await expect(supervision(panel)).toContainText('Recovery required');
+      await expect
+        .poll(() => readExtensionLocalStorage(panel, 'kiloBrowserExecutionSafety'))
+        .toEqual(expect.objectContaining({ tabIds: expect.arrayContaining([expect.any(Number)]) }));
+      const safety = await readExtensionLocalStorage(panel, 'kiloBrowserExecutionSafety');
+      await panel.getByLabel('Settings', { exact: true }).click();
+      await panel.getByRole('button', { name: 'Sign out' }).click();
+      await expect(panel.getByRole('button', { exact: true, name: 'Sign in' })).toBeVisible();
+      expect(await readExtensionLocalStorage(panel, 'kiloBrowserExecutionSafety')).toEqual(safety);
+      relay.expireResults();
+      await seedExtensionAuth(panel);
+      await panel.reload();
+      await expect(supervision(panel)).toContainText('CLI tasks: Disabled');
+      await expect(supervision(panel).getByText(/^Profile:/u)).toHaveText(profile ?? '');
+      await enable(panel, false, 'Recovery required');
+      await supervision(panel).getByRole('button', { name: 'Refresh status' }).click();
+      await supervision(panel).getByRole('button', { name: 'Check recovery readiness' }).click();
+      await expect(panel.getByRole('button', { name: 'Recover browser control' })).toHaveCount(0);
+      await expect(target.locator('#count')).toHaveText('0');
+      await capture(panel, 'signed-in-quarantine-with-expired-results');
+      completion.resolve();
+    },
+    { gateway: { beforeFirstCompletion: () => completion.promise } }
+  );
+});
+
+test('Safe delegation rejects an unsafe model tool without a browser side effect', async () => {
+  await withHarness(
+    async ({ panel, relay, target }) => {
+      await enable(panel);
+      relay.submit('Do not execute an unsafe model tool.');
+      await approve(panel);
+      await expect(supervision(panel)).toContainText('permission_denied');
+      await expect(supervision(panel)).not.toContainText('Last outcome: succeeded');
+      await expect(target.locator('#count')).toHaveText('0');
+    },
+    {
+      gateway: {
+        firstCompletionEvents: toolCall('eval', {
+          code: 'document.querySelector("#effect").click(); return 1;',
+        }),
+        toolNames: safeToolNames,
+      },
+    }
+  );
+});
+
+for (const scenario of [
+  { expected: 'Unsupported', options: { supported: false } },
+  { expected: 'Unavailable', options: { registrationError: true } },
+  { expected: 'Connecting', options: { silent: true } },
+]) {
+  test(`provider ${scenario.expected.toLowerCase()} explains the failure without dispatch`, async () => {
+    await withHarness(
+      async ({ panel, relay, target }) => {
+        await enable(panel, false, scenario.expected);
+        for (const mode of ['Browser', 'Agents']) {
+          await panel.getByRole('tab', { exact: true, name: mode }).click();
+          await expect(supervision(panel)).toContainText(`CLI tasks: ${scenario.expected}`);
+          await expect(panel.getByRole('button', { exact: true, name: 'Approve tab' })).toHaveCount(
+            0
+          );
+          await expect(target.locator('#count')).toHaveText('0');
+          await capture(panel, `${mode}-${scenario.expected.toLowerCase()}`);
+        }
+        expect(relay.results).toHaveLength(0);
+      },
+      { relay: scenario.options }
+    );
+  });
+}
+
+test('missing native Web Locks disables delegation without disabling ordinary local work', async () => {
+  await withHarness(
+    async ({ panel, target }) => {
+      await expect(supervision(panel)).toContainText('does not support Web Locks');
+      await expect(panel.getByRole('button', { exact: true, name: 'Approve tab' })).toHaveCount(0);
+      await panel.getByLabel('Message agent').fill('Read this page locally.');
+      await panel.getByLabel('Message agent').press('Enter');
+      await expect(panel.getByText('Observed the requested page.', { exact: true })).toBeVisible();
+      await expect(target.locator('#count')).toHaveText('0');
+    },
+    {
+      init: context =>
+        context.addInitScript(() => {
+          Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined });
+        }),
+    }
+  );
+});
+
+for (const modal of [
+  'Settings panel',
+  'Select model',
+  'Conversation history',
+  'Run workflow',
+] as const) {
+  test(`${modal} keeps bound-tab supervision and keyboard Stop inside its focus boundary`, async () => {
+    const completion = Promise.withResolvers<void>();
+    await withHarness(
+      async ({ panel, relay, target }) => {
+        await enable(panel);
+        if (modal === 'Run workflow') {
+          const script = 'return { done: true, result: input.name };';
+          await setExtensionStorage(panel, {
+            kiloAgentWorkflows: [
+              {
+                approvedScriptHash: createHash('sha256').update(script).digest('hex'),
+                createdAt: Date.now(),
+                description: 'Prompt fixture',
+                id: randomUUID(),
+                name: 'Prompt fixture',
+                params: [{ description: 'A name', name: 'name', required: true }],
+                scopeOrigin: new URL(target.url()).origin,
+                script,
+                updatedAt: Date.now(),
+              },
+            ],
+            kiloWorkflowSettings: {
+              allowWorkflowsInSafeMode: true,
+              autoApproveWorkflowChanges: false,
+              autoApproveWorkflowRuns: false,
+            },
+          });
+        }
+        relay.submit();
+        await approve(panel);
+        await expect(supervision(panel)).toContainText('CLI tasks: Running');
+        if (modal === 'Settings panel' || modal === 'Run workflow') {
+          await panel.getByLabel('Settings', { exact: true }).click();
+          if (modal === 'Run workflow') {
+            await panel.getByLabel('Run workflow "Prompt fixture"').click();
+          }
+        } else if (modal === 'Select model') {
+          await panel.getByLabel('Model', { exact: true }).click();
+        } else {
+          await panel.getByLabel('History', { exact: true }).click();
+        }
+        const dialog = panel.getByRole('dialog', {
+          exact: modal !== 'Run workflow',
+          name: modal === 'Run workflow' ? /Run workflow/u : modal,
+        });
+        await expect(dialog).toBeVisible();
+        await assertSupervision(dialog);
+        await keyboardReach(panel, dialog.getByRole('button', { name: 'Stop CLI task' }), dialog);
+        await capture(panel, `modal-${modal.replaceAll(' ', '-')}`);
+        await panel.keyboard.press('Enter');
+        await expect(supervision(dialog)).toContainText('cancelled');
+        completion.resolve();
+        const closeNames = {
+          'Conversation history': 'Close history',
+          'Run workflow': 'Cancel',
+          'Select model': 'Close model picker',
+          'Settings panel': 'Close settings',
+        };
+        const openerNames = {
+          'Conversation history': 'History',
+          'Run workflow': 'Run workflow "Prompt fixture"',
+          'Select model': 'Model',
+          'Settings panel': 'Settings',
+        };
+        await keyboardReach(
+          panel,
+          dialog.getByRole('button', { exact: true, name: closeNames[modal] }),
+          dialog
+        );
+        await panel.keyboard.press('Enter');
+        await expect(dialog).toBeHidden();
+        await expect(panel.getByLabel(openerNames[modal], { exact: true })).toBeFocused();
+        await expect(target.locator('#count')).toHaveText('0');
+      },
+      { gateway: { beforeFirstCompletion: () => completion.promise } }
+    );
+  });
+}

--- a/apps/extension/tests/e2e/browser-task.test.ts
+++ b/apps/extension/tests/e2e/browser-task.test.ts
@@ -436,9 +436,6 @@ const approve = async (root: Page | Locator): Promise<void> => {
 };
 const capture = async (panel: Page, name: string): Promise<void> => {
   await panel.setViewportSize({ height: 720, width: 320 });
-  await panel.evaluate(() => {
-    document.documentElement.style.fontSize = '200%';
-  });
   const dialogs = panel.getByRole('dialog');
   const root = (await dialogs.count()) > 0 ? dialogs.last() : panel;
   const stop = supervision(root).getByRole('button', { name: 'Stop CLI task' });
@@ -496,10 +493,7 @@ for (const mode of ['Browser', 'Agents'] as const) {
         );
         await expect(supervision(panel)).toContainText('Tab approval required');
         await expect(target.locator('#count')).toHaveText('0');
-        await panel.evaluate(() => {
-          document.documentElement.style.fontSize = '200%';
-        });
-        await capture(panel, `${mode}-approval-320px-200percent`);
+        await capture(panel, `${mode}-approval-320px`);
         await approve(panel);
         await expect(supervision(panel)).toContainText('CLI tasks: Running');
         await other.bringToFront();
@@ -519,7 +513,7 @@ for (const mode of ['Browser', 'Agents'] as const) {
         await expect(panel.getByRole('list', { name: 'Queued CLI tasks' })).toContainText(
           'Queue deadline:'
         );
-        await capture(panel, `${mode}-running-queued-320px-200percent`);
+        await capture(panel, `${mode}-running-queued-320px`);
         await panel
           .getByRole('button', { name: `Cancel queued task ${queued.job.jobId.slice(-8)}` })
           .click();
@@ -691,6 +685,68 @@ for (const profile of ['enabled', 'quarantined'] as const) {
         expect(ownerLocks).toEqual([
           expect.objectContaining({ clientId: expect.any(String), mode: 'exclusive' }),
         ]);
+        if (quarantined) {
+          const name = 'native-ownership-quarantined-original-owner-320px';
+          const conversation = panel.getByRole('region', { name: 'Agent conversation' });
+          await expect(
+            conversation.locator('xpath=../following-sibling::p[@role="status"]')
+          ).toBeVisible();
+          await capture(panel, name);
+          const geometry = await conversation.evaluate(section => {
+            const viewport = section.parentElement;
+            const greeting = section.querySelector(':scope > p');
+            const warning = viewport?.nextElementSibling;
+            if (
+              viewport === null ||
+              greeting === null ||
+              !(warning instanceof HTMLElement) ||
+              !warning.matches('p[role="status"]')
+            ) {
+              throw new Error('The empty conversation must precede the admission warning.');
+            }
+            // eslint-disable-next-line unicorn/consistent-function-scoping -- Playwright serializes this helper with the page callback.
+            const rectangle = (element: Element) => {
+              const { bottom, height, left, right, top, width } = element.getBoundingClientRect();
+              return { bottom, height, left, right, top, width };
+            };
+            const conversationRect = rectangle(section);
+            const greetingRect = rectangle(greeting);
+            const viewportRect = rectangle(viewport);
+            const overflowY = {
+              conversation: getComputedStyle(section).overflowY,
+              viewport: getComputedStyle(viewport).overflowY,
+            };
+            const clippingValues = new Set(['auto', 'clip', 'hidden', 'scroll']);
+            const viewportBottom = clippingValues.has(overflowY.viewport)
+              ? viewportRect.bottom
+              : Number.POSITIVE_INFINITY;
+            const conversationBottom = clippingValues.has(overflowY.conversation)
+              ? conversationRect.bottom
+              : Number.POSITIVE_INFINITY;
+            // Clip each boundary independently; raw greeting bounds can exceed the viewport.
+            return {
+              conversation: conversationRect,
+              greeting: greetingRect,
+              overflowY,
+              paintedConversationBottom: Math.min(conversationRect.bottom, viewportBottom),
+              paintedGreetingBottom: Math.min(
+                greetingRect.bottom,
+                conversationBottom,
+                viewportBottom
+              ),
+              viewport: viewportRect,
+              warning: rectangle(warning),
+            };
+          });
+          await test.info().attach(`${name}-geometry`, {
+            body: JSON.stringify(geometry, null, 2),
+            contentType: 'application/json',
+          });
+          expect(
+            Math.max(geometry.paintedConversationBottom, geometry.paintedGreetingBottom),
+            'The conversation must not paint into the quarantine warning.'
+          ).toBeLessThanOrEqual(geometry.warning.top);
+        }
         const second = await openPanel();
         const reload = supervision(second).getByRole('button', { name: 'Reload panel' });
         await expect(supervision(second)).toContainText('Ownership not acquired');

--- a/apps/extension/tests/e2e/browser-task.test.ts
+++ b/apps/extension/tests/e2e/browser-task.test.ts
@@ -413,8 +413,13 @@ const enable = async (
   );
   if (dangerous) {
     await settings.getByRole('button', { name: /Safe mode/u }).click();
-    await settings.getByRole('button', { exact: true, name: 'Dangerous' }).click();
+    await settings
+      .getByRole('button', { exact: true, name: 'Dangerous Arbitrary webpage control' })
+      .click();
   }
+  await expect(
+    settings.getByRole('button', { name: dangerous ? /^Danger mode:/u : /^Safe mode:/u })
+  ).toBeVisible();
   await settings.getByRole('switch', { exact: true, name: 'CLI tasks' }).click();
   await expect(settings.getByRole('switch', { exact: true, name: 'CLI tasks' })).toHaveAttribute(
     'aria-checked',
@@ -783,7 +788,9 @@ for (const loss of ['close', 'reload'] as const) {
           .getByLabel('Target tab')
           .selectOption({ label: 'Approved browser task tab' });
         await localOwner.getByRole('button', { name: /(?:Safe|Dangerous) mode/u }).click();
-        await localOwner.getByRole('button', { exact: true, name: 'Dangerous' }).click();
+        await localOwner
+          .getByRole('button', { exact: true, name: 'Dangerous Arbitrary webpage control' })
+          .click();
         await localOwner.getByLabel('Message agent').fill('Issue the local page action and wait.');
         await localOwner.getByLabel('Message agent').press('Enter');
         await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
@@ -843,7 +850,9 @@ for (const loss of ['close', 'reload'] as const) {
         await expect(panel.getByLabel('Message agent')).toHaveValue(draft);
         await panel.getByLabel('Target tab').selectOption({ label: 'Unapproved tab' });
         await panel.getByRole('button', { name: /(?:Safe|Dangerous) mode/u }).click();
-        await panel.getByRole('button', { exact: true, name: 'Dangerous' }).click();
+        await panel
+          .getByRole('button', { exact: true, name: 'Dangerous Arbitrary webpage control' })
+          .click();
         await panel.getByLabel('Message agent').press('Enter');
         await expect(panel.getByText(recoveredText, { exact: true })).toBeVisible();
         await expect.poll(() => heldExecutionModes(panel)).toEqual([]);

--- a/apps/extension/tests/e2e/browser-task.test.ts
+++ b/apps/extension/tests/e2e/browser-task.test.ts
@@ -332,8 +332,17 @@ const withHarness = async (
     },
     title: 'Approved browser task tab',
   });
-  const launched = await launchExtensionContext();
+  const launched = await launchExtensionContext({
+    recordVideo: {
+      dir: test.info().outputPath('videos'),
+      size: { height: 720, width: 320 },
+    },
+  });
   const { context, extensionId } = launched;
+  const recordedPages = context.pages();
+  context.on('page', page => {
+    recordedPages.push(page);
+  });
   try {
     await options.init?.(context);
     await mockAgentsApi(context, { activeSessions: [], historySessions: [] });
@@ -359,9 +368,22 @@ const withHarness = async (
     await expect(panel.getByLabel('Message agent')).toBeVisible();
     await run({ context, openPanel, other, panel, relay, target });
   } finally {
-    await context.close();
-    await fixture.close();
-    await rm(launched.userDataDir, { force: true, recursive: true });
+    try {
+      await context.close();
+      for (const [index, page] of recordedPages.entries()) {
+        const video = page.video();
+        expect.soft(video, 'Mocked browser-task pages must retain video.').not.toBeNull();
+        if (video !== null) {
+          await test.info().attach(`browser-task-page-${index}`, {
+            contentType: 'video/webm',
+            path: await video.path(),
+          });
+        }
+      }
+    } finally {
+      await fixture.close();
+      await rm(launched.userDataDir, { force: true, recursive: true });
+    }
   }
 };
 const supervision = (root: Page | Locator) =>
@@ -589,7 +611,7 @@ test('two panels share local locks, drain before delegation, and retain a blocke
   await withHarness(async ({ panel, openPanel, context, relay }) => {
     await enable(panel);
     const second = await openPanel();
-    await expect(supervision(second)).toContainText('Owned by another panel');
+    await expect(supervision(second)).toContainText('Ownership not acquired');
     await context.route('**/api/gateway/v1/chat/completions', async route => {
       await localCompletions.promise;
       await route.abort();
@@ -600,14 +622,18 @@ test('two panels share local locks, drain before delegation, and retain a blocke
       await expect(page.getByRole('button', { exact: true, name: 'Stop' })).toBeVisible();
     }
     await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared', 'shared']);
+    const reload = supervision(second).getByRole('button', { name: 'Reload panel' });
+    await expect(reload).toBeDisabled();
     relay.submit();
     await approve(panel);
     await expect(supervision(panel)).toContainText('Waiting for browser control');
+    await expect(reload).toBeDisabled();
     for (const page of [panel, second]) {
       await page.getByRole('button', { exact: true, name: 'Stop' }).click();
     }
     await expect(supervision(panel)).toContainText('CLI tasks: Running');
     await expect.poll(() => heldExecutionModes(panel)).toEqual(['exclusive']);
+    await expect(reload).toBeDisabled();
     await second.getByLabel('Message agent').fill('Preserve my unsent local draft.');
     await second.getByLabel('Message agent').press('Enter');
     await expect(second.getByLabel('Message agent')).toHaveValue('Preserve my unsent local draft.');
@@ -615,10 +641,128 @@ test('two panels share local locks, drain before delegation, and retain a blocke
     await supervision(panel).getByRole('button', { name: 'Stop CLI task' }).click();
     await expect(supervision(panel)).toContainText('cancelled');
     localCompletions.resolve();
+    await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+    await expect(reload).toBeEnabled();
     await expect(second.getByLabel('Message agent')).toHaveValue('Preserve my unsent local draft.');
     await expect(second.getByRole('button', { name: 'Send message' })).toBeVisible();
   });
 });
+
+const heldProviderLocks = (panel: Page): Promise<LockInfo[]> =>
+  panel.evaluate(async () => {
+    const state = await navigator.locks.query();
+    return (state.held ?? []).filter(lock => lock.name === 'kilo:browser-provider-owner');
+  });
+
+for (const profile of ['enabled', 'quarantined'] as const) {
+  test(`native ownership retry preserves the ${profile} profile after explicit reload`, async () => {
+    await withHarness(
+      async ({ panel, openPanel, context, relay, target, other }) => {
+        let requests = 0;
+        context.on('request', request => {
+          if (request.url().endsWith('/api/gateway/v1/chat/completions')) {
+            requests += 1;
+          }
+        });
+        const quarantined = profile === 'quarantined';
+        const phase = quarantined ? 'Recovery required' : 'Enabled — idle';
+        await setExtensionStorage(panel, {
+          kiloBrowserExecutionSafety: {
+            ...(quarantined ? { allTabs: true } : {}),
+            tabIds: [],
+            version: 1,
+          },
+        });
+        await enable(panel, true, phase);
+        const saved = await Promise.all(
+          [
+            'kiloAuth',
+            'kiloBrowserProviderIdentity',
+            'kiloBrowserProviderSettings',
+            'kiloBrowserExecutionSafety',
+          ].map(async key => ({ key, value: await readExtensionLocalStorage(panel, key) }))
+        );
+        const ownerLocks = await heldProviderLocks(panel);
+        expect(ownerLocks).toEqual([
+          expect.objectContaining({ clientId: expect.any(String), mode: 'exclusive' }),
+        ]);
+        const second = await openPanel();
+        const reload = supervision(second).getByRole('button', { name: 'Reload panel' });
+        await expect(supervision(second)).toContainText('Ownership not acquired');
+        await expect(reload).toBeEnabled();
+        await Promise.all([second.waitForEvent('load'), reload.click()]);
+        await expect(supervision(second)).toContainText('Ownership not acquired');
+        expect(await heldProviderLocks(second)).toEqual(ownerLocks);
+        await expect(target.locator('#count')).toHaveText('0');
+        expect(requests).toBe(0);
+        await capture(second, `native-ownership-${profile}-live-owner-retry`);
+
+        await panel.close();
+        await expect.poll(() => heldProviderLocks(second)).toEqual([]);
+        await expect(supervision(second)).toContainText('Ownership not acquired');
+        await expect(reload).toBeEnabled();
+        await expect(second.getByRole('button', { name: 'Refresh status' })).toHaveCount(0);
+        await Promise.all([second.waitForEvent('load'), reload.click()]);
+        await expect(supervision(second)).toContainText(`CLI tasks: ${phase}`);
+        await expect
+          .poll(() => heldProviderLocks(second))
+          .toEqual([expect.objectContaining({ clientId: expect.any(String), mode: 'exclusive' })]);
+        expect(await heldProviderLocks(second)).not.toEqual(ownerLocks);
+        for (const { key, value } of saved) {
+          expect(await readExtensionLocalStorage(second, key)).toEqual(value);
+        }
+        await expect(reload).toHaveCount(0);
+        await expect(second.getByRole('button', { exact: true, name: 'Approve tab' })).toHaveCount(
+          0
+        );
+        await expect(second.getByRole('button', { name: 'Stop CLI task' })).toHaveCount(0);
+        await expect(target.locator('#count')).toHaveText('0');
+        await expect(other.locator('#count')).toHaveText('0');
+        expect(requests).toBe(0);
+        await capture(second, `native-ownership-${profile}-explicit-acquisition`);
+
+        if (quarantined) {
+          await supervision(second)
+            .getByRole('button', { name: 'Check recovery readiness' })
+            .click();
+          await expect(supervision(second)).toContainText('Close all target tabs before recovery.');
+          await expect(second.getByRole('button', { name: 'Recover browser control' })).toHaveCount(
+            0
+          );
+          const draft = 'Keep this draft while browser control is quarantined.';
+          await second.getByLabel('Message agent').fill(draft);
+          await second.getByLabel('Message agent').press('Enter');
+          await expect(second.getByLabel('Message agent')).toHaveValue(draft);
+          await expect(target.locator('#count')).toHaveText('0');
+          expect(requests).toBe(0);
+        } else {
+          await expect(supervision(second)).toContainText('Queue empty.');
+          relay.submit('Run only after fresh tab consent in the new owning panel.');
+          await expect(supervision(second)).toContainText('Tab approval required');
+          await expect(supervision(second)).toContainText('Bound tab: Not approved');
+          await expect(supervision(second).getByLabel('Tab to approve')).toHaveValue('');
+          await expect(target.locator('#count')).toHaveText('0');
+          expect(requests).toBe(0);
+          await approve(second);
+          await expect(supervision(second)).toContainText('Last outcome: succeeded');
+          await expect(target.locator('#count')).toHaveText('1');
+          await expect(other.locator('#count')).toHaveText('0');
+          expect(requests).toBe(2);
+        }
+        await capture(second, `native-ownership-${profile}-consent-and-safety`);
+      },
+      {
+        gateway: {
+          firstCompletionEvents: toolCall('eval', {
+            code: 'document.querySelector("#effect").click(); return document.querySelector("#count").textContent;',
+          }),
+          secondCompletionEvents: content(resultText),
+          toolNames: dangerousToolNames,
+        },
+      }
+    );
+  });
+}
 
 for (const loss of ['close', 'reload'] as const) {
   test(`native local owner ${loss} blocks local and delegated work until explicit recovery`, async () => {

--- a/apps/extension/tests/e2e/browser-task.test.ts
+++ b/apps/extension/tests/e2e/browser-task.test.ts
@@ -1505,9 +1505,14 @@ const expectNativeSendPending = async (panel: Page, draft: string): Promise<void
   await expect(panel.getByRole('button', { exact: true, name: 'Send message' })).toBeDisabled();
 };
 
-// Each installation belongs to one Send action. Restore simultaneous gates in reverse order.
-const holdNativeSendBoundary = async (panel: Page, boundary: 'safety' | 'tab') => {
-  const handle = await panel.evaluateHandle(kind => {
+// Each installation belongs to one Send or Resume action. Restore simultaneous gates in reverse order.
+const holdNativeSendBoundary = async (
+  panel: Page,
+  boundary: 'safety' | 'tab',
+  action: 'send' | 'resume' = 'send'
+) => {
+  const options = { activation: action, kind: boundary };
+  const handle = await panel.evaluateHandle(({ kind, activation }) => {
     const scope = globalThis as typeof globalThis & {
       chrome: typeof browser;
     };
@@ -1552,16 +1557,21 @@ const holdNativeSendBoundary = async (panel: Page, boundary: 'safety' | 'tab') =
       if (!(input instanceof HTMLTextAreaElement)) {
         return;
       }
-      const send = input.form?.querySelector('button[type="submit"]');
+      const control =
+        activation === 'resume'
+          ? [...document.querySelectorAll('button')].find(
+              button => button.textContent?.trim() === 'Resume queued message'
+            )
+          : input.form?.querySelector('button[type="submit"]');
       const enter =
         event instanceof KeyboardEvent &&
         event.key === 'Enter' &&
         !event.shiftKey &&
-        event.target === input;
+        event.target === (activation === 'resume' ? control : input);
       const click =
         event.type === 'click' &&
         event.target instanceof Node &&
-        send?.contains(event.target) === true;
+        control?.contains(event.target) === true;
       if (!enter && !click) {
         return;
       }
@@ -1627,7 +1637,7 @@ const holdNativeSendBoundary = async (panel: Page, boundary: 'safety' | 'tab') =
     document.addEventListener('keydown', arm, true);
     document.addEventListener('click', arm, true);
     return state;
-  }, boundary);
+  }, options);
   return {
     dispose: async () => {
       try {
@@ -2170,3 +2180,480 @@ test('native gap A5 Send: conversation switches isolate pending drafts and settl
     }
   );
 });
+
+const nativeQueueRun = 'Finish local run A before resuming Q.';
+const nativeQueueRunResult = 'Local run A completed normally.';
+const nativeQueueResume = (panel: Page) =>
+  panel.getByRole('button', { exact: true, name: 'Resume queued message' });
+const nativeQueueGateway = (seenChatBodies: unknown[], finish: Promise<void>) => {
+  const gateway = nativeSendGateway(seenChatBodies);
+  return {
+    ...gateway,
+    beforeFirstCompletion: () => finish,
+    firstCompletionEvents: content(nativeQueueRunResult),
+    secondCompletionEvents: gateway.firstCompletionEvents,
+    thirdCompletionEvents: gateway.secondCompletionEvents,
+  };
+};
+const holdNativeQueueContender = (panel: Page) =>
+  panel.evaluateHandle(name => {
+    const hold = Promise.withResolvers<void>();
+    const released = navigator.locks.request(name, { mode: 'exclusive' }, () => hold.promise);
+    return {
+      release: async () => {
+        hold.resolve();
+        await released;
+      },
+    };
+  }, executionLock);
+const expectNativeQueueEmpty = async (panel: Page): Promise<void> => {
+  await expect(nativeQueueResume(panel)).toHaveCount(0);
+  await expect(panel.getByRole('button', { name: 'Cancel queued message' })).toHaveCount(0);
+  await expect(panel.getByText(/^Queued:/u)).toHaveCount(0);
+};
+const expectNativeQueueRetained = async (panel: Page, queued: string): Promise<void> => {
+  await expect(panel.getByText(`Queued: ${queued}`, { exact: true })).toBeVisible();
+  await expect(panel.getByRole('button', { name: 'Cancel queued message' })).toBeEnabled();
+  await expect(nativeQueueResume(panel)).toBeEnabled();
+  await expect(nativeQueueResume(panel)).toHaveAttribute('aria-busy', 'false');
+  await expect(nativeSendPending(panel)).toHaveCount(0);
+  await expect(panel.getByLabel('Message agent')).toHaveValue('');
+};
+const expectNativeQueuePending = async (panel: Page, queued: string): Promise<void> => {
+  await expectNativeSendPending(panel, '');
+  await expect(nativeQueueResume(panel)).toHaveAttribute('aria-busy', 'true');
+  await expect(nativeQueueResume(panel)).toBeDisabled();
+  await expect(panel.getByText(`Queued: ${queued}`, { exact: true })).toBeVisible();
+  await expect(panel.getByRole('button', { name: 'Cancel queued message' })).toBeEnabled();
+};
+const expectNativeQueueDrained = async (
+  { panel, target, other }: Harness,
+  effects: number
+): Promise<void> => {
+  await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+  if (!target.isClosed()) {
+    await expect(target.locator('#count')).toHaveText(String(effects));
+  }
+  if (!other.isClosed()) {
+    await expect(other.locator('#count')).toHaveText('0');
+  }
+};
+const expectNativeQueueUnsubmitted = async (
+  { panel, target, other }: Harness,
+  queued: string,
+  seenChatBodies: unknown[]
+): Promise<void> => {
+  const conversation = panel.getByRole('region', { name: 'Agent conversation' });
+  await expect(conversation.getByText(nativeQueueRun, { exact: true })).toHaveCount(1);
+  await expect(conversation.getByText(queued, { exact: true })).toHaveCount(0);
+  if (!target.isClosed()) {
+    await expect(target.locator('#count')).toHaveText('0');
+  }
+  if (!other.isClosed()) {
+    await expect(other.locator('#count')).toHaveText('0');
+  }
+  expect(seenChatBodies.map(body => nativeSendUserTexts(body))).toEqual([[nativeQueueRun]]);
+};
+const expectNativeQueueCompletion = async (
+  harness: Harness,
+  submitted: string,
+  seenChatBodies: unknown[]
+): Promise<void> => {
+  const { panel } = harness;
+  const conversation = panel.getByRole('region', { name: 'Agent conversation' });
+  await expect(conversation.getByText(resultText, { exact: true })).toBeVisible();
+  await expectNativeQueueDrained(harness, 1);
+  await expect(nativeSendPending(panel)).toHaveCount(0);
+  await expectNativeQueueEmpty(panel);
+  await expect(conversation.getByText(nativeQueueRun, { exact: true })).toHaveCount(1);
+  await expect(conversation.getByText(submitted, { exact: true })).toHaveCount(1);
+  expect(seenChatBodies.map(body => nativeSendUserTexts(body))).toEqual([
+    [nativeQueueRun],
+    [nativeQueueRun, submitted],
+    [nativeQueueRun, submitted],
+  ]);
+};
+const prepareNativeQueue = async (
+  harness: Harness,
+  queued: string,
+  { seenChatBodies, finish }: { seenChatBodies: unknown[]; finish: () => void }
+): Promise<void> => {
+  const { panel, openPanel } = harness;
+  const input = panel.getByLabel('Message agent');
+  try {
+    await expectNativeQueueEmpty(panel);
+    await input.fill(nativeQueueRun);
+    await input.press('Enter');
+    await expect(panel.getByRole('button', { exact: true, name: 'Stop' })).toBeVisible();
+    await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+    await expect.poll(() => seenChatBodies.length).toBe(1);
+    await input.fill(queued);
+    await input.press('Enter');
+    await expect(input).toHaveValue('');
+    await expect(panel.getByText(`Queued: ${queued}`, { exact: true })).toBeVisible();
+    await expect(panel.getByRole('button', { name: 'Cancel queued message' })).toBeVisible();
+    await expect(nativeQueueResume(panel)).toHaveCount(0);
+    await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+
+    const second = await openPanel();
+    try {
+      const contender = await holdNativeQueueContender(second);
+      try {
+        await expect
+          .poll(() =>
+            panel.evaluate(async name => {
+              const state = await navigator.locks.query();
+              return (state.pending ?? [])
+                .filter(lock => lock.name === name)
+                .map(lock => lock.mode);
+            }, executionLock)
+          )
+          .toEqual(['exclusive']);
+        await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+        // A must finish normally: Stop would discard Q instead of testing the automatic drain.
+        finish();
+        await expect(panel.getByText(nativeQueueRunResult, { exact: true })).toBeVisible();
+        await expect.poll(() => heldExecutionModes(panel)).toEqual(['exclusive']);
+        await expectNativeQueueRetained(panel, queued);
+        await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+        await contender.evaluate(held => held.release());
+      } finally {
+        // Release A before waiting for a contender that can still be queued behind A.
+        finish();
+        try {
+          await contender.evaluate(held => held.release());
+        } finally {
+          await contender.dispose();
+        }
+      }
+    } finally {
+      await second.close();
+    }
+    await expectNativeQueueDrained(harness, 0);
+    await expect(
+      panel.getByRole('status').filter({
+        hasText:
+          'Your queued message is retained. Use Resume queued message when browser control is available.',
+      })
+    ).toBeVisible();
+    await expectNativeQueueRetained(panel, queued);
+    await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+  } finally {
+    finish();
+    await expectNativeQueueDrained(harness, 0);
+  }
+};
+
+test('native gap A2: keyboard Resume retains focus and consumes captured Q once', async () => {
+  const completion = Promise.withResolvers<void>();
+  const seenChatBodies: unknown[] = [];
+  await withHarness(
+    async harness => {
+      const { panel } = harness;
+      const queued = 'Apply queued Q exactly once.';
+      await prepareNativeSend(panel);
+      await prepareNativeQueue(harness, queued, { finish: completion.resolve, seenChatBodies });
+      const resume = nativeQueueResume(panel);
+      const gate = await holdNativeSendBoundary(panel, 'safety', 'resume');
+      try {
+        await keyboardReach(panel, resume);
+        await expect(resume).toBeFocused();
+        await panel.keyboard.press('Enter');
+        await expectNativeQueuePending(panel, queued);
+        await gate.wait();
+        await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+        await expect(resume).toBeFocused();
+        await panel.keyboard.press('Enter');
+        await expect(resume).toBeFocused();
+        await expectNativeQueuePending(panel, queued);
+        await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+
+        await gate.release();
+        await expectNativeQueueCompletion(harness, queued, seenChatBodies);
+        await expect(panel.getByLabel('Message agent')).toHaveValue('');
+      } finally {
+        try {
+          await gate.dispose();
+        } finally {
+          await expectNativeQueueDrained(harness, 1);
+        }
+      }
+    },
+    { gateway: nativeQueueGateway(seenChatBodies, completion.promise) }
+  );
+});
+
+test('native gap A2: native contention retains Q until explicit Resume', async () => {
+  const completion = Promise.withResolvers<void>();
+  const seenChatBodies: unknown[] = [];
+  await withHarness(
+    async harness => {
+      const { panel, openPanel } = harness;
+      const queued = 'Retain Q through fresh native contention.';
+      await prepareNativeSend(panel);
+      await prepareNativeQueue(harness, queued, { finish: completion.resolve, seenChatBodies });
+      const second = await openPanel();
+      const gate = await holdNativeSendBoundary(panel, 'safety', 'resume');
+      try {
+        await nativeQueueResume(panel).click();
+        await expectNativeQueuePending(panel, queued);
+        await gate.wait();
+        const contender = await holdNativeQueueContender(second);
+        try {
+          await expect.poll(() => heldExecutionModes(panel)).toEqual(['exclusive']);
+          await gate.release();
+          await expectNativeQueueRetained(panel, queued);
+          await expect(
+            panel.getByRole('status').filter({ hasText: 'owns browser control' }).first()
+          ).toBeVisible();
+          await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+
+          await contender.evaluate(held => held.release());
+          await gate.restore();
+          await expectNativeQueueDrained(harness, 0);
+          await expect(
+            panel.getByRole('status').filter({
+              hasText:
+                'Your queued message is retained. Use Resume queued message when browser control is available.',
+            })
+          ).toBeVisible();
+          await expectNativeQueueRetained(panel, queued);
+          await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+          await nativeQueueResume(panel).click();
+          await expectNativeQueueCompletion(harness, queued, seenChatBodies);
+          await expect(panel.getByLabel('Message agent')).toHaveValue('');
+        } finally {
+          try {
+            await contender.evaluate(held => held.release());
+          } finally {
+            await contender.dispose();
+          }
+        }
+      } finally {
+        try {
+          await gate.dispose();
+        } finally {
+          await second.close();
+          await expectNativeQueueDrained(harness, 1);
+        }
+      }
+    },
+    { gateway: nativeQueueGateway(seenChatBodies, completion.promise) }
+  );
+});
+
+test('native gap A2: storage failure retains Q until explicit recovery and Resume', async () => {
+  const completion = Promise.withResolvers<void>();
+  const seenChatBodies: unknown[] = [];
+  await withHarness(
+    async harness => {
+      const { panel } = harness;
+      const queued = 'Retain Q through unavailable safety storage.';
+      await enable(panel);
+      await prepareNativeSend(panel);
+      await prepareNativeQueue(harness, queued, { finish: completion.resolve, seenChatBodies });
+      const gate = await holdNativeSendBoundary(panel, 'safety', 'resume');
+      try {
+        await nativeQueueResume(panel).click();
+        await expectNativeQueuePending(panel, queued);
+        await gate.wait();
+        await gate.reject();
+        await expectNativeQueueRetained(panel, queued);
+        await expect(
+          panel
+            .getByRole('status')
+            .filter({
+              hasText:
+                'Browser safety state is unavailable. No browser work can start. Restore storage access before recovery.',
+            })
+            .first()
+        ).toBeVisible();
+        await expectNativeQueueDrained(harness, 0);
+        await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+
+        await gate.restore();
+        await expectNativeQueueRetained(panel, queued);
+        await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+        const controls = supervision(panel);
+        await controls.getByRole('button', { name: 'Check recovery readiness' }).click();
+        const recover = controls.getByRole('button', { name: 'Recover browser control' });
+        await expect(recover).toBeEnabled();
+        await expectNativeQueueRetained(panel, queued);
+        await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+        await recover.click();
+        await expect(controls).toContainText('Enabled — idle');
+        await expectNativeQueueRetained(panel, queued);
+        await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+
+        await nativeQueueResume(panel).click();
+        await expectNativeQueueCompletion(harness, queued, seenChatBodies);
+        await expect(panel.getByLabel('Message agent')).toHaveValue('');
+      } finally {
+        try {
+          await gate.dispose();
+        } finally {
+          await expectNativeQueueDrained(harness, 1);
+        }
+      }
+    },
+    { gateway: nativeQueueGateway(seenChatBodies, completion.promise) }
+  );
+});
+
+for (const change of ['changed', 'closed'] as const) {
+  test(`native gap A2: ${change} target retains Q without retargeting`, async () => {
+    const completion = Promise.withResolvers<void>();
+    const seenChatBodies: unknown[] = [];
+    await withHarness(
+      async harness => {
+        const { panel, target } = harness;
+        const queued = `Retain Q when its target is ${change}.`;
+        await prepareNativeSend(panel);
+        await prepareNativeQueue(harness, queued, { finish: completion.resolve, seenChatBodies });
+        const gate = await holdNativeSendBoundary(panel, 'tab', 'resume');
+        try {
+          await nativeQueueResume(panel).click();
+          await expectNativeQueuePending(panel, queued);
+          await gate.wait();
+          await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+          await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+          await (change === 'changed'
+            ? panel.getByLabel('Target tab').selectOption({ label: 'Unapproved tab' })
+            : target.close());
+          await expectNativeQueuePending(panel, queued);
+          await gate.release();
+          await expect.poll(gate.outcome).toEqual({ failed: change === 'closed', settled: true });
+          await expectNativeQueueDrained(harness, 0);
+          await expectNativeQueueRetained(panel, queued);
+          await expect(
+            panel.getByRole('status').filter({
+              hasText:
+                'The target tab changed or closed. Your queued message is retained. Select a target tab and use Resume queued message.',
+            })
+          ).toBeVisible();
+          await gate.restore();
+          await panel.getByLabel('Target tab').selectOption({ label: 'Unapproved tab' });
+          await expectNativeQueueRetained(panel, queued);
+          await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+        } finally {
+          try {
+            await gate.dispose();
+          } finally {
+            await expectNativeQueueDrained(harness, 0);
+          }
+        }
+      },
+      { gateway: nativeQueueGateway(seenChatBodies, completion.promise) }
+    );
+  });
+}
+
+test('native gap A2: Cancel queued message invalidates a held target lookup', async () => {
+  const completion = Promise.withResolvers<void>();
+  const seenChatBodies: unknown[] = [];
+  await withHarness(
+    async harness => {
+      const { panel } = harness;
+      const queued = 'Never dispatch cancelled Q.';
+      await prepareNativeSend(panel);
+      await prepareNativeQueue(harness, queued, { finish: completion.resolve, seenChatBodies });
+      const gate = await holdNativeSendBoundary(panel, 'tab', 'resume');
+      try {
+        await nativeQueueResume(panel).click();
+        await expectNativeQueuePending(panel, queued);
+        await gate.wait();
+        await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+        await panel.getByRole('button', { name: 'Cancel queued message' }).click();
+        await expectNativeQueueEmpty(panel);
+        await expect(nativeSendPending(panel)).toHaveCount(0);
+        await expect(panel.getByLabel('Message agent')).toHaveValue('');
+        await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+
+        await gate.release();
+        await expect.poll(gate.outcome).toEqual({ failed: false, settled: true });
+        await expectNativeQueueDrained(harness, 0);
+        await expectNativeQueueEmpty(panel);
+        await expect(nativeSendPending(panel)).toHaveCount(0);
+        await expect(panel.getByLabel('Message agent')).toHaveValue('');
+        await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+      } finally {
+        try {
+          await gate.dispose();
+        } finally {
+          await expectNativeQueueDrained(harness, 0);
+        }
+      }
+    },
+    { gateway: nativeQueueGateway(seenChatBodies, completion.promise) }
+  );
+});
+
+for (const outcome of ['success', 'failure'] as const) {
+  test(`native gap A5 Queue: late lookup ${outcome} cannot clear a newer Send`, async () => {
+    const completion = Promise.withResolvers<void>();
+    const seenChatBodies: unknown[] = [];
+    await withHarness(
+      async harness => {
+        const { panel, other } = harness;
+        const queued = 'Never submit Q after its cancellation.';
+        const newDraft = 'Submit only the newer Send B.';
+        const followUp = 'Keep this unsent draft after B.';
+        await prepareNativeSend(panel);
+        await prepareNativeQueue(harness, queued, { finish: completion.resolve, seenChatBodies });
+        await panel.getByLabel('Target tab').selectOption({ label: 'Unapproved tab' });
+        const older = await holdNativeSendBoundary(panel, 'tab', 'resume');
+        try {
+          await nativeQueueResume(panel).click();
+          await expectNativeQueuePending(panel, queued);
+          await older.wait();
+          await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+          await panel.getByRole('button', { name: 'Cancel queued message' }).click();
+          await expectNativeQueueEmpty(panel);
+          await expect(nativeSendPending(panel)).toHaveCount(0);
+          await expect(panel.getByLabel('Message agent')).toHaveValue('');
+          await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+          if (outcome === 'failure') {
+            await other.close();
+          }
+          await panel.getByLabel('Target tab').selectOption({ label: 'Approved browser task tab' });
+          const newer = await holdNativeSendBoundary(panel, 'tab');
+          try {
+            const input = panel.getByLabel('Message agent');
+            await input.fill(newDraft);
+            await input.press('Enter');
+            await expectNativeSendPending(panel, newDraft);
+            await newer.wait();
+            await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared', 'shared']);
+            await input.fill(followUp);
+            await older.release();
+            await expect
+              .poll(older.outcome)
+              .toEqual({ failed: outcome === 'failure', settled: true });
+            await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+            await expectNativeSendPending(panel, followUp);
+            await expectNativeQueueEmpty(panel);
+            await expectNativeQueueUnsubmitted(harness, queued, seenChatBodies);
+            const conversation = panel.getByRole('region', { name: 'Agent conversation' });
+            await expect(conversation.getByText(newDraft, { exact: true })).toHaveCount(0);
+            await expect(conversation.getByText(followUp, { exact: true })).toHaveCount(0);
+
+            await newer.release();
+            await expectNativeQueueCompletion(harness, newDraft, seenChatBodies);
+            await expect(input).toHaveValue(followUp);
+            await expect(conversation.getByText(queued, { exact: true })).toHaveCount(0);
+            await expect(conversation.getByText(followUp, { exact: true })).toHaveCount(0);
+          } finally {
+            await newer.dispose();
+          }
+        } finally {
+          try {
+            await older.dispose();
+          } finally {
+            await expectNativeQueueDrained(harness, 1);
+          }
+        }
+      },
+      { gateway: nativeQueueGateway(seenChatBodies, completion.promise) }
+    );
+  });
+}

--- a/apps/extension/tests/e2e/browser-task.test.ts
+++ b/apps/extension/tests/e2e/browser-task.test.ts
@@ -3,6 +3,8 @@ import { expect, test } from '@playwright/test';
 import type { BrowserContext, Locator, Page, WebSocketRoute } from '@playwright/test';
 import { createHash, randomUUID } from 'node:crypto';
 import { rm, writeFile } from 'node:fs/promises';
+import type { browser } from 'wxt/browser';
+import { z } from 'zod';
 import {
   browserProviderInboundMessageSchema,
   webOutboundWithBrowserMessageSchema,
@@ -1438,3 +1440,733 @@ for (const modal of [
     );
   });
 }
+
+const nativeSendPending = (panel: Page) =>
+  panel.getByRole('status').filter({
+    hasText: 'Checking browser control… Your input is retained.',
+  });
+const nativeSendRequestSchema = z.object({
+  messages: z.array(z.object({ content: z.unknown(), role: z.string() })),
+});
+const nativeSendUserTexts = (body: unknown): string[] =>
+  nativeSendRequestSchema
+    .parse(body)
+    .messages.filter(message => message.role === 'user')
+    .map(message =>
+      z
+        .string()
+        .parse(message.content)
+        .replace(/\n\n<system_environment>[\s\S]*$/u, '')
+    );
+const nativeSendGateway = (seenChatBodies: unknown[]) => ({
+  firstCompletionEvents: toolCall('eval', {
+    code: 'document.querySelector("#effect").click(); return document.querySelector("#count").textContent;',
+  }),
+  secondCompletionEvents: content(resultText),
+  seenChatBodies,
+  toolNames: dangerousToolNames,
+});
+const prepareNativeSend = async (panel: Page, titles: string[] = []): Promise<void> => {
+  await selectModelById(panel, model);
+  await panel.getByLabel('Target tab').selectOption({ label: 'Approved browser task tab' });
+  await panel.getByRole('button', { name: /(?:Safe|Dangerous) mode/u }).click();
+  await panel
+    .getByRole('button', { exact: true, name: 'Dangerous Arbitrary webpage control' })
+    .click();
+  if (titles.length > 0) {
+    const selectedTabId = Number(await panel.getByLabel('Target tab').inputValue());
+    await setExtensionStorage(panel, {
+      kiloAgentConversations: {
+        activeConversationId: 'native-send-0',
+        conversations: titles.map((title, index) => ({
+          events: [{ id: `prior-${index}`, role: 'user', text: `Prior ${title}`, type: 'message' }],
+          id: `native-send-${index}`,
+          mode: 'dangerous',
+          model,
+          selectedTabId,
+          title,
+          updatedAt: new Date().toISOString(),
+        })),
+        openConversationIds: titles.map((_title, index) => `native-send-${index}`),
+      },
+    });
+    await panel.reload();
+  }
+  await expect(panel.getByLabel('Message agent')).toHaveValue('');
+  await expect(panel.getByRole('button', { exact: true, name: 'Send message' })).toBeDisabled();
+};
+const expectNativeSendPending = async (panel: Page, draft: string): Promise<void> => {
+  await expect(nativeSendPending(panel)).toHaveCount(1);
+  await expect(nativeSendPending(panel)).toBeVisible();
+  await expect(nativeSendPending(panel)).toHaveText(
+    'Checking browser control… Your input is retained.'
+  );
+  await expect(panel.getByLabel('Message agent')).toHaveValue(draft);
+  await expect(panel.getByRole('button', { exact: true, name: 'Send message' })).toBeDisabled();
+};
+
+// Each installation belongs to one Send action. Restore simultaneous gates in reverse order.
+const holdNativeSendBoundary = async (panel: Page, boundary: 'safety' | 'tab') => {
+  const handle = await panel.evaluateHandle(kind => {
+    const scope = globalThis as typeof globalThis & {
+      chrome: typeof browser;
+    };
+    const storage = scope.chrome.storage.local;
+    const { tabs } = scope.chrome;
+    // eslint-disable-next-line typescript/unbound-method -- Restore the original API; apply below preserves its receiver.
+    const originalStorageGet = storage.get;
+    const originalTabGet = tabs.get;
+    const gate = Promise.withResolvers<void>();
+    let rejectRead = false;
+    let restored = false;
+    const state = {
+      activated: false,
+      entered: false,
+      failed: false,
+      reject: () => {
+        rejectRead = true;
+        gate.resolve();
+      },
+      release: () => {
+        gate.resolve();
+      },
+      restore: () => {
+        if (restored) {
+          return;
+        }
+        restored = true;
+        gate.resolve();
+        document.removeEventListener('keydown', arm, true);
+        document.removeEventListener('click', arm, true);
+        if (kind === 'safety') {
+          storage.get = originalStorageGet;
+        } else {
+          tabs.get = originalTabGet;
+        }
+      },
+      settled: false,
+      submittedTabId: undefined as number | undefined,
+    };
+    const arm = (event: Event): void => {
+      const input = document.querySelector('#agent-message');
+      if (!(input instanceof HTMLTextAreaElement)) {
+        return;
+      }
+      const send = input.form?.querySelector('button[type="submit"]');
+      const enter =
+        event instanceof KeyboardEvent &&
+        event.key === 'Enter' &&
+        !event.shiftKey &&
+        event.target === input;
+      const click =
+        event.type === 'click' &&
+        event.target instanceof Node &&
+        send?.contains(event.target) === true;
+      if (!enter && !click) {
+        return;
+      }
+      const target = document.querySelector('[aria-label="Target tab"]');
+      if (!(target instanceof HTMLSelectElement)) {
+        throw new Error('Send must have a target selector.');
+      }
+      state.activated = true;
+      state.submittedTabId = Number(target.value);
+      document.removeEventListener('keydown', arm, true);
+      document.removeEventListener('click', arm, true);
+    };
+    const readAfterRelease = async <Value>(read: () => Value): Promise<Awaited<Value>> => {
+      state.entered = true;
+      try {
+        await gate.promise;
+        if (rejectRead) {
+          throw new Error('The native Send test rejects the safety read.');
+        }
+        return await read();
+      } catch (error) {
+        state.failed = true;
+        throw error;
+      } finally {
+        state.settled = true;
+      }
+    };
+    if (kind === 'safety') {
+      storage.get = ((...args: unknown[]) => {
+        const [keys, callback] = args;
+        // Forward every native overload unchanged, including callback-only callers.
+        const read = () =>
+          (originalStorageGet as (...nativeArgs: unknown[]) => unknown).apply(storage, args);
+        const includesSafety =
+          keys === 'kiloBrowserExecutionSafety' ||
+          (Array.isArray(keys) && keys.includes('kiloBrowserExecutionSafety')) ||
+          (keys !== null &&
+            typeof keys === 'object' &&
+            Object.hasOwn(keys, 'kiloBrowserExecutionSafety'));
+        // Preserve callback callers. The runtime safety read uses the Promise overload.
+        if (!state.activated || !includesSafety || callback !== undefined) {
+          return read();
+        }
+        // A background refresh can share this read; only the UI status proves pending Send.
+        return readAfterRelease(read);
+      }) as typeof originalStorageGet;
+    } else {
+      tabs.get = ((...args: unknown[]) => {
+        const [tabId, callback] = args;
+        const read = () =>
+          (originalTabGet as (...nativeArgs: unknown[]) => unknown).apply(tabs, args);
+        if (
+          !state.activated ||
+          state.entered ||
+          tabId !== state.submittedTabId ||
+          callback !== undefined
+        ) {
+          return read();
+        }
+        return readAfterRelease(read);
+      }) as typeof originalTabGet;
+    }
+    document.addEventListener('keydown', arm, true);
+    document.addEventListener('click', arm, true);
+    return state;
+  }, boundary);
+  return {
+    dispose: async () => {
+      try {
+        await handle.evaluate(state => {
+          state.restore();
+        });
+      } finally {
+        await handle.dispose();
+      }
+    },
+    outcome: () => handle.evaluate(state => ({ failed: state.failed, settled: state.settled })),
+    reject: () =>
+      handle.evaluate(state => {
+        state.reject();
+      }),
+    release: () =>
+      handle.evaluate(state => {
+        state.release();
+      }),
+    restore: () =>
+      handle.evaluate(state => {
+        state.restore();
+      }),
+    wait: async () => {
+      await expect.poll(() => handle.evaluate(state => state.entered)).toBe(true);
+    },
+  };
+};
+
+for (const activation of ['Enter', 'Send'] as const) {
+  test(`native gap A1: ${activation} retains focus and submits captured text once`, async () => {
+    const seenChatBodies: unknown[] = [];
+    await withHarness(
+      async ({ panel, target, other }) => {
+        await prepareNativeSend(panel);
+        const input = panel.getByLabel('Message agent');
+        const send = panel.getByRole('button', { exact: true, name: 'Send message' });
+        const conversation = panel.getByRole('region', { name: 'Agent conversation' });
+        const submitted = `Apply the ${activation} action once.`;
+        const draft = `  ${submitted}  `;
+        const newerDraft = 'Keep this newer unsent text.';
+        const gate = await holdNativeSendBoundary(panel, 'safety');
+        try {
+          await input.fill(draft);
+          if (activation === 'Enter') {
+            await input.press('Enter');
+            await expect(input).toBeFocused();
+          } else {
+            await send.click();
+            await expect(send).toBeFocused();
+          }
+          await expectNativeSendPending(panel, draft);
+          await gate.wait();
+          await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+
+          // Retry the focused control without forcing a click on a disabled button.
+          await panel.keyboard.press('Enter');
+          await expect(activation === 'Enter' ? input : send).toBeFocused();
+          await expectNativeSendPending(panel, draft);
+          await expect(conversation.getByText(submitted, { exact: true })).toHaveCount(0);
+          await expect(target.locator('#count')).toHaveText('0');
+          await expect(other.locator('#count')).toHaveText('0');
+          expect(seenChatBodies).toHaveLength(0);
+          if (activation === 'Send') {
+            await input.fill(newerDraft);
+            await expectNativeSendPending(panel, newerDraft);
+          }
+
+          await gate.release();
+          await expect(nativeSendPending(panel)).toHaveCount(0);
+          await expect(conversation.getByText(resultText, { exact: true })).toBeVisible();
+          await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+          await expect(conversation.getByText(submitted, { exact: true })).toHaveCount(1);
+          await expect(target.locator('#count')).toHaveText('1');
+          await expect(other.locator('#count')).toHaveText('0');
+          await expect(input).toHaveValue(activation === 'Send' ? newerDraft : '');
+          expect(seenChatBodies.map(body => nativeSendUserTexts(body))).toEqual([
+            [submitted],
+            [submitted],
+          ]);
+        } finally {
+          await gate.dispose();
+        }
+      },
+      { gateway: nativeSendGateway(seenChatBodies) }
+    );
+  });
+}
+
+test('native gap A1: native contention rejects Send until an explicit retry', async () => {
+  const seenChatBodies: unknown[] = [];
+  await withHarness(
+    async ({ panel, openPanel, target, other }) => {
+      await prepareNativeSend(panel);
+      const second = await openPanel();
+      const input = panel.getByLabel('Message agent');
+      const draft = 'Keep the draft while another native owner holds control.';
+      const gate = await holdNativeSendBoundary(panel, 'safety');
+      try {
+        await input.fill(draft);
+        await input.press('Enter');
+        await expectNativeSendPending(panel, draft);
+        await gate.wait();
+        const contender = await second.evaluateHandle(name => {
+          const hold = Promise.withResolvers<void>();
+          const released = navigator.locks.request(name, { mode: 'exclusive' }, () => hold.promise);
+          return {
+            release: async () => {
+              hold.resolve();
+              await released;
+            },
+          };
+        }, executionLock);
+        try {
+          await expect.poll(() => heldExecutionModes(panel)).toEqual(['exclusive']);
+          await expectNativeSendPending(panel, draft);
+          await gate.release();
+          await expect(nativeSendPending(panel)).toHaveCount(0);
+          await expect(
+            panel.getByRole('status').filter({ hasText: 'owns browser control' }).first()
+          ).toBeVisible();
+          await expect(input).toHaveValue(draft);
+          await expect(panel.getByRole('region', { name: 'Agent conversation' })).not.toContainText(
+            draft
+          );
+          await expect(target.locator('#count')).toHaveText('0');
+          await expect(other.locator('#count')).toHaveText('0');
+          expect(seenChatBodies).toHaveLength(0);
+
+          await contender.evaluate(held => held.release());
+          await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+          await expect(
+            panel.getByRole('status').filter({
+              hasText:
+                'Your message is retained. Submit it again when browser control is available.',
+            })
+          ).toBeVisible();
+          await expect(nativeSendPending(panel)).toHaveCount(0);
+          await expect(input).toHaveValue(draft);
+          await expect(target.locator('#count')).toHaveText('0');
+          await expect(other.locator('#count')).toHaveText('0');
+          expect(seenChatBodies).toHaveLength(0);
+
+          await panel.getByRole('button', { exact: true, name: 'Send message' }).click();
+          await expect(panel.getByText(resultText, { exact: true })).toBeVisible();
+          await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+          await expect(nativeSendPending(panel)).toHaveCount(0);
+          await expect(input).toHaveValue('');
+          await expect(target.locator('#count')).toHaveText('1');
+          await expect(other.locator('#count')).toHaveText('0');
+          expect(seenChatBodies.map(body => nativeSendUserTexts(body))).toEqual([[draft], [draft]]);
+        } finally {
+          try {
+            await contender.evaluate(held => held.release());
+          } finally {
+            await contender.dispose();
+          }
+        }
+      } finally {
+        await gate.dispose();
+      }
+    },
+    { gateway: nativeSendGateway(seenChatBodies) }
+  );
+});
+
+test('native gap A1: storage failure retains Send until explicit recovery and retry', async () => {
+  const seenChatBodies: unknown[] = [];
+  await withHarness(
+    async ({ panel, target, other }) => {
+      await enable(panel);
+      await prepareNativeSend(panel);
+      const input = panel.getByLabel('Message agent');
+      const draft = 'Keep this draft through the safety storage failure.';
+      const gate = await holdNativeSendBoundary(panel, 'safety');
+      try {
+        await input.fill(draft);
+        await input.press('Enter');
+        await expectNativeSendPending(panel, draft);
+        await gate.wait();
+        await gate.reject();
+        await expect(nativeSendPending(panel)).toHaveCount(0);
+        await expect(
+          panel
+            .getByRole('status')
+            .filter({
+              hasText:
+                'Browser safety state is unavailable. No browser work can start. Restore storage access before recovery.',
+            })
+            .first()
+        ).toBeVisible();
+        await expect(input).toHaveValue(draft);
+        await expect(panel.getByRole('region', { name: 'Agent conversation' })).not.toContainText(
+          draft
+        );
+        await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+        await expect(target.locator('#count')).toHaveText('0');
+        await expect(other.locator('#count')).toHaveText('0');
+        expect(seenChatBodies).toHaveLength(0);
+
+        await gate.restore();
+        const controls = supervision(panel);
+        await controls.getByRole('button', { name: 'Check recovery readiness' }).click();
+        const recover = controls.getByRole('button', { name: 'Recover browser control' });
+        await expect(recover).toBeEnabled();
+        await expect(nativeSendPending(panel)).toHaveCount(0);
+        await expect(input).toHaveValue(draft);
+        await expect(target.locator('#count')).toHaveText('0');
+        await expect(other.locator('#count')).toHaveText('0');
+        expect(seenChatBodies).toHaveLength(0);
+        await recover.click();
+        await expect(controls).toContainText('Enabled — idle');
+        await expect(nativeSendPending(panel)).toHaveCount(0);
+        await expect(input).toHaveValue(draft);
+        await expect(target.locator('#count')).toHaveText('0');
+        await expect(other.locator('#count')).toHaveText('0');
+        expect(seenChatBodies).toHaveLength(0);
+
+        await panel.getByRole('button', { exact: true, name: 'Send message' }).click();
+        await expect(panel.getByText(resultText, { exact: true })).toBeVisible();
+        await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+        await expect(nativeSendPending(panel)).toHaveCount(0);
+        await expect(input).toHaveValue('');
+        await expect(target.locator('#count')).toHaveText('1');
+        await expect(other.locator('#count')).toHaveText('0');
+        expect(seenChatBodies.map(body => nativeSendUserTexts(body))).toEqual([[draft], [draft]]);
+      } finally {
+        await gate.dispose();
+      }
+    },
+    { gateway: nativeSendGateway(seenChatBodies) }
+  );
+});
+
+for (const change of ['changed', 'closed'] as const) {
+  test(`native gap A1: ${change} target retains Send without retargeting`, async () => {
+    const seenChatBodies: unknown[] = [];
+    await withHarness(
+      async ({ panel, target, other }) => {
+        await prepareNativeSend(panel);
+        const input = panel.getByLabel('Message agent');
+        const draft = `Retain this message when the target is ${change}.`;
+        const gate = await holdNativeSendBoundary(panel, 'tab');
+        try {
+          await input.fill(draft);
+          await input.press('Enter');
+          await expectNativeSendPending(panel, draft);
+          await gate.wait();
+          await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+          await expect(target.locator('#count')).toHaveText('0');
+          await (change === 'changed'
+            ? panel.getByLabel('Target tab').selectOption({ label: 'Unapproved tab' })
+            : target.close());
+          await expectNativeSendPending(panel, draft);
+          expect(seenChatBodies).toHaveLength(0);
+          await gate.release();
+          await expect.poll(gate.outcome).toEqual({ failed: change === 'closed', settled: true });
+          await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+          await expect(nativeSendPending(panel)).toHaveCount(0);
+          await expect(
+            panel.getByRole('status').filter({
+              hasText:
+                'The target tab changed or closed. Your message is retained. Select a target tab and submit again.',
+            })
+          ).toBeVisible();
+          await expect(input).toHaveValue(draft);
+          await expect(panel.getByRole('region', { name: 'Agent conversation' })).not.toContainText(
+            draft
+          );
+          if (change === 'changed') {
+            await expect(target.locator('#count')).toHaveText('0');
+          }
+          await panel.getByLabel('Target tab').selectOption({ label: 'Unapproved tab' });
+          await expect(
+            panel.getByRole('button', { exact: true, name: 'Send message' })
+          ).toBeEnabled();
+          await expect(input).toHaveValue(draft);
+          await expect(other.locator('#count')).toHaveText('0');
+          expect(seenChatBodies).toHaveLength(0);
+        } finally {
+          await gate.dispose();
+        }
+      },
+      { gateway: nativeSendGateway(seenChatBodies) }
+    );
+  });
+}
+
+test('native gap A1: closing a nonempty conversation cancels Send and History retains its draft', async () => {
+  const seenChatBodies: unknown[] = [];
+  await withHarness(
+    async ({ panel, target, other }) => {
+      const title = 'Cancelled Send';
+      await prepareNativeSend(panel, [title]);
+      const input = panel.getByLabel('Message agent');
+      const draft = 'Retain this cancelled conversation draft.';
+      const tabs = panel.getByRole('tablist', { name: 'Conversation tabs' });
+      const gate = await holdNativeSendBoundary(panel, 'tab');
+      try {
+        await input.fill(draft);
+        await input.press('Enter');
+        await expectNativeSendPending(panel, draft);
+        await gate.wait();
+        await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+        await tabs.getByRole('button', { exact: true, name: `Close Prior ${title}` }).click();
+        await expect(tabs.getByRole('tab', { exact: true, name: `Prior ${title}` })).toHaveCount(0);
+        await expect(nativeSendPending(panel)).toHaveCount(0);
+        await expect(input).toHaveValue('');
+        await gate.release();
+        await expect.poll(gate.outcome).toEqual({ failed: false, settled: true });
+        await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+
+        await panel.getByRole('button', { exact: true, name: 'History' }).click();
+        await panel
+          .getByRole('dialog', { name: 'Conversation history' })
+          .getByRole('button', { exact: true, name: `Open Prior ${title}` })
+          .click();
+        await expect(
+          tabs.getByRole('tab', { exact: true, name: `Prior ${title}` })
+        ).toHaveAttribute('aria-selected', 'true');
+        await expect(input).toHaveValue(draft);
+        await expect(nativeSendPending(panel)).toHaveCount(0);
+        await expect(
+          panel.getByRole('button', { exact: true, name: 'Send message' })
+        ).toBeEnabled();
+        const conversation = panel.getByRole('region', { name: 'Agent conversation' });
+        await expect(conversation.getByText(`Prior ${title}`, { exact: true })).toBeVisible();
+        await expect(conversation.getByText(draft, { exact: true })).toHaveCount(0);
+        await expect(target.locator('#count')).toHaveText('0');
+        await expect(other.locator('#count')).toHaveText('0');
+        expect(seenChatBodies).toHaveLength(0);
+      } finally {
+        await gate.dispose();
+      }
+    },
+    { gateway: nativeSendGateway(seenChatBodies) }
+  );
+});
+
+test('native gap A1: blank and whitespace drafts never start Send admission', async () => {
+  const seenChatBodies: unknown[] = [];
+  await withHarness(
+    async ({ panel, target, other }) => {
+      await prepareNativeSend(panel);
+      const input = panel.getByLabel('Message agent');
+      // A tab gate leaves any accidental admission pending without trapping background safety reads.
+      const gate = await holdNativeSendBoundary(panel, 'tab');
+      try {
+        for (const draft of ['', '   \n  ']) {
+          await input.fill(draft);
+          await expect(
+            panel.getByRole('button', { exact: true, name: 'Send message' })
+          ).toBeDisabled();
+          await input.press('Enter');
+          await expect(input).toBeFocused();
+          await expect(input).toHaveValue(draft);
+          await expect(nativeSendPending(panel)).toHaveCount(0);
+          await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+          await expect(target.locator('#count')).toHaveText('0');
+          await expect(other.locator('#count')).toHaveText('0');
+          expect(seenChatBodies).toHaveLength(0);
+        }
+      } finally {
+        await gate.dispose();
+      }
+    },
+    { gateway: nativeSendGateway(seenChatBodies) }
+  );
+});
+
+for (const outcome of ['success', 'failure'] as const) {
+  test(`native gap A5 Send: late lookup ${outcome} cannot clear a newer Send`, async () => {
+    const seenChatBodies: unknown[] = [];
+    await withHarness(
+      async ({ panel, target, other }) => {
+        const title = 'Send race';
+        await prepareNativeSend(panel, [title]);
+        await panel.getByLabel('Target tab').selectOption({ label: 'Unapproved tab' });
+        const input = panel.getByLabel('Message agent');
+        const oldDraft = 'Never submit this cancelled older Send.';
+        const newDraft = 'Submit only this newer Send.';
+        const tabs = panel.getByRole('tablist', { name: 'Conversation tabs' });
+        const older = await holdNativeSendBoundary(panel, 'tab');
+        try {
+          await input.fill(oldDraft);
+          await input.press('Enter');
+          await expectNativeSendPending(panel, oldDraft);
+          await older.wait();
+          await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+          await tabs.getByRole('button', { exact: true, name: `Close Prior ${title}` }).click();
+          await expect(nativeSendPending(panel)).toHaveCount(0);
+          await expect(tabs.getByRole('tab', { exact: true, name: `Prior ${title}` })).toHaveCount(
+            0
+          );
+          await expect(other.locator('#count')).toHaveText('0');
+          if (outcome === 'failure') {
+            await other.close();
+          }
+          await panel.getByRole('button', { exact: true, name: 'History' }).click();
+          await panel
+            .getByRole('dialog', { name: 'Conversation history' })
+            .getByRole('button', { exact: true, name: `Open Prior ${title}` })
+            .click();
+          await expect(input).toHaveValue(oldDraft);
+          await expect(nativeSendPending(panel)).toHaveCount(0);
+          await panel.getByLabel('Target tab').selectOption({ label: 'Approved browser task tab' });
+          const newer = await holdNativeSendBoundary(panel, 'tab');
+          try {
+            await input.fill(newDraft);
+            await input.press('Enter');
+            await expectNativeSendPending(panel, newDraft);
+            await newer.wait();
+            await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared', 'shared']);
+            await older.release();
+            await expect
+              .poll(older.outcome)
+              .toEqual({ failed: outcome === 'failure', settled: true });
+            await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+            await expectNativeSendPending(panel, newDraft);
+            const conversation = panel.getByRole('region', { name: 'Agent conversation' });
+            await expect(conversation.getByText(oldDraft, { exact: true })).toHaveCount(0);
+            await expect(conversation.getByText(newDraft, { exact: true })).toHaveCount(0);
+            await expect(target.locator('#count')).toHaveText('0');
+            expect(seenChatBodies).toHaveLength(0);
+
+            await newer.release();
+            await expect(nativeSendPending(panel)).toHaveCount(0);
+            await expect(conversation.getByText(resultText, { exact: true })).toBeVisible();
+            await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+            await expect(conversation.getByText(oldDraft, { exact: true })).toHaveCount(0);
+            await expect(conversation.getByText(newDraft, { exact: true })).toHaveCount(1);
+            await expect(input).toHaveValue('');
+            await expect(target.locator('#count')).toHaveText('1');
+            if (outcome === 'success') {
+              await expect(other.locator('#count')).toHaveText('0');
+            }
+            expect(seenChatBodies.map(body => nativeSendUserTexts(body))).toEqual([
+              [`Prior ${title}`, newDraft],
+              [`Prior ${title}`, newDraft],
+            ]);
+          } finally {
+            await newer.dispose();
+          }
+        } finally {
+          await older.dispose();
+        }
+      },
+      { gateway: nativeSendGateway(seenChatBodies) }
+    );
+  });
+}
+
+test('native gap A5 Send: conversation switches isolate pending drafts and settled results', async () => {
+  const seenChatBodies: unknown[] = [];
+  const secondResult = 'Only the second conversation completed this message.';
+  await withHarness(
+    async ({ panel, target, other }) => {
+      await prepareNativeSend(panel, ['First Send', 'Second Send']);
+      const tabs = panel.getByRole('tablist', { name: 'Conversation tabs' });
+      const firstTab = tabs.getByRole('tab', { exact: true, name: 'Prior First Send' });
+      const secondTab = tabs.getByRole('tab', { exact: true, name: 'Prior Second Send' });
+      const input = panel.getByLabel('Message agent');
+      const firstDraft = 'Apply the first conversation action.';
+      const secondDraft = 'Answer only in the second conversation.';
+      const newerDraft = 'Keep the second conversation draft after both attempts settle.';
+      const first = await holdNativeSendBoundary(panel, 'tab');
+      try {
+        await input.fill(firstDraft);
+        await input.press('Enter');
+        await expectNativeSendPending(panel, firstDraft);
+        await first.wait();
+        await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+        await secondTab.click();
+        await expect(nativeSendPending(panel)).toHaveCount(0);
+        await expect(input).toHaveValue('');
+        await input.fill(secondDraft);
+        await expect(
+          panel.getByRole('button', { exact: true, name: 'Send message' })
+        ).toBeEnabled();
+        await firstTab.click();
+        await expectNativeSendPending(panel, firstDraft);
+        await secondTab.click();
+        await expect(nativeSendPending(panel)).toHaveCount(0);
+        await expect(input).toHaveValue(secondDraft);
+        const second = await holdNativeSendBoundary(panel, 'tab');
+        try {
+          await input.press('Enter');
+          await expectNativeSendPending(panel, secondDraft);
+          await second.wait();
+          await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared', 'shared']);
+          await input.fill(newerDraft);
+          await first.release();
+          await expect.poll(() => heldExecutionModes(panel)).toEqual(['shared']);
+          await expectNativeSendPending(panel, newerDraft);
+          const conversation = panel.getByRole('region', { name: 'Agent conversation' });
+          await expect(conversation.getByText(firstDraft, { exact: true })).toHaveCount(0);
+          await expect(conversation.getByText(resultText, { exact: true })).toHaveCount(0);
+          await expect(target.locator('#count')).toHaveText('1');
+          expect(seenChatBodies.map(body => nativeSendUserTexts(body))).toEqual([
+            ['Prior First Send', firstDraft],
+            ['Prior First Send', firstDraft],
+          ]);
+
+          await second.release();
+          await expect(nativeSendPending(panel)).toHaveCount(0);
+          await expect(conversation.getByText(secondResult, { exact: true })).toBeVisible();
+          await expect.poll(() => heldExecutionModes(panel)).toEqual([]);
+          await expect(conversation.getByText(secondDraft, { exact: true })).toHaveCount(1);
+          await expect(input).toHaveValue(newerDraft);
+          await firstTab.click();
+          await expect(nativeSendPending(panel)).toHaveCount(0);
+          await expect(input).toHaveValue('');
+          await expect(conversation.getByText(firstDraft, { exact: true })).toHaveCount(1);
+          await expect(conversation.getByText(resultText, { exact: true })).toBeVisible();
+          await expect(conversation.getByText(secondResult, { exact: true })).toHaveCount(0);
+          await secondTab.click();
+          await expect(nativeSendPending(panel)).toHaveCount(0);
+          await expect(input).toHaveValue(newerDraft);
+          await expect(conversation.getByText(secondResult, { exact: true })).toBeVisible();
+          await expect(conversation.getByText(resultText, { exact: true })).toHaveCount(0);
+          await expect(target.locator('#count')).toHaveText('1');
+          await expect(other.locator('#count')).toHaveText('0');
+          expect(seenChatBodies.map(body => nativeSendUserTexts(body))).toEqual([
+            ['Prior First Send', firstDraft],
+            ['Prior First Send', firstDraft],
+            ['Prior Second Send', secondDraft],
+          ]);
+        } finally {
+          await second.dispose();
+        }
+      } finally {
+        await first.dispose();
+      }
+    },
+    {
+      gateway: {
+        ...nativeSendGateway(seenChatBodies),
+        thirdCompletionEvents: content(secondResult),
+      },
+    }
+  );
+});

--- a/apps/extension/tests/e2e/browser-task.test.ts
+++ b/apps/extension/tests/e2e/browser-task.test.ts
@@ -436,6 +436,17 @@ const approve = async (root: Page | Locator): Promise<void> => {
 };
 const capture = async (panel: Page, name: string): Promise<void> => {
   expect(panel.viewportSize()).toEqual({ height: 720, width: 320 });
+  const viewport = await panel.evaluate(() => ({
+    height: innerHeight,
+    scale: visualViewport?.scale,
+    visibility: document.visibilityState,
+    width: innerWidth,
+  }));
+  await test.info().attach(`${name}-viewport`, {
+    body: JSON.stringify(viewport, null, 2),
+    contentType: 'application/json',
+  });
+  expect(viewport).toMatchObject({ height: 720, scale: 1, width: 320 });
   const dialogs = panel.getByRole('dialog');
   const root = (await dialogs.count()) > 0 ? dialogs.last() : panel;
   const stop = supervision(root).getByRole('button', { name: 'Stop CLI task' });
@@ -798,6 +809,30 @@ for (const profile of ['enabled', 'quarantined'] as const) {
           await expect(second.getByLabel('Message agent')).toHaveValue(draft);
           await expect(target.locator('#count')).toHaveText('0');
           expect(requests).toBe(0);
+          await test.step('Scroll to the footer and activate Send without clearing quarantine', async () => {
+            const send = second.getByRole('button', { name: 'Send message' });
+            const before = await send.boundingBox();
+            // Use native scrolling, then ordinary keyboard navigation and an unforced click.
+            await send.scrollIntoViewIfNeeded();
+            await keyboardReach(second, send);
+            await expect(send).toBeFocused();
+            await expect(send).toBeInViewport({ ratio: 1 });
+            await expect(send).toBeEnabled();
+            await test.info().attach('native-ownership-quarantined-footer-scroll', {
+              body: JSON.stringify({ after: await send.boundingBox(), before }, null, 2),
+              contentType: 'application/json',
+            });
+            await capture(second, 'native-ownership-quarantined-footer-reachable');
+            await send.click();
+            await expect(second.getByLabel('Message agent')).toHaveValue(draft);
+            await expect(supervision(second)).toContainText('Recovery required');
+            await expect(
+              second.getByRole('button', { name: 'Recover browser control' })
+            ).toHaveCount(0);
+            await expect(target.locator('#count')).toHaveText('0');
+            await expect(other.locator('#count')).toHaveText('0');
+            expect(requests).toBe(0);
+          });
         } else {
           await expect(supervision(second)).toContainText('Queue empty.');
           relay.submit('Run only after fresh tab consent in the new owning panel.');
@@ -806,11 +841,61 @@ for (const profile of ['enabled', 'quarantined'] as const) {
           await expect(supervision(second).getByLabel('Tab to approve')).toHaveValue('');
           await expect(target.locator('#count')).toHaveText('0');
           expect(requests).toBe(0);
-          await approve(second);
+          await test.step('Reach and select the consent controls before approving the tab', async () => {
+            const controls = supervision(second);
+            const tab = controls.getByLabel('Tab to approve');
+            const approveTab = controls.getByRole('button', { exact: true, name: 'Approve tab' });
+            await expect(approveTab).toBeDisabled();
+            await tab.scrollIntoViewIfNeeded();
+            await expect(tab).toBeInViewport({ ratio: 1 });
+            await expect(tab).toBeEnabled();
+            await capture(second, 'native-ownership-enabled-tab-consent');
+            await tab.selectOption({ label: 'Approved browser task tab' });
+            await expect(
+              controls.getByText('Tab: Approved browser task tab', { exact: true })
+            ).toBeVisible();
+            for (const control of [
+              approveTab,
+              controls.getByRole('button', { exact: true, name: 'Reject' }),
+              controls.getByRole('button', { exact: true, name: 'Refresh tabs' }),
+            ]) {
+              await control.scrollIntoViewIfNeeded();
+              await expect(control).toBeInViewport({ ratio: 1 });
+              await expect(control).toBeEnabled();
+            }
+            await expect(target.locator('#count')).toHaveText('0');
+            expect(requests).toBe(0);
+            await capture(second, 'native-ownership-enabled-selected-tab-consent');
+            await approveTab.click();
+          });
           await expect(supervision(second)).toContainText('Last outcome: succeeded');
           await expect(target.locator('#count')).toHaveText('1');
           await expect(other.locator('#count')).toHaveText('0');
           expect(requests).toBe(2);
+          await test.step('Reach the final controls and retrieve status without replaying work', async () => {
+            const controls = supervision(second);
+            const refresh = controls.getByRole('button', { name: 'Refresh status' });
+            await refresh.scrollIntoViewIfNeeded();
+            await expect(refresh).toBeInViewport({ ratio: 1 });
+            await refresh.click();
+            await expect(controls).toContainText(
+              'Status retrieved. This does not approve execution or resubmit work.'
+            );
+            const composer = second.getByLabel('Message agent');
+            await composer.scrollIntoViewIfNeeded();
+            await expect(composer).toBeInViewport({ ratio: 1 });
+            await expect(composer).toBeEditable();
+            const outcome = controls.getByText(/Last outcome: succeeded/u);
+            await outcome.scrollIntoViewIfNeeded();
+            await expect(outcome).toBeInViewport({ ratio: 1 });
+            await expect(
+              controls.getByRole('button', { exact: true, name: 'Approve tab' })
+            ).toHaveCount(0);
+            await expect(controls.getByRole('button', { name: 'Stop CLI task' })).toHaveCount(0);
+            await expect(target.locator('#count')).toHaveText('1');
+            await expect(other.locator('#count')).toHaveText('0');
+            expect(requests).toBe(2);
+          });
         }
         await capture(second, `native-ownership-${profile}-consent-and-safety`);
       },

--- a/apps/extension/tests/e2e/extension-context-fixture.ts
+++ b/apps/extension/tests/e2e/extension-context-fixture.ts
@@ -103,7 +103,8 @@ export const launchExtensionContext = async ({
     ],
     ...(executablePath === undefined ? { channel } : { executablePath }),
     headless: !isHeaded,
-    ignoreDefaultArgs: ['--enable-automation'],
+    // Keep Playwright's native capture defaults without changing unrecorded analytics callers.
+    ignoreDefaultArgs: recordVideo === undefined ? ['--enable-automation'] : [],
     ...(recordVideo === undefined ? {} : { recordVideo, viewport: recordVideo.size }),
     userAgent: EXTENSION_E2E_USER_AGENT,
   });

--- a/apps/extension/tests/e2e/extension-context-fixture.ts
+++ b/apps/extension/tests/e2e/extension-context-fixture.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-nodejs-modules, max-lines, promise/avoid-new, promise/prefer-await-to-callbacks */
 import { chromium, expect } from '@playwright/test';
-import type { BrowserContext, Page } from '@playwright/test';
+import type { BrowserContext, BrowserContextOptions, Page } from '@playwright/test';
 import { access, mkdtemp } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
@@ -77,7 +77,9 @@ export const startFixtureServer = async ({
   };
 };
 
-export const launchExtensionContext = async (): Promise<{
+export const launchExtensionContext = async ({
+  recordVideo,
+}: Pick<BrowserContextOptions, 'recordVideo'> = {}): Promise<{
   context: BrowserContext;
   extensionId: string;
   /** `/flags` and `/decide/` URLs that hit the stub (must stay empty with flags disabled). */
@@ -102,6 +104,7 @@ export const launchExtensionContext = async (): Promise<{
     ...(executablePath === undefined ? { channel } : { executablePath }),
     headless: !isHeaded,
     ignoreDefaultArgs: ['--enable-automation'],
+    ...(recordVideo === undefined ? {} : { recordVideo }),
     userAgent: EXTENSION_E2E_USER_AGENT,
   });
 

--- a/apps/extension/tests/e2e/extension-context-fixture.ts
+++ b/apps/extension/tests/e2e/extension-context-fixture.ts
@@ -104,7 +104,7 @@ export const launchExtensionContext = async ({
     ...(executablePath === undefined ? { channel } : { executablePath }),
     headless: !isHeaded,
     ignoreDefaultArgs: ['--enable-automation'],
-    ...(recordVideo === undefined ? {} : { recordVideo }),
+    ...(recordVideo === undefined ? {} : { recordVideo, viewport: recordVideo.size }),
     userAgent: EXTENSION_E2E_USER_AGENT,
   });
 

--- a/apps/extension/tests/e2e/firefox-selenium-e2e.ts
+++ b/apps/extension/tests/e2e/firefox-selenium-e2e.ts
@@ -2,17 +2,17 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { accessSync, readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import type { IncomingMessage, Server, ServerResponse } from 'node:http';
-import { dirname, resolve as resolvePath } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolve as resolvePath } from 'node:path';
+import { parseArgs } from 'node:util';
 import { Builder, By, Key } from 'selenium-webdriver';
 import type { WebDriver, WebElement } from 'selenium-webdriver';
 import firefox, { ServiceBuilder } from 'selenium-webdriver/firefox';
 import { z } from 'zod';
 
-const extensionRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), '../..');
+const extensionRoot = resolvePath(import.meta.dirname, '../..');
 const packageManifest = z
   .object({ version: z.string().min(1) })
   .parse(JSON.parse(readFileSync(resolvePath(extensionRoot, 'package.json'), 'utf8')));
@@ -282,10 +282,10 @@ const closeServer = (server: Server): Promise<void> =>
     });
   });
 
-const listen = async (server: Server): Promise<ServerHandle> => {
+const listen = async (server: Server, port = 0): Promise<ServerHandle> => {
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject);
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(port, '127.0.0.1', () => {
       server.off('error', reject);
       resolve();
     });
@@ -321,7 +321,7 @@ const sendSse = (response: ServerResponse, events: unknown[]): void => {
   response.end(chatCompletionStreamResponse(events));
 };
 
-const startKiloApiServer = async (): Promise<KiloApiHandle> => {
+const startKiloApiServer = async (port = 0): Promise<KiloApiHandle> => {
   let options: KiloApiOptions = {};
   let chatCompletionCalls = 0;
   let modelCalls = 0;
@@ -490,7 +490,7 @@ const startKiloApiServer = async (): Promise<KiloApiHandle> => {
     })();
   });
 
-  const handle = await listen(server);
+  const handle = await listen(server, port);
 
   return { ...handle, reset };
 };
@@ -3400,7 +3400,7 @@ const scenarios: FirefoxScenario[] = [
           assert.deepEqual(await firefoxExecutionModes(session.driver), ['exclusive']);
           await session.openSidePanel();
           const otherHandle = await session.driver.getWindowHandle();
-          await waitForText(session.driver, 'Owned by another panel');
+          await waitForText(session.driver, 'Ownership not acquired');
           const draft = await session.driver.findElement(By.css('[aria-label="Message agent"]'));
           await draft.sendKeys('Preserve this blocked Firefox draft.', Key.ENTER);
           assert.equal(await draft.getAttribute('value'), 'Preserve this blocked Firefox draft.');
@@ -3468,7 +3468,7 @@ const scenarios: FirefoxScenario[] = [
           await enableFirefoxBrowserTasks(driver);
           await session.openSidePanel();
           const localOwnerHandle = await driver.getWindowHandle();
-          await waitForText(driver, 'Owned by another panel');
+          await waitForText(driver, 'Ownership not acquired');
           await waitForModel(driver);
           await waitForTargetOption(driver, 'Firefox affected local tab');
           await setSelectByText(driver, 'Target tab', 'Firefox affected local tab');
@@ -3649,12 +3649,46 @@ assert.deepStrictEqual(
 );
 
 const main = async (): Promise<void> => {
-  const api = await startKiloApiServer();
+  const { values } = parseArgs({
+    allowPositionals: false,
+    options: {
+      'api-port': { type: 'string' },
+      'no-build': { default: false, type: 'boolean' },
+      scenario: { multiple: true, type: 'string' },
+    },
+    strict: true,
+  });
+  const selectedNames = z
+    .array(z.enum(chromeWorkflowNames))
+    .min(1)
+    .max(6)
+    .optional()
+    .parse(values.scenario);
+  const selectedScenarios =
+    selectedNames === undefined
+      ? scenarios
+      : scenarios.filter(scenario => selectedNames.includes(scenario.name));
+  assert.ok(selectedScenarios.length > 0, 'Select at least one Firefox scenario.');
+  // The prepared ZIP must use this same port in VITE_KILO_API_BASE_URL.
+  assert.ok(
+    !values['no-build'] || values['api-port'] !== undefined,
+    '--no-build requires --api-port matching the prepared Firefox ZIP.'
+  );
+  const apiPort =
+    values['api-port'] === undefined
+      ? 0
+      : z.coerce.number().int().min(1).max(65_535).parse(values['api-port']);
+  if (values['no-build']) {
+    accessSync(firefoxZipPath);
+  }
+  const api = await startKiloApiServer(apiPort);
 
   try {
-    await runCommand('pnpm', ['run', 'zip:firefox'], {
-      VITE_KILO_API_BASE_URL: api.url,
-    });
+    if (!values['no-build']) {
+      await runCommand('pnpm', ['run', 'zip:firefox'], {
+        VITE_KILO_API_BASE_URL: api.url,
+      });
+    }
 
     const firefoxManifestPath = resolvePath(extensionRoot, '.output/firefox-mv3/manifest.json');
     const firefoxManifest = z
@@ -3665,13 +3699,15 @@ const main = async (): Promise<void> => {
       'Firefox manifest must include the contextMenus permission'
     );
 
-    for (const scenario of scenarios) {
+    for (const scenario of selectedScenarios) {
       process.stdout.write(`Firefox e2e: ${scenario.name} ... `);
       await scenario.run({ api });
       process.stdout.write('passed\n');
     }
 
-    console.log(`Firefox e2e passed ${scenarios.length}/${chromeWorkflowNames.length} workflows.`);
+    console.log(
+      `Firefox e2e passed ${selectedScenarios.length}/${selectedScenarios.length} selected workflows (${chromeWorkflowNames.length} available).`
+    );
   } finally {
     await api.close();
   }

--- a/apps/extension/tests/e2e/firefox-selenium-e2e.ts
+++ b/apps/extension/tests/e2e/firefox-selenium-e2e.ts
@@ -60,6 +60,8 @@ const chromeWorkflowNames = [
   'workflow create, approve, and run returns result',
   'workflow auto-approve save stores approved hash',
   'CLI task consent and cancellation use native cross-panel locks',
+  'native local owner close blocks local and delegated work until explicit recovery',
+  'native local owner reload blocks local and delegated work until explicit recovery',
   'unsupported native locks keep CLI delegation disabled',
 ] as const;
 
@@ -1364,6 +1366,119 @@ const submitDangerousPrompt = async (
   await switchToDangerousMode(session.driver);
   await sendMessage(session.driver, prompt);
 };
+
+const installFirefoxBrowserTaskPeer = (driver: FirefoxWebDriver): Promise<string> =>
+  driver.script().pin(`() => {
+    if (location.protocol !== 'moz-extension:') return;
+    const key = 'firefox-browser-task-peer';
+    const state = JSON.parse(sessionStorage.getItem(key) || '{"generation":0}');
+    const persist = () => sessionStorage.setItem(key, JSON.stringify(state));
+    let socket;
+    const snapshot = () => socket.receive({ type: 'provider_snapshot', providerId: state.providerId, generation: state.generation, jobs: state.job ? [state.job] : [] });
+    class PeerSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      readyState = 0;
+      onopen = null;
+      onmessage = null;
+      onclose = null;
+      onerror = null;
+      constructor(url) {
+        super();
+        this.url = String(url);
+        socket = this;
+        setTimeout(() => {
+          this.readyState = 1;
+          const event = new Event('open');
+          this.dispatchEvent(event);
+          this.onopen?.(event);
+          this.receive({ type: 'system', event: 'connected', data: {} });
+        }, 0);
+      }
+      receive(value) {
+        queueMicrotask(() => {
+          if (this.readyState !== 1) return;
+          const event = new MessageEvent('message', { data: JSON.stringify(value) });
+          this.dispatchEvent(event);
+          this.onmessage?.(event);
+        });
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === 'ping') this.receive({ type: 'pong', nonce: message.nonce, capabilities: { browserJobsV1: true } });
+        if (message.type === 'provider_register') {
+          state.providerId = message.providerId;
+          state.generation = Math.max(state.generation, message.generation) + 1;
+          persist();
+        }
+        if (message.type === 'provider_register' || message.type === 'provider_heartbeat') {
+          this.receive({ type: 'provider_lease_ack', providerId: state.providerId, generation: state.generation, requestId: message.requestId, leaseExpiresAt: new Date(Date.now() + 15000).toISOString() });
+          if (message.type === 'provider_heartbeat') this.receive({ type: 'provider_snapshot', providerId: state.providerId, generation: state.generation, requestId: message.requestId, jobs: state.job?.generation === state.generation ? [state.job] : [] });
+        }
+        if (message.type === 'provider_status') this.receive({ type: 'provider_status_result', providerId: state.providerId, requestId: message.requestId, jobs: state.job ? [state.job] : [] });
+        if (message.type === 'provider_approval' && message.approval.decision === 'approved') {
+          state.job.approvedTab = message.approval.tab;
+          state.job.status = 'running';
+          state.job.deadlines.execution = new Date(Date.now() + 600000).toISOString();
+          persist();
+          snapshot();
+        }
+        if ((message.type === 'provider_cancel' || message.type === 'provider_unavailable') && state.job && !state.job.result) {
+          const job = state.job;
+          const cancelled = message.type === 'provider_cancel';
+          job.status = cancelled ? 'cancelled' : 'interrupted';
+          job.result = { providerId: job.providerId, browserTaskId: job.browserTaskId, jobId: job.jobId, invocationId: job.invocationId, status: job.status, reason: cancelled ? 'cancelled' : message.reason, summary: cancelled ? 'Cancelled without replay.' : 'Provider unavailable without execution.', evidence: [], effectsUncertain: message.effectsUncertain ?? false };
+          persist();
+          if (cancelled) this.receive({ ...message, type: 'provider_job_cancel', reason: 'cancelled' });
+          snapshot();
+        }
+        if (message.type === 'provider_result' && state.job?.jobId === message.jobId && !state.job.result) {
+          state.job.status = message.result.status;
+          state.job.result = message.result;
+          persist();
+          snapshot();
+        }
+      }
+      close() {
+        this.readyState = 3;
+        const event = new CloseEvent('close', { code: 1000 });
+        this.dispatchEvent(event);
+        this.onclose?.(event);
+      }
+    }
+    Object.defineProperty(globalThis, 'WebSocket', { configurable: true, value: PeerSocket });
+    globalThis.submitFirefoxBrowserTask = () => {
+      const now = Date.now();
+      state.job = { providerId: state.providerId, generation: state.generation, browserTaskId: 'bt_' + crypto.randomUUID(), jobId: 'bj_' + crypto.randomUUID(), invocationId: 'b1.' + now + '.' + 'a'.repeat(64), payloadFingerprint: 'b'.repeat(64), createdAt: new Date(now).toISOString(), expiresAt: new Date(now + 604800000).toISOString(), deadlines: { approval: new Date(now + 120000).toISOString(), queue: new Date(now + 600000).toISOString() }, ownerLabel: 'ses_firefox_parent_A1', status: 'awaiting_approval' };
+      persist();
+      socket.receive({ type: 'provider_job', job: state.job, ownerLabel: 'ses_firefox_parent_A1', goal: 'Inspect only the explicitly approved tab.', conversationMode: 'new' });
+    };
+  }`);
+
+const enableFirefoxBrowserTasks = async (driver: WebDriver): Promise<void> => {
+  await driver.findElement(By.css('button[aria-label="Settings"]')).click();
+  await driver
+    .findElement(By.css('[aria-label="CLI task settings"] button[aria-label="Model"]'))
+    .click();
+  await selectModelByIdFirefox(driver, 'anthropic/claude-sonnet-4');
+  await driver
+    .findElement(By.css('[aria-label="CLI task settings"] button[aria-label*="Safe mode"]'))
+    .click();
+  await clickButtonByText(driver, 'Dangerous');
+  await driver
+    .findElement(By.css('[aria-label="CLI task settings"] [role="switch"][aria-label="CLI tasks"]'))
+    .click();
+  await driver.findElement(By.css('button[aria-label="Close settings"]')).click();
+  await waitForText(driver, 'Enabled — idle');
+};
+
+const firefoxExecutionModes = (driver: WebDriver): Promise<unknown> =>
+  driver.executeAsyncScript(async (done: (value: unknown) => void) => {
+    const state = await navigator.locks.query();
+    done(state.held?.filter(lock => lock.name === 'kilo:browser-execution').map(lock => lock.mode));
+  });
 
 const scenarios: FirefoxScenario[] = [
   {
@@ -3258,109 +3373,14 @@ const scenarios: FirefoxScenario[] = [
           toolNames: dangerousToolNames,
         },
         async session => {
-          // Only the network peer is a fixture. Both browsers run the same shipped provider and coordinator.
-          await session.driver.script().pin(`() => {
-          if (location.protocol !== 'moz-extension:') return;
-          const key = 'firefox-browser-task-peer';
-          const state = JSON.parse(sessionStorage.getItem(key) || '{"generation":0}');
-          const persist = () => sessionStorage.setItem(key, JSON.stringify(state));
-          let socket;
-          const snapshot = () => socket.receive({ type: 'provider_snapshot', providerId: state.providerId, generation: state.generation, jobs: state.job ? [state.job] : [] });
-          class PeerSocket extends EventTarget {
-            static CONNECTING = 0;
-            static OPEN = 1;
-            static CLOSING = 2;
-            static CLOSED = 3;
-            readyState = 0;
-            onopen = null;
-            onmessage = null;
-            onclose = null;
-            onerror = null;
-            constructor(url) {
-              super();
-              this.url = String(url);
-              socket = this;
-              setTimeout(() => {
-                this.readyState = 1;
-                const event = new Event('open');
-                this.dispatchEvent(event);
-                this.onopen?.(event);
-                this.receive({ type: 'system', event: 'connected', data: {} });
-              }, 0);
-            }
-            receive(value) {
-              queueMicrotask(() => {
-                if (this.readyState !== 1) return;
-                const event = new MessageEvent('message', { data: JSON.stringify(value) });
-                this.dispatchEvent(event);
-                this.onmessage?.(event);
-              });
-            }
-            send(raw) {
-              const message = JSON.parse(raw);
-              if (message.type === 'ping') this.receive({ type: 'pong', nonce: message.nonce, capabilities: { browserJobsV1: true } });
-              if (message.type === 'provider_register') {
-                state.providerId = message.providerId;
-                state.generation = Math.max(state.generation, message.generation) + 1;
-                persist();
-              }
-              if (message.type === 'provider_register' || message.type === 'provider_heartbeat') {
-                this.receive({ type: 'provider_lease_ack', providerId: state.providerId, generation: state.generation, requestId: message.requestId, leaseExpiresAt: new Date(Date.now() + 15000).toISOString() });
-                if (message.type === 'provider_heartbeat') this.receive({ type: 'provider_snapshot', providerId: state.providerId, generation: state.generation, requestId: message.requestId, jobs: state.job?.generation === state.generation ? [state.job] : [] });
-              }
-              if (message.type === 'provider_status') this.receive({ type: 'provider_status_result', providerId: state.providerId, requestId: message.requestId, jobs: state.job ? [state.job] : [] });
-              if (message.type === 'provider_approval' && message.approval.decision === 'approved') {
-                state.job.approvedTab = message.approval.tab;
-                state.job.status = 'running';
-                state.job.deadlines.execution = new Date(Date.now() + 600000).toISOString();
-                persist();
-                snapshot();
-              }
-              if (message.type === 'provider_cancel') {
-                const job = state.job;
-                job.status = 'cancelled';
-                job.result = { providerId: job.providerId, browserTaskId: job.browserTaskId, jobId: job.jobId, invocationId: job.invocationId, status: 'cancelled', reason: 'cancelled', summary: 'Cancelled without replay.', evidence: [], effectsUncertain: false };
-                persist();
-                this.receive({ ...message, type: 'provider_job_cancel', reason: 'cancelled' });
-                snapshot();
-              }
-            }
-            close() {
-              this.readyState = 3;
-              const event = new CloseEvent('close', { code: 1000 });
-              this.dispatchEvent(event);
-              this.onclose?.(event);
-            }
-          }
-          Object.defineProperty(globalThis, 'WebSocket', { configurable: true, value: PeerSocket });
-          globalThis.submitFirefoxBrowserTask = () => {
-            const now = Date.now();
-            state.job = { providerId: state.providerId, generation: state.generation, browserTaskId: 'bt_' + crypto.randomUUID(), jobId: 'bj_' + crypto.randomUUID(), invocationId: 'b1.' + now + '.' + 'a'.repeat(64), payloadFingerprint: 'b'.repeat(64), createdAt: new Date(now).toISOString(), expiresAt: new Date(now + 604800000).toISOString(), deadlines: { approval: new Date(now + 120000).toISOString(), queue: new Date(now + 600000).toISOString() }, ownerLabel: 'ses_firefox_parent_A1', status: 'awaiting_approval' };
-            persist();
-            socket.receive({ type: 'provider_job', job: state.job, ownerLabel: 'ses_firefox_parent_A1', goal: 'Inspect only the explicitly approved tab.', conversationMode: 'new' });
-          };
-        }`);
+          // Only the network peer is a fixture. Both browsers run the shipped provider and coordinator.
+          await installFirefoxBrowserTaskPeer(session.driver);
           await session.openTargetPage();
           const targetHandle = await session.driver.getWindowHandle();
           await openAuthenticatedPanel(session);
           const ownerHandle = await session.driver.getWindowHandle();
           await waitForModel(session.driver);
-          await session.driver.findElement(By.css('button[aria-label="Settings"]')).click();
-          await session.driver
-            .findElement(By.css('[aria-label="CLI task settings"] button[aria-label="Model"]'))
-            .click();
-          await selectModelByIdFirefox(session.driver, 'anthropic/claude-sonnet-4');
-          await session.driver
-            .findElement(By.css('[aria-label="CLI task settings"] button[aria-label*="Safe mode"]'))
-            .click();
-          await clickButtonByText(session.driver, 'Dangerous');
-          await session.driver
-            .findElement(
-              By.css('[aria-label="CLI task settings"] [role="switch"][aria-label="CLI tasks"]')
-            )
-            .click();
-          await session.driver.findElement(By.css('button[aria-label="Close settings"]')).click();
-          await waitForText(session.driver, 'Enabled — idle');
+          await enableFirefoxBrowserTasks(session.driver);
           await session.driver.executeScript('globalThis.submitFirefoxBrowserTask()');
           await waitForText(session.driver, 'Tab approval required');
           const approveButton = await session.driver.findElement(
@@ -3377,19 +3397,7 @@ const scenarios: FirefoxScenario[] = [
           await approveButton.click();
           await waitForText(session.driver, 'CLI tasks: Running');
           await waitForText(session.driver, 'Bound tab: Kilo extension fixture');
-          const modes = await session.driver.executeAsyncScript(
-            (done: (value: unknown) => void) => {
-              void navigator.locks.query().then(state => {
-                done(
-                  state.held
-                    ?.filter(lock => lock.name === 'kilo:browser-execution')
-                    .map(lock => lock.mode)
-                );
-                return null;
-              });
-            }
-          );
-          assert.deepEqual(modes, ['exclusive']);
+          assert.deepEqual(await firefoxExecutionModes(session.driver), ['exclusive']);
           await session.openSidePanel();
           const otherHandle = await session.driver.getWindowHandle();
           await waitForText(session.driver, 'Owned by another panel');
@@ -3424,6 +3432,186 @@ const scenarios: FirefoxScenario[] = [
       );
     },
   },
+  ...(['close', 'reload'] as const).map(loss => ({
+    name: `native local owner ${loss} blocks local and delegated work until explicit recovery` as const,
+    run: async (context: ScenarioContext): Promise<void> => {
+      const issueAction = Promise.withResolvers<void>();
+      const bodies: unknown[] = [];
+      const recoveredText = 'Explicitly submitted Firefox work completed.';
+      await withSession(
+        context.api,
+        {
+          beforeFirstCompletion: () => issueAction.promise,
+          browserTasks: true,
+          firstCompletionEvents: toolCallCompletion(
+            'eval',
+            {
+              code: 'document.querySelector("h1").textContent = "Issued local page action"; document.documentElement.setAttribute("data-local-action", "issued"); await new Promise(resolve => document.addEventListener("finish-local-action", resolve, { once: true })); document.documentElement.setAttribute("data-local-action", "finished"); return "finished";',
+            },
+            'firefox-issued-local-action'
+          ),
+          secondCompletionEvents: contentOnlyCompletion(recoveredText),
+          seenChatBodies: bodies,
+          thirdCompletionEvents: contentOnlyCompletion(recoveredText),
+          toolNames: dangerousToolNames,
+        },
+        async session => {
+          const { driver } = session;
+          await installFirefoxBrowserTaskPeer(driver);
+          await session.openTargetPage('Firefox affected local tab');
+          const targetHandle = await driver.getWindowHandle();
+          await session.openTargetPage('Firefox recovery target');
+          const otherHandle = await driver.getWindowHandle();
+          await openAuthenticatedPanel(session);
+          const providerHandle = await driver.getWindowHandle();
+          await waitForModel(driver);
+          await enableFirefoxBrowserTasks(driver);
+          await session.openSidePanel();
+          const localOwnerHandle = await driver.getWindowHandle();
+          await waitForText(driver, 'Owned by another panel');
+          await waitForModel(driver);
+          await waitForTargetOption(driver, 'Firefox affected local tab');
+          await setSelectByText(driver, 'Target tab', 'Firefox affected local tab');
+          await switchToDangerousMode(driver);
+          await sendMessage(driver, 'Issue the local page action and wait.');
+          await waitUntil(
+            driver,
+            async () => JSON.stringify(await firefoxExecutionModes(driver)) === '["shared"]',
+            'The local run must hold a native shared execution lock.'
+          );
+          await driver.switchTo().window(providerHandle);
+          await driver.executeScript('globalThis.submitFirefoxBrowserTask()');
+          await waitForText(driver, 'Tab approval required');
+          await driver
+            .findElement(
+              By.xpath(
+                '//section[@aria-label="CLI task supervision"]//select/option[normalize-space(.)="Firefox affected local tab"]'
+              )
+            )
+            .click();
+          const initialApproval = await getButtonByText(driver, 'Approve tab');
+          await initialApproval.click();
+          await waitForText(driver, 'Waiting for browser control');
+          assert.equal(bodies.length, 1);
+
+          // Destroy the local owner only after real page code starts, not during the held model request.
+          issueAction.resolve();
+          await driver.switchTo().window(targetHandle);
+          await waitUntil(
+            driver,
+            async () =>
+              (await driver.findElement(By.css('html')).getAttribute('data-local-action')) ===
+              'issued',
+            'The local runner must issue a page action before owner loss.'
+          );
+          await driver.switchTo().window(localOwnerHandle);
+          await (loss === 'close' ? driver.close() : driver.navigate().refresh());
+          await driver.switchTo().window(targetHandle);
+          await driver.executeScript('document.dispatchEvent(new Event("finish-local-action"))');
+          await waitUntil(
+            driver,
+            async () =>
+              (await driver.findElement(By.css('html')).getAttribute('data-local-action')) ===
+              'finished',
+            'Issued page code must finish after its panel owner disappears.'
+          );
+          assert.equal(
+            await driver.findElement(By.css('h1')).getText(),
+            'Issued local page action'
+          );
+          await driver.switchTo().window(providerHandle);
+          await waitForText(driver, 'Recovery required');
+          await waitUntil(
+            driver,
+            async () => JSON.stringify(await firefoxExecutionModes(driver)) === '[]',
+            'Native lock release must not clear the durable local protection.'
+          );
+          const stored = await readFirefoxStorage(driver, ['kiloBrowserExecutionSafety']);
+          const safety = z
+            .object({
+              localRuns: z.array(z.object({ tabId: z.number() })),
+              tabIds: z.array(z.number()),
+            })
+            .parse(stored['kiloBrowserExecutionSafety']);
+          assert.equal(safety.localRuns.length, 1);
+          assert.deepEqual(safety.tabIds, []);
+          const draft = 'Keep this Firefox draft until explicit recovery.';
+          await sendMessage(driver, draft);
+          assert.equal(
+            await driver.findElement(By.css('#agent-message')).getAttribute('value'),
+            draft
+          );
+          await waitForText(driver, 'an action may still be running');
+          const affected = await driver
+            .findElement(By.css('[aria-label="Affected tabs"]'))
+            .getText();
+          assert.ok(affected.includes('Firefox affected local tab'));
+          await clickButtonByText(driver, 'Check recovery readiness');
+          await waitForText(driver, 'Close all affected tabs before recovery.');
+          const recoveryButtons = await driver.findElements(
+            By.xpath('//button[normalize-space(.)="Recover browser control"]')
+          );
+          const approvalButtons = await driver.findElements(
+            By.xpath('//button[normalize-space(.)="Approve tab"]')
+          );
+          assert.equal(recoveryButtons.length, 0);
+          assert.equal(approvalButtons.length, 0);
+          assert.equal(bodies.length, 1);
+
+          await driver.switchTo().window(targetHandle);
+          await driver.close();
+          await driver.switchTo().window(providerHandle);
+          await clickButtonByText(driver, 'Check recovery readiness');
+          await waitForText(driver, 'Browser control is ready for recovery.');
+          await sendMessage(driver, draft);
+          assert.equal(
+            await driver.findElement(By.css('#agent-message')).getAttribute('value'),
+            draft
+          );
+          assert.equal(bodies.length, 1);
+          await clickButtonByText(driver, 'Recover browser control');
+          await waitForText(driver, 'Enabled — idle');
+          assert.deepEqual(await firefoxExecutionModes(driver), []);
+          assert.equal(bodies.length, 1);
+          await setSelectByText(driver, 'Target tab', 'Firefox recovery target');
+          await driver
+            .findElement(
+              By.css('button[aria-label^="Safe mode"], button[aria-label^="Dangerous mode"]')
+            )
+            .click();
+          await clickButtonByText(driver, 'Dangerous');
+          await sendMessage(driver, draft);
+          await waitForText(driver, recoveredText);
+          await waitUntil(
+            driver,
+            async () => JSON.stringify(await firefoxExecutionModes(driver)) === '[]',
+            'The explicitly submitted local run must finish.'
+          );
+          assert.equal(bodies.length, 2);
+          await driver.executeScript('globalThis.submitFirefoxBrowserTask()');
+          await waitForText(driver, 'Tab approval required');
+          const freshApproval = await getButtonByText(driver, 'Approve tab');
+          assert.equal(await freshApproval.isEnabled(), false);
+          assert.equal(bodies.length, 2);
+          await driver
+            .findElement(
+              By.xpath(
+                '//section[@aria-label="CLI task supervision"]//select/option[normalize-space(.)="Firefox recovery target"]'
+              )
+            )
+            .click();
+          await freshApproval.click();
+          await waitForText(driver, 'Last outcome: succeeded');
+          assert.equal(bodies.length, 3);
+          await driver.switchTo().window(otherHandle);
+          assert.equal(
+            await driver.findElement(By.css('html')).getAttribute('data-local-action'),
+            null
+          );
+        }
+      );
+    },
+  })),
   {
     name: 'unsupported native locks keep CLI delegation disabled',
     run: async context => {

--- a/apps/extension/tests/e2e/firefox-selenium-e2e.ts
+++ b/apps/extension/tests/e2e/firefox-selenium-e2e.ts
@@ -59,6 +59,8 @@ const chromeWorkflowNames = [
   'model picker search filters and selects by model id',
   'workflow create, approve, and run returns result',
   'workflow auto-approve save stores approved hash',
+  'CLI task consent and cancellation use native cross-panel locks',
+  'unsupported native locks keep CLI delegation disabled',
 ] as const;
 
 const PENDING_DRAFT_KEY = 'kiloPendingAgentMemoryDraft';
@@ -96,6 +98,7 @@ interface Organization {
 interface KiloApiOptions {
   readonly beforeFirstCompletion?: () => Promise<void>;
   readonly beforeModels?: (organizationId: string) => Promise<void>;
+  readonly browserTasks?: boolean;
   readonly firstCompletionEvents?: unknown[];
   readonly modelFailuresBeforeSuccess?: number;
   readonly modelFailuresBeforeSuccessByOrganizationId?: Record<string, number>;
@@ -124,8 +127,10 @@ interface ScenarioContext {
   readonly api: KiloApiHandle;
 }
 
+// Selenium 4.45 supplies script().pin; the installed 4.35 declarations omit it.
 type FirefoxWebDriver = WebDriver & {
   readonly installAddon: (path: string, temporary: boolean) => Promise<string>;
+  readonly script: () => { pin: (script: string) => Promise<string> };
 };
 
 interface FirefoxScenario {
@@ -350,6 +355,15 @@ const startKiloApiServer = async (): Promise<KiloApiHandle> => {
 
         {
           const requestPath = (request.url ?? '').split('?')[0] ?? '';
+
+          if (
+            options.browserTasks === true &&
+            requestPath === '/api/trpc/activeSessions.createWebTicket'
+          ) {
+            const result = { result: { data: { token: 'firefox-fixture-ticket' } } };
+            sendJson(response, request.url?.includes('batch=1') === true ? [result] : result);
+            return;
+          }
 
           if (requestPath.startsWith('/api/trpc/modelPreferences.')) {
             if (requestPath.endsWith('/modelPreferences.get')) {
@@ -803,6 +817,7 @@ const startFirefoxSession = async (): Promise<FirefoxSession> => {
   const options = new firefox.Options();
 
   options.addArguments('-headless');
+  options.set('webSocketUrl', true);
   options.setPreference('extensions.install.requireBuiltInCerts', false);
   options.setPreference('xpinstall.signatures.required', false);
 
@@ -3204,6 +3219,238 @@ const scenarios: FirefoxScenario[] = [
       } finally {
         await targetServer.close();
       }
+    },
+  },
+  {
+    name: 'CLI task consent and cancellation use native cross-panel locks',
+    run: async context => {
+      const completion = Promise.withResolvers<void>();
+      const bodies: unknown[] = [];
+      await withSession(
+        context.api,
+        {
+          beforeFirstCompletion: () => completion.promise,
+          browserTasks: true,
+          firstCompletionEvents: [
+            {
+              choices: [
+                {
+                  delta: {
+                    tool_calls: [
+                      {
+                        function: {
+                          arguments: JSON.stringify({
+                            code: 'document.documentElement.setAttribute("data-cli-effect", "issued"); return "issued";',
+                          }),
+                          name: 'eval',
+                        },
+                        id: 'firefox-cli-action',
+                        index: 0,
+                        type: 'function',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+          seenChatBodies: bodies,
+          toolNames: dangerousToolNames,
+        },
+        async session => {
+          // Only the network peer is a fixture. Both browsers run the same shipped provider and coordinator.
+          await session.driver.script().pin(`() => {
+          if (location.protocol !== 'moz-extension:') return;
+          const key = 'firefox-browser-task-peer';
+          const state = JSON.parse(sessionStorage.getItem(key) || '{"generation":0}');
+          const persist = () => sessionStorage.setItem(key, JSON.stringify(state));
+          let socket;
+          const snapshot = () => socket.receive({ type: 'provider_snapshot', providerId: state.providerId, generation: state.generation, jobs: state.job ? [state.job] : [] });
+          class PeerSocket extends EventTarget {
+            static CONNECTING = 0;
+            static OPEN = 1;
+            static CLOSING = 2;
+            static CLOSED = 3;
+            readyState = 0;
+            onopen = null;
+            onmessage = null;
+            onclose = null;
+            onerror = null;
+            constructor(url) {
+              super();
+              this.url = String(url);
+              socket = this;
+              setTimeout(() => {
+                this.readyState = 1;
+                const event = new Event('open');
+                this.dispatchEvent(event);
+                this.onopen?.(event);
+                this.receive({ type: 'system', event: 'connected', data: {} });
+              }, 0);
+            }
+            receive(value) {
+              queueMicrotask(() => {
+                if (this.readyState !== 1) return;
+                const event = new MessageEvent('message', { data: JSON.stringify(value) });
+                this.dispatchEvent(event);
+                this.onmessage?.(event);
+              });
+            }
+            send(raw) {
+              const message = JSON.parse(raw);
+              if (message.type === 'ping') this.receive({ type: 'pong', nonce: message.nonce, capabilities: { browserJobsV1: true } });
+              if (message.type === 'provider_register') {
+                state.providerId = message.providerId;
+                state.generation = Math.max(state.generation, message.generation) + 1;
+                persist();
+              }
+              if (message.type === 'provider_register' || message.type === 'provider_heartbeat') {
+                this.receive({ type: 'provider_lease_ack', providerId: state.providerId, generation: state.generation, requestId: message.requestId, leaseExpiresAt: new Date(Date.now() + 15000).toISOString() });
+                if (message.type === 'provider_heartbeat') this.receive({ type: 'provider_snapshot', providerId: state.providerId, generation: state.generation, requestId: message.requestId, jobs: state.job?.generation === state.generation ? [state.job] : [] });
+              }
+              if (message.type === 'provider_status') this.receive({ type: 'provider_status_result', providerId: state.providerId, requestId: message.requestId, jobs: state.job ? [state.job] : [] });
+              if (message.type === 'provider_approval' && message.approval.decision === 'approved') {
+                state.job.approvedTab = message.approval.tab;
+                state.job.status = 'running';
+                state.job.deadlines.execution = new Date(Date.now() + 600000).toISOString();
+                persist();
+                snapshot();
+              }
+              if (message.type === 'provider_cancel') {
+                const job = state.job;
+                job.status = 'cancelled';
+                job.result = { providerId: job.providerId, browserTaskId: job.browserTaskId, jobId: job.jobId, invocationId: job.invocationId, status: 'cancelled', reason: 'cancelled', summary: 'Cancelled without replay.', evidence: [], effectsUncertain: false };
+                persist();
+                this.receive({ ...message, type: 'provider_job_cancel', reason: 'cancelled' });
+                snapshot();
+              }
+            }
+            close() {
+              this.readyState = 3;
+              const event = new CloseEvent('close', { code: 1000 });
+              this.dispatchEvent(event);
+              this.onclose?.(event);
+            }
+          }
+          Object.defineProperty(globalThis, 'WebSocket', { configurable: true, value: PeerSocket });
+          globalThis.submitFirefoxBrowserTask = () => {
+            const now = Date.now();
+            state.job = { providerId: state.providerId, generation: state.generation, browserTaskId: 'bt_' + crypto.randomUUID(), jobId: 'bj_' + crypto.randomUUID(), invocationId: 'b1.' + now + '.' + 'a'.repeat(64), payloadFingerprint: 'b'.repeat(64), createdAt: new Date(now).toISOString(), expiresAt: new Date(now + 604800000).toISOString(), deadlines: { approval: new Date(now + 120000).toISOString(), queue: new Date(now + 600000).toISOString() }, ownerLabel: 'ses_firefox_parent_A1', status: 'awaiting_approval' };
+            persist();
+            socket.receive({ type: 'provider_job', job: state.job, ownerLabel: 'ses_firefox_parent_A1', goal: 'Inspect only the explicitly approved tab.', conversationMode: 'new' });
+          };
+        }`);
+          await session.openTargetPage();
+          const targetHandle = await session.driver.getWindowHandle();
+          await openAuthenticatedPanel(session);
+          const ownerHandle = await session.driver.getWindowHandle();
+          await waitForModel(session.driver);
+          await session.driver.findElement(By.css('button[aria-label="Settings"]')).click();
+          await session.driver
+            .findElement(By.css('[aria-label="CLI task settings"] button[aria-label="Model"]'))
+            .click();
+          await selectModelByIdFirefox(session.driver, 'anthropic/claude-sonnet-4');
+          await session.driver
+            .findElement(By.css('[aria-label="CLI task settings"] button[aria-label*="Safe mode"]'))
+            .click();
+          await clickButtonByText(session.driver, 'Dangerous');
+          await session.driver
+            .findElement(
+              By.css('[aria-label="CLI task settings"] [role="switch"][aria-label="CLI tasks"]')
+            )
+            .click();
+          await session.driver.findElement(By.css('button[aria-label="Close settings"]')).click();
+          await waitForText(session.driver, 'Enabled — idle');
+          await session.driver.executeScript('globalThis.submitFirefoxBrowserTask()');
+          await waitForText(session.driver, 'Tab approval required');
+          const approveButton = await session.driver.findElement(
+            By.xpath('//button[normalize-space(.)="Approve tab"]')
+          );
+          assert.equal(await approveButton.isEnabled(), false);
+          await session.driver
+            .findElement(
+              By.xpath(
+                '//section[@aria-label="CLI task supervision"]//select/option[contains(., "Kilo extension fixture")]'
+              )
+            )
+            .click();
+          await approveButton.click();
+          await waitForText(session.driver, 'CLI tasks: Running');
+          await waitForText(session.driver, 'Bound tab: Kilo extension fixture');
+          const modes = await session.driver.executeAsyncScript(
+            (done: (value: unknown) => void) => {
+              void navigator.locks.query().then(state => {
+                done(
+                  state.held
+                    ?.filter(lock => lock.name === 'kilo:browser-execution')
+                    .map(lock => lock.mode)
+                );
+                return null;
+              });
+            }
+          );
+          assert.deepEqual(modes, ['exclusive']);
+          await session.openSidePanel();
+          const otherHandle = await session.driver.getWindowHandle();
+          await waitForText(session.driver, 'Owned by another panel');
+          const draft = await session.driver.findElement(By.css('[aria-label="Message agent"]'));
+          await draft.sendKeys('Preserve this blocked Firefox draft.', Key.ENTER);
+          assert.equal(await draft.getAttribute('value'), 'Preserve this blocked Firefox draft.');
+          await waitForText(session.driver, 'owns browser control');
+          await session.driver.switchTo().window(ownerHandle);
+          await session.driver.findElement(By.css('[aria-label="Stop CLI task"]')).click();
+          await waitForText(session.driver, 'cancelled');
+          completion.resolve();
+          await session.driver.navigate().refresh();
+          await waitForText(session.driver, 'Cancelled without replay.');
+          const stopButtons = await session.driver.findElements(
+            By.css('[aria-label="Stop CLI task"]')
+          );
+          assert.equal(stopButtons.length, 0);
+          await session.driver.switchTo().window(targetHandle);
+          assert.equal(
+            await session.driver.findElement(By.css('html')).getAttribute('data-cli-effect'),
+            null
+          );
+          await session.driver.switchTo().window(otherHandle);
+          assert.equal(
+            await session.driver
+              .findElement(By.css('[aria-label="Message agent"]'))
+              .getAttribute('value'),
+            'Preserve this blocked Firefox draft.'
+          );
+          assert.equal(bodies.length, 1);
+        }
+      );
+    },
+  },
+  {
+    name: 'unsupported native locks keep CLI delegation disabled',
+    run: async context => {
+      await withSession(
+        context.api,
+        {
+          firstCompletionEvents: contentOnlyCompletion('Local Firefox work remains available.'),
+          toolNames: [...safeToolNames],
+        },
+        async session => {
+          await session.driver
+            .script()
+            .pin(
+              "() => { Object.defineProperty(navigator, 'locks', { configurable: true, value: undefined }); }"
+            );
+          await session.openTargetPage();
+          await openAuthenticatedPanel(session);
+          await waitForText(session.driver, 'does not support Web Locks');
+          await waitForModel(session.driver);
+          await sendMessage(session.driver, 'Read the page locally.');
+          await waitForText(session.driver, 'Local Firefox work remains available.');
+          const approvals = await session.driver.findElements(
+            By.xpath('//button[normalize-space(.)="Approve tab"]')
+          );
+          assert.equal(approvals.length, 0);
+        }
+      );
     },
   },
 ];

--- a/apps/extension/tests/e2e/local-backend-live.test.ts
+++ b/apps/extension/tests/e2e/local-backend-live.test.ts
@@ -5,6 +5,7 @@ import { rm } from 'node:fs/promises';
 import { z } from 'zod';
 import { launchExtensionContext, startFixtureServer } from './extension-context-fixture';
 import { expectSelectedModelId, selectModelById } from './model-picker-e2e-helpers';
+import { signInWithLocalDeviceAuth } from './local-device-auth-helpers';
 
 const localBackendUrl = process.env['LOCAL_BACKEND_ORIGIN'] ?? 'http://localhost:3000';
 const localUserEmail = 'fl@fl.fl';
@@ -176,73 +177,6 @@ const recordChatRequestOutcomes = (
   });
 };
 
-const signInWithLocalDeviceAuth = async ({
-  context,
-  extensionId,
-  sidePanel,
-}: {
-  context: BrowserContext;
-  extensionId: string;
-  sidePanel: Page;
-}): Promise<void> => {
-  await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
-  const codeLocator = sidePanel.getByText(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/u).first();
-  let codeText: string | null = null;
-
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    await sidePanel.getByRole('button', { name: 'Sign in' }).click();
-
-    const didShowCode = await codeLocator
-      .waitFor({ state: 'visible', timeout: 20_000 })
-      .then(() => true)
-      .catch(() => false);
-
-    if (didShowCode) {
-      codeText = await codeLocator.textContent();
-      break;
-    }
-
-    await expect(sidePanel.getByText('Failed to start sign in. Try again.')).toBeVisible();
-  }
-
-  const code = codeText?.trim();
-
-  if (code === undefined || code === '') {
-    throw new Error('Device auth code was not visible.');
-  }
-
-  const authPage = await context.newPage();
-  const callbackPath = `/device-auth?code=${encodeURIComponent(code)}&app=1`;
-  // Shared stack may run with APP_URL_OVERRIDE at a LAN IP.
-  // Cookies set off-origin make the post-login redirect silently drop authentication.
-  let authOrigin = localBackendUrl;
-
-  try {
-    const probe = await context.request.get(`${localBackendUrl}/users/after-sign-in`, {
-      maxRedirects: 0,
-    });
-    const { location } = probe.headers();
-
-    if (
-      probe.status() >= 300 &&
-      probe.status() < 400 &&
-      location !== undefined &&
-      location !== ''
-    ) {
-      authOrigin = new URL(location).origin;
-    }
-  } catch {
-    // Fall back to localBackendUrl on non-redirect, missing/invalid location, or request error.
-  }
-
-  await authPage.goto(
-    `${authOrigin}/users/sign_in?fakeUser=${encodeURIComponent(localUserEmail)}&callbackPath=${encodeURIComponent(callbackPath)}`
-  );
-  await authPage.getByRole('button', { name: 'Authorize' }).click({ timeout: 60_000 });
-  await expect(sidePanel.getByLabel('Message agent')).toBeVisible({ timeout: 30_000 });
-  await authPage.close();
-};
-
 const selectFrontierModel = async (sidePanel: Page): Promise<void> => {
   await selectModelById(sidePanel, frontierModel);
 
@@ -377,7 +311,13 @@ test('live local backend keeps frontier conversations stable across modes, reloa
     await targetPage.goto(fixture.url);
 
     const sidePanel = await context.newPage();
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Target tab')).toContainText('Kilo live backend E2E target');
     await selectFrontierModel(sidePanel);
 
@@ -470,7 +410,13 @@ test('live local backend snapshots the selected target tab per send', async () =
     await firstTarget.bringToFront();
 
     const sidePanel = await context.newPage();
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Target tab')).toContainText('Kilo live target alpha');
     await selectFrontierModel(sidePanel);
     await sidePanel.getByLabel('Target tab').selectOption({ label: 'Kilo live target alpha' });
@@ -530,7 +476,13 @@ test('live local backend runs parallel frontier conversations without switching 
     await targetPage.goto(fixture.url);
 
     const sidePanel = await context.newPage();
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Target tab')).toContainText('Kilo live parallel target');
     await selectFrontierModel(sidePanel);
 
@@ -617,7 +569,13 @@ test('live local backend aborts an active frontier request on logout', async () 
     await targetPage.goto(fixture.url);
 
     const sidePanel = await context.newPage();
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Target tab')).toContainText('Kilo live logout abort target');
     await selectFrontierModel(sidePanel);
 
@@ -658,7 +616,13 @@ test('live local backend can stop a frontier response and continue chatting', as
     await targetPage.goto(fixture.url);
 
     const sidePanel = await context.newPage();
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Target tab')).toContainText('Kilo live manual stop target');
     await selectFrontierModel(sidePanel);
 
@@ -708,7 +672,13 @@ test('live local backend recovers after side panel reload during an active reque
     await targetPage.goto(fixture.url);
 
     const sidePanel = await context.newPage();
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Target tab')).toContainText(
       'Kilo live reload recovery target'
     );
@@ -769,7 +739,13 @@ test('live local backend keeps real tool rows from overlapping', async () => {
     await targetPage.goto(fixture.url);
 
     const sidePanel = await context.newPage();
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Target tab')).toContainText('Kilo live tool spacing target');
     await selectFrontierModel(sidePanel);
     await startConversationGapSampler(sidePanel);
@@ -805,7 +781,13 @@ test('live local backend preserves and deletes frontier conversations through hi
     await targetPage.goto(fixture.url);
 
     const sidePanel = await context.newPage();
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Target tab')).toContainText('Kilo live history target');
     await selectFrontierModel(sidePanel);
 
@@ -884,7 +866,13 @@ test('live local backend dangerous mode eval can update the selected page', asyn
     await targetPage.goto(fixture.url);
 
     const sidePanel = await context.newPage();
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Target tab')).toContainText('Kilo live eval target');
     await selectFrontierModel(sidePanel);
     await sidePanel.getByLabel('Target tab').selectOption({ label: 'Kilo live eval target' });
@@ -933,7 +921,13 @@ test('live local backend manual Compact now compacts a frontier conversation', a
     await targetPage.goto(fixture.url);
 
     const sidePanel = await context.newPage();
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Target tab')).toContainText('Kilo live compaction target');
     await selectFrontierModel(sidePanel);
 
@@ -1039,7 +1033,13 @@ test('live local backend personal favorites round-trip for frontier', async () =
   let wasFavoriteBefore: 'unknown' | boolean = 'unknown';
 
   try {
-    await signInWithLocalDeviceAuth({ context, extensionId, sidePanel });
+    await signInWithLocalDeviceAuth({
+      context,
+      extensionId,
+      localBackendUrl,
+      localUserEmail,
+      sidePanel,
+    });
     await expect(sidePanel.getByLabel('Model')).toBeEnabled({ timeout: 30_000 });
 
     await sidePanel.getByLabel('Model').click();

--- a/apps/extension/tests/e2e/local-device-auth-helpers.ts
+++ b/apps/extension/tests/e2e/local-device-auth-helpers.ts
@@ -1,0 +1,73 @@
+/* eslint-disable no-await-in-loop -- Device authorization retries only the existing sign-in initiation. */
+import { expect } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
+
+export const signInWithLocalDeviceAuth = async ({
+  context,
+  extensionId,
+  localBackendUrl,
+  localUserEmail,
+  sidePanel,
+}: {
+  context: BrowserContext;
+  extensionId: string;
+  localBackendUrl: string;
+  localUserEmail: string;
+  sidePanel: Page;
+}): Promise<void> => {
+  await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
+  const codeLocator = sidePanel.getByText(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/u).first();
+  let codeText: string | null = null;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await sidePanel.getByRole('button', { name: 'Sign in' }).click();
+
+    const didShowCode = await codeLocator
+      .waitFor({ state: 'visible', timeout: 20_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (didShowCode) {
+      codeText = await codeLocator.textContent();
+      break;
+    }
+
+    await expect(sidePanel.getByText('Failed to start sign in. Try again.')).toBeVisible();
+  }
+
+  const code = codeText?.trim();
+
+  if (code === undefined || code === '') {
+    throw new Error('Device auth code was not visible.');
+  }
+
+  const authPage = await context.newPage();
+  const callbackPath = `/device-auth?code=${encodeURIComponent(code)}&app=1`;
+  // Shared stacks can redirect to a LAN origin. Sign in there so the callback retains its cookie.
+  let authOrigin = localBackendUrl;
+
+  try {
+    const probe = await context.request.get(`${localBackendUrl}/users/after-sign-in`, {
+      maxRedirects: 0,
+    });
+    const { location } = probe.headers();
+
+    if (
+      probe.status() >= 300 &&
+      probe.status() < 400 &&
+      location !== undefined &&
+      location !== ''
+    ) {
+      authOrigin = new URL(location).origin;
+    }
+  } catch {
+    // Fall back to localBackendUrl on a request error or an invalid redirect.
+  }
+
+  await authPage.goto(
+    `${authOrigin}/users/sign_in?fakeUser=${encodeURIComponent(localUserEmail)}&callbackPath=${encodeURIComponent(callbackPath)}`
+  );
+  await authPage.getByRole('button', { name: 'Authorize' }).click({ timeout: 60_000 });
+  await expect(sidePanel.getByLabel('Message agent')).toBeVisible({ timeout: 30_000 });
+  await authPage.close();
+};


### PR DESCRIPTION
No new behavior — this change adds automated checks and removes duplicate test setup without changing the product.

---

## Summary

Live acceptance drives `browser_task` through the real command-line interface (CLI), extension, and relay instead of substituting protocol calls for successful execution. `EXTENSION_LOCAL_BACKEND_E2E` gates execution, and the harness requires `SCRATCH`, `KILO_CLI_WORKTREE`, `LOCAL_USER_EMAIL`, `KILO_API_KEY`, and `KILO_WORKFLOW`. Authenticated readiness probes, production deadlines, and sanitized `Evidence` distinguish live execution from discovery; an unavailable required model blocks verification.

<details>
<summary>Files</summary>

- `apps/extension/tests/e2e/browser-task-live.test.ts` — Test; added (A); +1,162/−0 lines. Starts two authenticated CLI processes with isolated XDG roots and creates three parent chats using one account. Checks empty discovery, explicit provider selection, first-in/first-out queueing, useful parent-specific results, and continuation only after fresh tab consent. Requires continuation success, `effectsUncertain: false`, the current count, and the prior page observation. Inspects model requests for owned history and excludes other parents' content without logging request bodies. Exercises foreign status, cancel, and continuation denial through both the real tool and authenticated relay probes. Repeats invocations and drops connections before acceptance, after dispatch, and before completion while checking one browser action and stable handles. After an accepted dispatch loses its complete reply, a CLI restart must recover the original task, job, and invocation handles. If the request never reached acceptance, recovery reports an authoritative absence without a new invocation. Checks immutable historical and latest results, fixed tab binding, and reload without execution. Covers Stop, tab loss, socket loss, panel close/reload, disablement, extension shutdown, and the ten-minute execution timeout for active and queued parents. Resolves running service ports, allocates new ports, validates JSON response types, and authenticates health and proxy control requests. Uses the required model without substitution and disables automatic screenshots, traces, and video. Writes sanitized checks, scenarios, model, clock source, and explicit screenshot paths through `Evidence`; cleans only its own runtime resources.

</details>

Chrome and Firefox gain acceptance checks for delegated consent, native lock coordination, cancellation, supervision, and recovery without a separate product runtime. `KiloApiOptions.browserTasks` enables `activeSessions.createWebTicket` fixture replies; `FirefoxWebDriver.script().pin` and `webSocketUrl` enable preload injection despite older Selenium declarations. Mocked relay and model traffic isolate browser behavior, so these cases do not replace live acceptance or visual inspection.

<details>
<summary>Files</summary>

- `apps/extension/tests/e2e/browser-task.test.ts` — Test; added (A); +1,033/−0 lines. Supplies schema-validated relay messages and deterministic model replies for Browser and Agents modes. Covers disabled and idle displays, connecting, unsupported and unavailable states, consent, running, queue details, terminal results, interruption, and recovery. Asserts no action before approval, no silent tab replacement, Safe-mode tool rejection, duplicate-delivery safety, and cancellation during queued dispatch races. Queries native shared local locks and exclusive delegated locks across panels, while checking that blocked drafts remain unsent. When locks are unavailable, checks that delegation stays disabled while ordinary local work remains usable. Injects timeout and permission failures; verifies that stale dispatch and reload do not restart execution. Retains safety and provider identity after sign-out and expired results; recovery requires tab closure, drained locks, and an explicit action. Uses a controlled clock only for deterministic expiry. Cancels workflow approval with keyboard Stop and checks that reload cannot restore the draft. Exercises memory approval, saving, a failed save and retry, and confirmation while retaining owner, tab, and Stop controls. Checks supervision in settings, model selection, conversation history, and workflow parameter dialogs. Captures long content at 320 pixels and 200% text; asserts Stop visibility and size, no horizontal overflow, keyboard focus containment, and restoration.
- `apps/extension/tests/e2e/firefox-selenium-e2e.ts` — Test; modified (M); +247/−0 lines. Adds consent and native-lock scenarios to the required scenario inventory. Supplies single and batched web-ticket replies when `browserTasks` is enabled. Enables bidirectional Selenium sessions and pins the network peer before panel startup. Declares the supported pinned-script API missing from the installed Selenium types. Checks explicit tab selection, bound-tab display, exclusive locking, cross-panel draft retention, cancellation persistence after reload, and no browser action. Removes Web Locks in a separate case to check that local work still runs without delegation.

</details>

The shared `signInWithLocalDeviceAuth` contract takes `localBackendUrl` and `localUserEmail` from each live test instead of duplicated enclosing constants. Centralizing the existing authorization flow preserves sign-in retries, redirect handling, wait limits, and completion cleanup. Both existing suites retain their prior backend and account choices; the new live harness supplies its prepared account.

<details>
<summary>Files</summary>

- `apps/extension/tests/e2e/local-device-auth-helpers.ts` — Test helper; added (A); +73/−0 lines. Exports the device-authorization flow with explicit backend and account parameters. Retains three initiation attempts, redirect-origin probing and fallback, authorization waits, and closure of the authorization page after success.
- `apps/extension/tests/e2e/agents-mode-live.test.ts` — Test; modified (M); +16/−72 lines. Imports the shared helper, removes its private copy and unused `BrowserContext` import, and forwards the unchanged backend and account values.
- `apps/extension/tests/e2e/local-backend-live.test.ts` — Test; modified (M); +78/−78 lines. Updates every sign-in call to pass the unchanged backend and fixed account; replaces the private implementation with the shared import.

</details>

Tests: 6 files (3 added, 3 modified), +2,609/−150 lines: `browser-task-live.test.ts`, `browser-task.test.ts`, `firefox-selenium-e2e.ts`, `local-device-auth-helpers.ts`, `agents-mode-live.test.ts`, `local-backend-live.test.ts`.
Generated: none (0 files).

---

## Verification

No manual verification ran. This implementation level permits scoped static checks only; native browser, live-stack, and visual verification belong to the bot-e2e phase.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Human steps

- **before merge** — The requesting human has no runtime setup or acceptance task. The bot workflow owns both.
- **after merge** — No production migration, new production secret, deployment flag, or other manual deployment step is required.

### Pending bot verification

- **Local stack:** The bot checks `pnpm -s dev:status --json` and starts only missing `nextjs` and `cloudflare-session-ingest` services with `KILO_PORT_OFFSET=auto`.
- **Account:** The bot inspects `pnpm dev:seed` without arguments before preparing the test account and credits. It supplies matching `LOCAL_USER_EMAIL` and `KILO_API_KEY` privately.
- **Harness:** The bot prepares `SCRATCH`, `KILO_CLI_WORKTREE`, and `KILO_WORKFLOW`, then explicitly runs the live spec with `EXTENSION_LOCAL_BACKEND_E2E=1`. Test discovery alone does not establish live acceptance.
- **Extension:** The bot builds the unpacked extension with `VITE_KILO_API_BASE_URL` and `VITE_SESSION_INGEST_WS_URL` from the existing port resolver. It allocates new server ports dynamically.
- **Model:** The CLI requires `kilo/deepseek/deepseek-v4-flash-0731`; delegated settings require `deepseek/deepseek-v4-flash-0731`. Model unavailability blocks verification; the bot cannot substitute another model.
- **Acceptance:** Native Chrome and Firefox runs, real CLI/relay acceptance, and visual inspection remain pending. Do not assign the PR or request review before the completion gate passes.

### Scope and dependencies

- Scope: Cloud level 13, `browser-task-0787-s12...browser-task-0787-s13`; six test/helper files and no production source changes.
- Cloud worktree: `/Users/igor/Projects/.worktrees/browser-task-0787`; branch `browser-task-0787-s13`.
- Command-line interface (CLI) worktree: `/Users/igor/Projects/.worktrees/browser-task-0787-kilocode`; branch `browser-task-0787-s6`. This level changes no CLI files.
- Runtime prerequisite: [Cloud level 12, #5734](https://github.com/Kilo-Org/cloud/pull/5734) supplies the extension runtime exercised by these tests.
- Cross-repository dependency: [CLI level 6, #13567](https://github.com/Kilo-Org/kilocode/pull/13567) supplies the real `browser_task` tool and parent-owned recovery.

### Notes

The handoff reports that all scoped static checks passed. This is the final implementation level, not completed runtime verification.

Native Chrome/Firefox, real CLI/relay, and visual verification remain pending in the bot-e2e phase.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `browser-task-0787` — #5638
2. `browser-task-0787-s2` — #5644
3. `browser-task-0787-s3` — #5648
4. `browser-task-0787-s4` — #5653
7. `browser-task-0787-s7` — #5681
8. `browser-task-0787-s8` — #5694
9. `browser-task-0787-s9` — #5698
10. `browser-task-0787-s10` — #5702
11. `browser-task-0787-s11` — #5716
12. `browser-task-0787-s12` — #5734
13. `browser-task-0787-s13` — #5742 ← this PR (tip)

