### PR TITLE
feat(agent-harness): authorize named Kilo operation dispatch

### DIFF
--- a/apps/web/src/lib/agent-harness/operation-dispatch.test.ts
+++ b/apps/web/src/lib/agent-harness/operation-dispatch.test.ts
@@ -1,0 +1,439 @@
+import { beforeEach, expect, it, jest } from '@jest/globals';
+import { TRPCError } from '@trpc/server';
+import jwt from 'jsonwebtoken';
+import { OrganizationRoleSchema } from '@/lib/organizations/organization-types';
+import {
+  access,
+  authority,
+  call,
+  capability,
+  conversationId,
+  operationId,
+  originalTime,
+  runId,
+  runtime,
+  toolCallId,
+} from './operation-test-fixture';
+import type * as Dispatch from './operation-dispatch';
+import type * as CloudContext from './cloud-agent-context';
+import type * as Invitation from './invitation';
+
+const sessionId = 'ses_12345678901234567890123456';
+const mutations = [
+  ['start', { prompt: 'Fix', modelId: 'model' }],
+  ['continue', { sessionId, message: 'Continue' }],
+  ['stop', { sessionId }],
+] as const;
+let output: unknown, cloudOutcome: unknown, failure: Error | undefined;
+const effects = new Map<string, number>();
+const cloudInputs: unknown[] = [],
+  contexts: unknown[] = [];
+jest.mock('@/routers/root-router', () => ({
+  rootRouter: {
+    createCaller: (ctx: unknown) => {
+      contexts.push(ctx);
+      return {};
+    },
+  },
+}));
+jest.mock('./kilo-reads', () => ({
+  executeHarnessRead: async () => {
+    if (failure) throw failure;
+    return output;
+  },
+}));
+jest.mock('./invitation', () => ({
+  executeHarnessInvitation: async (_token: string, input: { arguments: { role: string } }) => {
+    OrganizationRoleSchema.parse(input.arguments.role);
+    effects.set('invitation', (effects.get('invitation') ?? 0) + 1);
+    if (failure) throw failure;
+    return { invitationId: toolCallId, emailQueued: true };
+  },
+  reconcileHarnessInvitation: async (_token: string, input: { arguments: { role: string } }) => {
+    OrganizationRoleSchema.parse(input.arguments.role);
+    return effects.has('invitation') ? { invitationId: toolCallId, emailQueued: true } : null;
+  },
+}));
+jest.mock('./cloud-agent', () => ({
+  executeHarnessCloudAgent: (token: string, input: unknown) => cloud(token, input, false),
+  reconcileHarnessCloudAgent: (token: string, input: unknown) => cloud(token, input, true),
+}));
+const { executeHarnessDispatch } = jest.requireActual<typeof Dispatch>('./operation-dispatch');
+async function cloud(token: string, input: unknown, reconcile: boolean) {
+  cloudInputs.push(input);
+  const context = jest
+    .requireActual<typeof CloudContext>('./cloud-agent-context')
+    .createHarnessCloudAgentContext(token, input);
+  await context.fresh();
+  if (cloudOutcome !== undefined) return cloudOutcome;
+  if (!context.messageId) return context.succeeded(output);
+  if (!reconcile) {
+    effects.set(context.messageId, (effects.get(context.messageId) ?? 0) + 1);
+    if (failure) throw failure;
+  }
+  return effects.has(context.messageId) &&
+    !(reconcile && context.request.name === 'kilo.sessions.stop')
+    ? context.succeeded({ sessionId })
+    : {
+        status: 'outcome_unknown',
+        reason: 'provider-secret',
+        providerReference: 'private-reference',
+      };
+}
+const invoke = async (raw: unknown, token = capability(raw)) =>
+  (await executeHarnessDispatch(
+    JSON.parse(JSON.stringify(raw)),
+    token,
+    new AbortController().signal
+  )) as any;
+beforeEach(() => {
+  output = [];
+  cloudOutcome = failure = undefined;
+  effects.clear();
+  cloudInputs.length = contexts.length = 0;
+  Object.assign(authority, { organizationId: runId });
+});
+
+const reads = [
+  ['kilo.organizations', {}, [], [{ id: 'resource', name: 'Resource' }]],
+  ['kilo.members', {}, [], [{ id: 'user', email: 'person@example.com', role: 'member' }]],
+  ['kilo.repositories', {}, [], [{ id: 'repository', name: 'owner/repo' }]],
+  ['kilo.usage', {}, {}, { totalCost: 12 }],
+  ['kilo.sessions.search', { query: 'scope' }, [], [{ sessionId, title: 'Existing session' }]],
+  [
+    'kilo.sessions.attach',
+    { sessionId },
+    { sessionId, untrusted: true, messages: [] },
+    { sessionId, untrusted: true, messages: [{ role: 'user', content: 'Selected context' }] },
+  ],
+  [
+    'kilo.sessions.progress',
+    { sessionId },
+    { sessionId, status: 'idle' },
+    { sessionId, status: 'running' },
+  ],
+] as const;
+it.each(reads)(
+  'returns actual and empty %s results without a dispatch timestamp',
+  async (name, args, empty, actual) => {
+    for (output of [empty, actual])
+      expect(await invoke({ ...call(name, args), dispatchStartedAt: undefined })).toEqual({
+        result: { status: 'succeeded', output },
+      });
+  }
+);
+it.each(reads)('rejects unsupported %s reconciliation', async (name, args) => {
+  expect(await invoke({ ...call(name, args), type: 'reconcile' })).toMatchObject({
+    error: { code: 'invalid_input', retryable: false },
+  });
+  expect(effects.size).toBe(0);
+});
+it.each(['kilo.organizations', 'kilo.members', 'kilo.repositories'])(
+  'bounds and validates %s output',
+  async name => {
+    output = [{ id: 'resource', name: '界'.repeat(22000) }];
+    expect((await invoke(call('kilo.organizations'))).error.code).toBe('limit_exceeded');
+    for (output of [null, [{ token: 'provider-secret' }]])
+      expect((await invoke(call(name))).error.code).toBe('invalid_output');
+  }
+);
+it.each(
+  mutations.flatMap(([name, args]) =>
+    [false, true].flatMap(lost =>
+      [null, runId].map(organizationId => ({ name, args, lost, organizationId }))
+    )
+  )
+)(
+  '$name preserves identity in $organizationId (response lost: $lost)',
+  async ({ name, args, lost, organizationId }) => {
+    Object.assign(authority, { organizationId });
+    const input = call(`kilo.sessions.${name}`, args);
+    for (const dispatchStartedAt of [undefined, null, -1, 0.5, '0']) {
+      const raw = { ...input, dispatchStartedAt };
+      const token = capability(dispatchStartedAt === undefined ? raw : input);
+      expect((await invoke(raw, token)).error.code).toBe('invalid_input');
+    }
+    expect(effects.size).toBe(0);
+    failure = lost ? new Error('provider-secret') : undefined;
+    expect(await invoke(input)).toMatchObject(
+      lost
+        ? { error: { code: 'outcome_unknown', retryable: false } }
+        : { result: { status: 'succeeded', output: { sessionId } } }
+    );
+    expect(contexts).toEqual([
+      {
+        user: { id: 'oauth/owner', blocked_reason: null },
+        authViaToken: true,
+        tokenSource: 'agent-harness',
+        ip: null,
+      },
+    ]);
+    jest.mocked(Date.now).mockReturnValue(originalTime + 120000);
+    expect((await invoke({ ...input, type: 'reconcile' })).result).toMatchObject(
+      name === 'stop'
+        ? { status: 'outcome_unknown' }
+        : { status: 'succeeded', output: { sessionId } }
+    );
+    expect(cloudInputs[1]).toHaveProperty('dispatchStartedAt', originalTime);
+    expect([...effects.values()]).toEqual([1]);
+  }
+);
+it.each(mutations)(
+  'passes explicit absent identity for legacy %s reconciliation',
+  async (name, args) => {
+    const input = {
+      ...call(`kilo.sessions.${name}`, args),
+      type: 'reconcile',
+      dispatchStartedAt: undefined,
+    };
+    expect(await invoke(input)).toMatchObject({
+      error: { code: 'outcome_unknown', retryable: false },
+    });
+    expect(cloudInputs).toStrictEqual([
+      { ...input.request, conversationId, operationId, dispatchStartedAt: undefined },
+    ]);
+    expect(effects.size).toBe(0);
+  }
+);
+it.each(['account', 'membership', 'expiry', 'mint', 'signature'])(
+  'rejects lost %s authority before effects',
+  async loss => {
+    const input = call('kilo.invite', { recipient: 'member@example.com', role: 'member' });
+    const token = capability(input);
+    if (loss === 'account') access.active = false;
+    if (loss === 'membership') access.role = false;
+    if (loss === 'expiry') access.expires = new Date(originalTime).toISOString();
+    if (loss === 'mint')
+      jest.spyOn(runtime, 'lookupThread').mockResolvedValueOnce(authority).mockResolvedValue(null);
+    expect(await invoke(input, loss === 'signature' ? 'forged-token' : token)).toMatchObject({
+      error: { code: 'access_revoked', retryable: false },
+    });
+    expect(effects.size).toBe(0);
+  }
+);
+it.each([
+  ['type', 'reconcile'],
+  ['conversationId', runId],
+  ['operationId', runId],
+  ['runId', operationId],
+  ['toolCallId', runId],
+  ['dispatchStartedAt', originalTime + 1],
+  ['request', { name: 'kilo.sessions.start', arguments: { prompt: 'Changed', modelId: 'model' } }],
+])('rejects a changed signed %s', async (field, value) => {
+  const input = call('kilo.sessions.start', mutations[0][1]);
+  expect((await invoke({ ...input, [String(field)]: value }, capability(input))).error.code).toBe(
+    'access_revoked'
+  );
+  expect(effects.size).toBe(0);
+});
+it.each([
+  ['audience', 'another-service'],
+  ['definitionVersion', '2'],
+  ['target', { kind: 'client', clientId: runId }],
+  ['inputDigest', '0'.repeat(64)],
+])('rejects a valid signature with forged %s scope', async (field, value) => {
+  const input = call('kilo.sessions.start', mutations[0][1]);
+  const claims = jwt.decode(capability(input)) as jwt.JwtPayload;
+  const token = jwt.sign(
+    { ...claims, scope: { ...claims.scope, [String(field)]: value } },
+    'test-signing-key'
+  );
+  expect((await invoke(input, token)).error.code).toBe('access_revoked');
+  expect(effects.size).toBe(0);
+});
+it.each([
+  ['app.currentScreen', {}],
+  ['app.openScreen', { screen: 'preferences' }],
+  ['app.setPreference', { name: 'showToolDetails', value: true }],
+  ['app.notifications', {}],
+  ['app.openSettings', {}],
+  [
+    'question.ask',
+    {
+      questionId: 'q',
+      prompt: 'Choose',
+      choices: [],
+      minSelections: 0,
+      maxSelections: 0,
+      allowCancellation: true,
+    },
+  ],
+  ['mcp.discover', {}],
+  [
+    'mcp.call',
+    {
+      serverId: 's',
+      configurationVersion: '1',
+      name: 'remote',
+      definitionVersion: '1',
+      arguments: {},
+    },
+  ],
+  ['web.search', { query: 'test' }],
+  ['web.retrieve', { url: 'https://example.com' }],
+])('rejects %s outside the named Kilo boundary', async (name, args) => {
+  expect(await invoke(call(String(name), args))).toMatchObject({
+    error: { code: 'invalid_input', retryable: false },
+  });
+  expect(effects.size).toBe(0);
+});
+it.each([
+  ['SERVICE_UNAVAILABLE', 'unavailable_tool', true],
+  ['PRECONDITION_FAILED', 'unavailable_tool', false],
+] as const)('preserves sanitized %s read recovery', async (code, expected, retryable) => {
+  failure = new TRPCError({ code, message: 'provider-secret' });
+  const result = await invoke(call());
+  expect(result).toMatchObject({ error: { code: expected, retryable } });
+  expect(JSON.stringify(result)).not.toContain('provider-secret');
+  failure = undefined;
+  expect(await invoke(call())).toEqual({ result: { status: 'succeeded', output: [] } });
+});
+it('preserves failed, denied, cancelled, and unknown outcomes without provider text', async () => {
+  const input = call('kilo.sessions.start', mutations[0][1]);
+  for (const retryable of [true, false]) {
+    cloudOutcome = {
+      status: 'failed',
+      error: { code: 'unavailable_tool', message: 'provider-secret', retryable },
+    };
+    expect((await invoke(input)).result).toEqual({
+      status: 'failed',
+      error: {
+        code: 'unavailable_tool',
+        message: 'This tool is unavailable in the current context.',
+        retryable,
+      },
+    });
+  }
+  for (const status of ['denied', 'cancelled']) {
+    cloudOutcome = { status };
+    expect((await invoke(input)).result).toEqual({ status });
+  }
+  cloudOutcome = {
+    status: 'outcome_unknown',
+    reason: 'provider-secret',
+    providerReference: 'private-reference',
+  };
+  expect((await invoke(input)).result).toEqual({
+    status: 'outcome_unknown',
+    reason: 'Check the recorded outcome; do not repeat this mutation.',
+    providerReference: operationId,
+  });
+});
+it.each([
+  { status: 'invalid' },
+  { status: 'succeeded', output: { sessionId: '界'.repeat(22000) } },
+])('keeps malformed or oversized mutation output uncertain', async outcome => {
+  cloudOutcome = outcome;
+  expect(await invoke(call('kilo.sessions.start', mutations[0][1]))).toMatchObject({
+    error: { code: 'outcome_unknown', retryable: false },
+  });
+});
+it('keeps invitation uncertainty distinct and reconciles without redispatch', async () => {
+  const input = call('kilo.invite', { recipient: 'member@example.com', role: 'member' });
+  expect((await invoke({ ...input, type: 'reconcile' })).result.status).toBe('outcome_unknown');
+  failure = new Error('provider-secret');
+  expect(await invoke(input)).toMatchObject({
+    error: { code: 'outcome_unknown', retryable: false },
+  });
+  jest.mocked(Date.now).mockReturnValue(originalTime + 120000);
+  expect((await invoke({ ...input, type: 'reconcile' })).result.output).toEqual({
+    invitationId: toolCallId,
+    emailQueued: true,
+  });
+  expect([...effects.values()]).toEqual([1]);
+});
+it.each(OrganizationRoleSchema.options)(
+  'dispatches and reconciles invitations with the %s role',
+  async role => {
+    const input = call('kilo.invite', { recipient: 'member@example.com', role });
+    const expected = {
+      result: { status: 'succeeded', output: { invitationId: toolCallId, emailQueued: true } },
+    };
+    expect(await invoke(input)).toEqual(expected);
+    expect(await invoke({ ...input, type: 'reconcile' })).toEqual(expected);
+    expect([...effects.values()]).toEqual([1]);
+  }
+);
+it.each(['execute', 'reconcile'])(
+  'rejects an unsupported invitation role before %s',
+  async type => {
+    const input = {
+      ...call('kilo.invite', { recipient: 'member@example.com', role: 'not-a-role' }),
+      type,
+    };
+    expect(await invoke(input)).toEqual({
+      error: {
+        code: 'invalid_input',
+        message: 'The operation input is invalid.',
+        retryable: false,
+      },
+    });
+    expect(effects.size).toBe(0);
+  }
+);
+it.each([
+  ['kilo.organizations', {}],
+  ['kilo.invite', { recipient: 'member@example.com', role: 'member' }],
+  ['kilo.sessions.start', mutations[0][1]],
+] as const)('cancels %s before adapter dispatch', async (name, args) => {
+  const input = call(name, args);
+  const controller = new AbortController();
+  controller.abort();
+  expect(await executeHarnessDispatch(input, capability(input), controller.signal)).toEqual({
+    result: { status: 'cancelled' },
+  });
+  expect(effects.size).toBe(0);
+  expect(cloudInputs).toEqual([]);
+});
+it.each([
+  ['kilo.invite', { recipient: 'member@example.com', role: 'member' }],
+  ...mutations.map(([name, args]) => [`kilo.sessions.${name}`, args] as const),
+] as const)('keeps %s uncertain when reconciliation aborts', async (name, args) => {
+  const input = call(name, args);
+  failure = new Error('provider-secret');
+  expect(await invoke(input)).toMatchObject({
+    error: { code: 'outcome_unknown', retryable: false },
+  });
+  expect([...effects.values()]).toEqual([1]);
+  const priorInputs = cloudInputs.length;
+  const reconcile = { ...input, type: 'reconcile' };
+  const controller = new AbortController();
+  controller.abort(new Error('private-abort-reason'));
+  expect(await executeHarnessDispatch(reconcile, capability(reconcile), controller.signal)).toEqual(
+    {
+      error: {
+        code: 'outcome_unknown',
+        message: 'Check the recorded outcome; do not repeat this mutation.',
+        retryable: false,
+      },
+    }
+  );
+  expect(cloudInputs).toHaveLength(priorInputs);
+  expect([...effects.values()]).toEqual([1]);
+  expect((await invoke(reconcile)).result.status).toBe(
+    name === 'kilo.sessions.stop' ? 'outcome_unknown' : 'succeeded'
+  );
+  expect([...effects.values()]).toEqual([1]);
+});
+it('keeps an invitation effect uncertain when its response aborts', async () => {
+  const input = call('kilo.invite', { recipient: 'member@example.com', role: 'member' });
+  const controller = new AbortController();
+  jest
+    .spyOn(jest.requireMock<typeof Invitation>('./invitation'), 'executeHarnessInvitation')
+    .mockImplementationOnce(async () => {
+      effects.set('invitation', 1);
+      controller.abort(new Error('provider-secret'));
+      throw controller.signal.reason;
+    });
+  expect(await executeHarnessDispatch(input, capability(input), controller.signal)).toEqual({
+    error: {
+      code: 'outcome_unknown',
+      message: 'Check the recorded outcome; do not repeat this mutation.',
+      retryable: false,
+    },
+  });
+  expect(await invoke({ ...input, type: 'reconcile' })).toEqual({
+    result: { status: 'succeeded', output: { invitationId: toolCallId, emailQueued: true } },
+  });
+  expect([...effects.values()]).toEqual([1]);
+});

