### PR TITLE
feat(auth): add opt-in token issuance policy contracts

### DIFF
--- a/docs/token-issuance-policy.md
+++ b/docs/token-issuance-policy.md
@@ -7,7 +7,7 @@ Phase 1 defines an **opt-in** token-policy module, `packages/worker-utils/src/ki
 Existing operation-specific audiences remain mandatory and unchanged:
 
 | Existing audience | Current issuer/consumer evidence |
-| --- | --- |
+|---|---|
 | `git-token-service:bitbucket-repositories` | `apps/web/src/lib/integrations/platforms/bitbucket/token-service-client.ts`; `services/git-token-service/src/index.ts` |
 | `git-token-service:bitbucket-code-review:pull-request` | `packages/worker-utils/src/internal-service-token-audiences.ts`; `services/git-token-service/src/index.ts` |
 | `git-token-service:bitbucket-code-review:webhook-ensure` | `packages/worker-utils/src/internal-service-token-audiences.ts`; `services/git-token-service/src/index.ts` |
@@ -24,7 +24,7 @@ The current shared verifier rejects a token with an audience when no audience is
 `generateApiToken` originally used `expiresIn: '5y'` in commit `bc8179c70` (2026-02-04). Commit `c6bf3468f` (2026-02-10) changed the default to `5 * 365 * 24 * 60 * 60` seconds.
 
 | Legacy issuer expression | Exact `exp - iat` | Evidence |
-| --- | ---: | --- |
+|---|---:|---|
 | Current numeric five-year default | `157680000` | `apps/web/src/lib/tokens.ts` |
 | Historical `'5y'` default | `157788000` | `bc8179c70:src/lib/tokens.ts`; installed `ms` parser defines a year as 365.25 days |
 
@@ -53,14 +53,17 @@ It defines boolean `credentialExchange` and two resource audience modes: `requir
 - Verified session: a context obtained by calling the trusted session verifier, not generic bearer-capable user authentication. A bare database user or fabricated session/bearer object is not a policy context.
 - Modern bearer: `tokenPurpose === 'human-api'`, `credentialExchange === true`, and the **sole** audience is `kilo-api` (string or singleton array).
 - Legacy bearer: explicitly select `legacy: 'five-year-api'`, described below; `legacy: 'deny'` disables that fallback.
-- Both bearer classes require a present pepper claim and reject all of the markers listed in the legacy class below, even if false or empty. This is deliberately conservative: a modern exchangeable human issuer must not add these metadata fields without revisiting that policy.
+- Both bearer classes require a present pepper claim and an explicit allowlist of signed claim names: `version`, `kiloUserId`, `apiTokenPepper`, `env`, `iat`, `exp`, `aud`, `tokenPurpose`, `credentialExchange`, and `deviceAuthRequestCode`. Every other name blocks exchange, even when its value is false, null, or empty. Adding a field to the shared schema does not add it to this allowlist.
+- The verifier retains a frozen `claimNames` list from the original signed payload before schema projection. Unknown claim values remain outside the supported claims contract, but their names cannot disappear from exchange classification. Ordinary resource verification is not made strict merely to enforce the narrower exchange policy; unknown claims still block exchange.
 - Bearer expiration is checked again at the issuance decision. Original lifetime uses verified `exp - iat`, never remaining validity.
 
-Policy inputs must be verified, claim-complete token contexts from either a separate signature-verification result or a trusted existing session-verifier callback. Do not accept raw database `User` records, decoded JWTs, or claims that an existing legacy projection has dropped. Signature verification alone is not account authentication: callers still perform their existing user/account, environment, pepper, and session-revocation checks before using a token to issue another credential.
+`isKiloCredentialExchangeEligible` assesses credential shape and purpose only; it does not authorize issuance. A token can be shape-eligible yet revoked, have a stale pepper, or belong to a blocked account. Policy inputs must be verified token contexts from either a separate signature-verification result or a trusted existing session-verifier callback. Do not accept raw database `User` records, decoded JWTs, or claims that an existing legacy projection has dropped. Signature verification alone is not account authentication: callers must independently perform user/account, environment, current-pepper equality, and session-revocation checks before issuance.
 
-Use `verifyKiloTokenForPolicy` on the original signed token, not `verifyKiloToken`'s projected payload. Use `verifyKiloSessionForPolicy` only with a trusted session-only verifier, never a generic function that also authenticates bearer tokens. Pass the returned context object itself to `canIssueKiloCredentials`; cloning or serializing it loses its module-local verified provenance. The context is not a replacement for account authentication and must remain bound to the same authenticated user.
+Use `verifyKiloTokenForPolicy` on the original signed token, not `verifyKiloToken`'s projected payload. Use `verifyKiloSessionForPolicy` only with a trusted session-only verifier, never a generic function that also authenticates bearer tokens. Pass the returned context object itself to `isKiloCredentialExchangeEligible`; cloning or serializing it loses its module-local verified provenance. The context is not a replacement for account authentication and must remain bound to the same authenticated user.
 
-`buildModernKiloTokenPayload` validates a future signer's payload without signing anything. Its strict extras schema rejects reserved identity, pepper, environment, audience, temporal, purpose, exchange, and registered JWT claim overrides, even when their values would otherwise be valid. Authoritative fields must come from the builder parameters. Existing signers are intentionally not routed through it in Phase 1.
+`buildModernKiloTokenPayload` validates a future signer's payload without signing anything. Its strict extras schema rejects reserved identity, pepper, environment, audience, temporal, purpose, exchange, and registered JWT claim overrides, even when their values would otherwise be valid. Exchangeable output additionally requires a pepper claim, the `kilo-api` audience, and only exchange-safe claims; conflicting extras are rejected rather than producing a token the eligibility policy refuses. Known optional extras set to `undefined` are ignored by the builder's exchange-safety check because JWT JSON serialization omits them; false, null, empty, and other defined values do not receive that exemption. Unknown or reserved extras remain rejected even if undefined. The original signed claim-name check remains authoritative at verification. Non-exchangeable output can retain supported workload/scope metadata. The output type preserves the discriminated purpose/exchange relationship. Authoritative fields must come from the builder parameters. Existing signers are intentionally not routed through it in Phase 1.
+
+Verified bearer contexts expose recursively readonly, deeply frozen supported claim values, including the organization-membership array and its entries. This protects the verification snapshot; it does not imply that account state remains current.
 
 No main signer or verifier changes in Phase 1. In particular, this module does not add claims to `apps/web/src/lib/tokens.ts` or `packages/worker-utils/src/kilo-token.ts`.
 
@@ -71,17 +74,19 @@ No main signer or verifier changes in Phase 1. In particular, this module does n
 - no `aud`;
 - no modern policy fields;
 - `apiTokenPepper` is present, whether a string or `null`;
-- no `tokenSource`, `botId`, `internalApiUse`, `createdOnPlatform`, `deviceSessionId`, `gastownAccess`, `isAdmin`, `orgMemberships`, `organizationId`, or `organizationRole`;
+- only the exchange-safe claim names listed above; this excludes `tokenSource`, `botId`, `internalApiUse`, `createdOnPlatform`, `deviceSessionId`, `gastownAccess`, `isAdmin`, `orgMemberships`, `organizationId`, `organizationRole`, and any future or unknown claim;
 - `deviceAuthRequestCode` is allowed, preserving legacy device authorization output.
 
 Known marked automation and system-style issuers fail this shape. Residual risk remains from historical or current unmarked automation that happens to match it; the class must never be labeled or relied on as definitive human identity.
+
+Future issuance routes should use `legacy: 'deny'` by default. A route requiring proof of human issuance must use trustworthy server-side issuance provenance or fresh session authentication, not enable the shape fallback as a substitute. Any compatibility exception requires an explicit policy decision accepting the documented residual risk. This concerns permission to exchange credentials, not supported ordinary legacy resource access; Phase 1 does not invalidate tokens.
 
 ## Issuer and consumer map
 
 This is a concrete, selective map from the shared Kilo token entry points. It does not claim every consumer path is known.
 
 | Flow | Issuer | Known consumers | Existing audience | Proposed canonical boundary | Unresolved split |
-| --- | --- | --- | --- | --- | --- |
+|---|---|---|---|---|---|
 | Chat fanout | `apps/web/src/lib/kilo-chat/token.ts`; mobile requests through `apps/mobile/src/components/kilo-chat/hooks/use-kilo-chat-token.ts` | Kilo Chat and Event Service via `apps/web/src/contexts/EventServiceContext.tsx`; Notifications badges via `apps/mobile/src/lib/hooks/use-unread-counts.ts` | None | `kilo-chat`, `event-service`, `notifications` | One chat token fans out to three services; decide whether it becomes a single multi-audience read token or separate audience-specific tokens. |
 | Cloud Agent control and downstream Kilo access | `apps/web/src/lib/tokens.ts` (`generateCloudAgentToken`) and Cloud Agent routers | `services/cloud-agent-next/src/validate-kilo-token.ts`; backend balance call; raw runtime bearer or contained capability in `services/cloud-agent-next/src/session-service.ts` | None | `cloud-agent-next`, `kilo-api`, `kilo-gateway`, `session-ingest` | The raw user token can reach multiple downstream routes; contained Kilo capability has separate routing controls. |
 | App Builder | `apps/web/src/routers/app-builder-router.ts`; `apps/web/src/routers/organizations/organization-app-builder-router.ts` | `apps/web/src/lib/app-builder/app-builder-service.ts` forwards to `services/cloud-agent-next/src/middleware/auth.ts` | None; default five-year token, often unmarked | Cloud Agent control and downstream API/gateway boundaries | Unmarked tokens can match the legacy exchange class; separate control assertions from runtime credentials. |
@@ -129,3 +134,5 @@ Before moving any resource from `allow-legacy` to `required`:
 3. Deploy compatible readers first, then migrate issuers and renewal paths, preserving the mandatory operation-specific audiences above. Renewal must retain non-exchangeable workload purpose; migrating issuers first breaks today's unexpected-audience rejection.
 4. Ensure the caller has a verified, non-lossy token context and retains existing account/authentication checks.
 5. Measure or otherwise retire the relevant legacy population before enforcing `required` mode.
+
+Before wiring a real credential-issuance route, use an application-owned authentication adapter that validates current account state and records session-versus-bearer provenance. A narrower session-only callback or account-authenticated capability belongs at that integration boundary; a generic database-user callback is not proof of a session. Add route regressions for revoked/blocked accounts, rotated peppers, wrong environments, and bearer-capable authentication incorrectly classified as a session. None of those account checks or route integrations is introduced in this infrastructure-only PR.

