### PR TITLE
fix(web): reduce API request log retention to seven days

### DIFF
--- a/apps/web/src/app/api/cron/cleanup-api-request-log/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-api-request-log/route.test.ts
@@ -83,10 +83,10 @@ describe('GET /api/cron/cleanup-api-request-log', () => {
     });
   });
 
-  it('deletes expired records and preserves recent records', async () => {
+  it('deletes records older than seven days and preserves recent records', async () => {
     await insertApiRequestLogRecord(daysAgo(45));
-    await insertApiRequestLogRecord(daysAgo(31));
-    const recent = await insertApiRequestLogRecord(daysAgo(1));
+    await insertApiRequestLogRecord(daysAgo(8));
+    const recent = await insertApiRequestLogRecord(daysAgo(6));
 
     const response = await GET(makeRequest({ authorization: 'Bearer cron-secret' }));
 

--- a/apps/web/src/app/api/cron/cleanup-api-request-log/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-api-request-log/route.ts
@@ -10,7 +10,7 @@ import { api_request_log } from '@kilocode/db/schema';
 import { asc, inArray, lt } from 'drizzle-orm';
 import { CRON_SECRET } from '@/lib/config.server';
 
-const RETENTION_DAYS = 30;
+const RETENTION_DAYS = 7;
 const BATCH_SIZE = 1_000;
 
 function getDaysAgo(days: number) {


### PR DESCRIPTION
## Summary

- Reduce `api_request_log` retention from 30 days to 7 days in the existing cleanup job.
- Update regression coverage to delete eight-day-old records while preserving six-day-old records.

## Verification

No manual runtime tests were run; test execution is delegated to CI as requested.

## Visual Changes

N/A

## Reviewer Notes

No schema migration is needed. Existing batching (1,000 rows per run) and the five-minute schedule are unchanged, so newly eligible records drain through the existing cleanup job.

Changed-file formatting and `git diff --check` passed. Local targeted lint and incremental typechecking were attempted but each exceeded the sandbox two-minute limit; CI will provide validation.