### PR TITLE
fix(cloud-agent-next): suppress warm preparation rows

### DIFF
--- a/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
+++ b/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
@@ -1467,16 +1467,17 @@ export class SandboxSession extends DurableObject<Env> {
         return;
       }
       if (!wrapperInstanceId) throw new Error('Wrapper identity is missing');
-      if (
-        this.terminalLifecycle.getAttachedWrapperInstanceId() !== wrapperInstanceId ||
-        status.attachment?.kilo?.containmentEnabled === false
-      ) {
-        recorder.onProgress('workspace_setup', 'Setting up workspace…');
+      const needsPreparation =
+        this.terminalLifecycle.getAttachedWrapperInstanceId() !== wrapperInstanceId;
+      if (needsPreparation || status.attachment?.kilo?.containmentEnabled === false) {
+        if (needsPreparation) recorder.onProgress('workspace_setup', 'Setting up workspace…');
         if (!status.attachment?.kilo)
           throw new Error('Contained session attachment is unavailable');
         const attachPayload = {
           ...status.attachment,
-          preparation: { attemptId: recorder.attemptId, triggerMessageId: messageId },
+          ...(needsPreparation
+            ? { preparation: { attemptId: recorder.attemptId, triggerMessageId: messageId } }
+            : {}),
         };
         phase = 'attach';
         await wait(() =>

--- a/services/cloud-agent-next/src/sandbox-session/session-message-queue.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-message-queue.test.ts
@@ -3039,7 +3039,7 @@ describe('SandboxSession orchestration', () => {
   });
 
   it.each(['cloudflare', 'vercel'] as const)(
-    'applies fresh direct credentials before a warm prompt across eviction on %s',
+    'refreshes direct credentials without warm preparation across eviction on %s',
     async sandboxProvider => {
       const fixture = sessionFixture({
         workspace: { sandboxId: SANDBOX_ID, workspacePath: DIRECTORY, sandboxProvider },
@@ -3057,6 +3057,20 @@ describe('SandboxSession orchestration', () => {
       fixture.control.ensureReady.mockResolvedValue(ready);
       await fixture.admit('cold');
       await fixture.flush();
+      const coldPreparation = fixture.eventQueries.findByEntityPrefix('preparation/attempt/');
+      expect(coldPreparation.length).toBeGreaterThan(0);
+      expect(fixture.control.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'session.attach',
+          payload: {
+            ...initial,
+            preparation: {
+              attemptId: fixture.record('cold')?.preparationAttemptId,
+              triggerMessageId: 'cold',
+            },
+          },
+        })
+      );
       await fixture.outcome('cold', 'completed');
       await fixture.flush();
       fixture.reload();
@@ -3068,21 +3082,22 @@ describe('SandboxSession orchestration', () => {
       };
       fixture.control.ensureReady.mockResolvedValue({ ...ready, attachment: refreshed });
       fixture.control.request.mockClear();
+      orchestrationMocks.broadcast.mockClear();
       const attached = deferred<ResponseFrame>();
       delegateRequest(fixture, 'session.attach', () => attached.promise);
       await fixture.admit('warm');
       await fixture.flush();
+      expect(orchestrationMocks.broadcast).not.toHaveBeenCalledWith(
+        expect.objectContaining({ stream_event_type: 'preparing' })
+      );
+      expect(fixture.eventQueries.findByEntityPrefix('preparation/attempt/')).toEqual(
+        coldPreparation
+      );
       expect(fixture.control.request).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
           operation: 'session.attach',
           expectedWrapperInstanceId: RUNTIME_ID,
-          payload: {
-            ...refreshed,
-            preparation: {
-              attemptId: fixture.record('warm')?.preparationAttemptId,
-              triggerMessageId: 'warm',
-            },
-          },
+          payload: refreshed,
         })
       );
       expect(fixture.record('warm')).toMatchObject({ state: 'queued', unresolvedDispatch: true });
@@ -3098,8 +3113,57 @@ describe('SandboxSession orchestration', () => {
       });
       expect(fixture.record('warm')?.unresolvedDispatch).toBeUndefined();
       expect(fixture.control.quarantineRuntime).not.toHaveBeenCalled();
+      expect(orchestrationMocks.broadcast).not.toHaveBeenCalledWith(
+        expect.objectContaining({ stream_event_type: 'preparing' })
+      );
+      expect(fixture.eventQueries.findByEntityPrefix('preparation/attempt/')).toEqual(
+        coldPreparation
+      );
+      expect(await fixture.snapshot()).toMatchObject({ preparationSnapshots: coldPreparation });
     }
   );
+
+  it('reports a failed warm credential refresh without preparation or prompt delivery', async () => {
+    const fixture = sessionFixture();
+    fixture.control.ensureReady.mockResolvedValue({
+      physical: 'running',
+      connection: 'ready',
+      wrapperInstanceId: RUNTIME_ID,
+      attachment: {
+        ...ATTACHMENT,
+        kilo: { ...ATTACHMENT.kilo, containmentEnabled: false },
+      },
+    });
+    await fixture.admit('cold');
+    await fixture.flush();
+    await fixture.outcome('cold', 'completed');
+    await fixture.flush();
+    const coldPreparation = fixture.eventQueries.findByEntityPrefix('preparation/attempt/');
+    fixture.reload();
+    fixture.control.request.mockClear();
+    orchestrationMocks.broadcast.mockClear();
+    delegateRequest(fixture, 'session.attach', async () => controlFailure(false));
+    await fixture.admit('warm');
+    await fixture.flush();
+    expect(fixture.record('warm')).toMatchObject({
+      state: 'failed',
+      failedReason: 'attach_exhausted',
+    });
+    expect(fixture.control.request.mock.calls.map(([input]) => input.operation)).toEqual([
+      'session.attach',
+    ]);
+    expect(orchestrationMocks.broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({ stream_event_type: 'cloud.message.failed' })
+    );
+    expect(orchestrationMocks.broadcast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ stream_event_type: 'preparing' })
+    );
+    expect(fixture.eventQueries.findByEntityPrefix('preparation/attempt/')).toEqual(
+      coldPreparation
+    );
+    expect(fixture.control.quarantineRuntime).not.toHaveBeenCalled();
+    expect(await fixture.snapshot()).toMatchObject({ preparationSnapshots: coldPreparation });
+  });
 
   it.each(['stop', 'expiry'] as const)(
     'retains ambiguous warm prompt ownership through direct reattachment and %s',


### PR DESCRIPTION
## Summary
- Keep warm direct-credential reattachment, but omit preparation events and attach preparation metadata when the session is already attached to the same wrapper.
- Preserve cold-start/rebuild preparation, credential refresh ordering, runtime fences, and visible delivery failures.
- Cover Cloudflare and Vercel warm refresh, pending/completed visibility, snapshot replay, and failed refresh without prompt delivery.

Control-plane flow only. Existing saved preparation rows are unchanged.

## Verification
- Red/green: all three regression cases failed on unwanted preparation broadcasts before the fix.
- `pnpm --filter cloud-agent-next test src/sandbox-session/session-message-queue.test.ts src/sandbox-session/control-plane-preparing.test.ts src/sandbox-session/control-dispatch.test.ts src/session/preparation-progress.test.ts src/session/preparation-history.test.ts` — 246 passed.
- `pnpm -C services/cloud-agent-next/wrapper exec bun test ./src/control/apply-attach.test.ts` — 52 passed.
- `pnpm --filter cloud-agent-next typecheck` — passed for service and wrapper.
- `pnpm --filter cloud-agent-next lint` and explicit regression-test lint — passed.
- Changed-file formatting and `git diff --check` — passed.

No live-provider, Workers integration, or browser E2E run.