### PR TITLE
fix(gastown): use BYOK model for review classification

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/direct-byok-meta.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/direct-byok-meta.ts
@@ -1,6 +1,7 @@
 import type { DirectUserByokInferenceProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 
 // Client-safe display names for direct BYOK providers.
+// Keep the ids in sync with DIRECT_BYOK_PROVIDER_IDS in packages/worker-utils/src/direct-byok-model.ts.
 export const DIRECT_BYOK_PROVIDERS_META = {
   'alibaba-token-plan': 'Alibaba Token Plan (Singapore)',
   'byteplus-coding': 'BytePlus Coding Plan',

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/direct-byok-provider-ids.drift.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/direct-byok-provider-ids.drift.test.ts
@@ -1,0 +1,8 @@
+import { DIRECT_BYOK_PROVIDER_IDS } from '@kilocode/worker-utils/direct-byok-model';
+import { DIRECT_BYOK_PROVIDERS_META } from './direct-byok-meta';
+
+it('keeps the worker-utils direct BYOK provider ids in sync with the meta list', () => {
+  expect([...DIRECT_BYOK_PROVIDER_IDS].sort()).toEqual(
+    Object.keys(DIRECT_BYOK_PROVIDERS_META).sort()
+  );
+});

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -36,7 +36,8 @@
     "./review-agents": "./src/review-agents.ts",
     "./code-review-council": "./src/code-review-council.ts",
     "./scheduled-job-observability": "./src/scheduled-job-observability.ts",
-    "./r2-client": "./src/r2-client.ts"
+    "./r2-client": "./src/r2-client.ts",
+    "./direct-byok-model": "./src/direct-byok-model.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/worker-utils/src/direct-byok-model.ts
+++ b/packages/worker-utils/src/direct-byok-model.ts
@@ -1,0 +1,38 @@
+/**
+ * Provider ids whose models route to the user's own API key (direct BYOK) and
+ * never bill Kilo credits. A model id is `<providerId>/<model...>` — see
+ * `formatDirectByokModelId` in
+ * apps/web/src/lib/ai-gateway/providers/direct-byok/index.ts:17.
+ *
+ * Source of truth is `DIRECT_BYOK_PROVIDERS_META` in
+ * apps/web/src/lib/ai-gateway/providers/direct-byok/direct-byok-meta.ts:4.
+ * This copy exists because Cloudflare Workers cannot import from apps/web.
+ * A drift-guard test keeps the two lists equal.
+ */
+export const DIRECT_BYOK_PROVIDER_IDS = [
+  'alibaba-token-plan',
+  'byteplus-coding',
+  'chutes-byok',
+  'crofai',
+  'edenai',
+  'kimi-coding',
+  'inceptron-byok',
+  'martian',
+  'morph-byok',
+  'neuralwatt',
+  'nvidia-byok',
+  'ollama-cloud',
+  'opencode-go',
+  'orcarouter',
+  'synthetic',
+  'xiaomi-token-plan-ams',
+  'xiaomi-token-plan-sgp',
+  'zai-coding',
+] as const;
+
+const ids: ReadonlySet<string> = new Set(DIRECT_BYOK_PROVIDER_IDS);
+
+export function isDirectByokModelId(modelId: string | undefined | null): boolean {
+  if (!modelId) return false;
+  return ids.has(modelId.toLowerCase().split('/')[0] ?? '');
+}

--- a/services/gastown/src/dos/town/town-scm.test.ts
+++ b/services/gastown/src/dos/town/town-scm.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { areThreadsBlocking, type SCMContext } from './town-scm';
+import { TownConfigSchema } from '../../types';
+
+const THREADS = [
+  {
+    isResolved: false,
+    comments: { nodes: [{ body: 'LGTM', author: { login: 'reviewer' } }] },
+  },
+];
+
+function makeCtx(config: Record<string, unknown>) {
+  const aiRun = vi.fn();
+  const ctx = {
+    env: {
+      AI: { run: aiRun },
+      GASTOWN_AE: undefined,
+      KILO_API_URL: 'https://api.test',
+    },
+    townId: 'town-1',
+    getTownConfig: async () => TownConfigSchema.parse({ town_id: 'town-1', ...config }),
+  } as unknown as SCMContext;
+  return { ctx, aiRun };
+}
+
+describe('areThreadsBlocking', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('uses the Kilo gateway when the configured model is direct BYOK', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: '{"blocking": false}' } }] }), {
+        status: 200,
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { ctx, aiRun } = makeCtx({
+      default_model: 'neuralwatt/glm-5.2-short',
+      kilocode_token: 'kilo-token',
+    });
+
+    expect(await areThreadsBlocking(ctx, THREADS)).toBe(false);
+    expect(aiRun).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.test/api/openrouter/chat/completions');
+    expect(JSON.parse(init.body).model).toBe('neuralwatt/glm-5.2-short');
+  });
+
+  it('falls back to Workers AI when the configured model is not direct BYOK', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { ctx, aiRun } = makeCtx({
+      default_model: 'anthropic/claude-sonnet-4.6',
+      kilocode_token: 'kilo-token',
+    });
+    aiRun.mockResolvedValue({ response: '{"blocking": false}' });
+
+    expect(await areThreadsBlocking(ctx, THREADS)).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(aiRun).toHaveBeenCalledWith('@cf/google/gemma-4-26b-a4b-it', expect.anything());
+  });
+
+  it('blocks without falling back to Workers AI when the gateway rejects the call', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('payment required', { status: 402 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { ctx, aiRun } = makeCtx({
+      default_model: 'neuralwatt/glm-5.2-short',
+      kilocode_token: 'kilo-token',
+    });
+
+    expect(await areThreadsBlocking(ctx, THREADS)).toBe(true);
+    expect(aiRun).not.toHaveBeenCalled();
+  });
+});

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -7,6 +7,7 @@ import {
   parseGitUrl,
 } from '../../util/platform-pr.util';
 import { writeEvent } from '../../util/analytics.util';