--- a/docs/token-issuance-policy.md
+++ b/docs/token-issuance-policy.md
@@ -1,0 +1,131 @@
+# Token Issuance Policy (Phase 1)
+
+## Scope and status
+
+Phase 1 defines an **opt-in** token-policy module, `packages/worker-utils/src/kilo-token-policy.ts`, and documents the issuer-to-consumer boundaries. It is not an enforcement rollout or a security fix. No existing signer or verifier behavior changes in this phase; callers opt in deliberately after their existing verification/authentication flow.
+
+Existing operation-specific audiences remain mandatory and unchanged:
+
+| Existing audience | Current issuer/consumer evidence |
+| --- | --- |
+| `git-token-service:bitbucket-repositories` | `apps/web/src/lib/integrations/platforms/bitbucket/token-service-client.ts`; `services/git-token-service/src/index.ts` |
+| `git-token-service:bitbucket-code-review:pull-request` | `packages/worker-utils/src/internal-service-token-audiences.ts`; `services/git-token-service/src/index.ts` |
+| `git-token-service:bitbucket-code-review:webhook-ensure` | `packages/worker-utils/src/internal-service-token-audiences.ts`; `services/git-token-service/src/index.ts` |
+| `git-token-service:bitbucket-code-review:webhook-delete` | `packages/worker-utils/src/internal-service-token-audiences.ts`; `services/git-token-service/src/index.ts` |
+| `git-token-service:gitlab-credentials` | `apps/web/src/lib/integrations/platforms/gitlab/credential-broker-client.ts`; `services/git-token-service/src/index.ts` |
+| `git-token-service:github-user-access-token` | `apps/web/src/lib/integrations/platforms/github/user-token-client.ts`; `services/git-token-service/src/index.ts` |
+| `user-data-export` | `apps/web/src/lib/user-data-export-worker-client.ts`; `services/user-data-export/src/index.ts` |
+| `session-ingest:user-deletion` | `apps/web/src/lib/user/deletion-queue/handlers/cli-v2.ts`; `services/session-ingest/src/middleware/kilo-jwt-auth.ts` |
+
+The current shared verifier rejects a token with an audience when no audience is expected (`packages/worker-utils/src/kilo-token.ts`); that existing behavior is not altered.
+
+## Historical compatibility
+
+`generateApiToken` originally used `expiresIn: '5y'` in commit `bc8179c70` (2026-02-04). Commit `c6bf3468f` (2026-02-10) changed the default to `5 * 365 * 24 * 60 * 60` seconds.
+
+| Legacy issuer expression | Exact `exp - iat` | Evidence |
+| --- | ---: | --- |
+| Current numeric five-year default | `157680000` | `apps/web/src/lib/tokens.ts` |
+| Historical `'5y'` default | `157788000` | `bc8179c70:src/lib/tokens.ts`; installed `ms` parser defines a year as 365.25 days |
+
+Both values are required for the narrow legacy five-year class. Confidence is limited to repository history plus the presently installed parser: historical production cutovers, issued-token population, and dependency-lockfile history have not been independently confirmed. The class is compatibility evidence, not proof of a human credential: unmarked automation also calls the generic five-year issuer, including `apps/web/src/routers/app-builder-router.ts` and `apps/web/src/routers/cli-sessions-v2-router.ts`.
+
+## Opt-in contract
+
+`kilo-token-policy.ts` exports `KILO_TOKEN_PURPOSES` for the `tokenPurpose` claim:
+
+```text
+human-api | device-access | delegated-workload | internal-service
+```
+
+It defines boolean `credentialExchange` and two resource audience modes: `required` and `allow-legacy`. None of these helpers is wired into production authentication in Phase 1.
+
+- If either modern claim is present, both `tokenPurpose` and `credentialExchange` are required, and `aud` is required.
+- A modern read token accepts `aud` as either a nonempty string or a nonempty, unique string array; access is membership-based.
+- The modern payload builder accepts a single audience only; it does not sign or issue tokens. Multi-audience support is read compatibility, not builder output.
+- `required` requires a matching explicit audience. Existing operation-audience tokens do not need new purpose claims just to pass this audience policy.
+- `allow-legacy` additionally accepts an absent audience for ordinary resource access. An explicit wrong, empty, malformed, or unknown nonmatching audience is never treated as missing. All array entries must be valid and unique; matching uses exact membership, not substring or wildcard rules.
+- If modern claims are present, the new verifier validates their completeness and consistency in either mode. Only `human-api` may set `credentialExchange: true`. Resource-specific purpose permissions remain the consumer's responsibility.
+- The opt-in verifier requires safe, nonnegative integer `iat`/`exp`, `exp > iat`, an unexpired token, and no future `iat`; it also checks the HS256 signature and any `nbf`. These requirements do not change the existing verifier or its optional-date compatibility.
+
+`credentialExchange` has one initially defined exchange route:
+
+- Verified session: a context obtained by calling the trusted session verifier, not generic bearer-capable user authentication. A bare database user or fabricated session/bearer object is not a policy context.
+- Modern bearer: `tokenPurpose === 'human-api'`, `credentialExchange === true`, and the **sole** audience is `kilo-api` (string or singleton array).
+- Legacy bearer: explicitly select `legacy: 'five-year-api'`, described below; `legacy: 'deny'` disables that fallback.
+- Both bearer classes require a present pepper claim and reject all of the markers listed in the legacy class below, even if false or empty. This is deliberately conservative: a modern exchangeable human issuer must not add these metadata fields without revisiting that policy.
+- Bearer expiration is checked again at the issuance decision. Original lifetime uses verified `exp - iat`, never remaining validity.
+
+Policy inputs must be verified, claim-complete token contexts from either a separate signature-verification result or a trusted existing session-verifier callback. Do not accept raw database `User` records, decoded JWTs, or claims that an existing legacy projection has dropped. Signature verification alone is not account authentication: callers still perform their existing user/account, environment, pepper, and session-revocation checks before using a token to issue another credential.
+
+Use `verifyKiloTokenForPolicy` on the original signed token, not `verifyKiloToken`'s projected payload. Use `verifyKiloSessionForPolicy` only with a trusted session-only verifier, never a generic function that also authenticates bearer tokens. Pass the returned context object itself to `canIssueKiloCredentials`; cloning or serializing it loses its module-local verified provenance. The context is not a replacement for account authentication and must remain bound to the same authenticated user.
+
+`buildModernKiloTokenPayload` validates a future signer's payload without signing anything. Its strict extras schema rejects reserved identity, pepper, environment, audience, temporal, purpose, exchange, and registered JWT claim overrides, even when their values would otherwise be valid. Authoritative fields must come from the builder parameters. Existing signers are intentionally not routed through it in Phase 1.
+
+No main signer or verifier changes in Phase 1. In particular, this module does not add claims to `apps/web/src/lib/tokens.ts` or `packages/worker-utils/src/kilo-token.ts`.
+
+## Legacy exchange class
+
+`five-year-api` is deliberately narrow. It permits both exact historical durations (`157680000`, `157788000`) and requires all of the following:
+
+- no `aud`;
+- no modern policy fields;
+- `apiTokenPepper` is present, whether a string or `null`;
+- no `tokenSource`, `botId`, `internalApiUse`, `createdOnPlatform`, `deviceSessionId`, `gastownAccess`, `isAdmin`, `orgMemberships`, `organizationId`, or `organizationRole`;
+- `deviceAuthRequestCode` is allowed, preserving legacy device authorization output.
+
+Known marked automation and system-style issuers fail this shape. Residual risk remains from historical or current unmarked automation that happens to match it; the class must never be labeled or relied on as definitive human identity.
+
+## Issuer and consumer map
+
+This is a concrete, selective map from the shared Kilo token entry points. It does not claim every consumer path is known.
+
+| Flow | Issuer | Known consumers | Existing audience | Proposed canonical boundary | Unresolved split |
+| --- | --- | --- | --- | --- | --- |
+| Chat fanout | `apps/web/src/lib/kilo-chat/token.ts`; mobile requests through `apps/mobile/src/components/kilo-chat/hooks/use-kilo-chat-token.ts` | Kilo Chat and Event Service via `apps/web/src/contexts/EventServiceContext.tsx`; Notifications badges via `apps/mobile/src/lib/hooks/use-unread-counts.ts` | None | `kilo-chat`, `event-service`, `notifications` | One chat token fans out to three services; decide whether it becomes a single multi-audience read token or separate audience-specific tokens. |
+| Cloud Agent control and downstream Kilo access | `apps/web/src/lib/tokens.ts` (`generateCloudAgentToken`) and Cloud Agent routers | `services/cloud-agent-next/src/validate-kilo-token.ts`; backend balance call; raw runtime bearer or contained capability in `services/cloud-agent-next/src/session-service.ts` | None | `cloud-agent-next`, `kilo-api`, `kilo-gateway`, `session-ingest` | The raw user token can reach multiple downstream routes; contained Kilo capability has separate routing controls. |
+| App Builder | `apps/web/src/routers/app-builder-router.ts`; `apps/web/src/routers/organizations/organization-app-builder-router.ts` | `apps/web/src/lib/app-builder/app-builder-service.ts` forwards to `services/cloud-agent-next/src/middleware/auth.ts` | None; default five-year token, often unmarked | Cloud Agent control and downstream API/gateway boundaries | Unmarked tokens can match the legacy exchange class; separate control assertions from runtime credentials. |
+| Code Review | `apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts` | `services/code-review-infra/src/code-review-orchestrator.ts` forwards to Cloud Agent Next | None; default five-year token with `botId: 'reviewer'` | Cloud Agent control and downstream API/gateway boundaries | Preserve delegated workload purpose through forwarding and renewal. |
+| Auto Fix | `apps/web/src/lib/auto-fix/triggers/prepare-fix-payload.ts` | `services/auto-fix-infra/src/services/cloud-agent-next-client.ts` forwards to Cloud Agent Next | None; default five-year token with `botId: 'auto-fix'` | Cloud Agent control and downstream API/gateway boundaries | Do not bind only to the infrastructure service when the token reaches the runtime. |
+| Auto Triage | `apps/web/src/lib/auto-triage/triggers/prepare-triage-payload.ts` | `services/auto-triage-infra/src/triage-orchestrator.ts` forwards to Cloud Agent Next | None; default five-year token with `botId: 'auto-triage'` | Cloud Agent control and downstream API/gateway boundaries | Same control/runtime separation as other Cloud Agent workflows. |
+| Security Auto Analysis | `services/security-auto-analysis/src/token.ts` | `services/security-auto-analysis/src/launch.ts`, `remediation.ts`, and `manual-analysis.ts` forward user credentials to Cloud Agent Next | None; one-hour marked user tokens and separate minimal internal assertions | Cloud Agent control and downstream API/gateway boundaries for user tokens; identify each internal assertion consumer separately | Keep internal assertions distinct from runtime user credentials. |
+| Webhook Agent Ingest | `services/webhook-agent-ingest/src/services/token-minting-service.ts` | `services/webhook-agent-ingest/src/queue-consumer.ts` forwards to Cloud Agent Next | None; one-hour personal/bot-user token branches | Cloud Agent control and downstream API/gateway boundaries | Preserve non-exchangeable classification for both personal and bot-user branches. |
+| Gastown and Wasteland control | `apps/web/src/app/api/gastown/token/route.ts`; `apps/web/src/app/api/wasteland/token/route.ts` | `services/gastown/src/middleware/kilo-auth.middleware.ts`; `services/wasteland/src/middleware/kilo-auth.middleware.ts` | None | `gastown`; `wasteland` | Keep the two control planes separate. |
+| Gastown agent runtime | `services/gastown/src/util/kilo-token.util.ts` | Kilo LLM gateway through the stored `kilocode_token` path | None | `kilo-gateway` | Runtime token is distinct from Gastown control despite its issuer. |
+| KiloClaw control and cookie | `apps/web/src/routers/kiloclaw-router.ts`; cookie minted in `services/kiloclaw/src/routes/access-gateway.ts` | `services/kiloclaw/src/auth/middleware.ts` | None | `kiloclaw` | Bearer control and 24-hour cookie share the verifier but may need different later purposes. |
+| KiloClaw runtime | `apps/web/src/routers/kiloclaw-router.ts`; reminted in `services/kiloclaw/src/durable-objects/kiloclaw-instance/config.ts` | OpenClaw KiloCode provider configuration in `services/kiloclaw/controller/src/config-writer.ts` | None | `kilo-gateway` | Separate runtime credential from KiloClaw control. |
+| Session ingest | `apps/web/src/lib/tokens.ts` (`generateInternalServiceToken`) | `services/session-ingest/src/middleware/kilo-jwt-auth.ts` | Generic tokens plus unchanged deletion audience | `session-ingest` | Generic service JWT, deletion JWT, opaque web ticket, and Cloud Agent contained access are different families. |
+| Git operations | `apps/web/src/lib/integrations/platforms/{bitbucket,github,gitlab}/`; generic GitHub disconnect in `apps/web/src/lib/integrations/platforms/github/user-authorization-client.ts` | `services/git-token-service/src/index.ts` | Operation-specific values listed above; disconnect has none | Preserve existing values; potential later `git-token-service:github-user-authorizations:disconnect` | Do not replace mandatory operation-specific audiences with broad `git-token-service`. |
+| User-data export | `apps/web/src/lib/user-data-export-worker-client.ts` | `services/user-data-export/src/index.ts` | `user-data-export` | Preserve `user-data-export` | Requires its additional internal API key and five-minute assertion limit. |
+| Organization and attribution | `apps/web/src/app/api/organizations/[id]/user-tokens/route.ts` | `services/ai-attribution/src/util/auth.ts` | None | `ai-attribution` | Organization-bearing tokens have other valid uses; attribution consumer transport was not fully traced. |
+| Auto-routing benchmark | `apps/web/src/app/api/internal/auto-routing-benchmark/token/route.ts` | `services/auto-routing-benchmark/src/run.ts` decider CLI | None | `kilo-api` / `kilo-gateway` based on actual downstream call | `tokenSource: 'auto-routing-benchmark'` identifies issuance, not an authorization audience; full CLI call graph is unresolved. |
+
+## Existing markers and excluded families
+
+Core optional markers accepted by the shared schema are documented in `packages/worker-utils/src/kilo-token.ts`: `tokenSource`, `botId`, `internalApiUse`, `createdOnPlatform`, `deviceAuthRequestCode`, `deviceSessionId`, admin/Gastown flags, and organization claims.
+
+- Confirmed `tokenSource` values: `cloud-agent`, `kilo-chat`, `auto-routing-benchmark`.
+- Confirmed `botId` values: `reviewer`, `auto-fix`, `auto-triage`, `discord-bot`, `webhook-bot`.
+- `internalApiUse` and `createdOnPlatform` are additional automation markers; `services/security-auto-analysis/src/token.ts` emits `internalApiUse: true` and `createdOnPlatform: 'security-agent'`.
+- No universal signed system marker or reliable system-user-ID convention was confirmed.
+
+Excluded from the credential-exchange compatibility class or treated as separate token families:
+
+- internal-service tokens with no pepper claim;
+- existing operation-audience JWTs;
+- KiloClaw cookie and runtime credentials unless a resource opts in with their own modern policy;
+- Cloud Agent stream tickets and wrapper-dispatch tickets in `services/cloud-agent-next/src/auth.ts`;
+- encrypted Git/Kilo session capabilities, which have their own `purpose` field (for example `kilo_api_session`) in `services/git-token-service/src/kilo-session-capability.ts`;
+- container, share, repository, and MCP credentials, which require separate family-specific analysis rather than automatic migration as core Kilo API tokens.
+
+KiloClaw's five-minute control tokens (one-hour setup token), 24-hour access cookies, and 30-day runtime keys are distinct. Gastown runtime credentials also last 30 days; organization tokens last 15 minutes and benchmark tokens six hours. None qualifies for the five-year exchange compatibility class.
+
+## Migration preconditions
+
+Before moving any resource from `allow-legacy` to `required`:
+
+1. Identify that resource's actual issuer and all consumer paths, including browser, mobile, runtime, and delegated paths.
+2. Establish a canonical audience and whether the resource needs one builder-minted audience or read-side membership across multiple audiences.
+3. Deploy compatible readers first, then migrate issuers and renewal paths, preserving the mandatory operation-specific audiences above. Renewal must retain non-exchangeable workload purpose; migrating issuers first breaks today's unexpected-audience rejection.
+4. Ensure the caller has a verified, non-lossy token context and retains existing account/authentication checks.
+5. Measure or otherwise retire the relevant legacy population before enforcing `required` mode.

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -12,6 +12,7 @@
     "./instance-id": "./src/instance-id.ts",
     "./kilo-token-auth": "./src/kilo-token-auth.ts",
     "./kilo-token": "./src/kilo-token.ts",
