### PR TITLE
fix: increase API request cleanup batch size to 10000

### DIFF
--- a/apps/web/src/app/api/cron/cleanup-api-request-log/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-api-request-log/route.test.ts
@@ -21,7 +21,7 @@ import { GET } from './route';
 
 const mockEmitScheduledJobEvent = jest.mocked(emitScheduledJobEvent);
 
-const BATCH_SIZE = 1_000;
+const BATCH_SIZE = 10_000;
 
 function daysAgo(days: number): string {
   const date = new Date();

--- a/apps/web/src/app/api/cron/cleanup-api-request-log/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-api-request-log/route.ts
@@ -11,7 +11,7 @@ import { asc, inArray, lt } from 'drizzle-orm';
 import { CRON_SECRET } from '@/lib/config.server';
 
 const RETENTION_DAYS = 7;
-const BATCH_SIZE = 1_000;
+const BATCH_SIZE = 10_000;
 
 function getDaysAgo(days: number) {
   const date = new Date();


### PR DESCRIPTION
## Summary
- Increase the API request log cleanup batch size from 1,000 to 10,000 rows per request.
- Update the existing cleanup tests to expect the new limit; retain seven-day retention and single-batch behavior.

## Validation
- All applicable CI checks passed, including tests, typecheck, lint, formatting, migration checks, builds, and extension E2E tests.
- Automated Kilo Code Review completed with no issues found.
- Tests ran only in CI as requested.
- Local targeted formatting and `git diff --check` passed. Local focused lint and web typecheck exceeded the environment’s two-minute limit; both passed in CI.