### PR TITLE
feat(cloud-agent): diversify branch names and shorten suffixes

### DIFF
--- a/packages/worker-utils/src/deployment-slug.test.ts
+++ b/packages/worker-utils/src/deployment-slug.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  generateBranchSlug,
   generateDeploymentSlug,
   generateEphemeralDeploymentSlug,
   slugSchema,
@@ -17,6 +18,71 @@ describe('deployment slug policy', () => {
     expect(validateSlug('dpl-private')).toBe('Subdomain cannot start with "dpl-"');
     expect(validateSlug('qdpl-private')).toBe('Subdomain cannot start with "qdpl-"');
     expect(validateSlug('my--project')).toBe('Subdomain cannot contain consecutive hyphens');
+  });
+});
+
+describe('generateBranchSlug', () => {
+  it('generates readable slugs with exactly three random alphanumeric characters', () => {
+    const generatedSuffixes = new Set<string>();
+
+    for (let i = 0; i < 100; i++) {
+      const slug = generateBranchSlug();
+      generatedSuffixes.add(slug.slice(-3));
+      expect(slug).toMatch(/^[a-z]+-[a-z]+-[a-z0-9]{3}$/);
+      expect(slugSchema.safeParse(slug).success).toBe(true);
+    }
+
+    expect(generatedSuffixes.size).toBeGreaterThan(1);
+  });
+
+  it.each([
+    { value: 0, suffix: '000' },
+    { value: 9, suffix: '009' },
+    { value: 10, suffix: '00a' },
+    { value: 35, suffix: '00z' },
+    { value: 36, suffix: '010' },
+    { value: 1295, suffix: '0zz' },
+    { value: 1296, suffix: '100' },
+    { value: 46655, suffix: 'zzz' },
+  ])('encodes random value $value as the three-character suffix $suffix', ({ value, suffix }) => {
+    const getRandomValues = vi
+      .spyOn(crypto, 'getRandomValues')
+      .mockImplementation(values => {
+        if (values instanceof Uint32Array) values.fill(0);
+        return values;
+      })
+      .mockImplementationOnce(values => {
+        if (values instanceof Uint32Array) values[0] = value;
+        return values;
+      });
+
+    try {
+      expect(generateBranchSlug()).toBe(`autumn-birch-${suffix}`);
+    } finally {
+      getRandomValues.mockRestore();
+    }
+  });
+
+  it('offers at least 256 distinct short adjectives and nouns', () => {
+    let wordIndex = 0;
+    const getRandomValues = vi.spyOn(crypto, 'getRandomValues').mockImplementation(values => {
+      if (values instanceof Uint32Array) values.fill(wordIndex);
+      return values;
+    });
+
+    try {
+      const slugs = Array.from({ length: 256 }, (_, index) => {
+        wordIndex = index;
+        const slug = generateBranchSlug();
+        expect(slug).toMatch(/^[a-z]{1,10}-[a-z]{1,10}-[a-z0-9]{3}$/);
+        return slug;
+      });
+
+      expect(new Set(slugs.map(slug => slug.split('-')[0])).size).toBe(256);
+      expect(new Set(slugs.map(slug => slug.split('-')[1])).size).toBe(256);
+    } finally {
+      getRandomValues.mockRestore();
+    }
   });
 });
 