--- a/apps/web/src/lib/agent-harness/operation-dispatch.ts
+++ b/apps/web/src/lib/agent-harness/operation-dispatch.ts
@@ -1,0 +1,117 @@
+import 'server-only';
+import { ToolOutcomeSchema } from '@kilocode/agent-harness/contracts';
+import { toolDefinitions } from '@kilocode/agent-harness/tools';
+import { OrganizationRoleSchema } from '@/lib/organizations/organization-types';
+import {
+  authorizeHarnessCapability,
+  harnessInputDigest,
+  mintHarnessCapability,
+} from './authorization';
+import { executeHarnessInvitation, reconcileHarnessInvitation } from './invitation';
+import { executeHarnessRead } from './kilo-reads';
+import { executeHarnessCloudAgent, reconcileHarnessCloudAgent } from './cloud-agent';
+import {
+  HarnessOperationSchema,
+  bounded,
+  harnessOperationFailure,
+  harnessOperationScope,
+  invalid,
+  messages,
+  safeError,
+} from './operation-contract';
+
+export async function executeHarnessDispatch(raw: unknown, token: string, signal: AbortSignal) {
+  let uncertain = false;
+  try {
+    const parsed = HarnessOperationSchema.safeParse(raw);
+    if (!parsed.success) return invalid();
+    const input = parsed.data;
+    if (input.type !== 'execute' && input.type !== 'reconcile') return invalid();
+    const scope = harnessOperationScope(bounded(input));
+    const { grant } = await authorizeHarnessCapability(token, scope);
+    const { request, dispatchStartedAt } = input;
+    const definition = toolDefinitions.find(tool => tool.name === request.name);
+    if (!definition || definition.group !== 'kilo' || definition.executorKind !== 'backend')
+      return invalid();
+    if (
+      request.name === 'kilo.invite' &&
+      !OrganizationRoleSchema.safeParse(request.arguments.role).success
+    )
+      return invalid();
+    const cloud = request.name.startsWith('kilo.sessions.');
+    if (
+      input.type === 'reconcile' &&
+      request.name !== 'kilo.invite' &&
+      !(cloud && definition.effect === 'side_effect')
+    )
+      invalid();
+    if (
+      input.type === 'execute' &&
+      cloud &&
+      definition.effect === 'side_effect' &&
+      dispatchStartedAt === undefined
+    )
+      invalid();
+    // Bind the whole envelope above; mint only the adapter's existing, narrower input contract.
+    const capability = await mintHarnessCapability(grant.id, {
+      ...scope,
+      operation: request.name,
+      definitionVersion: definition.version,
+      inputDigest: harnessInputDigest(
+        cloud && definition.effect === 'side_effect' && dispatchStartedAt !== undefined
+          ? { arguments: request.arguments, dispatchStartedAt }
+          : request.arguments
+      ),
+    });
+    if (signal.aborted) {
+      // Cancelling a status check does not cancel the original mutation.
+      return input.type === 'reconcile'
+        ? harnessOperationFailure(undefined, true)
+        : { result: { status: 'cancelled' as const } };
+    }
+    const invocation = { conversationId: input.conversationId, operationId: input.operationId };
+    uncertain = input.type === 'reconcile' || definition.effect !== 'read';
+    const output =
+      request.name === 'kilo.invite'
+        ? await (input.type === 'execute' ? executeHarnessInvitation : reconcileHarnessInvitation)(
+            capability,
+            { ...invocation, arguments: request.arguments }
+          )
+        : cloud
+          ? await (
+              input.type === 'execute' ? executeHarnessCloudAgent : reconcileHarnessCloudAgent
+            )(capability, {
+              ...invocation,
+              name: request.name,
+              arguments: request.arguments,
+              // Old attempts lack this field. Keep explicit absence until those records are gone.
+              dispatchStartedAt,
+            })
+          : await executeHarnessRead(capability, { ...invocation, ...request });
+    const outcome = ToolOutcomeSchema.parse(
+      cloud
+        ? output
+        : request.name === 'kilo.invite' && input.type === 'reconcile' && output === null
+          ? { status: 'outcome_unknown', reason: messages.outcome_unknown }
+          : { status: 'succeeded', output }
+    );
+    if (outcome.status === 'succeeded')
+      return {
+        result: bounded({ ...outcome, output: definition.outputSchema.parse(outcome.output) }),
+      };
+    if (outcome.status === 'failed')
+      return { result: { ...outcome, error: safeError(outcome.error) } };
+    return {
+      result:
+        outcome.status === 'outcome_unknown'
+          ? {
+              status: outcome.status,
+              reason: messages.outcome_unknown,
+              providerReference: input.operationId,
+            }
+          : outcome,
+    };
+  } catch (error) {
+    return harnessOperationFailure(error, uncertain);
+  }
+}


