### PR TITLE
feat(web): add a hide-forks option to the repository picker

### DIFF
--- a/apps/web/src/components/auto-fix/AutoFixConfigForm.tsx
+++ b/apps/web/src/components/auto-fix/AutoFixConfigForm.tsx
@@ -356,6 +356,7 @@ export function AutoFixConfigForm({ organizationId }: AutoFixConfigFormProps) {
                             name: repo.name,
                             full_name: repo.fullName,
                             private: repo.private,
+                            fork: repo.fork,
                           })) as Repository[]
                         }
                         selectedIds={selectedRepositoryIds}

--- a/apps/web/src/components/auto-triage/AutoTriageConfigForm.tsx
+++ b/apps/web/src/components/auto-triage/AutoTriageConfigForm.tsx
@@ -317,6 +317,7 @@ export function AutoTriageConfigForm({ organizationId }: AutoTriageConfigFormPro
                             name: repo.name,
                             full_name: repo.fullName,
                             private: repo.private,
+                            fork: repo.fork,
                           })) as Repository[]
                         }
                         selectedIds={selectedRepositoryIds}

--- a/apps/web/src/components/code-reviews/RepositoryMultiSelect.tsx
+++ b/apps/web/src/components/code-reviews/RepositoryMultiSelect.tsx
@@ -6,6 +6,12 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Lock, Unlock, Search } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import {
+  visibleRepositories,
+  withVisibleSelected,
+  withoutVisibleSelected,
+} from './repository-multi-select-selection';
 
 export type RepositoryId = string | number;
 
@@ -14,6 +20,7 @@ export type Repository<TId extends RepositoryId = number> = {
   name: string;
   full_name: string;
   private: boolean;
+  fork?: boolean;
 };
 
 export type RepositoryMultiSelectProps<TId extends RepositoryId = number> = {
@@ -30,13 +37,22 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
   renderRepositoryAccessory,
 }: RepositoryMultiSelectProps<TId>) {
   const [searchQuery, setSearchQuery] = useState('');
+  const [hideForks, setHideForks] = useLocalStorage<boolean>('repo-picker:hide-forks', false, {
+    initializeWithValue: false,
+  });
+
+  const forkCount = useMemo(() => repositories.filter(repo => repo.fork).length, [repositories]);
+  const visible = useMemo(
+    () => visibleRepositories(repositories, hideForks),
+    [repositories, hideForks]
+  );
 
   const filteredRepositories = useMemo(() => {
-    if (!searchQuery.trim()) return repositories;
+    if (!searchQuery.trim()) return visible;
 
     const query = searchQuery.toLowerCase();
-    return repositories.filter(repo => repo.full_name.toLowerCase().includes(query));
-  }, [repositories, searchQuery]);
+    return visible.filter(repo => repo.full_name.toLowerCase().includes(query));
+  }, [visible, searchQuery]);
 
   const handleToggle = (repoId: TId) => {
     const newSelection = selectedIds.includes(repoId)
@@ -47,15 +63,26 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
   };
 
   const handleSelectAll = () => {
-    onSelectionChange(repositories.map(repo => repo.id));
+    onSelectionChange(
+      withVisibleSelected(
+        selectedIds,
+        visible.map(repo => repo.id)
+      )
+    );
   };
 
   const handleDeselectAll = () => {
-    onSelectionChange([]);
+    onSelectionChange(
+      withoutVisibleSelected(
+        selectedIds,
+        visible.map(repo => repo.id)
+      )
+    );
   };
 
