### PR TITLE
feat(agent-harness): secure the internal operations endpoint

### DIFF
--- a/apps/web/src/app/api/internal/agent-harness/operations/route.ts
+++ b/apps/web/src/app/api/internal/agent-harness/operations/route.ts
@@ -1,0 +1,76 @@
+import { timingSafeEqual } from '@kilocode/encryption';
+import { TRPCError } from '@trpc/server';
+import { INTERNAL_API_SECRET } from '@/lib/config.server';
+import { executeHarnessOperation, harnessOperationFailure } from '@/lib/agent-harness/operations';
+
+export const maxDuration = 60;
+
+export async function POST(request: Request) {
+  const reply = (body: Awaited<ReturnType<typeof executeHarnessOperation>>, status = 200) => {
+    let json = JSON.stringify(body);
+    if (Buffer.byteLength(json, 'utf8') > 1024 * 1024) {
+      const failure = harnessOperationFailure(new TRPCError({ code: 'PAYLOAD_TOO_LARGE' }));
+      const result = 'result' in body ? body.result : undefined;
+      if (result && typeof result === 'object' && 'costMicrodollars' in result) {
+        // Keep the validated actual cost, even when cancellation races with the completed reply.
+        body = {
+          result: { status: 'failed', ...failure, costMicrodollars: result.costMicrodollars },
+        };
+      } else {
+        body = failure;
+        status = 400;
+      }
+      json = JSON.stringify(body);
+    }
+    return new Response(json, {
+      status,
+      headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+    });
+  };
+  const service = request.headers.get('x-internal-api-key');
+  if (!INTERNAL_API_SECRET || !service || !timingSafeEqual(service, INTERNAL_API_SECRET))
+    return reply(harnessOperationFailure(new TRPCError({ code: 'UNAUTHORIZED' })), 401);
+  const token = request.headers.get('authorization')?.match(/^Bearer ([^\s]+)$/)?.[1];
+  if (!token) return reply(harnessOperationFailure(new TRPCError({ code: 'UNAUTHORIZED' })), 401);
+  let input: unknown;
+  const reader = request.body?.getReader();
+  try {
+    if (
+      request.headers.get('content-type')?.split(';')[0].trim().toLowerCase() !==
+        'application/json' ||
+      !reader
+    )
+      throw new TRPCError({ code: 'BAD_REQUEST' });
+    const chunks: Uint8Array[] = [];
+    let length = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      length += value.byteLength;
+      if (length > 64 * 1024) throw new TRPCError({ code: 'PAYLOAD_TOO_LARGE' });
+      chunks.push(value);
+    }
+    input = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(Buffer.concat(chunks)));
+  } catch (error) {
+    return reply(
+      harnessOperationFailure(
+        error instanceof TRPCError ? error : new TRPCError({ code: 'BAD_REQUEST' })
+      ),
+      400
+    );
+  } finally {
+    await reader?.cancel().catch(() => undefined);
+    reader?.releaseLock();
+  }
+  const result = await executeHarnessOperation(token, input, request.signal);
+  return reply(
+    result,
+    'error' in result
+      ? result.error.code === 'access_revoked'
+        ? 403
+        : result.error.retryable
+          ? 503
+          : 400
+      : 200
+  );
+}

