### PR TITLE
feat(auth): enable audience-aware Session Ingest readers

### DIFF
--- a/services/session-ingest/src/cloud-agent-session-scope-audience.test.ts
+++ b/services/session-ingest/src/cloud-agent-session-scope-audience.test.ts
@@ -1,0 +1,217 @@
+import { Hono } from 'hono';
+import { SignJWT } from 'jose';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearSecretCacheForTest } from '@kilocode/worker-utils';
+import type { Env } from './env';
+import {
+  SESSION_INGEST_AUDIENCE,
+  SESSION_INGEST_USER_DELETION_AUDIENCE,
+} from '@kilocode/worker-utils/internal-service-token-audiences';
+
+const JWT_SECRET = 'session-scope-test-secret-that-is-long-enough-for-hs256';
+const INTERNAL_SECRET = 'session-scope-internal-secret';
+const USER_ID = 'usr_session_scope';
+const PEPPER = 'current-pepper';
+
+const userRows = vi.hoisted(
+  () => new Map<string, { pepper: string | null; blockedReason: string | null }>()
+);
+const getUserById = vi.hoisted(() => vi.fn());
+const dispatches = vi.hoisted(() => vi.fn());
+
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class DurableObject {},
+  WorkerEntrypoint: class WorkerEntrypoint {},
+}));
+
+vi.mock('@kilocode/db/client', () => ({
+  getWorkerDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => {
+            getUserById();
+            const row = userRows.get(USER_ID);
+            return row ? [{ api_token_pepper: row.pepper, blocked_reason: row.blockedReason }] : [];
+          },
+        }),
+      }),
+    }),
+  }),
+}));
+
+vi.mock('./routes/cloud-agent-session-scope', () => {
+  const cloudAgentSessionScopeApi = new Hono<{ Variables: { user_id: string } }>();
+  cloudAgentSessionScopeApi.post('/session', c => {
+    dispatches({ path: c.req.path, userId: c.get('user_id') });
+    return c.body(null, 204);
+  });
+  cloudAgentSessionScopeApi.post('/session/:sessionId/ingest', c => {
+    dispatches({ path: c.req.path, userId: c.get('user_id') });
+    return c.body(null, 204);
+  });
+  return { cloudAgentSessionScopeApi };
+});
+
+vi.mock('./dos/SessionIngestDO', () => ({ getSessionIngestDO: vi.fn() }));
+vi.mock('./dos/SessionAccessCacheDO', () => ({ getSessionAccessCacheDO: vi.fn() }));
+
+const { app } = await import('./app');
+
+const env = {
+  HYPERDRIVE: { connectionString: 'postgres://test' },
+  NEXTAUTH_SECRET_PROD: { get: async () => JWT_SECRET },
+  INTERNAL_API_SECRET_PROD: { get: async () => INTERNAL_SECRET },
+} as Env;
+
+type Audience = string | string[] | undefined;
+
+async function signToken(
+  options: {
+    audience?: Audience;
+    secret?: string;
+    expiresAt?: number;
+  } = {}
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  let jwt = new SignJWT({ version: 3, kiloUserId: USER_ID, apiTokenPepper: PEPPER })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setIssuedAt(now - 60)
+    .setExpirationTime(options.expiresAt ?? now + 3600);
+  if (options.audience !== undefined) jwt = jwt.setAudience(options.audience);
+  return jwt.sign(new TextEncoder().encode(options.secret ?? JWT_SECRET));
+}
+
+async function request(
+  path: string,
+  headers: Record<string, string | undefined>
+): Promise<Response> {
+  const requestHeaders = new Headers();
+  for (const [name, value] of Object.entries(headers)) {
+    if (value !== undefined) requestHeaders.set(name, value);
+  }
+  return app.request(path, { method: 'POST', headers: requestHeaders }, env);
+}
+
+const routes = [
+  '/internal/cloud-agent/v1/session',
+  '/internal/cloud-agent/v1/session/child/ingest',
+];
+
+describe('Cloud Agent session scope audience authentication', () => {
+  beforeEach(() => {
+    clearSecretCacheForTest();
+    userRows.clear();
+    userRows.set(USER_ID, { pepper: PEPPER, blockedReason: null });
+    getUserById.mockClear();
+    dispatches.mockClear();
+  });
+
+  it.each([
+    ['legacy user JWT', undefined],
+    ['session-ingest string audience', SESSION_INGEST_AUDIENCE],
+    ['session-ingest array audience', ['another-service', SESSION_INGEST_AUDIENCE]],
+  ] as [string, Audience][])(
+    'dispatches both scoped routes for a valid %s',
+    async (_name, audience) => {
+      const token = await signToken({ audience });
+
+      for (const path of routes) {
+        const response = await request(path, {
+          Authorization: `Bearer ${token}`,
+          'X-Internal-Secret': INTERNAL_SECRET,
+        });
+
+        expect(response.status).toBe(204);
+      }
+
+      expect(dispatches).toHaveBeenCalledTimes(2);
+      expect(dispatches).toHaveBeenNthCalledWith(1, { path: routes[0], userId: USER_ID });
+      expect(dispatches).toHaveBeenNthCalledWith(2, { path: routes[1], userId: USER_ID });
+    }
+  );
+
+  it('rejects a JWT-only request even with a trusted lineage marker', async () => {
+    const token = await signToken({ audience: SESSION_INGEST_AUDIENCE });
+
+    const response = await request(routes[0], {
+      Authorization: `Bearer ${token}`,
+      'X-Kilo-Trusted-Session-Lineage': '1',
+    });
+
+    expect(response.status).toBe(401);
+    expect(getUserById).toHaveBeenCalledTimes(1);
+    expect(dispatches).not.toHaveBeenCalled();
+  });
+
+  it('rejects an internal-secret-only request', async () => {
+    const response = await request(routes[0], { 'X-Internal-Secret': INTERNAL_SECRET });
+
+    expect(response.status).toBe(401);
+    expect(getUserById).not.toHaveBeenCalled();
+    expect(dispatches).not.toHaveBeenCalled();
+  });
+
+  it('rejects a foreign-audience token before looking up its user', async () => {
+    const token = await signToken({ audience: 'foreign-service' });
+
+    const response = await request(routes[0], {
+      Authorization: `Bearer ${token}`,
+      'X-Internal-Secret': INTERNAL_SECRET,
+    });
+
+    expect(response.status).toBe(401);
+    expect(getUserById).not.toHaveBeenCalled();
+    expect(dispatches).not.toHaveBeenCalled();
+  });
+
+  it('rejects a deletion-audience token without dispatching', async () => {
+    const token = await signToken({ audience: SESSION_INGEST_USER_DELETION_AUDIENCE });
+
+    const response = await request(routes[0], {
+      Authorization: `Bearer ${token}`,
+      'X-Internal-Secret': INTERNAL_SECRET,
+    });
+
+    expect(response.status).toBe(403);
+    expect(getUserById).toHaveBeenCalledTimes(1);
+    expect(dispatches).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wrong internal key after validating an otherwise valid JWT', async () => {
+    const token = await signToken({ audience: SESSION_INGEST_AUDIENCE });
+
+    const response = await request(routes[0], {
+      Authorization: `Bearer ${token}`,
+      'X-Internal-Secret': 'wrong-internal-secret',
+    });
+
+    expect(response.status).toBe(401);
+    expect(getUserById).toHaveBeenCalledTimes(1);
+    expect(dispatches).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['malformed', 'not-a-jwt'],
+    ['expired', () => signToken({ audience: SESSION_INGEST_AUDIENCE, expiresAt: 1 })],
+    [
+      'wrong-signature',
+      () =>
+        signToken({
+          audience: SESSION_INGEST_AUDIENCE,
+          secret: 'another-valid-test-secret-for-hs256',
+        }),
+    ],
+  ] as const)('rejects a %s token with a valid internal key', async (_name, tokenFixture) => {
+    const token = typeof tokenFixture === 'string' ? tokenFixture : await tokenFixture();
+
+    const response = await request(routes[0], {
+      Authorization: `Bearer ${token}`,
+      'X-Internal-Secret': INTERNAL_SECRET,
+    });
+
+    expect(response.status).toBe(401);
+    expect(getUserById).not.toHaveBeenCalled();
+    expect(dispatches).not.toHaveBeenCalled();
+  });
+});