--- a/packages/worker-utils/src/deployment-slug.ts
+++ b/packages/worker-utils/src/deployment-slug.ts
@@ -122,6 +122,52 @@ const adjectives = [
   'wild',
   'winter',
   'young',
+  'airy',
+  'amber',
+  'arctic',
+  'azure',
+  'breezy',
+  'briny',
+  'bronze',
+  'cerulean',
+  'cherry',
+  'cloudy',
+  'coral',
+  'crisp',
+  'dewy',
+  'dusky',
+  'emerald',
+  'ferny',
+  'hazy',
+  'honey',
+  'indigo',
+  'ivory',
+  'jade',
+  'leafy',
+  'lilac',
+  'mellow',
+  'mossy',
+  'oceanic',
+  'peach',
+  'pearly',
+  'rainy',
+  'rosy',
+  'ruby',
+  'sandy',
+  'scarlet',
+  'shadowy',
+  'silvery',
+  'smoky',
+  'solar',
+  'starry',
+  'stormy',
+  'sunny',
+  'teal',
+  'verdant',
+  'violet',
+  'windy',
+  'wintry',
+  'woodsy',
   // neutral / general
   'bright',
   'broad',
@@ -163,6 +209,66 @@ const adjectives = [
   'steady',
   'true',
   'vast',
+  'able',
+  'adept',
+  'alert',
+  'amused',
+  'artful',
+  'astute',
+  'balanced',
+  'blissful',
+  'bouncy',
+  'brave',
+  'brisk',
+  'bubbly',
+  'buoyant',
+  'candid',
+  'capable',
+  'cheerful',
+  'clever',
+  'cozy',
+  'curious',
+  'dapper',
+  'daring',
+  'dazzling',
+  'eager',
+  'earnest',
+  'easy',
+  'elegant',
+  'epic',
+  'fair',
+  'fancy',
+  'fearless',
+  'festive',
+  'fleet',
+  'focused',
+  'friendly',
+  'gallant',
+  'glad',
+  'gleeful',
+  'graceful',
+  'handy',
+  'happy',
+  'hearty',
+  'honest',
+  'humble',
+  'jaunty',
+  'jolly',
+  'jovial',
+  'joyful',
+  'kind',
+  'lively',
+  'lofty',
+  'merry',
+  'mighty',
+  'patient',
+  'playful',
+  'plucky',
+  'polished',
+  'quirky',
+  'snappy',
+  'spirited',
+  'witty',
   // tech / computing
   'active',
   'agile',
@@ -190,6 +296,35 @@ const adjectives = [
   'turbo',
   'ultra',
   'wired',
+  'adaptive',
+  'analog',
+  'astral',
+  'bionic',
+  'celestial',
+  'clockwork',
+  'compact',
+  'digital',
+  'electric',
+  'fractal',
+  'fused',
+  'galactic',
+  'harmonic',
+  'hybrid',
+  'ionic',
+  'logical',
+  'lucid',
+  'magnetic',
+  'modular',
+  'orbital',
+  'plasma',
+  'quantum',
+  'radial',
+  'robotic',
+  'spectral',
+  'stellar',
+  'tuned',
+  'virtual',
+  'wireless',
 ] as const;
 
 const nouns = [
@@ -247,6 +382,70 @@ const nouns = [
   'wave',
   'wind',
   'wood',
+  'acorn',
+  'albatross',
+  'alpaca',
+  'badger',
+  'bamboo',
+  'bay',
+  'bear',
+  'beaver',
+  'bison',
+  'blossom',
+  'bobcat',
+  'canyon',
+  'capybara',
+  'chameleon',
+  'clover',
+  'comet',
+  'condor',
+  'cosmos',
+  'coyote',
+  'crane',
+  'cricket',
+  'dahlia',
+  'dolphin',
+  'dragon',
+  'eagle',
+  'falcon',
+  'finch',
+  'firefly',
+  'fjord',
+  'fox',
+  'gecko',
+  'heron',
+  'ibis',
+  'island',
+  'jaguar',
+  'juniper',
+  'koala',
+  'lagoon',
+  'lark',
+  'lemur',
+  'lotus',
+  'lynx',
+  'maple',
+  'meteor',
+  'nebula',
+  'otter',
+  'owl',
+  'panda',
+  'panther',
+  'penguin',
+  'phoenix',
+  'puffin',
+  'quail',
+  'raven',
+  'redwood',
+  'robin',
+  'sequoia',
+  'sparrow',
+  'tiger',
+  'tulip',
+  'turtle',
+  'willow',
+  'wolf',
+  'wren',
   // neutral / general
   'arch',
   'band',
@@ -298,6 +497,36 @@ const nouns = [
   'trail',
   'vault',
   'wing',
+  'anchor',
+  'anvil',
+  'arrow',
+  'atlas',
+  'beacon',
+  'canvas',
+  'chime',
+  'compass',
+  'copper',
+  'crystal',
+  'domino',
+  'fable',
+  'feather',
+  'flute',
+  'gadget',
+  'gem',
+  'glider',
+  'lantern',
+  'marble',
+  'mosaic',
+  'paddle',
+  'pebble',
+  'piano',
+  'ribbon',
+  'riddle',
+  'rocket',
+  'saddle',
+  'velvet',
+  'violin',
+  'voyage',
   // tech / computing
   'bit',
   'block',
@@ -343,6 +572,21 @@ const nouns = [
   'vector',
   'voxel',
   'wire',
+  'axiom',
+  'boson',
+  'circuit',
+  'diode',
+  'electron',
+  'engine',
+  'fractal',
+  'laser',
+  'logic',
+  'module',
+  'photon',
+  'qubit',
+  'radar',
+  'socket',
+  'vertex',
 ] as const;
 
 const MAX_SLUG_LENGTH = 63;
@@ -350,6 +594,7 @@ const MAX_SLUG_LENGTH = 63;
 const SUFFIX_LENGTH = 1 + 4;
 const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
 const EPHEMERAL_SUFFIX_LENGTH = 8;
+const BRANCH_SUFFIX_LENGTH = 3;
 
 function cryptoRandomInt(max: number): number {
   const array = new Uint32Array(1);
@@ -378,7 +623,7 @@ function generateEphemeralSuffix(): string {
   return Array.from(values, value => BASE32_ALPHABET.charAt(value & 31)).join('');
 }
 
-function generatePronounceableDeploymentSlug(suffix: string): string {
+function generatePronounceableSlug(suffix: string): string {
   return `${pickRandom(adjectives)}-${pickRandom(nouns)}-${suffix}`;
 }
 
@@ -401,9 +646,16 @@ function sanitizePrefix(raw: string): string {
   return prefix;
 }
 
+export function generateBranchSlug(): string {
+  const suffix = cryptoRandomInt(36 ** BRANCH_SUFFIX_LENGTH)
+    .toString(36)
+    .padStart(BRANCH_SUFFIX_LENGTH, '0');
+  return generatePronounceableSlug(suffix);
+}
+
 /** Generate a pronounceable slug with a high-entropy suffix for public ephemeral deployments. */
 export function generateEphemeralDeploymentSlug(): string {
-  return generatePronounceableDeploymentSlug(generateEphemeralSuffix());
+  return generatePronounceableSlug(generateEphemeralSuffix());
 }
 
 /**
@@ -417,17 +669,17 @@ export function generateDeploymentSlug(repoName: string | null): string {
 
   let slug: string;
   if (repoName === null) {
-    slug = generatePronounceableDeploymentSlug(number);
+    slug = generatePronounceableSlug(number);
   } else {
     const prefix = sanitizePrefix(repoName);
-    slug = prefix ? `${prefix}-${number}` : generatePronounceableDeploymentSlug(number);
+    slug = prefix ? `${prefix}-${number}` : generatePronounceableSlug(number);
   }
 
   // Safety: if the generated slug doesn't pass validation (shouldn't happen
   // with curated word lists, but just in case), fall back to a simple pattern.
   const result = slugSchema.safeParse(slug);
   if (!result.success) {
-    slug = generatePronounceableDeploymentSlug(number);
+    slug = generatePronounceableSlug(number);
   }
 
   return slug;

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -6,7 +6,7 @@
 
 import { DurableObject } from 'cloudflare:workers';
 import type { CloudAgentQueueReport } from '@kilocode/worker-utils/cloud-agent-queue-report';
-import { generateEphemeralDeploymentSlug } from '@kilocode/worker-utils/deployment-slug';
+import { generateBranchSlug } from '@kilocode/worker-utils/deployment-slug';
 import type { OperationResult } from './types.js';
 import {
   getSandboxProvider,
@@ -2560,7 +2560,7 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       workspace: {
         ...input.workspace,
         sandboxProvider: input.workspace?.sandboxProvider ?? 'cloudflare',
-        branchName: repository?.upstreamBranch ?? `kilo/${generateEphemeralDeploymentSlug()}`,
+        branchName: repository?.upstreamBranch ?? `kilo/${generateBranchSlug()}`,
       },
       lifecycle: {
         version: now,

--- a/services/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
+++ b/services/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
@@ -43,7 +43,7 @@ describe('CloudAgentSession message admission', () => {
     const replayedMetadata = await stub.getMetadata();
 
     expect(first).toEqual({ success: true });
-    expect(metadata?.workspace?.branchName).toMatch(/^kilo\/[a-z]+-[a-z]+-[a-z2-7]{8}$/);
+    expect(metadata?.workspace?.branchName).toMatch(/^kilo\/[a-z]+-[a-z]+-[a-z0-9]{3}$/);
     expect(branchNameSchema.safeParse(metadata?.workspace?.branchName).success).toBe(true);
     expect(metadata?.repository?.upstreamBranch).toBeUndefined();
     expect(metadata?.lifecycle.preparedAt).toBeUndefined();
@@ -698,7 +698,7 @@ describe('CloudAgentSession message admission', () => {
 
     expect(result.first).toMatchObject({ success: true, messageId, outcome: 'queued' });
     expect(result.second).toEqual(result.first);
-    expect(result.firstBranch).toMatch(/^kilo\/[a-z]+-[a-z]+-[a-z2-7]{8}$/);
+    expect(result.firstBranch).toMatch(/^kilo\/[a-z]+-[a-z]+-[a-z0-9]{3}$/);
     expect(result.secondBranch).toBe(result.firstBranch);
     expect(result.pending).toHaveLength(1);
     expect(result.pending[0]?.messageId).toBe(messageId);


### PR DESCRIPTION
## Summary
- Expand the shared vocabulary to 256 adjectives and 256 nouns: 65,536 word pairs, up from 17,787.
- Give new default branches a dedicated generator with exactly three random lowercase alphanumeric suffix characters.
- Preserve explicit and persisted branches, registration retry behavior, and deployment suffix formats.

## Verification
No manual end-to-end session test was run. This backend-only naming change was checked with focused generator tests and Workers integration tests rather than starting the full application stack.

## Visual Changes
N/A

## Reviewer Notes
- The expanded vocabulary also applies to newly generated deployment slugs; deployment suffix lengths remain unchanged.
- The shorter branch suffix lowers the complete name space to 3,057,647,616 combinations. Collision probability increases compared with the old eight-character suffix; this change does not add collision handling.
- Validation ran on Node 22.22.3; the repository specifies Node 24.

### Automated checks
- `pnpm --filter @kilocode/worker-utils run test src/deployment-slug.test.ts` — 18 passed.
- `pnpm --filter cloud-agent-next run test src/session-service.test.ts -t branch` — 7 passed, 136 skipped.
- `pnpm --filter cloud-agent-next run test:integration test/integration/session/start-execution-v2.test.ts -t "branch|retried grouped admission"` — 5 passed, 34 skipped.
- `pnpm --filter @kilocode/worker-utils run typecheck` — passed.
- `pnpm --filter cloud-agent-next exec tsgo --noEmit` — passed; unrelated wrapper checks were not run.
- Changed-file `oxlint`, `oxfmt --list-different`, and `git diff --check` — passed.