### PR DESCRIPTION
No new behavior — the new support is not active in the product.

---

## Summary

`executeHarnessDispatch` verifies current primary authority and the complete signed `HarnessOperationSchema` envelope before minting narrow capabilities for named backend Kilo operations.
Fresh Cloud Agent mutations require numeric `dispatchStartedAt`; reads need no timestamp, and reconciliation preserves original time or explicit legacy absence.
`OrganizationRoleSchema` rejects invalid invitations before effects; bounded, sanitized responses preserve pre-dispatch `cancelled` and non-retryable `outcome_unknown` for uncertain mutations or aborted reconciliation.

<details>
<summary>Files</summary>

- `apps/web/src/lib/agent-harness/operation-dispatch.ts` — Added source (+117/−0 lines). Routes organization, member, repository, and usage reads, invitations, and Cloud Agent session search, attachment, progress, start, continuation, and stop. Rejects other tools and unsupported reconciliation. Validates outputs with `ToolOutcomeSchema` and each tool’s schema, with 65,536-byte input/output limits. Uses separate reconciliation adapters, preserves outcome statuses, and replaces uncertain provider references with the operation identity. Leaves existing adapter signatures and stored formats unchanged; adds no endpoint.
- `apps/web/src/lib/agent-harness/operation-dispatch.test.ts` — Added test (+439/−0 lines). Covers authority loss, envelope tampering, rejected tools and roles, empty reads, result limits, safe recovery, and personal and organization mutation identity. Verifies legacy timestamp absence, lost responses, cancellation, and reconciliation without duplicate effects, including uncertain stop outcomes.

