### PR TITLE
fix(ai-gateway): log Nvidia overload without Sentry reporting

### DIFF
--- a/apps/web/src/lib/ai-gateway/processUsage.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.test.ts
@@ -1,4 +1,5 @@
-import { test, describe, expect, jest } from '@jest/globals';
+import { test, describe, expect, beforeEach, afterEach } from '@jest/globals';
+import { captureException, captureMessage } from '@sentry/nextjs';
 import type { MicrodollarUsageStats, MicrodollarUsageContext } from './processUsage.types';
 import {
   extractPromptInfo,
@@ -39,6 +40,12 @@ import { Readable } from 'node:stream';
 import { getFraudDetectionHeaders, toMicrodollars } from '../utils';
 import { createTestOrganization } from '@/tests/helpers/organization.helper';
 import { PgDialect } from 'drizzle-orm/pg-core';
+
+jest.mock('@sentry/nextjs', () => ({
+  ...jest.requireActual<object>('@sentry/nextjs'),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
 
 // Note: Legacy banned_ja4/whitelist_ja4 tests removed - abuse classification
 // is now handled by the external abuse detection service (src/lib/abuse-service.ts)
@@ -291,6 +298,118 @@ describe('parseMicrodollarUsageFromStream approval tests', () => {
 
     expect(result.hasError).toBe(true);
     expect(result.status_code).toBe(502);
+  });
+
+  describe('upstream error reporting', () => {
+    const overloadMessage = 'Upstream error from Nvidia: Service temporarily overloaded';
+
+    beforeEach(() => {
+      jest.mocked(captureException).mockClear();
+      jest.mocked(captureMessage).mockClear();
+      jest.spyOn(console, 'info').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    const parseChunks = (chunks: object[]) =>
+      parseMicrodollarUsageFromStream(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            for (const chunk of chunks) {
+              controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+            }
+            controller.enqueue(new TextEncoder().encode('data: [DONE]\n\n'));
+            controller.close();
+          },
+        }),
+        'fake-user-id',
+        undefined,
+        'openrouter',
+        200
+      );
+
+    test.each([502, '502', undefined])(
+      'logs Nvidia overload without reporting to Sentry when code is %s',
+      async code => {
+        const result = await parseChunks([
+          {
+            id: 'gen-nvidia-overload',
+            model: 'nvidia/nemotron-3-ultra-550b-a55b:free',
+            provider: 'Nvidia',
+            choices: [],
+            error: { code, message: overloadMessage },
+          },
+        ]);
+
+        expect(console.info).toHaveBeenCalledWith(`OpenRouter error: ${overloadMessage}`, {
+          source: 'sse_processing',
+          provider: 'openrouter',
+          code,
+          messageId: 'gen-nvidia-overload',
+          model: 'nvidia/nemotron-3-ultra-550b-a55b:free',
+        });
+        expect(captureException).not.toHaveBeenCalled();
+        expect(captureMessage).not.toHaveBeenCalled();
+        expect(result).toMatchObject({
+          hasError: true,
+          status_code: typeof code === 'number' ? code : 200,
+          messageId: 'gen-nvidia-overload',
+          model: 'nvidia/nemotron-3-ultra-550b-a55b:free',
+          inference_provider: 'Nvidia',
+        });
+      }
+    );
+
+    test.each([
+      'Upstream error from Nvidia: Internal server error',
+      'Upstream error from Nvidia: ResourceExhausted: Worker local total request limit reached (16/16)',
+      'Upstream error from Tencent: Service temporarily overloaded',
+      'Upstream idle timeout exceeded',
+    ])('still reports %s to Sentry', async message => {
+      const chunk = { error: { code: 502, message } };
+      const result = await parseChunks([chunk]);
+
+      expect(console.info).not.toHaveBeenCalled();
+      expect(captureException).toHaveBeenCalledTimes(1);
+      expect(captureException).toHaveBeenCalledWith(new Error(`OpenRouter error: ${message}`), {
+        tags: { source: 'sse_processing' },
+        extra: { json: chunk, event: expect.objectContaining({ data: JSON.stringify(chunk) }) },
+      });
+      expect(result).toMatchObject({ hasError: true, status_code: 502 });
+    });
+
+    test('preserves partial content and usage and reports later errors after Nvidia overload', async () => {
+      const result = await parseChunks([
+        { id: 'gen-partial', model: 'test-model', choices: [{ delta: { content: 'Hello' } }] },
+        { error: { code: 502, message: overloadMessage } },
+        {
+          choices: [{ delta: { content: ' world' } }],
+          usage: { prompt_tokens: 10, completion_tokens: 2, cost: 0.001, is_byok: false },
+        },
+        { error: { code: 504, message: 'Upstream idle timeout exceeded' } },
+      ]);
+
+      expect(console.info).toHaveBeenCalledWith(
+        `OpenRouter error: ${overloadMessage}`,
+        expect.objectContaining({ messageId: 'gen-partial', model: 'test-model' })
+      );
+      expect(captureException).toHaveBeenCalledTimes(1);
+      expect(captureException).toHaveBeenCalledWith(
+        new Error('OpenRouter error: Upstream idle timeout exceeded'),
+        expect.any(Object)
+      );
+      expect(captureMessage).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        hasError: true,
+        status_code: 504,
+        responseContent: 'Hello world',
+        inputTokens: 10,
+        outputTokens: 2,
+        cost_mUsd: 1000,
+      });
+    });
   });
 
   test('records the Vercel upstream provider request id as upstream_id', async () => {

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -1079,10 +1079,20 @@ export async function parseMicrodollarUsageFromStream(
         if (typeof error.code === 'number') {
           effectiveStatusCode = error.code;
         }
-        captureException(new Error(`OpenRouter error: ${error.message}`), {
-          tags: { source: 'sse_processing' },
-          extra: { json, event },
-        });
+        if (error.message === 'Upstream error from Nvidia: Service temporarily overloaded') {
+          console.info(`OpenRouter error: ${error.message}`, {
+            source: 'sse_processing',
+            provider,
+            code: error.code,
+            messageId: json.id ?? messageId,
+            model: json.model ?? model,
+          });
+        } else {
+          captureException(new Error(`OpenRouter error: ${error.message}`), {
+            tags: { source: 'sse_processing' },
+            extra: { json, event },
+          });
+        }
       }
 
       model = json.model ?? model;


### PR DESCRIPTION
## Summary

- Log the exact upstream message `Upstream error from Nvidia: Service temporarily overloaded` with `console.info` rather than capturing a Sentry exception during chat-completion SSE usage parsing.
- Preserve failed-request classification, numeric upstream status codes, partial response content, usage accounting, and Sentry reporting for all other errors.
- Investigation of [KILOCODE-WEB-27J5](https://kilo-code.sentry.io/issues/KILOCODE-WEB-27J5) found this exact message accounts for approximately 81% of production events over the last 24 hours. The issue groups other upstream errors too, so it should not be ignored or resolved wholesale.

## Verification

No manual request or live-provider tests were run: this is a narrow server-side reporting change, and reliably reproducing Nvidia overload requires an upstream capacity failure. The production Sentry event payload and aggregate error distribution were inspected; automated verification is listed below.

## Visual Changes

N/A

## Reviewer Notes

- Matching is exact; Nvidia internal errors, ResourceExhausted errors, other providers, and timeouts still reach Sentry.
- `console.info` is outside the configured Sentry console-log integration levels. Logged context is limited to source, gateway provider, code, generation ID, and model; no raw response content or upstream metadata is added to logs.
- Regression tests cover numeric/string/missing error codes, other upstream errors, partial content and usage preservation, and a later reportable error after an overload.
- Automated checks passed:
  - `pnpm --filter web test --runInBand --runTestsByPath src/lib/ai-gateway/processUsage.test.ts --silent` — 60 tests passed.
  - `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/processUsage.ts apps/web/src/lib/ai-gateway/processUsage.test.ts` — no warnings or errors.
  - `pnpm --filter web typecheck` — passed; declaration bundling emitted unresolved-external warnings.
  - `pnpm format apps/web/src/lib/ai-gateway/processUsage.ts apps/web/src/lib/ai-gateway/processUsage.test.ts` and `git diff --check` — passed.
- Test setup emitted missing local Upstash configuration warnings on the initial run; all 60 tests passed on the final run. Full repository validation was not run.