### PR TITLE
chore(web): remove reduced-availability banner from usage page

### DIFF
--- a/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
+++ b/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
@@ -7,7 +7,6 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { UsageTableBase, type UsageTableColumn } from '@/components/usage/UsageTableBase';
-import { UsageAvailabilityBanner } from '@/components/usage/UsageAvailabilityBanner';
 import { UsageWarning } from '@/components/usage/UsageWarning';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import {
@@ -792,8 +791,6 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
 
         <div className="flex-1 overflow-y-auto">
           <div className="m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
-            {!isSalesDemo && <UsageAvailabilityBanner />}
-
             {hasEnterpriseUsageViews && (
               <div className="space-y-4">
                 <div>


### PR DESCRIPTION
## Summary

Removes the "Usage currently has reduced availability. Check the status page for
updates." warning banner from the usage page. The banner was tied to a past
status-page incident and is no longer wanted on the dashboard.

- Deleted the `<UsageAvailabilityBanner />` render (and its import) from
  `UsageAnalyticsDashboard.tsx`; no other code paths referenced the banner.
- Kept the `UsageAvailabilityBanner` component file in place so the banner can
  be re-enabled with a one-line change if a similar incident recurs.

## Verification

- No manual verification was performed in this session: the change is a render
  removal in one file, and the sandboxed environment could not run the web app
  or a browser to exercise the usage page.
- [ ] Verify the usage page renders normally (no banner, no layout gap) in a
      preview deployment.

## Visual Changes

| Before | After |
|---|---|
| Usage page shows warning banner: "Usage currently has reduced availability. Check the status page for updates." | Banner no longer rendered; page content starts directly with the Usage heading |

## Reviewer Notes

- Small, mechanical diff: one file, 3 deleted lines, no logic changes.
- `isSalesDemo` remains used elsewhere in the dashboard, so no unused-variable
  fallout from removing its use in the banner condition.
- Re-enabling later is trivial: restore the component import and the
  `{!isSalesDemo && <UsageAvailabilityBanner />}` line.