+    "./kilo-token-policy": "./src/kilo-token-policy.ts",
     "./sandbox-id": "./src/sandbox-id.ts",
     "./hostname-label": "./src/hostname-label.ts",
     "./deployment-slug": "./src/deployment-slug.ts",

--- a/packages/worker-utils/src/index.ts
+++ b/packages/worker-utils/src/index.ts
@@ -141,13 +141,13 @@ export {
   KILO_TOKEN_PURPOSES,
   LEGACY_API_TOKEN_LIFETIMES_SECONDS,
   buildModernKiloTokenPayload,
-  canIssueKiloCredentials,
+  isKiloCredentialExchangeEligible,
   isKiloResourceAudienceAllowed,
   verifyKiloSessionForPolicy,
   verifyKiloTokenForPolicy,
 } from './kilo-token-policy.js';
 export type {
-  KiloCredentialIssuancePolicy,
+  KiloCredentialExchangeEligibilityPolicy,
   KiloResourceAudiencePolicy,
   KiloTokenPolicyClaims,
   ModernKiloTokenClaims,

--- a/packages/worker-utils/src/index.ts
+++ b/packages/worker-utils/src/index.ts
@@ -53,6 +53,17 @@ export type {
 export { CloudAgentNextBillingError, CloudAgentNextError } from './cloud-agent-next-client.js';
 
 export {
+  KILO_API_AUDIENCE,
+  KILO_GATEWAY_AUDIENCE,
+  GASTOWN_AUDIENCE,
+  WASTELAND_AUDIENCE,
+  KILO_CHAT_AUDIENCE,
+  EVENT_SERVICE_AUDIENCE,
+  NOTIFICATIONS_AUDIENCE,
+  CLOUD_AGENT_NEXT_AUDIENCE,
+  KILOCLAW_AUDIENCE,
+  SESSION_INGEST_AUDIENCE,
+  AI_ATTRIBUTION_AUDIENCE,
   BITBUCKET_REPOSITORY_LIST_AUDIENCE,
   GITLAB_CREDENTIAL_BROKER_AUDIENCE,
   GITHUB_USER_ACCESS_TOKEN_AUDIENCE,
@@ -126,6 +137,23 @@ export {
   KILO_TOKEN_VERSION,
 } from './kilo-token.js';
 export type { KiloTokenPayload, SignKiloTokenExtra } from './kilo-token.js';
+export {
+  KILO_TOKEN_PURPOSES,
+  LEGACY_API_TOKEN_LIFETIMES_SECONDS,
+  buildModernKiloTokenPayload,
+  canIssueKiloCredentials,
+  isKiloResourceAudienceAllowed,
+  verifyKiloSessionForPolicy,
+  verifyKiloTokenForPolicy,
+} from './kilo-token-policy.js';
+export type {
+  KiloCredentialIssuancePolicy,
+  KiloResourceAudiencePolicy,
+  KiloTokenPolicyClaims,
+  ModernKiloTokenClaims,
+  ModernKiloTokenPurpose,
+  VerifiedKiloAuthContext,
+} from './kilo-token-policy.js';
 
 export { SessionMetricsParamsSchema, TerminationReasons } from './session-metrics-schema.js';
 export type { SessionMetricsParams, SessionMetricsParamsInput } from './session-metrics-schema.js';

--- a/packages/worker-utils/src/internal-service-token-audiences.ts
+++ b/packages/worker-utils/src/internal-service-token-audiences.ts
@@ -1,3 +1,15 @@
+export const KILO_API_AUDIENCE = 'kilo-api';
+export const KILO_GATEWAY_AUDIENCE = 'kilo-gateway';
+export const GASTOWN_AUDIENCE = 'gastown';
+export const WASTELAND_AUDIENCE = 'wasteland';
+export const KILO_CHAT_AUDIENCE = 'kilo-chat';
+export const EVENT_SERVICE_AUDIENCE = 'event-service';
+export const NOTIFICATIONS_AUDIENCE = 'notifications';
+export const CLOUD_AGENT_NEXT_AUDIENCE = 'cloud-agent-next';
+export const KILOCLAW_AUDIENCE = 'kiloclaw';
+export const SESSION_INGEST_AUDIENCE = 'session-ingest';
+export const AI_ATTRIBUTION_AUDIENCE = 'ai-attribution';
+
 export const BITBUCKET_REPOSITORY_LIST_AUDIENCE = 'git-token-service:bitbucket-repositories';
 export const BITBUCKET_CODE_REVIEW_PULL_REQUEST_AUDIENCE =
   'git-token-service:bitbucket-code-review:pull-request';

--- a/packages/worker-utils/src/kilo-token-policy.test.ts
+++ b/packages/worker-utils/src/kilo-token-policy.test.ts
@@ -1,12 +1,13 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { SignJWT } from 'jose';
 import {
   LEGACY_API_TOKEN_LIFETIMES_SECONDS,
   buildModernKiloTokenPayload,
-  canIssueKiloCredentials,
+  isKiloCredentialExchangeEligible,
   isKiloResourceAudienceAllowed,
   verifyKiloSessionForPolicy,
   verifyKiloTokenForPolicy,
+  type ModernKiloTokenClaims,
   type VerifiedKiloAuthContext,
 } from './kilo-token-policy.js';
 import { verifyKiloToken } from './kilo-token.js';
@@ -104,6 +105,64 @@ describe('verifyKiloTokenForPolicy', () => {
     expect(Object.isFrozen(context)).toBe(true);
     expect(Object.isFrozen(context.claims)).toBe(true);
     expect(Object.isFrozen(context.claims.aud)).toBe(true);
+  });
+
+  it.each([true, false, null, '', [], { restricted: true }])(
+    'retains unknown claim names and refuses legacy exchange for value %j',
+    async value => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+      const context = await verifyKiloTokenForPolicy(
+        await sign(legacyClaims({ futureAutomation: value })),
+        SECRET,
+        LEGACY_POLICY
+      );
+
+      expect(context.claimNames).toContain('futureAutomation');
+      expect(Object.isFrozen(context.claimNames)).toBe(true);
+      expect(isKiloCredentialExchangeEligible(context, { legacy: 'five-year-api' })).toBe(false);
+    }
+  );
+
+  it('retains future restriction claim names while refusing modern credential exchange', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const context = await verifyKiloTokenForPolicy(
+      await sign(
+        legacyClaims({
+          aud: 'kilo-api',
+          tokenPurpose: 'human-api',
+          credentialExchange: true,
+          futureCredentialRestriction: true,
+        })
+      ),
+      SECRET,
+      API_POLICY
+    );
+
+    expect(context.claimNames).toContain('futureCredentialRestriction');
+    expect(isKiloCredentialExchangeEligible(context, { legacy: 'deny' })).toBe(false);
+  });
+
+  it('freezes nested organization membership claims', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const context = await verifyKiloTokenForPolicy(
+      await sign(legacyClaims({ orgMemberships: [{ orgId: 'synthetic-org', role: 'member' }] })),
+      SECRET,
+      LEGACY_POLICY
+    );
+
+    const memberships = context.claims.orgMemberships;
+    if (memberships === undefined)
+      throw new Error('organization memberships were unexpectedly absent');
+    expect(Object.isFrozen(memberships)).toBe(true);
+    expect(Object.isFrozen(memberships[0])).toBe(true);
+    expect(() =>
+      Object.assign(memberships, { 0: { orgId: 'different-org', role: 'owner' } })
+    ).toThrow();
+    expect(() => Object.assign(memberships[0], { role: 'owner' })).toThrow();
+    expect(isKiloCredentialExchangeEligible(context, { legacy: 'five-year-api' })).toBe(false);
   });
 
   it('allows legacy operation audience tokens without requiring modern claims', async () => {
@@ -264,21 +323,21 @@ describe('verifyKiloTokenForPolicy', () => {
   });
 });
 
