### PR TITLE
test(agent-harness): cover model gateway security boundaries

### DIFF
--- a/apps/web/src/lib/agent-harness/model-gateway-security.test.ts
+++ b/apps/web/src/lib/agent-harness/model-gateway-security.test.ts
@@ -1,0 +1,279 @@
+import { beforeEach, expect, it, jest } from '@jest/globals';
+import jwt from 'jsonwebtoken';
+import * as fixtures from './operation-test-fixture';
+import { harnessInputDigest } from './authorization';
+import type * as Gateway from './model-gateway';
+import type * as Route from '@/app/api/internal/agent-harness/model/route';
+
+const { authority, conversationId, operationId, originalTime, primary, runId } = fixtures;
+jest.mock('@/lib/constants', () => ({
+  APP_URL: 'https://app.example',
+  ORGANIZATION_ID_HEADER: 'x-kilocode-organizationid',
+}));
+jest.mock('@/lib/utils.server', () => ({ warnExceptInTest: jest.fn() }));
+const { harnessModelScope } = jest.requireActual<typeof Gateway>('./model-gateway');
+const { POST } = jest.requireActual<typeof Route>('@/app/api/internal/agent-harness/model/route');
+const completion = {
+  model: 'paid/model',
+  messages: [{ role: 'user' as const, content: 'Hello' }],
+  stream: true,
+  max_tokens: 128,
+};
+const chunk = {
+  id: 'generation-1',
+  model: completion.model,
+  created: 1,
+  choices: [{ index: 0, delta: { content: 'Hello' }, finish_reason: 'stop' }],
+  usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5, cost: 0.002 },
+};
+const outputHeaders = {
+  'content-type': 'text/event-stream',
+  'request-id': 'request-1',
+  authorization: 'upstream-secret',
+};
+const sse = (data = `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`) =>
+  new Response(data, { headers: outputHeaders });
+const requests: Request[] = [];
+let gateway: () => Response;
+function capability(
+  body: unknown,
+  context: unknown = authority,
+  scopePatch: Record<string, unknown> = {}
+) {
+  const input = { conversationId, operationId, runId, completion: body };
+  const scope = {
+    ...harnessModelScope({ ...input, completion }),
+    inputDigest: harnessInputDigest(input),
+    ...scopePatch,
+  };
+  return jwt.sign({ grantId: runId, authority: context, scope }, 'test-signing-key', {
+    issuer: 'agent-harness',
+    audience: scope.audience,
+    expiresIn: 60,
+  });
+}
+function invoke(
+  body: unknown = completion,
+  token = capability(completion),
+  init: RequestInit = {}
+) {
+  const request = new Request('https://app.example/api/internal/agent-harness/model', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    ...init,
+    headers: {
+      'content-type': 'application/json',
+      'x-internal-api-key': 'test-service-key',
+      authorization: `Bearer ${token}`,
+      'x-agent-harness-conversation-id': conversationId,
+      'x-agent-harness-operation-id': operationId,
+      'x-agent-harness-run-id': runId,
+      'x-kilocode-organizationid': 'forged-org',
+      'x-kilocode-feature': 'forged-feature',
+      ...init.headers,
+    },
+  });
+  return POST(request);
+}
+beforeEach(() => {
+  requests.length = 0;
+  gateway = () => sse();
+  const user = { id: authority.userId, blocked_reason: null, api_token_pepper: 'current-pepper' };
+  jest.spyOn(primary.query.kilocode_users, 'findFirst').mockResolvedValue(user);
+  jest.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+    requests.push(new Request(url, init));
+    return gateway();
+  });
+});
+
+it.each([
+  'capability header',
+  'grant revocation',
+  'generation',
+  'blocked user',
+  'messages',
+  'conversation',
+  'operation',
+])('blocks %s before inference', async reason => {
+  const token = capability(completion);
+  if (reason === 'grant revocation') {
+    const grants = primary.query.agent_harness_conversation_grants;
+    jest.spyOn(grants, 'findFirst').mockResolvedValue({
+      ...(await grants.findFirst()),
+      revoked_at: new Date(originalTime).toISOString(),
+    } as any);
+  }
+  if (reason === 'generation') {
+    const registry = primary.query.agent_harness_conversation_registry;
+    jest
+      .spyOn(registry, 'findFirst')
+      .mockResolvedValue({ ...(await registry.findFirst()), generation: 1 });
+  }
+  if (reason === 'blocked user')
+    jest.spyOn(primary.query.kilocode_users, 'findFirst').mockResolvedValue({
+      id: authority.userId,
+      blocked_reason: 'private-block-details',
+    } as any);
+  const headers: Record<string, string> = {};
+  if (reason === 'capability header') headers.authorization = '';
+  if (reason === 'conversation') headers['x-agent-harness-conversation-id'] = operationId;
+  if (reason === 'operation') headers['x-agent-harness-operation-id'] = runId;
+  const body =
+    reason === 'messages'
+      ? { ...completion, messages: [{ role: 'user', content: 'Forged' }] }
+      : completion;
+  const response = await invoke(body, token, { headers });
+  expect(response.status).toBe(
+    reason.includes('service') || reason === 'capability header' ? 401 : 403
+  );
+  expect(await response.json()).toMatchObject({
+    error: { type: 'access_revoked', retryable: false },
+  });
+  expect(response.headers.get('cache-control')).toBe('no-store');
+  expect(requests).toEqual([]);
+});
+it.each([
+  { audience: 'agent-harness:operations' },
+  { operation: 'read' },
+  { definitionVersion: '2' },
+  { dispatchId: runId },
+  { inputDigest: '0'.repeat(64) },
+  { target: { kind: 'client', clientId: operationId } },
+])('rejects a capability for a different scope %j', async scope => {
+  const response = await invoke(completion, capability(completion, authority, scope));
+  expect(response.status).toBe(403);
+  expect(await response.json()).toMatchObject({
+    error: { type: 'access_revoked', retryable: false },
+  });
+  expect(requests).toEqual([]);
+});
+it.each([{ model: ' ' }, { model: null }, { max_tokens: 0 }, { max_tokens: 1.5 }])(
+  'rejects invalid inference input %j',
+  async patch => {
+    const body = { ...completion, ...patch };
+    expect((await invoke(body, capability(body))).status).toBe(400);
+    expect(requests).toEqual([]);
+  }
+);
+it.each([
+  [400, 'invalid_input', false],
+  [401, 'access_revoked', false],
+  [402, 'limit_exceeded', false],
+  [403, 'access_revoked', false],
+  [404, 'invalid_input', false],
+  [408, 'storage_unavailable', true],
+  [429, 'storage_unavailable', true],
+  [503, 'storage_unavailable', true],
+] as const)('preserves HTTP and stream error %s', async (code, type, retryable) => {
+  for (const streaming of [false, true]) {
+    const error = JSON.stringify({
+      error: { code, message: 'upstream-secret', metadata: { authorization: 'credential' } },
+    });
+    gateway = () =>
+      streaming ? sse(`data: ${error}\n\ndata: [DONE]\n\n`) : new Response(error, { status: code });
+    const response = await invoke();
+    const text = await response.text();
+    expect(response.status).toBe(streaming ? 200 : code);
+    expect(text).toContain(`"code":${code}`);
+    expect(text).toContain(`"type":"${type}"`);
+    expect(text).toContain(`"retryable":${retryable}`);
+    expect(text).not.toMatch(/upstream-secret|credential|\[DONE\]/);
+  }
+  expect(requests).toHaveLength(2);
+});
+it.each([
+  [0, 'data: private-malformed\n\n', 422],
+  [1, 'data: {"choices":[{"delta":{"content":["private-malformed"]}}]}\n\n', 422],
+  [2, `data: ${'x'.repeat(1024 * 1024)}\n\n`, 413],
+] as const)('rejects malformed or oversized streams (case %s)', async (_case, data, code) => {
+  gateway = () => sse(data);
+  const text = await (await invoke()).text();
+  expect(text).toContain(`"code":${code}`);
+  expect(text).not.toContain('private-malformed');
+});
+it('rejects wrong upstream media without forwarding its body', async () => {
+  gateway = () =>
+    new Response('<html>private</html>', { headers: { 'content-type': 'text/html' } });
+  const response = await invoke();
+  expect(response.status).toBe(422);
+  const text = await response.text();
+  expect(text).toContain('"retryable":false');
+  expect(text).not.toContain('private');
+});
+it.each([''])('preserves empty output %j', async data => {
+  gateway = () => sse(data);
+  const response = await invoke();
+  expect(response.status).toBe(200);
+  expect(await response.text()).toBe(data);
+});
+it('sanitizes a failed upstream read after progressive output', async () => {
+  const logs = (['log', 'info', 'debug', 'warn', 'error'] as const).map(method =>
+    jest.spyOn(console, method).mockImplementation(() => undefined)
+  );
+  let upstream!: ReadableStreamDefaultController<Uint8Array>;
+  gateway = () =>
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          upstream = controller;
+          controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+        },
+      }),
+      { headers: outputHeaders }
+    );
+  const response = await invoke();
+  const reader = response.body!.getReader();
+  expect(new TextDecoder().decode((await reader.read()).value)).toContain('"content":"Hello"');
+  const token = requests[0].headers.get('authorization')!;
+  upstream.error(new TypeError(`private-read-error ${token}`));
+  const text = new TextDecoder().decode((await reader.read()).value);
+  expect(text).toContain('"code":503');
+  expect(text).toContain('"retryable":true');
+  expect(text).not.toContain(token);
+  expect(text).not.toMatch(/private-read-error|\[DONE\]/);
+  expect((await reader.read()).done).toBe(true);
+  expect(requests[0].signal.aborted).toBe(true);
+  expect(JSON.stringify(logs.flatMap(log => log.mock.calls))).not.toContain(token);
+});
+it('rejects oversized request bytes and empty bodies', async () => {
+  expect(
+    (await invoke(completion, capability(completion), { body: '界'.repeat(350000) })).status
+  ).toBe(413);
+  expect((await invoke(completion, capability(completion), { body: null })).status).toBe(400);
+  expect(requests).toEqual([]);
+});
+it.each([[0, 'private-malformed']] as const)(
+  'rejects malformed JSON and UTF-8 requests (case %s)',
+  async (_case, body) => {
+    const response = await invoke(completion, capability(completion), { body });
+    expect(response.status).toBe(400);
+    const text = await response.text();
+    expect(text).toContain('"retryable":false');
+    expect(text).not.toContain('private-malformed');
+    expect(requests).toEqual([]);
+  }
+);
+it.each([['deadline', 503]] as const)('cancels inference through the %s', async (target, code) => {
+  expect(
+    (await invoke(completion, capability(completion), { signal: AbortSignal.abort('private') }))
+      .status
+  ).toBe(499);
+  expect(requests).toEqual([]);
+  const cancelled = Promise.withResolvers<void>();
+  gateway = () =>
+    new Response(new ReadableStream({ cancel: () => cancelled.resolve() }), {
+      headers: outputHeaders,
+    });
+  const abort = new AbortController();
+  if (target === 'deadline') jest.spyOn(AbortSignal, 'timeout').mockReturnValue(abort.signal);
+  const response = await invoke(completion, capability(completion), {
+    signal: undefined,
+  });
+  const output = response.text();
+  abort.abort(new Error('private'));
+  const text = await output;
+  expect(text).toContain(`"code":${code}`);
+  expect(text).not.toMatch(/private|\[DONE\]/);
+  await cancelled.promise;
+  expect(requests[0].signal.aborted).toBe(true);
+});