--- a/services/session-ingest/src/middleware/kilo-jwt-auth.test.ts
+++ b/services/session-ingest/src/middleware/kilo-jwt-auth.test.ts
@@ -2,24 +2,29 @@ import { Hono } from 'hono';
 import { SignJWT } from 'jose';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearSecretCacheForTest, signKiloToken } from '@kilocode/worker-utils';
-import { SESSION_INGEST_USER_DELETION_AUDIENCE } from '@kilocode/worker-utils/internal-service-token-audiences';
+import {
+  SESSION_INGEST_AUDIENCE,
+  SESSION_INGEST_USER_DELETION_AUDIENCE,
+} from '@kilocode/worker-utils/internal-service-token-audiences';
 
 import { kiloJwtAuthMiddleware, type KiloJwtAuthVariables } from './kilo-jwt-auth';
 
 const TEST_JWT_SECRET = 'test-secret-that-is-long-enough-for-hs256';
 
 const userRowByUserId = vi.hoisted(
-  () => new Map<string, { pepper: string | null; blockedReason: string | null }>()
+  () => new Map<string, { pepper?: string | null; blockedReason: string | null }>()
 );
 
-const dbState = vi.hoisted(() => ({ fails: false }));
+const dbState = vi.hoisted(() => ({ fails: false, queries: 0, downstreamCalls: 0 }));
+const getWorkerDbMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@kilocode/db/client', () => ({
-  getWorkerDb: () => ({
+  getWorkerDb: getWorkerDbMock.mockImplementation(() => ({
     select: () => ({
       from: () => ({
         where: () => ({
           limit: async () => {
+            dbState.queries++;
             if (dbState.fails) throw new Error('connection refused');
             const row = userRowByUserId.get('usr_123');
             if (!row) return [];
@@ -28,7 +33,7 @@ vi.mock('@kilocode/db/client', () => ({
         }),
       }),
     }),
-  }),
+  })),
 }));
 
 type TicketStore = {
@@ -68,7 +73,7 @@ function makeTicketStore(): TicketStore {
 
 type TestEnv = {
   NEXTAUTH_SECRET_PROD: {
-    get: () => Promise<string>;
+    get: () => Promise<string | null>;
   };
   HYPERDRIVE: {
     connectionString: string;
@@ -76,7 +81,7 @@ type TestEnv = {
   CONNECTION_TICKET_DO: TicketStore['namespace'];
 };
 
-function makeEnv(secret: string, ticketStore: TicketStore = makeTicketStore()): TestEnv {
+function makeEnv(secret: string | null, ticketStore: TicketStore = makeTicketStore()): TestEnv {
   return {
     NEXTAUTH_SECRET_PROD: {
       get: async () => secret,
@@ -89,9 +94,18 @@ function makeEnv(secret: string, ticketStore: TicketStore = makeTicketStore()): 
 function makeApp() {
   const app = new Hono<{ Bindings: TestEnv; Variables: KiloJwtAuthVariables }>();
   app.use('/api/*', kiloJwtAuthMiddleware);
-  app.get('/api/me', c => c.json({ user_id: c.get('user_id') }));
-  app.get('/api/user/cli', c => c.json({ user_id: c.get('user_id') }));
-  app.get('/api/user/web', c => c.json({ user_id: c.get('user_id') }));
+  app.get('/api/me', c => {
+    dbState.downstreamCalls++;
+    return c.json({ user_id: c.get('user_id') });
+  });
+  app.get('/api/user/cli', c => {
+    dbState.downstreamCalls++;
+    return c.json({ user_id: c.get('user_id') });
+  });
+  app.get('/api/user/web', c => {
+    dbState.downstreamCalls++;
+    return c.json({ user_id: c.get('user_id') });
+  });
   app.delete('/api/session/:sessionId', c =>
     c.json({ user_id: c.get('user_id'), deletionAudience: c.get('deletionAudience') === true })
   );
@@ -119,11 +133,63 @@ async function signInternalToken(): Promise<string> {
     .sign(new TextEncoder().encode(TEST_JWT_SECRET));
 }
 
+async function signClaims(
+  claims: Record<string, unknown>,
+  secret = TEST_JWT_SECRET
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3600)
+    .sign(new TextEncoder().encode(secret));
+}
+
+async function signAudienceToken(
+  aud: unknown,
+  options: { pepper?: string | null; env?: string } = {}
+) {
+  return signClaims({
+    version: 3,
+    kiloUserId: 'usr_123',
+    apiTokenPepper: 'pepper' in options ? options.pepper : 'pepper-current',
+    ...('env' in options ? { env: options.env } : { env: 'production' }),
+    aud,
+  });
+}
+
+function request(
+  token: string | null,
+  options: {
+    path?: string;
+    method?: string;
+    websocket?: boolean;
+    query?: string;
+    ticketStore?: TicketStore;
+    secret?: string | null;
+  } = {}
+) {
+  const app = makeApp();
+  const url = `http://local${options.path ?? '/api/me'}${options.query ?? ''}`;
+  const headers = new Headers();
+  if (token !== null) headers.set('Authorization', `Bearer ${token}`);
+  if (options.websocket) headers.set('Upgrade', 'websocket');
+  return {
+    response: app.fetch(
+      new Request(url, { method: options.method, headers }),
+      makeEnv('secret' in options ? (options.secret ?? null) : TEST_JWT_SECRET, options.ticketStore)
+    ),
+  };
+}
+
 describe('kiloJwtAuthMiddleware', () => {
   beforeEach(() => {
     clearSecretCacheForTest();
     userRowByUserId.clear();
     dbState.fails = false;
+    dbState.queries = 0;
+    dbState.downstreamCalls = 0;
+    getWorkerDbMock.mockClear();
   });
 
   it('returns a retryable 503 when the secret store fails', async () => {
@@ -408,5 +474,251 @@ describe('kiloJwtAuthMiddleware', () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ success: false, error: 'Invalid or expired token' });
+  });
+
+  it.each([
+    ['a matching string audience', () => signAudienceToken(SESSION_INGEST_AUDIENCE)],
+    ['a matching array audience', () => signAudienceToken([SESSION_INGEST_AUDIENCE, 'other'])],
+    [
+      'a legacy app-builder token without an environment',
+      () =>
+        signClaims({
+          version: 3,
+          kiloUserId: 'usr_123',
+          apiTokenPepper: 'pepper-current',
+          tokenSource: 'app-builder',
+        }),
+    ],
+    [
+      'a legacy cloud-agent token',
+      () => signClaims({ version: 3, kiloUserId: 'usr_123', tokenSource: 'cloud-agent' }),
+    ],
+    ['a legacy internal token without audience', signInternalToken],
+    [
+      'a resource token with a nonmatching environment',
+      () => signAudienceToken(SESSION_INGEST_AUDIENCE, { env: 'development' }),
+    ],
+  ])('accepts %s through the generic resource branch', async (_name, createToken) => {
+    userRowByUserId.set('usr_123', { pepper: 'pepper-current', blockedReason: null });
+    const { response } = request(await createToken());
+
+    expect((await response).status).toBe(200);
+    expect(dbState.queries).toBe(1);
+    expect(dbState.downstreamCalls).toBe(1);
+  });
+
+  it.each([
+    ['foreign audience', () => signAudienceToken('other-service')],
+    ['explicit null audience', () => signAudienceToken(null)],
+    ['blank audience', () => signAudienceToken('')],
+    [
+      'duplicate audience array',
+      () => signAudienceToken([SESSION_INGEST_AUDIENCE, SESSION_INGEST_AUDIENCE]),
+    ],
+    ['non-string audience array', () => signAudienceToken([SESSION_INGEST_AUDIENCE, 1])],
+    ['empty audience array', () => signAudienceToken([])],
+    ['malformed JWT', async () => 'not-a-jwt'],
+    [
+      'wrong signature',
+      () => signAudienceToken(SESSION_INGEST_AUDIENCE).then(token => `${token}x`),
+    ],
+    [
+      'expired JWT',
+      () =>
+        new SignJWT({ version: 3, kiloUserId: 'usr_123', apiTokenPepper: 'pepper-current' })
+          .setProtectedHeader({ alg: 'HS256' })
+          .setIssuedAt(Math.floor(Date.now() / 1000) - 120)
+          .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+          .setAudience(SESSION_INGEST_AUDIENCE)
+          .sign(new TextEncoder().encode(TEST_JWT_SECRET)),
+    ],
+    [
+      'invalid token schema',
+      () => signClaims({ version: 2, kiloUserId: 'usr_123', aud: SESSION_INGEST_AUDIENCE }),
+    ],
+  ])('rejects %s before database or downstream access', async (_name, createToken) => {
+    const { response } = request(await createToken());
+
+    expect((await response).status).toBe(401);
+    expect(getWorkerDbMock).not.toHaveBeenCalled();
+    expect(dbState.queries).toBe(0);
+    expect(dbState.downstreamCalls).toBe(0);
+  });
+
+  it.each([
+    ['current string pepper', 'pepper-current', 'pepper-current', 200],
+    ['stale string pepper', 'pepper-stale', 'pepper-current', 401],
+    ['null claim against a null current pepper', null, null, 200],
+    ['null claim against an absent current pepper', null, undefined, 200],
+    ['null claim against a current pepper', null, 'pepper-current', 401],
+  ] as const)('enforces %s exactly', async (_name, tokenPepper, currentPepper, status) => {
+    userRowByUserId.set('usr_123', { pepper: currentPepper, blockedReason: null });
+    const { response } = request(
+      await signAudienceToken(SESSION_INGEST_AUDIENCE, { pepper: tokenPepper })
+    );
+
+    expect((await response).status).toBe(status);
+  });
+
+  it('accepts an absent pepper claim, but rejects missing users and blocked resource users', async () => {
+    const internal = await signClaims({
+      version: 3,
+      kiloUserId: 'usr_123',
+      aud: SESSION_INGEST_AUDIENCE,
+    });
+    userRowByUserId.set('usr_123', { pepper: 'pepper-current', blockedReason: null });
+    expect((await request(internal).response).status).toBe(200);
+
+    userRowByUserId.clear();
+    expect((await request(internal).response).status).toBe(401);
+    userRowByUserId.set('usr_123', { pepper: 'pepper-current', blockedReason: 'blocked' });
+    expect((await request(internal).response).status).toBe(401);
+  });
+
+  it('uses identical resource policy for bearer and CLI websocket query tokens', async () => {
+    userRowByUserId.set('usr_123', { pepper: 'pepper-current', blockedReason: null });
+    const token = await signAudienceToken(SESSION_INGEST_AUDIENCE);
+
+    expect((await request(token).response).status).toBe(200);
+    expect(
+      (
+        await request(null, { path: '/api/user/cli', websocket: true, query: `?token=${token}` })
+          .response
+      ).status
+    ).toBe(200);
+    expect(
+      (await request(null, { path: '/api/user/cli', query: `?token=${token}` }).response).status
+    ).toBe(401);
+  });
+
+  it.each(['cloud-agent-next', 'kilo-api', null])(
+    'rejects a %s audience in a legacy CLI websocket query token before lookup',
+    async audience => {
+      userRowByUserId.set('usr_123', { pepper: 'pepper-current', blockedReason: null });
+      const token = await signAudienceToken(audience);
+      const { response } = request(null, {
+        path: '/api/user/cli',
+        websocket: true,
+        query: `?token=${token}`,
+      });
+
+      expect((await response).status).toBe(401);
+      expect(getWorkerDbMock).not.toHaveBeenCalled();
+      expect(dbState.downstreamCalls).toBe(0);
+    }
+  );
+
+  it('does not fall back from an invalid bearer to a valid websocket query token', async () => {
+    userRowByUserId.set('usr_123', { pepper: 'pepper-current', blockedReason: null });
+    const validToken = await signAudienceToken(SESSION_INGEST_AUDIENCE);
+    const { response } = request('not-a-jwt', {
+      path: '/api/user/cli',
+      websocket: true,
+      query: `?token=${validToken}`,
+    });
+
+    expect((await response).status).toBe(401);
+    expect(dbState.queries).toBe(0);
+  });
+
+  it('keeps web websocket tickets opaque and cannot fall back to JWT credentials', async () => {
+    userRowByUserId.set('usr_123', { pepper: 'pepper-current', blockedReason: null });
+    const jwt = await signAudienceToken(SESSION_INGEST_AUDIENCE);
+    const tickets = makeTicketStore();
+    const ticket = tickets.mint('usr_123', Date.now() + 60_000);
+
+    expect(
+      (
+        await request('not-a-jwt', {
+          path: '/api/user/web',
+          websocket: true,
+          query: `?ticket=${ticket}`,
+          ticketStore: tickets,
+        }).response
+      ).status
+    ).toBe(200);
+    expect(dbState.queries).toBe(0);
+    expect(
+      (
+        await request(jwt, { path: '/api/user/web', websocket: true, ticketStore: tickets })
+          .response
+      ).status
+    ).toBe(401);
+    expect(
+      (
+        await request(jwt, {
+          path: '/api/user/web',
+          websocket: true,
+          query: '?ticket=invalid',
+          ticketStore: tickets,
+        }).response
+      ).status
+    ).toBe(401);
+    expect(dbState.queries).toBe(0);
+  });
+
+  it.each([null, ''] as const)('maps a %s secret result to 503', async secret => {
+    const token = await signAudienceToken(SESSION_INGEST_AUDIENCE);
+    const { response } = request(token, { secret });
+    expect((await response).status).toBe(503);
+  });
+
+  it.each([null, 'deleted'])(
+    'keeps deletion validation first for a mixed-audience token when blockedReason is %s',
+    async blockedReason => {
+      const deletion = await signClaims({
+        version: 3,
+        kiloUserId: 'usr_123',
+        apiTokenPepper: 'pepper-current',
+        aud: [SESSION_INGEST_AUDIENCE, SESSION_INGEST_USER_DELETION_AUDIENCE],
+      });
+      userRowByUserId.set('usr_123', { pepper: 'pepper-current', blockedReason });
+
+      expect((await request(deletion, { path: '/api/me' }).response).status).toBe(403);
+      expect((await request(deletion, { path: '/api/session/ses_abc' }).response).status).toBe(403);
+      const cleanup = await request(deletion, { path: '/api/session/ses_abc', method: 'DELETE' })
+        .response;
+      expect(cleanup.status).toBe(200);
+      expect(await cleanup.json()).toEqual({ user_id: 'usr_123', deletionAudience: true });
+      expect(
+        (await request(deletion, { path: '/api/session/ses_abc/child', method: 'DELETE' }).response)
+          .status
+      ).toBe(403);
+    }
+  );
+
+  it('allows only active resource or legacy DELETE users and preserves deletion assertion checks', async () => {
+    const resource = await signAudienceToken(SESSION_INGEST_AUDIENCE);
+    const legacy = await signUserToken('pepper-current');
+    const deletion = await signClaims({
+      version: 3,
+      kiloUserId: 'usr_123',
+      apiTokenPepper: 'pepper-current',
+      aud: SESSION_INGEST_USER_DELETION_AUDIENCE,
+    });
+
+    userRowByUserId.set('usr_123', { pepper: 'pepper-current', blockedReason: null });
+    const resourceResponse = await request(resource, {
+      path: '/api/session/ses_abc',
+      method: 'DELETE',
+    }).response;
+    expect(resourceResponse.status).toBe(200);
+    expect(await resourceResponse.json()).toEqual({ user_id: 'usr_123', deletionAudience: false });
+    const legacyResponse = await request(legacy, { path: '/api/session/ses_abc', method: 'DELETE' })
+      .response;
+    expect(legacyResponse.status).toBe(200);
+    expect(await legacyResponse.json()).toEqual({ user_id: 'usr_123', deletionAudience: false });
+    userRowByUserId.set('usr_123', { pepper: 'pepper-current', blockedReason: 'blocked' });
+    expect(
+      (await request(resource, { path: '/api/session/ses_abc', method: 'DELETE' }).response).status
+    ).toBe(401);
+    userRowByUserId.clear();
+    expect(
+      (await request(deletion, { path: '/api/session/ses_abc', method: 'DELETE' }).response).status
+    ).toBe(401);
+    userRowByUserId.set('usr_123', { pepper: 'pepper-stale', blockedReason: 'deleted' });
+    expect(
+      (await request(deletion, { path: '/api/session/ses_abc', method: 'DELETE' }).response).status
+    ).toBe(401);
   });
 });

--- a/services/session-ingest/src/middleware/kilo-jwt-auth.ts
+++ b/services/session-ingest/src/middleware/kilo-jwt-auth.ts
@@ -1,6 +1,9 @@
 import { createMiddleware } from 'hono/factory';
 import { extractBearerToken } from '@kilocode/worker-utils';
-import { SESSION_INGEST_USER_DELETION_AUDIENCE } from '@kilocode/worker-utils/internal-service-token-audiences';
+import {
+  SESSION_INGEST_AUDIENCE,
+  SESSION_INGEST_USER_DELETION_AUDIENCE,
+} from '@kilocode/worker-utils/internal-service-token-audiences';
 import { verifyKiloBearerAgainstCurrentPepper } from '@kilocode/worker-utils/kilo-token-auth';
 
 import type { Env } from '../env';
@@ -73,6 +76,7 @@ export const kiloJwtAuthMiddleware = createMiddleware<{
         token,
         nextAuthSecret: c.env.NEXTAUTH_SECRET_PROD,
         connectionString: c.env.HYPERDRIVE.connectionString,
+        resourceAudience: { audience: SESSION_INGEST_AUDIENCE, mode: 'allow-legacy' },
       });
     }
   } catch (error) {


### PR DESCRIPTION
## Summary

Phase 4, batch 4: enable the generic Session Ingest JWT reader to accept tokens addressed to `session-ingest`, reject explicit audience mismatches, and preserve supported audience-less legacy tokens.

The production change is confined to the generic verification branch. Dedicated deletion assertions, blocked-user cleanup, web connection tickets, and public share tokens retain their existing separate behavior.

## Verification

No manual browser, deployed-service, or production credential testing was performed. Signed-token and actual Hono authentication routing were exercised through automated tests with local/mock dependencies; existing Workers-runtime suites were also run. Automated results are listed below.

## Visual Changes

N/A

## Reviewer Notes

- Preserve strict deletion-first verification using `session-ingest:user-deletion` and its leaf-DELETE-only restriction. Generic resource tokens do not gain the blocked-user exception or the `deletionAudience` flag.
- Mixed resource/deletion audience tests cover both active and blocked users, ensuring deletion validation wins even when generic authentication could succeed.
- Preserve HTTP bearer and legacy CLI WebSocket query-token semantics. A present invalid bearer cannot fall back to a valid query token; web WebSocket upgrades continue to consume only opaque, single-use tickets.
- Preserve current pepper/account checks and retryable 503 responses for secret-store/database failures. No new environment-equality requirement is introduced.
- New scoped-route tests use the actual JWT and internal-secret middleware, with dispatch mocked at the route boundary. Both credentials remain required; a trusted-lineage header or internal secret cannot authorize an invalid JWT.
- No issuer, lifetime, share-token, DO/RPC implementation, or other-service changes. This PR targets `main` independently of the Cloud Agent batch #5835. System-wide issuer migration is still separate work.
- This PR does not change the legacy device-auth Sentry telemetry discussed separately.

Automated validation:
- Session Ingest unit suites: 1,075 passed, 3 skipped.
- Existing Workers-runtime integration suites: 94 passed. Their harness does not mount the production HTTP auth app; real HTTP auth-chain coverage is in the Node/Hono tests.
- Shared JWT verification/authentication/policy suites: 192 passed.
- Service lint and typecheck passed; changed files formatted and whitespace checks passed.