### PR TITLE
feat: map OpenRouter provider sort to Vercel gateway

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
@@ -13,7 +13,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 
 export type OpenRouterProviderConfig = {
   order?: string[];
-  sort?: unknown;
+  sort?: string | { by: string; partition?: 'model' | 'none' };
   only?: string[];
   ignore?: string[];
   data_collection?: 'allow' | 'deny';

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
@@ -11,9 +11,11 @@ import type Anthropic from '@anthropic-ai/sdk';
 // Base types for OpenRouter API that don't depend on other lib files
 // This breaks circular dependencies with mistral.ts, minimax.ts, etc.
 
+type OpenRouterProviderSort = 'price' | 'throughput' | 'latency';
+
 export type OpenRouterProviderConfig = {
   order?: string[];
-  sort?: string | { by: string; partition?: 'model' | 'none' };
+  sort?: OpenRouterProviderSort | { by: OpenRouterProviderSort; partition?: 'model' | 'none' };
   only?: string[];
   ignore?: string[];
   data_collection?: 'allow' | 'deny';

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
@@ -13,6 +13,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 
 export type OpenRouterProviderConfig = {
   order?: string[];
+  sort?: unknown;
   only?: string[];
   ignore?: string[];
   data_collection?: 'allow' | 'deny';

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
@@ -11,11 +11,9 @@ import type Anthropic from '@anthropic-ai/sdk';
 // Base types for OpenRouter API that don't depend on other lib files
 // This breaks circular dependencies with mistral.ts, minimax.ts, etc.
 
-type OpenRouterProviderSort = 'price' | 'throughput' | 'latency';
-
 export type OpenRouterProviderConfig = {
   order?: string[];
-  sort?: OpenRouterProviderSort | { by: OpenRouterProviderSort; partition?: 'model' | 'none' };
+  sort?: 'price' | 'throughput' | 'latency';
   only?: string[];
   ignore?: string[];
   data_collection?: 'allow' | 'deny';

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -350,10 +350,10 @@ describe('shouldRouteToVercel', () => {
 
   it('allows Vercel routing with an unrecognized sort preference', async () => {
     const shouldRouteToVercel = await loadShouldRouteToVercel();
-    const provider = {
-      sort: 'future-sort',
+    const provider: OpenRouterProviderConfig = {
+      sort: 'future-sort' as OpenRouterProviderConfig['sort'],
       only: ['anthropic'],
-    } as OpenRouterProviderConfig;
+    };
 
     await expect(
       shouldRouteToVercel(

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -350,7 +350,10 @@ describe('shouldRouteToVercel', () => {
 
   it('allows Vercel routing with an unrecognized sort preference', async () => {
     const shouldRouteToVercel = await loadShouldRouteToVercel();
-    const provider = { sort: 'future-sort', only: ['anthropic'] };
+    const provider = {
+      sort: 'future-sort',
+      only: ['anthropic'],
+    } as OpenRouterProviderConfig;
 
     await expect(
       shouldRouteToVercel(
@@ -412,7 +415,7 @@ describe('applyVercelSettings BYOK pinning', () => {
     { sort: 'future-sort', expected: undefined },
   ])('converts sort $sort without changing BYOK pinning', async ({ sort, expected }) => {
     const request = byokRequest([]);
-    request.body.provider = { sort };
+    request.body.provider = { sort: sort as OpenRouterProviderConfig['sort'] };
 
     await applyVercelSettings('anthropic/claude-sonnet-4.5', request, [
       { decryptedAPIKey: 'sk-anthropic', providerId: 'anthropic' },

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -164,9 +164,6 @@ describe('convertProviderOptions', () => {
     { sort: 'price', expected: 'cost' },
     { sort: 'throughput', expected: 'tps' },
     { sort: 'latency', expected: 'ttft' },
-    { sort: { by: 'price' }, expected: 'cost' },
-    { sort: { by: 'throughput', partition: 'model' }, expected: 'tps' },
-    { sort: { by: 'latency', partition: 'none' }, expected: 'ttft' },
   ] as const)(
     'converts sort $sort to $expected alongside existing preferences',
     ({ sort, expected }) => {
@@ -206,8 +203,8 @@ describe('convertProviderOptions', () => {
     true,
     ['price'],
     {},
-    { by: 'future-sort' },
-    { by: ['price'] },
+    { by: 'price' },
+    { by: 'latency', partition: 'none' },
   ])('omits unsupported sort %j without rejecting the conversion', sort => {
     const request: GatewayRequest = {
       kind: 'chat_completions',

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -157,6 +157,64 @@ describe('getVercelInferenceProvidersExcludingIgnored', () => {
 });
 
 describe('convertProviderOptions', () => {
+  it.each([
+    { sort: 'price', expected: 'cost' },
+    { sort: 'throughput', expected: 'tps' },
+    { sort: 'latency', expected: 'ttft' },
+    { sort: { by: 'price' }, expected: 'cost' },
+    { sort: { by: 'throughput', partition: 'model' }, expected: 'tps' },
+    { sort: { by: 'latency', partition: 'none' }, expected: 'ttft' },
+  ])('converts sort $sort to $expected alongside existing preferences', ({ sort, expected }) => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'anthropic/claude-sonnet-4.5',
+        messages: [{ role: 'user', content: 'hello' }],
+        provider: {
+          sort,
+          only: ['anthropic', 'amazon-bedrock'],
+          order: ['amazon-bedrock'],
+          zdr: true,
+          data_collection: 'deny',
+        },
+      },
+    };
+    const originalRequest = structuredClone(request);
+
+    expect(convertProviderOptions(request, null).gateway).toMatchObject({
+      sort: expected,
+      only: ['anthropic', 'bedrock'],
+      order: ['bedrock'],
+      zeroDataRetention: true,
+      disallowPromptTraining: true,
+    });
+    expect(request).toEqual(originalRequest);
+  });
+
+  it.each([
+    undefined,
+    null,
+    'future-sort',
+    'toString',
+    42,
+    true,
+    ['price'],
+    {},
+    { by: 'future-sort' },
+    { by: ['price'] },
+  ])('omits unsupported sort %j without rejecting the conversion', sort => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'anthropic/claude-sonnet-4.5',
+        messages: [{ role: 'user', content: 'hello' }],
+        provider: { sort },
+      },
+    };
+
+    expect(convertProviderOptions(request, null).gateway?.sort).toBeUndefined();
+  });
+
   it('emits only available non-ignored providers without changing provider.only', () => {
     const request: GatewayRequest = {
       kind: 'chat_completions',
@@ -284,6 +342,20 @@ describe('shouldRouteToVercel', () => {
     ).resolves.toBe(true);
   });
 
+  it('allows Vercel routing with an unrecognized sort preference', async () => {
+    const shouldRouteToVercel = await loadShouldRouteToVercel();
+    const provider = { sort: 'future-sort', only: ['anthropic'] };
+
+    await expect(
+      shouldRouteToVercel(
+        'anthropic/claude-sonnet-4.5',
+        request(provider),
+        'seed',
+        async () => provider
+      )
+    ).resolves.toBe(true);
+  });
+
   it('does not resolve provider policy for models opted out of Vercel routing', async () => {
     const shouldRouteToVercel = await loadShouldRouteToVercel({ optOut: true });
     const getRoutingProviderConfig = jest.fn(async () => ({ only: ['anthropic'] }));
@@ -327,6 +399,29 @@ describe('applyVercelSettings BYOK pinning', () => {
       privateKey: '-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----\n',
       clientEmail: 'gateway@example-project.iam.gserviceaccount.com',
     },
+  });
+
+  it.each([
+    { sort: 'throughput', expected: 'tps' },
+    { sort: 'future-sort', expected: undefined },
+  ])('converts sort $sort without changing BYOK pinning', async ({ sort, expected }) => {
+    const request = byokRequest([]);
+    request.body.provider = { sort };
+
+    await applyVercelSettings('anthropic/claude-sonnet-4.5', request, [
+      { decryptedAPIKey: 'sk-anthropic', providerId: 'anthropic' },
+      { decryptedAPIKey: bedrockCredentials, providerId: 'bedrock' },
+    ]);
+
+    expect(request.body.providerOptions?.gateway).toEqual({
+      sort: expected,
+      only: ['anthropic', 'bedrock'],
+      byok: {
+        anthropic: [{ apiKey: 'sk-anthropic' }],
+        bedrock: [{ accessKeyId: 'AKIAEXAMPLE', secretAccessKey: 'secret', region: 'us-east-1' }],
+      },
+    });
+    expect(request.body.provider).toBeUndefined();
   });
 
   it('drops a BYOK provider the caller ignored when another serving provider remains', async () => {
@@ -471,6 +566,19 @@ describe('applyVercelSettings managed requests', () => {
       body: { model, messages: [{ role: 'user', content: 'hello' }], provider },
     };
   }
+
+  it.each(['chat_completions', 'messages', 'responses'] as const)(
+    'converts provider.sort for managed %s requests',
+    async kind => {
+      const request = managedRequestForApi(kind, 'anthropic/claude-sonnet-4.5');
+      request.body.provider = { sort: 'latency' };
+
+      await applyManagedVercelSettings('anthropic/claude-sonnet-4.5', request, ['anthropic']);
+
+      expect(request.body.providerOptions?.gateway?.sort).toBe('ttft');
+      expect(request.body.provider).toBeUndefined();
+    }
+  );
 
   it.each(
     [minimax_m3_free_model, minimax_m27_free_model].flatMap(model =>

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -10,7 +10,10 @@ import {
   passesVercelRoutingPercentage,
 } from '@/lib/ai-gateway/providers/vercel';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
-import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import type {
+  GatewayRequest,
+  OpenRouterProviderConfig,
+} from '@/lib/ai-gateway/providers/openrouter/types';
 import { applyKiloExclusiveModelSettings } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 import { minimax_m27_free_model, minimax_m3_free_model } from '@/lib/ai-gateway/providers/minimax';
 
@@ -164,32 +167,35 @@ describe('convertProviderOptions', () => {
     { sort: { by: 'price' }, expected: 'cost' },
     { sort: { by: 'throughput', partition: 'model' }, expected: 'tps' },
     { sort: { by: 'latency', partition: 'none' }, expected: 'ttft' },
-  ])('converts sort $sort to $expected alongside existing preferences', ({ sort, expected }) => {
-    const request: GatewayRequest = {
-      kind: 'chat_completions',
-      body: {
-        model: 'anthropic/claude-sonnet-4.5',
-        messages: [{ role: 'user', content: 'hello' }],
-        provider: {
-          sort,
-          only: ['anthropic', 'amazon-bedrock'],
-          order: ['amazon-bedrock'],
-          zdr: true,
-          data_collection: 'deny',
+  ] as const)(
+    'converts sort $sort to $expected alongside existing preferences',
+    ({ sort, expected }) => {
+      const request: GatewayRequest = {
+        kind: 'chat_completions',
+        body: {
+          model: 'anthropic/claude-sonnet-4.5',
+          messages: [{ role: 'user', content: 'hello' }],
+          provider: {
+            sort,
+            only: ['anthropic', 'amazon-bedrock'],
+            order: ['amazon-bedrock'],
+            zdr: true,
+            data_collection: 'deny',
+          },
         },
-      },
-    };
-    const originalRequest = structuredClone(request);
+      };
+      const originalRequest = structuredClone(request);
 
-    expect(convertProviderOptions(request, null).gateway).toMatchObject({
-      sort: expected,
-      only: ['anthropic', 'bedrock'],
-      order: ['bedrock'],
-      zeroDataRetention: true,
-      disallowPromptTraining: true,
-    });
-    expect(request).toEqual(originalRequest);
-  });
+      expect(convertProviderOptions(request, null).gateway).toMatchObject({
+        sort: expected,
+        only: ['anthropic', 'bedrock'],
+        order: ['bedrock'],
+        zeroDataRetention: true,
+        disallowPromptTraining: true,
+      });
+      expect(request).toEqual(originalRequest);
+    }
+  );
 
   it.each([
     undefined,
@@ -208,7 +214,7 @@ describe('convertProviderOptions', () => {
       body: {
         model: 'anthropic/claude-sonnet-4.5',
         messages: [{ role: 'user', content: 'hello' }],
-        provider: { sort },
+        provider: { sort: sort as OpenRouterProviderConfig['sort'] },
       },
     };
 

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -136,7 +136,9 @@ export async function shouldRouteToVercel(
   return true;
 }
 
-function convertProviderSort(sort: unknown): GatewayProviderOptions['sort'] {
+function convertProviderSort(
+  sort: OpenRouterProviderConfig['sort']
+): GatewayProviderOptions['sort'] {
   const by =
     typeof sort === 'object' && sort !== null && !Array.isArray(sort) && 'by' in sort
       ? sort.by

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -21,6 +21,7 @@ import {
   getVercelModelsFromRedis,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { getRuntimeGatewayRoutingConfig } from '@/lib/ai-gateway/providers/routing-config';
 import { passesRoutingPercentage } from '@/lib/ai-gateway/providers/routing-percentage';
 import { getEnvVariable } from '@/lib/dotenvx';
@@ -135,6 +136,24 @@ export async function shouldRouteToVercel(
   return true;
 }
 
+function convertProviderSort(sort: unknown): GatewayProviderOptions['sort'] {
+  const by =
+    typeof sort === 'object' && sort !== null && !Array.isArray(sort) && 'by' in sort
+      ? sort.by
+      : sort;
+
+  switch (by) {
+    case 'price':
+      return 'cost';
+    case 'throughput':
+      return 'tps';
+    case 'latency':
+      return 'ttft';
+    default:
+      return undefined;
+  }
+}
+
 export function convertProviderOptions(
   requestToMutate: GatewayRequest,
   vercelInferenceProviders: string[] | null
@@ -165,6 +184,7 @@ export function convertProviderOptions(
     gateway: {
       only,
       order: provider?.order?.map(openRouterToVercelInferenceProviderId),
+      sort: convertProviderSort(provider?.sort),
       zeroDataRetention: provider?.zdr,
       disallowPromptTraining: provider?.data_collection === 'deny' || undefined,
       models: requestToMutate.body.models,
@@ -280,6 +300,7 @@ export async function applyVercelSettings(
     requestToMutate.body.providerOptions = {
       gateway: {
         only: Object.keys(byokProviders),
+        sort: convertProviderSort(requestToMutate.body.provider?.sort),
         byok: byokProviders,
         models: requestToMutate.body.models,
       },

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -139,12 +139,7 @@ export async function shouldRouteToVercel(
 function convertProviderSort(
   sort: OpenRouterProviderConfig['sort']
 ): GatewayProviderOptions['sort'] {
-  const by =
-    typeof sort === 'object' && sort !== null && !Array.isArray(sort) && 'by' in sort
-      ? sort.by
-      : sort;
-
-  switch (by) {
+  switch (sort) {
     case 'price':
       return 'cost';
     case 'throughput':


### PR DESCRIPTION
## Summary
- Map OpenRouter `provider.sort` values `price`, `throughput`, and `latency` to Vercel `gateway.sort` values `cost`, `tps`, and `ttft`.
- Support only the documented string values; ignore unsupported values (including object forms) without blocking Vercel routing.
- Apply the mapping to managed and user-BYOK requests without changing provider restrictions or credential pinning.
- Add regression coverage for mappings, unsupported inputs, routing eligibility, BYOK pinning, and all three supported request APIs.

## Validation
- Changed-file formatting, focused lint, and `git diff --check` passed.
- Local web typecheck previously timed out after 120 seconds during the tRPC dependency build; typecheck and tests are verified by CI.
- Tests delegated to CI as requested.