### PR DESCRIPTION
No new behavior — this change adds tests only.

---

## Summary

The new security suite adds 34 cases for existing authorization, request validation, stream limits, error redaction, and cancellation; production behavior and deployed contracts remain unchanged.
It reuses the existing operation fixture and private helpers to test the composed `POST` gateway against mocked storage and upstream transport.
These checks establish delegation and error boundaries, not live provider calls or ledger writes.

<details>
<summary>Files</summary>

- `apps/web/src/lib/agent-harness/model-gateway-security.test.ts` — adds the isolated security cases. Checks missing capabilities, revoked grants, stale generations, blocked users, modified messages, mismatched identifiers, and mismatched audience, operation, version, dispatch, digest, or target scopes. Rejections stop before inference with non-retryable `access_revoked` errors; the authorization group also checks `no-store`. Rejects blank/null models, zero/fractional `max_tokens`, malformed JavaScript Object Notation (JSON), and empty requests with 400, and oversized multibyte requests with 413. These validation failures prevent upstream requests; malformed request errors remain non-retryable and omit private text. Rejects malformed stream data, invalid content shapes, and wrong upstream media with 422 without forwarding private data. Oversized frames produce 413, and empty streams retain 200 with an empty body. Covers Hypertext Transfer Protocol (HTTP) and stream errors: 400/404 map to `invalid_input`, 401/403 to `access_revoked`, 402 to `limit_exceeded`, and 408/429/503 to retryable `storage_unavailable`. HTTP failures retain their status; stream errors retain status 200, and both omit secrets and `[DONE]`. A failed read after progressive output emits retryable 503, closes the stream, aborts upstream work, and excludes tokens from responses and console logs. Already-aborted requests return 499 without inference; deadlines emit sanitized 503, abort the upstream request, and cancel its stream.