-  const isAllSelected = selectedIds.length === repositories.length && repositories.length > 0;
-  const isNoneSelected = selectedIds.length === 0;
+  const visibleSelectedCount = visible.filter(repo => selectedIds.includes(repo.id)).length;
+  const isAllSelected = visible.length > 0 && visibleSelectedCount === visible.length;
+  const isNoneSelected = visibleSelectedCount === 0;
 
   return (
     <div className="space-y-3">
@@ -91,6 +118,18 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
         >
           Deselect All
         </Button>
+        {forkCount > 0 && (
+          <div className="ml-auto flex items-center gap-2">
+            <Checkbox
+              id="hide-forks"
+              checked={hideForks}
+              onCheckedChange={checked => setHideForks(checked === true)}
+            />
+            <label htmlFor="hide-forks" className="text-muted-foreground cursor-pointer text-xs">
+              Hide forks
+            </label>
+          </div>
+        )}
       </div>
 
       <div className="border-border bg-background h-64 overflow-y-auto rounded-md border">
@@ -136,7 +175,10 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
       </div>
 
       <div className="text-muted-foreground text-xs">
-        {selectedIds.length} of {repositories.length} repositories selected
+        {visibleSelectedCount} of {visible.length} repositories selected
+        {hideForks && forkCount > 0
+          ? ` · ${forkCount} ${forkCount === 1 ? 'fork' : 'forks'} hidden`
+          : ''}
       </div>
     </div>
   );

--- a/apps/web/src/components/code-reviews/repository-multi-select-selection.test.ts
+++ b/apps/web/src/components/code-reviews/repository-multi-select-selection.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  visibleRepositories,
+  withVisibleSelected,
+  withoutVisibleSelected,
+} from './repository-multi-select-selection';
+
+// `fork: undefined` is a repo cached before the flag existed — it must stay listed.
+const repositories = [
+  { id: 1, fork: false },
+  { id: 2, fork: true },
+  { id: 3, fork: undefined },
+];
+
+describe('visibleRepositories', () => {
+  it('lists every repository when forks are not hidden', () => {
+    expect(visibleRepositories(repositories, false).map(repo => repo.id)).toEqual([1, 2, 3]);
+  });
+
+  it('drops only forks when forks are hidden', () => {
+    expect(visibleRepositories(repositories, true).map(repo => repo.id)).toEqual([1, 3]);
+  });
+});
+
+describe('withVisibleSelected', () => {
+  it('adds the visible repositories without duplicating a selected one', () => {
+    expect(withVisibleSelected([1, 5], [1, 3])).toEqual([1, 5, 3]);
+  });
+});
+
+describe('withoutVisibleSelected', () => {
+  it('clears the visible repositories and keeps a hidden selection', () => {
+    expect(withoutVisibleSelected([1, 2, 3], [1, 3])).toEqual([2]);
+  });
+});

--- a/apps/web/src/components/code-reviews/repository-multi-select-selection.ts
+++ b/apps/web/src/components/code-reviews/repository-multi-select-selection.ts
@@ -1,0 +1,24 @@
+/** The repositories the picker lists. Forks drop out only when the user hides them. */
+export function visibleRepositories<T extends { fork?: boolean }>(
+  repositories: readonly T[],
+  hideForks: boolean
+): T[] {
+  return hideForks ? repositories.filter(repository => !repository.fork) : [...repositories];
+}
+
+/** Select-all adds the listed repositories and keeps selections the fork filter hides. */
+export function withVisibleSelected<TId>(
+  selectedIds: readonly TId[],
+  visibleIds: readonly TId[]
+): TId[] {
+  return [...new Set([...selectedIds, ...visibleIds])];
+}
+
+/** Deselect-all clears the listed repositories and keeps selections the fork filter hides. */
+export function withoutVisibleSelected<TId>(
+  selectedIds: readonly TId[],
+  visibleIds: readonly TId[]
+): TId[] {
+  const visible = new Set(visibleIds);
+  return selectedIds.filter(id => !visible.has(id));
+}

--- a/apps/web/src/components/security-agent/security-config-types.ts
+++ b/apps/web/src/components/security-agent/security-config-types.ts
@@ -25,6 +25,7 @@ export type SecurityRepository = {
   fullName: string;
   name: string;
   private: boolean;
+  fork?: boolean;
   dependabotAlerts: DependabotAlertsAvailability;
 };
 
@@ -166,5 +167,6 @@ export function toRepositoryOptions(repositories: SecurityRepository[]): Reposit
     name: repository.name,
     full_name: repository.fullName,
     private: repository.private,
+    fork: repository.fork,
   }));
 }

--- a/apps/web/src/lib/auto-triage/application/routers/shared-router-factory.ts
+++ b/apps/web/src/lib/auto-triage/application/routers/shared-router-factory.ts
@@ -45,6 +45,7 @@ type GitHubRepositoriesResult = {
     name: string;
     fullName: string;
     private: boolean;
+    fork?: boolean;
   }[];
   errorMessage?: string;
 };

