### PR TITLE
fix(ai-gateway): disable LongCat free model

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -566,6 +566,17 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     expect(mockedUpstreamRequest).not.toHaveBeenCalled();
   });
 
+  it('rejects the disabled LongCat free model before upstream', async () => {
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody('meituan/longcat-2.0-free')) as never);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error_type: 'unavailable_model',
+    });
+    expect(mockedUpstreamRequest).not.toHaveBeenCalled();
+  });
+
   it('rate limits rules-engine rate-limit actions before upstream', async () => {
     mockedRedisGet.mockResolvedValue(cachedRulesEngineAction('rate-limit'));
     mockedClassifyAbuse.mockResolvedValue(classifyResult('rate-limit'));
@@ -636,8 +647,12 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
 
     expect(response.status).toBe(200);
     expect(mockedGetProvider).toHaveBeenCalledTimes(2);
-    expect(mockedGetProvider.mock.calls[1]?.[0].requestedModel).toBe('meituan/longcat-2.0-free');
-    expect(mockedUpstreamRequest.mock.calls[0]?.[0].body.model).toBe('LongCat-2.0');
+    expect(mockedGetProvider.mock.calls[1]?.[0].requestedModel).toBe(
+      stepfun_37_flash_free_model.public_id
+    );
+    expect(mockedUpstreamRequest.mock.calls[0]?.[0].body.model).toBe(
+      stepfun_37_flash_free_model.internal_id
+    );
     expect(mockedAccountForMicrodollarUsage.mock.calls[0]?.[1]).toMatchObject({
       abuse_delay: 6000,
       abuse_downgraded_from: 'openai/gpt-4o',

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -3,6 +3,7 @@ import {
   autoFreeModels,
   findKiloExclusiveModel,
   getKiloExclusiveInferenceProviderRestriction,
+  isDisabledKiloExclusiveModel,
   isKiloExclusiveRateLimitedModel,
   kiloExclusiveModels,
   preferredModels,
@@ -90,20 +91,16 @@ describe('isFreeModel', () => {
       expect(preferredModels).not.toContain(tencent_hy3_free_model.public_id);
     });
 
-    test('registers LongCat 2.0 as an Auto Free model', async () => {
+    test('disables LongCat 2.0 free and excludes it from Auto Free and preferred models', async () => {
       expect(kiloExclusiveModels).toContain(longcat_2_free_model);
-      expect(findKiloExclusiveModel(longcat_2_free_model.public_id)).toBe(longcat_2_free_model);
-      expect(await isFreeModel(longcat_2_free_model.public_id)).toBe(true);
-      expect(longcat_2_free_model).toMatchObject({
-        internal_id: 'LongCat-2.0',
-        gateway: 'longcat',
-        context_length: 1_048_756,
-        max_completion_tokens: 131_072,
-        status: 'public',
-      });
-      expect(autoFreeModels.map(({ model }) => model)).toContain(longcat_2_free_model.public_id);
-      expect(preferredModels).toContain(longcat_2_free_model.public_id);
-      expect(getAiSdkProvider(longcat_2_free_model.public_id, null)).toBeUndefined();
+      expect(longcat_2_free_model.status).toBe('disabled');
+      expect(isDisabledKiloExclusiveModel(longcat_2_free_model.public_id)).toBe(true);
+      expect(findKiloExclusiveModel(longcat_2_free_model.public_id)).toBeNull();
+      expect(await isFreeModel(longcat_2_free_model.public_id)).toBe(false);
+      expect(autoFreeModels.map(({ model }) => model)).not.toContain(
+        longcat_2_free_model.public_id
+      );
+      expect(preferredModels).not.toContain(longcat_2_free_model.public_id);
     });
 
     test.each(['minimax/minimax-m3:free', 'minimax/minimax-m2.7:free'])(
@@ -218,7 +215,6 @@ describe('isFreeModel', () => {
       ).toEqual({
         'stepfun/step-3.7-flash:free': { enabled: true, effort: 'high' },
         'poolside/laguna-s-2.1:free': { enabled: true, effort: 'high' },
-        'meituan/longcat-2.0-free': { enabled: true, effort: 'high' },
         'minimax/minimax-m3:free': { enabled: true, effort: 'high' },
       });
     });
@@ -229,7 +225,6 @@ describe('isFreeModel', () => {
       ).toEqual({
         'stepfun/step-3.7-flash:free': 1,
         'poolside/laguna-s-2.1:free': 1,
-        'meituan/longcat-2.0-free': 1,
         'minimax/minimax-m3:free': 1,
       });
     });

--- a/apps/web/src/lib/ai-gateway/providers/longcat.ts
+++ b/apps/web/src/lib/ai-gateway/providers/longcat.ts
@@ -11,7 +11,7 @@ export const longcat_2_free_model: KiloExclusiveModel = {
     'LongCat 2.0 is a sparse mixture-of-experts language model from Meituan, with 48B active parameters out of 1.6T total. It is suited for coding, repository-level changes, long-horizon problem solving, and agentic workflows. Available free in Kilo for a limited time.',
   context_length: 1_048_756,
   max_completion_tokens: 131_072,
-  status: 'public',
+  status: 'disabled',
   flags: ['reasoning'],
   gateway: 'longcat',
   internal_id: 'LongCat-2.0',


### PR DESCRIPTION
## Summary
- Disable `meituan/longcat-2.0-free` using the existing model status mechanism.
- Remove it from Auto Free and preferred models, hide it from the catalog, and reject direct requests.
- Update model membership and quarantine fallback coverage; add a direct-request rejection regression test.

## Validation
- Tests ran in CI only, as requested.
- CI passed: tests, build, lint, typecheck, formatting, Drizzle checks, extension checks/E2E, and secret scanning.
- Kilo Code Review completed with no issues found; no actionable review threads.
- Changed-file formatting and `git diff --check` passed locally. Local lint/typecheck attempts exceeded the sandbox two-minute limit; both subsequently passed in CI.
