### PR TITLE
fix(mobile): center the sheet title when Cancel is present, and release on merge

### DIFF
--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -3,8 +3,9 @@ name: kilo-app Release
 on:
   push:
     branches: [main]
-    # kilo-app and its direct workspace:* inputs. Keep this list and the
-    # check-changes git diff below in step.
+    # kilo-app and its direct workspace:* inputs. No pnpm-lock.yaml: an
+    # unrelated bump elsewhere in the monorepo must not submit a build. A bump
+    # of an app dependency also edits apps/mobile/package.json, which is here.
     paths:
       - 'apps/mobile/**'
       - 'packages/trpc/**'
@@ -14,7 +15,6 @@ on:
       - 'packages/event-service/**'
       - 'packages/notifications/**'
       - 'packages/cloud-agent-sdk/**'
-      - 'pnpm-lock.yaml'
   workflow_dispatch:
 
 # cancel-in-progress: false lets a running release finish. GitHub keeps one run

--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -3,8 +3,18 @@ name: kilo-app Release
 on:
   push:
     branches: [main]
+    # kilo-app and its direct workspace:* inputs. Keep this list and the
+    # check-changes git diff below in step.
     paths:
       - 'apps/mobile/**'
+      - 'packages/trpc/**'
+      - 'packages/app-shared/**'
+      - 'packages/kilo-chat/**'
+      - 'packages/kilo-chat-hooks/**'
+      - 'packages/event-service/**'
+      - 'packages/notifications/**'
+      - 'packages/cloud-agent-sdk/**'
+      - 'pnpm-lock.yaml'
   workflow_dispatch:
 
 # cancel-in-progress: false lets a running release finish. GitHub keeps one run

--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
     paths:
       - 'apps/mobile/**'
-  schedule:
-    - cron: '0 6 * * *'
   workflow_dispatch:
 
 # cancel-in-progress: false lets a running release finish. GitHub keeps one run

--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -1,10 +1,17 @@
 name: kilo-app Release
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/**'
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+# cancel-in-progress: false lets a running release finish. GitHub keeps one run
+# pending per group and cancels the previously pending run, so a burst of merges
+# releases the newest commit, not every one of them.
 concurrency:
   group: kilo-app-release
   cancel-in-progress: false

--- a/apps/mobile/src/components/sheet-header-layout.mounted.test.tsx
+++ b/apps/mobile/src/components/sheet-header-layout.mounted.test.tsx
@@ -1,0 +1,63 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as sheet-header.mounted.test.tsx) */
+import { type ComponentProps, createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SheetHeader } from './sheet-header';
+import '@/i18n';
+
+vi.mock('react-native', () => ({ Pressable: 'Pressable', View: 'View' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/components/ui/icons', () => ({ Share: 'Share' }));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({ foreground: '#111827' }),
+}));
+
+async function mount(
+  props: ComponentProps<typeof SheetHeader>
+): Promise<TestRenderer.ReactTestRenderer> {
+  const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+  await act(async () => {
+    await Promise.resolve();
+    ref.current = TestRenderer.create(createElement(SheetHeader, props));
+  });
+  const renderer = ref.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return renderer;
+}
+
+function pressablesByLabel(
+  root: TestRenderer.ReactTestInstance,
+  label: string
+): TestRenderer.ReactTestInstance[] {
+  return root.findAll(
+    node =>
+      typeof node.type === 'string' &&
+      (node.type as string) === 'Pressable' &&
+      node.props.accessibilityLabel === label
+  );
+}
+
+describe('SheetHeader layout', () => {
+  it.each([false, true])('keeps the title and Done on one row (Cancel=%s)', async withCancel => {
+    const onCancel = withCancel ? () => undefined : undefined;
+    const renderer = await mount({ title: 'Run on', onDone: () => undefined, onCancel });
+    const title = renderer.root.findByProps({ accessibilityRole: 'header' });
+    const done = pressablesByLabel(renderer.root, 'Done')[0];
+    const titleRegion = title.parent;
+    const row = done?.parent;
+
+    expect(row?.props.className).toContain('flex-row');
+    expect(row?.props.className).not.toContain('flex-wrap');
+    expect(row?.props.className).toContain('items-center');
+    expect(title.props.ellipsizeMode).toBe('tail');
+    expect(String(title.props.className).includes('text-center')).toBe(withCancel);
+    expect(titleRegion?.props.className).toContain('min-w-0');
+    expect(titleRegion?.parent).toBe(row);
+    expect(done?.props.className).toContain('shrink-0');
+
+    renderer.unmount();
+  });
+});