--- a/apps/web/src/lib/agent-harness/internal.test.ts
+++ b/apps/web/src/lib/agent-harness/internal.test.ts
@@ -1,0 +1,516 @@
+import { beforeEach, expect, it, jest } from '@jest/globals';
+import { createHash } from 'node:crypto';
+import jwt from 'jsonwebtoken';
+import { TRPCError } from '@trpc/server';
+import {
+  access,
+  authority,
+  call,
+  capability,
+  conversationId,
+  operationId,
+  originalTime,
+  primary,
+  runId,
+  runtime,
+  toolCallId,
+} from './operation-test-fixture';
+import type * as Route from '@/app/api/internal/agent-harness/operations/route';
+import type * as CloudContext from './cloud-agent-context';
+
+let output: unknown, failure: Error | undefined;
+let onWebDispatch: ((signal: AbortSignal) => void) | undefined;
+const effects = new Map<string, unknown>();
+const cloudInputs: unknown[] = [];
+jest.mock('@/routers/root-router', () => ({ rootRouter: { createCaller: () => ({}) } }));
+jest.mock('./kilo-reads', () => ({
+  executeHarnessRead: async () => {
+    if (failure) throw failure;
+    return output;
+  },
+}));
+jest.mock('./invitation', () => ({
+  executeHarnessInvitation: async () => {
+    effects.set('invitation', Number(effects.get('invitation') ?? 0) + 1);
+    if (failure) throw failure;
+    return { invitationId: toolCallId, emailQueued: true };
+  },
+  reconcileHarnessInvitation: async () =>
+    effects.has('invitation') ? { invitationId: toolCallId, emailQueued: true } : null,
+}));
+jest.mock('./cloud-agent', () => ({
+  executeHarnessCloudAgent: (token: string, input: unknown) => cloud(token, input),
+  reconcileHarnessCloudAgent: (token: string, input: unknown) => cloud(token, input),
+}));
+jest.mock('./mcp', () => ({
+  authorizeHarnessMcp: async () => {
+    if (failure) throw failure;
+    return output;
+  },
+}));
+jest.mock('./web-tools', () => ({
+  executeHarnessWeb: async (
+    _token: string,
+    _input: unknown,
+    _limit: number,
+    signal: AbortSignal
+  ) => {
+    effects.set('web', true);
+    onWebDispatch?.(signal);
+    return output;
+  },
+}));
+async function cloud(token: string, input: unknown) {
+  cloudInputs.push(input);
+  const context = jest
+    .requireActual<typeof CloudContext>('./cloud-agent-context')
+    .createHarnessCloudAgentContext(token, input);
+  await context.fresh();
+  return context.succeeded({ sessionId: 'ses_12345678901234567890123456' });
+}
+const { POST } = jest.requireActual<typeof Route>(
+  '@/app/api/internal/agent-harness/operations/route'
+);
+const invokeResponse = (
+  input: unknown,
+  token = capability(input),
+  service = 'test-service-key',
+  init: RequestInit = {}
+) => {
+  const headers = new Headers({
+    'content-type': 'application/json',
+    authorization: `Bearer ${token}`,
+    'x-internal-api-key': service,
+  });
+  new Headers(init.headers).forEach((value, key) => headers.set(key, value));
+  return POST(
+    new Request('https://app.example/api/internal/agent-harness/operations', {
+      method: 'POST',
+      body: JSON.stringify(input),
+      ...init,
+      headers,
+    })
+  );
+};
+const invoke = async (...args: Parameters<typeof invokeResponse>) => {
+  const response = await invokeResponse(...args);
+  return {
+    status: response.status,
+    body: (await response.json()) as any,
+    cache: response.headers.get('cache-control'),
+  };
+};
+const identity = { conversationId, operationId };
+const reservation = {
+  id: operationId,
+  runId,
+  toolCallId,
+  startedAt: originalTime,
+  deadline: originalTime + 30000,
+  kind: 'tool',
+  status: 'reserved',
+  webRequest: true,
+};
+const web = { ...call('web.search', { query: 'Kilo' }), reservation };
+beforeEach(() => {
+  output = [];
+  failure = onWebDispatch = undefined;
+  effects.clear();
+  cloudInputs.length = 0;
+});
+
+it.each([
+  'service',
+  'wrong service',
+  'bearer',
+  'signature',
+  'expired capability',
+  'expired grant',
+  'role',
+  'retirement',
+])('blocks %s without an effect', async reason => {
+  const input = call('kilo.invite', { recipient: 'member@example.com', role: 'member' });
+  const token = capability(input);
+  if (reason === 'expired capability') jest.mocked(Date.now).mockReturnValue(originalTime + 60000);
+  if (reason === 'expired grant') access.expires = new Date(originalTime).toISOString();
+  if (reason === 'role') access.role = false;
+  if (reason === 'retirement') access.active = false;
+  const result = await invoke(
+    input,
+    reason === 'signature' ? 'forged' : reason === 'bearer' ? '' : token,
+    reason === 'service'
+      ? ''
+      : reason === 'wrong service'
+        ? 'wrong-service-key'
+        : 'test-service-key'
+  );
+  expect(result.body).toMatchObject({ error: { code: 'access_revoked', retryable: false } });
+  expect(result.status).toBe(['service', 'wrong service', 'bearer'].includes(reason) ? 401 : 403);
+  expect(result.cache).toBe('no-store');
+  expect(effects.size).toBe(0);
+  expect(JSON.stringify(result)).not.toContain('secret-role-details');
+});
+it.each([
+  { type: 'arbitrary.trpc' },
+  { userId: 'forged' },
+  { request: { name: 'app.openScreen', arguments: { screen: 'preferences' } } },
+  {
+    request: {
+      name: 'kilo.invite',
+      arguments: { recipient: 'another@example.com', role: 'owner' },
+    },
+  },
+  { type: 'reconcile' },
+  { dispatchStartedAt: originalTime + 1 },
+])('rejects forged routing or input %j', async patch => {
+  const input = call('kilo.invite', { recipient: 'member@example.com', role: 'member' });
+  expect((await invoke({ ...input, ...patch }, capability(input))).status).not.toBe(200);
+  expect(effects.size).toBe(0);
+});
+it.each([
+  call('mcp.discover'),
+  call('mcp.call', {
+    serverId: 'server',
+    configurationVersion: '1',
+    name: 'remote',
+    definitionVersion: '1',
+    arguments: {},
+  }),
+])('keeps derived $request.name connections uncached and redacted', async input => {
+  const connection = {
+    serverId: 'server',
+    configurationVersion: '1',
+    url: 'https://gateway.example/server',
+    authorization: 'Bearer derived',
+  };
+  output = [{ ...connection, providerSecret: 'provider-secret' }];
+  expect(await invoke(input)).toEqual({
+    status: 200,
+    body: { result: [connection] },
+    cache: 'no-store',
+  });
+});
+it('rejects oversized UTF-8 request bytes before JSON parsing and never returns the body', async () => {
+  const result = await invoke(call(), capability(call()), 'test-service-key', {
+    body: '界'.repeat(22000),
+  });
+  expect(result.status).toBe(400);
+  expect(result.body.error.code).toBe('limit_exceeded');
+  expect(result.cache).toBe('no-store');
+  expect(JSON.stringify(result)).not.toContain('界');
+  expect(effects.size).toBe(0);
+});
+it.each<RequestInit>([
+  { body: '{private-body' },
+  { body: null },
+  { headers: { 'content-type': 'text/plain' } },
+])('rejects malformed JSON, missing bodies, and unsupported media (case %#)', async init => {
+  const result = await invoke(call(), capability(call()), 'test-service-key', init);
+  expect(result).toMatchObject({
+    status: 400,
+    body: { error: { code: 'invalid_input', retryable: false } },
+    cache: 'no-store',
+  });
+  expect(effects.size).toBe(0);
+  expect(JSON.stringify(result)).not.toContain('private-body');
+});
+it('rejects invalid UTF-8 rather than executing replacement text', async () => {
+  const input = call('kilo.sessions.start', { prompt: '�', modelId: 'model' });
+  const body = Buffer.from(JSON.stringify(input).replace('�', '\xff'), 'latin1');
+  expect(
+    (await invoke(input, capability(input), 'test-service-key', { body })).body.error.code
+  ).toBe('invalid_input');
+  expect(cloudInputs).toEqual([]);
+});
+it.each(['kilo.organizations', 'mcp.discover'])('returns honest empty %s results', async name => {
+  expect((await invoke(call(name))).body).toEqual({
+    result: name === 'mcp.discover' ? [] : { status: 'succeeded', output: [] },
+  });
+});
+it.each([
+  ['SERVICE_UNAVAILABLE', 'provider-secret', 'unavailable_tool', true, 503],
+  ['PRECONDITION_FAILED', 'reauthorization_required', 'reauthorization_required', false, 400],
+] as const)(
+  'preserves sanitized %s recovery',
+  async (code, message, expected, retryable, status) => {
+    failure = new TRPCError({ code, message, cause: new Error('provider-secret') });
+    const result = await invoke(call('mcp.discover'));
+    expect(result).toMatchObject({
+      status,
+      body: { error: { code: expected, retryable } },
+      cache: 'no-store',
+    });
+    expect(JSON.stringify(result)).not.toContain('provider-secret');
+    failure = undefined;
+    expect((await invoke(call('mcp.discover'))).body).toEqual({ result: [] });
+  }
+);
+it.each([null, [{ id: 'resource', name: '界'.repeat(22000) }]])(
+  'rejects invalid or oversized read output (case %#)',
+  async value => {
+    output = value;
+    expect((await invoke(call())).body.error.code).toBe(
+      value === null ? 'invalid_output' : 'limit_exceeded'
+    );
+  }
+);
+it('preserves dispatch time, its digest, and explicit legacy reconciliation absence', async () => {
+  const input = call('kilo.sessions.start', { prompt: 'Fix', modelId: 'model' });
+  expect((await invoke(input)).body.result.status).toBe('succeeded');
+  jest.mocked(Date.now).mockReturnValue(originalTime + 120000);
+  expect((await invoke({ ...input, type: 'reconcile' })).body.result.status).toBe('succeeded');
+  const invocation = { ...identity, ...input.request, dispatchStartedAt: originalTime };
+  expect(cloudInputs).toStrictEqual([invocation, invocation]);
+  expect((await invoke({ ...input, dispatchStartedAt: undefined })).body.error.code).toBe(
+    'invalid_input'
+  );
+  const legacy = { ...input, type: 'reconcile', dispatchStartedAt: undefined };
+  expect((await invoke(legacy)).body.error).toMatchObject({
+    code: 'outcome_unknown',
+    retryable: false,
+  });
+  expect(cloudInputs[2]).toStrictEqual({ ...invocation, dispatchStartedAt: undefined });
+});
+it('reconciles a lost invitation result without another effect', async () => {
+  const input = call('kilo.invite', { recipient: 'member@example.com', role: 'member' });
+  failure = new Error('provider-secret');
+  expect((await invoke(input)).body.error).toMatchObject({
+    code: 'outcome_unknown',
+    retryable: false,
+  });
+  expect((await invoke({ ...input, type: 'reconcile' })).body.result).toEqual({
+    status: 'succeeded',
+    output: { invitationId: toolCallId, emailQueued: true },
+  });
+  expect(effects.get('invitation')).toBe(1);
+});
+it.each([
+  call('web.search', { query: 'Kilo' }),
+  call('web.retrieve', { url: 'https://example.com' }),
+])('passes the signed reservation for $request.name and preserves unknown cost', async input => {
+  output = { status: 'succeeded', body: { results: [] }, costMicrodollars: null };
+  expect(await invoke({ ...input, reservation })).toEqual({
+    status: 200,
+    body: { result: output },
+    cache: 'no-store',
+  });
+  expect(effects.get('web')).toBe(true);
+});
+it.each([
+  undefined,
+  { ...reservation, id: runId },
+  { ...reservation, runId: toolCallId },
+  { ...reservation, toolCallId: runId },
+])('rejects a signed absent or foreign reservation (case %#)', async value => {
+  expect((await invoke({ ...web, reservation: value })).body.error.code).toBe('invalid_input');
+  expect(effects.size).toBe(0);
+});
+it('rejects reservation signature tampering before provider dispatch', async () => {
+  expect(
+    (await invoke({ ...web, reservation: { ...reservation, toolCallId: runId } }, capability(web)))
+      .body.error.code
+  ).toBe('access_revoked');
+  expect(effects.size).toBe(0);
+});
+it.each([call('kilo.invite', { recipient: 'member@example.com', role: 'member' }), web])(
+  'forwards cancellation before $request.name dispatch',
+  async input => {
+    const signal = AbortSignal.abort(new Error('private-abort-reason'));
+    const result = await invoke(input, capability(input), 'test-service-key', { signal });
+    expect(result.body).toMatchObject(
+      input.request.name === 'web.search'
+        ? { error: { code: 'cancelled', retryable: false } }
+        : { result: { status: 'cancelled' } }
+    );
+    expect(effects.size).toBe(0);
+    expect(JSON.stringify(result)).not.toContain('private-abort-reason');
+  }
+);
+it('propagates HTTP cancellation to an active web request', async () => {
+  const controller = new AbortController();
+  onWebDispatch = signal => {
+    controller.abort(new Error('private-abort-reason'));
+    signal.throwIfAborted();
+  };
+  expect(
+    (await invoke(web, capability(web), 'test-service-key', { signal: controller.signal })).body
+      .error
+  ).toMatchObject({ code: 'cancelled', retryable: false });
+});
+it.each([
+  call('kilo.invite', { recipient: 'member@example.com', role: 'member' }),
+  call('kilo.sessions.start', { prompt: 'Fix', modelId: 'model' }),
+  call('mcp.discover'),
+  web,
+])('rechecks primary authority before $request.name dispatch', async input => {
+  jest.spyOn(runtime, 'lookupThread').mockResolvedValueOnce(authority).mockResolvedValue(null);
+  expect(await invoke(input)).toMatchObject({
+    status: 403,
+    body: { error: { code: 'access_revoked', retryable: false } },
+    cache: 'no-store',
+  });
+  expect(effects.size).toBe(0);
+  expect(cloudInputs).toEqual([]);
+});
+it.each([
+  call('kilo.invite', { recipient: 'member@example.com', role: 'member' }),
+  call('kilo.sessions.start', { prompt: 'Fix', modelId: 'model' }),
+])('keeps aborted $request.name reconciliation uncertain', async input => {
+  const reconcile = { ...input, type: 'reconcile' };
+  const signal = AbortSignal.abort(new Error('private-abort-reason'));
+  const result = await invoke(reconcile, capability(reconcile), 'test-service-key', { signal });
+  expect(result).toMatchObject({
+    status: 400,
+    body: { error: { code: 'outcome_unknown', retryable: false } },
+    cache: 'no-store',
+  });
+  expect(JSON.stringify(result)).not.toContain('private-abort-reason');
+  expect(effects.size).toBe(0);
+  expect(cloudInputs).toEqual([]);
+});
+it.each(
+  [web, { ...call('web.retrieve', { url: 'https://example.com' }), reservation }].flatMap(input =>
+    [null, 0, 2000].flatMap(costMicrodollars =>
+      [false, true].map(cancelled => ({ input, costMicrodollars, cancelled }))
+    )
+  )
+)(
+  'retains $input.request.name cost $costMicrodollars on HTTP reply overflow (cancelled: $cancelled)',
+  async ({ input, costMicrodollars, cancelled }) => {
+    const body = { text: `provider-secret${'界'.repeat(349510)}` };
+    output = { status: 'succeeded', body, costMicrodollars };
+    expect(Buffer.byteLength(JSON.stringify(body), 'utf8')).toBeLessThan(1024 * 1024);
+    const controller = new AbortController();
+    onWebDispatch = () => {
+      if (cancelled) controller.abort(new Error('private-abort-reason'));
+    };
+    const result = await invoke(input, capability(input), 'test-service-key', {
+      signal: controller.signal,
+    });
+    expect(result).toEqual({
+      status: 200,
+      body: {
+        result: {
+          status: 'failed',
+          error: {
+            code: 'limit_exceeded',
+            message: 'The operation exceeds its limit.',
+            retryable: false,
+          },
+          costMicrodollars,
+        },
+      },
+      cache: 'no-store',
+    });
+    expect(Buffer.byteLength(JSON.stringify(result), 'utf8')).toBeLessThan(1024);
+  }
+);
+it.each(
+  [web, { ...call('web.retrieve', { url: 'https://example.com' }), reservation }].flatMap(input =>
+    [null, 0, 2000].flatMap(costMicrodollars =>
+      [false, true].flatMap(cancelled =>
+        [0, 1].map(extraBytes => ({ input, costMicrodollars, cancelled, extraBytes }))
+      )
+    )
+  )
+)(
+  'bounds $input.request.name HTTP bytes at 1 MiB + $extraBytes with cost $costMicrodollars (cancelled: $cancelled)',
+  async ({ input, costMicrodollars, cancelled, extraBytes }) => {
+    const limit = 1024 * 1024;
+    const body = { text: 'provider-secret界' };
+    const reply = { status: 'succeeded', body, costMicrodollars };
+    const padding =
+      limit + extraBytes - Buffer.byteLength(JSON.stringify({ result: reply }), 'utf8');
+    body.text += '界'.repeat(Math.floor(padding / 3)) + 'x'.repeat(padding % 3);
+    output = reply;
+    expect(Buffer.byteLength(JSON.stringify(reply), 'utf8')).toBeLessThanOrEqual(limit);
+    expect(Buffer.byteLength(JSON.stringify({ result: reply }), 'utf8')).toBe(limit + extraBytes);
+    const controller = new AbortController();
+    onWebDispatch = () => {
+      if (cancelled) controller.abort(new Error('private-abort-reason'));
+    };
+    const response = await invokeResponse(input, capability(input), 'test-service-key', {
+      signal: controller.signal,
+    });
+    const bytes = Buffer.from(await response.arrayBuffer());
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('content-type')).toBe('application/json');
+    expect(bytes.byteLength).toBeLessThanOrEqual(limit);
+    if (extraBytes === 0) {
+      expect(bytes.byteLength).toBe(limit);
+      expect(JSON.parse(bytes.toString('utf8'))).toEqual({ result: reply });
+    } else {
+      expect(bytes.byteLength).toBeLessThan(1024);
+      expect(JSON.parse(bytes.toString('utf8'))).toEqual({
+        result: {
+          status: 'failed',
+          error: {
+            code: 'limit_exceeded',
+            message: 'The operation exceeds its limit.',
+            retryable: false,
+          },
+          costMicrodollars,
+        },
+      });
+    }
+  }
+);
+it('routes authority, empty history, and a projection through current primary access', async () => {
+  const projection = {
+    id: toolCallId,
+    key: `agent-harness:${conversationId}:${toolCallId}`,
+    role: 'assistant',
+    content: 'Actual text',
+    createdAt: new Date(originalTime).toISOString(),
+  };
+  Object.assign(runtime, {
+    claimPending: async () => [],
+    hasPending: async () => false,
+    projectText: async (owner: unknown, value: { id: string; content: string }) => {
+      effects.set(value.id, { owner, content: value.content });
+      return value.id;
+    },
+  });
+  const inputs = [
+    { ...identity, type: 'read', purpose: 'read' },
+    { ...identity, type: 'history' },
+    { ...identity, type: 'projection', projection },
+  ];
+  expect((await invoke(inputs[0])).body).toEqual({ result: authority });
+  expect((await invoke(inputs[1])).body).toEqual({
+    result: { deliveries: [], backlog: 'drained' },
+  });
+  expect((await invoke(inputs[2])).body).toEqual({ result: toolCallId });
+  expect(effects.get(toolCallId)).toEqual({ owner: authority, content: 'Actual text' });
+  access.role = false;
+  effects.clear();
+  for (const input of inputs) expect((await invoke(input)).body.error.code).toBe('access_revoked');
+  expect(effects.size).toBe(0);
+});
+it('routes only the exact fenced retirement without requiring a live grant', async () => {
+  const input = { ...identity, type: 'retirement', generation: 0 };
+  const request = { type: 'purge', protocolVersion: 1, threadId: conversationId, generation: 0 };
+  const token = jwt.sign(
+    {
+      operation: 'purge',
+      threadId: conversationId,
+      generation: 0,
+      dispatchId: operationId,
+      inputDigest: createHash('sha256').update(JSON.stringify(request)).digest('hex'),
+    },
+    'test-signing-key',
+    { issuer: 'agent-harness', audience: 'agent-harness:maintenance', expiresIn: 60 }
+  );
+  let fence: { thread_id: string; generation: number } | undefined = {
+    thread_id: conversationId,
+    generation: 0,
+  };
+  Object.assign(primary.query, { agent_harness_retirements: { findFirst: async () => fence } });
+  access.active = false;
+  expect((await invoke(input, token)).body).toEqual({ result: { retired: true } });
+  expect((await invoke({ ...input, generation: 1 }, token)).status).toBe(403);
+  expect((await invoke(input, capability(input))).status).toBe(403);
+  fence = undefined;
+  expect((await invoke(input, token)).status).toBe(403);
+});

