### PR TITLE
fix(code-reviews): restore live review transcripts

### DIFF
--- a/apps/web/src/app/(app)/code-reviews/[reviewId]/CodeReviewDetailClient.tsx
+++ b/apps/web/src/app/(app)/code-reviews/[reviewId]/CodeReviewDetailClient.tsx
@@ -16,6 +16,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNow, format } from 'date-fns';
 import { TRPCClientError } from '@trpc/client';
 import { toast } from 'sonner';
+import { useCallback } from 'react';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import {
@@ -33,6 +34,11 @@ type CodeReviewDetailClientProps = {
 export function CodeReviewDetailClient({ reviewId }: CodeReviewDetailClientProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const handleComplete = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: trpc.codeReviews.get.queryKey({ reviewId }),
+    });
+  }, [queryClient, reviewId, trpc]);
 
   const { data, isLoading, error } = useQuery({
     ...trpc.codeReviews.get.queryOptions({ reviewId }),
@@ -327,11 +333,7 @@ export function CodeReviewDetailClient({ reviewId }: CodeReviewDetailClientProps
         <CodeReviewStreamView
           reviewId={reviewId}
           attempts={data.attempts}
-          onComplete={() => {
-            void queryClient.invalidateQueries({
-              queryKey: trpc.codeReviews.get.queryKey({ reviewId }),
-            });
-          }}
+          onComplete={handleComplete}
         />
       )}
     </PageContainer>

--- a/apps/web/src/components/code-reviews/CodeReviewStreamView.test.ts
+++ b/apps/web/src/components/code-reviews/CodeReviewStreamView.test.ts
@@ -1,0 +1,722 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { QueryClient, QueryClientProvider as ReactQueryProvider } from '@tanstack/react-query';
+import { TRPCClientError } from '@trpc/client';
+import type { inferRouterOutputs } from '@trpc/server';
+import { createRequire } from 'node:module';
+import React, { act, createElement, type ComponentProps, type ReactNode } from 'react';
+import type { createRoot as createReactRoot, Root } from 'react-dom/client';
+import type { CloudAgentEvent } from '@/lib/cloud-agent-next/event-types';
+import type {
+  ConnectionState,
+  createWebSocketManager,
+  WebSocketManagerConfig,
+} from '@/lib/cloud-agent-next/websocket-manager';
+import type * as Constants from '@/lib/constants';
+import type { RootRouter } from '@/routers/root-router';
+import type { CodeReviewStreamView as CodeReviewStreamViewComponent } from './CodeReviewStreamView';
+import type { fetchStreamTicket } from './fetch-stream-ticket';
+
+type ReviewInput = { reviewId: string; attemptId?: string };
+type ReviewOutputs = inferRouterOutputs<RootRouter>['codeReviews'];
+type StreamInfo = ReviewOutputs['getReviewStreamInfo'];
+type SessionMessages = ReviewOutputs['getSessionMessages'];
+type ViewProps = ComponentProps<typeof CodeReviewStreamViewComponent>;
+type Socket = {
+  config: WebSocketManagerConfig;
+  manager: ReturnType<typeof createWebSocketManager>;
+};
+
+const reviewId = '00000000-0000-4000-8000-000000000001';
+const organizationId = '00000000-0000-4000-8000-000000000002';
+const previousAttemptId = '00000000-0000-4000-8000-000000000003';
+const currentAttemptId = '00000000-0000-4000-8000-000000000004';
+const runtimeId = 'agent-current';
+const timestamp = '2026-08-29T00:00:00.000Z';
+const attempts: NonNullable<ViewProps['attempts']> = [
+  {
+    id: previousAttemptId,
+    attempt_number: 1,
+    retry_reason: null,
+    session_id: 'agent-previous',
+    cli_session_id: 'ses-previous',
+    status: 'completed',
+    error_message: null,
+    terminal_reason: null,
+  },
+  {
+    id: currentAttemptId,
+    attempt_number: 2,
+    retry_reason: 'manual_retry',
+    session_id: runtimeId,
+    cli_session_id: null,
+    status: 'running',
+    error_message: null,
+    terminal_reason: null,
+  },
+];
+
+const mockGetStreamInfo = jest.fn<(input: ReviewInput) => Promise<StreamInfo>>();
+const mockGetMessages = jest.fn<(input: ReviewInput) => Promise<SessionMessages>>();
+const mockFetchStreamTicket = jest.fn<typeof fetchStreamTicket>();
+const mockCreateWebSocketManager = jest.fn<typeof createWebSocketManager>();
+const mockOnComplete = jest.fn<() => void>();
+const mockSockets: Socket[] = [];
+let mockSearchParams = new URLSearchParams();
+const mockRouter = {
+  replace: jest.fn((url: string) => {
+    mockSearchParams = new URL(url, 'http://localhost/').searchParams;
+  }),
+};
+
+const mockTrpc = {
+  codeReviews: {
+    getReviewStreamInfo: {
+      queryOptions: (input: ReviewInput) => ({
+        queryKey: ['codeReviews', 'getReviewStreamInfo', input],
+        queryFn: () => mockGetStreamInfo(input),
+      }),
+    },
+    getSessionMessages: {
+      queryOptions: (input: ReviewInput) => ({
+        queryKey: ['codeReviews', 'getSessionMessages', input],
+        queryFn: () => mockGetMessages(input),
+      }),
+    },
+  },
+};
+
+jest.mock('@/lib/trpc/utils', () => ({ useTRPC: () => mockTrpc }));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => mockRouter,
+  usePathname: () => '/code-reviews/review',
+  useSearchParams: () => mockSearchParams,
+}));
+
+jest.mock('@/lib/cloud-agent-next/websocket-manager', () => ({
+  createWebSocketManager: (config: WebSocketManagerConfig) => mockCreateWebSocketManager(config),
+}));
+
+jest.mock('./fetch-stream-ticket', () => ({
+  fetchStreamTicket: (sessionId: string, organizationId?: string) =>
+    mockFetchStreamTicket(sessionId, organizationId),
+}));
+
+jest.mock('@/lib/constants', () => ({
+  ...jest.requireActual<typeof Constants>('@/lib/constants'),
+  CLOUD_AGENT_NEXT_WS_URL: 'http://localhost:8787',
+}));
+
+jest.mock('@/components/ui/select', () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    children: ReactNode;
+  }) =>
+    createElement(
+      'select',
+      {
+        'aria-label': 'Select session attempt',
+        value,
+        onChange: (event: React.ChangeEvent<HTMLSelectElement>) =>
+          onValueChange(event.currentTarget.value),
+      },
+      children
+    ),
+  SelectContent: ({ children }: { children: ReactNode }) => children,
+  SelectItem: ({ value, children }: { value: string; children: ReactNode }) =>
+    createElement('option', { value }, children),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+}));
+
+type LinkedomModule = {
+  parseHTML: (
+    html: string,
+    globals: Pick<typeof globalThis, 'setTimeout' | 'clearTimeout'> & { location: URL }
+  ) => { window: typeof globalThis; document: Document };
+};
+
+function installDom() {
+  const requireFromHere = createRequire(__filename);
+  const requireFromNext = createRequire(requireFromHere.resolve('next/package.json'));
+  const { window, document } = (requireFromNext('linkedom') as LinkedomModule).parseHTML(
+    '<!doctype html><html><body><div id="root"></div></body></html>',
+    { setTimeout, clearTimeout, location: new URL('http://localhost/') }
+  );
+  const container = document.getElementById('root');
+  if (!container) throw new Error('React root missing');
+  const globals = {
+    React,
+    window,
+    document,
+    HTMLElement: window.HTMLElement,
+    HTMLSelectElement: window.HTMLSelectElement,
+    Element: window.Element,
+    Node: window.Node,
+    Text: window.Text,
+    Comment: window.Comment,
+    DocumentFragment: window.DocumentFragment,
+    Document: window.Document,
+    SVGElement: window.SVGElement,
+    Event: window.Event,
+    CustomEvent: window.CustomEvent,
+    navigator: window.navigator,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  };
+  const previous = new Map(
+    Object.keys(globals).map(name => [name, Object.getOwnPropertyDescriptor(globalThis, name)])
+  );
+  for (const [name, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  }
+  return {
+    container,
+    cleanup: () => {
+      for (const [name, descriptor] of previous) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else Reflect.deleteProperty(globalThis, name);
+      }
+    },
+  };
+}
+
+function streamInfo(overrides: Partial<Extract<StreamInfo, { success: true }>> = {}): StreamInfo {
+  return {
+    success: true,
+    cloudAgentSessionId: runtimeId,
+    organizationId,
+    status: 'running',
+    agentVersion: 'v2',
+    ...overrides,
+  };
+}
+
+function transcript(...messages: string[]): SessionMessages {
+  return {
+    success: true,
+    entries: messages.map((message, index) => ({
+      key: `part-${index}`,
+      timestamp,
+      message,
+      eventType: 'text',
+    })),
+  };
+}
+
+let eventId = 0;
+
+function streamEvent(
+  streamEventType: string,
+  data: unknown = {},
+  executionId = 'exec-current'
+): CloudAgentEvent {
+  return {
+    eventId: ++eventId,
+    executionId,
+    sessionId: runtimeId,
+    streamEventType,
+    timestamp,
+    data,
+  };
+}
+
+function textPart(text: string): CloudAgentEvent {
+  return streamEvent('kilocode', {
+    type: 'message.part.updated',
+    properties: {
+      part: {
+        id: 'prt-current',
+        sessionID: 'ses-current',
+        messageID: 'msg-current',
+        type: 'text',
+        text,
+        time: { start: Date.parse(timestamp) },
+      },
+    },
+  });
+}
+
+async function advanceTime(milliseconds: number) {
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(milliseconds);
+  });
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(1);
+  });
+}
+
+async function settle(action: () => void) {
+  await act(async () => {
+    action();
+  });
+  await advanceTime(1);
+  await advanceTime(1);
+}
+
+describe('CodeReviewStreamView', () => {
+  let dom: ReturnType<typeof installDom>;
+  let root: Root;
+  let queryClient: QueryClient;
+  let QueryClientProvider: typeof ReactQueryProvider;
+  let createRoot: typeof createReactRoot;
+  let CodeReviewStreamView: typeof CodeReviewStreamViewComponent;
+  let props: ViewProps;
+
+  async function renderView(nextProps: Partial<ViewProps> = {}) {
+    props = { ...props, ...nextProps };
+    await settle(() =>
+      root.render(
+        createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          createElement(CodeReviewStreamView, props)
+        )
+      )
+    );
+  }
+
+  function text() {
+    return dom.container.textContent ?? '';
+  }
+
+  function status() {
+    return dom.container.querySelector('[data-slot="badge"]')?.textContent?.trim();
+  }
+
+  function socket() {
+    const current = mockSockets.at(-1);
+    if (!current) throw new Error('WebSocket manager missing');
+    return current;
+  }
+
+  async function navigateToAttempt(attemptId: string) {
+    mockSearchParams = new URLSearchParams({ attemptId });
+    await renderView();
+  }
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    eventId = 0;
+    mockSockets.length = 0;
+    mockSearchParams = new URLSearchParams();
+    mockGetStreamInfo.mockReset().mockResolvedValue(streamInfo());
+    mockGetMessages.mockReset().mockResolvedValue(transcript());
+    mockFetchStreamTicket
+      .mockReset()
+      .mockResolvedValue({ ticket: 'test-ticket', expiresAt: 123456 });
+    mockCreateWebSocketManager.mockReset().mockImplementation(config => {
+      let state: ConnectionState = { status: 'disconnected' };
+      const manager = {
+        connect: jest.fn(() => {
+          state = { status: 'connected', executionId: 'exec-current' };
+          config.onStateChange(state);
+        }),
+        disconnect: jest.fn(() => {
+          state = { status: 'disconnected' };
+          config.onStateChange(state);
+        }),
+        getState: () => state,
+      };
+      mockSockets.push({ config, manager });
+      return manager;
+    });
+    dom = installDom();
+    const reactQuery = await import('@tanstack/react-query');
+    expect(reactQuery.isServer).toBe(false);
+    QueryClientProvider = reactQuery.QueryClientProvider;
+    queryClient = new reactQuery.QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    ({ createRoot } = await import('react-dom/client'));
+    ({ CodeReviewStreamView } = await import('./CodeReviewStreamView'));
+    root = createRoot(dom.container);
+    props = { reviewId, onComplete: mockOnComplete };
+  });
+
+  afterEach(() => {
+    try {
+      act(() => root?.unmount());
+      queryClient?.clear();
+    } finally {
+      try {
+        dom?.cleanup();
+      } finally {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      }
+    }
+  });
+
+  it('replaces running organization snapshots every 2000 ms without requesting a bot-owner ticket', async () => {
+    let snapshot = transcript('Inspecting changed files.', 'Temporary progress row.');
+    mockGetMessages.mockImplementation(async () => snapshot);
+    await renderView();
+    expect(status()).toBe('Running');
+    expect(text()).toContain('Inspecting changed files.');
+    expect(text()).toContain('Temporary progress row.');
+    expect(text()).toContain('Live');
+
+    snapshot = transcript('Found a nullability regression.');
+    await advanceTime(2000);
+    expect(text()).toContain('Found a nullability regression.');
+    expect(text()).not.toContain('Inspecting changed files.');
+    expect(text()).not.toContain('Temporary progress row.');
+    expect(mockGetMessages).toHaveBeenCalledTimes(2);
+    expect(mockGetStreamInfo).toHaveBeenCalledTimes(2);
+
+    snapshot = transcript();
+    await advanceTime(2000);
+    expect(text()).not.toContain('Found a nullability regression.');
+    expect(text()).toContain('Waiting for events');
+
+    snapshot = transcript('Checking the remaining files.');
+    await advanceTime(2000);
+    expect(text()).toContain('Checking the remaining files.');
+    expect(status()).toBe('Running');
+    expect(mockGetMessages).toHaveBeenCalledWith({ reviewId, attemptId: undefined });
+    expect(mockGetStreamInfo).toHaveBeenCalledTimes(4);
+    expect(mockFetchStreamTicket).not.toHaveBeenCalled();
+    expect(mockCreateWebSocketManager).not.toHaveBeenCalled();
+    expect(mockOnComplete).not.toHaveBeenCalled();
+  });
+
+  it('refetches persisted history after partial organization progress and stops terminal polling', async () => {
+    const terminalStatus = Promise.withResolvers<StreamInfo>();
+    mockGetMessages.mockResolvedValue(transcript('Partial organization progress.'));
+    mockGetStreamInfo
+      .mockResolvedValueOnce(streamInfo())
+      .mockReturnValueOnce(terminalStatus.promise);
+    await renderView();
+    expect(text()).toContain('Partial organization progress.');
+    await advanceTime(2000);
+    expect(status()).toBe('Running');
+    const liveRequests = mockGetMessages.mock.calls.length;
+
+    const completed = streamInfo({ status: 'completed' });
+    mockGetStreamInfo.mockResolvedValue(completed);
+    mockGetMessages.mockResolvedValue(transcript('Persisted organization assessment.'));
+    await settle(() => terminalStatus.resolve(completed));
+    expect(status()).toBe('Complete');
+    expect(text()).toContain('Session Log');
+    expect(text()).toContain('Persisted organization assessment.');
+    expect(text()).not.toContain('Final verdict.');
+    expect(text()).not.toContain('Partial organization progress.');
+    expect(text()).not.toContain('Live');
+    expect(mockGetMessages.mock.calls.length).toBeGreaterThan(liveRequests);
+    expect(mockOnComplete).toHaveBeenCalledTimes(1);
+
+    mockGetMessages.mockResolvedValueOnce({ success: false, error: 'Transcript is syncing.' });
+    await advanceTime(2000);
+    expect(text()).toContain('Transcript is syncing.');
+    mockGetMessages.mockResolvedValue(
+      transcript('Persisted organization assessment.', 'Final verdict.')
+    );
+    await advanceTime(2000);
+    expect(text()).toContain('Final verdict.');
+    expect(text()).not.toContain('Transcript is syncing.');
+    await advanceTime(8000);
+    const requests = [mockGetStreamInfo.mock.calls.length, mockGetMessages.mock.calls.length];
+    mockGetMessages.mockResolvedValue(transcript('Unexpected post-terminal update.'));
+    await advanceTime(6000);
+    expect([mockGetStreamInfo.mock.calls.length, mockGetMessages.mock.calls.length]).toEqual(
+      requests
+    );
+    expect(text()).toContain('Persisted organization assessment.');
+    expect(text()).not.toContain('Unexpected post-terminal update.');
+    expect(mockFetchStreamTicket).not.toHaveBeenCalled();
+  });
+
+  it('renders canonical personal text, survives replayed completion, and reconciles authoritative completion', async () => {
+    const running = streamInfo({ organizationId: undefined });
+    mockGetStreamInfo.mockResolvedValue(running);
+    await renderView();
+    expect(mockFetchStreamTicket).toHaveBeenCalledWith(runtimeId, undefined);
+    const live = socket();
+    await settle(() => live.config.onEvent(textPart('Draft assessment.')));
+    expect(text()).toContain('Draft assessment.');
+    expect(status()).toBe('Running');
+    expect(mockGetMessages).not.toHaveBeenCalled();
+
+    for (const type of ['complete', 'interrupted']) {
+      const authoritativeStatus = Promise.withResolvers<StreamInfo>();
+      const requests = mockGetStreamInfo.mock.calls.length;
+      mockGetStreamInfo.mockReturnValueOnce(authoritativeStatus.promise);
+      await settle(() => live.config.onEvent(streamEvent(type, {}, 'exec-previous')));
+      expect(mockGetStreamInfo).toHaveBeenCalledTimes(requests + 1);
+      expect(status()).toBe('Running');
+      expect(live.manager.disconnect).not.toHaveBeenCalled();
+      await settle(() => authoritativeStatus.resolve(running));
+      expect(status()).toBe('Running');
+      expect(text()).toContain('Draft assessment.');
+      expect(live.manager.disconnect).not.toHaveBeenCalled();
+      expect(mockOnComplete).not.toHaveBeenCalled();
+    }
+
+    await settle(() => live.config.onEvent(textPart('Current execution is still reviewing.')));
+    expect(text()).toContain('Current execution is still reviewing.');
+    expect(text()).not.toContain('Draft assessment.');
+    expect(text()).toContain('Live');
+    expect(mockCreateWebSocketManager).toHaveBeenCalledTimes(1);
+    expect(mockGetMessages).not.toHaveBeenCalled();
+
+    mockGetStreamInfo.mockResolvedValue(
+      streamInfo({ organizationId: undefined, status: 'completed' })
+    );
+    mockGetMessages.mockResolvedValue(
+      transcript('Persisted personal assessment.', 'Final personal verdict.')
+    );
+    await settle(() => live.config.onEvent(streamEvent('complete')));
+    expect(status()).toBe('Complete');
+    expect(text()).toContain('Persisted personal assessment.');
+    expect(text()).toContain('Final personal verdict.');
+    expect(text()).not.toContain('Current execution is still reviewing.');
+    expect(text()).not.toContain('Live');
+    expect(live.manager.disconnect).toHaveBeenCalled();
+    expect(mockOnComplete).toHaveBeenCalledTimes(1);
+    const requests = mockGetStreamInfo.mock.calls.length;
+    await advanceTime(6000);
+    expect(mockGetStreamInfo).toHaveBeenCalledTimes(requests);
+    expect(mockCreateWebSocketManager).toHaveBeenCalledTimes(1);
+    expect(text()).toContain('Persisted personal assessment.');
+  });
+
+  it('shows running metadata and transcript errors, then hides revoked data and stops polling', async () => {
+    mockGetMessages.mockResolvedValue(transcript('Organization-only transcript.'));
+    await renderView();
+    expect(text()).toContain('Organization-only transcript.');
+    expect(status()).toBe('Running');
+
+    mockGetStreamInfo.mockResolvedValueOnce({
+      success: false,
+      error: 'Review metadata unavailable.',
+    });
+    await advanceTime(2000);
+    expect(text()).toContain('Review metadata unavailable.');
+    expect(mockOnComplete).not.toHaveBeenCalled();
+
+    mockGetMessages.mockResolvedValueOnce({
+      success: false,
+      error: 'Review transcript unavailable.',
+    });
+    await advanceTime(2000);
+    expect(text()).toContain('Review transcript unavailable.');
+    expect(text()).not.toContain('Review metadata unavailable.');
+    expect(mockOnComplete).not.toHaveBeenCalled();
+
+    await advanceTime(2000);
+    expect(text()).toContain('Organization-only transcript.');
+    expect(text()).not.toContain('Review transcript unavailable.');
+    expect(status()).toBe('Running');
+
+    mockGetMessages.mockRejectedValue(
+      TRPCClientError.from<RootRouter>({
+        error: {
+          code: -32003,
+          message: 'Organization membership revoked.',
+          data: { code: 'FORBIDDEN', httpStatus: 403 },
+        },
+      })
+    );
+    await advanceTime(2000);
+    expect(text()).toContain('Organization membership revoked.');
+    expect(text()).not.toContain('Organization-only transcript.');
+    expect(text()).not.toContain(runtimeId);
+    const requests = [mockGetStreamInfo.mock.calls.length, mockGetMessages.mock.calls.length];
+    await advanceTime(6000);
+    expect([mockGetStreamInfo.mock.calls.length, mockGetMessages.mock.calls.length]).toEqual(
+      requests
+    );
+    expect(text()).not.toContain('Organization-only transcript.');
+    expect(mockFetchStreamTicket).not.toHaveBeenCalled();
+    expect(mockOnComplete).not.toHaveBeenCalled();
+  });
+
+  it('keeps attempt selection available when a historical transcript fails', async () => {
+    mockSearchParams = new URLSearchParams({ attemptId: previousAttemptId });
+    mockGetStreamInfo.mockImplementation(async input =>
+      streamInfo({
+        status: input.attemptId === previousAttemptId ? 'completed' : 'running',
+        cloudAgentSessionId: input.attemptId === previousAttemptId ? 'agent-previous' : runtimeId,
+      })
+    );
+    mockGetMessages.mockImplementation(async input =>
+      input.attemptId === previousAttemptId
+        ? { success: false, error: 'Historical transcript unavailable.' }
+        : transcript('Current attempt progress.')
+    );
+    await renderView({ attempts });
+    expect(dom.container.querySelector('[role="alert"]')?.textContent).toContain(
+      'Historical transcript unavailable.'
+    );
+
+    const selector = dom.container.querySelector<HTMLSelectElement>(
+      'select[aria-label="Select session attempt"]'
+    );
+    expect(selector).not.toBeNull();
+    if (!selector) throw new Error('Attempt selector missing');
+    await settle(() => {
+      for (const option of selector.options) {
+        option.selected = option.value === currentAttemptId;
+      }
+      selector.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await renderView();
+
+    expect(status()).toBe('Running');
+    expect(text()).toContain('Current attempt progress.');
+    expect(text()).not.toContain('Historical transcript unavailable.');
+  });
+
+  it('resets organization attempts and ignores late transcript and status responses', async () => {
+    const lateMessages = Promise.withResolvers<SessionMessages>();
+    const lateStatus = Promise.withResolvers<StreamInfo>();
+    const history = Promise.withResolvers<SessionMessages>();
+    mockSearchParams = new URLSearchParams({ attemptId: currentAttemptId });
+    mockGetStreamInfo.mockImplementation(async input =>
+      streamInfo({
+        status: input.attemptId === previousAttemptId ? 'completed' : 'running',
+        cloudAgentSessionId: input.attemptId === previousAttemptId ? 'agent-previous' : runtimeId,
+      })
+    );
+    mockGetMessages.mockImplementation(input =>
+      input.attemptId === previousAttemptId
+        ? history.promise
+        : Promise.resolve(transcript('Current attempt progress.'))
+    );
+    await renderView({ attempts });
+    expect(text()).toContain('Current attempt progress.');
+    mockGetMessages.mockReturnValueOnce(lateMessages.promise);
+    mockGetStreamInfo.mockReturnValueOnce(lateStatus.promise);
+    await advanceTime(2000);
+
+    await navigateToAttempt(previousAttemptId);
+    expect(text()).not.toContain('Current attempt progress.');
+    await settle(() => {
+      lateMessages.resolve(transcript('Late unselected transcript.'));
+      lateStatus.resolve(streamInfo({ status: 'failed' }));
+    });
+    expect(text()).not.toContain('Late unselected transcript.');
+    expect(status()).toBe('Complete');
+    await settle(() => history.resolve(transcript('Selected attempt history.')));
+    expect(text()).toContain('Selected attempt history.');
+    expect(text()).not.toContain('Current attempt progress.');
+    expect(mockGetMessages).toHaveBeenCalledWith({ reviewId, attemptId: previousAttemptId });
+
+    await navigateToAttempt(currentAttemptId);
+    expect(status()).toBe('Running');
+    expect(text()).toContain('Current attempt progress.');
+    expect(text()).not.toContain('Selected attempt history.');
+    expect(text()).not.toContain('Late unselected transcript.');
+    mockGetMessages.mockResolvedValue(transcript('Resumed current attempt progress.'));
+    await advanceTime(2000);
+    expect(text()).toContain('Resumed current attempt progress.');
+    expect(status()).toBe('Running');
+    expect(mockFetchStreamTicket).not.toHaveBeenCalled();
+  });
+
+  it('reconciles completion after switching between cached running attempts', async () => {
+    queryClient.setDefaultOptions({
+      queries: { retry: false, gcTime: Infinity, staleTime: 60_000 },
+    });
+    mockSearchParams = new URLSearchParams({ attemptId: previousAttemptId });
+    let completed = false;
+    let currentTranscript = transcript('Current cached progress.');
+    mockGetStreamInfo.mockImplementation(async input =>
+      streamInfo({
+        status: input.attemptId === currentAttemptId && completed ? 'completed' : 'running',
+      })
+    );
+    mockGetMessages.mockImplementation(async input =>
+      input.attemptId === previousAttemptId
+        ? transcript('Previous cached progress.')
+        : currentTranscript
+    );
+    for (const attempt of attempts) {
+      const input = { reviewId, attemptId: attempt.id };
+      queryClient.setQueryData(
+        mockTrpc.codeReviews.getReviewStreamInfo.queryOptions(input).queryKey,
+        streamInfo()
+      );
+      queryClient.setQueryData(
+        mockTrpc.codeReviews.getSessionMessages.queryOptions(input).queryKey,
+        attempt.id === previousAttemptId
+          ? transcript('Previous cached progress.')
+          : currentTranscript
+      );
+    }
+    await renderView({ attempts: attempts.map(attempt => ({ ...attempt, status: 'running' })) });
+    expect(text()).toContain('Previous cached progress.');
+    await navigateToAttempt(currentAttemptId);
+    expect(text()).toContain('Current cached progress.');
+    expect(text()).not.toContain('Previous cached progress.');
+
+    completed = true;
+    await advanceTime(2000);
+    expect(status()).toBe('Complete');
+    currentTranscript = transcript('Final result from the selected attempt.');
+    await advanceTime(2000);
+    expect(text()).toContain('Final result from the selected attempt.');
+    expect(text()).not.toContain('Current cached progress.');
+  });
+
+  it('shows live WebSocket errors and ignores stale callbacks and tickets after attempt switches', async () => {
+    mockSearchParams = new URLSearchParams({ attemptId: currentAttemptId });
+    mockGetStreamInfo.mockImplementation(async input =>
+      streamInfo({
+        organizationId: undefined,
+        status: input.attemptId === previousAttemptId ? 'completed' : 'running',
+        cloudAgentSessionId: input.attemptId === previousAttemptId ? 'agent-previous' : runtimeId,
+      })
+    );
+    mockGetMessages.mockResolvedValue(transcript('Previous personal attempt history.'));
+    await renderView({ attempts });
+    const live = socket();
+    await settle(() => live.config.onEvent(textPart('Current personal attempt progress.')));
+    expect(text()).toContain('Current personal attempt progress.');
+    await settle(() =>
+      live.config.onError?.({
+        type: 'error',
+        code: 'WS_INTERNAL_ERROR',
+        message: 'Live transport failed.',
+      })
+    );
+    expect(text()).toContain('Live transport failed.');
+    expect(mockOnComplete).not.toHaveBeenCalled();
+
+    await navigateToAttempt(previousAttemptId);
+    expect(live.manager.disconnect).toHaveBeenCalled();
+    expect(text()).toContain('Previous personal attempt history.');
+    expect(text()).not.toContain('Current personal attempt progress.');
+    expect(text()).not.toContain('Live transport failed.');
+    await settle(() => {
+      live.config.onEvent(textPart('Late disconnected stream text.'));
+      live.config.onError?.({
+        type: 'error',
+        code: 'WS_AUTH_ERROR',
+        message: 'Late stream error.',
+      });
+    });
+    expect(text()).toContain('Previous personal attempt history.');
+    expect(text()).not.toContain('Late disconnected stream text.');
+    expect(text()).not.toContain('Late stream error.');
+    expect(status()).toBe('Complete');
+
+    const lateTicket = Promise.withResolvers<Awaited<ReturnType<typeof fetchStreamTicket>>>();
+    mockFetchStreamTicket.mockReturnValueOnce(lateTicket.promise);
+    await navigateToAttempt(currentAttemptId);
+    expect(text()).not.toContain('Previous personal attempt history.');
+    expect(mockFetchStreamTicket).toHaveBeenCalledTimes(2);
+    await navigateToAttempt(previousAttemptId);
+    await settle(() => lateTicket.resolve({ ticket: 'late-ticket', expiresAt: 123456 }));
+    expect(mockCreateWebSocketManager).toHaveBeenCalledTimes(1);
+    expect(text()).toContain('Previous personal attempt history.');
+    expect(text()).not.toContain('Late disconnected stream text.');
+    expect(status()).toBe('Complete');
+  });
+});

