### PR TITLE
fix(mobile): keep dark status bar icons until the splash reveal ends

### DIFF
--- a/apps/mobile/.oxlintrc.json
+++ b/apps/mobile/.oxlintrc.json
@@ -257,7 +257,7 @@
       }
     },
     {
-      "files": ["src/app/_layout.tsx"],
+      "files": ["src/app/_layout.tsx", "src/components/animated-splash-overlay.tsx"],
       "rules": {
         "react/style-prop-object": "off"
       }

--- a/apps/mobile/src/components/animated-splash-overlay-reveal.mounted.test.tsx
+++ b/apps/mobile/src/components/animated-splash-overlay-reveal.mounted.test.tsx
@@ -43,6 +43,7 @@ vi.mock('expo-splash-screen', () => ({
   preventAutoHideAsync: vi.fn(),
 }));
 vi.mock('@sentry/react-native', () => ({ TimeToFullDisplay: () => null }));
+vi.mock('expo-status-bar', () => ({ StatusBar: 'StatusBar' }));
 vi.mock('@/components/ui/image', () => ({ Image: 'Image' }));
 vi.mock('@/../assets/images/logo.png', () => ({ default: 1 }));
 

--- a/apps/mobile/src/components/animated-splash-overlay.mounted.test.tsx
+++ b/apps/mobile/src/components/animated-splash-overlay.mounted.test.tsx
@@ -31,6 +31,8 @@ vi.mock('expo-splash-screen', () => ({
   preventAutoHideAsync: vi.fn(),
 }));
 vi.mock('@sentry/react-native', () => ({ TimeToFullDisplay: () => null }));
+// String host so findByType can assert the splash status bar override.
+vi.mock('expo-status-bar', () => ({ StatusBar: 'StatusBar' }));
 // String host so findByType works and props.onLoad stays callable.
 vi.mock('@/components/ui/image', () => ({ Image: 'Image' }));
 // No Vitest project transforms .png.
@@ -79,6 +81,11 @@ describe('AnimatedSplashOverlay mounted', () => {
     expect(logoImages).toHaveLength(1);
     expect(SplashScreen.hideAsync).not.toHaveBeenCalled();
 
+    // The yellow frame forces dark status bar icons in either theme.
+    const statusBars = findByType(renderer.root, 'StatusBar');
+    expect(statusBars).toHaveLength(1);
+    expect(statusBars[0]?.props.style).toBe('dark');
+
     const logoImage = logoImages[0];
     if (!logoImage) {
       throw new Error('expected one Image host');
@@ -101,6 +108,7 @@ describe('AnimatedSplashOverlay mounted', () => {
 
     expect(SplashScreen.hideAsync).toHaveBeenCalledTimes(1);
     expect(findByType(renderer.root, 'Image')).toHaveLength(0);
+    expect(findByType(renderer.root, 'StatusBar')).toHaveLength(0);
 
     act(() => {
       renderer.unmount();

--- a/apps/mobile/src/components/animated-splash-overlay.tsx
+++ b/apps/mobile/src/components/animated-splash-overlay.tsx
@@ -1,4 +1,5 @@
 import * as SplashScreen from 'expo-splash-screen';
+import { StatusBar } from 'expo-status-bar';
 import { TimeToFullDisplay } from '@sentry/react-native';
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import Animated, {
@@ -191,26 +192,32 @@ export function AnimatedSplashOverlay() {
           is gone, for every outcome — error screens are the launch's full display too. */}
       <TimeToFullDisplay ready={dismissed} />
       {dismissed ? null : (
-        <Animated.View
-          pointerEvents="none"
-          className="absolute inset-0 items-center justify-center bg-[#FAF74F]"
-          style={overlayStyle}
-        >
+        <>
+          {/* The overlay is yellow, so the status bar needs dark icons whatever the
+              theme is. Mounted after the root `style="auto"` bar, it wins the merge
+              until the reveal ends and this unmounts. */}
+          <StatusBar style="dark" />
           <Animated.View
-            className="absolute h-[120px] w-[120px] rounded-full bg-background"
-            style={discStyle}
-          />
-          <Animated.View style={logoStyle}>
-            <Image
-              source={logo}
-              className="h-[100px] w-[100px]"
-              transition={0}
-              onLoad={() => {
-                setLogoLoaded(true);
-              }}
+            pointerEvents="none"
+            className="absolute inset-0 items-center justify-center bg-[#FAF74F]"
+            style={overlayStyle}
+          >
+            <Animated.View
+              className="absolute h-[120px] w-[120px] rounded-full bg-background"
+              style={discStyle}
             />
+            <Animated.View style={logoStyle}>
+              <Image
+                source={logo}
+                className="h-[100px] w-[100px]"
+                transition={0}
+                onLoad={() => {
+                  setLogoLoaded(true);
+                }}
+              />
+            </Animated.View>
           </Animated.View>
-        </Animated.View>
+        </>
       )}
     </>
   );


### PR DESCRIPTION
## Problem

In dark mode the status bar icons (clock, WiFi, battery) turn white at cold start, while the yellow splash overlay is still on screen. White on yellow is unreadable, and the flip happens before the entry animation finishes.

Cause: `<StatusBar style="auto" />` in `src/app/_layout.tsx` resolves to light content as soon as the tree mounts. It does not know the overlay is still painting yellow.

## Fix

`AnimatedSplashOverlay` mounts its own `<StatusBar style="dark" />` while the yellow frame is visible. React Native merges status bar props in mount order, so the overlay's bar wins over the root `auto` bar. The overlay unmounts at the end of the reveal, the override pops, and `auto` takes over again.

## Test

`animated-splash-overlay.mounted.test.tsx` asserts the dark bar is mounted during the splash and gone after dismissal.

## Checks

- `pnpm test` (623 files, 7997 tests) — pass
- `pnpm typecheck` — pass
- `scripts/lint-all.sh` — pass
- `pnpm check:unused` — pass