--- a/apps/web/src/lib/agent-harness/operations.ts
+++ b/apps/web/src/lib/agent-harness/operations.ts
@@ -1,0 +1,36 @@
+import 'server-only';
+import { TRPCError } from '@trpc/server';
+import { HarnessOperationSchema, bounded, harnessOperationFailure } from './operation-contract';
+import { executeHarnessMaintenance, retirement } from './operation-maintenance';
+import { executeHarnessDispatch } from './operation-dispatch';
+import { executeHarnessProviders } from './operation-providers';
+
+export { harnessOperationFailure } from './operation-contract';
+
+export async function executeHarnessOperation(token: string, raw: unknown, signal: AbortSignal) {
+  try {
+    const parsed = HarnessOperationSchema.safeParse(raw);
+    if (!parsed.success) return harnessOperationFailure(new TRPCError({ code: 'BAD_REQUEST' }));
+    const input = bounded(parsed.data);
+    switch (input.type) {
+      case 'retirement':
+        return { result: await retirement(input, token) };
+      case 'read':
+      case 'history':
+      case 'projection':
+        return await executeHarnessMaintenance(input, token);
+      case 'execute':
+      case 'reconcile':
+        if (
+          input.request.name === 'mcp.discover' ||
+          input.request.name === 'mcp.call' ||
+          input.request.name === 'web.search' ||
+          input.request.name === 'web.retrieve'
+        )
+          return await executeHarnessProviders(input, token, signal);
+        return await executeHarnessDispatch(input, token, signal);
+    }
+  } catch (error) {
+    return harnessOperationFailure(error);
+  }
+}


