### PR TITLE
fix(ai-gateway): use Kimi K3 for balanced and efficient fallback

### DIFF
--- a/apps/web/src/lib/ai-gateway/auto-model/index.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/index.ts
@@ -9,7 +9,7 @@ import {
   type OpenCodeSettings,
   type Verbosity,
 } from '@kilocode/db/schema-types';
-import { QWEN37_PLUS_MODEL_ID } from '@/lib/ai-gateway/providers/qwen';
+import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
 
 export type AutoModelPricing = {
   prompt: string;
@@ -87,8 +87,8 @@ export const FRONTIER_MODE_TO_MODEL: Record<Mode, ResolvedAutoModel> = {
 // Whoever changes this model constant must re-verify image support
 // (via live OpenRouter data or the `model_stats` table) before
 // swapping it — do not assume parity with the prior value.
-export const BALANCED_QWEN_MODEL: ResolvedAutoModel = {
-  model: QWEN37_PLUS_MODEL_ID,
+export const BALANCED_FALLBACK_MODEL: ResolvedAutoModel = {
+  model: KIMI_CURRENT_MODEL_ID,
   reasoning: { enabled: true },
 };
 

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -6,7 +6,7 @@ jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
 
 import { resolveAutoModel } from './resolution';
 import {
-  BALANCED_QWEN_MODEL,
+  BALANCED_FALLBACK_MODEL,
   FRONTIER_MODE_TO_MODEL,
   KILO_AUTO_BALANCED_MODEL,
   KILO_AUTO_EFFICIENT_MODEL,
@@ -100,51 +100,58 @@ describe('resolveAutoModel — kilo-auto/efficient branch', () => {
     expect(result).toEqual({ kind: 'ok', resolved: { model: 'anthropic/claude-haiku-4' } });
   });
 
-  it('falls back to BALANCED_QWEN_MODEL when no thunk is provided and apiKind=responses', async () => {
+  it('falls back to BALANCED_FALLBACK_MODEL when no thunk is provided and apiKind=responses', async () => {
     const result = await resolveAutoModel(
       { ...baseParams, apiKind: 'responses' },
       nullUserPromise,
       zeroBalancePromise
     );
 
-    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_QWEN_MODEL });
+    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_FALLBACK_MODEL });
   });
 
-  it('falls back to BALANCED_QWEN_MODEL when no thunk is provided and apiKind=messages', async () => {
+  it('falls back to BALANCED_FALLBACK_MODEL when no thunk is provided and apiKind=messages', async () => {
     const result = await resolveAutoModel(
       { ...baseParams, apiKind: 'messages' },
       nullUserPromise,
       zeroBalancePromise
     );
 
-    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_QWEN_MODEL });
+    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_FALLBACK_MODEL });
   });
 
-  it('falls back to BALANCED_QWEN_MODEL when no thunk is provided and apiKind=chat_completions', async () => {
+  it('falls back to BALANCED_FALLBACK_MODEL when no thunk is provided and apiKind=chat_completions', async () => {
     const result = await resolveAutoModel(
       { ...baseParams, apiKind: 'chat_completions' },
       nullUserPromise,
       zeroBalancePromise
     );
 
-    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_QWEN_MODEL });
+    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_FALLBACK_MODEL });
   });
 
-  it('falls back to BALANCED_QWEN_MODEL when thunk returns null and apiKind=chat_completions', async () => {
-    const result = await resolveAutoModel(
-      {
-        ...baseParams,
-        apiKind: 'chat_completions',
-        efficientDecision: async () => null,
-      },
-      nullUserPromise,
-      zeroBalancePromise
-    );
+  it.each([KILO_AUTO_BALANCED_MODEL.id, KILO_AUTO_EFFICIENT_MODEL.id])(
+    'falls back to Kimi K3 with reasoning for %s when the worker returns no decision',
+    async model => {
+      const result = await resolveAutoModel(
+        {
+          ...baseParams,
+          model,
+          apiKind: 'chat_completions',
+          efficientDecision: async () => null,
+        },
+        nullUserPromise,
+        zeroBalancePromise
+      );
 
-    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_QWEN_MODEL });
-  });
+      expect(result).toEqual({
+        kind: 'ok',
+        resolved: { model: 'moonshotai/kimi-k3', reasoning: { enabled: true } },
+      });
+    }
+  );
 
