### PR TITLE
fix(gdpr): use message ID for Pylon completion replies

### DIFF
--- a/apps/web/src/lib/user/deletion-queue/handlers/pylon-reply.test.ts
+++ b/apps/web/src/lib/user/deletion-queue/handlers/pylon-reply.test.ts
@@ -75,7 +75,7 @@ describe('handlePylonReply', () => {
     expect(outcome).toEqual({ kind: 'not_applicable' });
   });
 
-  it('posts the unwrapped confirmation HTML to the latest public customer message and always sends to_emails', async () => {
+  it('posts the unwrapped confirmation HTML using the latest public customer message ID, not its thread ID, and always sends to_emails', async () => {
     const { request, step, context } = await setupReplyRequest();
     const fetchSpy = mockPylon({
       requesterEmail: TARGET_EMAIL,
@@ -117,7 +117,7 @@ describe('handlePylonReply', () => {
     expect(posted).toHaveLength(1);
     expect(JSON.parse(String(posted[0]?.[1]?.body))).toEqual({
       body_html: USER_DELETION_PYLON_REPLY_HTML,
-      message_id: 'thread-latest',
+      message_id: 'msg-latest',
       email_info: { to_emails: [TARGET_EMAIL] },
     });
     expect(closedIssue(fetchSpy)).toBe(false);

--- a/apps/web/src/lib/user/deletion-queue/handlers/pylon-reply.ts
+++ b/apps/web/src/lib/user/deletion-queue/handlers/pylon-reply.ts
@@ -372,7 +372,7 @@ export const handlePylonReply: DeletionHandler = async ({ request, step, context
 
       const body: Record<string, unknown> = {
         body_html: USER_DELETION_PYLON_REPLY_HTML,
-        message_id: replyTarget.threadId ?? replyTarget.id,
+        message_id: replyTarget.id,
         email_info: { to_emails: [emailOrOutcome] },
       };
 


### PR DESCRIPTION
## Summary
- Send the top-level Pylon message ID in the completion reply payload instead of preferring the thread ID.
- Correct the existing regression test, whose fixture already contains distinct message and thread IDs, to enforce the provider contract.

## Verification
- No live reply POST or end-to-end deletion was performed, to avoid sending customer messages or changing a production deletion request.
- Reviewed operator-supplied read-only Pylon issue/messages responses and the [Pylon reply API contract](https://docs.usepylon.com/pylon-docs/developer/api/api-reference/messages). The returned thread IDs are distinct from the required message IDs.

## Visual Changes
N/A

## Reviewer Notes
- Scope is limited to the outbound reply target. Recipient validation, checkpointing, reconciliation, and deletion ordering are unchanged.
- Regression test failed before the handler fix: expected `msg-latest`, received `thread-latest`.
- Automated checks passed:
  - `pnpm --filter web test --runInBand --runTestsByPath src/lib/user/deletion-queue/handlers/pylon-reply.test.ts` — 18 tests, isolated local PostgreSQL with mocked provider HTTP.
  - `pnpm --filter web lint`
  - `pnpm typecheck --changes-only`
  - Changed-file `pnpm format` and `git diff --check`.