### PR DESCRIPTION
No new behavior — the product's screens and available actions remain unchanged.

---

## Summary

`POST /api/internal/agent-harness/operations` requires `x-internal-api-key` to match the existing `INTERNAL_API_SECRET` and a signed `Authorization: Bearer` capability.
It enforces 65,536-byte requests, 1,048,576-byte complete replies, `cache-control: no-store`, and a 60-second `maxDuration` to bound transport without caching authority-sensitive results.
On overflow, web replies retain actual nullable `costMicrodollars` in a sanitized, non-retryable `limit_exceeded` result, even during cancellation races.

<details>
<summary>Files</summary>

- `apps/web/src/app/api/internal/agent-harness/operations/route.ts` — Added source (+76/−0 lines). Compares service secrets in constant time and rejects missing or malformed bearer credentials before reading the body. Requires JavaScript Object Notation (JSON) bodies and rejects malformed 8-bit Unicode Transformation Format (UTF-8) encoding. Counts streamed bytes before parsing, then cancels and releases the body reader. Measures the complete serialized reply, including its envelope, and sends the checked string with `application/json` and `no-store` headers. Accepts exactly 1,048,576 bytes; larger web replies retain null, zero, or positive cost in a small `status: failed` result with status 200. Other reply overflow returns status 400. Service authentication failures and missing bearer credentials return 401. Operation errors use 403 for `access_revoked`, 503 when retryable, and 400 otherwise; result envelopes return 200. Forwards the request's cancellation signal to execution.
- `apps/web/src/lib/agent-harness/internal.test.ts` — Added test (+516/−0 lines). Covers service and capability authentication, authority loss, signed request tampering, malformed or oversized bodies, output validation, connection redaction, empty results, and sanitized recovery. Exercises dispatch identity, legacy reconciliation, lost invitation outcomes, reservation binding, cancellation, history, projection, and fenced retirement. Checks exact-limit and one-byte-over web responses with null, zero, and positive costs, including cancellation races and actual response bytes.