--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.test.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.test.ts
@@ -47,7 +47,9 @@ jest.mock('@/components/cloud-agent/demo-config', () => ({
   DEMO_SOURCE_REPO_NAME: 'demo-repo',
 }));
 
-const cachedRepositories = [{ id: 1, name: 'repo', full_name: 'org/repo', private: false }];
+const cachedRepositories = [
+  { id: 1, name: 'repo', full_name: 'org/repo', private: false, fork: false },
+];
 
 const buildIntegration = (overrides: Partial<PlatformIntegration> = {}): PlatformIntegration =>
   ({
@@ -78,7 +80,7 @@ describe('github-integration-helpers', () => {
 
       expect(result.integrationInstalled).toBe(true);
       expect(result.repositories).toEqual([
-        { id: 1, name: 'repo', fullName: 'org/repo', private: false },
+        { id: 1, name: 'repo', fullName: 'org/repo', private: false, fork: false },
       ]);
       expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
     });
@@ -137,6 +139,28 @@ describe('github-integration-helpers', () => {
       expect(mockUpdateRepositoriesForIntegration).not.toHaveBeenCalled();
     });
 
+    it('refetches when the cached repositories predate the fork flag', async () => {
+      mockGetIntegrationForOwner.mockResolvedValue(
+        buildIntegration({
+          repositories: [{ id: 1, name: 'repo', full_name: 'org/repo', private: false }],
+        })
+      );
+      mockFetchGitHubRepositories.mockResolvedValue([
+        { id: 1, name: 'repo', full_name: 'org/repo', private: false, fork: true },
+      ]);
+
+      const { fetchGitHubRepositoriesForUser } = await import('./github-integration-helpers');
+      const result = await fetchGitHubRepositoriesForUser('user-123');
+
+      expect(mockFetchGitHubRepositories).toHaveBeenCalled();
+      expect(mockUpdateRepositoriesForIntegration).toHaveBeenCalledWith('integration-1', [
+        { id: 1, name: 'repo', full_name: 'org/repo', private: false, fork: true },
+      ]);
+      expect(result.repositories).toEqual([
+        { id: 1, name: 'repo', fullName: 'org/repo', private: false, fork: true },
+      ]);
+    });
+
     it('fetches fresh repositories when forceRefresh is true', async () => {
       mockGetIntegrationForOwner.mockResolvedValue(buildIntegration());
       mockFetchGitHubRepositories.mockResolvedValue([
@@ -171,6 +195,7 @@ describe('github-integration-helpers', () => {
           name: 'repo',
           fullName: 'org/repo',
           private: false,
+          fork: false,
           platformIntegrationId: 'integration-1',
         },
       ]);
@@ -182,14 +207,22 @@ describe('github-integration-helpers', () => {
         buildIntegration({
           id: 'integration-1',
           platform_account_login: 'acme-core',
-          repositories: [{ id: 1, name: 'api', full_name: 'acme-core/api', private: true }],
+          repositories: [
+            { id: 1, name: 'api', full_name: 'acme-core/api', private: true, fork: false },
+          ],
         }),
         buildIntegration({
           id: 'integration-2',
           platform_installation_id: 'installation-2',
           platform_account_login: 'acme-security',
           repositories: [
-            { id: 2, name: 'scanner', full_name: 'acme-security/scanner', private: true },
+            {
+              id: 2,
+              name: 'scanner',
+              full_name: 'acme-security/scanner',
+              private: true,
+              fork: false,
+            },
           ],
         }),
       ]);
@@ -216,7 +249,9 @@ describe('github-integration-helpers', () => {
       mockGetIntegrationsByOrganization.mockResolvedValue([
         buildIntegration({
           id: 'integration-1',
-          repositories: [{ id: 1, name: 'api', full_name: 'acme-core/api', private: true }],
+          repositories: [
+            { id: 1, name: 'api', full_name: 'acme-core/api', private: true, fork: false },
+          ],
         }),
         buildIntegration({
           id: 'integration-2',

--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
@@ -18,6 +18,7 @@ import {
   isPlatformIntegrationSuspended,
 } from '@/lib/integrations/core/health';
 import {
+  needsForkFlagBackfill,
   requireNumericPlatformRepositories,
   type PlatformRepository,
 } from '@/lib/integrations/core/types';
@@ -29,6 +30,7 @@ type GitHubRepositoriesResult = {
     name: string;
     fullName: string;
     private: boolean;
+    fork?: boolean;
     platformIntegrationId?: string;
     platformAccountLogin?: string;
   }[];
@@ -45,6 +47,7 @@ const mapRepositories = (
     name: repo.name,
     fullName: repo.full_name,
     private: repo.private,
+    fork: repo.fork,
     ...(integration
       ? {
           platformIntegrationId: integration.id,
@@ -162,7 +165,7 @@ export async function fetchGitHubRepositoriesForOrganization(
 
   try {
     const cachedRepositories = requireNumericPlatformRepositories(integration.repositories);
-    if (forceRefresh || !cachedRepositories?.length) {
+    if (forceRefresh || !cachedRepositories?.length || needsForkFlagBackfill(cachedRepositories)) {
       const repositories = await fetchGitHubRepositories(
         integration.platform_installation_id,
         integration.github_app_type || 'standard'
@@ -210,7 +213,11 @@ async function fetchRepositoriesForIntegrations(
       integrations.map(async integration => {
         if (!integration.platform_installation_id) return { repositories: [], syncedAt: null };
         const cachedRepositories = requireNumericPlatformRepositories(integration.repositories);
-        if (forceRefresh || !cachedRepositories?.length) {
+        if (
+          forceRefresh ||
+          !cachedRepositories?.length ||
+          needsForkFlagBackfill(cachedRepositories)
+        ) {
           const repositories = await fetchGitHubRepositories(
             integration.platform_installation_id,
             integration.github_app_type || 'standard'
@@ -271,7 +278,7 @@ export async function fetchGitHubRepositoriesForUser(
   try {
     const cachedRepositories = requireNumericPlatformRepositories(integration.repositories);
     // If forceRefresh or no cached repos, fetch from GitHub and update cache
-    if (forceRefresh || !cachedRepositories?.length) {
+    if (forceRefresh || !cachedRepositories?.length || needsForkFlagBackfill(cachedRepositories)) {
       const appType = integration.github_app_type || 'standard';
       const repositories = await fetchGitHubRepositories(
         integration.platform_installation_id,

--- a/apps/web/src/lib/code-reviews/core/selectable-repositories.ts
+++ b/apps/web/src/lib/code-reviews/core/selectable-repositories.ts
@@ -18,6 +18,7 @@ export type FetchedRepository = {
   name: string;
   fullName: string;
   private: boolean;
+  fork?: boolean;
 };
 
 export type ManuallyAddedRepository = {
@@ -32,6 +33,7 @@ export type SelectableRepository = {
   name: string;
   full_name: string;
   private: boolean;
+  fork?: boolean;
 };
 
 /** The deduped repository list offered for review config / conversion (fetched + legacy manual). */
@@ -44,6 +46,7 @@ export function buildSelectableRepositories(
     name: repo.name,
     full_name: repo.fullName,
     private: repo.private,
+    fork: repo.fork,
   }));
   const seenIds = new Set(canonical.map(repo => repo.id));
   const legacy = manuallyAdded.filter(repo => !seenIds.has(repo.id));

--- a/apps/web/src/lib/integrations/core/types.ts
+++ b/apps/web/src/lib/integrations/core/types.ts
@@ -17,6 +17,11 @@ export function requireNumericPlatformRepositories(
   return repositories;
 }
 
+/** True when a cached GitHub repository list predates the `fork` flag and must be refetched. */
+export function needsForkFlagBackfill(repositories: PlatformRepository[] | null): boolean {
+  return repositories?.some(repository => repository.fork === undefined) ?? false;
+}
+
 /**
  * Represents ownership of an integration
  * Can be either a user or an organization

--- a/apps/web/src/lib/integrations/platforms/github/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.ts
@@ -123,6 +123,7 @@ type GitHubRepository = {
   full_name: string;
   private: boolean;
   created_at: string;
+  fork: boolean;
 };
 
 type GitHubBranch = {
@@ -162,6 +163,7 @@ export async function fetchGitHubRepositories(
           full_name: repo.full_name,
           private: repo.private,
           created_at: repo.created_at ?? new Date().toISOString(),
+          fork: repo.fork,
         }))
     );
 

--- a/apps/web/src/lib/security-agent/router/shared-handlers.test.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.test.ts
@@ -203,7 +203,7 @@ function createHandlers() {
         id: 'integration-123',
         integration_status: 'active',
         platform_installation_id: 'installation-123',
-        repositories: [{ id: 1, full_name: 'kilo/repo', name: 'repo', private: true }],
+        repositories: [{ id: 1, full_name: 'kilo/repo', name: 'repo', private: true, fork: false }],
       }) as never,
     trackingExtras: () => ({}),
   });
@@ -365,6 +365,7 @@ describe('getRepositories', () => {
         fullName: 'kilo/repo',
         name: 'repo',
         private: true,
+        fork: false,
         dependabotAlerts: 'disabled',
       },
     ]);
@@ -378,6 +379,7 @@ describe('getRepositories', () => {
           fullName: 'kilo/repo',
           name: 'repo',
           private: true,
+          fork: false,
         },
       ]
     );

--- a/apps/web/src/lib/security-agent/router/shared-handlers.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.ts
@@ -10,7 +10,10 @@ import {
   updateRepositoriesForIntegration,
 } from '@/lib/integrations/db/platform-integrations';
 import { fetchGitHubRepositories } from '@/lib/integrations/platforms/github/adapter';
-import { requireNumericPlatformRepositories } from '@/lib/integrations/core/types';
+import {
+  needsForkFlagBackfill,
+  requireNumericPlatformRepositories,
+} from '@/lib/integrations/core/types';
 import {
   getSecurityAgentConfigWithStatus,
   upsertSecurityAgentConfig,
@@ -1304,7 +1307,10 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
 
       // Auto-fetch repositories from GitHub if not cached
       let repos = requireNumericPlatformRepositories(integration.repositories) ?? [];
-      if (repos.length === 0 && integration.platform_installation_id) {
+      if (
+        (repos.length === 0 || needsForkFlagBackfill(repos)) &&
+        integration.platform_installation_id
+      ) {
         const appType = integration.github_app_type || 'standard';
         const fetchedRepos = await fetchGitHubRepositories(
           integration.platform_installation_id,
@@ -1319,6 +1325,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         fullName: repo.full_name,
         name: repo.name,
         private: repo.private,
+        fork: repo.fork,
       }));
       const installationId = integration.platform_installation_id;
       if (!installationId || !hasSecurityReviewPermissions(integration)) {

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1265,6 +1265,7 @@ export type PlatformRepository<TId extends number | string = number> = {
   full_name: string;
   private: boolean;
   default_branch?: string;
+  fork?: boolean;
 };
 
 export const REVIEW_MEMORY_PLATFORMS = ['github'] as const;


### PR DESCRIPTION
## What changed

- The repository picker shows a **Hide forks** checkbox when the account has at least one forked repository.
- When the checkbox is on, the picker hides forked repositories from the list.
- The checkbox state persists per browser under the `repo-picker:hide-forks` local-storage key.
- Select All and Deselect All act on the listed repositories only. They keep selections that the fork filter hides.
- The counter reports the listed selection, and adds `N forks hidden` when the filter is on.
- The GitHub repository fetch carries the `fork` flag through to the picker for Code Reviewer, Security Agent, Auto Triage, and Auto Fix.
- A cached repository list that predates the `fork` flag triggers one refetch, so the flag backfills without a migration.

## Why

Issue #4498 asks for a way to hide forked repositories when a user selects repositories to watch. An account with many forks makes the picker hard to read. The GitHub API already returns the `fork` flag, but the picker's data path dropped it.

## Verification

- Driver checks: per-slice checks passed.
- Section e2e `backend` passed: no changed service.

## Notes for the reviewer

- `fork` is optional on the repository types. A repository cached before this change reports `fork: undefined` and stays listed until the backfill refetch replaces it.
- The selection helpers are pure functions in `repository-multi-select-selection.ts` and have unit tests.