</details>

Tests: 1 test file added — `operation-dispatch.test.ts` (+439/−0 lines).
Generated: 0 files changed.

---

## Visual Changes

Visual Changes: N/A

## Verification

Manual verification: not run.
No endpoint activates at this level. Provider operations and endpoint composition remain in later levels.
Actual PostgreSQL execution and deployed runtime verification remain unverified.

## Reviewer Notes

### Human steps

No human steps are required before or after merge.

### Recorded checks

- Saved evidence reports one passing suite with all 78 cases passing, plus scoped `oxfmt`, `oxlint`, and `oxfmt --check` passes.
- The tests use mocked business adapters and omit environment and database setup hooks; they do not prove actual database effects.
- This description round did not rerun product checks.
- Full type, build, and repository checks remain owned by continuous integration (CI).

### Scope

- Repository: `Kilo-Org/cloud`; worktree: `/Users/igor/Projects/.worktrees/shared-agent-harness-3bb0`.
- Review range: `shared-agent-harness-3bb0-s31...shared-agent-harness-3bb0-s32`.

### Notes

Runtime verification remains pending at the stack tip. This level adds named Kilo dispatch without activating an endpoint.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `shared-agent-harness-3bb0` — #5632
2. `shared-agent-harness-3bb0-s2` — #5637
3. `shared-agent-harness-3bb0-s3` — #5639
4. `shared-agent-harness-3bb0-s4` — #5643
5. `shared-agent-harness-3bb0-s5` — #5647
6. `shared-agent-harness-3bb0-s6` — #5655
7. `shared-agent-harness-3bb0-s7` — #5659
8. `shared-agent-harness-3bb0-s8` — #5662
9. `shared-agent-harness-3bb0-s9` — #5667
10. `shared-agent-harness-3bb0-s10` — #5675
11. `shared-agent-harness-3bb0-s11` — #5678
12. `shared-agent-harness-3bb0-s12` — #5688
13. `shared-agent-harness-3bb0-s13` — #5693
14. `shared-agent-harness-3bb0-s14` — #5697
15. `shared-agent-harness-3bb0-s15` — #5701
16. `shared-agent-harness-3bb0-s16` — #5704
17. `shared-agent-harness-3bb0-s17` — #5710
18. `shared-agent-harness-3bb0-s18` — #5714
19. `shared-agent-harness-3bb0-s19` — #5718
20. `shared-agent-harness-3bb0-s20` — #5724
21. `shared-agent-harness-3bb0-s21` — #5726
22. `shared-agent-harness-3bb0-s22` — #5731
23. `shared-agent-harness-3bb0-s23` — #5733
24. `shared-agent-harness-3bb0-s24` — #5737
25. `shared-agent-harness-3bb0-s25` — #5740
26. `shared-agent-harness-3bb0-s26` — #5743
27. `shared-agent-harness-3bb0-s27` — #5746
28. `shared-agent-harness-3bb0-s28` — #5747
29. `shared-agent-harness-3bb0-s29` — #5749
30. `shared-agent-harness-3bb0-s30` — #5753
31. `shared-agent-harness-3bb0-s31` — #5754
32. `shared-agent-harness-3bb0-s32` — #5755 ← this PR
33. `shared-agent-harness-3bb0-s33` — #5757
34. `shared-agent-harness-3bb0-s34` — #5758
35. `shared-agent-harness-3bb0-s35` — #5767
36. `shared-agent-harness-3bb0-s36` — #5776
37. `shared-agent-harness-3bb0-s37` — #5777 (tip)
