### PR TITLE
fix(gateway): route MiniMax M3 free through OpenRouter

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -106,48 +106,46 @@ describe('isFreeModel', () => {
       expect(getAiSdkProvider(longcat_2_free_model.public_id, null)).toBeUndefined();
     });
 
-    test.each([
-      {
-        name: 'MiniMax M3',
-        model: minimax_m3_free_model,
-        publicId: 'minimax/minimax-m3:free',
-        internalId: 'minimax/minimax-m3-free',
-        contextLength: 1_048_576,
-        vision: true,
-        isAutoFree: true,
-      },
-      {
-        name: 'MiniMax M2.7',
-        model: minimax_m27_free_model,
-        publicId: 'minimax/minimax-m2.7:free',
-        internalId: 'minimax/minimax-m2.7-free',
-        contextLength: 196_608,
-        vision: false,
-        isAutoFree: false,
-      },
-    ])(
-      'registers $name as a free Vercel GMI Cloud model',
-      async ({ model, publicId, internalId, contextLength, vision, isAutoFree }) => {
-        expect(findKiloExclusiveModel(model.public_id)).toBe(model);
-        expect(await isFreeModel(model.public_id)).toBe(true);
-        expect(model).toMatchObject({
-          public_id: publicId,
-          internal_id: internalId,
-          gateway: 'vercel',
-          context_length: contextLength,
-          max_completion_tokens: contextLength,
-          status: 'public',
-          inference_provider_restriction: ['gmicloud'],
-        });
-        expect(model.flags.includes('reasoning')).toBe(true);
-        expect(model.flags.includes('vision')).toBe(vision);
-        expect(getInferenceProvider(model)?.slug).toBe('gmicloud');
-        expect(autoFreeModels.some(({ model: modelId }) => modelId === model.public_id)).toBe(
-          isAutoFree
-        );
-        expect(preferredModels.includes(model.public_id)).toBe(isAutoFree);
-      }
-    );
+    test('registers MiniMax M3 as a free OpenRouter model', async () => {
+      expect(findKiloExclusiveModel(minimax_m3_free_model.public_id)).toBe(minimax_m3_free_model);
+      expect(await isFreeModel(minimax_m3_free_model.public_id)).toBe(true);
+      expect(minimax_m3_free_model).toMatchObject({
+        public_id: 'minimax/minimax-m3:free',
+        internal_id: 'minimax/minimax-m3:free',
+        gateway: 'openrouter',
+        context_length: 1_048_576,
+        max_completion_tokens: 1_048_576,
+        status: 'public',
+        pricing: null,
+        inference_provider_restriction: [],
+      });
+      expect(minimax_m3_free_model.flags).toEqual(['reasoning', 'vision']);
+      expect(getInferenceProvider(minimax_m3_free_model)).toBeNull();
+      expect(autoFreeModels.some(({ model }) => model === minimax_m3_free_model.public_id)).toBe(
+        true
+      );
+      expect(preferredModels).toContain(minimax_m3_free_model.public_id);
+    });
+
+    test('registers MiniMax M2.7 as a free Vercel GMI Cloud model', async () => {
+      expect(findKiloExclusiveModel(minimax_m27_free_model.public_id)).toBe(minimax_m27_free_model);
+      expect(await isFreeModel(minimax_m27_free_model.public_id)).toBe(true);
+      expect(minimax_m27_free_model).toMatchObject({
+        public_id: 'minimax/minimax-m2.7:free',
+        internal_id: 'minimax/minimax-m2.7-free',
+        gateway: 'vercel',
+        context_length: 196_608,
+        max_completion_tokens: 196_608,
+        status: 'public',
+        inference_provider_restriction: ['gmicloud'],
+      });
+      expect(minimax_m27_free_model.flags).toEqual(['reasoning']);
+      expect(getInferenceProvider(minimax_m27_free_model)?.slug).toBe('gmicloud');
+      expect(autoFreeModels.some(({ model }) => model === minimax_m27_free_model.public_id)).toBe(
+        false
+      );
+      expect(preferredModels).not.toContain(minimax_m27_free_model.public_id);
+    });
 
     test('routes the discounted Claude Opus offering through the stealth provider identity', () => {
       expect(getInferenceProvider(claude_opus_4_7_stealth_model)?.slug).toBe('stealth');

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.local-fake.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.local-fake.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, test } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
 import { getProvider } from '@/lib/ai-gateway/providers/get-provider';
 import { OPENROUTER, VERCEL_AI_GATEWAY } from '@/lib/ai-gateway/providers/provider-definitions';
+import { shouldRouteToVercel } from '@/lib/ai-gateway/providers/vercel';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { User } from '@kilocode/db/schema';
 
@@ -54,6 +55,10 @@ function replaceEnv(overrides: {
 }
 
 describe('getProvider local fake deterministic routing', () => {
+  beforeEach(() => {
+    jest.mocked(shouldRouteToVercel).mockReset().mockResolvedValue(false);
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });
@@ -111,15 +116,24 @@ describe('getProvider local fake deterministic routing', () => {
     missingUrl.restore();
   });
 
-  test.each(['minimax/minimax-m3:free', 'minimax/minimax-m2.7:free'])(
-    'routes %s through Vercel AI Gateway',
-    async model => {
-      expect(await getProvider(providerInput(model))).toEqual({
-        kind: 'provider',
-        provider: VERCEL_AI_GATEWAY,
-        userByok: null,
-        bypassAccessCheck: false,
-      });
-    }
-  );
+  test('routes MiniMax M3 through its declared OpenRouter gateway regardless of Vercel routing', async () => {
+    jest.mocked(shouldRouteToVercel).mockResolvedValue(true);
+
+    expect(await getProvider(providerInput('minimax/minimax-m3:free'))).toEqual({
+      kind: 'provider',
+      provider: OPENROUTER,
+      userByok: null,
+      bypassAccessCheck: false,
+    });
+    expect(shouldRouteToVercel).not.toHaveBeenCalled();
+  });
+
+  test('routes MiniMax M2.7 through its declared Vercel AI Gateway', async () => {
+    expect(await getProvider(providerInput('minimax/minimax-m2.7:free'))).toEqual({
+      kind: 'provider',
+      provider: VERCEL_AI_GATEWAY,
+      userByok: null,
+      bypassAccessCheck: false,
+    });
+  });
 });

--- a/apps/web/src/lib/ai-gateway/providers/minimax.ts
+++ b/apps/web/src/lib/ai-gateway/providers/minimax.ts
@@ -2,20 +2,19 @@ import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusi
 
 export const MINIMAX_CURRENT_MODEL_ID = 'minimax/minimax-m3';
 
-// Remove both routing overrides when Vercel's GMI Cloud promotion ends 2026-09-06.
 export const minimax_m3_free_model: KiloExclusiveModel = {
   public_id: 'minimax/minimax-m3:free',
   display_name: 'MiniMax: MiniMax M3 (free)',
   description:
-    'MiniMax-M3 is a frontier-class foundation model that combines a 1M-token context window, coding and agentic performance, and native multimodality. Available free through Vercel AI Gateway via GMI Cloud until September 6, 2026.',
+    'MiniMax-M3 is a frontier-class foundation model that combines a 1M-token context window, coding and agentic performance, and native multimodality. Available free through OpenRouter via GMI Cloud.',
   context_length: 1_048_576,
   max_completion_tokens: 1_048_576,
   status: 'public',
   flags: ['reasoning', 'vision'],
-  gateway: 'vercel',
-  internal_id: 'minimax/minimax-m3-free',
+  gateway: 'openrouter',
+  internal_id: 'minimax/minimax-m3:free',
   pricing: null,
-  inference_provider_restriction: ['gmicloud'],
+  inference_provider_restriction: [],
 };
 
 export const minimax_m27_free_model: KiloExclusiveModel = {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -224,31 +224,61 @@ describe('auto models', () => {
   });
 });
 
-describe('MiniMax Vercel promotion models', () => {
+describe('MiniMax free models', () => {
   afterEach(() => {
     global.fetch = originalFetch;
   });
 
-  it.each([minimax_m3_free_model, minimax_m27_free_model])(
-    'replaces the OpenRouter catalog entry for $public_id without duplicating it',
-    async model => {
-      global.fetch = jest.fn(() =>
-        Promise.resolve(
-          createMockResponse({
-            jsonData: {
-              data: [buildModel({ id: model.public_id, name: 'OpenRouter catalog name' })],
-            },
-          })
-        )
-      ) as unknown as typeof fetch;
+  it('replaces the MiniMax M3 OpenRouter catalog entry without duplicating free metadata', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve(
+        createMockResponse({
+          jsonData: {
+            data: [
+              buildModel({
+                id: minimax_m3_free_model.public_id,
+                name: 'OpenRouter catalog name',
+              }),
+            ],
+          },
+        })
+      )
+    ) as unknown as typeof fetch;
 
-      const models = await getEnhancedOpenRouterModels();
-      const matches = models.data.filter(entry => entry.id === model.public_id);
+    const models = await getEnhancedOpenRouterModels();
+    const matches = models.data.filter(entry => entry.id === minimax_m3_free_model.public_id);
 
-      expect(matches).toHaveLength(1);
-      expect(matches[0]?.name).toBe(model.display_name);
-    }
-  );
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      id: minimax_m3_free_model.public_id,
+      name: minimax_m3_free_model.display_name,
+      isFree: true,
+      pricing: { prompt: '0.000000000000', completion: '0.000000000000' },
+    });
+  });
+
+  it('replaces the MiniMax M2.7 catalog entry without duplicating it', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve(
+        createMockResponse({
+          jsonData: {
+            data: [
+              buildModel({
+                id: minimax_m27_free_model.public_id,
+                name: 'OpenRouter catalog name',
+              }),
+            ],
+          },
+        })
+      )
+    ) as unknown as typeof fetch;
+
+    const models = await getEnhancedOpenRouterModels();
+    const matches = models.data.filter(entry => entry.id === minimax_m27_free_model.public_id);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.name).toBe(minimax_m27_free_model.display_name);
+  });
 });
 
 describe('reasoning variants', () => {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -586,21 +586,30 @@ describe('applyVercelSettings managed requests', () => {
     }
   );
 
-  it.each(
-    [minimax_m3_free_model, minimax_m27_free_model].flatMap(model =>
-      (['chat_completions', 'messages', 'responses'] as const).map(kind => ({ model, kind }))
-    )
-  )(
-    'routes $model.public_id $kind requests with unrelated ignores when metadata is unavailable',
-    async ({ model, kind }) => {
-      const request = managedRequestForApi(kind, model.public_id);
-      applyKiloExclusiveModelSettings(request, model);
+  it.each(['chat_completions', 'messages', 'responses'] as const)(
+    'routes MiniMax M2.7 $kind requests with unrelated ignores when metadata is unavailable',
+    async kind => {
+      const request = managedRequestForApi(kind, minimax_m27_free_model.public_id);
+      applyKiloExclusiveModelSettings(request, minimax_m27_free_model);
 
-      await applyManagedVercelSettings(model.public_id, request, null);
+      await applyManagedVercelSettings(minimax_m27_free_model.public_id, request, null);
 
-      expect(request.body.model).toBe(model.internal_id);
+      expect(request.body.model).toBe(minimax_m27_free_model.internal_id);
       expect(request.body.provider).toBeUndefined();
       expect(request.body.providerOptions?.gateway?.only).toEqual(['gmicloud']);
+    }
+  );
+
+  it.each(['chat_completions', 'messages', 'responses'] as const)(
+    'does not inject a GMI provider-only setting for MiniMax M3 $kind requests',
+    kind => {
+      const request = managedRequestForApi(kind, minimax_m3_free_model.public_id);
+      const originalProvider = structuredClone(request.body.provider);
+
+      applyKiloExclusiveModelSettings(request, minimax_m3_free_model);
+
+      expect(request.body.model).toBe('minimax/minimax-m3:free');
+      expect(request.body.provider).toEqual(originalProvider);
     }
   );
 


### PR DESCRIPTION
## Summary
- Route MiniMax M3 Free through OpenRouter using its exact `minimax/minimax-m3:free` upstream ID.
- Preserve the free public model and GMI Cloud attribution; remove the gateway-specific provider restriction and promotion date since i have no clue if its the same for openrouter.

## Verification
No manual inference requests were performed. This change was validated locally without accessing production systems; live inference behavior remains unverified.

## Visual Changes
N/A

## Reviewer Notes
- Automated validation passed: 135 tests across four focused suites, scoped formatting/lint, and web typecheck.
- Tests used an isolated Jest configuration with database/Redis dependencies mocked and the database-backed global setup omitted; this was not the full integration suite.
- The free OpenRouter endpoint still uses GMI Cloud. Changing the gateway does not guarantee provider availability; verify completed inference and capacity after rollout.
- No production logs, user identifiers, credentials, or internal evidence links are included.