### PR TITLE
feat(agent-harness): secure billed model inference

### DIFF
--- a/apps/web/src/app/api/internal/agent-harness/model/route.ts
+++ b/apps/web/src/app/api/internal/agent-harness/model/route.ts
@@ -1,0 +1,3 @@
+export { proxyHarnessModel as POST } from '@/lib/agent-harness/model-gateway';
+
+export const maxDuration = 100;

--- a/apps/web/src/lib/agent-harness/model-gateway.test.ts
+++ b/apps/web/src/lib/agent-harness/model-gateway.test.ts
@@ -1,0 +1,268 @@
+import { beforeEach, expect, it, jest } from '@jest/globals';
+import jwt from 'jsonwebtoken';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { streamText } from 'ai';
+import * as fixtures from './operation-test-fixture';
+import { harnessInputDigest } from './authorization';
+import type * as Gateway from './model-gateway';
+import type * as Route from '@/app/api/internal/agent-harness/model/route';
+
+const { access, authority, conversationId, operationId, originalTime, primary, runId } = fixtures;
+jest.mock('@/lib/constants', () => ({
+  APP_URL: 'https://app.example',
+  ORGANIZATION_ID_HEADER: 'x-kilocode-organizationid',
+}));
+jest.mock('@/lib/utils.server', () => ({ warnExceptInTest: jest.fn() }));
+const { harnessModelScope } = jest.requireActual<typeof Gateway>('./model-gateway');
+const { POST } = jest.requireActual<typeof Route>('@/app/api/internal/agent-harness/model/route');
+const completion = {
+  model: 'paid/model',
+  messages: [{ role: 'user' as const, content: 'Hello' }],
+  stream: true,
+  max_tokens: 128,
+};
+const chunk = {
+  id: 'generation-1',
+  model: completion.model,
+  created: 1,
+  choices: [{ index: 0, delta: { content: 'Hello' }, finish_reason: 'stop' }],
+  usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5, cost: 0.002 },
+};
+const outputHeaders = {
+  'content-type': 'text/event-stream',
+  'request-id': 'request-1',
+  authorization: 'upstream-secret',
+};
+const sse = (data = `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`) =>
+  new Response(data, { headers: outputHeaders });
+const requests: Request[] = [];
+let gateway: () => Response;
+function capability(body: unknown, context: unknown = authority) {
+  const input = { conversationId, operationId, runId, completion: body };
+  const scope = {
+    ...harnessModelScope({ ...input, completion }),
+    inputDigest: harnessInputDigest(input),
+  };
+  return jwt.sign({ grantId: runId, authority: context, scope }, 'test-signing-key', {
+    issuer: 'agent-harness',
+    audience: scope.audience,
+    expiresIn: 60,
+  });
+}
+function invoke(
+  body: unknown = completion,
+  token = capability(completion),
+  init: RequestInit = {}
+) {
+  const request = new Request('https://app.example/api/internal/agent-harness/model', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    ...init,
+    headers: {
+      'content-type': 'application/json',
+      'x-internal-api-key': 'test-service-key',
+      authorization: `Bearer ${token}`,
+      'x-agent-harness-conversation-id': conversationId,
+      'x-agent-harness-operation-id': operationId,
+      'x-agent-harness-run-id': runId,
+      'x-kilocode-organizationid': 'forged-org',
+      'x-kilocode-feature': 'forged-feature',
+      ...init.headers,
+    },
+  });
+  return POST(request);
+}
+beforeEach(() => {
+  requests.length = 0;
+  gateway = () => sse();
+  const user = { id: authority.userId, blocked_reason: null, api_token_pepper: 'current-pepper' };
+  jest.spyOn(primary.query.kilocode_users, 'findFirst').mockResolvedValue(user);
+  jest.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+    requests.push(new Request(url, init));
+    return gateway();
+  });
+});
+
+it.each([
+  ['paid/model', runId],
+  ['provider/model:free', null],
+  ['direct-byok/model', runId],
+] as const)('streams billed SDK output for %s in %s', async (model, organizationId) => {
+  const registry = primary.query.agent_harness_conversation_registry;
+  jest
+    .spyOn(registry, 'findFirst')
+    .mockResolvedValue({ ...(await registry.findFirst()), organization_id: organizationId } as any);
+  let upstream!: ReadableStreamDefaultController<Uint8Array>;
+  gateway = () =>
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          upstream = controller;
+          const data = JSON.stringify(chunk, null, 2).replaceAll('\n', '\ndata: ');
+          controller.enqueue(new TextEncoder().encode(`data: ${data}\n\n`));
+        },
+      }),
+      { headers: outputHeaders }
+    );
+  const replies: Response[] = [];
+  const provider = createOpenAICompatible({
+    name: 'harness',
+    baseURL: 'https://fixed.example',
+    fetch: async (_url, init) => {
+      const body: unknown = JSON.parse(String(init?.body));
+      const response = await invoke(body, capability(body, { ...authority, organizationId }));
+      replies.push(response.clone());
+      return response;
+    },
+  });
+  const result = streamText({
+    model: provider(model),
+    messages: completion.messages,
+    maxOutputTokens: 128,
+    maxRetries: 0,
+  });
+  const reader = result.textStream.getReader();
+  expect((await reader.read()).value).toBe('Hello');
+  upstream.enqueue(new TextEncoder().encode('data: [DONE]\n\n'));
+  upstream.close();
+  expect((await reader.read()).done).toBe(true);
+  expect((await result.response).id).toBe('generation-1');
+  expect(await result.usage).toMatchObject({ inputTokens: 3, outputTokens: 2 });
+  const output = await replies[0].text();
+  expect(output).toContain(JSON.stringify(chunk));
+  expect(replies[0].headers.get('authorization')).toBeNull();
+  expect(replies[0].headers.get('request-id')).toBe('request-1');
+  expect(requests).toHaveLength(1);
+  expect(requests[0].url).toBe('https://app.example/api/openrouter/chat/completions');
+  expect(requests[0].redirect).toBe('error');
+  expect(await requests[0].json()).toMatchObject({ model, max_tokens: 128, stream: true });
+  expect(requests[0].headers.get('x-kilocode-organizationid')).toBe(organizationId);
+  expect(requests[0].headers.get('x-kilocode-feature')).toBe('quick-chat');
+  expect(requests[0].headers.get('x-kilo-request')).toBe(operationId);
+  expect(requests[0].headers.get('x-kilocode-taskid')).toBe(runId);
+  expect(requests[0].headers.get('x-kilo-session')).toBe(conversationId);
+  expect(requests[0].headers.get('x-internal-api-key')).toBeNull();
+  const token = requests[0].headers.get('authorization')!.slice(7);
+  expect(jwt.verify(token, 'test-signing-key')).toEqual({
+    env: 'test',
+    version: 3,
+    tokenSource: 'agent-harness',
+    kiloUserId: 'oauth/owner',
+    apiTokenPepper: 'current-pepper',
+    iat: Math.floor(originalTime / 1000),
+    exp: Math.floor(originalTime / 1000) + 300,
+  });
+  expect(output).not.toContain(token);
+  expect(JSON.stringify(await result.response)).not.toContain(token);
+});
+it.each([
+  'service',
+  'wrong service',
+  'signature',
+  'capability expiry',
+  'grant expiry',
+  'role',
+  'retirement',
+  'input',
+  'context',
+  'run',
+])('blocks %s before inference', async reason => {
+  let token = capability(completion);
+  if (reason === 'capability expiry') jest.mocked(Date.now).mockReturnValue(originalTime + 60000);
+  if (reason === 'grant expiry') access.expires = new Date(originalTime).toISOString();
+  if (reason === 'role') access.role = false;
+  if (reason === 'retirement') access.active = false;
+  if (reason === 'signature') token = 'ordinary-client-token';
+  if (reason === 'context')
+    token = capability(completion, { ...authority, organizationId: operationId });
+  const headers: Record<string, string> = {};
+  if (reason.includes('service'))
+    headers['x-internal-api-key'] = reason === 'service' ? '' : 'wrong';
+  if (reason === 'run') headers['x-agent-harness-run-id'] = operationId;
+  const body = reason === 'input' ? { ...completion, model: 'forged/model' } : completion;
+  const response = await invoke(body, token, { headers });
+  expect(response.status).toBe(
+    reason.includes('service') || reason === 'capability header' ? 401 : 403
+  );
+  expect(await response.json()).toMatchObject({
+    error: { type: 'access_revoked', retryable: false },
+  });
+  expect(response.headers.get('cache-control')).toBe('no-store');
+  expect(requests).toEqual([]);
+});
+it.each([
+  { model: '' },
+  { messages: [] },
+  { stream: false },
+  { max_tokens: 8193 },
+  { max_completion_tokens: 99999 },
+  { n: 2 },
+  { tools: [{ type: 'web_search' }] },
+  { plugins: [{ id: 'web' }] },
+])('rejects invalid inference input %j', async patch => {
+  const body = { ...completion, ...patch };
+  expect((await invoke(body, capability(body))).status).toBe(400);
+  expect(requests).toEqual([]);
+});
+it('rejects invalid upstream UTF-8 without a retryable transport error', async () => {
+  gateway = () => new Response(new Uint8Array([0xc3, 0x28]), { headers: outputHeaders });
+  const text = await (await invoke()).text();
+  expect(text).toContain('"code":422');
+  expect(text).toContain('"retryable":false');
+});
+it('sanitizes retryable transport failures', async () => {
+  gateway = () => {
+    throw new TypeError('transport-secret');
+  };
+  const response = await invoke();
+  expect(response.status).toBe(503);
+  const text = await response.text();
+  expect(text).toContain('"retryable":true');
+  expect(text).not.toContain('transport-secret');
+});
+it.each(['data: [DONE]\n\n'])('preserves empty output %j', async data => {
+  gateway = () => sse(data);
+  const response = await invoke();
+  expect(response.status).toBe(200);
+  expect(await response.text()).toBe(data);
+});
+it.each([[1, new Uint8Array([0xc3, 0x28])]] as const)(
+  'rejects malformed JSON and UTF-8 requests (case %s)',
+  async (_case, body) => {
+    const response = await invoke(completion, capability(completion), { body });
+    expect(response.status).toBe(400);
+    const text = await response.text();
+    expect(text).toContain('"retryable":false');
+    expect(text).not.toContain('private-malformed');
+    expect(requests).toEqual([]);
+  }
+);
+it.each([
+  ['request', 499],
+  ['reader', null],
+] as const)('cancels inference through the %s', async (target, code) => {
+  expect(
+    (await invoke(completion, capability(completion), { signal: AbortSignal.abort('private') }))
+      .status
+  ).toBe(499);
+  expect(requests).toEqual([]);
+  const cancelled = Promise.withResolvers<void>();
+  gateway = () =>
+    new Response(new ReadableStream({ cancel: () => cancelled.resolve() }), {
+      headers: outputHeaders,
+    });
+  const abort = new AbortController();
+  const response = await invoke(completion, capability(completion), {
+    signal: target === 'request' ? abort.signal : undefined,
+  });
+  if (target === 'reader') await response.body!.cancel();
+  else {
+    const output = response.text();
+    abort.abort(new Error('private'));
+    const text = await output;
+    expect(text).toContain(`"code":${code}`);
+    expect(text).not.toMatch(/private|\[DONE\]/);
+  }
+  await cancelled.promise;
+  expect(requests[0].signal.aborted).toBe(true);
+});