--- a/apps/mobile/src/components/sheet-header.mounted.test.tsx
+++ b/apps/mobile/src/components/sheet-header.mounted.test.tsx
@@ -167,25 +167,6 @@ describe('SheetHeader', () => {
     renderer.unmount();
   });
 
-  it('keeps the left-aligned title and Done on one row', async () => {
-    const renderer = await mount({ title: 'Run on', onDone: () => undefined });
-    const title = renderer.root.findByProps({ accessibilityRole: 'header' });
-    const done = pressablesByLabel(renderer.root, 'Done')[0];
-    const titleRegion = title.parent;
-    const row = done?.parent;
-
-    expect(row?.props.className).toContain('flex-row');
-    expect(row?.props.className).not.toContain('flex-wrap');
-    expect(row?.props.className).toContain('items-center');
-    expect(title.props.ellipsizeMode).toBe('tail');
-    expect(title.props.className).not.toContain('text-center');
-    expect(titleRegion?.props.className).toContain('min-w-0');
-    expect(titleRegion?.parent).toBe(row);
-    expect(done?.props.className).toContain('shrink-0');
-
-    renderer.unmount();
-  });
-
   it('keeps Run on and action text with native font scaling and unlimited action lines', async () => {
     const title = 'Run on';
     const cancelLabel = 'Previous picker';

--- a/apps/mobile/src/components/sheet-header.tsx
+++ b/apps/mobile/src/components/sheet-header.tsx
@@ -4,6 +4,7 @@ import { Pressable, View } from 'react-native';
 import { Share } from '@/components/ui/icons';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { cn } from '@/lib/utils';
 
 export function SheetHeader({
   title,
@@ -74,10 +75,12 @@ export function SheetHeader({
           </Pressable>
         ) : null}
         {/* min-w-0 lets the title shrink below its content width so it truncates
-            instead of pushing the trailing action out of the row. */}
+            instead of pushing the trailing action out of the row. Cancel and
+            Done bracket the title, so center it between them; without Cancel the
+            title stays leading against the sheet edge. */}
         <View className="min-w-0 shrink grow">
           <Text
-            className="text-lg font-semibold text-foreground"
+            className={cn('text-lg font-semibold text-foreground', onCancel && 'text-center')}
             numberOfLines={2}
             ellipsizeMode={titleEllipsis}
             accessibilityRole="header"


### PR DESCRIPTION
## What

1. `SheetHeader` centers its title only when the sheet supplies a Cancel control. A sheet with Done alone keeps the left-aligned title from #5808.
2. `kilo-app Release` now triggers on a push to `main` that touches `apps/mobile/**`, and the nightly cron is gone.

## Why

Cancel and Done bracket the title, so a leading title looked off-balance between the two controls.

A merged mobile change had to be released by hand or wait for the 06:00 cron. The cron then rebuilt commits that had already shipped.

## Concurrency

Unchanged, because it already does what we want. `cancel-in-progress: false` lets a running release finish, and GitHub keeps only one run pending per concurrency group — a new run cancels the previously pending one. A burst of merges therefore releases the newest commit, not every one of them. The comment above the block records this.

## Test

- `apps/mobile/src/components/sheet-header-layout.mounted.test.tsx` asserts both alignments in one `it.each`. The layout tests moved to this new file because the parent test file hit the 300-line lint cap.
- `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused && pnpm test` pass in `apps/mobile`.
- `scripts/lint-all.sh` passes.
- The workflow change is trigger-only. It cannot be proven before the merge; this PR touches `apps/mobile`, so the merge itself is the first live run.

## Not done

- `PrFormSheetHeader` (PR review sheets) keeps its own alignment. Its leading control is a close chevron, not a Cancel button.
- The `check-changes` job stays. It is a no-op for a path-filtered push and still guards a manual dispatch when nothing changed since the last release tag.