--- a/apps/web/src/components/code-reviews/CodeReviewStreamView.test.ts
+++ b/apps/web/src/components/code-reviews/CodeReviewStreamView.test.ts
@@ -266,6 +266,7 @@ describe('CodeReviewStreamView', () => {
   let createRoot: typeof createReactRoot;
   let CodeReviewStreamView: typeof CodeReviewStreamViewComponent;
   let props: ViewProps;
+  let committedText: string[];
 
   async function renderView(nextProps: Partial<ViewProps> = {}) {
     props = { ...props, ...nextProps };
@@ -274,7 +275,11 @@ describe('CodeReviewStreamView', () => {
         createElement(
           QueryClientProvider,
           { client: queryClient },
-          createElement(CodeReviewStreamView, props)
+          createElement(
+            React.Profiler,
+            { id: 'review-stream', onRender: () => committedText.push(text()) },
+            createElement(CodeReviewStreamView, props)
+          )
         )
       )
     );
@@ -303,6 +308,7 @@ describe('CodeReviewStreamView', () => {
     jest.useFakeTimers();
     jest.clearAllMocks();
     eventId = 0;
+    committedText = [];
     mockSockets.length = 0;
     mockSearchParams = new URLSearchParams();
     mockGetStreamInfo.mockReset().mockResolvedValue(streamInfo());
@@ -372,8 +378,8 @@ describe('CodeReviewStreamView', () => {
 
     snapshot = transcript();
     await advanceTime(2000);
-    expect(text()).not.toContain('Found a nullability regression.');
-    expect(text()).toContain('Waiting for events');
+    expect(text()).toContain('Found a nullability regression.');
+    expect(text()).not.toContain('Waiting for events');
 
     snapshot = transcript('Checking the remaining files.');
     await advanceTime(2000);
@@ -400,13 +406,13 @@ describe('CodeReviewStreamView', () => {
 
     const completed = streamInfo({ status: 'completed' });
     mockGetStreamInfo.mockResolvedValue(completed);
-    mockGetMessages.mockResolvedValue(transcript('Persisted organization assessment.'));
+    mockGetMessages.mockResolvedValue(transcript());
     await settle(() => terminalStatus.resolve(completed));
     expect(status()).toBe('Complete');
     expect(text()).toContain('Session Log');
-    expect(text()).toContain('Persisted organization assessment.');
+    expect(text()).toContain('Partial organization progress.');
+    expect(text()).not.toContain('No session logs available.');
     expect(text()).not.toContain('Final verdict.');
-    expect(text()).not.toContain('Partial organization progress.');
     expect(text()).not.toContain('Live');
     expect(mockGetMessages.mock.calls.length).toBeGreaterThan(liveRequests);
     expect(mockOnComplete).toHaveBeenCalledTimes(1);
@@ -486,6 +492,42 @@ describe('CodeReviewStreamView', () => {
     expect(text()).toContain('Persisted personal assessment.');
   });
 
+  it.each([true, false])(
+    'preserves personal text across empty reconciliation responses (ingest recovers: %s)',
+    async recovers => {
+      mockGetStreamInfo.mockResolvedValue(streamInfo({ organizationId: undefined }));
+      await renderView();
+      const live = socket();
+      await settle(() => live.config.onEvent(textPart('Live personal assessment.')));
+      mockGetStreamInfo.mockResolvedValue(
+        streamInfo({ organizationId: undefined, status: 'completed' })
+      );
+      await settle(() => live.config.onEvent(streamEvent('complete')));
+      expect(status()).toBe('Complete');
+      expect(mockGetMessages).toHaveBeenCalled();
+      expect(text()).toContain('Live personal assessment.');
+      expect(text()).not.toContain('No session logs available.');
+      expect(live.manager.disconnect).toHaveBeenCalled();
+
+      await advanceTime(2000);
+      expect(text()).toContain('Live personal assessment.');
+      if (recovers) {
+        mockGetMessages.mockResolvedValue(transcript('Persisted personal assessment.'));
+        await advanceTime(2000);
+        expect(text()).toContain('Persisted personal assessment.');
+        expect(text()).not.toContain('Live personal assessment.');
+        mockGetMessages.mockResolvedValue(transcript());
+      }
+      await advanceTime(12_000);
+      expect(text()).toContain(
+        recovers ? 'Persisted personal assessment.' : 'Live personal assessment.'
+      );
+      const requests = mockGetMessages.mock.calls.length;
+      await advanceTime(6000);
+      expect(mockGetMessages).toHaveBeenCalledTimes(requests);
+    }
+  );
+
   it('shows running metadata and transcript errors, then hides revoked data and stops polling', async () => {
     mockGetMessages.mockResolvedValue(transcript('Organization-only transcript.'));
     await renderView();
@@ -513,6 +555,9 @@ describe('CodeReviewStreamView', () => {
     expect(text()).toContain('Organization-only transcript.');
     expect(text()).not.toContain('Review transcript unavailable.');
     expect(status()).toBe('Running');
+    mockGetMessages.mockResolvedValue(transcript());
+    await advanceTime(2000);
+    expect(text()).toContain('Organization-only transcript.');
 
     mockGetMessages.mockRejectedValue(
       TRPCClientError.from<RootRouter>({
@@ -619,6 +664,42 @@ describe('CodeReviewStreamView', () => {
     expect(status()).toBe('Running');
     expect(mockFetchStreamTicket).not.toHaveBeenCalled();
   });
+
+  it.each(['review', 'attempt'])(
+    'clears retained logs before committing a cached %s',
+    async identity => {
+      mockGetMessages.mockResolvedValue(transcript('Retained organization progress.'));
+      await renderView({ attempts });
+      mockGetMessages.mockResolvedValue(transcript());
+      await advanceTime(2000);
+      expect(text()).toContain('Retained organization progress.');
+
+      queryClient.setDefaultOptions({
+        queries: { retry: false, gcTime: Infinity, staleTime: 60_000 },
+      });
+      const input = {
+        reviewId: identity === 'review' ? '00000000-0000-4000-8000-000000000005' : reviewId,
+        attemptId: identity === 'attempt' ? previousAttemptId : currentAttemptId,
+      };
+      queryClient.setQueryData(
+        mockTrpc.codeReviews.getReviewStreamInfo.queryOptions(input).queryKey,
+        streamInfo()
+      );
+      queryClient.setQueryData(
+        mockTrpc.codeReviews.getSessionMessages.queryOptions(input).queryKey,
+        transcript()
+      );
+      committedText.length = 0;
+      if (identity === 'review') {
+        await renderView({ reviewId: input.reviewId });
+      } else {
+        await navigateToAttempt(input.attemptId);
+      }
+      expect(committedText.length).toBeGreaterThan(0);
+      expect(committedText.join('\n')).not.toContain('Retained organization progress.');
+      expect(text()).toContain('Waiting for events');
+    }
+  );
 
   it('reconciles completion after switching between cached running attempts', async () => {
     queryClient.setDefaultOptions({

--- a/apps/web/src/components/code-reviews/CodeReviewStreamView.tsx
+++ b/apps/web/src/components/code-reviews/CodeReviewStreamView.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/select';
 import { AlertCircle, Loader2, Terminal, CheckCircle2, XCircle } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
+import { TRPCClientError } from '@trpc/client';
 import { useTRPC } from '@/lib/trpc/utils';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
@@ -66,6 +67,15 @@ function formatStatusLabel(status: string): string {
   return status.slice(0, 1).toUpperCase() + status.slice(1);
 }
 
+function isAccessDeniedError(error: unknown): boolean {
+  return (
+    error instanceof TRPCClientError &&
+    (error.data?.code === 'UNAUTHORIZED' ||
+      error.data?.code === 'FORBIDDEN' ||
+      error.data?.code === 'NOT_FOUND')
+  );
+}
+
 function formatAttemptLabel(attempt: CodeReviewAttemptSummary): string {
   const parts = [`Attempt ${attempt.attempt_number}`, formatStatusLabel(attempt.status)];
   const sessionId = attempt.session_id ?? attempt.cli_session_id;
@@ -93,7 +103,7 @@ export function CodeReviewStreamView({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [events, setEvents] = useState<DisplayEvent[]>([]);
-  const [isComplete, setIsComplete] = useState(false);
+  const [accessDenied, setAccessDenied] = useState(false);
   const [connectionState, setConnectionState] = useState<ConnectionState>({
     status: 'disconnected',
   });
@@ -101,6 +111,8 @@ export function CodeReviewStreamView({
   const scrollRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
   const wsManagerRef = useRef<ReturnType<typeof createWebSocketManager> | null>(null);
+  const wasRunningRef = useRef(false);
+  const reconcileUntilRef = useRef(0);
 
   const orderedAttempts = [...attempts].sort((a, b) => a.attempt_number - b.attempt_number);
   const attemptIds = orderedAttempts.map(attempt => attempt.id).join('|');
@@ -143,10 +155,12 @@ export function CodeReviewStreamView({
 
   useEffect(() => {
     setEvents([]);
-    setIsComplete(false);
+    setAccessDenied(false);
     setConnectionState({ status: 'disconnected' });
     setWsError(null);
     setAutoScroll(true);
+    wasRunningRef.current = false;
+    reconcileUntilRef.current = 0;
     wsManagerRef.current?.disconnect();
     wsManagerRef.current = null;
   }, [reviewId, effectiveAttemptId]);
@@ -155,56 +169,40 @@ export function CodeReviewStreamView({
   // Step 1: Get stream info to determine which mode to use
   // ---------------------------------------------------------------------------
 
-  const { data: streamInfo } = useQuery({
+  const {
+    data: streamInfo,
+    error: streamInfoError,
+    refetch: refetchStreamInfo,
+  } = useQuery({
     ...trpc.codeReviews.getReviewStreamInfo.queryOptions({
       reviewId,
       attemptId: effectiveAttemptId,
     }),
     refetchInterval: query => {
+      if (isAccessDeniedError(query.state.error)) return false;
       const data = query.state.data;
       if (!data?.success) return 2000;
 
-      const behavior = getCodeReviewDisplayBehavior({
-        agentVersion: data.agentVersion,
-        status: data.status,
-        cloudAgentSessionId: data.cloudAgentSessionId,
-      });
-      return behavior.shouldPollStatus ? 2000 : false;
+      return getCodeReviewDisplayBehavior(data).shouldPollStatus ? 2000 : false;
     },
-    enabled: !!reviewId,
+    retry: (failureCount, error) => !isAccessDeniedError(error) && failureCount < 3,
+    enabled: !!reviewId && !accessDenied,
   });
 
   const cloudAgentSessionId = streamInfo?.success ? streamInfo.cloudAgentSessionId : null;
   const organizationId = streamInfo?.success ? streamInfo.organizationId : undefined;
   const reviewStatus = streamInfo?.success ? streamInfo.status : undefined;
-  const displayBehavior = streamInfo?.success
-    ? getCodeReviewDisplayBehavior({
-        agentVersion: streamInfo.agentVersion,
-        status: streamInfo.status,
-        cloudAgentSessionId: streamInfo.cloudAgentSessionId,
-      })
-    : null;
+  const displayBehavior = streamInfo?.success ? getCodeReviewDisplayBehavior(streamInfo) : null;
   const isHistoricalReview = displayBehavior?.isHistorical ?? false;
-  const isTerminal = displayBehavior?.isTerminal ?? false;
-  const shouldLoadHistory = displayBehavior?.shouldLoadHistory ?? false;
+  const isComplete = displayBehavior?.isTerminal ?? false;
+  const shouldLoadMessages = displayBehavior?.shouldLoadMessages ?? false;
+  const shouldPollMessages = displayBehavior?.shouldPollMessages ?? false;
+  const useWebSocket =
+    !!displayBehavior && !shouldLoadMessages && isSelectedLatestAttempt && !accessDenied;
 
-  // Only current Cloud Agent Next attempts have a live runtime connection.
-  const useWebSocket = streamInfo?.success
-    ? streamInfo.agentVersion === 'v2' && isSelectedLatestAttempt
-    : false;
-
-  // Mark as complete if the review is already in a terminal state
   useEffect(() => {
-    if (
-      reviewStatus === 'completed' ||
-      reviewStatus === 'failed' ||
-      reviewStatus === 'cancelled' ||
-      reviewStatus === 'interrupted'
-    ) {
-      setIsComplete(true);
-      if (reviewStatus === 'completed') {
-        onComplete?.();
-      }
+    if (reviewStatus === 'completed') {
+      onComplete?.();
     }
   }, [reviewStatus, onComplete]);
 
@@ -221,35 +219,32 @@ export function CodeReviewStreamView({
 
   const handleEvent = useCallback(
     (event: CloudAgentEvent) => {
+      setWsError(null);
       const displayEvent = toCodeReviewDisplayEvent(event);
       if (displayEvent) {
         setEvents(prev => appendCodeReviewDisplayEvent(prev, displayEvent));
       }
       if (event.streamEventType === 'complete' || event.streamEventType === 'interrupted') {
-        setIsComplete(true);
-        onComplete?.();
+        void refetchStreamInfo();
       }
     },
-    [onComplete]
+    [refetchStreamInfo]
   );
 
   const handleWsError = useCallback((error: StreamError) => {
     setWsError(`${error.code}: ${error.message}`);
-    if (
-      error.code === 'WS_SESSION_NOT_FOUND' ||
-      error.code === 'WS_EXECUTION_NOT_FOUND' ||
-      error.code === 'WS_AUTH_ERROR'
-    ) {
-      setIsComplete(true);
-    }
   }, []);
 
   // Connect WebSocket when cloudAgentSessionId becomes available
   useEffect(() => {
-    if (!useWebSocket || !cloudAgentSessionId || isComplete) return;
-    if (!CLOUD_AGENT_NEXT_WS_URL) return;
+    if (!useWebSocket || !cloudAgentSessionId) return;
+    if (!CLOUD_AGENT_NEXT_WS_URL) {
+      setWsError('Live stream is unavailable.');
+      return;
+    }
 
     let cancelled = false;
+    setWsError(null);
 
     async function connect() {
       if (cancelled || !cloudAgentSessionId) return;
@@ -263,11 +258,18 @@ export function CodeReviewStreamView({
         const manager = createWebSocketManager({
           url: url.toString(),
           ticket: result.ticket,
-          onEvent: handleEvent,
-          onError: handleWsError,
-          onStateChange: setConnectionState,
+          onEvent: event => {
+            if (!cancelled) handleEvent(event);
+          },
+          onError: error => {
+            if (!cancelled) handleWsError(error);
+          },
+          onStateChange: state => {
+            if (!cancelled) setConnectionState(state);
+          },
           onRefreshTicket: async () => {
             const refreshed = await getTicket(cloudAgentSessionId);
+            if (cancelled) throw new Error('Review stream disconnected');
             return refreshed.ticket;
           },
         });
@@ -288,28 +290,68 @@ export function CodeReviewStreamView({
       wsManagerRef.current?.disconnect();
       wsManagerRef.current = null;
     };
-  }, [useWebSocket, cloudAgentSessionId, isComplete, getTicket, handleEvent, handleWsError]);
+  }, [
+    reviewId,
+    effectiveAttemptId,
+    useWebSocket,
+    cloudAgentSessionId,
+    getTicket,
+    handleEvent,
+    handleWsError,
+  ]);
 
-  // ---------------------------------------------------------------------------
-  // Historical session data
-  // ---------------------------------------------------------------------------
-
-  const { data: sessionMessages, isLoading: isLoadingHistory } = useQuery({
+  const {
+    data: sessionMessages,
+    error: sessionMessagesError,
+    isLoading: isLoadingMessages,
+    refetch: refetchSessionMessages,
+  } = useQuery({
     ...trpc.codeReviews.getSessionMessages.queryOptions({
       reviewId,
       attemptId: effectiveAttemptId,
     }),
-    enabled: !!reviewId && shouldLoadHistory && events.length === 0,
+    enabled: !!reviewId && shouldLoadMessages && !accessDenied,
+    refetchInterval: query => {
+      if (isAccessDeniedError(query.state.error)) return false;
+      return shouldPollMessages || (isComplete && Date.now() < reconcileUntilRef.current)
+        ? 2000
+        : false;
+    },
+    retry: (failureCount, error) => !isAccessDeniedError(error) && failureCount < 3,
   });
 
-  // Populate events from historical session data
   useEffect(() => {
-    if (!shouldLoadHistory || events.length > 0) return;
-    if (!sessionMessages?.success) return;
-    if (sessionMessages.entries.length === 0) return;
+    if (displayBehavior?.shouldPollStatus) {
+      wasRunningRef.current = true;
+    } else if (isComplete && wasRunningRef.current && !accessDenied) {
+      wasRunningRef.current = false;
+      reconcileUntilRef.current = Date.now() + 10_000;
+      void refetchSessionMessages();
+    }
+  }, [
+    reviewId,
+    effectiveAttemptId,
+    displayBehavior?.shouldPollStatus,
+    isComplete,
+    accessDenied,
+    refetchSessionMessages,
+  ]);
 
-    setEvents(sessionMessages.entries);
-  }, [shouldLoadHistory, sessionMessages, events.length]);
+  useEffect(() => {
+    if (isAccessDeniedError(streamInfoError) || isAccessDeniedError(sessionMessagesError)) {
+      setAccessDenied(true);
+    }
+  }, [streamInfoError, sessionMessagesError]);
+
+  const displayEvents: DisplayEvent[] =
+    shouldLoadMessages && sessionMessages?.success ? sessionMessages.entries : events;
+  const displayError =
+    streamInfoError?.message ??
+    (streamInfo && !streamInfo.success ? streamInfo.error : null) ??
+    (shouldLoadMessages
+      ? (sessionMessagesError?.message ??
+        (sessionMessages && !sessionMessages.success ? sessionMessages.error : null))
+      : (wsError ?? (connectionState.status === 'error' ? connectionState.error : null)));
 
   // ---------------------------------------------------------------------------
   // Auto-scroll
@@ -319,14 +361,14 @@ export function CodeReviewStreamView({
     if (autoScroll && scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [events, autoScroll]);
+  }, [displayEvents, autoScroll]);
 
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
 
   // Waiting for stream info
-  if (!streamInfo?.success) {
+  if (!streamInfo?.success && !displayError) {
     return (
       <Card className="border-l-4 border-l-blue-500">
         <CardHeader>
@@ -339,8 +381,12 @@ export function CodeReviewStreamView({
     );
   }
 
-  // Error state (WebSocket only)
-  if (wsError && isComplete) {
+  if (
+    displayError &&
+    (accessDenied ||
+      isAccessDeniedError(streamInfoError) ||
+      isAccessDeniedError(sessionMessagesError))
+  ) {
     return (
       <Card className="border-l-4 border-l-red-500">
         <CardHeader className="pb-3">
@@ -350,8 +396,8 @@ export function CodeReviewStreamView({
           </div>
         </CardHeader>
         <CardContent className="pt-0">
-          <div className="rounded-md bg-slate-950 p-4 font-mono text-xs text-red-400">
-            {wsError}
+          <div role="alert" className="rounded-md bg-slate-950 p-4 font-mono text-xs text-red-400">
+            {displayError}
           </div>
         </CardContent>
       </Card>
@@ -365,7 +411,7 @@ export function CodeReviewStreamView({
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             <Terminal className="h-4 w-4" />
             <CardTitle className="shrink-0 text-sm font-medium">
-              {shouldLoadHistory ? 'Session Log' : 'Code Review Progress'}
+              {isHistoricalReview || isComplete ? 'Session Log' : 'Code Review Progress'}
             </CardTitle>
             {cloudAgentSessionId && (
               <span
@@ -394,7 +440,7 @@ export function CodeReviewStreamView({
                 </Select>
               </div>
             )}
-            {isHistoricalReview && !isTerminal ? (
+            {isHistoricalReview && !isComplete ? (
               <Badge variant="secondary" className="gap-1.5">
                 <AlertCircle className="h-3 w-3" />
                 Historical
@@ -446,14 +492,18 @@ export function CodeReviewStreamView({
             setAutoScroll(isAtBottom);
           }}
         >
-          {events.length === 0 && !shouldLoadHistory ? (
+          {displayError ? (
+            <div role="alert" className="text-red-400">
+              {displayError}
+            </div>
+          ) : displayEvents.length === 0 && !isHistoricalReview && !isComplete ? (
             <div className="flex items-center gap-2 text-slate-400">
               <Loader2 className="h-4 w-4 animate-spin" />
               <span>Waiting for events...</span>
             </div>
-          ) : events.length === 0 ? (
+          ) : displayEvents.length === 0 ? (
             <div className="text-slate-500">
-              {isLoadingHistory ? (
+              {isLoadingMessages ? (
                 <div className="flex items-center gap-2">
                   <Loader2 className="h-4 w-4 animate-spin" />
                   <span>Loading session log...</span>
@@ -464,7 +514,7 @@ export function CodeReviewStreamView({
             </div>
           ) : (
             <div className="space-y-1">
-              {events.map((event, index) => (
+              {displayEvents.map((event, index) => (
                 <div
                   key={event.key ?? index}
                   className="rounded px-2 py-1 transition-colors hover:bg-slate-900/50"

--- a/apps/web/src/components/code-reviews/CodeReviewStreamView.tsx
+++ b/apps/web/src/components/code-reviews/CodeReviewStreamView.tsx
@@ -102,7 +102,11 @@ export function CodeReviewStreamView({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const [events, setEvents] = useState<DisplayEvent[]>([]);
+  const [events, setEvents] = useState<{
+    reviewId: string;
+    attemptId?: string;
+    entries: DisplayEvent[];
+  }>({ reviewId, entries: [] });
   const [accessDenied, setAccessDenied] = useState(false);
   const [connectionState, setConnectionState] = useState<ConnectionState>({
     status: 'disconnected',
@@ -154,7 +158,7 @@ export function CodeReviewStreamView({
   }, [attemptIds, effectiveAttemptId, orderedAttempts.length, queryAttemptId, updateAttemptParam]);
 
   useEffect(() => {
-    setEvents([]);
+    setEvents({ reviewId, attemptId: effectiveAttemptId, entries: [] });
     setAccessDenied(false);
     setConnectionState({ status: 'disconnected' });
     setWsError(null);
@@ -222,13 +226,20 @@ export function CodeReviewStreamView({
       setWsError(null);
       const displayEvent = toCodeReviewDisplayEvent(event);
       if (displayEvent) {
-        setEvents(prev => appendCodeReviewDisplayEvent(prev, displayEvent));
+        setEvents(prev => ({
+          reviewId,
+          attemptId: effectiveAttemptId,
+          entries: appendCodeReviewDisplayEvent(
+            prev.reviewId === reviewId && prev.attemptId === effectiveAttemptId ? prev.entries : [],
+            displayEvent
+          ),
+        }));
       }
       if (event.streamEventType === 'complete' || event.streamEventType === 'interrupted') {
         void refetchStreamInfo();
       }
     },
-    [refetchStreamInfo]
+    [reviewId, effectiveAttemptId, refetchStreamInfo]
   );
 
   const handleWsError = useCallback((error: StreamError) => {
@@ -321,6 +332,12 @@ export function CodeReviewStreamView({
   });
 
   useEffect(() => {
+    if (shouldLoadMessages && sessionMessages?.success && sessionMessages.entries.length > 0) {
+      setEvents({ reviewId, attemptId: effectiveAttemptId, entries: sessionMessages.entries });
+    }
+  }, [reviewId, effectiveAttemptId, shouldLoadMessages, sessionMessages]);
+
+  useEffect(() => {
     if (displayBehavior?.shouldPollStatus) {
       wasRunningRef.current = true;
     } else if (isComplete && wasRunningRef.current && !accessDenied) {
@@ -344,7 +361,11 @@ export function CodeReviewStreamView({
   }, [streamInfoError, sessionMessagesError]);
 
   const displayEvents: DisplayEvent[] =
-    shouldLoadMessages && sessionMessages?.success ? sessionMessages.entries : events;
+    shouldLoadMessages && sessionMessages?.success && sessionMessages.entries.length > 0
+      ? sessionMessages.entries
+      : events.reviewId === reviewId && events.attemptId === effectiveAttemptId
+        ? events.entries
+        : [];
   const displayError =
     streamInfoError?.message ??
     (streamInfo && !streamInfo.success ? streamInfo.error : null) ??

--- a/apps/web/src/components/code-reviews/code-review-stream-behavior.test.ts
+++ b/apps/web/src/components/code-reviews/code-review-stream-behavior.test.ts
@@ -6,43 +6,66 @@ describe('getCodeReviewDisplayBehavior', () => {
       getCodeReviewDisplayBehavior({
         agentVersion: 'v1',
         status: 'running',
-        cloudAgentSessionId: 'agent_historical',
       })
     ).toEqual({
       isHistorical: true,
       isTerminal: false,
-      shouldLoadHistory: true,
+      shouldLoadMessages: true,
+      shouldPollMessages: false,
       shouldPollStatus: false,
     });
   });
 
-  it('keeps an active V2 review on the live stream path', () => {
+  it('keeps a personal V2 review on the live stream path while polling its status', () => {
     expect(
       getCodeReviewDisplayBehavior({
         agentVersion: 'v2',
         status: 'running',
-        cloudAgentSessionId: 'agent_current',
       })
     ).toEqual({
       isHistorical: false,
       isTerminal: false,
-      shouldLoadHistory: false,
-      shouldPollStatus: false,
-    });
-  });
-
-  it('polls while a V2 review is waiting for its session', () => {
-    expect(
-      getCodeReviewDisplayBehavior({
-        agentVersion: 'v2',
-        status: 'queued',
-        cloudAgentSessionId: null,
-      })
-    ).toEqual({
-      isHistorical: false,
-      isTerminal: false,
-      shouldLoadHistory: false,
+      shouldLoadMessages: false,
+      shouldPollMessages: false,
       shouldPollStatus: true,
     });
   });
+
+  it.each(['pending', 'queued', 'running'])(
+    'polls organization review transcripts when %s',
+    status => {
+      expect(
+        getCodeReviewDisplayBehavior({
+          agentVersion: 'v2',
+          status,
+          organizationId: 'org-1',
+        })
+      ).toEqual({
+        isHistorical: false,
+        isTerminal: false,
+        shouldLoadMessages: true,
+        shouldPollMessages: true,
+        shouldPollStatus: true,
+      });
+    }
+  );
+
+  it.each(['completed', 'failed', 'cancelled', 'interrupted'])(
+    'loads the transcript without polling when %s',
+    status => {
+      expect(
+        getCodeReviewDisplayBehavior({
+          agentVersion: 'v2',
+          status,
+          organizationId: 'org-1',
+        })
+      ).toEqual({
+        isHistorical: false,
+        isTerminal: true,
+        shouldLoadMessages: true,
+        shouldPollMessages: false,
+        shouldPollStatus: false,
+      });
+    }
+  );
 });

--- a/apps/web/src/components/code-reviews/code-review-stream-behavior.ts
+++ b/apps/web/src/components/code-reviews/code-review-stream-behavior.ts
@@ -3,13 +3,14 @@ const TERMINAL_REVIEW_STATUSES = new Set(['completed', 'failed', 'cancelled', 'i
 type CodeReviewStreamSnapshot = {
   agentVersion: string;
   status: string;
-  cloudAgentSessionId: string | null;
+  organizationId?: string;
 };
 
 type CodeReviewDisplayBehavior = {
   isHistorical: boolean;
   isTerminal: boolean;
-  shouldLoadHistory: boolean;
+  shouldLoadMessages: boolean;
+  shouldPollMessages: boolean;
   shouldPollStatus: boolean;
 };
 
@@ -18,11 +19,14 @@ export function getCodeReviewDisplayBehavior(
 ): CodeReviewDisplayBehavior {
   const isHistorical = snapshot.agentVersion !== 'v2';
   const isTerminal = TERMINAL_REVIEW_STATUSES.has(snapshot.status);
+  const shouldPollStatus = !isHistorical && !isTerminal;
+  const shouldPollMessages = shouldPollStatus && !!snapshot.organizationId;
 
   return {
     isHistorical,
     isTerminal,
-    shouldLoadHistory: isHistorical || isTerminal,
-    shouldPollStatus: !isHistorical && !isTerminal && !snapshot.cloudAgentSessionId,
+    shouldLoadMessages: isHistorical || isTerminal || shouldPollMessages,
+    shouldPollMessages,
+    shouldPollStatus,
   };
 }

--- a/apps/web/src/components/code-reviews/code-review-stream-events.test.ts
+++ b/apps/web/src/components/code-reviews/code-review-stream-events.test.ts
@@ -103,25 +103,39 @@ describe('toCodeReviewDisplayEvent', () => {
     ).toBeNull();
   });
 
-  it('skips streaming text parts until they complete', () => {
-    expect(
-      toCodeReviewDisplayEvent(
-        kilocode('message.part.updated', {
-          part: { type: 'text', text: 'Looking at the diff now.' },
-        })
-      )
-    ).toBeNull();
-  });
-
-  it('does not drop completed text parts whose state is an object', () => {
+  it('shows canonical text parts while the review is running', () => {
     expect(
       toCodeReviewDisplayEvent(
         kilocode('message.part.updated', {
           part: {
             id: 'prt_text',
+            sessionID: 'ses-1',
+            messageID: 'msg-1',
+            type: 'text',
+            text: 'Looking at the diff now.',
+            time: { start: 1787054400000 },
+          },
+        })
+      )
+    ).toEqual({
+      timestamp: '2026-08-18T12:00:00.000Z',
+      message: 'Looking at the diff now.',
+      eventType: 'text',
+      key: 'prt_text',
+    });
+  });
+
+  it('shows completed canonical text parts without a tool state', () => {
+    expect(
+      toCodeReviewDisplayEvent(
+        kilocode('message.part.updated', {
+          part: {
+            id: 'prt_text',
+            sessionID: 'ses-1',
+            messageID: 'msg-1',
             type: 'text',
             text: 'Review summary',
-            state: { status: 'completed' },
+            time: { start: 1787054400000, end: 1787054401000 },
           },
         })
       )
@@ -131,6 +145,33 @@ describe('toCodeReviewDisplayEvent', () => {
       eventType: 'text',
       key: 'prt_text',
     });
+  });
+
+  it.each(['', '   '])('skips empty text parts: %j', text => {
+    expect(
+      toCodeReviewDisplayEvent(
+        kilocode('message.part.updated', {
+          part: { id: 'prt_text', type: 'text', text },
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('updates a text part in place as new text arrives', () => {
+    const partial = toCodeReviewDisplayEvent(
+      kilocode('message.part.updated', {
+        part: { id: 'prt_text', type: 'text', text: 'Looking at' },
+      })
+    );
+    const updated = toCodeReviewDisplayEvent(
+      kilocode('message.part.updated', {
+        part: { id: 'prt_text', type: 'text', text: 'Looking at the diff now.' },
+      })
+    );
+    expect(partial).not.toBeNull();
+    expect(updated).not.toBeNull();
+    if (!partial || !updated) return;
+    expect(appendCodeReviewDisplayEvent([partial], updated)).toEqual([updated]);
   });
 
   it('shows session.status when status is an object', () => {

--- a/apps/web/src/components/code-reviews/code-review-stream-events.ts
+++ b/apps/web/src/components/code-reviews/code-review-stream-events.ts
@@ -103,8 +103,6 @@ function toDisplayEventFromKilocode(
     }
 
     if (partType === 'text') {
-      const status = partStateStatus(part.state);
-      if (!isCompletedStatus(status)) return null;
       const text = typeof part.text === 'string' ? part.text : undefined;
       if (text && text.trim()) {
         const truncated = text.length > 200 ? `${text.slice(0, 200)}...` : text;

--- a/apps/web/src/routers/code-reviews-router.test.ts
+++ b/apps/web/src/routers/code-reviews-router.test.ts
@@ -87,6 +87,8 @@ jest.mock('@/lib/integrations/platforms/gitlab/adapter', () => ({
 }));
 
 import { db } from '@/lib/drizzle';
+import { verifyOrgOwnsSessionV2ByCloudAgentId } from '@/lib/cloud-agent/session-ownership';
+import type { SessionSnapshot } from '@/lib/session-ingest-client';
 import type { SuccessResult } from '@/lib/maybe-result';
 import type * as BotUserService from '@/lib/bot-users/bot-user-service';
 import { generateBotUserId } from '@/lib/bot-users/types';
@@ -2324,7 +2326,7 @@ describe('codeReviewRouter attempts', () => {
     expect(mockTryDispatchPendingReviews).not.toHaveBeenCalled();
   });
 
-  it('rejects stream info attempts from another review', async () => {
+  it('rejects stream info and transcript attempts from another review', async () => {
     const [review] = await db
       .insert(cloud_agent_code_reviews)
       .values(reviewValues(testUser.id, 'running', { session_id: 'agent-review' }))
@@ -2350,9 +2352,15 @@ describe('codeReviewRouter attempts', () => {
         attemptId: otherAttempt.id,
       })
     ).rejects.toThrow('Code review attempt not found');
+    await expect(
+      caller.codeReviews.getSessionMessages({
+        reviewId: review.id,
+        attemptId: otherAttempt.id,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND', message: 'Code review attempt not found' });
   });
 
-  it('loads a historical V1 review from PostgreSQL and R2 without a worker request', async () => {
+  it('loads historical V1 session messages before and after a V2 retry', async () => {
     const cliSessionId = crypto.randomUUID();
     await db.insert(cliSessions).values({
       session_id: cliSessionId,
@@ -2390,9 +2398,338 @@ describe('codeReviewRouter attempts', () => {
       });
       expect(mockGetBlobContent).toHaveBeenCalledWith(`sessions/${cliSessionId}/ui_messages.json`);
       expect(fetchSpy).not.toHaveBeenCalled();
+
+      const [attempt] = await db
+        .insert(cloud_agent_code_review_attempts)
+        .values({
+          code_review_id: review.id,
+          attempt_number: 1,
+          status: 'completed',
+          cli_session_id: cliSessionId,
+        })
+        .returning();
+      await db
+        .update(cloud_agent_code_reviews)
+        .set({ agent_version: 'v2', status: 'running', cli_session_id: null })
+        .where(eq(cloud_agent_code_reviews.id, review.id));
+
+      await expect(
+        caller.codeReviews.getSessionMessages({ reviewId: review.id, attemptId: attempt.id })
+      ).resolves.toEqual(result);
+      expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
       fetchSpy.mockRestore();
     }
+  });
+});
+
+describe('codeReviewRouter.getSessionMessages V2 authorization', () => {
+  let ownerUser: User;
+  let memberUser: User;
+  let outsiderUser: User;
+  let botUser: User;
+  let organization: Organization;
+  let otherOrganization: Organization;
+  const repo = `${REPO}-transcript`;
+
+  beforeAll(async () => {
+    ownerUser = await insertTestUser();
+    memberUser = await insertTestUser();
+    outsiderUser = await insertTestUser();
+    organization = await createTestOrganization(
+      'Review Transcript Org',
+      ownerUser.id,
+      0,
+      {},
+      false
+    );
+    otherOrganization = await createTestOrganization(
+      'Other Review Transcript Org',
+      ownerUser.id,
+      0,
+      {},
+      false
+    );
+    botUser = await insertTestUser({
+      id: generateBotUserId(organization.id, 'code-review'),
+      is_bot: true,
+    });
+  });
+
+  beforeEach(async () => {
+    await db
+      .insert(organization_memberships)
+      .values([
+        { organization_id: organization.id, kilo_user_id: memberUser.id, role: 'member' },
+        { organization_id: organization.id, kilo_user_id: botUser.id, role: 'member' },
+      ])
+      .onConflictDoNothing();
+    mockFetchSessionSnapshot.mockResolvedValue({
+      info: {},
+      messages: [
+        {
+          info: { id: 'msg_review_progress', role: 'assistant', time: { created: 1 } },
+          parts: [{ id: 'prt_review_progress', type: 'text', text: 'Review in progress' }],
+        },
+      ],
+    } satisfies SessionSnapshot);
+  });
+
+  afterEach(async () => {
+    await db
+      .delete(cloud_agent_code_reviews)
+      .where(eq(cloud_agent_code_reviews.repo_full_name, repo));
+    await db
+      .delete(cli_sessions_v2)
+      .where(
+        inArray(cli_sessions_v2.kilo_user_id, [
+          ownerUser.id,
+          memberUser.id,
+          outsiderUser.id,
+          botUser.id,
+        ])
+      );
+    mockFetchSessionSnapshot.mockReset();
+  });
+
+  afterAll(async () => {
+    await db
+      .delete(organization_memberships)
+      .where(
+        inArray(organization_memberships.organization_id, [organization.id, otherOrganization.id])
+      );
+    await db
+      .delete(organizations)
+      .where(inArray(organizations.id, [organization.id, otherOrganization.id]));
+    await db
+      .delete(kilocode_users)
+      .where(
+        inArray(kilocode_users.id, [ownerUser.id, memberUser.id, outsiderUser.id, botUser.id])
+      );
+  });
+
+  async function insertReviewWithSession(
+    reviewOverrides: Partial<CodeReviewInsert> = {},
+    sessionOverrides: Partial<typeof cli_sessions_v2.$inferInsert> = {}
+  ) {
+    const cloudAgentSessionId = `agent_review_transcript_${crypto.randomUUID()}`;
+    const [session] = await db
+      .insert(cli_sessions_v2)
+      .values({
+        session_id: `ses_review_transcript_${crypto.randomUUID()}`,
+        cloud_agent_session_id: cloudAgentSessionId,
+        kilo_user_id: botUser.id,
+        organization_id: organization.id,
+        ...sessionOverrides,
+      })
+      .returning();
+    const [review] = await db
+      .insert(cloud_agent_code_reviews)
+      .values(
+        reviewValues(ownerUser.id, 'running', {
+          repo_full_name: repo,
+          owned_by_user_id: null,
+          owned_by_organization_id: organization.id,
+          session_id: cloudAgentSessionId,
+          cli_session_id: session.session_id,
+          ...reviewOverrides,
+        })
+      )
+      .returning();
+    return { review, session, cloudAgentSessionId };
+  }
+
+  it('reads a running bot-owned org transcript without granting generic session access', async () => {
+    const { review, session, cloudAgentSessionId } = await insertReviewWithSession();
+    const caller = await createCallerForUser(memberUser.id);
+
+    const result = await caller.codeReviews.getSessionMessages({ reviewId: review.id });
+
+    expect(result).toMatchObject({
+      success: true,
+      entries: [{ eventType: 'text', message: 'Review in progress' }],
+    });
+    expect(mockFetchSessionSnapshot).toHaveBeenCalledWith(session.session_id, botUser.id);
+    await expect(
+      verifyOrgOwnsSessionV2ByCloudAgentId(db, organization.id, memberUser.id, cloudAgentSessionId)
+    ).resolves.toBeNull();
+  });
+
+  it('denies outsiders and rechecks viewer membership on every transcript read', async () => {
+    const { review } = await insertReviewWithSession();
+    const memberCaller = await createCallerForUser(memberUser.id);
+    const outsiderCaller = await createCallerForUser(outsiderUser.id);
+    await expect(
+      memberCaller.codeReviews.getSessionMessages({ reviewId: review.id })
+    ).resolves.toMatchObject({ success: true, entries: [{ message: 'Review in progress' }] });
+    mockFetchSessionSnapshot.mockClear();
+
+    await expect(
+      outsiderCaller.codeReviews.getSessionMessages({ reviewId: review.id })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    await db
+      .delete(organization_memberships)
+      .where(
+        and(
+          eq(organization_memberships.organization_id, organization.id),
+          eq(organization_memberships.kilo_user_id, memberUser.id)
+        )
+      );
+
+    await expect(
+      memberCaller.codeReviews.getSessionMessages({ reviewId: review.id })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockFetchSessionSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('resolves a selected runtime-only continuation to its original session and owner', async () => {
+    const original = await insertReviewWithSession(
+      { status: 'completed' },
+      { kilo_user_id: ownerUser.id }
+    );
+    const { review } = await insertReviewWithSession();
+    const [attempt] = await db
+      .insert(cloud_agent_code_review_attempts)
+      .values({
+        code_review_id: review.id,
+        attempt_number: 1,
+        status: 'running',
+        session_id: original.cloudAgentSessionId,
+      })
+      .returning();
+    const caller = await createCallerForUser(memberUser.id);
+
+    const result = await caller.codeReviews.getSessionMessages({
+      reviewId: review.id,
+      attemptId: attempt.id,
+    });
+
+    expect(result).toMatchObject({ success: true, entries: [{ message: 'Review in progress' }] });
+    expect(mockFetchSessionSnapshot).toHaveBeenCalledWith(
+      original.session.session_id,
+      ownerUser.id
+    );
+  });
+
+  it('does not fall back to the review when a selected attempt has no session IDs', async () => {
+    const { review } = await insertReviewWithSession();
+    const [attempt] = await db
+      .insert(cloud_agent_code_review_attempts)
+      .values({ code_review_id: review.id, attempt_number: 1, status: 'pending' })
+      .returning();
+    const caller = await createCallerForUser(memberUser.id);
+
+    await expect(
+      caller.codeReviews.getSessionMessages({ reviewId: review.id, attemptId: attempt.id })
+    ).resolves.toEqual({ success: true, entries: [] });
+    expect(mockFetchSessionSnapshot).not.toHaveBeenCalled();
+  });
+
+  it.each(['missing', 'for a different CLI session'] as const)(
+    'returns no transcript when the runtime mapping is %s',
+    async mapping => {
+      const { review } = await insertReviewWithSession();
+      const cloudAgentSessionId =
+        mapping === 'missing'
+          ? `agent_unmapped_${crypto.randomUUID()}`
+          : (await insertReviewWithSession()).cloudAgentSessionId;
+      await db
+        .update(cloud_agent_code_reviews)
+        .set({ session_id: cloudAgentSessionId })
+        .where(eq(cloud_agent_code_reviews.id, review.id));
+      const caller = await createCallerForUser(memberUser.id);
+
+      await expect(caller.codeReviews.getSessionMessages({ reviewId: review.id })).resolves.toEqual(
+        { success: true, entries: [] }
+      );
+      expect(mockFetchSessionSnapshot).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['another organization', 'personal scope'] as const)(
+    'does not fetch an organization review session mapped to %s',
+    async scope => {
+      const { review } = await insertReviewWithSession(
+        {},
+        {
+          kilo_user_id: ownerUser.id,
+          organization_id: scope === 'personal scope' ? null : otherOrganization.id,
+        }
+      );
+      const caller = await createCallerForUser(memberUser.id);
+
+      await expect(caller.codeReviews.getSessionMessages({ reviewId: review.id })).resolves.toEqual(
+        { success: true, entries: [] }
+      );
+      expect(mockFetchSessionSnapshot).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['another user', 'an organization'] as const)(
+    'does not fetch a personal review session owned by %s',
+    async owner => {
+      const { review } = await insertReviewWithSession(
+        { owned_by_user_id: ownerUser.id, owned_by_organization_id: null },
+        {
+          kilo_user_id: owner === 'another user' ? outsiderUser.id : ownerUser.id,
+          organization_id: owner === 'an organization' ? organization.id : null,
+        }
+      );
+      const caller = await createCallerForUser(ownerUser.id);
+
+      await expect(caller.codeReviews.getSessionMessages({ reviewId: review.id })).resolves.toEqual(
+        { success: true, entries: [] }
+      );
+      expect(mockFetchSessionSnapshot).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['organization', 'personal'] as const)(
+    'reads scoped %s CLI-only history despite another owner having the same CLI ID',
+    async scope => {
+      const cliSessionId = `ses_history_${crypto.randomUUID()}`;
+      await db.insert(cli_sessions_v2).values({
+        session_id: cliSessionId,
+        kilo_user_id: outsiderUser.id,
+        organization_id: scope === 'organization' ? otherOrganization.id : null,
+      });
+      const { review, session } = await insertReviewWithSession(
+        {
+          status: 'completed',
+          agent_version: null,
+          session_id: null,
+          owned_by_user_id: scope === 'personal' ? ownerUser.id : null,
+          owned_by_organization_id: scope === 'organization' ? organization.id : null,
+        },
+        {
+          session_id: cliSessionId,
+          kilo_user_id: scope === 'personal' ? ownerUser.id : botUser.id,
+          organization_id: scope === 'organization' ? organization.id : null,
+        }
+      );
+      const caller = await createCallerForUser(scope === 'personal' ? ownerUser.id : memberUser.id);
+
+      const result = await caller.codeReviews.getSessionMessages({ reviewId: review.id });
+
+      expect(result).toMatchObject({ success: true, entries: [{ message: 'Review in progress' }] });
+      expect(mockFetchSessionSnapshot).toHaveBeenCalledWith(cliSessionId, session.kilo_user_id);
+    }
+  );
+
+  it('returns no transcript for ambiguous organization CLI-only history', async () => {
+    const { review, session } = await insertReviewWithSession({ session_id: null });
+    await db.insert(cli_sessions_v2).values({
+      session_id: session.session_id,
+      kilo_user_id: ownerUser.id,
+      organization_id: organization.id,
+    });
+    const caller = await createCallerForUser(memberUser.id);
+
+    await expect(caller.codeReviews.getSessionMessages({ reviewId: review.id })).resolves.toEqual({
+      success: true,
+      entries: [],
+    });
+    expect(mockFetchSessionSnapshot).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/routers/code-reviews/code-reviews-router.ts
+++ b/apps/web/src/routers/code-reviews/code-reviews-router.ts
@@ -62,7 +62,7 @@ import { isNewSession } from '@/lib/cloud-agent/session-type';
 import { fetchSessionSnapshot } from '@/lib/session-ingest-client';
 import { getBlobContent } from '@/lib/r2/cli-sessions';
 import { db } from '@/lib/drizzle';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { v2SnapshotToLogEntries, v1BlobToLogEntries } from '@/lib/code-reviews/session-log';
 import { codeReviewAnalyticsRouter } from './code-review-analytics-router';
 import {
@@ -801,11 +801,6 @@ export const codeReviewRouter = createTRPCRouter({
       }
     }),
 
-  /**
-   * Get historical session messages for a completed code review.
-   * Fetches from session-ingest (v2) or R2 blob storage (v1) and returns
-   * pre-formatted log entries for the terminal view.
-   */
   getSessionMessages: baseProcedure
     .input(
       z.object({
@@ -851,27 +846,41 @@ export const codeReviewRouter = createTRPCRouter({
           });
         }
 
-        const cliSessionId = attempt?.cli_session_id ?? review.cli_session_id;
-        // old both-missing form; keep while any client depends on empty entries.
-        if (!cliSessionId) {
+        const source = attempt ?? review;
+        const cliSessionId = source.cli_session_id;
+        const cloudAgentSessionId = source.session_id;
+        if (!cliSessionId && !cloudAgentSessionId) {
           return successResult({ entries: [] });
         }
 
-        // V2 sessions (ses_* prefix): fetch from session-ingest worker
-        if (isNewSession(cliSessionId)) {
-          const [session] = await db
-            .select({ kilo_user_id: cli_sessions_v2.kilo_user_id })
+        if (cliSessionId ? isNewSession(cliSessionId) : review.agent_version === 'v2') {
+          const [session, duplicateSession] = await db
+            .select({
+              session_id: cli_sessions_v2.session_id,
+              kilo_user_id: cli_sessions_v2.kilo_user_id,
+            })
             .from(cli_sessions_v2)
-            .where(eq(cli_sessions_v2.session_id, cliSessionId))
-            .limit(1);
+            .where(
+              and(
+                cloudAgentSessionId
+                  ? eq(cli_sessions_v2.cloud_agent_session_id, cloudAgentSessionId)
+                  : undefined,
+                cliSessionId ? eq(cli_sessions_v2.session_id, cliSessionId) : undefined,
+                review.owned_by_organization_id
+                  ? eq(cli_sessions_v2.organization_id, review.owned_by_organization_id)
+                  : and(
+                      eq(cli_sessions_v2.kilo_user_id, ctx.user.id),
+                      isNull(cli_sessions_v2.organization_id)
+                    )
+              )
+            )
+            .limit(2);
 
-          if (!session) {
+          if (!session || duplicateSession) {
             return successResult({ entries: [] });
           }
 
-          // old swallow returned empty entries on snapshot failure; web ignores
-          // a failed success flag; remove when web shows this error.
-          const snapshot = await fetchSessionSnapshot(cliSessionId, session.kilo_user_id);
+          const snapshot = await fetchSessionSnapshot(session.session_id, session.kilo_user_id);
           if (!snapshot) {
             return successResult({ entries: [] });
           }
@@ -881,6 +890,10 @@ export const codeReviewRouter = createTRPCRouter({
               includeFullAssistantText: isLocalKiloCodeReview(review),
             }),
           });
+        }
+
+        if (!cliSessionId) {
+          return successResult({ entries: [] });
         }
 
         // V1 sessions (UUID): fetch from R2 blob storage

--- a/apps/web/src/routers/organizations/organization-modes-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-modes-router.test.ts
@@ -3,6 +3,7 @@ import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createTestOrganization } from '@/tests/helpers/organization.helper';
 import { addUserToOrganization, getOrganizationById } from '@/lib/organizations/organizations';
 import { getAllOrganizationModes } from '@/lib/organizations/organization-modes';
+import type { OpenRouterModelsResponse } from '@/lib/organizations/organization-types';
 import type { User, Organization } from '@kilocode/db/schema';
 import { organization_audit_logs } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
@@ -13,10 +14,38 @@ jest.mock('@/lib/posthog-feature-flags', () => ({
   isReleaseToggleEnabled: jest.fn(async () => true),
 }));
 
+jest.mock('@/lib/ai-gateway/providers/openrouter', () => ({
+  getEnhancedOpenRouterModels: jest.fn(
+    async () =>
+      ({
+        data: [
+          {
+            id: 'openai/gpt-4o',
+            name: 'GPT-4o',
+            created: 0,
+            description: '',
+            architecture: {
+              input_modalities: ['text'],
+              output_modalities: ['text'],
+              tokenizer: 'test',
+            },
+            top_provider: { is_moderated: false },
+            pricing: { prompt: '0', completion: '0' },
+            context_length: 8192,
+          },
+        ],
+      }) satisfies OpenRouterModelsResponse
+  ),
+}));
+
 jest.mock('@/lib/ai-gateway/providers/openrouter/models-by-provider-index.server', () => ({
   getProviderSlugsForModel: jest.fn(async (modelId: string) =>
     modelId === 'openai/gpt-4o' ? new Set(['openai']) : new Set()
   ),
+}));
+
+jest.mock('@/lib/ai-gateway/experiments/membership', () => ({
+  isPublicIdExperimented: jest.fn(async () => false),
 }));
 
 const mockedIsReleaseToggleEnabled = jest.mocked(


### PR DESCRIPTION
## Summary

- Restore live Code Reviewer progress for organization members by polling the existing review-authorized transcript endpoint instead of requesting creator-only access to bot-owned sessions. Personal reviews retain WebSockets and now render canonical text parts without requiring tool-state metadata.
- Keep review status fresh, reconcile persisted transcripts briefly after completion, and isolate state and late callbacks when switching attempts. Recoverable errors stay inside the log area so attempt selection remains available; authorization failures hide cached transcript data and runtime IDs.
- Scope transcript lookup to the review's owner/organization and selected attempt, including runtime-only continuations, without broadening generic Cloud Agent session access.

## Verification

Browser and API verification against the local development stack on August 29:

- [x] Ran a local read-only organization review with `kilo-auto/efficient`, viewed by an ordinary member rather than the bot/session creator. Observed 16 changing log snapshots while running; the final transcript contained 11 persisted messages. Final text remained visible and transcript polling stopped after the terminal reconciliation window.
- [x] Ran a personal review through the real Worker, Durable Object, sandbox, wrapper, and browser WebSocket, with deterministic inference only. Canonical text rendered before completion and the final two-message transcript persisted.
- [x] Switched attempts and deep links. Temporarily stopped local session-ingest: the error remained visible, attempt selection stayed usable, and selecting the completed attempt recovered its transcript after the service restarted.
- [x] Confirmed generic bot-session stream tickets still return 403, personal non-owner transcript reads return 403, and cross-review attempt lookups return 404. Revoking organization membership denied both transcript and stream-info reads; refresh hid cached content and runtime identity. Membership was restored. This revocation check occurred after completion, not during an active model run.

## Visual Changes

The existing layout is retained; live log content and recoverable error behavior change.

| Before | After |
|---|---|
| Screenshot not captured. | Screenshot unavailable: browser screenshot capture timed out. Live updates and error/attempt navigation were verified through DOM and network observations. |

## Reviewer Notes

- Generic Cloud Agent session authorization remains creator-only. Organization transcripts recheck review membership on every read, and session lookup fails closed for mismatched or ambiguous mappings.
- Successful local runs used Cloud Agent Next's V2 legacy execution plane. The worktree's enabled control-plane path failed before execution with `Prepared admission is legacy-only`; a temporary Worker CLI override disabled control-plane enrollment for verification and was removed afterward. This existing execution-path incompatibility is outside this web fix.
- All review jobs used local read-only output mode: no GitHub comments, statuses, or reactions were published. No Worker changes, migrations, production dependencies, or deployments are included.
