### PR TITLE
fix(auth): enforce credential issuance boundaries (phase 2)

### DIFF
--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -53,7 +53,7 @@ const config: Config = {
   ],
   modulePathIgnorePatterns: ['<rootDir>/../../.worktrees/'],
   transformIgnorePatterns: [
-    'node_modules/.pnpm/(?!(@octokit|universal-user-agent|universal-github-app-jwt|before-after-hook|bottleneck|p-limit|yocto-queue|ai@|@ai-sdk|@standard-schema|@workflow|eventsource-parser|cbor2|@cto\\.af))',
+    'node_modules/.pnpm/(?!(@octokit|universal-user-agent|universal-github-app-jwt|before-after-hook|bottleneck|p-limit|yocto-queue|jose@|ai@|@ai-sdk|@standard-schema|@workflow|eventsource-parser|cbor2|@cto\\.af))',
   ],
 
   // Parallel execution configuration

--- a/apps/web/src/app/(app)/profile/page.test.ts
+++ b/apps/web/src/app/(app)/profile/page.test.ts
@@ -1,0 +1,111 @@
+import React from 'react';
+
+const mockGetUserForCredentialIssuance = jest.fn();
+const mockGenerateApiToken = jest.fn();
+const mockGetCustomerInfo = jest.fn();
+const mockIntegrationsCard = jest.fn(() => null);
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+jest.mock('@/lib/user/server', () => ({
+  getUserFromSessionForCredentialIssuanceOrRedirect: mockGetUserForCredentialIssuance,
+}));
+jest.mock('@/lib/tokens', () => ({ generateApiToken: mockGenerateApiToken }));
+jest.mock('@/lib/customerInfo', () => ({ getCustomerInfo: mockGetCustomerInfo }));
+jest.mock('@/components/auth/getExtensionUrl', () => ({
+  getExtensionUrl: jest.fn(() => ({ ideName: 'VS Code' })),
+}));
+jest.mock('next/headers', () => ({ cookies: jest.fn() }));
+jest.mock('@/components/PageLayout', () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('@/components/profile/ProfileCreditsCounter', () => () => null);
+jest.mock('@/components/profile/ProfileExpiringCredits', () => () => null);
+jest.mock('@/components/dev/DevNukeAccountButton', () => ({ DevNukeAccountButton: () => null }));
+jest.mock('@/components/dev/DevConsumeCreditsButton', () => ({
+  DevConsumeCreditsButton: () => null,
+}));
+jest.mock('@/components/dev/DevAddCreditsButton', () => ({ DevAddCreditsButton: () => null }));
+jest.mock('@/components/payment/CreditPurchaseOptions', () => () => null);
+jest.mock('@/components/cloud-agent/MessageErrorBoundary', () => ({
+  MessageErrorBoundary: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('@/components/SurveyCredits', () => ({ SurveyCredits: () => null }));
+jest.mock('@/components/profile/RedeemPromoCode', () => ({ RedeemPromoCode: () => null }));
+jest.mock('@/components/payment/AutoTopUpToggle', () => ({ AutoTopUpToggle: () => null }));
+jest.mock('@/components/profile/IntegrationsCard', () => ({
+  IntegrationsCard: mockIntegrationsCard,
+}));
+jest.mock('@/components/profile/ProfileOrganizationsSection', () => ({
+  ProfileOrganizationsSection: () => null,
+}));
+jest.mock('@/components/profile/ProfileKiloPassSection', () => ({
+  ProfileKiloPassSection: () => null,
+}));
+jest.mock('@/components/dev/CreateKilocodeOrgButton', () => ({
+  CreateKilocodeOrgButton: () => null,
+}));
+jest.mock('@/components/profile/UserProfileCard', () => ({ UserProfileCard: () => null }));
+jest.mock('@/components/auto-routing/AutoRoutingModeCard', () => ({
+  AutoRoutingModeCard: () => null,
+}));
+jest.mock('@/components/profile/DeleteAccountDialog', () => ({ DeleteAccountDialog: () => null }));
+jest.mock('@/lib/user', () => ({ getOAuthDisplayNames: jest.fn(() => new Map()) }));
+jest.mock('@/lib/organizations/organizations', () => ({
+  getUserOrganizationsWithSeats: jest.fn(() => []),
+}));
+jest.mock('@/lib/posthog-feature-flags', () => ({ isFeatureFlagEnabled: jest.fn(() => false) }));
+jest.mock('@/lib/contributor-champions/service', () => ({
+  getContributorChampionProfileBadgeForUser: jest.fn(() => null),
+}));
+
+describe('ProfilePage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not issue an API token when the session credential guard redirects', async () => {
+    mockGetUserForCredentialIssuance.mockRejectedValue(new Error('NEXT_REDIRECT'));
+    const { default: ProfilePage } = await import('./page');
+
+    await expect(
+      ProfilePage({ params: Promise.resolve(undefined), searchParams: Promise.resolve({}) })
+    ).rejects.toThrow('NEXT_REDIRECT');
+    expect(mockGetUserForCredentialIssuance).toHaveBeenCalledWith('/users/sign_in');
+    expect(mockGenerateApiToken).not.toHaveBeenCalled();
+    expect(mockGetCustomerInfo).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, 'vscode'])(
+    'passes only the issued credential with source %s',
+    async source => {
+      const user = { id: 'profile-user' };
+      mockGetUserForCredentialIssuance.mockResolvedValue(user);
+      mockGenerateApiToken.mockReturnValue('profile-test-token');
+      mockGetCustomerInfo.mockResolvedValue({ hasOrganizations: false, hasPaid: false, user });
+      const { default: ProfilePage } = await import('./page');
+
+      const page = await ProfilePage({
+        params: Promise.resolve(undefined),
+        searchParams: Promise.resolve({ source }),
+      });
+      const cards: unknown[] = [];
+      function collectCards(node: React.ReactNode) {
+        if (!React.isValidElement<{ children?: React.ReactNode }>(node)) return;
+        if (node.type === mockIntegrationsCard) cards.push(node.props);
+        React.Children.forEach(node.props.children, collectCards);
+      }
+      collectCards(page);
+
+      expect(mockGenerateApiToken).toHaveBeenCalledWith(user);
+      expect(cards).toEqual([
+        {
+          kiloToken: 'profile-test-token',
+          ideName: 'VS Code',
+          logoSrc: undefined,
+          isProminent: !!source,
+        },
+      ]);
+    }
+  );
+});

--- a/apps/web/src/app/(app)/profile/page.tsx
+++ b/apps/web/src/app/(app)/profile/page.tsx
@@ -7,7 +7,8 @@ import { getCustomerInfo } from '@/lib/customerInfo';
 import { DevNukeAccountButton } from '@/components/dev/DevNukeAccountButton';
 import { DevConsumeCreditsButton } from '@/components/dev/DevConsumeCreditsButton';
 import { DevAddCreditsButton } from '@/components/dev/DevAddCreditsButton';
-import { getUserFromAuthOrRedirect } from '@/lib/user/server';
+import { getUserFromSessionForCredentialIssuanceOrRedirect } from '@/lib/user/server';
+import { generateApiToken } from '@/lib/tokens';
 import { getOAuthDisplayNames } from '@/lib/user';
 import { getExtensionUrl } from '@/components/auth/getExtensionUrl';
 import { cookies } from 'next/headers';
@@ -34,7 +35,8 @@ import { DeleteAccountDialog } from '@/components/profile/DeleteAccountDialog';
 export const metadata = { itunes: smartAppBannerItunes('/profile') };
 
 export default async function ProfilePage({ searchParams }: AppPageProps) {
-  const user = await getUserFromAuthOrRedirect('/users/sign_in');
+  const user = await getUserFromSessionForCredentialIssuanceOrRedirect('/users/sign_in');
+  const kiloToken = generateApiToken(user);
   const params = await searchParams;
   const customerInfo = await getCustomerInfo(user, params);
 
@@ -114,7 +116,7 @@ export default async function ProfilePage({ searchParams }: AppPageProps) {
 
       {params.source && (
         <IntegrationsCard
-          customerInfo={customerInfo}
+          kiloToken={kiloToken}
           ideName={ideName}
           logoSrc={logoSrc}
           isProminent={true}
@@ -127,7 +129,7 @@ export default async function ProfilePage({ searchParams }: AppPageProps) {
 
       {!params.source && (
         <IntegrationsCard
-          customerInfo={customerInfo}
+          kiloToken={kiloToken}
           ideName={ideName}
           logoSrc={logoSrc}
           isProminent={false}

--- a/apps/web/src/app/api/auth/native/exchange/route.integration.test.ts
+++ b/apps/web/src/app/api/auth/native/exchange/route.integration.test.ts
@@ -1,0 +1,176 @@
+const mockHeaders = jest.fn<Promise<Headers>, []>();
+const mockGetServerSession = jest.fn();
+const mockCreateDeviceSession = jest.fn();
+const mockIssueSessionCredentials = jest.fn();
+
+jest.mock('next/headers', () => ({
+  headers: () => mockHeaders(),
+  cookies: jest.fn(),
+}));
+
+jest.mock('next-auth', () => ({
+  __esModule: true,
+  ...jest.requireActual('next-auth'),
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+jest.mock('@/lib/auth/device-sessions', () => ({
+  createDeviceSession: (...args: unknown[]) => mockCreateDeviceSession(...args),
+  issueSessionCredentials: (...args: unknown[]) => mockIssueSessionCredentials(...args),
+}));
+
+import { NextRequest } from 'next/server';
+import jwt from 'jsonwebtoken';
+import { POST } from './route';
+import { APP_URL } from '@/lib/constants';
+import { NEXTAUTH_SECRET } from '@/lib/config.server';
+import { generateApiToken, TOKEN_EXPIRY } from '@/lib/tokens';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { KILO_GATEWAY_AUDIENCE } from '@kilocode/worker-utils/internal-service-token-audiences';
+
+const credentials = {
+  token: 'short-lived-token',
+  refreshToken: 'refresh-token',
+  expiresIn: 3600,
+};
+
+function createRequest(headers: Record<string, string> = {}) {
+  return new NextRequest(`${APP_URL}/api/auth/native/exchange`, {
+    method: 'POST',
+    headers,
+  });
+}
+
+function setCurrentSession(userId: string, webSessionPepper: string | null) {
+  mockHeaders.mockResolvedValue(new Headers({ Cookie: 'next-auth.session-token=valid-cookie' }));
+  mockGetServerSession.mockResolvedValue({ kiloUserId: userId, webSessionPepper });
+}
+
+function expectNoCredentialsIssued() {
+  expect(mockCreateDeviceSession).not.toHaveBeenCalled();
+  expect(mockIssueSessionCredentials).not.toHaveBeenCalled();
+}
+
+describe('POST /api/auth/native/exchange integration', () => {
+  beforeEach(() => {
+    mockHeaders.mockReset();
+    mockGetServerSession.mockReset();
+    mockCreateDeviceSession.mockReset();
+    mockIssueSessionCredentials.mockReset();
+  });
+
+  test('exchanges a legacy generated API token with a null pepper and device authorization code', async () => {
+    const user = await insertTestUser({ api_token_pepper: null });
+    const token = generateApiToken(user, { deviceAuthRequestCode: 'ABCD-EFGH' });
+    mockCreateDeviceSession.mockResolvedValue('device-session-id');
+    mockIssueSessionCredentials.mockResolvedValue(credentials);
+
+    const response = await POST(createRequest({ Authorization: `Bearer ${token}` }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(credentials);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(mockCreateDeviceSession).toHaveBeenCalledWith({
+      userId: user.id,
+      userAgent: undefined,
+    });
+    expect(mockIssueSessionCredentials).toHaveBeenCalledWith(user, 'device-session-id');
+    expect(mockGetServerSession).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    [
+      'one-hour legacy token',
+      (user: Awaited<ReturnType<typeof insertTestUser>>) =>
+        generateApiToken(user, undefined, { expiresIn: TOKEN_EXPIRY.oneHour }),
+    ],
+    [
+      'device-session access token',
+      (user: Awaited<ReturnType<typeof insertTestUser>>) =>
+        generateApiToken(
+          user,
+          { deviceSessionId: crypto.randomUUID() },
+          { expiresIn: TOKEN_EXPIRY.oneHour }
+        ),
+    ],
+    [
+      'worker audience token',
+      (user: Awaited<ReturnType<typeof insertTestUser>>) =>
+        jwt.sign(
+          {
+            version: 3,
+            kiloUserId: user.id,
+            apiTokenPepper: user.api_token_pepper,
+            env: process.env.NODE_ENV,
+            aud: KILO_GATEWAY_AUDIENCE,
+          },
+          NEXTAUTH_SECRET,
+          { algorithm: 'HS256', expiresIn: TOKEN_EXPIRY.oneHour }
+        ),
+    ],
+    [
+      'cloud-agent token',
+      (user: Awaited<ReturnType<typeof insertTestUser>>) =>
+        generateApiToken(user, { tokenSource: 'cloud-agent' }),
+    ],
+  ])('rejects a %s without issuing credentials', async (_name, createToken) => {
+    const user = await insertTestUser({ api_token_pepper: crypto.randomUUID() });
+    const response = await POST(createRequest({ Authorization: `Bearer ${createToken(user)}` }));
+
+    expect(response.status).toBe(401);
+    expectNoCredentialsIssued();
+    expect(mockGetServerSession).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['empty', ''],
+    ['malformed', 'Basic not-a-bearer-token'],
+  ])(
+    'does not fall back to a valid cookie for an %s authorization header',
+    async (_name, authorization) => {
+      const user = await insertTestUser({ web_session_pepper: 'current-session-pepper' });
+      setCurrentSession(user.id, user.web_session_pepper);
+
+      const response = await POST(
+        createRequest({
+          Authorization: authorization,
+          Cookie: 'next-auth.session-token=valid-cookie',
+        })
+      );
+
+      expect(response.status).toBe(401);
+      expectNoCredentialsIssued();
+      expect(mockGetServerSession).not.toHaveBeenCalled();
+    }
+  );
+
+  test('does not issue credentials for a same-origin revoked session', async () => {
+    const user = await insertTestUser({ web_session_pepper: 'current-session-pepper' });
+    setCurrentSession(user.id, 'revoked-session-pepper');
+
+    const response = await POST(
+      createRequest({
+        Origin: new URL(APP_URL).origin,
+        Cookie: 'next-auth.session-token=valid-cookie',
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expectNoCredentialsIssued();
+  });
+
+  test('does not issue credentials for a same-origin blocked session', async () => {
+    const user = await insertTestUser({ blocked_reason: 'blocked for integration test' });
+    setCurrentSession(user.id, null);
+
+    const response = await POST(
+      createRequest({
+        Origin: new URL(APP_URL).origin,
+        Cookie: 'next-auth.session-token=valid-cookie',
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expectNoCredentialsIssued();
+  });
+});

--- a/apps/web/src/app/api/auth/native/exchange/route.test.ts
+++ b/apps/web/src/app/api/auth/native/exchange/route.test.ts
@@ -1,32 +1,44 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { failureResult } from '@/lib/maybe-result';
+import { APP_URL } from '@/lib/constants';
 
-jest.mock('@/lib/user/server');
+jest.mock('@/lib/user/server', () => ({
+  getUserFromBearerForCredentialExchange: jest.fn(),
+  getUserFromSessionForCredentialIssuance: jest.fn(),
+}));
 jest.mock('@/lib/auth/device-sessions');
 
 import { POST } from './route';
-import { getUserFromAuth } from '@/lib/user/server';
+import {
+  getUserFromBearerForCredentialExchange,
+  getUserFromSessionForCredentialIssuance,
+} from '@/lib/user/server';
 import { createDeviceSession, issueSessionCredentials } from '@/lib/auth/device-sessions';
 import type { User } from '@kilocode/db/schema';
 
-const mockGetUserFromAuth = jest.mocked(getUserFromAuth);
+const mockGetUserFromBearer = jest.mocked(getUserFromBearerForCredentialExchange);
+const mockGetUserFromSession = jest.mocked(getUserFromSessionForCredentialIssuance);
 const mockCreateDeviceSession = jest.mocked(createDeviceSession);
 const mockIssueSessionCredentials = jest.mocked(issueSessionCredentials);
 
 const fakeUser = { id: 'user-1', api_token_pepper: 'pepper' } as User;
 
 describe('POST /api/auth/native/exchange', () => {
-  const createRequest = () =>
+  const createRequest = (headers: Record<string, string> = {}) =>
     new NextRequest('http://localhost:3000/api/auth/native/exchange', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer old-token' },
+      headers: { 'Content-Type': 'application/json', ...headers },
     });
+
+  const bearerHeaders = { Authorization: 'Bearer old-token' };
+  const sessionHeaders = { Origin: new URL(APP_URL).origin };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('returns 200 with short-lived pair when authenticated', async () => {
-    mockGetUserFromAuth.mockResolvedValue({
+    mockGetUserFromBearer.mockResolvedValue({
       user: fakeUser,
       authFailedResponse: null,
     });
@@ -37,7 +49,7 @@ describe('POST /api/auth/native/exchange', () => {
       expiresIn: 3600,
     });
 
-    const response = await POST(createRequest());
+    const response = await POST(createRequest(bearerHeaders));
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       token: 'short-jwt',
@@ -49,31 +61,74 @@ describe('POST /api/auth/native/exchange', () => {
       userAgent: undefined,
     });
     expect(mockIssueSessionCredentials).toHaveBeenCalledWith(fakeUser, 'session-1');
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(mockGetUserFromBearer).toHaveBeenCalledWith(expect.any(Headers), {
+      legacy: 'five-year-api',
+    });
+    expect(mockGetUserFromSession).not.toHaveBeenCalled();
   });
 
-  it('returns the auth failed response when token is invalid', async () => {
-    mockGetUserFromAuth.mockResolvedValue({
+  it('returns the bearer failure without falling back to a session', async () => {
+    mockGetUserFromBearer.mockResolvedValue({
       user: null,
-      authFailedResponse: new Response(JSON.stringify({ error: 'Invalid token' }), {
-        status: 401,
-        headers: { 'content-type': 'application/json' },
-      }) as any,
+      authFailedResponse: NextResponse.json(failureResult('Invalid token'), { status: 401 }),
     });
 
-    const response = await POST(createRequest());
+    const response = await POST(createRequest(bearerHeaders));
     expect(response.status).toBe(401);
+    expect(mockGetUserFromSession).not.toHaveBeenCalled();
+    expect(mockCreateDeviceSession).not.toHaveBeenCalled();
+    expect(mockIssueSessionCredentials).not.toHaveBeenCalled();
   });
 
-  it('does not call createDeviceSession when auth fails', async () => {
-    mockGetUserFromAuth.mockResolvedValue({
+  it('does not issue credentials when the bearer user is blocked', async () => {
+    mockGetUserFromBearer.mockResolvedValue({
       user: null,
-      authFailedResponse: new Response(JSON.stringify({ error: 'Invalid token' }), {
-        status: 401,
-        headers: { 'content-type': 'application/json' },
-      }) as any,
+      authFailedResponse: NextResponse.json(failureResult('User blocked'), { status: 403 }),
     });
 
-    await POST(createRequest());
+    const response = await POST(createRequest(bearerHeaders));
+    expect(response.status).toBe(403);
     expect(mockCreateDeviceSession).not.toHaveBeenCalled();
+    expect(mockIssueSessionCredentials).not.toHaveBeenCalled();
+  });
+
+  it('rejects a cookie request with no origin before authenticating', async () => {
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(403);
+    expect(mockGetUserFromSession).not.toHaveBeenCalled();
+    expect(mockCreateDeviceSession).not.toHaveBeenCalled();
+    expect(mockIssueSessionCredentials).not.toHaveBeenCalled();
+  });
+
+  it('rejects a cookie request with a foreign origin before authenticating', async () => {
+    const response = await POST(createRequest({ Origin: 'https://evil.example' }));
+
+    expect(response.status).toBe(403);
+    expect(mockGetUserFromSession).not.toHaveBeenCalled();
+    expect(mockCreateDeviceSession).not.toHaveBeenCalled();
+    expect(mockIssueSessionCredentials).not.toHaveBeenCalled();
+  });
+
+  it('issues credentials for a same-origin authenticated browser session', async () => {
+    mockGetUserFromSession.mockResolvedValue({ user: fakeUser, authFailedResponse: null });
+    mockCreateDeviceSession.mockResolvedValue('session-1');
+    mockIssueSessionCredentials.mockResolvedValue({
+      token: 'short-jwt',
+      refreshToken: 'refresh-abc',
+      expiresIn: 3600,
+    });
+
+    const response = await POST(createRequest(sessionHeaders));
+
+    expect(response.status).toBe(200);
+    expect(mockGetUserFromSession).toHaveBeenCalledWith();
+    expect(mockGetUserFromBearer).not.toHaveBeenCalled();
+    expect(mockCreateDeviceSession).toHaveBeenCalledWith({
+      userId: fakeUser.id,
+      userAgent: undefined,
+    });
+    expect(mockIssueSessionCredentials).toHaveBeenCalledWith(fakeUser, 'session-1');
   });
 });

--- a/apps/web/src/app/api/auth/native/exchange/route.ts
+++ b/apps/web/src/app/api/auth/native/exchange/route.ts
@@ -1,7 +1,11 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { getUserFromAuth } from '@/lib/user/server';
+import {
+  getUserFromBearerForCredentialExchange,
+  getUserFromSessionForCredentialIssuance,
+} from '@/lib/user/server';
 import { createDeviceSession, issueSessionCredentials } from '@/lib/auth/device-sessions';
+import { APP_URL } from '@/lib/constants';
 
 /**
  * Token exchange endpoint. Authenticates with the existing long-lived bearer
@@ -17,9 +21,9 @@ import { createDeviceSession, issueSessionCredentials } from '@/lib/auth/device-
  *   403 — blocked user
  */
 export async function POST(request: NextRequest) {
-  const auth = await getUserFromAuth({
-    adminOnly: false,
-  });
+  const auth = request.headers.has('authorization')
+    ? await getUserFromBearerForCredentialExchange(request.headers, { legacy: 'five-year-api' })
+    : await getSessionAuth(request);
 
   if (auth.authFailedResponse) {
     return auth.authFailedResponse;
@@ -42,6 +46,18 @@ export async function POST(request: NextRequest) {
       refreshToken: pair.refreshToken,
       expiresIn: pair.expiresIn,
     },
-    { status: 200 }
+    { status: 200, headers: { 'Cache-Control': 'no-store' } }
   );
+}
+
+async function getSessionAuth(request: NextRequest) {
+  const origin = request.headers.get('origin');
+  if (origin !== new URL(APP_URL).origin) {
+    return {
+      user: null,
+      authFailedResponse: NextResponse.json({ error: 'Invalid origin' }, { status: 403 }),
+    };
+  }
+
+  return getUserFromSessionForCredentialIssuance();
 }

--- a/apps/web/src/app/api/device-auth/tokens/route.integration.test.ts
+++ b/apps/web/src/app/api/device-auth/tokens/route.integration.test.ts
@@ -1,0 +1,76 @@
+const mockHeaders = jest.fn<Promise<Headers>, []>();
+const mockGetServerSession = jest.fn();
+const mockApproveDeviceAuthRequest = jest.fn();
+
+jest.mock('next/headers', () => ({
+  headers: () => mockHeaders(),
+  cookies: jest.fn(),
+}));
+
+jest.mock('next-auth', () => ({
+  __esModule: true,
+  ...jest.requireActual('next-auth'),
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+jest.mock('@/lib/device-auth/device-auth', () => ({
+  approveDeviceAuthRequest: (...args: unknown[]) => mockApproveDeviceAuthRequest(...args),
+}));
+
+import { POST } from './route';
+import { APP_URL } from '@/lib/constants';
+import { generateApiToken } from '@/lib/tokens';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+
+function createRequest(headers: Record<string, string> = {}) {
+  return new Request(`${APP_URL}/api/device-auth/tokens`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Origin: new URL(APP_URL).origin, ...headers },
+    body: JSON.stringify({ code: 'ABCD-EFGH' }),
+  });
+}
+
+describe('POST /api/device-auth/tokens integration', () => {
+  beforeEach(() => {
+    mockHeaders.mockReset();
+    mockGetServerSession.mockReset();
+    mockApproveDeviceAuthRequest.mockReset();
+  });
+
+  test('approves with a valid same-origin current session', async () => {
+    const user = await insertTestUser({ web_session_pepper: 'current-session-pepper' });
+    mockHeaders.mockResolvedValue(new Headers({ Cookie: 'next-auth.session-token=valid-cookie' }));
+    mockGetServerSession.mockResolvedValue({
+      kiloUserId: user.id,
+      webSessionPepper: user.web_session_pepper,
+    });
+    mockApproveDeviceAuthRequest.mockResolvedValue(undefined);
+
+    const response = await POST(createRequest({ Cookie: 'next-auth.session-token=valid-cookie' }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(mockApproveDeviceAuthRequest).toHaveBeenCalledWith('ABCD-EFGH', user.id);
+  });
+
+  test.each(['valid bearer', 'empty authorization'])(
+    'never approves with %s and a cookie',
+    async kind => {
+      const user = await insertTestUser({ api_token_pepper: crypto.randomUUID() });
+      const authorization = kind === 'valid bearer' ? `Bearer ${generateApiToken(user)}` : '';
+      mockHeaders.mockResolvedValue(
+        new Headers({
+          Authorization: authorization,
+          Cookie: 'next-auth.session-token=valid-cookie',
+        })
+      );
+      mockGetServerSession.mockResolvedValue({ kiloUserId: user.id, webSessionPepper: null });
+
+      const response = await POST(createRequest({ Authorization: authorization }));
+
+      expect(response.status).toBe(401);
+      expect(mockGetServerSession).not.toHaveBeenCalled();
+      expect(mockApproveDeviceAuthRequest).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/apps/web/src/app/api/device-auth/tokens/route.test.ts
+++ b/apps/web/src/app/api/device-auth/tokens/route.test.ts
@@ -1,0 +1,87 @@
+import { APP_URL } from '@/lib/constants';
+import { NextResponse } from 'next/server';
+import { failureResult } from '@/lib/maybe-result';
+import { defineTestUser } from '@/tests/helpers/user.helper';
+
+jest.mock('@/lib/user/server', () => ({
+  getUserFromSessionForCredentialIssuance: jest.fn(),
+}));
+jest.mock('@/lib/device-auth/device-auth', () => ({
+  approveDeviceAuthRequest: jest.fn(),
+}));
+
+import { approveDeviceAuthRequest } from '@/lib/device-auth/device-auth';
+import { getUserFromSessionForCredentialIssuance } from '@/lib/user/server';
+import { POST } from './route';
+
+const mockApprove = jest.mocked(approveDeviceAuthRequest);
+const mockGetUserFromSession = jest.mocked(getUserFromSessionForCredentialIssuance);
+
+describe('POST /api/device-auth/tokens', () => {
+  const createRequest = (body: string, headers: Record<string, string> = {}) =>
+    new Request('http://localhost:3000/api/device-auth/tokens', {
+      method: 'POST',
+      body,
+      headers: { 'Content-Type': 'application/json', ...headers },
+    });
+
+  const sessionHeaders = { Origin: new URL(APP_URL).origin };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('approves a valid code for an authenticated same-origin session', async () => {
+    mockGetUserFromSession.mockResolvedValue({
+      user: defineTestUser({ id: 'user-1' }),
+      authFailedResponse: null,
+    });
+
+    const response = await POST(
+      createRequest(JSON.stringify({ code: 'ABCD-EFGH' }), sessionHeaders)
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(mockApprove).toHaveBeenCalledWith('ABCD-EFGH', 'user-1');
+  });
+
+  it.each([undefined, 'https://evil.example'])(
+    'rejects a %s origin before authenticating',
+    async origin => {
+      const headers: Record<string, string> = origin ? { Origin: origin } : {};
+
+      const response = await POST(createRequest(JSON.stringify({ code: 'ABCD-EFGH' }), headers));
+
+      expect(response.status).toBe(403);
+      expect(mockGetUserFromSession).not.toHaveBeenCalled();
+      expect(mockApprove).not.toHaveBeenCalled();
+    }
+  );
+
+  it('returns the session authentication failure without approving', async () => {
+    mockGetUserFromSession.mockResolvedValue({
+      user: null,
+      authFailedResponse: NextResponse.json(failureResult('Unauthorized'), { status: 401 }),
+    });
+
+    const response = await POST(
+      createRequest(JSON.stringify({ code: 'ABCD-EFGH' }), sessionHeaders)
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockApprove).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid payload without approving', async () => {
+    mockGetUserFromSession.mockResolvedValue({
+      user: defineTestUser({ id: 'user-1' }),
+      authFailedResponse: null,
+    });
+
+    const response = await POST(createRequest('{', sessionHeaders));
+
+    expect(response.status).toBe(400);
+    expect(mockApprove).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/device-auth/tokens/route.ts
+++ b/apps/web/src/app/api/device-auth/tokens/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { approveDeviceAuthRequest } from '@/lib/device-auth/device-auth';
-import { getUserFromAuth } from '@/lib/user/server';
+import { getUserFromSessionForCredentialIssuance } from '@/lib/user/server';
+import { APP_URL } from '@/lib/constants';
 import * as z from 'zod';
 
 const TokensSchema = z.object({
@@ -8,14 +9,18 @@ const TokensSchema = z.object({
 });
 
 export async function POST(request: Request) {
-  // Authenticate the user
-  const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
+  const origin = request.headers.get('origin');
+  if (origin !== new URL(APP_URL).origin) {
+    return NextResponse.json({ error: 'Invalid origin' }, { status: 403 });
+  }
+
+  const { user, authFailedResponse } = await getUserFromSessionForCredentialIssuance();
 
   if (authFailedResponse) {
     return authFailedResponse;
   }
 
-  const body = await request.json();
+  const body = await request.json().catch(() => undefined);
   const validation = TokensSchema.safeParse(body);
   if (!validation.success) {
     return NextResponse.json(

--- a/apps/web/src/app/sign-in-to-editor/page.test.ts
+++ b/apps/web/src/app/sign-in-to-editor/page.test.ts
@@ -1,0 +1,116 @@
+import React from 'react';
+
+const mockGetUserForCredentialIssuance = jest.fn();
+const mockGenerateApiToken = jest.fn();
+const mockRedirect = jest.fn();
+const mockGetExtensionUrl = jest.fn();
+const mockManualSetupSteps = jest.fn(() => null);
+const mockOpenIdeAutomatically = jest.fn(() => null);
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+jest.mock('@/lib/user/server', () => ({
+  getUserFromSessionForCredentialIssuanceOrRedirect: mockGetUserForCredentialIssuance,
+}));
+jest.mock('@/lib/tokens', () => ({ generateApiToken: mockGenerateApiToken }));
+jest.mock('next/navigation', () => ({ redirect: mockRedirect }));
+jest.mock('next/headers', () => ({ cookies: jest.fn() }));
+jest.mock('@/components/auth/getExtensionUrl', () => ({ getExtensionUrl: mockGetExtensionUrl }));
+jest.mock('@/components/auth/OpenCodeEditor', () => ({ OpenCodeEditor: () => null }));
+jest.mock('@/components/auth/DelayedLinks', () => ({ DelayedLinks: () => null }));
+jest.mock('@/components/KiloCardLayout', () => ({
+  KiloCardLayout: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('@/components/auth/ManualSetupSteps', () => ({ ManualSetupSteps: mockManualSetupSteps }));
+jest.mock('@/components/auth/OpenIdeAutomatically', () => ({
+  OpenIdeAutomatically: mockOpenIdeAutomatically,
+}));
+
+function findElementProps(
+  element: React.ReactNode,
+  component: React.ElementType
+): Record<string, unknown> | null {
+  if (!React.isValidElement(element)) return null;
+  const props = element.props as { children?: React.ReactNode };
+  if (element.type === component) return props;
+
+  for (const child of React.Children.toArray(props.children)) {
+    const childProps = findElementProps(child, component);
+    if (childProps) return childProps;
+  }
+
+  return null;
+}
+
+describe('RedirectPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetExtensionUrl.mockReturnValue({
+      extensionUrl: 'kilo://open',
+      ideName: 'VS Code',
+      urlScheme: 'kilo',
+      logoSrc: '/vscode.svg',
+    });
+    mockGenerateApiToken.mockReturnValue('minted-token');
+  });
+
+  it('does not issue an API token when the session credential guard redirects', async () => {
+    mockGetUserForCredentialIssuance.mockRejectedValue(new Error('NEXT_REDIRECT'));
+    const { default: RedirectPage } = await import('./page');
+
+    await expect(RedirectPage({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+      'NEXT_REDIRECT'
+    );
+    expect(mockGetUserForCredentialIssuance).toHaveBeenCalledWith(
+      '/users/sign_in?callbackPath=/sign-in-to-editor'
+    );
+    expect(mockGenerateApiToken).not.toHaveBeenCalled();
+  });
+
+  it('redirects unverified users before issuing an API token', async () => {
+    mockGetUserForCredentialIssuance.mockResolvedValue({ has_validation_stytch: null });
+    mockRedirect.mockImplementation(() => {
+      throw new Error('NEXT_REDIRECT');
+    });
+    const { default: RedirectPage } = await import('./page');
+
+    await expect(RedirectPage({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+      'NEXT_REDIRECT'
+    );
+    expect(mockRedirect).toHaveBeenCalledWith('/account-verification');
+    expect(mockGenerateApiToken).not.toHaveBeenCalled();
+  });
+
+  it('preserves the web manual setup flow', async () => {
+    mockGetExtensionUrl.mockReturnValue({
+      extensionUrl: 'https://app.kilo.ai',
+      ideName: 'Web',
+      urlScheme: 'web',
+      logoSrc: undefined,
+    });
+    mockGetUserForCredentialIssuance.mockResolvedValue({ has_validation_stytch: true });
+    const { default: RedirectPage } = await import('./page');
+
+    const page = await RedirectPage({ searchParams: Promise.resolve({}) });
+
+    expect(mockGenerateApiToken).toHaveBeenCalledTimes(1);
+    expect(findElementProps(page, mockManualSetupSteps)).toMatchObject({
+      kiloToken: 'minted-token',
+    });
+    expect(findElementProps(page, mockOpenIdeAutomatically)).toBeNull();
+  });
+
+  it('preserves editor selection props for native IDEs', async () => {
+    mockGetUserForCredentialIssuance.mockResolvedValue({ has_validation_stytch: true });
+    const { default: RedirectPage } = await import('./page');
+
+    const page = await RedirectPage({ searchParams: Promise.resolve({}) });
+
+    expect(findElementProps(page, mockOpenIdeAutomatically)).toMatchObject({
+      url: 'kilo://open?token=minted-token',
+      ideName: 'VS Code',
+      logoSrc: '/vscode.svg',
+      kiloToken: 'minted-token',
+    });
+  });
+});

--- a/apps/web/src/app/sign-in-to-editor/page.tsx
+++ b/apps/web/src/app/sign-in-to-editor/page.tsx
@@ -2,7 +2,7 @@ import { OpenCodeEditor } from '@/components/auth/OpenCodeEditor';
 import { DelayedLinks } from '@/components/auth/DelayedLinks';
 import { getExtensionUrl } from '@/components/auth/getExtensionUrl';
 import { generateApiToken } from '@/lib/tokens';
-import { getUserFromAuthOrRedirect } from '@/lib/user/server';
+import { getUserFromSessionForCredentialIssuanceOrRedirect } from '@/lib/user/server';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { KiloCardLayout } from '@/components/KiloCardLayout';
@@ -18,7 +18,9 @@ export default async function RedirectPage({
     await searchParams,
     await cookies()
   );
-  const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/sign-in-to-editor');
+  const user = await getUserFromSessionForCredentialIssuanceOrRedirect(
+    '/users/sign_in?callbackPath=/sign-in-to-editor'
+  );
 
   if (user.has_validation_stytch === null) {
     // account-status does stytch verification and redirects to welcome when that's done

--- a/apps/web/src/components/profile/IntegrationsCard.tsx
+++ b/apps/web/src/components/profile/IntegrationsCard.tsx
@@ -4,13 +4,12 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { OpenInExtensionButton } from '@/components/auth/OpenInExtensionButton';
 import { CopyTokenButton } from '@/components/auth/CopyTokenButton';
 import { Code, Terminal } from 'lucide-react';
-import type { CustomerInfo } from '@/lib/customerInfo';
 import { ResetAPITokenDialog } from './ResetAPITokenDialog';
 import Image from 'next/image';
 import Link from 'next/link';
 
 type IntegrationsCardProps = {
-  customerInfo: CustomerInfo;
+  kiloToken: string;
   ideName: string;
   logoSrc: string | undefined;
   isProminent?: boolean;
@@ -35,7 +34,7 @@ function LastUsedBadge() {
 }
 
 export function IntegrationsCard({
-  customerInfo,
+  kiloToken,
   ideName,
   logoSrc,
   isProminent = false,
@@ -124,7 +123,7 @@ export function IntegrationsCard({
         </div>
         <div className="mt-6 space-y-3">
           <h3 className="text-sm font-medium">API Key</h3>
-          <CopyTokenButton kiloToken={customerInfo.kiloToken} />
+          <CopyTokenButton kiloToken={kiloToken} />
         </div>
       </CardContent>
     </Card>

--- a/apps/web/src/lib/customerInfo.test.ts
+++ b/apps/web/src/lib/customerInfo.test.ts
@@ -1,0 +1,36 @@
+const mockGenerateApiToken = jest.fn();
+const mockFindFirst = jest.fn();
+
+jest.mock('@/lib/tokens', () => ({ generateApiToken: mockGenerateApiToken }));
+jest.mock('@/lib/stripe-client', () => ({ hasPaymentMethodInStripe: jest.fn(() => false) }));
+jest.mock('@/lib/creditTransactions', () => ({
+  summarizeUserPayments: jest.fn(() => ({ payments_count: 0 })),
+}));
+jest.mock('@/lib/organizations/organizations', () => ({
+  userHasOrganizations: jest.fn(() => false),
+}));
+jest.mock('@/lib/welcomeCredits', () => ({
+  hasReceivedAnyFreeWelcomeCredits: jest.fn(() => false),
+}));
+jest.mock('@/lib/drizzle', () => ({
+  db: { query: { payment_methods: { findFirst: mockFindFirst } } },
+}));
+
+describe('getCustomerInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindFirst.mockResolvedValue(undefined);
+  });
+
+  it('does not issue an API token', async () => {
+    const { getCustomerInfo } = await import('./customerInfo');
+
+    const customerInfo = await getCustomerInfo(
+      { id: 'user-1', stripe_customer_id: null } as never,
+      {}
+    );
+
+    expect(customerInfo).not.toHaveProperty('kiloToken');
+    expect(mockGenerateApiToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/customerInfo.ts
+++ b/apps/web/src/lib/customerInfo.ts
@@ -3,7 +3,6 @@ import { hasPaymentMethodInStripe } from '@/lib/stripe-client';
 import { db } from '@/lib/drizzle';
 import { payment_methods, kilocode_users, type User } from '@kilocode/db/schema';
 import { eq, and, isNull } from 'drizzle-orm';
-import { generateApiToken } from './tokens';
 import { userHasOrganizations } from '@/lib/organizations/organizations';
 import { hasReceivedAnyFreeWelcomeCredits } from '@/lib/welcomeCredits';
 
@@ -14,7 +13,6 @@ export type CustomerInfo = {
   paymentStatus_untrusted: string;
   hasPaymentMethodEligibleForFreeCredits: boolean;
   user: User;
-  kiloToken: string;
   hasOrganizations: boolean;
   hasReceivedWelcomeCredits: boolean;
 };
@@ -52,7 +50,6 @@ export const getCustomerInfo = async (
     hasPaymentMethodEligibleForFreeCredits: await paymentEligblePromise,
     paymentStatus_untrusted: searchParams.payment_status as string,
     user,
-    kiloToken: generateApiToken(user),
     hasOrganizations: hasOrganizations,
     hasReceivedWelcomeCredits,
   };

--- a/apps/web/src/lib/user/server.test.ts
+++ b/apps/web/src/lib/user/server.test.ts
@@ -6,11 +6,19 @@ jest.mock('next/headers', () => ({
 }));
 
 const mockGetServerSession = jest.fn();
+const mockRedirect = jest.fn((url: string) => {
+  throw new Error(`NEXT_REDIRECT:${url}`);
+});
 
 jest.mock('next-auth', () => ({
   __esModule: true,
   ...jest.requireActual('next-auth'),
-  getServerSession: () => mockGetServerSession(),
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+jest.mock('next/navigation', () => ({
+  ...jest.requireActual('next/navigation'),
+  redirect: (url: string) => mockRedirect(url),
 }));
 
 import { afterEach, beforeAll, beforeEach, describe, test, expect } from '@jest/globals';
@@ -26,6 +34,9 @@ import {
   parseSignInRedirectContext,
   getProfileRedirectPath,
   getUserFromAuth,
+  getUserFromBearerForCredentialExchange,
+  getUserFromSessionForCredentialIssuance,
+  getUserFromSessionForCredentialIssuanceOrRedirect,
 } from './server';
 import { db } from '@/lib/drizzle';
 import { setAdminAccessSinkForTest, type AdminAccessEvent } from '@/lib/admin/admin-access-log';
@@ -42,6 +53,11 @@ import { createCallerForUser } from '@/routers/test-utils';
 import { generateApiToken } from '@/lib/tokens';
 import { eq } from 'drizzle-orm';
 import { v5 as uuidv5 } from 'uuid';
+import jwt from 'jsonwebtoken';
+import { KILO_API_AUDIENCE } from '@kilocode/worker-utils/internal-service-token-audiences';
+import { signKiloToken } from '@kilocode/worker-utils/kilo-token';
+import { buildModernKiloTokenPayload } from '@kilocode/worker-utils/kilo-token-policy';
+import { NEXTAUTH_SECRET } from '@/lib/config.server';
 
 // Same namespace UUID used in user.server.ts
 const USER_UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
@@ -49,7 +65,12 @@ const USER_UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
 beforeEach(() => {
   mockHeaders.mockReset();
   mockGetServerSession.mockReset();
+  mockRedirect.mockClear();
 });
+
+function signPolicyClaims(claims: Record<string, unknown>, secret = NEXTAUTH_SECRET): string {
+  return jwt.sign(claims, secret, { algorithm: 'HS256' });
+}
 
 describe('isEmailBlacklistedByDomain', () => {
   test('should return false when blacklisted_domains is undefined', () => {
@@ -648,6 +669,492 @@ describe('getUserFromAuth', () => {
     expect(result.authFailedResponse).not.toBeNull();
     expect(result.user).toBeNull();
     expect(result.deviceSessionId).toBeUndefined();
+  });
+});
+
+describe('credential issuance authentication guards', () => {
+  test.each([
+    ['Bearer token', { Authorization: 'Bearer token' }],
+    ['empty authorization', { Authorization: '' }],
+    [
+      'cookie and bearer',
+      { Authorization: 'Bearer token', Cookie: 'next-auth.session-token=session' },
+    ],
+  ])('session-only guard rejects %s', async (_name, headers) => {
+    mockHeaders.mockResolvedValue(new Headers(headers));
+
+    const result = await getUserFromSessionForCredentialIssuance();
+
+    expect(result.user).toBeNull();
+    expect(result.authFailedResponse?.status).toBe(401);
+    expect(mockGetServerSession).not.toHaveBeenCalled();
+  });
+
+  test('uses the genuine session and primary database user', async () => {
+    const user = await insertTestUser({ web_session_pepper: 'current-web-session-pepper' });
+    mockHeaders.mockResolvedValue(new Headers());
+    mockGetServerSession.mockResolvedValue({
+      kiloUserId: user.id,
+      webSessionPepper: 'current-web-session-pepper',
+      isNewUser: false,
+    });
+
+    const result = await getUserFromSessionForCredentialIssuance();
+
+    expect(result.user?.id).toBe(user.id);
+    expect(mockGetServerSession).toHaveBeenCalledWith(authOptions);
+  });
+
+  test('rejects a revoked web session', async () => {
+    const user = await insertTestUser({ web_session_pepper: 'current-web-session-pepper' });
+    mockHeaders.mockResolvedValue(new Headers());
+    mockGetServerSession.mockResolvedValue({
+      kiloUserId: user.id,
+      webSessionPepper: 'revoked-web-session-pepper',
+    });
+
+    const result = await getUserFromSessionForCredentialIssuance();
+
+    expect(result.user).toBeNull();
+    expect(result.authFailedResponse?.status).toBe(401);
+  });
+
+  test('does not authorize blocked users for credential issuance', async () => {
+    const user = await insertTestUser({ blocked_reason: 'blocked for test' });
+    mockHeaders.mockResolvedValue(new Headers());
+    mockGetServerSession.mockResolvedValue({ kiloUserId: user.id, webSessionPepper: null });
+
+    const result = await getUserFromSessionForCredentialIssuance();
+
+    expect(result.user).toBeNull();
+    expect(result.authFailedResponse?.status).toBe(403);
+  });
+
+  test('leaves generic bearer authentication available', async () => {
+    const user = await insertTestUser({ api_token_pepper: 'generic-bearer-pepper' });
+    mockHeaders.mockResolvedValue(
+      new Headers({ Authorization: `Bearer ${generateApiToken(user)}` })
+    );
+
+    const result = await getUserFromAuth({ adminOnly: false });
+
+    expect(result.user?.id).toBe(user.id);
+  });
+
+  test('redirects an absent session to the callback-aware sign-in URL', async () => {
+    mockHeaders.mockResolvedValue(new Headers({ 'x-pathname': '/profile' }));
+    mockGetServerSession.mockResolvedValue(null);
+
+    await expect(getUserFromSessionForCredentialIssuanceOrRedirect()).rejects.toThrow(
+      'NEXT_REDIRECT:/users/sign_in?callbackPath=%2Fprofile'
+    );
+    expect(mockRedirect).toHaveBeenCalledWith('/users/sign_in?callbackPath=%2Fprofile');
+  });
+
+  test('redirects blocked sessions to the blocked account page', async () => {
+    const user = await insertTestUser({ blocked_reason: 'blocked for test' });
+    mockHeaders.mockResolvedValue(new Headers({ 'x-pathname': '/profile' }));
+    mockGetServerSession.mockResolvedValue({ kiloUserId: user.id, webSessionPepper: null });
+
+    await expect(getUserFromSessionForCredentialIssuanceOrRedirect()).rejects.toThrow(
+      'NEXT_REDIRECT:/account-blocked'
+    );
+    expect(mockRedirect).toHaveBeenCalledWith('/account-blocked');
+  });
+
+  test.each([
+    ['bearer', { authorization: 'Bearer token' }],
+    ['mixed cookie and bearer', { authorization: 'Bearer token', cookie: 'session=value' }],
+  ])('redirects %s authentication to the callback-aware sign-in URL', async (_name, headers) => {
+    mockHeaders.mockResolvedValue(new Headers({ ...headers, 'x-pathname': '/profile' }));
+
+    await expect(getUserFromSessionForCredentialIssuanceOrRedirect()).rejects.toThrow(
+      'NEXT_REDIRECT:/users/sign_in?callbackPath=%2Fprofile'
+    );
+    expect(mockGetServerSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('credential exchange bearer authentication guard', () => {
+  async function createModernToken(user: User, pepper = user.api_token_pepper) {
+    const now = Math.floor(Date.now() / 1000);
+    return signPolicyClaims(
+      buildModernKiloTokenPayload({
+        userId: user.id,
+        pepper,
+        env: process.env.NODE_ENV,
+        audience: KILO_API_AUDIENCE,
+        issuedAt: now,
+        expiresAt: now + 300,
+        tokenPurpose: 'human-api',
+        credentialExchange: true,
+      })
+    );
+  }
+
+  test('authorizes an eligible modern bearer token', async () => {
+    const user = await insertTestUser({ api_token_pepper: 'modern-exchange-pepper' });
+    const token = await createModernToken(user);
+
+    const result = await getUserFromBearerForCredentialExchange(
+      new Headers({ authorization: `Bearer ${token}` }),
+      { legacy: 'deny' }
+    );
+
+    expect(result.user?.id).toBe(user.id);
+  });
+
+  test.each([157_680_000, 157_788_000])(
+    'authorizes eligible legacy bearer tokens with a %i second lifetime',
+    async expiresInSeconds => {
+      const user = await insertTestUser({ api_token_pepper: `legacy-pepper-${expiresInSeconds}` });
+      const { token } = await signKiloToken({
+        userId: user.id,
+        pepper: user.api_token_pepper,
+        secret: NEXTAUTH_SECRET,
+        expiresInSeconds,
+        env: process.env.NODE_ENV,
+      });
+
+      const result = await getUserFromBearerForCredentialExchange(
+        new Headers({ authorization: `Bearer ${token}` }),
+        { legacy: 'five-year-api' }
+      );
+
+      expect(result.user?.id).toBe(user.id);
+    }
+  );
+
+  test.each([157_680_000, 157_788_000])(
+    'authorizes a near-expiry legacy bearer token with a %i second lifetime',
+    async lifetime => {
+      const user = await insertTestUser({ api_token_pepper: `near-expiry-pepper-${lifetime}` });
+      const now = Math.floor(Date.now() / 1000);
+      const token = signPolicyClaims({
+        version: 3,
+        kiloUserId: user.id,
+        apiTokenPepper: user.api_token_pepper,
+        env: process.env.NODE_ENV,
+        iat: now - lifetime + 300,
+        exp: now + 300,
+      });
+
+      const result = await getUserFromBearerForCredentialExchange(
+        new Headers({ authorization: `Bearer ${token}` }),
+        { legacy: 'five-year-api' }
+      );
+
+      expect(result.user?.id).toBe(user.id);
+    }
+  );
+
+  test.each([3600, 15 * 60, 24 * 60 * 60, 30 * 24 * 60 * 60])(
+    'rejects a %i second legacy bearer token',
+    async expiresInSeconds => {
+      const user = await insertTestUser({
+        api_token_pepper: `short-legacy-pepper-${expiresInSeconds}`,
+      });
+      const { token } = await signKiloToken({
+        userId: user.id,
+        pepper: user.api_token_pepper,
+        secret: NEXTAUTH_SECRET,
+        expiresInSeconds,
+        env: process.env.NODE_ENV,
+      });
+
+      const result = await getUserFromBearerForCredentialExchange(
+        new Headers({ authorization: `Bearer ${token}` }),
+        { legacy: 'five-year-api' }
+      );
+
+      expect(result.authFailedResponse?.status).toBe(401);
+    }
+  );
+
+  test('rejects a legacy bearer token when legacy exchange is disabled', async () => {
+    const user = await insertTestUser({ api_token_pepper: 'legacy-denied-pepper' });
+    const { token } = await signKiloToken({
+      userId: user.id,
+      pepper: user.api_token_pepper,
+      secret: NEXTAUTH_SECRET,
+      expiresInSeconds: 157_680_000,
+      env: process.env.NODE_ENV,
+    });
+
+    const result = await getUserFromBearerForCredentialExchange(
+      new Headers({ authorization: `Bearer ${token}` }),
+      { legacy: 'deny' }
+    );
+
+    expect(result.authFailedResponse?.status).toBe(401);
+  });
+
+  test('rejects absent and mismatched pepper claims, including a null database pepper', async () => {
+    const user = await insertTestUser({ api_token_pepper: null });
+    const noPepper = await signPolicyClaims({
+      version: 3,
+      kiloUserId: user.id,
+      env: process.env.NODE_ENV,
+      aud: KILO_API_AUDIENCE,
+      tokenPurpose: 'human-api',
+      credentialExchange: true,
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 300,
+    });
+    const mismatched = await createModernToken(user, 'different-pepper');
+
+    for (const token of [noPepper, mismatched]) {
+      const result = await getUserFromBearerForCredentialExchange(
+        new Headers({ authorization: `Bearer ${token}` }),
+        { legacy: 'deny' }
+      );
+      expect(result.authFailedResponse?.status).toBe(401);
+    }
+  });
+
+  test('accepts an explicit null pepper only when the database pepper is null', async () => {
+    const user = await insertTestUser({ api_token_pepper: null });
+    const token = await createModernToken(user, null);
+
+    const result = await getUserFromBearerForCredentialExchange(
+      new Headers({ authorization: `Bearer ${token}` }),
+      { legacy: 'deny' }
+    );
+
+    expect(result.user?.id).toBe(user.id);
+  });
+
+  test('rejects an explicit null pepper for a user with a string pepper', async () => {
+    const user = await insertTestUser({ api_token_pepper: 'string-pepper' });
+    const token = await createModernToken(user, null);
+
+    const result = await getUserFromBearerForCredentialExchange(
+      new Headers({ authorization: `Bearer ${token}` }),
+      { legacy: 'deny' }
+    );
+
+    expect(result.authFailedResponse?.status).toBe(401);
+  });
+
+  test('rejects a token after its database pepper is rotated', async () => {
+    const user = await insertTestUser({ api_token_pepper: 'before-rotation-pepper' });
+    const token = await createModernToken(user);
+    await db
+      .update(kilocode_users)
+      .set({ api_token_pepper: 'after-rotation-pepper' })
+      .where(eq(kilocode_users.id, user.id));
+
+    const result = await getUserFromBearerForCredentialExchange(
+      new Headers({ authorization: `Bearer ${token}` }),
+      { legacy: 'deny' }
+    );
+
+    expect(result.authFailedResponse?.status).toBe(401);
+  });
+
+  test.each([
+    [
+      'missing environment',
+      (user: User, now: number) => ({
+        version: 3,
+        kiloUserId: user.id,
+        apiTokenPepper: user.api_token_pepper,
+        aud: KILO_API_AUDIENCE,
+        tokenPurpose: 'human-api',
+        credentialExchange: true,
+        iat: now,
+        exp: now + 300,
+      }),
+    ],
+    [
+      'device purpose',
+      (user: User, now: number) => ({
+        version: 3,
+        kiloUserId: user.id,
+        apiTokenPepper: user.api_token_pepper,
+        env: process.env.NODE_ENV,
+        aud: KILO_API_AUDIENCE,
+        tokenPurpose: 'device-access',
+        credentialExchange: false,
+        iat: now,
+        exp: now + 300,
+      }),
+    ],
+    [
+      'unknown signed claim',
+      (user: User, now: number) => ({
+        version: 3,
+        kiloUserId: user.id,
+        apiTokenPepper: user.api_token_pepper,
+        env: process.env.NODE_ENV,
+        aud: KILO_API_AUDIENCE,
+        tokenPurpose: 'human-api',
+        credentialExchange: true,
+        futureRestriction: false,
+        iat: now,
+        exp: now + 300,
+      }),
+    ],
+  ])('rejects an eligible-looking token with %s', async (_name, claimsFor) => {
+    const user = await insertTestUser({ api_token_pepper: 'ineligible-claim-pepper' });
+    const token = await signPolicyClaims(claimsFor(user, Math.floor(Date.now() / 1000)));
+
+    const result = await getUserFromBearerForCredentialExchange(
+      new Headers({ authorization: `Bearer ${token}` }),
+      { legacy: 'five-year-api' }
+    );
+
+    expect(result.authFailedResponse?.status).toBe(401);
+  });
+
+  test.each([
+    ['device session', { deviceSessionId: '' }],
+    ['bot', { botId: '' }],
+    ['organization', { organizationId: '' }],
+    ['token source', { tokenSource: '' }],
+    ['admin', { isAdmin: false }],
+    ['internal use', { internalApiUse: false }],
+    ['gastown access', { gastownAccess: false }],
+  ])('rejects a legacy bearer token with a %s marker', async (_name, marker) => {
+    const user = await insertTestUser({ api_token_pepper: 'system-marker-pepper' });
+    const now = Math.floor(Date.now() / 1000);
+    const token = signPolicyClaims({
+      version: 3,
+      kiloUserId: user.id,
+      apiTokenPepper: user.api_token_pepper,
+      env: process.env.NODE_ENV,
+      iat: now,
+      exp: now + 157_680_000,
+      ...marker,
+    });
+
+    const result = await getUserFromBearerForCredentialExchange(
+      new Headers({ authorization: `Bearer ${token}` }),
+      { legacy: 'five-year-api' }
+    );
+
+    expect(result.authFailedResponse?.status).toBe(401);
+  });
+
+  test.each([
+    'invalid signature',
+    'expired',
+    'future-issued',
+    'missing expiry',
+    'missing issuance',
+  ])('rejects an otherwise eligible token with %s without a session fallback', async invalidity => {
+    const user = await insertTestUser({ api_token_pepper: 'verification-test-pepper' });
+    const now = Math.floor(Date.now() / 1000);
+    const claims: Record<string, unknown> = buildModernKiloTokenPayload({
+      userId: user.id,
+      pepper: user.api_token_pepper,
+      env: process.env.NODE_ENV,
+      audience: KILO_API_AUDIENCE,
+      issuedAt: now,
+      expiresAt: now + 300,
+      tokenPurpose: 'human-api',
+      credentialExchange: true,
+    });
+    if (invalidity === 'expired') {
+      claims.iat = now - 600;
+      claims.exp = now - 300;
+    } else if (invalidity === 'future-issued') {
+      claims.iat = now + 300;
+      claims.exp = now + 600;
+    } else if (invalidity === 'missing expiry') {
+      delete claims.exp;
+    }
+    const token = jwt.sign(
+      claims,
+      invalidity === 'invalid signature' ? 'wrong-test-signing-secret' : NEXTAUTH_SECRET,
+      { algorithm: 'HS256', noTimestamp: invalidity === 'missing issuance' }
+    );
+
+    const result = await getUserFromBearerForCredentialExchange(
+      new Headers({ authorization: `Bearer ${token}` }),
+      { legacy: 'deny' }
+    );
+
+    expect(result.authFailedResponse?.status).toBe(401);
+    expect(mockGetServerSession).not.toHaveBeenCalled();
+  });
+
+  test('rejects a valid token for a missing user', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signPolicyClaims({
+      version: 3,
+      kiloUserId: 'missing-credential-exchange-user',
+      apiTokenPepper: 'pepper',
+      env: process.env.NODE_ENV,
+      aud: KILO_API_AUDIENCE,
+      tokenPurpose: 'human-api',
+      credentialExchange: true,
+      iat: now,
+      exp: now + 300,
+    });
+
+    const result = await getUserFromBearerForCredentialExchange(
+      new Headers({ authorization: `Bearer ${token}` }),
+      { legacy: 'deny' }
+    );
+
+    expect(result.authFailedResponse?.status).toBe(401);
+  });
+
+  test('rejects wrong audiences, environment, blocked users, and ineligible modern claims', async () => {
+    const user = await insertTestUser({ api_token_pepper: 'rejected-exchange-pepper' });
+    const now = Math.floor(Date.now() / 1000);
+    const invalidClaims = [
+      {
+        version: 3,
+        kiloUserId: user.id,
+        apiTokenPepper: user.api_token_pepper,
+        env: process.env.NODE_ENV,
+        aud: 'other-audience',
+        tokenPurpose: 'human-api',
+        credentialExchange: true,
+        iat: now,
+        exp: now + 300,
+      },
+      buildModernKiloTokenPayload({
+        userId: user.id,
+        pepper: user.api_token_pepper,
+        env: 'other-environment',
+        audience: KILO_API_AUDIENCE,
+        issuedAt: now,
+        expiresAt: now + 300,
+        tokenPurpose: 'human-api',
+        credentialExchange: true,
+      }),
+      buildModernKiloTokenPayload({
+        userId: user.id,
+        pepper: user.api_token_pepper,
+        env: process.env.NODE_ENV,
+        audience: KILO_API_AUDIENCE,
+        issuedAt: now,
+        expiresAt: now + 300,
+        tokenPurpose: 'human-api',
+        credentialExchange: false,
+      }),
+    ];
+
+    for (const claims of invalidClaims) {
+      const result = await getUserFromBearerForCredentialExchange(
+        new Headers({ authorization: `Bearer ${await signPolicyClaims(claims)}` }),
+        { legacy: 'deny' }
+      );
+      expect(result.authFailedResponse?.status).toBe(401);
+    }
+
+    await db
+      .update(kilocode_users)
+      .set({ blocked_reason: 'blocked for test' })
+      .where(eq(kilocode_users.id, user.id));
+    const blocked = await getUserFromBearerForCredentialExchange(
+      new Headers({ authorization: `Bearer ${await createModernToken(user)}` }),
+      { legacy: 'deny' }
+    );
+    expect(blocked.authFailedResponse?.status).toBe(403);
   });
 });
 

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -102,6 +102,13 @@ import { getLowerDomainFromEmail } from '@/lib/utils';
 import { z } from 'zod';
 import { v5 as uuidv5 } from 'uuid';
 import { isWebSessionCurrent } from '@/lib/web-session-revocation';
+import { extractBearerToken } from '@kilocode/worker-utils/extract-bearer-token';
+import { KILO_API_AUDIENCE } from '@kilocode/worker-utils/internal-service-token-audiences';
+import {
+  isKiloCredentialExchangeEligible,
+  verifyKiloTokenForPolicy,
+  type KiloCredentialExchangeEligibilityPolicy,
+} from '@kilocode/worker-utils/kilo-token-policy';
 
 export type TurnstileJwtPayload = {
   /**
@@ -1128,6 +1135,81 @@ export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAut
   return result;
 }
 
+export async function getUserFromSessionForCredentialIssuance(): Promise<GetAuthResponse> {
+  const headersList = await headers();
+  if (headersList.has('authorization')) {
+    return authError(401, 'Unauthorized', '?');
+  }
+
+  return resolveUserFromSession({ adminOnly: false }, db);
+}
+
+export async function getUserFromSessionForCredentialIssuanceOrRedirect(
+  loggedOutRedirectUrl = '/users/sign_in'
+): Promise<User> {
+  const headersList = await headers();
+  if (headersList.has('authorization')) {
+    redirect(await appendCallbackPath(loggedOutRedirectUrl));
+  }
+
+  const { user } = await resolveUserFromSession(
+    { adminOnly: false, DANGEROUS_allowBlockedUsers: true },
+    db
+  );
+  if (!user) {
+    redirect(await appendCallbackPath(loggedOutRedirectUrl));
+  }
+  if (user.blocked_reason) {
+    redirect('/account-blocked');
+  }
+  return user;
+}
+
+export async function getUserFromBearerForCredentialExchange(
+  requestHeaders: Headers,
+  policy: KiloCredentialExchangeEligibilityPolicy
+): Promise<GetAuthResponse> {
+  const token = extractBearerToken(requestHeaders.get('authorization'));
+  if (!token) return authError(401, 'Unauthorized', '?');
+
+  let auth: Awaited<ReturnType<typeof verifyKiloTokenForPolicy>>;
+  try {
+    auth = await verifyKiloTokenForPolicy(token, NEXTAUTH_SECRET, {
+      audience: KILO_API_AUDIENCE,
+      mode: 'allow-legacy',
+    });
+  } catch {
+    return authError(401, 'Unauthorized', '?');
+  }
+
+  if (auth.claims.env !== process.env.NODE_ENV) {
+    return authError(401, 'Unauthorized', auth.userId);
+  }
+
+  const user = await findUserById(auth.userId, db);
+  if (
+    auth.claims.apiTokenPepper === undefined ||
+    auth.claims.apiTokenPepper !== user?.api_token_pepper
+  ) {
+    return authError(401, 'Unauthorized', auth.userId);
+  }
+
+  const result = await validateUserAuthorization(
+    auth.userId,
+    user,
+    { adminOnly: false },
+    false,
+    undefined,
+    undefined,
+    db
+  );
+  if (!result.user) return result;
+  if (!isKiloCredentialExchangeEligible(auth, policy)) {
+    return authError(401, 'Unauthorized', auth.userId);
+  }
+  return result;
+}
+
 async function resolveUserFromAuth(
   opts: RequiredPermissions,
   headersList: Awaited<ReturnType<typeof headers>>
@@ -1169,12 +1251,19 @@ async function resolveUserFromAuth(
     );
   }
 
+  return resolveUserFromSession(opts, readDb);
+}
+
+async function resolveUserFromSession(
+  opts: RequiredPermissions,
+  fromDb: typeof db
+): Promise<GetAuthResponse> {
   const session = await getServerSession(authOptions);
   const maybeKiloUserId = session?.kiloUserId;
 
   if (!maybeKiloUserId) return authError(401, 'Unauthorized', '?');
 
-  const user = await findUserById(maybeKiloUserId, readDb);
+  const user = await findUserById(maybeKiloUserId, fromDb);
   if (!user) return authError(401, 'Unauthorized (D)', maybeKiloUserId);
 
   if (!isWebSessionCurrent(session.webSessionPepper, user))
@@ -1188,7 +1277,7 @@ async function resolveUserFromAuth(
     session.isNewUser,
     undefined,
     undefined,
-    readDb
+    fromDb
   );
 }
 


### PR DESCRIPTION
## Stack
Depends on #5785. This PR intentionally targets `feat/token-issuance-policy-contracts`; its diff contains Phase 2 only. Retarget to `main` after Phase 1 merges, adjusting the stack if needed.

## Summary
- Require current NextAuth web sessions for device authorization approval and profile/editor credential disclosure; reject bearer/mixed authentication on those surfaces.
- Gate native exchange with Phase 1 audience and exchange-eligibility policy, current primary-database account state, exact pepper equality, and environment validation. Preserve the explicit five-year legacy API migration exception and existing mobile response contract.
- Require configured same-origin requests for cookie-authenticated approval/exchange, without requiring Origin for native bearer clients; mark exchange responses `no-store`.
- Remove incidental token minting from customer information reads and pass only the token to the profile integrations component.
- Add real signed-token/account integration regressions, endpoint tests, and disclosure tests; enable Jest transformation of the shared policy module’s ESM jose dependency.

## Compatibility and scope
- Existing ordinary API authentication and opaque refresh-grant rotation remain unchanged. No global token invalidation, signing-key rotation, or pepper reset.
- The narrow legacy exchange exception accepts both historical five-year lifetimes. Unmarked legacy automation can still be indistinguishable from human API tokens; this is a compatibility exception, not proof of human origin.
- Cloud Agent/App Builder indirect reissuance, Worker audience-reader/issuer migrations, and service renewal redesign remain deferred. This PR closes the audited direct approval/exchange/disclosure paths, not every bearer-triggered downstream mint.
- Previously approved device requests can remain redeemable until their existing approximately ten-minute expiry.

## Validation
- 333 tests passed across 15 targeted web suites, including real-guard integration tests and adjacent native refresh, device sessions, device authorization, token, session-revocation, and promotional-credit regressions.
- `pnpm --filter web lint` passed.
- `pnpm --filter web typecheck` passed; declaration bundling emitted external-dependency warnings.
- Changed files formatted with `pnpm format`; `git diff --check` passed.
- No production requests or browser E2E run performed.