--- a/apps/web/src/lib/agent-harness/model-gateway.ts
+++ b/apps/web/src/lib/agent-harness/model-gateway.ts
@@ -1,0 +1,131 @@
+import 'server-only';
+import { z } from 'zod';
+import { timingSafeEqual } from '@kilocode/encryption';
+import { TRPCError } from '@trpc/server';
+import { getHTTPStatusCodeFromError } from '@trpc/server/http';
+import { boundedBody, mediaType, streamHarnessModel } from './model-stream';
+import { INTERNAL_API_SECRET } from '@/lib/config.server';
+import { APP_URL, ORGANIZATION_ID_HEADER } from '@/lib/constants';
+import { FEATURE_HEADER } from '@/lib/feature-detection';
+import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
+import { authorizeHarnessCapability, harnessInputDigest } from './authorization';
+import { Id, messages } from './operation-contract';
+
+// Keep the SDK's chat-completions wire data; validate only the inference boundary here.
+const Input = z.strictObject({
+  conversationId: Id,
+  runId: Id,
+  operationId: Id,
+  completion: z.looseObject({
+    model: z.string().trim().min(1),
+    messages: z.array(z.json()).min(1),
+    stream: z.literal(true),
+    max_tokens: z.int().positive().max(8192),
+    max_completion_tokens: z.never().optional(),
+    n: z.literal(1).optional(),
+    tools: z.array(z.looseObject({ type: z.literal('function') })).optional(),
+    plugins: z.never().optional(),
+  }),
+});
+export function harnessModelScope(raw: unknown) {
+  const input = Input.parse(raw);
+  return {
+    audience: 'agent-harness:model',
+    conversationId: input.conversationId,
+    operation: 'model',
+    definitionVersion: '1',
+    inputDigest: harnessInputDigest(input),
+    dispatchId: input.operationId,
+    target: { kind: 'backend' as const },
+  };
+}
+function failure(status: number) {
+  const type =
+    status === 401 || status === 403
+      ? 'access_revoked'
+      : status === 402 || status === 413
+        ? 'limit_exceeded'
+        : status === 499
+          ? 'cancelled'
+          : status === 422
+            ? 'invalid_output'
+            : status === 408 || status === 429 || status >= 500
+              ? 'storage_unavailable'
+              : 'invalid_input';
+  return {
+    error: {
+      code: status,
+      type,
+      message: messages[type],
+      retryable: type === 'storage_unavailable',
+    },
+  };
+}
+
+export async function proxyHarnessModel(request: Request) {
+  const headers = new Headers({ 'cache-control': 'no-store', 'content-type': 'application/json' });
+  const reply = (status: number) => Response.json(failure(status), { status, headers });
+  const service = request.headers.get('x-internal-api-key');
+  const token = request.headers.get('authorization')?.match(/^Bearer ([^\s]+)$/)?.[1];
+  if (!INTERNAL_API_SECRET || !service || !timingSafeEqual(service, INTERNAL_API_SECRET) || !token)
+    return reply(401);
+  const abort = new AbortController();
+  const signal = AbortSignal.any([request.signal, abort.signal, AbortSignal.timeout(90_000)]);
+  const errorStatus = (error: unknown, invalid: number) => {
+    if (request.signal.aborted) return 499;
+    if (error instanceof TRPCError)
+      return error.code === 'UNAUTHORIZED' ? 403 : getHTTPStatusCodeFromError(error);
+    // Native decoding errors retain their code across JavaScript realms.
+    if (
+      error instanceof z.ZodError ||
+      error instanceof SyntaxError ||
+      (typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        error.code === 'ERR_ENCODING_INVALID_ENCODED_DATA')
+    )
+      return invalid;
+    // Other request-body TypeErrors reject input; upstream transport errors remain retryable.
+    return invalid === 400 && error instanceof TypeError ? 400 : 503;
+  };
+  let input: z.infer<typeof Input>;
+  try {
+    if (mediaType(request.headers) !== 'application/json' || !request.body) return reply(400);
+    const bytes = await new Response(boundedBody(request.body, signal)).arrayBuffer();
+    input = Input.parse({
+      conversationId: request.headers.get('x-agent-harness-conversation-id'),
+      runId: request.headers.get('x-agent-harness-run-id'),
+      operationId: request.headers.get('x-agent-harness-operation-id'),
+      completion: JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)),
+    });
+  } catch (error) {
+    return reply(errorStatus(error, 400));
+  }
+  try {
+    const { authority, ctx } = await authorizeHarnessCapability(token, harnessModelScope(input));
+    signal.throwIfAborted();
+    const upstreamHeaders = new Headers({
+      authorization: `Bearer ${generateApiToken(ctx.user, { tokenSource: 'agent-harness' }, { expiresIn: TOKEN_EXPIRY.fiveMinutes })}`,
+      'content-type': 'application/json',
+      accept: 'text/event-stream',
+      [FEATURE_HEADER]: 'quick-chat',
+      'x-kilo-request': input.operationId,
+      'x-kilocode-taskid': input.runId,
+      'x-kilo-session': input.conversationId,
+    });
+    if (authority.organizationId)
+      upstreamHeaders.set(ORGANIZATION_ID_HEADER, authority.organizationId);
+    // The billed gateway owns availability, organization policy, BYOK/free exceptions, and charges.
+    const response = await fetch(`${APP_URL}/api/openrouter/chat/completions`, {
+      method: 'POST',
+      headers: upstreamHeaders,
+      body: JSON.stringify(input.completion),
+      signal,
+      redirect: 'error',
+    });
+    return await streamHarnessModel(response, headers, { signal, abort, failure, errorStatus });
+  } catch (error) {
+    abort.abort();
+    return reply(errorStatus(error, 422));
+  }
+}