+import { isDirectByokModelId } from '@kilocode/worker-utils/direct-byok-model';
 
 const TOWN_LOG = '[town-scm]';
 
@@ -298,6 +299,46 @@ export async function checkPRStatus(ctx: SCMContext, prUrl: string): Promise<PRS
 }
 
 /**
+ * Send the review-thread classification to the Kilo LLM gateway on the town's
+ * configured model. Only used when that model is a direct BYOK model, so the
+ * call bills the user's own provider key instead of Kilo credits (#4268).
+ */
+async function classifyThreadsViaKiloGateway(
+  ctx: SCMContext,
+  townConfig: TownConfig,
+  model: string,
+  prompt: string
+): Promise<unknown> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${townConfig.kilocode_token}`,
+    'Content-Type': 'application/json',
+    // Feature attribution for microdollar usage; 'gastown' is in FEATURE_VALUES
+    // (apps/web/src/lib/feature-detection.ts:46).
+    'x-kilocode-feature': 'gastown',
+  };
+  if (townConfig.organization_id) {
+    headers['X-KiloCode-OrganizationId'] = townConfig.organization_id;
+  }
+
+  const response = await fetch(`${ctx.env.KILO_API_URL}/api/openrouter/chat/completions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 256,
+      temperature: 0,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Kilo gateway returned ${response.status} for model ${model}: ${(await response.text()).slice(0, 300)}`
+    );
+  }
+  return await response.json();
+}
+
+/**
  * Use Workers AI to determine if unresolved PR review threads contain
  * blocking feedback that should prevent auto-merge.
  */
@@ -331,20 +372,29 @@ Important: A comment is only NON-BLOCKING if it expresses approval or is purely 
 
 Respond with ONLY a JSON object (no markdown, no explanation): { "blocking": true/false, "reason": "brief one-sentence explanation" }`;
 
+    const townConfig = await ctx.getTownConfig();
+    // The refinery role owns the review flow, so its model is the one the user
+    // configured for reviews; fall back to the town default.
+    const configuredModel = townConfig.role_models?.refinery ?? townConfig.default_model;
+    const byokModel =
+      townConfig.kilocode_token && isDirectByokModelId(configuredModel) ? configuredModel : null;
+
     const startTime = Date.now();
-    const response: unknown = await ctx.env.AI.run('@cf/google/gemma-4-26b-a4b-it', {
-      messages: [{ role: 'user', content: prompt }],
-      max_tokens: 256,
-      temperature: 0,
-      chat_template_kwargs: { enable_thinking: false },
-    });
+    const response: unknown = byokModel
+      ? await classifyThreadsViaKiloGateway(ctx, townConfig, byokModel, prompt)
+      : await ctx.env.AI.run('@cf/google/gemma-4-26b-a4b-it', {
+          messages: [{ role: 'user', content: prompt }],
+          max_tokens: 256,
+          temperature: 0,
+          chat_template_kwargs: { enable_thinking: false },
+        });
     const durationMs = Date.now() - startTime;
 
     // Track the AI call via analytics event
     writeEvent(ctx.env, {
       event: 'api.external_request',
       townId: ctx.townId,
-      label: 'workers_ai_review_threads',
+      label: byokModel ? 'byok_review_threads' : 'workers_ai_review_threads',
       durationMs,
     });
 


### PR DESCRIPTION
## What changed

- Review-thread classification uses the configured direct BYOK reviewer model.
- Non-BYOK reviews keep the existing Workers AI classifier.
- A failed BYOK call blocks the review without using the Kilo-billed fallback.

## Why

The auxiliary classification call used Kilo credits even when the user configured a BYOK model (#4268).

## Verification

- Unit tests for the changed packages pass (gastown, worker-utils, web drift test).
- Typecheck and lint pass on the changed packages.
- The web Playwright smoke is advisory in the local harness and did not run to completion; CI covers it.