-  it('falls back to BALANCED_QWEN_MODEL when the worker returns a virtual auto model', async () => {
+  it('falls back to BALANCED_FALLBACK_MODEL when the worker returns a virtual auto model', async () => {
     const result = await resolveAutoModel(
       {
         ...baseParams,
@@ -158,7 +165,7 @@ describe('resolveAutoModel — kilo-auto/efficient branch', () => {
       zeroBalancePromise
     );
 
-    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_QWEN_MODEL });
+    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_FALLBACK_MODEL });
   });
 
   it('does not call the thunk more than once', async () => {
@@ -252,7 +259,7 @@ describe('resolveAutoModel — kilo-auto/efficient branch', () => {
     });
   });
 
-  it('falls back to BALANCED_QWEN_MODEL when variant is absent from the model catalog', async () => {
+  it('falls back to BALANCED_FALLBACK_MODEL when variant is absent from the model catalog', async () => {
     // Claude has no "thinking" key — only none/low/medium/high/xhigh/max
     const result = await resolveAutoModel(
       {
@@ -268,10 +275,10 @@ describe('resolveAutoModel — kilo-auto/efficient branch', () => {
       zeroBalancePromise
     );
 
-    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_QWEN_MODEL });
+    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_FALLBACK_MODEL });
   });
 
-  it('falls back to BALANCED_QWEN_MODEL when the model exposes no variants but decision has a variant', async () => {
+  it('falls back to BALANCED_FALLBACK_MODEL when the model exposes no variants but decision has a variant', async () => {
     const result = await resolveAutoModel(
       {
         ...baseParams,
@@ -286,7 +293,7 @@ describe('resolveAutoModel — kilo-auto/efficient branch', () => {
       zeroBalancePromise
     );
 
-    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_QWEN_MODEL });
+    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_FALLBACK_MODEL });
   });
 
   it('applies exact thinking and instant variant settings', async () => {
@@ -396,7 +403,7 @@ describe('resolveAutoModel — kilo-auto/efficient branch', () => {
       zeroBalancePromise
     );
 
-    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_QWEN_MODEL });
+    expect(result).toEqual({ kind: 'ok', resolved: BALANCED_FALLBACK_MODEL });
   });
 });
 
@@ -644,7 +651,7 @@ describe('resolveAutoModel — Organization Auto branch', () => {
 
     expect(result).toEqual({
       kind: 'ok',
-      resolved: BALANCED_QWEN_MODEL,
+      resolved: BALANCED_FALLBACK_MODEL,
       routingTarget: 'kilo-auto/balanced',
     });
   });

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -20,7 +20,7 @@ import {
   KILO_AUTO_BALANCED_MODEL,
   KILO_AUTO_EFFICIENT_MODEL,
   modeSchema,
-  BALANCED_QWEN_MODEL,
+  BALANCED_FALLBACK_MODEL,
   FRONTIER_MODE_TO_MODEL,
   FRONTIER_CODE_MODEL,
   type ResolvedAutoModel,
@@ -328,10 +328,10 @@ export async function resolveAutoModel(
       }
       // Exact catalog variant missing or removed: never serve the chosen model
       // with implicit defaults — same balanced fallback as the no-decision path.
-      return { kind: 'ok', resolved: BALANCED_QWEN_MODEL };
+      return { kind: 'ok', resolved: BALANCED_FALLBACK_MODEL };
     }
     // Static fallback when the worker is slow or unavailable.
-    return { kind: 'ok', resolved: BALANCED_QWEN_MODEL };
+    return { kind: 'ok', resolved: BALANCED_FALLBACK_MODEL };
   }
   const mode = resolveMode(modeHeader, featureHeader);
   return {

--- a/apps/web/src/lib/ai-gateway/auto-routing-denied-models.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-routing-denied-models.test.ts
@@ -178,6 +178,6 @@ describe('candidateModelIdsFromSources', () => {
       null
     );
     expect(ids).not.toContain('kilo-auto/balanced');
-    expect(ids).not.toContain('qwen/qwen3.7-plus');
+    expect(ids).not.toContain('moonshotai/kimi-k3');
   });
 });


### PR DESCRIPTION
## Summary
- Change the shared Auto Balanced / Auto Efficient static fallback from Qwen 3.7 Plus to `moonshotai/kimi-k3`, retaining reasoning.
- Rename the fallback constant to `BALANCED_FALLBACK_MODEL` and cover both aliases with explicit Kimi K3 regression assertions.

## Why
Qwen 3.7 Plus currently has only Alibaba available through OpenRouter. Kimi K3 has broader cross-provider availability, making it less likely to conflict with provider access policies while retaining the image support required by these Auto modes. Existing access-policy enforcement is unchanged: this is a mitigation, not a guarantee that every policy permits the fallback. A better, policy-aware fallback fix will be developed separately.

DeepSeek V4 Pro 0813 was initially proposed for its better cross-provider availability than Qwen and lower likelihood of access-policy conflicts. Live OpenRouter metadata confirmed that it is text-only, so the requester chose Kimi K3 instead to preserve image support.

Live capability/provider checks (2026-08-31):
- [Kimi K3](https://openrouter.ai/api/v1/models/moonshotai/kimi-k3/endpoints): text, image, and video input; multiple providers.
- [Qwen 3.7 Plus](https://openrouter.ai/api/v1/models/qwen/qwen3.7-plus/endpoints): Alibaba only.
- [DeepSeek V4 Pro 0813](https://openrouter.ai/api/v1/models/deepseek/deepseek-v4-pro-0813/endpoints): text-only.

## Verification
- Changed-file `pnpm format`: passed.
- Targeted `pnpm exec oxlint --config .oxlintrc.json`: passed, no warnings/errors.
- `git diff --check`: passed.
- `pnpm --filter web typecheck`: timed out after 120 seconds during the prerequisite tRPC build; local Node 22 also differs from the required Node 24. CI will perform full validation.
- Tests intentionally left to CI, as requested.