### PR DESCRIPTION
The current Quick Chat experience stays unchanged. This adds a protected model endpoint for the shared harness.

---

## Summary

The new `POST /api/internal/agent-harness/model` route requires service authentication and `agent-harness:model` capabilities; `Input` and `harnessModelScope` bind requests to current primary authority.
`proxyHarnessModel` mints five-minute user tokens for the existing billed gateway, retaining policy checks, organization billing, and Quick Chat attribution.
Bounded streaming preserves progressive output, identifiers, cancellation, empty output, and sanitized failures; `maxDuration` permits 100 seconds around the 90-second request deadline.

<details>
<summary>Files</summary>

- `apps/web/src/lib/agent-harness/model-gateway.ts` — adds the server-only proxy and capability scope. Checks existing `INTERNAL_API_SECRET` with a timing-safe comparison and requires a Bearer capability; ordinary client tokens cannot authorize inference. Reads `x-agent-harness-conversation-id`, `x-agent-harness-run-id`, and `x-agent-harness-operation-id`. Validates bounded JavaScript Object Notation (JSON) bodies with strict 8-bit Unicode Transformation Format (UTF-8) decoding. Requires a nonempty trimmed model, messages, `stream: true`, and `max_tokens` between 1 and 8192. Allows optional `n: 1` and function tools; rejects `max_completion_tokens` and `plugins` while retaining other completion fields. The scope includes the input digest, dispatch identity, model audience, definition version `1`, and backend target. Delegates current grant, conversation, user, and membership checks to the existing authorizer. Creates a token with `tokenSource: 'agent-harness'` and posts the completion to `/api/openrouter/chat/completions` under existing `APP_URL`, with redirects disabled. The billed gateway retains eligibility, balance checks, free-model exceptions, bring-your-own-key exceptions, and charges. Uses the authorized organization instead of incoming attribution, sets `FEATURE_HEADER` to `quick-chat`, and maps identifiers to `x-kilo-request`, `x-kilocode-taskid`, and `x-kilo-session`. Composes `boundedBody` and `streamHarnessModel` with request cancellation, reader cancellation, the deadline, and `no-store` responses. Keeps server credentials out of returned headers, output, checkpoints, and logs. Shared messages classify access, limits, cancellation, invalid input/output, and availability failures. Invalid request UTF-8 returns 400; invalid upstream UTF-8 produces 422; transport failures return retryable 503. Marks only `storage_unavailable` errors as retryable.
- `apps/web/src/app/api/internal/agent-harness/model/route.ts` — adds the `POST` export through `proxyHarnessModel` and sets `maxDuration` to 100 seconds. Existing routes and stored formats remain unchanged.