</details>

The server-only `executeHarnessOperation` applies `HarnessOperationSchema` to route `execute`, `reconcile`, `read`, `history`, `projection`, and `retirement` through existing helpers.
This preserves current primary authority, signed input digests, immutable `dispatchStartedAt`, and matching web reservations without exposing arbitrary procedure names.
Legacy reconciliation keeps an absent `dispatchStartedAt` explicit, and uncertain mutations retain `outcome_unknown` instead of claiming cancellation or success.

<details>
<summary>Files</summary>

- `apps/web/src/lib/agent-harness/operations.ts` — Added source (+36/−0 lines). Validates and bounds input before routing authority reads, history delivery, text projection, and retirement to their existing helpers. Routes Model Context Protocol (MCP) operations `mcp.discover` and `mcp.call`, plus `web.search` and `web.retrieve`, to provider helpers. Sends other allowed execution and reconciliation requests to the dispatch helper, retaining named preconditions and primary authorization checks. Preserves original dispatch timestamps and digests; new cloud mutations still require a timestamp, while legacy reconciliation keeps its absence. Retains signed reservation checks for the operation, run, call, and original deadline rather than creating a replacement reservation. Keeps retirement tied to the exact signed purge and matching primary generation fence, without requiring a live grant. Passes cancellation through execution and reconciliation, preserves validated outputs, and re-exports `harnessOperationFailure` for shared sanitized errors and outer failures.

