### PR TITLE
feat(cloud-agent): use readable kilo branch names

### DIFF
--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -6,6 +6,7 @@
 
 import { DurableObject } from 'cloudflare:workers';
 import type { CloudAgentQueueReport } from '@kilocode/worker-utils/cloud-agent-queue-report';
+import { generateEphemeralDeploymentSlug } from '@kilocode/worker-utils/deployment-slug';
 import type { OperationResult } from './types.js';
 import {
   getSandboxProvider,
@@ -526,7 +527,7 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       ...(status === 'completed'
         ? {}
         : { clientError: projectTerminalClientError({ status, error }) }),
-      lastSeenBranch: metadata.repository?.upstreamBranch,
+      lastSeenBranch: metadata.repository?.upstreamBranch ?? metadata.workspace?.branchName,
       kiloSessionId: metadata.auth.kiloSessionId,
       gateResult,
       lastAssistantMessageText,
@@ -2559,6 +2560,7 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       workspace: {
         ...input.workspace,
         sandboxProvider: input.workspace?.sandboxProvider ?? 'cloudflare',
+        branchName: repository?.upstreamBranch ?? `kilo/${generateEphemeralDeploymentSlug()}`,
       },
       lifecycle: {
         version: now,

--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -1042,6 +1042,31 @@ describe('SessionService.prepareWorkspace', () => {
     portMocks.randomPort.mockReturnValue(4173);
   });
 
+  it.each([undefined, 1])(
+    'uses the persisted readable branch during workspace preparation with preparedAt=%s',
+    async preparedAt => {
+      const branchName = 'kilo/calm-cedar-az234567';
+      const session = createSession(false);
+      const result = await new SessionService().prepareWorkspace({
+        sandbox: createSandbox(session),
+        sandboxId: 'ses-abcdef',
+        userId: 'user_test',
+        sessionId: 'agent_test' as SessionId,
+        env: createEnv(),
+        metadata: createMetadata({ branchName, preparedAt }),
+        kilocodeModel: 'test-model',
+      });
+
+      expect(workspaceMocks.manageBranch).toHaveBeenCalledWith(
+        session,
+        '/workspace/user/sessions/agent_test',
+        branchName,
+        false
+      );
+      expect(result.ready.branchName).toBe(branchName);
+    }
+  );
+
   it('prepares a cold workspace and returns ready metadata', async () => {
     const session = createSession(false);
     const sandbox = createSandbox(session);
@@ -2433,6 +2458,29 @@ describe('SessionService.buildWrapperSessionReadyAndPromptRequests', () => {
     expect(result.ready.workspacePath).toBe(workspacePath);
     expect(result.readyRequest.workspace.workspacePath).toBe(workspacePath);
   });
+
+  it.each([undefined, 1])(
+    'uses the persisted readable branch in wrapper readiness with preparedAt=%s',
+    async preparedAt => {
+      const branchName = 'kilo/calm-cedar-az234567';
+      const result = await buildPromptWrapperRequests(createMetadata({ branchName, preparedAt }));
+
+      expect(result.ready.branchName).toBe(branchName);
+      expect(result.readyRequest.workspace.branchName).toBe(branchName);
+      expect(result.readyRequest.workspace.upstreamBranch).toBeUndefined();
+    }
+  );
+
+  it.each([undefined, 'session/agent_existing'])(
+    'preserves historical branch selection with stored branch=%s',
+    async branchName => {
+      const result = await buildPromptWrapperRequests(createMetadata({ branchName }));
+      const expectedBranch = branchName ?? 'session/agent_test';
+
+      expect(result.ready.branchName).toBe(expectedBranch);
+      expect(result.readyRequest.workspace.branchName).toBe(expectedBranch);
+    }
+  );
 
   it('prefers and requires snapshot restore in wrapper readiness for clone metadata', async () => {
     const result = await buildPromptWrapperRequests(createCloneMetadata());

--- a/services/cloud-agent-next/src/session/message-settlement-outbox.test.ts
+++ b/services/cloud-agent-next/src/session/message-settlement-outbox.test.ts
@@ -705,6 +705,47 @@ describe('MessageSettlementOutbox', () => {
     expect(JSON.stringify(harness.callbackJobs[0])).not.toContain('token=secret');
   });
 
+  it.each([
+    {
+      name: 'uses the workspace branch when the upstream branch is absent',
+      upstreamBranch: undefined,
+      branchName: 'kilo/quiet-forest-abcdefgh',
+      expectedBranch: 'kilo/quiet-forest-abcdefgh',
+    },
+    {
+      name: 'prefers the upstream branch over a different workspace branch',
+      upstreamBranch: 'feature/observed-branch',
+      branchName: 'kilo/quiet-forest-abcdefgh',
+      expectedBranch: 'feature/observed-branch',
+    },
+    {
+      name: 'leaves the branch absent for historical metadata without either branch',
+      upstreamBranch: undefined,
+      branchName: undefined,
+      expectedBranch: undefined,
+    },
+  ])('$name in callback jobs', async ({ upstreamBranch, branchName, expectedBranch }) => {
+    const harness = createHarness({
+      metadata: {
+        ...metadata,
+        repository: { type: 'github', repo: 'owner/repo', upstreamBranch },
+        workspace: branchName === undefined ? undefined : { branchName },
+      },
+    });
+    await putSessionMessageState(
+      harness.storage,
+      acceptedMessageState(firstMessageId, { url: 'https://example.com/callback' })
+    );
+
+    await harness.outbox.terminalizeSessionMessageOnce(firstMessageId, {
+      kind: 'completed',
+      completionSource: 'assistant_message_event',
+    });
+
+    expect(harness.callbackJobs).toHaveLength(1);
+    expect(harness.callbackJobs[0].payload.lastSeenBranch).toBe(expectedBranch);
+  });
+
   it('omits clientError from completed callback jobs', async () => {
     const harness = createHarness();
     await putSessionMessageState(

--- a/services/cloud-agent-next/src/session/message-settlement-outbox.ts
+++ b/services/cloud-agent-next/src/session/message-settlement-outbox.ts
@@ -468,7 +468,7 @@ export function createMessageSettlementOutbox(
               error: failure?.message ?? legacyErrorMessage,
             }),
           }),
-      lastSeenBranch: metadata?.repository?.upstreamBranch,
+      lastSeenBranch: metadata?.repository?.upstreamBranch ?? metadata?.workspace?.branchName,
       kiloSessionId: metadata?.auth.kiloSessionId,
       gateResult: state.gateResult,
       lastAssistantMessageText,

--- a/services/cloud-agent-next/test/integration/session/legacy-callback-enqueue.test.ts
+++ b/services/cloud-agent-next/test/integration/session/legacy-callback-enqueue.test.ts
@@ -66,6 +66,104 @@ describe('legacy execution callback enqueue', () => {
     });
   });
 
+  it.each([
+    {
+      name: 'uses the workspace branch when the upstream branch is absent',
+      upstreamBranch: undefined,
+      expectedBranch: 'kilo/quiet-forest-abcdefgh',
+    },
+    {
+      name: 'prefers the observed upstream branch over a different workspace branch',
+      upstreamBranch: 'feature/observed-branch',
+      expectedBranch: 'feature/observed-branch',
+    },
+  ])('$name in callback jobs', async ({ upstreamBranch, expectedBranch }) => {
+    const userId = 'user_legacy_callback_branch';
+    const sessionId = `agent_legacy_callback_branch_${upstreamBranch ? 'observed' : 'fallback'}`;
+    const stub = env.CLOUD_AGENT_SESSION.get(
+      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
+    );
+
+    const jobs = await runInDurableObject(stub, async instance => {
+      const sentCallbackJobs: CallbackJob[] = [];
+      installCallbackQueue(instance, async job => {
+        sentCallbackJobs.push(job);
+      });
+      await registerReadySession(instance, {
+        sessionId,
+        userId,
+        prompt: 'prepared prompt',
+        mode: 'code',
+        model: 'test-model',
+        githubRepo: 'owner/repo',
+        branchName: 'kilo/quiet-forest-abcdefgh',
+        callbackTarget: { url: 'https://example.com/callback' },
+      });
+      if (upstreamBranch !== undefined) {
+        await instance.updateUpstreamBranch(upstreamBranch);
+      }
+      await instance.addExecution({
+        executionId: 'exc_legacy_callback_branch',
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: 'exc_legacy_callback_branch',
+      });
+      await instance.updateExecutionStatus({
+        executionId: 'exc_legacy_callback_branch',
+        status: 'running',
+      });
+      await instance.updateExecutionStatus({
+        executionId: 'exc_legacy_callback_branch',
+        status: 'completed',
+      });
+      return sentCallbackJobs;
+    });
+
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].payload.lastSeenBranch).toBe(expectedBranch);
+  });
+
+  it('leaves the branch absent for historical metadata without either branch', async () => {
+    const userId = 'user_legacy_callback_no_branch';
+    const sessionId = 'agent_legacy_callback_no_branch';
+    const stub = env.CLOUD_AGENT_SESSION.get(
+      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
+    );
+
+    const jobs = await runInDurableObject(stub, async instance => {
+      const sentCallbackJobs: CallbackJob[] = [];
+      installCallbackQueue(instance, async job => {
+        sentCallbackJobs.push(job);
+      });
+      await instance.updateMetadata({
+        metadataSchemaVersion: 2,
+        identity: { sessionId, userId },
+        auth: {},
+        repository: { type: 'github', repo: 'owner/repo' },
+        callback: { target: { url: 'https://example.com/callback' } },
+        lifecycle: { version: 1, timestamp: Date.now() },
+      });
+      await instance.addExecution({
+        executionId: 'exc_legacy_callback_no_branch',
+        mode: 'code',
+        streamingMode: 'websocket',
+        ingestToken: 'exc_legacy_callback_no_branch',
+      });
+      await instance.updateExecutionStatus({
+        executionId: 'exc_legacy_callback_no_branch',
+        status: 'running',
+      });
+      await instance.updateExecutionStatus({
+        executionId: 'exc_legacy_callback_no_branch',
+        status: 'completed',
+      });
+      return sentCallbackJobs;
+    });
+
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].payload.lastSeenBranch).toBeUndefined();
+  });
+
   it('adds retryable fallback client errors without parsing legacy error text', async () => {
     const userId = 'user_legacy_callback_error';
     const sessionId = 'agent_legacy_callback_error';

--- a/services/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
+++ b/services/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../src/session/pending-messages.js';
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import { listNonTerminalAcceptedMessages } from '../../../src/session/session-message-state.js';
+import { branchNameSchema } from '../../../src/persistence/schemas.js';
 
 import {
   groupedRegisterSessionInput,
@@ -21,6 +22,63 @@ import {
 } from '../../helpers/session-setup.js';
 
 describe('CloudAgentSession message admission', () => {
+  it('persists a readable default branch before preparation and retains it on registration retry', async () => {
+    const userId = 'user_readable_branch';
+    const sessionId = 'agent_readable_branch';
+    const stub = env.CLOUD_AGENT_SESSION.get(
+      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
+    );
+    const input = groupedRegisterSessionInput({
+      sessionId,
+      userId,
+      prompt: 'use a readable branch',
+      mode: 'code',
+      model: 'test-model',
+      githubRepo: 'acme/repo',
+    });
+
+    const first = await stub.registerSession(input);
+    const metadata = await stub.getMetadata();
+    const replay = await stub.registerSession(input);
+    const replayedMetadata = await stub.getMetadata();
+
+    expect(first).toEqual({ success: true });
+    expect(metadata?.workspace?.branchName).toMatch(/^kilo\/[a-z]+-[a-z]+-[a-z2-7]{8}$/);
+    expect(branchNameSchema.safeParse(metadata?.workspace?.branchName).success).toBe(true);
+    expect(metadata?.repository?.upstreamBranch).toBeUndefined();
+    expect(metadata?.lifecycle.preparedAt).toBeUndefined();
+    expect(replay).toEqual({ success: false, error: 'Session already registered' });
+    expect(replayedMetadata?.workspace?.branchName).toBe(metadata?.workspace?.branchName);
+  });
+
+  it.each(['main', 'feature/custom-branch', 'refs/pull/4273/head'])(
+    'preserves the explicit branch %s during registration',
+    async branch => {
+      const userId = 'user_explicit_branch';
+      const sessionId = `agent_explicit_branch_${branch.replaceAll('/', '_')}`;
+      const stub = env.CLOUD_AGENT_SESSION.get(
+        env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
+      );
+
+      const result = await stub.registerSession(
+        groupedRegisterSessionInput({
+          sessionId,
+          userId,
+          prompt: 'keep the selected branch',
+          mode: 'code',
+          model: 'test-model',
+          githubRepo: 'acme/repo',
+          upstreamBranch: branch,
+        })
+      );
+      const metadata = await stub.getMetadata();
+
+      expect(result).toEqual({ success: true });
+      expect(metadata?.repository?.upstreamBranch).toBe(branch);
+      expect(metadata?.workspace?.branchName).toBe(branch);
+    }
+  );
+
   it('admits the already accepted initial turn through grouped session creation', async () => {
     const userId = 'user_grouped_start' as const;
     const sessionId = 'agent_grouped_start' as const;
@@ -627,12 +685,21 @@ describe('CloudAgentSession message admission', () => {
 
     const result = await runInDurableObject(stub, async instance => {
       const first = await instance.createSessionWithInitialAdmission(input);
+      const firstBranch = (await instance.getMetadata())?.workspace?.branchName;
       const second = await instance.createSessionWithInitialAdmission(input);
-      return { first, second, pending: await listPendingSessionMessages(instance.ctx.storage) };
+      return {
+        first,
+        second,
+        firstBranch,
+        secondBranch: (await instance.getMetadata())?.workspace?.branchName,
+        pending: await listPendingSessionMessages(instance.ctx.storage),
+      };
     });
 
     expect(result.first).toMatchObject({ success: true, messageId, outcome: 'queued' });
     expect(result.second).toEqual(result.first);
+    expect(result.firstBranch).toMatch(/^kilo\/[a-z]+-[a-z]+-[a-z2-7]{8}$/);
+    expect(result.secondBranch).toBe(result.firstBranch);
     expect(result.pending).toHaveLength(1);
     expect(result.pending[0]?.messageId).toBe(messageId);
   });
@@ -868,7 +935,7 @@ describe('CloudAgentSession message admission', () => {
 
     expect(result.first).toMatchObject({ success: true, messageId });
     expect(result.replay).toMatchObject({ success: false, code: 'BAD_REQUEST' });
-    expect(result.metadata?.workspace).toEqual(input.workspace);
+    expect(result.metadata?.workspace).toMatchObject(input.workspace);
   });
 
   it('rejects readiness updates that change a shared route to another sandbox', async () => {


### PR DESCRIPTION
## Summary

- Replace new UUID-based branch defaults with names such as `kilo/calm-cedar-az234567`, using the existing App Builder-style word generator and an eight-character random suffix.
- Persist the branch at registration so retries and workspace restoration reuse it; preserve explicit and existing branches.
- Fall back to the stored workspace branch in callbacks when no observed branch is available.

## Verification

- No manual live-session verification: a live Cloud Agent environment was not started for this narrow backend change.
- [ ] Additional manual verification details.

## Visual Changes

N/A

## Reviewer Notes

- Applies to the `agent_*` runtime that currently creates UUID-based branches. The control-plane runtime's default-branch behavior is unchanged.
- No new dependencies or migrations. Historical `session/` fallbacks remain intact.
- The broader local Workers suite reported 240 passing tests but emitted teardown errors. Focused registration/callback suites completed without teardown errors.