</details>

Tests: 1 file added — `apps/web/src/lib/agent-harness/model-gateway.test.ts` (+268/−0 lines), with 27 focused cases. Covers authorization, inference validation, billing attribution, progressive output, both UTF-8 boundaries, sanitized transport errors, cancellation, and terminal-only empty output.
Generated: 0 files changed.

---

## Verification

Manual and end-to-end (E2E) verification did not run because Worker composition and the completed runtime stack remain pending.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Recorded checks and scope

- The supplied isolation evidence records 27 passing focused Jest cases and passing scoped formatting, lint, import, whitespace, and preservation checks.
- The recorded lint check reports zero warnings and errors.
- The mocked tests prove delegation and attribution, not real ledger writes or live provider behavior.
- This description round did not rerun product checks. No current-head continuous integration (CI) pass or final section acceptance exists.
- The additional 34 security cases belong to level 37 and are absent from this pull request.
- Worker composition remains a22; live proof remains a32 and the final tip E2E loop.

### Human steps

No action is required before merge or after merge for this level.

- **After merge, for full-stack deployment only:** supply scoped Worker and web configuration.

### Notes

- Runtime verification remains pending on the completed stack; this server-only level has no visual changes.
- Font-scaling variants, including large text and dynamic type: owner-descoped.
- Light, dark, and other theme variants, including variant-only geometry: owner-descoped.
- Visual contrast, scaled-text layout, and screen-reader presentation checks: owner-descoped.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `shared-agent-harness-3bb0` — #5632
2. `shared-agent-harness-3bb0-s2` — #5637
3. `shared-agent-harness-3bb0-s3` — #5639
4. `shared-agent-harness-3bb0-s4` — #5643
5. `shared-agent-harness-3bb0-s5` — #5647
6. `shared-agent-harness-3bb0-s6` — #5655
7. `shared-agent-harness-3bb0-s7` — #5659
8. `shared-agent-harness-3bb0-s8` — #5662
9. `shared-agent-harness-3bb0-s9` — #5667
10. `shared-agent-harness-3bb0-s10` — #5675
11. `shared-agent-harness-3bb0-s11` — #5678
12. `shared-agent-harness-3bb0-s12` — #5688
13. `shared-agent-harness-3bb0-s13` — #5693
14. `shared-agent-harness-3bb0-s14` — #5697
15. `shared-agent-harness-3bb0-s15` — #5701
16. `shared-agent-harness-3bb0-s16` — #5704
17. `shared-agent-harness-3bb0-s17` — #5710
18. `shared-agent-harness-3bb0-s18` — #5714
19. `shared-agent-harness-3bb0-s19` — #5718
20. `shared-agent-harness-3bb0-s20` — #5724
21. `shared-agent-harness-3bb0-s21` — #5726
22. `shared-agent-harness-3bb0-s22` — #5731
23. `shared-agent-harness-3bb0-s23` — #5733
24. `shared-agent-harness-3bb0-s24` — #5737
25. `shared-agent-harness-3bb0-s25` — #5740
26. `shared-agent-harness-3bb0-s26` — #5743
27. `shared-agent-harness-3bb0-s27` — #5746
28. `shared-agent-harness-3bb0-s28` — #5747
29. `shared-agent-harness-3bb0-s29` — #5749
30. `shared-agent-harness-3bb0-s30` — #5753
31. `shared-agent-harness-3bb0-s31` — #5754
32. `shared-agent-harness-3bb0-s32` — #5755
33. `shared-agent-harness-3bb0-s33` — #5757
34. `shared-agent-harness-3bb0-s34` — #5758
35. `shared-agent-harness-3bb0-s35` — #5767
36. `shared-agent-harness-3bb0-s36` — #5776 ← this PR
37. `shared-agent-harness-3bb0-s37` — #5777 (tip)