-describe('canIssueKiloCredentials', () => {
+describe('isKiloCredentialExchangeEligible', () => {
   it('only accepts authentic verified session contexts', async () => {
     const session = await verifyKiloSessionForPolicy(async () => ({
       userId: 'synthetic-session-user',
     }));
     if (session === null) throw new Error('synthetic session was unexpectedly absent');
-    expect(canIssueKiloCredentials(session, { legacy: 'deny' })).toBe(true);
+    expect(isKiloCredentialExchangeEligible(session, { legacy: 'deny' })).toBe(true);
     expect(
-      canIssueKiloCredentials(
+      isKiloCredentialExchangeEligible(
         { type: 'session', userId: 'synthetic-session-user' } as VerifiedKiloAuthContext,
         { legacy: 'deny' }
       )
     ).toBe(false);
     expect(
-      canIssueKiloCredentials(
+      isKiloCredentialExchangeEligible(
         {
           type: 'bearer',
           userId: 'synthetic-user',
@@ -297,19 +356,24 @@ describe('canIssueKiloCredentials', () => {
       SECRET,
       LEGACY_POLICY
     );
-    expect(canIssueKiloCredentials(bearer, { legacy: 'five-year-api' })).toBe(true);
-    expect(canIssueKiloCredentials({ ...bearer }, { legacy: 'five-year-api' })).toBe(false);
+    expect(isKiloCredentialExchangeEligible(bearer, { legacy: 'five-year-api' })).toBe(true);
+    expect(isKiloCredentialExchangeEligible({ ...bearer }, { legacy: 'five-year-api' })).toBe(
+      false
+    );
     const fabricated = { type: 'session', userId: 'synthetic-other-user' };
     for (const symbol of Object.getOwnPropertySymbols(bearer)) {
       Object.defineProperty(fabricated, symbol, { value: true });
     }
-    expect(canIssueKiloCredentials(fabricated as VerifiedKiloAuthContext, { legacy: 'deny' })).toBe(
-      false
-    );
     expect(
-      canIssueKiloCredentials({ id: 'synthetic-db-user' } as unknown as VerifiedKiloAuthContext, {
-        legacy: 'five-year-api',
-      })
+      isKiloCredentialExchangeEligible(fabricated as VerifiedKiloAuthContext, { legacy: 'deny' })
+    ).toBe(false);
+    expect(
+      isKiloCredentialExchangeEligible(
+        { id: 'synthetic-db-user' } as unknown as VerifiedKiloAuthContext,
+        {
+          legacy: 'five-year-api',
+        }
+      )
     ).toBe(false);
   });
 
@@ -345,9 +409,9 @@ describe('canIssueKiloCredentials', () => {
         SECRET,
         LEGACY_POLICY
       );
-      expect(canIssueKiloCredentials(valid, { legacy: 'five-year-api' })).toBe(true);
-      expect(canIssueKiloCredentials(valid, { legacy: 'deny' })).toBe(false);
-      expect(canIssueKiloCredentials(nearExpiry, { legacy: 'five-year-api' })).toBe(true);
+      expect(isKiloCredentialExchangeEligible(valid, { legacy: 'five-year-api' })).toBe(true);
+      expect(isKiloCredentialExchangeEligible(valid, { legacy: 'deny' })).toBe(false);
+      expect(isKiloCredentialExchangeEligible(nearExpiry, { legacy: 'five-year-api' })).toBe(true);
     }
   );
 
@@ -365,7 +429,7 @@ describe('canIssueKiloCredentials', () => {
       SECRET,
       LEGACY_POLICY
     );
-    expect(canIssueKiloCredentials(context, { legacy: 'five-year-api' })).toBe(false);
+    expect(isKiloCredentialExchangeEligible(context, { legacy: 'five-year-api' })).toBe(false);
   });
 
   it.each([
@@ -388,7 +452,7 @@ describe('canIssueKiloCredentials', () => {
         SECRET,
         LEGACY_POLICY
       );
-      expect(canIssueKiloCredentials(context, { legacy: 'five-year-api' })).toBe(false);
+      expect(isKiloCredentialExchangeEligible(context, { legacy: 'five-year-api' })).toBe(false);
     }
   );
 
@@ -401,7 +465,7 @@ describe('canIssueKiloCredentials', () => {
       LEGACY_POLICY
     );
     expect(context.claims.exp - context.claims.iat).toBe(157_680_001);
-    expect(canIssueKiloCredentials(context, { legacy: 'five-year-api' })).toBe(false);
+    expect(isKiloCredentialExchangeEligible(context, { legacy: 'five-year-api' })).toBe(false);
   });
 
   it.each([
@@ -431,7 +495,7 @@ describe('canIssueKiloCredentials', () => {
       SECRET,
       LEGACY_POLICY
     );
-    expect(canIssueKiloCredentials(context, { legacy: 'five-year-api' })).toBe(false);
+    expect(isKiloCredentialExchangeEligible(context, { legacy: 'five-year-api' })).toBe(false);
   });
 
   it('denies pepperless tokens but permits device authorization request codes', async () => {
@@ -447,8 +511,8 @@ describe('canIssueKiloCredentials', () => {
       SECRET,
       LEGACY_POLICY
     );
-    expect(canIssueKiloCredentials(pepperless, { legacy: 'five-year-api' })).toBe(false);
-    expect(canIssueKiloCredentials(deviceCode, { legacy: 'five-year-api' })).toBe(true);
+    expect(isKiloCredentialExchangeEligible(pepperless, { legacy: 'five-year-api' })).toBe(false);
+    expect(isKiloCredentialExchangeEligible(deviceCode, { legacy: 'five-year-api' })).toBe(true);
   });
 
   it('uses decision time rather than verification time for an eligible modern bearer expiry', async () => {
@@ -464,9 +528,9 @@ describe('canIssueKiloCredentials', () => {
       credentialExchange: true,
     });
     const context = await verifyKiloTokenForPolicy(await sign(claims), SECRET, API_POLICY);
-    expect(canIssueKiloCredentials(context, { legacy: 'deny' })).toBe(true);
+    expect(isKiloCredentialExchangeEligible(context, { legacy: 'deny' })).toBe(true);
     vi.setSystemTime(new Date((NOW_SECONDS + 1) * 1000));
-    expect(canIssueKiloCredentials(context, { legacy: 'deny' })).toBe(false);
+    expect(isKiloCredentialExchangeEligible(context, { legacy: 'deny' })).toBe(false);
   });
 
   it('permits explicitly exchangeable modern human API tokens only for the sole API audience', async () => {
@@ -482,25 +546,121 @@ describe('canIssueKiloCredentials', () => {
       credentialExchange: true,
     });
     const context = await verifyKiloTokenForPolicy(await sign(claims), SECRET, API_POLICY);
-    expect(canIssueKiloCredentials(context, { legacy: 'deny' })).toBe(true);
+    expect(isKiloCredentialExchangeEligible(context, { legacy: 'deny' })).toBe(true);
     const multipleAudiences = await verifyKiloTokenForPolicy(
       await sign({ ...claims, aud: ['kilo-api', 'kilo-gateway'] }),
       SECRET,
       API_POLICY
     );
-    expect(canIssueKiloCredentials(multipleAudiences, { legacy: 'deny' })).toBe(false);
+    expect(isKiloCredentialExchangeEligible(multipleAudiences, { legacy: 'deny' })).toBe(false);
     const singletonArray = await verifyKiloTokenForPolicy(
       await sign({ ...claims, aud: ['kilo-api'] }),
       SECRET,
       API_POLICY
     );
-    expect(canIssueKiloCredentials(singletonArray, { legacy: 'deny' })).toBe(true);
+    expect(isKiloCredentialExchangeEligible(singletonArray, { legacy: 'deny' })).toBe(true);
     const wrongAudience = await verifyKiloTokenForPolicy(
       await sign({ ...claims, aud: 'kilo-gateway' }),
       SECRET,
       { audience: 'kilo-gateway', mode: 'required' }
     );
-    expect(canIssueKiloCredentials(wrongAudience, { legacy: 'deny' })).toBe(false);
+    expect(isKiloCredentialExchangeEligible(wrongAudience, { legacy: 'deny' })).toBe(false);
+  });
+
+  it.each([
+    ['a token-source marker', { extra: { tokenSource: 'automation' } }],
+    ['a bot marker', { extra: { botId: 'synthetic-bot' } }],
+    ['an internal marker', { extra: { internalApiUse: false } }],
+    ['a platform marker', { extra: { createdOnPlatform: '' } }],
+    ['a device session', { extra: { deviceSessionId: '' } }],
+    ['an organization', { extra: { organizationId: 'synthetic-org' } }],
+    ['an organization role', { extra: { organizationRole: 'member' } }],
+    ['organization memberships', { extra: { orgMemberships: [] } }],
+    ['an admin marker', { extra: { isAdmin: false } }],
+    ['a Gastown marker', { extra: { gastownAccess: false } }],
+    ['a wrong audience', { audience: 'kilo-gateway' }],
+    ['a missing pepper', { pepper: undefined }],
+  ] satisfies [string, Partial<Parameters<typeof buildModernKiloTokenPayload>[0]>][])(
+    'rejects builder-generated exchangeable human API tokens with %s',
+    (_name, overrides) => {
+      expect(() =>
+        buildModernKiloTokenPayload({
+          userId: 'synthetic-user',
+          pepper: 'synthetic-pepper',
+          audience: 'kilo-api',
+          issuedAt: NOW_SECONDS,
+          expiresAt: NOW_SECONDS + 60,
+          tokenPurpose: 'human-api',
+          credentialExchange: true,
+          ...overrides,
+        })
+      ).toThrow();
+    }
+  );
+
+  it('round-trips exchangeable builder output with exchange-safe extras', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const claims = buildModernKiloTokenPayload({
+      userId: 'synthetic-user',
+      pepper: null,
+      audience: 'kilo-api',
+      issuedAt: NOW_SECONDS,
+      expiresAt: NOW_SECONDS + 60,
+      tokenPurpose: 'human-api',
+      credentialExchange: true,
+      extra: { deviceAuthRequestCode: 'synthetic-request-code' },
+    });
+    const context = await verifyKiloTokenForPolicy(await sign(claims), SECRET, API_POLICY);
+    expect(isKiloCredentialExchangeEligible(context, { legacy: 'deny' })).toBe(true);
+  });
+
+  it('allows undefined optional extras that are omitted from the signed JWT', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const claims = buildModernKiloTokenPayload({
+      userId: 'synthetic-user',
+      pepper: null,
+      audience: 'kilo-api',
+      issuedAt: NOW_SECONDS,
+      expiresAt: NOW_SECONDS + 60,
+      tokenPurpose: 'human-api',
+      credentialExchange: true,
+      extra: {
+        tokenSource: undefined,
+        botId: undefined,
+        internalApiUse: undefined,
+        orgMemberships: undefined,
+      },
+    });
+    const context = await verifyKiloTokenForPolicy(await sign(claims), SECRET, API_POLICY);
+    expect(context.claimNames).not.toContain('tokenSource');
+    expect(context.claimNames).not.toContain('botId');
+    expect(context.claimNames).not.toContain('internalApiUse');
+    expect(context.claimNames).not.toContain('orgMemberships');
+    expect(isKiloCredentialExchangeEligible(context, { legacy: 'deny' })).toBe(true);
+  });
+
+  it('allows builder-generated non-exchangeable modern token extras at resource verification', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const claims = buildModernKiloTokenPayload({
+      userId: 'synthetic-user',
+      pepper: 'synthetic-pepper',
+      audience: 'kilo-api',
+      issuedAt: NOW_SECONDS,
+      expiresAt: NOW_SECONDS + 60,
+      tokenPurpose: 'device-access',
+      credentialExchange: false,
+      extra: { botId: 'synthetic-bot', tokenSource: 'automation' },
+    });
+
+    await expect(
+      verifyKiloTokenForPolicy(await sign(claims), SECRET, API_POLICY)
+    ).resolves.toMatchObject({
+      userId: 'synthetic-user',
+      claims: { botId: 'synthetic-bot', tokenSource: 'automation' },
+    });
   });
 
   it.each(['device-access', 'delegated-workload', 'internal-service'] as const)(
@@ -513,7 +673,7 @@ describe('canIssueKiloCredentials', () => {
         SECRET,
         API_POLICY
       );
-      expect(canIssueKiloCredentials(context, { legacy: 'five-year-api' })).toBe(false);
+      expect(isKiloCredentialExchangeEligible(context, { legacy: 'five-year-api' })).toBe(false);
     }
   );
 
@@ -534,12 +694,25 @@ describe('canIssueKiloCredentials', () => {
     });
     for (const claims of [human, audienceOnly, marked]) {
       const context = await verifyKiloTokenForPolicy(await sign(claims), SECRET, API_POLICY);
-      expect(canIssueKiloCredentials(context, { legacy: 'five-year-api' })).toBe(false);
+      expect(isKiloCredentialExchangeEligible(context, { legacy: 'five-year-api' })).toBe(false);
     }
   });
 });
 
 describe('buildModernKiloTokenPayload and compatibility', () => {
+  type DeviceAccessModernKiloTokenClaims = ModernKiloTokenClaims & {
+    tokenPurpose: 'device-access';
+  };
+  type ExpectedReadonlyOrganizationMemberships = readonly {
+    readonly orgId: string;
+    readonly role: 'owner' | 'member' | 'billing_manager';
+  }[];
+
+  expectTypeOf<DeviceAccessModernKiloTokenClaims['credentialExchange']>().toEqualTypeOf<false>();
+  expectTypeOf<ExpectedReadonlyOrganizationMemberships>().toEqualTypeOf<
+    NonNullable<Extract<VerifiedKiloAuthContext, { type: 'bearer' }>['claims']['orgMemberships']>
+  >();
+
   it('builds a signable modern payload that policy verification round-trips', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
@@ -578,6 +751,9 @@ describe('buildModernKiloTokenPayload and compatibility', () => {
     { extra: { tokenPurpose: 'human-api' } },
     { extra: { credentialExchange: false } },
     { extra: { unknown: true } },
+    { extra: { unknown: undefined } },
+    { extra: { tokenPurpose: undefined } },
+    { extra: { apiTokenPepper: undefined } },
   ])('rejects invalid builder inputs: %o', invalid => {
     expect(() =>
       buildModernKiloTokenPayload({

--- a/packages/worker-utils/src/kilo-token-policy.test.ts
+++ b/packages/worker-utils/src/kilo-token-policy.test.ts
@@ -1,0 +1,619 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SignJWT } from 'jose';
+import {
+  LEGACY_API_TOKEN_LIFETIMES_SECONDS,
+  buildModernKiloTokenPayload,
+  canIssueKiloCredentials,
+  isKiloResourceAudienceAllowed,
+  verifyKiloSessionForPolicy,
+  verifyKiloTokenForPolicy,
+  type VerifiedKiloAuthContext,
+} from './kilo-token-policy.js';
+import { verifyKiloToken } from './kilo-token.js';
+import {
+  BITBUCKET_REPOSITORY_LIST_AUDIENCE,
+  BITBUCKET_CODE_REVIEW_PULL_REQUEST_AUDIENCE,
+  BITBUCKET_CODE_REVIEW_WEBHOOK_ENSURE_AUDIENCE,
+  BITBUCKET_CODE_REVIEW_WEBHOOK_DELETE_AUDIENCE,
+  GITLAB_CREDENTIAL_BROKER_AUDIENCE,
+  GITHUB_USER_ACCESS_TOKEN_AUDIENCE,
+  USER_DATA_EXPORT_AUDIENCE,
+  SESSION_INGEST_USER_DELETION_AUDIENCE,
+} from './internal-service-token-audiences.js';
+
+const SECRET = 'synthetic-policy-test-secret-at-least-32-chars';
+const NOW = new Date('2030-01-02T03:04:05.000Z');
+const NOW_SECONDS = Math.floor(NOW.getTime() / 1000);
+const HISTORICAL_FIVE_YEAR_LIFETIMES = [157_680_000, 157_788_000] as const;
+const API_POLICY = { audience: 'kilo-api', mode: 'required' } as const;
+const LEGACY_POLICY = { audience: 'kilo-api', mode: 'allow-legacy' } as const;
+
+function key(secret = SECRET) {
+  return new TextEncoder().encode(secret);
+}
+
+async function sign(
+  claims: Record<string, unknown>,
+  options: { secret?: string; algorithm?: 'HS256' | 'HS384'; nbf?: number; dates?: boolean } = {}
+) {
+  let jwt = new SignJWT(claims).setProtectedHeader({
+    alg: options.algorithm ?? 'HS256',
+    typ: 'JWT',
+  });
+  if (options.dates !== false) {
+    jwt = jwt
+      .setIssuedAt(typeof claims.iat === 'number' ? claims.iat : NOW_SECONDS)
+      .setExpirationTime(typeof claims.exp === 'number' ? claims.exp : NOW_SECONDS + 300);
+  }
+  if (options.nbf !== undefined) jwt = jwt.setNotBefore(options.nbf);
+  return jwt.sign(key(options.secret));
+}
+
+function legacyClaims(extra: Record<string, unknown> = {}) {
+  return {
+    version: 3,
+    kiloUserId: 'synthetic-user',
+    apiTokenPepper: 'synthetic-pepper',
+    iat: NOW_SECONDS,
+    exp: NOW_SECONDS + LEGACY_API_TOKEN_LIFETIMES_SECONDS[0],
+    ...extra,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('isKiloResourceAudienceAllowed', () => {
+  it.each([
+    ['kilo-api', API_POLICY, true],
+    [['kilo-api', 'kilo-gateway'], API_POLICY, true],
+    ['kilo-gateway', API_POLICY, false],
+    [undefined, LEGACY_POLICY, true],
+    [undefined, API_POLICY, false],
+    [[], API_POLICY, false],
+    [['kilo-api', 'kilo-api'], API_POLICY, false],
+    [' kilo-api', API_POLICY, false],
+    [null, API_POLICY, false],
+  ])('handles %j with %o', (audience, policy, expected) => {
+    expect(isKiloResourceAudienceAllowed(audience, policy)).toBe(expected);
+  });
+
+  it('rejects invalid resource policy audiences', () => {
+    expect(
+      isKiloResourceAudienceAllowed('kilo-api', { audience: ' kilo-api', mode: 'required' })
+    ).toBe(false);
+  });
+});
+
+describe('verifyKiloTokenForPolicy', () => {
+  it('verifies a signed audience token and returns frozen, restricted claims', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const token = await sign(
+      legacyClaims({ aud: ['kilo-api', 'kilo-gateway'], deviceSessionId: 'device-session' })
+    );
+
+    const context = await verifyKiloTokenForPolicy(token, SECRET, API_POLICY);
+
+    expect(context).toMatchObject({ type: 'bearer', userId: 'synthetic-user' });
+    expect(context.claims).toMatchObject({
+      aud: ['kilo-api', 'kilo-gateway'],
+      deviceSessionId: 'device-session',
+    });
+    expect(Object.isFrozen(context)).toBe(true);
+    expect(Object.isFrozen(context.claims)).toBe(true);
+    expect(Object.isFrozen(context.claims.aud)).toBe(true);
+  });
+
+  it('allows legacy operation audience tokens without requiring modern claims', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const token = await sign(legacyClaims({ aud: 'kilo-gateway' }));
+
+    await expect(
+      verifyKiloTokenForPolicy(token, SECRET, { audience: 'kilo-gateway', mode: 'required' })
+    ).resolves.toMatchObject({ type: 'bearer' });
+  });
+
+  it.each([
+    [BITBUCKET_REPOSITORY_LIST_AUDIENCE, 'git-token-service:bitbucket-repositories'],
+    [
+      BITBUCKET_CODE_REVIEW_PULL_REQUEST_AUDIENCE,
+      'git-token-service:bitbucket-code-review:pull-request',
+    ],
+    [
+      BITBUCKET_CODE_REVIEW_WEBHOOK_ENSURE_AUDIENCE,
+      'git-token-service:bitbucket-code-review:webhook-ensure',
+    ],
+    [
+      BITBUCKET_CODE_REVIEW_WEBHOOK_DELETE_AUDIENCE,
+      'git-token-service:bitbucket-code-review:webhook-delete',
+    ],
+    [GITLAB_CREDENTIAL_BROKER_AUDIENCE, 'git-token-service:gitlab-credentials'],
+    [GITHUB_USER_ACCESS_TOKEN_AUDIENCE, 'git-token-service:github-user-access-token'],
+    [USER_DATA_EXPORT_AUDIENCE, 'user-data-export'],
+    [SESSION_INGEST_USER_DELETION_AUDIENCE, 'session-ingest:user-deletion'],
+  ])('preserves mandatory operation audience %s', async (audience, expected) => {
+    expect(audience).toBe(expected);
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const token = await sign(legacyClaims({ aud: audience }));
+    await expect(verifyKiloToken(token, SECRET)).rejects.toThrow();
+    await expect(verifyKiloToken(token, SECRET, { audience })).resolves.toMatchObject({
+      kiloUserId: 'synthetic-user',
+    });
+    await expect(
+      verifyKiloToken(await sign(legacyClaims()), SECRET, { audience })
+    ).rejects.toThrow();
+    await expect(
+      verifyKiloTokenForPolicy(token, SECRET, { audience, mode: 'required' })
+    ).resolves.toMatchObject({ type: 'bearer' });
+    await expect(verifyKiloTokenForPolicy(token, SECRET, API_POLICY)).rejects.toThrow();
+    await expect(
+      verifyKiloTokenForPolicy(await sign(legacyClaims()), SECRET, { audience, mode: 'required' })
+    ).rejects.toThrow();
+    await expect(
+      verifyKiloTokenForPolicy(await sign(legacyClaims()), SECRET, {
+        audience,
+        mode: 'allow-legacy',
+      })
+    ).resolves.toMatchObject({ type: 'bearer' });
+  });
+
+  it.each([
+    ['missing dates', { version: 3, kiloUserId: 'synthetic-user' }],
+    ['missing issued at', { ...legacyClaims(), iat: undefined }],
+    ['missing expiration', { ...legacyClaims(), exp: undefined }],
+    ['negative issued at', legacyClaims({ iat: -1 })],
+    ['negative expiration', legacyClaims({ exp: -1 })],
+    ['string issued at', legacyClaims({ iat: '0' })],
+    ['string expiration', legacyClaims({ exp: '1893553505' })],
+    ['fractional expiration', legacyClaims({ exp: NOW_SECONDS + 1.5 })],
+    ['unsafe issued at', legacyClaims({ iat: Number.MAX_SAFE_INTEGER + 1 })],
+    ['expiration before issuance', legacyClaims({ exp: NOW_SECONDS })],
+    ['future issued at', legacyClaims({ iat: NOW_SECONDS + 1, exp: NOW_SECONDS + 10 })],
+    [
+      'unknown purpose',
+      legacyClaims({ aud: 'kilo-api', tokenPurpose: 'unknown', credentialExchange: false }),
+    ],
+    ['missing exchange flag', legacyClaims({ aud: 'kilo-api', tokenPurpose: 'human-api' })],
+    [
+      'null purpose',
+      legacyClaims({ aud: 'kilo-api', tokenPurpose: null, credentialExchange: false }),
+    ],
+    [
+      'non-human exchange',
+      legacyClaims({ aud: 'kilo-api', tokenPurpose: 'device-access', credentialExchange: true }),
+    ],
+    ['empty audience array', legacyClaims({ aud: [] })],
+    ['empty audience entry', legacyClaims({ aud: ['kilo-api', ''] })],
+    ['mixed audience entries', legacyClaims({ aud: ['kilo-api', 1] })],
+    ['wrong audience with legacy opt-in', legacyClaims({ aud: 'kilo-gateway' })],
+    [
+      'modern purpose without audience',
+      legacyClaims({ tokenPurpose: 'human-api', credentialExchange: true }),
+    ],
+    [
+      'modern exchange without purpose',
+      legacyClaims({ aud: 'kilo-api', credentialExchange: true }),
+    ],
+    [
+      'null exchange',
+      legacyClaims({ aud: 'kilo-api', tokenPurpose: 'human-api', credentialExchange: null }),
+    ],
+    [
+      'numeric exchange',
+      legacyClaims({ aud: 'kilo-api', tokenPurpose: 'human-api', credentialExchange: 1 }),
+    ],
+    [
+      'string exchange',
+      legacyClaims({ aud: 'kilo-api', tokenPurpose: 'human-api', credentialExchange: 'true' }),
+    ],
+  ])('rejects %s', async (_name, claims) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    await expect(
+      verifyKiloTokenForPolicy(
+        await sign(claims, {
+          dates: ![
+            'missing dates',
+            'missing issued at',
+            'missing expiration',
+            'string issued at',
+            'string expiration',
+          ].includes(_name),
+        }),
+        SECRET,
+        LEGACY_POLICY
+      )
+    ).rejects.toThrow();
+  });
+
+  it('rejects expiry, not-before, signatures, and algorithms jose validates', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    await expect(
+      verifyKiloTokenForPolicy(
+        await sign(legacyClaims({ exp: NOW_SECONDS - 1 })),
+        SECRET,
+        LEGACY_POLICY
+      )
+    ).rejects.toThrow();
+    await expect(
+      verifyKiloTokenForPolicy(
+        await sign(legacyClaims(), { nbf: NOW_SECONDS + 1 }),
+        SECRET,
+        LEGACY_POLICY
+      )
+    ).rejects.toThrow();
+    await expect(
+      verifyKiloTokenForPolicy(
+        await sign(legacyClaims(), { secret: 'another-synthetic-test-secret-at-least-32' }),
+        SECRET,
+        LEGACY_POLICY
+      )
+    ).rejects.toThrow();
+    await expect(
+      verifyKiloTokenForPolicy(
+        await sign(legacyClaims(), { algorithm: 'HS384' }),
+        SECRET,
+        LEGACY_POLICY
+      )
+    ).rejects.toThrow();
+  });
+});
+
+describe('canIssueKiloCredentials', () => {
+  it('only accepts authentic verified session contexts', async () => {
+    const session = await verifyKiloSessionForPolicy(async () => ({
+      userId: 'synthetic-session-user',
+    }));
+    if (session === null) throw new Error('synthetic session was unexpectedly absent');
+    expect(canIssueKiloCredentials(session, { legacy: 'deny' })).toBe(true);
+    expect(
+      canIssueKiloCredentials(
+        { type: 'session', userId: 'synthetic-session-user' } as VerifiedKiloAuthContext,
+        { legacy: 'deny' }
+      )
+    ).toBe(false);
+    expect(
+      canIssueKiloCredentials(
+        {
+          type: 'bearer',
+          userId: 'synthetic-user',
+          claims: legacyClaims(),
+        } as VerifiedKiloAuthContext,
+        { legacy: 'five-year-api' }
+      )
+    ).toBe(false);
+  });
+
+  it('rejects cloned contexts and copied provenance symbols', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const bearer = await verifyKiloTokenForPolicy(
+      await sign(legacyClaims()),
+      SECRET,
+      LEGACY_POLICY
+    );
+    expect(canIssueKiloCredentials(bearer, { legacy: 'five-year-api' })).toBe(true);
+    expect(canIssueKiloCredentials({ ...bearer }, { legacy: 'five-year-api' })).toBe(false);
+    const fabricated = { type: 'session', userId: 'synthetic-other-user' };
+    for (const symbol of Object.getOwnPropertySymbols(bearer)) {
+      Object.defineProperty(fabricated, symbol, { value: true });
+    }
+    expect(canIssueKiloCredentials(fabricated as VerifiedKiloAuthContext, { legacy: 'deny' })).toBe(
+      false
+    );
+    expect(
+      canIssueKiloCredentials({ id: 'synthetic-db-user' } as unknown as VerifiedKiloAuthContext, {
+        legacy: 'five-year-api',
+      })
+    ).toBe(false);
+  });
+
+  it('requires a trusted session callback and validates its result', async () => {
+    await expect(verifyKiloSessionForPolicy(undefined as never)).rejects.toThrow();
+    await expect(verifyKiloSessionForPolicy(async () => null)).resolves.toBeNull();
+    await expect(verifyKiloSessionForPolicy(async () => ({ userId: '' }))).rejects.toThrow();
+    await expect(
+      verifyKiloSessionForPolicy(async () =>
+        Promise.reject(new Error('synthetic dependency unavailable'))
+      )
+    ).rejects.toThrow('synthetic dependency unavailable');
+  });
+
+  it.each(HISTORICAL_FIVE_YEAR_LIFETIMES)(
+    'permits historical %i-second legacy API tokens, including near expiry',
+    async lifetime => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+      expect(LEGACY_API_TOKEN_LIFETIMES_SECONDS).toContain(lifetime);
+      const valid = await verifyKiloTokenForPolicy(
+        await sign(legacyClaims({ exp: NOW_SECONDS + lifetime })),
+        SECRET,
+        LEGACY_POLICY
+      );
+      const nearExpiry = await verifyKiloTokenForPolicy(
+        await sign(
+          legacyClaims({
+            iat: NOW_SECONDS - lifetime + 1,
+            exp: NOW_SECONDS + 1,
+          })
+        ),
+        SECRET,
+        LEGACY_POLICY
+      );
+      expect(canIssueKiloCredentials(valid, { legacy: 'five-year-api' })).toBe(true);
+      expect(canIssueKiloCredentials(valid, { legacy: 'deny' })).toBe(false);
+      expect(canIssueKiloCredentials(nearExpiry, { legacy: 'five-year-api' })).toBe(true);
+    }
+  );
+
+  it.each([
+    6 * 60 * 60,
+    24 * 60 * 60,
+    30 * 24 * 60 * 60,
+    ...HISTORICAL_FIVE_YEAR_LIFETIMES.map(lifetime => lifetime - 1),
+    ...HISTORICAL_FIVE_YEAR_LIFETIMES.map(lifetime => lifetime + 1),
+  ])('rejects legacy original lifetime %i seconds', async lifetime => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const context = await verifyKiloTokenForPolicy(
+      await sign(legacyClaims({ exp: NOW_SECONDS + lifetime })),
+      SECRET,
+      LEGACY_POLICY
+    );
+    expect(canIssueKiloCredentials(context, { legacy: 'five-year-api' })).toBe(false);
+  });
+
+  it.each([
+    ['tokenSource', ''],
+    ['botId', ''],
+    ['internalApiUse', false],
+    ['createdOnPlatform', ''],
+    ['deviceSessionId', ''],
+    ['gastownAccess', false],
+    ['isAdmin', false],
+    ['orgMemberships', []],
+    ['organizationId', ''],
+  ])(
+    'denies legacy bearer credentials when %s has a false or empty value',
+    async (marker, value) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+      const context = await verifyKiloTokenForPolicy(
+        await sign(legacyClaims({ [marker]: value })),
+        SECRET,
+        LEGACY_POLICY
+      );
+      expect(canIssueKiloCredentials(context, { legacy: 'five-year-api' })).toBe(false);
+    }
+  );
+
+  it('rejects a longer original lifetime even when exactly five years remain', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const context = await verifyKiloTokenForPolicy(
+      await sign(legacyClaims({ iat: NOW_SECONDS - 1, exp: NOW_SECONDS + 157_680_000 })),
+      SECRET,
+      LEGACY_POLICY
+    );
+    expect(context.claims.exp - context.claims.iat).toBe(157_680_001);
+    expect(canIssueKiloCredentials(context, { legacy: 'five-year-api' })).toBe(false);
+  });
+
+  it.each([
+    'tokenSource',
+    'botId',
+    'internalApiUse',
+    'createdOnPlatform',
+    'deviceSessionId',
+    'gastownAccess',
+    'isAdmin',
+    'orgMemberships',
+    'organizationId',
+    'organizationRole',
+  ])('denies legacy bearer credentials when %s is present', async marker => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const value =
+      marker === 'isAdmin' || marker === 'internalApiUse' || marker === 'gastownAccess'
+        ? true
+        : marker === 'orgMemberships'
+          ? [{ orgId: 'synthetic-org', role: 'member' }]
+          : marker === 'organizationRole'
+            ? 'member'
+            : 'present';
+    const context = await verifyKiloTokenForPolicy(
+      await sign(legacyClaims({ [marker]: value })),
+      SECRET,
+      LEGACY_POLICY
+    );
+    expect(canIssueKiloCredentials(context, { legacy: 'five-year-api' })).toBe(false);
+  });
+
+  it('denies pepperless tokens but permits device authorization request codes', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const pepperless = await verifyKiloTokenForPolicy(
+      await sign(legacyClaims({ apiTokenPepper: undefined })),
+      SECRET,
+      LEGACY_POLICY
+    );
+    const deviceCode = await verifyKiloTokenForPolicy(
+      await sign(legacyClaims({ deviceAuthRequestCode: 'request-code' })),
+      SECRET,
+      LEGACY_POLICY
+    );
+    expect(canIssueKiloCredentials(pepperless, { legacy: 'five-year-api' })).toBe(false);
+    expect(canIssueKiloCredentials(deviceCode, { legacy: 'five-year-api' })).toBe(true);
+  });
+
+  it('uses decision time rather than verification time for an eligible modern bearer expiry', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const claims = buildModernKiloTokenPayload({
+      userId: 'synthetic-user',
+      pepper: null,
+      audience: 'kilo-api',
+      issuedAt: NOW_SECONDS,
+      expiresAt: NOW_SECONDS + 1,
+      tokenPurpose: 'human-api',
+      credentialExchange: true,
+    });
+    const context = await verifyKiloTokenForPolicy(await sign(claims), SECRET, API_POLICY);
+    expect(canIssueKiloCredentials(context, { legacy: 'deny' })).toBe(true);
+    vi.setSystemTime(new Date((NOW_SECONDS + 1) * 1000));
+    expect(canIssueKiloCredentials(context, { legacy: 'deny' })).toBe(false);
+  });
+
+  it('permits explicitly exchangeable modern human API tokens only for the sole API audience', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const claims = buildModernKiloTokenPayload({
+      userId: 'synthetic-user',
+      pepper: 'synthetic-pepper',
+      audience: 'kilo-api',
+      issuedAt: NOW_SECONDS,
+      expiresAt: NOW_SECONDS + 60,
+      tokenPurpose: 'human-api',
+      credentialExchange: true,
+    });
+    const context = await verifyKiloTokenForPolicy(await sign(claims), SECRET, API_POLICY);
+    expect(canIssueKiloCredentials(context, { legacy: 'deny' })).toBe(true);
+    const multipleAudiences = await verifyKiloTokenForPolicy(
+      await sign({ ...claims, aud: ['kilo-api', 'kilo-gateway'] }),
+      SECRET,
+      API_POLICY
+    );
+    expect(canIssueKiloCredentials(multipleAudiences, { legacy: 'deny' })).toBe(false);
+    const singletonArray = await verifyKiloTokenForPolicy(
+      await sign({ ...claims, aud: ['kilo-api'] }),
+      SECRET,
+      API_POLICY
+    );
+    expect(canIssueKiloCredentials(singletonArray, { legacy: 'deny' })).toBe(true);
+    const wrongAudience = await verifyKiloTokenForPolicy(
+      await sign({ ...claims, aud: 'kilo-gateway' }),
+      SECRET,
+      { audience: 'kilo-gateway', mode: 'required' }
+    );
+    expect(canIssueKiloCredentials(wrongAudience, { legacy: 'deny' })).toBe(false);
+  });
+
+  it.each(['device-access', 'delegated-workload', 'internal-service'] as const)(
+    'denies %s modern tokens despite legacy opt-in',
+    async tokenPurpose => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+      const context = await verifyKiloTokenForPolicy(
+        await sign(legacyClaims({ aud: 'kilo-api', tokenPurpose, credentialExchange: false })),
+        SECRET,
+        API_POLICY
+      );
+      expect(canIssueKiloCredentials(context, { legacy: 'five-year-api' })).toBe(false);
+    }
+  );
+
+  it('denies non-exchangeable human, audience-only, and marked modern bearer tokens', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const human = legacyClaims({
+      aud: 'kilo-api',
+      tokenPurpose: 'human-api',
+      credentialExchange: false,
+    });
+    const audienceOnly = legacyClaims({ aud: 'kilo-api' });
+    const marked = legacyClaims({
+      aud: 'kilo-api',
+      tokenPurpose: 'human-api',
+      credentialExchange: true,
+      tokenSource: '',
+    });
+    for (const claims of [human, audienceOnly, marked]) {
+      const context = await verifyKiloTokenForPolicy(await sign(claims), SECRET, API_POLICY);
+      expect(canIssueKiloCredentials(context, { legacy: 'five-year-api' })).toBe(false);
+    }
+  });
+});
+
+describe('buildModernKiloTokenPayload and compatibility', () => {
+  it('builds a signable modern payload that policy verification round-trips', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const payload = buildModernKiloTokenPayload({
+      userId: 'synthetic-user',
+      audience: 'kilo-api',
+      issuedAt: NOW_SECONDS,
+      expiresAt: NOW_SECONDS + 60,
+      tokenPurpose: 'human-api',
+      credentialExchange: false,
+      extra: { deviceAuthRequestCode: 'request-code' },
+    });
+    expect(payload).toMatchObject({ version: 3, kiloUserId: 'synthetic-user', aud: 'kilo-api' });
+    await expect(
+      verifyKiloTokenForPolicy(await sign(payload), SECRET, API_POLICY)
+    ).resolves.toMatchObject({ userId: 'synthetic-user' });
+  });
+
+  it.each([
+    { audience: ['kilo-api'] },
+    { issuedAt: -1 },
+    { expiresAt: NOW_SECONDS },
+    { tokenPurpose: 'device-access', credentialExchange: true },
+    { tokenPurpose: undefined, credentialExchange: undefined },
+    { extra: { version: 3 } },
+    { extra: { kiloUserId: 'other-user' } },
+    { extra: { apiTokenPepper: null } },
+    { extra: { env: 'production' } },
+    { extra: { aud: 'kilo-api' } },
+    { extra: { iat: NOW_SECONDS } },
+    { extra: { exp: NOW_SECONDS + 60 } },
+    { extra: { nbf: NOW_SECONDS } },
+    { extra: { iss: 'synthetic-issuer' } },
+    { extra: { sub: 'synthetic-subject' } },
+    { extra: { jti: 'synthetic-id' } },
+    { extra: { tokenPurpose: 'human-api' } },
+    { extra: { credentialExchange: false } },
+    { extra: { unknown: true } },
+  ])('rejects invalid builder inputs: %o', invalid => {
+    expect(() =>
+      buildModernKiloTokenPayload({
+        userId: 'synthetic-user',
+        audience: 'kilo-api',
+        issuedAt: NOW_SECONDS,
+        expiresAt: NOW_SECONDS + 60,
+        tokenPurpose: 'human-api',
+        credentialExchange: false,
+        ...invalid,
+      } as never)
+    ).toThrow();
+  });
+
+  it('leaves the legacy verifier behavior unchanged for audiences, stripped modern fields, and absent dates', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const audienceToken = await sign({ version: 3, kiloUserId: 'synthetic-user', aud: 'kilo-api' });
+    await expect(verifyKiloToken(audienceToken, SECRET)).rejects.toThrow();
+    await expect(
+      verifyKiloToken(audienceToken, SECRET, { audience: 'kilo-api' })
+    ).resolves.toMatchObject({ kiloUserId: 'synthetic-user' });
+    await expect(
+      verifyKiloTokenForPolicy(audienceToken, SECRET, API_POLICY)
+    ).resolves.toMatchObject({ userId: 'synthetic-user' });
+    const noDates = await new SignJWT({
+      version: 3,
+      kiloUserId: 'synthetic-user',
+      tokenPurpose: 'unrecognized',
+    })
+      .setProtectedHeader({ alg: 'HS256' })
+      .sign(key());
+    await expect(verifyKiloToken(noDates, SECRET)).resolves.toEqual({
+      version: 3,
+      kiloUserId: 'synthetic-user',
+    });
+    await expect(verifyKiloTokenForPolicy(noDates, SECRET, LEGACY_POLICY)).rejects.toThrow();
+  });
+});