</details>

Tests: 1 test file added — `internal.test.ts` (+516/−0 lines).
Generated: 0 files changed.

---

## Verification

Manual verification: not run because the endpoint does not yet connect to a complete product journey.
Worker composition, billed model inference, live providers, presentation, and cross-client verification remain later planned work.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Human steps

This level requires no human setup before or after merge.
Product pull request merges remain human-owned.

### Recorded checks

- The supplied repair report records 83 passing endpoint cases, including 24 exact-size and cancellation cases, plus clean scoped lint, formatting, and whitespace checks.
- The isolated suite replaces database access and external adapters; it does not verify live providers or committed reservation origin.
- This description round did not rerun product checks. Repository-wide lint, tests, type checks, builds, and actual PostgreSQL execution remain unverified.

### Notes

- Runtime verification remains pending until the complete backend, browser, iOS, and Android integration reaches the stack tip.
- Font-scaling variants, including large text and dynamic type: owner-descoped.
- Light, dark, and other theme variants, including variant-only geometry: owner-descoped.
- Visual contrast, scaled-text layout, and screen-reader presentation checks: owner-descoped.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `shared-agent-harness-3bb0` — #5632
2. `shared-agent-harness-3bb0-s2` — #5637
3. `shared-agent-harness-3bb0-s3` — #5639
4. `shared-agent-harness-3bb0-s4` — #5643
5. `shared-agent-harness-3bb0-s5` — #5647
6. `shared-agent-harness-3bb0-s6` — #5655
7. `shared-agent-harness-3bb0-s7` — #5659
8. `shared-agent-harness-3bb0-s8` — #5662
9. `shared-agent-harness-3bb0-s9` — #5667
10. `shared-agent-harness-3bb0-s10` — #5675
11. `shared-agent-harness-3bb0-s11` — #5678
12. `shared-agent-harness-3bb0-s12` — #5688
13. `shared-agent-harness-3bb0-s13` — #5693
14. `shared-agent-harness-3bb0-s14` — #5697
15. `shared-agent-harness-3bb0-s15` — #5701
16. `shared-agent-harness-3bb0-s16` — #5704
17. `shared-agent-harness-3bb0-s17` — #5710
18. `shared-agent-harness-3bb0-s18` — #5714
19. `shared-agent-harness-3bb0-s19` — #5718
20. `shared-agent-harness-3bb0-s20` — #5724
21. `shared-agent-harness-3bb0-s21` — #5726
22. `shared-agent-harness-3bb0-s22` — #5731
23. `shared-agent-harness-3bb0-s23` — #5733
24. `shared-agent-harness-3bb0-s24` — #5737
25. `shared-agent-harness-3bb0-s25` — #5740
26. `shared-agent-harness-3bb0-s26` — #5743
27. `shared-agent-harness-3bb0-s27` — #5746
28. `shared-agent-harness-3bb0-s28` — #5747
29. `shared-agent-harness-3bb0-s29` — #5749
30. `shared-agent-harness-3bb0-s30` — #5753
31. `shared-agent-harness-3bb0-s31` — #5754
32. `shared-agent-harness-3bb0-s32` — #5755
33. `shared-agent-harness-3bb0-s33` — #5757
34. `shared-agent-harness-3bb0-s34` — #5758 ← this PR
35. `shared-agent-harness-3bb0-s35` — #5767
36. `shared-agent-harness-3bb0-s36` — #5776
37. `shared-agent-harness-3bb0-s37` — #5777 (tip)