</details>

Tests: 1 test file added, `model-gateway-security.test.ts` (+279/−0 lines), with 34 focused cases.
Generated: 0 files changed.

---

## Verification

No manual verification is reported for this test-only level; it changes no runtime or visual behavior.
Full-stack end-to-end (E2E) verification remains pending.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Recorded checks and scope

- The supplied review records 34 passing focused cases and 61 passing cases across both gateway suites.
- Scoped format, lint, import-boundary, and whitespace checks passed. The added file matches the reviewed preservation hash.
- The suites test the composed gateway with mocks; they establish delegation and error boundaries, not live provider calls or ledger writes.
- This description round did not rerun product checks. No current-head continuous integration (CI) pass or final section acceptance is claimed.
- Worker composition remains a22; live proof remains a32 and the final tip E2E loop.

### Human steps

No human action is required before merge or after merge for this test-only level.

### Notes

- This test-only level has no runtime or visual changes; full-stack E2E remains pending.
- Font-scaling variants, including large text and dynamic type: owner-descoped.
- Light, dark, and other theme variants, including variant-only geometry: owner-descoped.
- Visual contrast, scaled-text layout, and screen-reader presentation checks: owner-descoped.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `shared-agent-harness-3bb0` — #5632
2. `shared-agent-harness-3bb0-s2` — #5637
3. `shared-agent-harness-3bb0-s3` — #5639
4. `shared-agent-harness-3bb0-s4` — #5643
5. `shared-agent-harness-3bb0-s5` — #5647
6. `shared-agent-harness-3bb0-s6` — #5655
7. `shared-agent-harness-3bb0-s7` — #5659
8. `shared-agent-harness-3bb0-s8` — #5662
9. `shared-agent-harness-3bb0-s9` — #5667
10. `shared-agent-harness-3bb0-s10` — #5675
11. `shared-agent-harness-3bb0-s11` — #5678
12. `shared-agent-harness-3bb0-s12` — #5688
13. `shared-agent-harness-3bb0-s13` — #5693
14. `shared-agent-harness-3bb0-s14` — #5697
15. `shared-agent-harness-3bb0-s15` — #5701
16. `shared-agent-harness-3bb0-s16` — #5704
17. `shared-agent-harness-3bb0-s17` — #5710
18. `shared-agent-harness-3bb0-s18` — #5714
19. `shared-agent-harness-3bb0-s19` — #5718
20. `shared-agent-harness-3bb0-s20` — #5724
21. `shared-agent-harness-3bb0-s21` — #5726
22. `shared-agent-harness-3bb0-s22` — #5731
23. `shared-agent-harness-3bb0-s23` — #5733
24. `shared-agent-harness-3bb0-s24` — #5737
25. `shared-agent-harness-3bb0-s25` — #5740
26. `shared-agent-harness-3bb0-s26` — #5743
27. `shared-agent-harness-3bb0-s27` — #5746
28. `shared-agent-harness-3bb0-s28` — #5747
29. `shared-agent-harness-3bb0-s29` — #5749
30. `shared-agent-harness-3bb0-s30` — #5753
31. `shared-agent-harness-3bb0-s31` — #5754
32. `shared-agent-harness-3bb0-s32` — #5755
33. `shared-agent-harness-3bb0-s33` — #5757
34. `shared-agent-harness-3bb0-s34` — #5758
35. `shared-agent-harness-3bb0-s35` — #5767
36. `shared-agent-harness-3bb0-s36` — #5776
37. `shared-agent-harness-3bb0-s37` — #5777 ← this PR (tip)