--- a/packages/worker-utils/src/kilo-token-policy.ts
+++ b/packages/worker-utils/src/kilo-token-policy.ts
@@ -78,11 +78,20 @@ export function isKiloResourceAudienceAllowed(
 
 const verifiedAuth = Symbol('verified-kilo-policy-auth');
 
+type DeepReadonly<T> = { readonly [K in keyof T]: DeepReadonly<T[K]> };
+
+function freezeClaimValue(value: unknown): void {
+  if (value === null || typeof value !== 'object') return;
+  for (const child of Object.values(value)) freezeClaimValue(child);
+  Object.freeze(value);
+}
+
 type VerifiedKiloBearerContext = {
   readonly [verifiedAuth]: true;
   readonly type: 'bearer';
   readonly userId: string;
-  readonly claims: Readonly<KiloTokenPolicyClaims>;
+  readonly claims: DeepReadonly<KiloTokenPolicyClaims>;
+  readonly claimNames: readonly string[];
 };
 
 type VerifiedKiloSessionContext = {
@@ -93,6 +102,8 @@ type VerifiedKiloSessionContext = {
 
 export type VerifiedKiloAuthContext = VerifiedKiloBearerContext | VerifiedKiloSessionContext;
 
+// The private symbol brands the type; WeakSet membership checks verifier-created
+// object identity so copied, serialized, or fabricated contexts cannot qualify.
 const verifiedContexts = new WeakSet<VerifiedKiloAuthContext>();
 
 export async function verifyKiloTokenForPolicy(
@@ -112,12 +123,13 @@ export async function verifyKiloTokenForPolicy(
   if (!isKiloResourceAudienceAllowed(claims.aud, audiencePolicy)) {
     throw new Error('Unexpected token audience');
   }
-  if (Array.isArray(claims.aud)) Object.freeze(claims.aud);
+  freezeClaimValue(claims);
   const auth = Object.freeze({
     [verifiedAuth]: true,
     type: 'bearer',
     userId: claims.kiloUserId,
-    claims: Object.freeze(claims),
+    claims,
+    claimNames: Object.freeze(Object.keys(payload)),
   } satisfies VerifiedKiloBearerContext);
   verifiedContexts.add(auth);
   return auth;
@@ -140,26 +152,30 @@ export async function verifyKiloSessionForPolicy(
 
 export const LEGACY_API_TOKEN_LIFETIMES_SECONDS = [157_680_000, 157_788_000] as const;
 
-export type KiloCredentialIssuancePolicy = {
+export type KiloCredentialExchangeEligibilityPolicy = {
   legacy: 'deny' | 'five-year-api';
 };
 
-const nonExchangeableMarkers = [
-  'tokenSource',
-  'botId',
-  'internalApiUse',
-  'createdOnPlatform',
-  'deviceSessionId',
-  'gastownAccess',
-  'isAdmin',
-  'orgMemberships',
-  'organizationId',
-  'organizationRole',
-] as const satisfies readonly (keyof KiloTokenPolicyClaims)[];
+const exchangeSafeClaimNames: ReadonlySet<string> = new Set([
+  'version',
+  'kiloUserId',
+  'apiTokenPepper',
+  'env',
+  'iat',
+  'exp',
+  'aud',
+  'tokenPurpose',
+  'credentialExchange',
+  'deviceAuthRequestCode',
+] satisfies (keyof KiloTokenPolicyClaims)[]);
 
-export function canIssueKiloCredentials(
+function hasOnlyExchangeSafeClaims(claimNames: readonly string[]): boolean {
+  return claimNames.every(name => exchangeSafeClaimNames.has(name));
+}
+
+export function isKiloCredentialExchangeEligible(
   auth: VerifiedKiloAuthContext,
-  policy: KiloCredentialIssuancePolicy
+  policy: KiloCredentialExchangeEligibilityPolicy
 ): boolean {
   if (!verifiedContexts.has(auth)) return false;
   if (auth.type === 'session') return true;
@@ -167,7 +183,7 @@ export function canIssueKiloCredentials(
   const now = Math.floor(Date.now() / 1000);
   if (claims.iat > now || claims.exp <= now || claims.exp <= claims.iat) return false;
   if (claims.apiTokenPepper === undefined) return false;
-  if (nonExchangeableMarkers.some(marker => claims[marker] !== undefined)) return false;
+  if (!hasOnlyExchangeSafeClaims(auth.claimNames)) return false;
   if (claims.tokenPurpose !== undefined || claims.credentialExchange !== undefined) {
     const soleAudience =
       typeof claims.aud === 'string'
@@ -199,18 +215,40 @@ const modernTokenExtra = kiloTokenPayload
   })
   .strict();
 
-export type ModernKiloTokenPurpose =
-  | { tokenPurpose: 'human-api'; credentialExchange: boolean }
-  | {
-      tokenPurpose: 'device-access' | 'delegated-workload' | 'internal-service';
-      credentialExchange: false;
-    };
+const modernPurpose = z.discriminatedUnion('tokenPurpose', [
+  z.object({ tokenPurpose: z.literal('human-api'), credentialExchange: z.boolean() }),
+  z.object({
+    tokenPurpose: purposeClaim.exclude(['human-api']),
+    credentialExchange: z.literal(false),
+  }),
+]);
 
-const modernClaims = policyClaims.safeExtend({
-  aud: audienceName,
-  tokenPurpose: purposeClaim,
-  credentialExchange: z.boolean(),
-});
+export type ModernKiloTokenPurpose = z.infer<typeof modernPurpose>;
+
+const modernClaims = policyClaims
+  .safeExtend({
+    aud: audienceName,
+    tokenPurpose: purposeClaim,
+    credentialExchange: z.boolean(),
+  })
+  .and(modernPurpose)
+  .superRefine((claims, ctx) => {
+    if (!claims.credentialExchange) return;
+    const serializedClaimNames = Object.entries(claims)
+      .filter(([, value]) => value !== undefined)
+      .map(([name]) => name);
+    if (
+      claims.aud !== KILO_API_AUDIENCE ||
+      claims.apiTokenPepper === undefined ||
+      !hasOnlyExchangeSafeClaims(serializedClaimNames)
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        message:
+          'Exchangeable tokens require the Kilo API audience, a pepper claim and only exchange-safe claims',
+      });
+    }
+  });
 
 export type ModernKiloTokenClaims = z.infer<typeof modernClaims>;
 

--- a/packages/worker-utils/src/kilo-token-policy.ts
+++ b/packages/worker-utils/src/kilo-token-policy.ts
@@ -1,0 +1,243 @@
+import { jwtVerify } from 'jose';
+import { z } from 'zod';
+import { KILO_API_AUDIENCE } from './internal-service-token-audiences';
+import { KILO_TOKEN_VERSION, kiloTokenPayload } from './kilo-token';
+
+const audienceName = z
+  .string()
+  .min(1)
+  .refine(value => value.trim() === value);
+const audienceClaim = z.union([
+  audienceName,
+  z
+    .array(audienceName)
+    .min(1)
+    .refine(values => new Set(values).size === values.length),
+]);
+const numericDate = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+export const KILO_TOKEN_PURPOSES = [
+  'human-api',
+  'device-access',
+  'delegated-workload',
+  'internal-service',
+] as const;
+const purposeClaim = z.enum(KILO_TOKEN_PURPOSES);
+
+const policyClaims = kiloTokenPayload
+  .extend({
+    aud: audienceClaim.optional(),
+    iat: numericDate,
+    exp: numericDate,
+    tokenPurpose: purposeClaim.optional(),
+    credentialExchange: z.boolean().optional(),
+  })
+  .superRefine((claims, ctx) => {
+    if (claims.exp <= claims.iat) {
+      ctx.addIssue({ code: 'custom', message: 'Expiration must follow issuance', path: ['exp'] });
+    }
+    if (claims.tokenPurpose !== undefined || claims.credentialExchange !== undefined) {
+      if (
+        claims.aud === undefined ||
+        claims.tokenPurpose === undefined ||
+        claims.credentialExchange === undefined
+      ) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Modern tokens require audience, purpose and exchange eligibility',
+        });
+      }
+      if (claims.credentialExchange === true && claims.tokenPurpose !== 'human-api') {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Only human API tokens may permit credential exchange',
+          path: ['credentialExchange'],
+        });
+      }
+    }
+  });
+
+export type KiloTokenPolicyClaims = z.infer<typeof policyClaims>;
+
+export type KiloResourceAudiencePolicy = {
+  audience: string;
+  mode: 'required' | 'allow-legacy';
+};
+
+export function isKiloResourceAudienceAllowed(
+  audience: unknown,
+  policy: KiloResourceAudiencePolicy
+): boolean {
+  if (!audienceName.safeParse(policy.audience).success) return false;
+  if (audience === undefined) return policy.mode === 'allow-legacy';
+  const parsed = audienceClaim.safeParse(audience);
+  if (!parsed.success) return false;
+  return typeof parsed.data === 'string'
+    ? parsed.data === policy.audience
+    : parsed.data.includes(policy.audience);
+}
+
+const verifiedAuth = Symbol('verified-kilo-policy-auth');
+
+type VerifiedKiloBearerContext = {
+  readonly [verifiedAuth]: true;
+  readonly type: 'bearer';
+  readonly userId: string;
+  readonly claims: Readonly<KiloTokenPolicyClaims>;
+};
+
+type VerifiedKiloSessionContext = {
+  readonly [verifiedAuth]: true;
+  readonly type: 'session';
+  readonly userId: string;
+};
+
+export type VerifiedKiloAuthContext = VerifiedKiloBearerContext | VerifiedKiloSessionContext;
+
+const verifiedContexts = new WeakSet<VerifiedKiloAuthContext>();
+
+export async function verifyKiloTokenForPolicy(
+  token: string,
+  secret: string,
+  audiencePolicy: KiloResourceAudiencePolicy
+): Promise<VerifiedKiloBearerContext> {
+  const currentDate = new Date();
+  const { payload } = await jwtVerify(token, new TextEncoder().encode(secret), {
+    algorithms: ['HS256'],
+    currentDate,
+  });
+  const claims = policyClaims.parse(payload);
+  if (claims.iat > Math.floor(currentDate.getTime() / 1000)) {
+    throw new Error('Token issued in the future');
+  }
+  if (!isKiloResourceAudienceAllowed(claims.aud, audiencePolicy)) {
+    throw new Error('Unexpected token audience');
+  }
+  if (Array.isArray(claims.aud)) Object.freeze(claims.aud);
+  const auth = Object.freeze({
+    [verifiedAuth]: true,
+    type: 'bearer',
+    userId: claims.kiloUserId,
+    claims: Object.freeze(claims),
+  } satisfies VerifiedKiloBearerContext);
+  verifiedContexts.add(auth);
+  return auth;
+}
+
+export async function verifyKiloSessionForPolicy(
+  verifySession: () => Promise<{ userId: string } | null>
+): Promise<VerifiedKiloSessionContext | null> {
+  const session = await verifySession();
+  if (session === null) return null;
+  const userId = z.string().min(1).parse(session.userId);
+  const auth = Object.freeze({
+    [verifiedAuth]: true,
+    type: 'session',
+    userId,
+  } satisfies VerifiedKiloSessionContext);
+  verifiedContexts.add(auth);
+  return auth;
+}
+
+export const LEGACY_API_TOKEN_LIFETIMES_SECONDS = [157_680_000, 157_788_000] as const;
+
+export type KiloCredentialIssuancePolicy = {
+  legacy: 'deny' | 'five-year-api';
+};
+
+const nonExchangeableMarkers = [
+  'tokenSource',
+  'botId',
+  'internalApiUse',
+  'createdOnPlatform',
+  'deviceSessionId',
+  'gastownAccess',
+  'isAdmin',
+  'orgMemberships',
+  'organizationId',
+  'organizationRole',
+] as const satisfies readonly (keyof KiloTokenPolicyClaims)[];
+
+export function canIssueKiloCredentials(
+  auth: VerifiedKiloAuthContext,
+  policy: KiloCredentialIssuancePolicy
+): boolean {
+  if (!verifiedContexts.has(auth)) return false;
+  if (auth.type === 'session') return true;
+  const { claims } = auth;
+  const now = Math.floor(Date.now() / 1000);
+  if (claims.iat > now || claims.exp <= now || claims.exp <= claims.iat) return false;
+  if (claims.apiTokenPepper === undefined) return false;
+  if (nonExchangeableMarkers.some(marker => claims[marker] !== undefined)) return false;
+  if (claims.tokenPurpose !== undefined || claims.credentialExchange !== undefined) {
+    const soleAudience =
+      typeof claims.aud === 'string'
+        ? claims.aud
+        : claims.aud?.length === 1
+          ? claims.aud[0]
+          : undefined;
+    return (
+      claims.tokenPurpose === 'human-api' &&
+      claims.credentialExchange === true &&
+      soleAudience === KILO_API_AUDIENCE
+    );
+  }
+  return (
+    policy.legacy === 'five-year-api' &&
+    claims.aud === undefined &&
+    LEGACY_API_TOKEN_LIFETIMES_SECONDS.some(lifetime => claims.exp - claims.iat === lifetime)
+  );
+}
+
+const modernTokenExtra = kiloTokenPayload
+  .omit({
+    version: true,
+    kiloUserId: true,
+    apiTokenPepper: true,
+    env: true,
+    iat: true,
+    exp: true,
+  })
+  .strict();
+
+export type ModernKiloTokenPurpose =
+  | { tokenPurpose: 'human-api'; credentialExchange: boolean }
+  | {
+      tokenPurpose: 'device-access' | 'delegated-workload' | 'internal-service';
+      credentialExchange: false;
+    };
+
+const modernClaims = policyClaims.safeExtend({
+  aud: audienceName,
+  tokenPurpose: purposeClaim,
+  credentialExchange: z.boolean(),
+});
+
+export type ModernKiloTokenClaims = z.infer<typeof modernClaims>;
+
+export function buildModernKiloTokenPayload(
+  params: {
+    userId: string;
+    pepper?: string | null;
+    env?: string;
+    audience: string;
+    issuedAt: number;
+    expiresAt: number;
+    extra?: z.infer<typeof modernTokenExtra>;
+  } & ModernKiloTokenPurpose
+): ModernKiloTokenClaims {
+  const extra = modernTokenExtra.parse(params.extra ?? {});
+  const audience = audienceName.parse(params.audience);
+  const claims = {
+    ...extra,
+    version: KILO_TOKEN_VERSION,
+    kiloUserId: params.userId,
+    apiTokenPepper: params.pepper,
+    env: params.env,
+    aud: audience,
+    iat: params.issuedAt,
+    exp: params.expiresAt,
+    tokenPurpose: params.tokenPurpose,
+    credentialExchange: params.credentialExchange,
+  };
+  return modernClaims.parse(claims);
+}


### PR DESCRIPTION
## Summary

- Add Phase 1 shared token-policy infrastructure without changing production authentication, token issuance, or existing token validity.
- Separate resource-audience acceptance from credential-issuance eligibility, retaining validated audience, purpose, temporal claims, and explicit exchange eligibility in verified session/bearer contexts.
- Add canonical resource audiences while preserving operation-specific audience values, plus a single-audience payload builder that rejects reserved-claim overrides.
- Add policy and compatibility coverage and an issuer-to-consumer map documenting historical lifetimes, downstream token forwarding, and reader-first migration requirements.

## Verification

- Manually reviewed the complete branch changes and confirmed existing web/Worker signers, authentication paths, and mandatory-audience checks are untouched.
- Corroborated the two historical five-year issuance durations against repository history and inspected concrete issuer/consumer paths documented in `docs/token-issuance-policy.md`.
- No manual endpoint or production-token testing was performed: this PR introduces opt-in helpers with no production callers. The findings are source analysis, not a runtime exploit reproduction.

## Visual Changes

N/A

## Reviewer Notes

- This is PR 1 of the planned two-PR sequence, not an enforced security fix. PR 2 will apply credential-issuance guards and endpoint regressions; reader/issuer migration remains separate.
- Review the strict distinction between missing legacy claims and explicit malformed, unknown, or mismatched restrictions. Existing operation-specific audiences must remain mandatory.
- The optional legacy exchange class accepts only original `exp - iat` values of 157680000 or 157788000 seconds, with a present pepper and no audience, modern restrictions, or system/scope markers. Unmarked five-year automation can still match this class; it is not proof of human provenance, and historical production populations remain unconfirmed.
- Modern exchange requires an explicitly exchangeable human API token whose sole audience is `kilo-api`. Marker rejection is deliberately conservative, including false or empty metadata values.
- Verified contexts must be passed by reference, and session adapters must use session-only verification. Signature verification and issuance eligibility do not replace account, environment, pepper, or revocation checks.
- No signing-secret rotation, token-version bump, global pepper reset, or mass invalidation is included.