### PR TITLE
feat(auth): enable audience-aware Cloud Agent readers

### DIFF
--- a/apps/web/src/lib/cloud-agent-next/cloud-agent-client.test.ts
+++ b/apps/web/src/lib/cloud-agent-next/cloud-agent-client.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type * as TrpcClientModule from '@trpc/client';
+import type * as CloudAgentClientModule from './cloud-agent-client';
 import type {
-  CloudAgentNextClient as CloudAgentNextClientType,
   ComputeBillingStatus,
   CreateWorktreeChatInput,
   CreateWorktreeChatOutput,
@@ -11,6 +11,7 @@ import type {
   PrepareSessionInput,
   SendMessageInput,
 } from './cloud-agent-client';
+import { signKiloToken } from '@kilocode/worker-utils/kilo-token';
 
 const mockCreateTRPCClient = jest.fn(() => ({}));
 const mockHttpLink =
@@ -78,12 +79,10 @@ beforeEach(() => {
 
 // Load the real `closeCloudAgentOrgStreams` (the module mock above does not
 // expose it) so the test exercises the actual fetch call, not a stub.
-const { closeCloudAgentOrgStreams, CloudAgentNextClient } = jest.requireActual(
-  './cloud-agent-client'
-) as {
-  closeCloudAgentOrgStreams: (userId: string, organizationId: string) => Promise<void>;
-  CloudAgentNextClient: typeof CloudAgentNextClientType;
-};
+const realCloudAgentClientModule =
+  jest.requireActual<typeof CloudAgentClientModule>('./cloud-agent-client');
+const { closeCloudAgentOrgStreams, CloudAgentNextClient, createAppBuilderCloudAgentNextClient } =
+  realCloudAgentClientModule;
 
 describe('createCloudAgentNextClientForModel', () => {
   it('returns the default client when the model is paid and has no BYOK', () => {
@@ -114,6 +113,71 @@ describe('createCloudAgentNextClientForModel', () => {
     expect(result).toEqual({ marker: 'appbuilder' });
     expect(mockCreateAppBuilderCloudAgentNextClient).toHaveBeenCalledWith('token');
     expect(mockCreateCloudAgentNextClient).not.toHaveBeenCalled();
+  });
+});
+
+describe('createAppBuilderCloudAgentNextClient', () => {
+  it('forwards the original App Builder JWT to Cloud Agent Next with its dedicated policy headers', async () => {
+    const { token } = await signKiloToken({
+      userId: 'synthetic-app-builder-user',
+      pepper: 'synthetic-app-builder-pepper',
+      secret: 'synthetic-app-builder-secret',
+      expiresInSeconds: 60,
+      extra: { tokenSource: 'app-builder' },
+    });
+    const prepareSession = jest.fn(async () => ({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      cloudAgentSessionId: 'workspace_12345678-1234-4234-9234-123456789abc',
+    }));
+    const getSession = jest.fn<
+      (input: { cloudAgentSessionId: string }) => Promise<Record<string, never>>
+    >(async () => ({}));
+    const interruptSession = jest.fn<
+      (input: {
+        sessionId: string;
+      }) => Promise<{ success: boolean; message: string; processesFound: boolean }>
+    >(async () => ({
+      success: true,
+      message: 'interrupted',
+      processesFound: true,
+    }));
+    const initiateFromKilocodeSessionV2 = jest.fn<
+      (input: { cloudAgentSessionId: string }) => Promise<Record<string, never>>
+    >(async () => ({}));
+    const sendMessageV2 = jest.fn(async () => ({}));
+    mockCreateTRPCClient.mockReturnValueOnce({
+      prepareSession: { mutate: prepareSession },
+      getSession: { query: getSession },
+      interruptSession: { mutate: interruptSession },
+      initiateFromKilocodeSessionV2: { mutate: initiateFromKilocodeSessionV2 },
+      sendMessageV2: { mutate: sendMessageV2 },
+    });
+
+    const client = createAppBuilderCloudAgentNextClient(token);
+    const cloudAgentSessionId = 'workspace_12345678-1234-4234-9234-123456789abc';
+    await client.prepareSession({ prompt: 'Build an app', mode: 'code', model: 'kilo/test-model' });
+    await client.getSession(cloudAgentSessionId);
+    await client.interruptSession(cloudAgentSessionId);
+    await client.initiateFromPreparedSession({ cloudAgentSessionId });
+    await client.sendMessage({
+      cloudAgentSessionId,
+      payload: { type: 'prompt', prompt: 'Continue', mode: 'code', model: 'kilo/test-model' },
+    });
+
+    expect(mockHttpLink).toHaveBeenCalledWith({
+      url: 'http://cloud-agent-next/trpc',
+      headers: expect.any(Function),
+    });
+    expect(mockHttpLink.mock.calls[0]?.[0].headers()).toEqual({
+      Authorization: `Bearer ${token}`,
+      'x-skip-balance-check': 'true',
+      'x-internal-api-key': 'test-secret',
+    });
+    expect(prepareSession).toHaveBeenCalledTimes(1);
+    expect(getSession).toHaveBeenCalledWith({ cloudAgentSessionId });
+    expect(interruptSession).toHaveBeenCalledWith({ sessionId: cloudAgentSessionId });
+    expect(initiateFromKilocodeSessionV2).toHaveBeenCalledWith({ cloudAgentSessionId });
+    expect(sendMessageV2).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/src/routers/app-builder-token-source.test.ts
+++ b/apps/web/src/routers/app-builder-token-source.test.ts
@@ -25,6 +25,9 @@ import { db } from '@/lib/drizzle';
 import { organizations, organization_memberships } from '@kilocode/db/schema';
 import { expectNonExchangeableSystemToken } from '@/tests/helpers/system-token.helper';
 import { insertTestUser } from '@/tests/helpers/user.helper';
+import { CLOUD_AGENT_NEXT_AUDIENCE } from '@kilocode/worker-utils/internal-service-token-audiences';
+import { verifyKiloTokenForResource } from '@kilocode/worker-utils/kilo-token-policy';
+import { NEXTAUTH_SECRET } from '@/lib/config.server';
 import type { Owner } from '@/lib/integrations/core/types';
 import type { User } from '@kilocode/db/schema';
 
@@ -155,6 +158,12 @@ describe('App Builder system tokens', () => {
 
     for (const { token } of tokens) {
       await expectNonExchangeableSystemToken(token, user, 'app-builder');
+      await expect(
+        verifyKiloTokenForResource(token, NEXTAUTH_SECRET, {
+          audience: CLOUD_AGENT_NEXT_AUDIENCE,
+          mode: 'allow-legacy',
+        })
+      ).resolves.toMatchObject({ kiloUserId: user.id, tokenSource: 'app-builder' });
     }
   });
 });

--- a/services/cloud-agent-next/src/auth.test.ts
+++ b/services/cloud-agent-next/src/auth.test.ts
@@ -162,31 +162,6 @@ describe('validateWrapperDispatchTicket', () => {
     });
   });
 
-  it('accepts legacy Kilo JWTs with no audience or a matching cloud-agent-next audience', async () => {
-    const tokens = [
-      jwt.sign({ version: 3, kiloUserId: 'user-1' }, secret, {
-        algorithm: 'HS256',
-        expiresIn: '1 minute',
-      }),
-      jwt.sign({ version: 3, kiloUserId: 'user-1', aud: 'cloud-agent-next' }, secret, {
-        algorithm: 'HS256',
-        expiresIn: '1 minute',
-      }),
-      jwt.sign(
-        { version: 3, kiloUserId: 'user-1', aud: ['other-service', 'cloud-agent-next'] },
-        secret,
-        { algorithm: 'HS256', expiresIn: '1 minute' }
-      ),
-    ];
-
-    for (const token of tokens) {
-      await expect(validateWrapperDispatchTicket(`Bearer ${token}`, secret)).resolves.toEqual({
-        success: true,
-        claims: { type: 'legacy_kilo_token', userId: 'user-1' },
-      });
-    }
-  });
-
   it('rejects an audience-scoped Kilo JWT on the legacy path', async () => {
     const audienceScopedToken = jwt.sign({ version: 3, kiloUserId: 'user-1' }, secret, {
       algorithm: 'HS256',
@@ -203,7 +178,11 @@ describe('validateWrapperDispatchTicket', () => {
   });
 
   it.each([
+    ['the Cloud Agent Next REST audience', 'cloud-agent-next'],
+    ['an array containing the REST audience', ['other-service', 'cloud-agent-next']],
     ['a different resource audience', 'kilo-gateway'],
+    ['an explicit null audience', null],
+    ['an explicit empty audience', ''],
     ['a malformed empty audience list', []],
     ['a malformed null audience list', [null]],
     ['a malformed audience object', { audience: 'cloud-agent-next' }],

--- a/services/cloud-agent-next/src/auth.test.ts
+++ b/services/cloud-agent-next/src/auth.test.ts
@@ -162,6 +162,31 @@ describe('validateWrapperDispatchTicket', () => {
     });
   });
 
+  it('accepts legacy Kilo JWTs with no audience or a matching cloud-agent-next audience', async () => {
+    const tokens = [
+      jwt.sign({ version: 3, kiloUserId: 'user-1' }, secret, {
+        algorithm: 'HS256',
+        expiresIn: '1 minute',
+      }),
+      jwt.sign({ version: 3, kiloUserId: 'user-1', aud: 'cloud-agent-next' }, secret, {
+        algorithm: 'HS256',
+        expiresIn: '1 minute',
+      }),
+      jwt.sign(
+        { version: 3, kiloUserId: 'user-1', aud: ['other-service', 'cloud-agent-next'] },
+        secret,
+        { algorithm: 'HS256', expiresIn: '1 minute' }
+      ),
+    ];
+
+    for (const token of tokens) {
+      await expect(validateWrapperDispatchTicket(`Bearer ${token}`, secret)).resolves.toEqual({
+        success: true,
+        claims: { type: 'legacy_kilo_token', userId: 'user-1' },
+      });
+    }
+  });
+
   it('rejects an audience-scoped Kilo JWT on the legacy path', async () => {
     const audienceScopedToken = jwt.sign({ version: 3, kiloUserId: 'user-1' }, secret, {
       algorithm: 'HS256',
@@ -172,6 +197,23 @@ describe('validateWrapperDispatchTicket', () => {
     await expect(
       validateWrapperDispatchTicket(`Bearer ${audienceScopedToken}`, secret)
     ).resolves.toEqual({
+      success: false,
+      error: 'Invalid ticket type',
+    });
+  });
+
+  it.each([
+    ['a different resource audience', 'kilo-gateway'],
+    ['a malformed empty audience list', []],
+    ['a malformed null audience list', [null]],
+    ['a malformed audience object', { audience: 'cloud-agent-next' }],
+  ])('rejects a legacy Kilo JWT with %s', async (_description, aud) => {
+    const token = jwt.sign({ version: 3, kiloUserId: 'user-1', aud }, secret, {
+      algorithm: 'HS256',
+      expiresIn: '1 minute',
+    });
+
+    await expect(validateWrapperDispatchTicket(`Bearer ${token}`, secret)).resolves.toEqual({
       success: false,
       error: 'Invalid ticket type',
     });

--- a/services/cloud-agent-next/src/auth.ts
+++ b/services/cloud-agent-next/src/auth.ts
@@ -1,7 +1,5 @@
 import jwt from 'jsonwebtoken';
-import { extractBearerToken } from '@kilocode/worker-utils';
-import { CLOUD_AGENT_NEXT_AUDIENCE } from '@kilocode/worker-utils/internal-service-token-audiences';
-import { verifyKiloTokenForResource } from '@kilocode/worker-utils/kilo-token-policy';
+import { verifyKiloToken, extractBearerToken } from '@kilocode/worker-utils';
 
 type StreamTicketPayload = {
   type: 'stream_ticket';
@@ -125,15 +123,17 @@ function isWrapperDispatchTicketClaims(payload: unknown): payload is WrapperDisp
   );
 }
 
+/**
+ * Grandfather only audience-less Kilo tokens for pre-migration wrappers.
+ * Resource-audience tokens, including cloud-agent-next, are not wrapper capabilities
+ * and must not inherit this legacy path's exemption from dispatch fence checks.
+ */
 async function legacyKiloTokenClaims(
   ticket: string,
   secret: string
 ): Promise<LegacyKiloTokenClaims | undefined> {
   try {
-    const payload = await verifyKiloTokenForResource(ticket, secret, {
-      audience: CLOUD_AGENT_NEXT_AUDIENCE,
-      mode: 'allow-legacy',
-    });
+    const payload = await verifyKiloToken(ticket, secret);
     return { type: 'legacy_kilo_token', userId: payload.kiloUserId };
   } catch {
     return undefined;

--- a/services/cloud-agent-next/src/auth.ts
+++ b/services/cloud-agent-next/src/auth.ts
@@ -1,5 +1,7 @@
 import jwt from 'jsonwebtoken';
-import { verifyKiloToken, extractBearerToken } from '@kilocode/worker-utils';
+import { extractBearerToken } from '@kilocode/worker-utils';
+import { CLOUD_AGENT_NEXT_AUDIENCE } from '@kilocode/worker-utils/internal-service-token-audiences';
+import { verifyKiloTokenForResource } from '@kilocode/worker-utils/kilo-token-policy';
 
 type StreamTicketPayload = {
   type: 'stream_ticket';
@@ -123,18 +125,15 @@ function isWrapperDispatchTicketClaims(payload: unknown): payload is WrapperDisp
   );
 }
 
-/**
- * Re-verifies the token through the canonical verifyKiloToken so the legacy
- * path enforces the same version/audience/shape guards as validateKiloToken —
- * in particular, audience-scoped tokens (e.g. internal service tokens) must
- * not be accepted as wrapper auth.
- */
 async function legacyKiloTokenClaims(
   ticket: string,
   secret: string
 ): Promise<LegacyKiloTokenClaims | undefined> {
   try {
-    const payload = await verifyKiloToken(ticket, secret);
+    const payload = await verifyKiloTokenForResource(ticket, secret, {
+      audience: CLOUD_AGENT_NEXT_AUDIENCE,
+      mode: 'allow-legacy',
+    });
     return { type: 'legacy_kilo_token', userId: payload.kiloUserId };
   } catch {
     return undefined;

--- a/services/cloud-agent-next/src/middleware/auth.integration.test.ts
+++ b/services/cloud-agent-next/src/middleware/auth.integration.test.ts
@@ -1,0 +1,252 @@
+import { Hono } from 'hono';
+import { trpcServer } from '@hono/trpc-server';
+import jwt from 'jsonwebtoken';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Context } from 'hono';
+import type { Env } from '../types.js';
+import type { HonoContext } from '../hono-context.js';
+
+const userRows = vi.hoisted(() => ({
+  value: [] as { api_token_pepper: string | null; blocked_reason: string | null }[],
+}));
+
+vi.mock('@kilocode/db/client', () => ({
+  getWorkerDb: vi.fn(() => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => userRows.value,
+        }),
+      }),
+    }),
+  })),
+}));
+
+const logging = vi.hoisted(() => ({ info: vi.fn(), withFields: vi.fn() }));
+
+vi.mock('../logger.js', () => {
+  const logger = {
+    setTags: vi.fn(),
+    info: logging.info,
+    warn: vi.fn(),
+    error: vi.fn(),
+    withFields: logging.withFields,
+  };
+  logger.withFields.mockReturnValue(logger);
+  return {
+    logger,
+    withLogTags: async (_tags: unknown, fn: () => Promise<unknown>) => fn(),
+    WithLogTags:
+      () =>
+      (
+        _target: unknown,
+        _propertyKey: string,
+        descriptor: PropertyDescriptor
+      ): PropertyDescriptor =>
+        descriptor,
+  };
+});
+
+const { getWorkerDb } = await import('@kilocode/db/client');
+const { authMiddleware } = await import('./auth.js');
+const { balanceMiddleware } = await import('./balance.js');
+const { internalApiProtectedProcedure, protectedProcedure, router } =
+  await import('../router/auth.js');
+
+const SECRET = 'test-secret-that-is-long-enough-for-hs256';
+const INTERNAL_API_SECRET = 'internal-api-secret';
+const USER_ID = 'user-1';
+
+const protectedCalls: { userId: string; authToken: string }[] = [];
+const internalCalls: { userId: string; authToken: string }[] = [];
+
+const testRouter = router({
+  start: protectedProcedure.mutation(({ ctx }) => {
+    protectedCalls.push({ userId: ctx.userId, authToken: ctx.authToken });
+    return { ok: true };
+  }),
+  internal: internalApiProtectedProcedure.mutation(({ ctx }) => {
+    internalCalls.push({ userId: ctx.userId, authToken: ctx.authToken });
+    return { ok: true };
+  }),
+});
+
+function createApp() {
+  const app = new Hono<HonoContext>();
+  app.use('/trpc/*', authMiddleware);
+  app.use('/trpc/*', balanceMiddleware);
+  app.use(
+    '/trpc/*',
+    trpcServer({
+      router: testRouter,
+      endpoint: '/trpc',
+      createContext: (_opts: unknown, c: Context<HonoContext>) => ({
+        env: c.env,
+        userId: c.get('userId'),
+        authToken: c.get('authToken'),
+        botId: c.get('botId'),
+        validatedSessionAccess: c.get('validatedSessionAccess'),
+        request: c.req.raw,
+      }),
+    })
+  );
+  return app;
+}
+
+function signToken(
+  options: {
+    audience?: string;
+    expiresIn?: number;
+    secret?: string;
+    tokenSource?: 'app-builder' | 'cloud-agent';
+  } = {}
+) {
+  return jwt.sign(
+    {
+      version: 3,
+      kiloUserId: USER_ID,
+      apiTokenPepper: 'current-pepper',
+      env: 'production',
+      ...(options.tokenSource ? { tokenSource: options.tokenSource } : {}),
+    },
+    options.secret ?? SECRET,
+    {
+      algorithm: 'HS256',
+      expiresIn: options.expiresIn ?? 3600,
+      ...(options.audience ? { audience: options.audience } : {}),
+    }
+  );
+}
+
+async function request(procedure: 'start' | 'internal', headers: Record<string, string> = {}) {
+  return createApp().fetch(
+    new Request(`https://worker.test/trpc/${procedure}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-skip-balance-check': 'true',
+        ...headers,
+      },
+      body: JSON.stringify({}),
+    }),
+    {
+      NEXTAUTH_SECRET: SECRET,
+      INTERNAL_API_SECRET,
+      HYPERDRIVE: { connectionString: 'postgres://test' },
+    } as Env
+  );
+}
+
+async function expectUnauthorized(response: Response, message: string, path: string) {
+  expect(response.status).toBe(401);
+  await expect(response.json()).resolves.toMatchObject({
+    error: {
+      message,
+      data: {
+        code: 'UNAUTHORIZED',
+        httpStatus: 401,
+        path,
+        clientError: {
+          code: 'UNAUTHORIZED',
+          message,
+          retryable: false,
+        },
+      },
+    },
+  });
+}
+
+describe('auth middleware with tRPC protected procedures', () => {
+  beforeEach(() => {
+    userRows.value = [{ api_token_pepper: 'current-pepper', blocked_reason: null }];
+    protectedCalls.length = 0;
+    internalCalls.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('passes an app-builder legacy token to an internal procedure without changing the JWT', async () => {
+    const token = signToken({ tokenSource: 'app-builder' });
+
+    const response = await request('internal', {
+      authorization: `Bearer ${token}`,
+      'x-internal-api-key': INTERNAL_API_SECRET,
+    });
+
+    expect(response.status).toBe(200);
+    expect(internalCalls).toEqual([{ userId: USER_ID, authToken: token }]);
+  });
+
+  it.each([
+    [
+      'a cloud-agent legacy token without an audience',
+      () => signToken({ tokenSource: 'cloud-agent' }),
+    ],
+    [
+      'a token explicitly targeted at Cloud Agent Next',
+      () => signToken({ audience: 'cloud-agent-next' }),
+    ],
+  ])('accepts %s for a protected procedure', async (_name, createToken) => {
+    const token = createToken();
+    const response = await request('start', { authorization: `Bearer ${token}` });
+
+    expect(response.status).toBe(200);
+    expect(protectedCalls).toEqual([{ userId: USER_ID, authToken: token }]);
+    expect(logging.withFields).toHaveBeenCalledWith({ procedure: 'start' });
+    expect(logging.info).toHaveBeenCalledWith('Skipping balance check per header');
+  });
+
+  it.each(['start', 'internal'] as const)(
+    'rejects a different audience before %s despite internal-key and balance-skip headers',
+    async procedure => {
+      const response = await request(procedure, {
+        authorization: `Bearer ${signToken({ audience: 'another-service' })}`,
+        'x-internal-api-key': INTERNAL_API_SECRET,
+      });
+
+      await expectUnauthorized(response, 'Invalid or expired token', procedure);
+      expect(getWorkerDb).not.toHaveBeenCalled();
+      expect(logging.info).not.toHaveBeenCalledWith('Skipping balance check per header');
+      expect(internalCalls).toEqual([]);
+      expect(protectedCalls).toEqual([]);
+    }
+  );
+
+  it.each([undefined, 'wrong-internal-api-secret'])(
+    'rejects a valid customer token with an invalid internal API key',
+    async internalApiKey => {
+      const response = await request('internal', {
+        authorization: `Bearer ${signToken({ tokenSource: 'app-builder' })}`,
+        ...(internalApiKey ? { 'x-internal-api-key': internalApiKey } : {}),
+      });
+
+      await expectUnauthorized(response, 'Invalid or missing internal API key', 'internal');
+      expect(internalCalls).toEqual([]);
+    }
+  );
+
+  it('rejects an internal API key without a customer JWT', async () => {
+    const response = await request('internal', { 'x-internal-api-key': INTERNAL_API_SECRET });
+
+    await expectUnauthorized(response, 'Missing or malformed Authorization header', 'internal');
+    expect(getWorkerDb).not.toHaveBeenCalled();
+    expect(internalCalls).toEqual([]);
+  });
+
+  it.each([
+    [
+      'unknown user',
+      () => {
+        userRows.value = [];
+        return signToken();
+      },
+    ],
+    ['malformed JWT', () => 'not-a-jwt'],
+    ['expired JWT', () => signToken({ expiresIn: -1 })],
+    ['JWT signed with another secret', () => signToken({ secret: 'another-test-secret' })],
+  ])('rejects an %s before the protected handler', async (_name, createToken) => {
+    const response = await request('start', { authorization: `Bearer ${createToken()}` });
+
+    await expectUnauthorized(response, 'Invalid or expired token', 'start');
+    expect(protectedCalls).toEqual([]);
+  });
+});

--- a/services/cloud-agent-next/src/server.test.ts
+++ b/services/cloud-agent-next/src/server.test.ts
@@ -840,23 +840,30 @@ describe('server /kilo facade route', () => {
 });
 
 describe('server raw global feed route', () => {
-  it('rejects a raw Kilo JWT with a different audience before session access or facade dispatch', async () => {
-    const env = createEnv();
-    const token = signKiloTokenWithAudience('another-resource', 'usr_feed');
+  it.each([
+    ['a different audience', 'another-resource'],
+    ['the Cloud Agent Next audience string', 'cloud-agent-next'],
+    ['an audience array containing Cloud Agent Next', ['another-resource', 'cloud-agent-next']],
+  ])(
+    'rejects a raw Kilo JWT with $0 before session access or facade dispatch',
+    async (_name, audience) => {
+      const env = createEnv();
+      const token = signKiloTokenWithAudience(audience, 'usr_feed');
 
-    const response = await fetchWorker(
-      new Request(
-        'http://worker.test/sessions/usr_feed/agent_live/kilo-global-ingest?kiloSessionId=ses_12345678901234567890123456&wrapperRunId=wr_1&wrapperGeneration=2&wrapperConnectionId=conn_1',
-        { headers: { Upgrade: 'websocket', Authorization: `Bearer ${token}` } }
-      ),
-      env
-    );
+      const response = await fetchWorker(
+        new Request(
+          'http://worker.test/sessions/usr_feed/agent_live/kilo-global-ingest?kiloSessionId=ses_12345678901234567890123456&wrapperRunId=wr_1&wrapperGeneration=2&wrapperConnectionId=conn_1',
+          { headers: { Upgrade: 'websocket', Authorization: `Bearer ${token}` } }
+        ),
+        env
+      );
 
-    expect(response.status).toBe(401);
-    expect(requireCurrentSessionAccessMock).not.toHaveBeenCalled();
-    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
-    expect(env.USER_KILO_FACADE.idFromName).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(401);
+      expect(requireCurrentSessionAccessMock).not.toHaveBeenCalled();
+      expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+      expect(env.USER_KILO_FACADE.idFromName).not.toHaveBeenCalled();
+    }
+  );
 
   it('rejects a raw Kilo JWT with a malformed explicit audience before session access', async () => {
     const env = createEnv();
@@ -875,7 +882,7 @@ describe('server raw global feed route', () => {
     expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
   });
 
-  it('accepts a raw Kilo JWT with the Cloud Agent Next audience through producer fencing', async () => {
+  it('accepts an audience-less legacy raw Kilo JWT through producer fencing', async () => {
     const env = createEnv();
     const validateKiloGlobalFeedProducer = vi.fn(async () => ({ success: true as const }));
     const facadeFetch = vi.fn().mockResolvedValue(new Response('accepted', { status: 200 }));
@@ -883,7 +890,7 @@ describe('server raw global feed route', () => {
     env.CLOUD_AGENT_SESSION.get.mockReturnValue({ validateKiloGlobalFeedProducer });
     env.USER_KILO_FACADE.idFromName.mockReturnValue('facade-id');
     env.USER_KILO_FACADE.get.mockReturnValue({ fetch: facadeFetch });
-    const token = signKiloTokenWithAudience('cloud-agent-next', 'usr_feed');
+    const token = signKiloToken('usr_feed');
 
     const response = await fetchWorker(
       new Request(
@@ -1083,6 +1090,8 @@ describe('server raw global feed route', () => {
 describe('server wrapper ingest route', () => {
   it.each([
     ['a different audience', 'another-resource'],
+    ['the Cloud Agent Next audience string', 'cloud-agent-next'],
+    ['an audience array containing Cloud Agent Next', ['another-resource', 'cloud-agent-next']],
     ['a malformed explicit audience', []],
   ])(
     'rejects a raw Kilo JWT with $0 before session access or Durable Object dispatch',
@@ -1103,9 +1112,9 @@ describe('server wrapper ingest route', () => {
     }
   );
 
-  it('rejects a matching-audience raw Kilo JWT for a different session user before session access', async () => {
+  it('rejects an audience-less legacy raw Kilo JWT for a different session user before session access', async () => {
     const env = createEnv();
-    const token = signKiloTokenWithAudience('cloud-agent-next', 'usr_feed');
+    const token = signKiloToken('usr_feed');
 
     const response = await fetchWorker(
       new Request('http://worker.test/sessions/usr_other/agent_live/ingest', {
@@ -1120,9 +1129,9 @@ describe('server wrapper ingest route', () => {
     expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
   });
 
-  it('keeps current session ownership enforcement for a raw Kilo JWT with the Cloud Agent Next audience', async () => {
+  it('keeps current session ownership enforcement for an audience-less legacy raw Kilo JWT', async () => {
     const env = createEnv();
-    const token = signKiloTokenWithAudience(['cloud-agent-next', 'another-resource'], 'usr_feed');
+    const token = signKiloToken('usr_feed');
     requireCurrentSessionAccessMock.mockRejectedValue(
       Object.assign(new Error('Session access denied'), { code: 'FORBIDDEN' })
     );
@@ -1245,6 +1254,8 @@ describe('server wrapper log upload route', () => {
 
   it.each([
     ['a different audience', 'another-resource'],
+    ['the Cloud Agent Next audience string', 'cloud-agent-next'],
+    ['an audience array containing Cloud Agent Next', ['another-resource', 'cloud-agent-next']],
     ['a malformed explicit audience', []],
   ])(
     'rejects a raw Kilo JWT with $0 before session access or R2 upload',
@@ -1270,9 +1281,9 @@ describe('server wrapper log upload route', () => {
     }
   );
 
-  it('keeps current session ownership enforcement for a raw Kilo JWT with the Cloud Agent Next audience', async () => {
+  it('keeps current session ownership enforcement for an audience-less legacy raw Kilo JWT', async () => {
     const env = createLogEnv();
-    const token = signKiloTokenWithAudience('cloud-agent-next', 'usr_feed');
+    const token = signKiloToken('usr_feed');
     requireCurrentSessionAccessMock.mockRejectedValue(
       Object.assign(new Error('Session access denied'), { code: 'FORBIDDEN' })
     );

--- a/services/cloud-agent-next/src/server.test.ts
+++ b/services/cloud-agent-next/src/server.test.ts
@@ -197,6 +197,18 @@ function signKiloToken(userId = 'usr_1'): string {
   );
 }
 
+function signKiloTokenWithAudience(audience: string | string[], userId = 'usr_1'): string {
+  return jwt.sign(
+    {
+      version: 3,
+      kiloUserId: userId,
+      aud: audience,
+    },
+    secret,
+    { algorithm: 'HS256' }
+  );
+}
+
 function signWrapperDispatchTicket(overrides: Partial<WrapperDispatchTicketClaims> = {}): string {
   return mintWrapperDispatchTicket(
     {
@@ -746,6 +758,43 @@ describe('server /kilo facade route', () => {
     expect(new URL(facadeFetch.mock.calls[0][0].url).pathname).toBe('/kilo');
   });
 
+  it.each([
+    ['a matching audience string', 'cloud-agent-next'],
+    ['a matching audience array', ['another-resource', 'cloud-agent-next']],
+  ])('accepts $0 before routing through the facade', async (_name, audience) => {
+    const env = createEnv();
+    const facadeFetch = vi.fn().mockResolvedValue(new Response('facade response', { status: 209 }));
+    env.USER_KILO_FACADE.idFromName.mockReturnValue('facade-id');
+    env.USER_KILO_FACADE.get.mockReturnValue({ fetch: facadeFetch });
+    const token = signKiloTokenWithAudience(audience, 'usr_facade');
+
+    const response = await fetchWorker(
+      new Request('http://worker.test/kilo', { headers: { Authorization: `Bearer ${token}` } }),
+      env
+    );
+
+    expect(response.status).toBe(209);
+    expect(env.USER_KILO_FACADE.idFromName).toHaveBeenCalledWith('usr_facade');
+    expect(facadeFetch).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['a different explicit audience', 'another-resource'],
+    ['a malformed explicit audience', []],
+  ])('rejects $0 before facade dispatch', async (_name, audience) => {
+    const env = createEnv();
+    const token = signKiloTokenWithAudience(audience, 'usr_facade');
+
+    const response = await fetchWorker(
+      new Request('http://worker.test/kilo', { headers: { Authorization: `Bearer ${token}` } }),
+      env
+    );
+
+    expect(response.status).toBe(401);
+    expect(env.USER_KILO_FACADE.idFromName).not.toHaveBeenCalled();
+    expect(env.USER_KILO_FACADE.get).not.toHaveBeenCalled();
+  });
+
   it('routes valid bearer-authenticated requests to the per-user facade without public credentials', async () => {
     const env = createEnv();
     const facadeFetch = vi.fn<(request: Request) => Promise<Response>>(
@@ -755,8 +804,9 @@ describe('server /kilo facade route', () => {
     env.USER_KILO_FACADE.get.mockReturnValue({ fetch: facadeFetch });
     const token = signKiloToken('usr_facade');
 
-    const response = await fetchWorker(
-      new Request('http://worker.test/kilo/session/ses_12345678901234567890123456/message', {
+    const request = new Request(
+      'http://worker.test/kilo/session/ses_12345678901234567890123456/message',
+      {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
@@ -766,9 +816,9 @@ describe('server /kilo facade route', () => {
           'x-kilo-facade-auth-token': 'attacker-token',
         },
         body: JSON.stringify({ ok: true }),
-      }),
-      env
+      }
     );
+    const response = await fetchWorker(request, env);
 
     expect(response.status).toBe(209);
     expect(env.USER_KILO_FACADE.idFromName).toHaveBeenCalledWith('usr_facade');
@@ -782,10 +832,73 @@ describe('server /kilo facade route', () => {
     expect(forwarded.headers.get('x-kilo-facade-auth-token')).toBe(token);
     expect(forwarded.headers.get('content-type')).toBe('application/json');
     await expect(forwarded.text()).resolves.toBe('{"ok":true}');
+    expect(request.headers.get('authorization')).toBe(`Bearer ${token}`);
+    expect(request.headers.get('cookie')).toBe('session=secret');
+    expect(request.headers.get('x-kilo-facade-user-id')).toBe('usr_attacker');
+    expect(request.headers.get('x-kilo-facade-auth-token')).toBe('attacker-token');
   });
 });
 
 describe('server raw global feed route', () => {
+  it('rejects a raw Kilo JWT with a different audience before session access or facade dispatch', async () => {
+    const env = createEnv();
+    const token = signKiloTokenWithAudience('another-resource', 'usr_feed');
+
+    const response = await fetchWorker(
+      new Request(
+        'http://worker.test/sessions/usr_feed/agent_live/kilo-global-ingest?kiloSessionId=ses_12345678901234567890123456&wrapperRunId=wr_1&wrapperGeneration=2&wrapperConnectionId=conn_1',
+        { headers: { Upgrade: 'websocket', Authorization: `Bearer ${token}` } }
+      ),
+      env
+    );
+
+    expect(response.status).toBe(401);
+    expect(requireCurrentSessionAccessMock).not.toHaveBeenCalled();
+    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+    expect(env.USER_KILO_FACADE.idFromName).not.toHaveBeenCalled();
+  });
+
+  it('rejects a raw Kilo JWT with a malformed explicit audience before session access', async () => {
+    const env = createEnv();
+    const token = signKiloTokenWithAudience([], 'usr_feed');
+
+    const response = await fetchWorker(
+      new Request(
+        'http://worker.test/sessions/usr_feed/agent_live/kilo-global-ingest?kiloSessionId=ses_12345678901234567890123456&wrapperRunId=wr_1&wrapperGeneration=2&wrapperConnectionId=conn_1',
+        { headers: { Upgrade: 'websocket', Authorization: `Bearer ${token}` } }
+      ),
+      env
+    );
+
+    expect(response.status).toBe(401);
+    expect(requireCurrentSessionAccessMock).not.toHaveBeenCalled();
+    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+  });
+
+  it('accepts a raw Kilo JWT with the Cloud Agent Next audience through producer fencing', async () => {
+    const env = createEnv();
+    const validateKiloGlobalFeedProducer = vi.fn(async () => ({ success: true as const }));
+    const facadeFetch = vi.fn().mockResolvedValue(new Response('accepted', { status: 200 }));
+    env.CLOUD_AGENT_SESSION.idFromName.mockReturnValue('session-do-id');
+    env.CLOUD_AGENT_SESSION.get.mockReturnValue({ validateKiloGlobalFeedProducer });
+    env.USER_KILO_FACADE.idFromName.mockReturnValue('facade-id');
+    env.USER_KILO_FACADE.get.mockReturnValue({ fetch: facadeFetch });
+    const token = signKiloTokenWithAudience('cloud-agent-next', 'usr_feed');
+
+    const response = await fetchWorker(
+      new Request(
+        'http://worker.test/sessions/usr_feed/agent_live/kilo-global-ingest?kiloSessionId=ses_12345678901234567890123456&wrapperRunId=wr_1&wrapperGeneration=2&wrapperConnectionId=conn_1',
+        { headers: { Upgrade: 'websocket', Authorization: `Bearer ${token}` } }
+      ),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(requireCurrentSessionAccessMock).toHaveBeenCalledOnce();
+    expect(validateKiloGlobalFeedProducer).toHaveBeenCalledOnce();
+    expect(facadeFetch).toHaveBeenCalledOnce();
+  });
+
   it('validates producer fencing and forwards accepted producer WebSockets to the user facade', async () => {
     const env = createEnv();
     const validateKiloGlobalFeedProducer = vi.fn(async () => ({ success: true as const }));
@@ -968,6 +1081,68 @@ describe('server raw global feed route', () => {
 });
 
 describe('server wrapper ingest route', () => {
+  it.each([
+    ['a different audience', 'another-resource'],
+    ['a malformed explicit audience', []],
+  ])(
+    'rejects a raw Kilo JWT with $0 before session access or Durable Object dispatch',
+    async (_name, audience) => {
+      const env = createEnv();
+      const token = signKiloTokenWithAudience(audience, 'usr_feed');
+
+      const response = await fetchWorker(
+        new Request('http://worker.test/sessions/usr_feed/agent_live/ingest', {
+          headers: { Upgrade: 'websocket', Authorization: `Bearer ${token}` },
+        }),
+        env
+      );
+
+      expect(response.status).toBe(401);
+      expect(requireCurrentSessionAccessMock).not.toHaveBeenCalled();
+      expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects a matching-audience raw Kilo JWT for a different session user before session access', async () => {
+    const env = createEnv();
+    const token = signKiloTokenWithAudience('cloud-agent-next', 'usr_feed');
+
+    const response = await fetchWorker(
+      new Request('http://worker.test/sessions/usr_other/agent_live/ingest', {
+        headers: { Upgrade: 'websocket', Authorization: `Bearer ${token}` },
+      }),
+      env
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe('Token does not match session user');
+    expect(requireCurrentSessionAccessMock).not.toHaveBeenCalled();
+    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+  });
+
+  it('keeps current session ownership enforcement for a raw Kilo JWT with the Cloud Agent Next audience', async () => {
+    const env = createEnv();
+    const token = signKiloTokenWithAudience(['cloud-agent-next', 'another-resource'], 'usr_feed');
+    requireCurrentSessionAccessMock.mockRejectedValue(
+      Object.assign(new Error('Session access denied'), { code: 'FORBIDDEN' })
+    );
+
+    const response = await fetchWorker(
+      new Request('http://worker.test/sessions/usr_feed/agent_live/ingest', {
+        headers: { Upgrade: 'websocket', Authorization: `Bearer ${token}` },
+      }),
+      env
+    );
+
+    expect(response.status).toBe(403);
+    expect(requireCurrentSessionAccessMock).toHaveBeenCalledWith({
+      env,
+      kiloUserId: 'usr_feed',
+      cloudAgentSessionId: 'agent_live',
+    });
+    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+  });
+
   it('accepts a valid wrapper dispatch ticket and forwards to the session Durable Object', async () => {
     const env = createEnv();
     const doFetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
@@ -1067,6 +1242,62 @@ describe('server wrapper log upload route', () => {
       R2_BUCKET: { put: vi.fn().mockResolvedValue(undefined) },
     });
   }
+
+  it.each([
+    ['a different audience', 'another-resource'],
+    ['a malformed explicit audience', []],
+  ])(
+    'rejects a raw Kilo JWT with $0 before session access or R2 upload',
+    async (_name, audience) => {
+      const env = createLogEnv();
+      const token = signKiloTokenWithAudience(audience, 'usr_feed');
+
+      const response = await fetchWorker(
+        new Request(
+          'http://worker.test/sessions/usr_feed/agent_live/logs/session/logs.tar.gz?kiloSessionId=ses_12345678901234567890123456',
+          {
+            method: 'PUT',
+            headers: { Authorization: `Bearer ${token}` },
+            body: new Uint8Array([1, 2, 3]),
+          }
+        ),
+        env
+      );
+
+      expect(response.status).toBe(401);
+      expect(requireCurrentSessionAccessMock).not.toHaveBeenCalled();
+      expect(env.R2_BUCKET.put).not.toHaveBeenCalled();
+    }
+  );
+
+  it('keeps current session ownership enforcement for a raw Kilo JWT with the Cloud Agent Next audience', async () => {
+    const env = createLogEnv();
+    const token = signKiloTokenWithAudience('cloud-agent-next', 'usr_feed');
+    requireCurrentSessionAccessMock.mockRejectedValue(
+      Object.assign(new Error('Session access denied'), { code: 'FORBIDDEN' })
+    );
+
+    const response = await fetchWorker(
+      new Request(
+        'http://worker.test/sessions/usr_feed/agent_live/logs/session/logs.tar.gz?kiloSessionId=ses_12345678901234567890123456',
+        {
+          method: 'PUT',
+          headers: { Authorization: `Bearer ${token}` },
+          body: new Uint8Array([1, 2, 3]),
+        }
+      ),
+      env
+    );
+
+    expect(response.status).toBe(403);
+    expect(requireCurrentSessionAccessMock).toHaveBeenCalledWith({
+      env,
+      kiloUserId: 'usr_feed',
+      cloudAgentSessionId: 'agent_live',
+      expectedKiloSessionId: 'ses_12345678901234567890123456',
+    });
+    expect(env.R2_BUCKET.put).not.toHaveBeenCalled();
+  });
 
   it('accepts a valid wrapper dispatch ticket and stores the upload in R2', async () => {
     const env = createLogEnv();

--- a/services/cloud-agent-next/src/validate-kilo-token.test.ts
+++ b/services/cloud-agent-next/src/validate-kilo-token.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { signKiloToken } from '@kilocode/worker-utils';
+import jwt from 'jsonwebtoken';
 import { validateKiloToken } from './validate-kilo-token.js';
 
 const TEST_JWT_SECRET = 'test-secret-that-is-long-enough-for-hs256';
@@ -7,26 +8,42 @@ const TEST_JWT_SECRET = 'test-secret-that-is-long-enough-for-hs256';
 const userRowByUserId = vi.hoisted(
   () => new Map<string, { pepper: string | null; blockedReason: string | null }>()
 );
+const getWorkerDb = vi.hoisted(() => vi.fn());
+const dbFailure = vi.hoisted(() => ({ error: null as Error | null }));
 
 vi.mock('@kilocode/db/client', () => ({
-  getWorkerDb: () => ({
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          limit: async () => {
-            const row = userRowByUserId.get('user-1');
-            if (!row) return [];
-            return [{ api_token_pepper: row.pepper, blocked_reason: row.blockedReason }];
-          },
-        }),
+  getWorkerDb,
+}));
+
+getWorkerDb.mockImplementation(() => ({
+  select: () => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => {
+          if (dbFailure.error) throw dbFailure.error;
+          const row = userRowByUserId.get('user-1');
+          if (!row) return [];
+          return [{ api_token_pepper: row.pepper, blocked_reason: row.blockedReason }];
+        },
       }),
     }),
   }),
 }));
 
+function signResourceToken(
+  claims: Record<string, unknown>,
+  options: jwt.SignOptions = { algorithm: 'HS256', expiresIn: '1 hour' }
+): string {
+  return jwt.sign({ version: 3, kiloUserId: 'user-1', ...claims }, TEST_JWT_SECRET, options);
+}
+
+const validParams = { secret: TEST_JWT_SECRET, connectionString: 'postgres://test' };
+
 describe('validateKiloToken', () => {
   beforeEach(() => {
     userRowByUserId.clear();
+    getWorkerDb.mockClear();
+    dbFailure.error = null;
   });
 
   it('returns a configuration error when NEXTAUTH_SECRET is missing', async () => {
@@ -65,6 +82,118 @@ describe('validateKiloToken', () => {
     ).resolves.toMatchObject({ success: true, userId: 'user-1', token });
   });
 
+  it('accepts legacy app-builder and cloud-agent tokens and forwards their original token', async () => {
+    userRowByUserId.set('user-1', { pepper: 'pepper-current', blockedReason: null });
+
+    for (const tokenSource of ['app-builder', 'cloud-agent']) {
+      const token = signResourceToken({ apiTokenPepper: 'pepper-current', tokenSource });
+      await expect(validateKiloToken(`Bearer ${token}`, validParams)).resolves.toEqual({
+        success: true,
+        userId: 'user-1',
+        token,
+      });
+    }
+  });
+
+  it('accepts matching cloud-agent-next audiences as a string or an array', async () => {
+    userRowByUserId.set('user-1', { pepper: 'pepper-current', blockedReason: null });
+
+    for (const aud of ['cloud-agent-next', ['another-service', 'cloud-agent-next']]) {
+      const token = signResourceToken({ apiTokenPepper: 'pepper-current', aud });
+      await expect(validateKiloToken(`Bearer ${token}`, validParams)).resolves.toMatchObject({
+        success: true,
+        userId: 'user-1',
+      });
+    }
+  });
+
+  it('rejects non-target or malformed audiences before constructing a database client', async () => {
+    const tokens = [
+      signResourceToken({ aud: 'kilo-api' }),
+      signResourceToken({ aud: 'kilo-gateway' }),
+      signResourceToken({ aud: 'foreign-service' }),
+      signResourceToken({ aud: [] }),
+      signResourceToken({ aud: [null] }),
+      signResourceToken({ aud: { audience: 'cloud-agent-next' } }),
+    ];
+
+    for (const token of tokens) {
+      await expect(validateKiloToken(`Bearer ${token}`, validParams)).resolves.toEqual({
+        success: false,
+        error: 'Invalid or expired token',
+      });
+    }
+    expect(getWorkerDb).not.toHaveBeenCalled();
+  });
+
+  it('preserves bot IDs and distinguishes absent, null, and stale pepper claims', async () => {
+    userRowByUserId.set('user-1', { pepper: 'pepper-current', blockedReason: null });
+    const absentPepper = signResourceToken({ botId: 'bot-1', aud: 'cloud-agent-next' });
+    const nullPepper = signResourceToken({ apiTokenPepper: null, aud: 'cloud-agent-next' });
+    const stalePepper = signResourceToken({
+      apiTokenPepper: 'pepper-stale',
+      aud: 'cloud-agent-next',
+    });
+
+    await expect(validateKiloToken(`Bearer ${absentPepper}`, validParams)).resolves.toEqual({
+      success: true,
+      userId: 'user-1',
+      token: absentPepper,
+      botId: 'bot-1',
+    });
+    await expect(validateKiloToken(`Bearer ${nullPepper}`, validParams)).resolves.toEqual({
+      success: false,
+      error: 'Invalid or expired token',
+    });
+    await expect(validateKiloToken(`Bearer ${stalePepper}`, validParams)).resolves.toEqual({
+      success: false,
+      error: 'Invalid or expired token',
+    });
+  });
+
+  it('accepts a null pepper only for an account with a null pepper', async () => {
+    userRowByUserId.set('user-1', { pepper: null, blockedReason: null });
+    const token = signResourceToken({ apiTokenPepper: null });
+
+    await expect(validateKiloToken(`Bearer ${token}`, validParams)).resolves.toMatchObject({
+      success: true,
+      userId: 'user-1',
+    });
+  });
+
+  it('skips the environment check when omitted and enforces it when supplied', async () => {
+    userRowByUserId.set('user-1', { pepper: 'pepper-current', blockedReason: null });
+    const token = signResourceToken({ apiTokenPepper: 'pepper-current', env: 'production' });
+    const tokenWithoutEnv = signResourceToken({ apiTokenPepper: 'pepper-current' });
+
+    await expect(validateKiloToken(`Bearer ${token}`, validParams)).resolves.toMatchObject({
+      success: true,
+      userId: 'user-1',
+    });
+    await expect(
+      validateKiloToken(`Bearer ${token}`, { ...validParams, workerEnv: 'production' })
+    ).resolves.toMatchObject({ success: true, userId: 'user-1' });
+    await expect(
+      validateKiloToken(`Bearer ${token}`, { ...validParams, workerEnv: 'staging' })
+    ).resolves.toEqual({ success: false, error: 'Invalid or expired token' });
+    await expect(
+      validateKiloToken(`Bearer ${tokenWithoutEnv}`, { ...validParams, workerEnv: 'production' })
+    ).resolves.toEqual({ success: false, error: 'Invalid or expired token' });
+  });
+
+  it('accepts legacy tokens without dates through the resource verifier', async () => {
+    userRowByUserId.set('user-1', { pepper: 'pepper-current', blockedReason: null });
+    const token = signResourceToken(
+      { apiTokenPepper: 'pepper-current', tokenSource: 'cloud-agent' },
+      { algorithm: 'HS256', noTimestamp: true }
+    );
+
+    await expect(validateKiloToken(`Bearer ${token}`, validParams)).resolves.toMatchObject({
+      success: true,
+      userId: 'user-1',
+    });
+  });
+
   it('rejects a token with a stale pepper', async () => {
     userRowByUserId.set('user-1', { pepper: 'pepper-current', blockedReason: null });
     const { token } = await signKiloToken({
@@ -99,5 +228,40 @@ describe('validateKiloToken', () => {
         connectionString: 'postgres://test',
       })
     ).resolves.toEqual({ success: false, error: 'Invalid or expired token' });
+  });
+
+  it('rejects a missing user and propagates database failures after token verification', async () => {
+    const token = signResourceToken({ apiTokenPepper: 'pepper-current' });
+
+    await expect(validateKiloToken(`Bearer ${token}`, validParams)).resolves.toEqual({
+      success: false,
+      error: 'Invalid or expired token',
+    });
+
+    userRowByUserId.set('user-1', { pepper: 'pepper-current', blockedReason: null });
+    dbFailure.error = new Error('database unavailable');
+    await expect(validateKiloToken(`Bearer ${token}`, validParams)).rejects.toThrow(
+      'database unavailable'
+    );
+  });
+
+  it.each([
+    ['a malformed token', 'not-a-jwt'],
+    ['a token with an invalid schema', signResourceToken({ version: 2 })],
+    [
+      'a token signed with another secret',
+      jwt.sign({ version: 3, kiloUserId: 'user-1' }, 'other-secret'),
+    ],
+    [
+      'an expired token',
+      jwt.sign({ version: 3, kiloUserId: 'user-1' }, TEST_JWT_SECRET, { expiresIn: -1 }),
+    ],
+  ])('rejects %s', async (_description, token) => {
+    userRowByUserId.set('user-1', { pepper: 'pepper-current', blockedReason: null });
+    await expect(validateKiloToken(`Bearer ${token}`, validParams)).resolves.toEqual({
+      success: false,
+      error: 'Invalid or expired token',
+    });
+    expect(getWorkerDb).not.toHaveBeenCalled();
   });
 });

--- a/services/cloud-agent-next/src/validate-kilo-token.ts
+++ b/services/cloud-agent-next/src/validate-kilo-token.ts
@@ -1,5 +1,6 @@
 import { extractBearerToken } from '@kilocode/worker-utils';
 import { verifyKiloBearerAgainstCurrentPepper } from '@kilocode/worker-utils/kilo-token-auth';
+import { CLOUD_AGENT_NEXT_AUDIENCE } from '@kilocode/worker-utils/internal-service-token-audiences';
 
 export async function validateKiloToken(
   authHeader: string | null,
@@ -26,6 +27,7 @@ export async function validateKiloToken(
     token,
     nextAuthSecret: secret,
     connectionString,
+    resourceAudience: { audience: CLOUD_AGENT_NEXT_AUDIENCE, mode: 'allow-legacy' },
     ...(workerEnv ? { workerEnv } : {}),
   });
 


### PR DESCRIPTION
## Summary

Phase 4, batch 3: enable Cloud Agent Next to accept Kilo JWTs addressed to `cloud-agent-next`, reject explicit audience mismatches, and preserve supported audience-less legacy tokens.

Audience-aware acceptance applies only to normal customer-token authentication. The legacy raw-Kilo-token wrapper fallback stays strict: it accepts only tokens with no audience. Add coverage for App Builder token/client compatibility, protected tRPC gates, public facade routing, and wrapper capability separation.

## Verification

No manual browser, deployed-service, or fake-LLM smoke-harness testing was performed. These are backend authentication changes; signed-token, middleware, routing, and client contracts were exercised through automated tests without production requests. Automated results are listed below.

## Visual Changes

N/A

## Reviewer Notes

- Normal customer authentication retains its existing account, pepper, optional environment checks, bot identity, and original token forwarding. Audience mismatches fail before account lookup or protected handlers.
- The legacy wrapper fallback rejects every explicit audience, including `cloud-agent-next` as a string or array member. REST access is not a wrapper-dispatch capability and must not inherit the legacy exemption from dispatch fences. Existing audience-less wrappers retain their ownership/current-session checks; this is not a revocation redesign.
- Specialized stream, terminal, and wrapper-dispatch tickets retain their separate existing validation and fencing. Internal API keys and balance-skip headers do not substitute for a valid customer JWT.
- App Builder tests exercise all ten real issuer paths against the resource policy and verify byte-for-byte token forwarding with the existing internal-key/balance headers. This is contract coverage, not a deployed end-to-end session run.
- No token issuance, lifetimes, runtime credential rotation/reuse, Session Ingest, or other services are changed. Issuer audience migration follows after the reader rollout.
- Rebased onto current main, preserving upstream compute-billing tests and diagnostics changes. This PR is independent of the final Session Ingest batch.

Automated validation after rebase and wrapper-auth review correction:
- Cloud Agent unit tests: 5,035 passed, 3 skipped. Eight regression cases first reproduced the incorrect wrapper acceptance, including successful log uploads, and pass after restoring the strict fallback.
- Shared JWT/authentication/policy tests: 192 passed.
- App Builder issuer and Cloud Agent client web tests: 37 passed.
- Cloud Agent and web lint passed; Cloud Agent, wrapper, and web typechecks passed, with existing declaration-bundling dependency warnings.
- Formatting and whitespace checks passed.
- Before the base refresh, the Workers-runtime suite reported 542 passing tests but emitted teardown/error diagnostics; it was not rerun after the rebase and is not claimed as clean final-runtime validation.