### PR TITLE
feat(web): gate data export UI behind PostHog flag

### DIFF
--- a/apps/storybook/stories/Sidebar.stories.tsx
+++ b/apps/storybook/stories/Sidebar.stories.tsx
@@ -14,7 +14,6 @@ import {
   Database,
   Download,
   Factory,
-  Gift,
   Key,
   List,
   ListChecks,
@@ -46,7 +45,7 @@ import {
   type OrganizationSwitcherOrganization,
 } from '@/app/(app)/components/OrganizationSwitcher';
 import SidebarMenuList from '@/app/(app)/components/SidebarMenuList';
-import SidebarUserFooter from '@/app/(app)/components/SidebarUserFooter';
+import { SidebarUserFooterView as SidebarUserFooter } from '@/app/(app)/components/SidebarUserFooter';
 
 const meta: Meta = {
   title: 'Components/Layout/Sidebar',

--- a/apps/web/src/app/(app)/components/SidebarUserFooter.test.ts
+++ b/apps/web/src/app/(app)/components/SidebarUserFooter.test.ts
@@ -51,7 +51,9 @@ describe('SidebarUserFooter export entry shared by personal and organization sid
       isSuccess: true,
     });
 
-    expect(await renderFooter()).toContain('Request data export');
+    const html = await renderFooter();
+    expect(html).toContain('Request data export');
+    expect(html).not.toContain('Request data deletion');
     expect(mockQueryOptions).toHaveBeenCalledWith(
       undefined,
       expect.objectContaining({ enabled: true })
@@ -64,12 +66,13 @@ describe('SidebarUserFooter export entry shared by personal and organization sid
     { data: { enabled: undefined, email: user.google_user_email }, isSuccess: true },
     { data: { enabled: true, email: user.google_user_email }, isSuccess: false },
     { data: { enabled: true, email: 'previous-user@example.com' }, isSuccess: true },
-  ])('hides export but preserves other menu entries for %j', async result => {
+  ])('keeps deletion reachable while hiding export for %j', async result => {
     mockUseQuery.mockReturnValue(result);
 
     const html = await renderFooter();
 
     expect(html).not.toContain('Request data export');
+    expect(html).toContain('Request data deletion');
     expect(html).toContain('Connected Accounts');
     expect(html).toContain('Install');
     expect(html).toContain('Learn');
@@ -84,6 +87,7 @@ describe('SidebarUserFooter export entry shared by personal and organization sid
 
     expect(html).toContain('Connected Accounts');
     expect(html).not.toContain('Request data export');
+    expect(html).toContain('Request data deletion');
     expect(mockUseQuery).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/(app)/components/SidebarUserFooter.test.ts
+++ b/apps/web/src/app/(app)/components/SidebarUserFooter.test.ts
@@ -1,0 +1,102 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const mockUseQuery = jest.fn();
+const mockQueryOptions = jest.fn((_input, options) => options);
+const mockPush = jest.fn();
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+}));
+jest.mock('@/lib/trpc/utils', () => ({
+  useTRPC: () => ({ userExports: { uiAccess: { queryOptions: mockQueryOptions } } }),
+}));
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }));
+jest.mock('next-auth/react', () => ({ signOut: jest.fn() }));
+jest.mock('@/components/ui/sidebar', () => ({
+  SidebarFooter: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('@/components/ui/dropdown-menu', () => {
+  const Content = ({ children }: { children: React.ReactNode }) => children;
+  return {
+    DropdownMenu: Content,
+    DropdownMenuContent: Content,
+    DropdownMenuItem: Content,
+    DropdownMenuTrigger: Content,
+    DropdownMenuSeparator: () => null,
+  };
+});
+
+const user = {
+  google_user_email: 'export-user@example.com',
+  google_user_name: 'Export User',
+  google_user_image_url: '',
+};
+
+describe('SidebarUserFooter export entry shared by personal and organization sidebars', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  async function renderFooter(isLoading = false) {
+    const { default: SidebarUserFooter } = await import('./SidebarUserFooter');
+    return renderToStaticMarkup(React.createElement(SidebarUserFooter, { user, isLoading }));
+  }
+
+  it('shows the export entry only for a successful enabled result for this user', async () => {
+    mockUseQuery.mockReturnValue({
+      data: { enabled: true, email: user.google_user_email },
+      isSuccess: true,
+    });
+
+    expect(await renderFooter()).toContain('Request data export');
+    expect(mockQueryOptions).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ enabled: true })
+    );
+  });
+
+  it.each([
+    { data: { enabled: false, email: user.google_user_email }, isSuccess: true },
+    { data: undefined, isSuccess: false },
+    { data: { enabled: undefined, email: user.google_user_email }, isSuccess: true },
+    { data: { enabled: true, email: user.google_user_email }, isSuccess: false },
+    { data: { enabled: true, email: 'previous-user@example.com' }, isSuccess: true },
+  ])('hides export but preserves other menu entries for %j', async result => {
+    mockUseQuery.mockReturnValue(result);
+
+    const html = await renderFooter();
+
+    expect(html).not.toContain('Request data export');
+    expect(html).toContain('Connected Accounts');
+    expect(html).toContain('Install');
+    expect(html).toContain('Learn');
+    expect(html).toContain('Sign out');
+  });
+
+  it('keeps the standalone view fail-closed without a query provider', async () => {
+    const { SidebarUserFooterView } = await import('./SidebarUserFooter');
+    const html = renderToStaticMarkup(
+      React.createElement(SidebarUserFooterView, { user, isLoading: false })
+    );
+
+    expect(html).toContain('Connected Accounts');
+    expect(html).not.toContain('Request data export');
+    expect(mockUseQuery).not.toHaveBeenCalled();
+  });
+
+  it('does not query or show export while the user is loading', async () => {
+    mockUseQuery.mockReturnValue({
+      data: { enabled: true, email: user.google_user_email },
+      isSuccess: true,
+    });
+
+    expect(await renderFooter(true)).not.toContain('Request data export');
+    expect(mockQueryOptions).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ enabled: false })
+    );
+  });
+});

--- a/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
+++ b/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
@@ -13,6 +13,8 @@ import { Avatar, AvatarImage, AvatarFallback } from '@radix-ui/react-avatar';
 import { BookOpen, ChevronsUpDown, Download, FileDown, LogOut, UserCog } from 'lucide-react';
 import { signOut } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/utils';
 
 type User = {
   google_user_name: string;
@@ -35,6 +37,30 @@ function getUserInitials(name: string) {
 }
 
 export default function SidebarUserFooter({ user, isLoading }: SidebarUserFooterProps) {
+  const trpc = useTRPC();
+  const { data: exportUIAccess, isSuccess } = useQuery(
+    trpc.userExports.uiAccess.queryOptions(undefined, {
+      enabled: !isLoading && !!user,
+      staleTime: 0,
+      gcTime: 0,
+      refetchOnMount: 'always',
+    })
+  );
+  const showDataExport =
+    isSuccess &&
+    exportUIAccess?.enabled === true &&
+    exportUIAccess.email === user?.google_user_email;
+
+  return (
+    <SidebarUserFooterView user={user} isLoading={isLoading} dataExportEnabled={showDataExport} />
+  );
+}
+
+export function SidebarUserFooterView({
+  user,
+  isLoading,
+  dataExportEnabled = false,
+}: SidebarUserFooterProps & { dataExportEnabled?: boolean }) {
   const router = useRouter();
 
   const handleLogout = async () => {
@@ -85,10 +111,12 @@ export default function SidebarUserFooter({ user, isLoading }: SidebarUserFooter
               <UserCog className="h-4 w-4" />
               Connected Accounts
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => router.push('/data-exports')}>
-              <FileDown className="h-4 w-4" />
-              Request data export
-            </DropdownMenuItem>
+            {dataExportEnabled === true && (
+              <DropdownMenuItem onClick={() => router.push('/data-exports')}>
+                <FileDown className="h-4 w-4" />
+                Request data export
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem onClick={() => router.push('/install')}>
               <Download className="h-4 w-4" />
               Install

--- a/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
+++ b/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
@@ -10,7 +10,15 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Avatar, AvatarImage, AvatarFallback } from '@radix-ui/react-avatar';
-import { BookOpen, ChevronsUpDown, Download, FileDown, LogOut, UserCog } from 'lucide-react';
+import {
+  BookOpen,
+  ChevronsUpDown,
+  Download,
+  FileDown,
+  LogOut,
+  Trash2,
+  UserCog,
+} from 'lucide-react';
 import { signOut } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
@@ -111,12 +119,19 @@ export function SidebarUserFooterView({
               <UserCog className="h-4 w-4" />
               Connected Accounts
             </DropdownMenuItem>
-            {dataExportEnabled === true && (
-              <DropdownMenuItem onClick={() => router.push('/data-exports')}>
-                <FileDown className="h-4 w-4" />
-                Request data export
-              </DropdownMenuItem>
-            )}
+            <DropdownMenuItem onClick={() => router.push('/data-exports')}>
+              {dataExportEnabled === true ? (
+                <>
+                  <FileDown className="h-4 w-4" />
+                  Request data export
+                </>
+              ) : (
+                <>
+                  <Trash2 className="h-4 w-4" />
+                  Request data deletion
+                </>
+              )}
+            </DropdownMenuItem>
             <DropdownMenuItem onClick={() => router.push('/install')}>
               <Download className="h-4 w-4" />
               Install

--- a/apps/web/src/app/(app)/data-exports/page.test.ts
+++ b/apps/web/src/app/(app)/data-exports/page.test.ts
@@ -12,13 +12,23 @@ jest.mock('@/lib/user/server', () => ({
 jest.mock('@/lib/user-data-export-ui', () => ({
   isCloudDataExportUIEnabled: mockIsCloudDataExportUIEnabled,
 }));
-jest.mock('next/navigation', () => ({
-  notFound: () => {
-    throw new Error('NEXT_NOT_FOUND');
-  },
-}));
 jest.mock('@/components/PageLayout', () => ({
-  PageLayout: ({ children }: { children: React.ReactNode }) => children,
+  PageLayout: ({
+    children,
+    title,
+    subtitle,
+  }: {
+    children: React.ReactNode;
+    title: string;
+    subtitle: string;
+  }) =>
+    React.createElement(
+      'main',
+      null,
+      React.createElement('h1', null, title),
+      React.createElement('p', null, subtitle),
+      children
+    ),
 }));
 jest.mock('./DataExportsClient', () => ({ DataExportsClient: () => 'Export controls' }));
 jest.mock('./RequestDataDeletionCard', () => ({
@@ -52,23 +62,35 @@ describe('DataExportsPage', () => {
 
     const html = renderToStaticMarkup(await DataExportsPage());
 
+    expect(html).toContain('<h1>Data exports</h1>');
+    expect(html).toContain(
+      'Request and download a copy of the data stored with your Kilo account.'
+    );
     expect(html).toContain('Export controls');
     expect(html).toContain('Deletion support');
     expect(mockIsCloudDataExportUIEnabled).toHaveBeenCalledWith('export-user@example.com');
   });
 
-  it.each([false, undefined])('rejects direct access when the flag is %s', async enabled => {
-    mockIsCloudDataExportUIEnabled.mockResolvedValue(enabled);
-    const { default: DataExportsPage } = await import('./page');
+  it.each([false, undefined])(
+    'preserves deletion without export controls when the flag is %s',
+    async enabled => {
+      mockIsCloudDataExportUIEnabled.mockResolvedValue(enabled);
+      const { default: DataExportsPage } = await import('./page');
 
-    await expect(DataExportsPage()).rejects.toThrow('NEXT_NOT_FOUND');
-  });
+      const html = renderToStaticMarkup(await DataExportsPage());
+
+      expect(html).toContain('<h1>Data deletion</h1>');
+      expect(html).toContain('Deletion support');
+      expect(html).not.toContain('Export controls');
+      expect(html).not.toContain('Request and download a copy');
+    }
+  );
 
   it('does not render while the flag evaluation is pending', async () => {
     const flag = Promise.withResolvers<boolean>();
     mockIsCloudDataExportUIEnabled.mockReturnValue(flag.promise);
     const { default: DataExportsPage } = await import('./page');
-    const rendered = jest.fn();
+    const rendered = jest.fn(renderToStaticMarkup);
     const result = DataExportsPage().then(rendered);
 
     await Promise.resolve();
@@ -76,8 +98,9 @@ describe('DataExportsPage', () => {
     expect(rendered).not.toHaveBeenCalled();
 
     flag.resolve(false);
-    await expect(result).rejects.toThrow('NEXT_NOT_FOUND');
-    expect(rendered).not.toHaveBeenCalled();
+    const html = await result;
+    expect(html).toContain('Deletion support');
+    expect(html).not.toContain('Export controls');
   });
 
   it('does not bypass the flag for staff', async () => {
@@ -89,6 +112,8 @@ describe('DataExportsPage', () => {
     mockIsCloudDataExportUIEnabled.mockResolvedValue(false);
     const { default: DataExportsPage } = await import('./page');
 
-    await expect(DataExportsPage()).rejects.toThrow('NEXT_NOT_FOUND');
+    const html = renderToStaticMarkup(await DataExportsPage());
+    expect(html).toContain('Deletion support');
+    expect(html).not.toContain('Export controls');
   });
 });

--- a/apps/web/src/app/(app)/data-exports/page.test.ts
+++ b/apps/web/src/app/(app)/data-exports/page.test.ts
@@ -1,22 +1,41 @@
 import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 const mockGetUserFromAuthOrRedirect = jest.fn();
+const mockIsCloudDataExportUIEnabled = jest.fn();
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 
 jest.mock('@/lib/user/server', () => ({
   getUserFromAuthOrRedirect: mockGetUserFromAuthOrRedirect,
 }));
-jest.mock('@/components/PageLayout', () => ({ PageLayout: () => null }));
-jest.mock('./DataExportsClient', () => ({ DataExportsClient: () => null }));
-jest.mock('./RequestDataDeletionCard', () => ({ RequestDataDeletionCard: () => null }));
+jest.mock('@/lib/user-data-export-ui', () => ({
+  isCloudDataExportUIEnabled: mockIsCloudDataExportUIEnabled,
+}));
+jest.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new Error('NEXT_NOT_FOUND');
+  },
+}));
+jest.mock('@/components/PageLayout', () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('./DataExportsClient', () => ({ DataExportsClient: () => 'Export controls' }));
+jest.mock('./RequestDataDeletionCard', () => ({
+  RequestDataDeletionCard: () => 'Deletion support',
+}));
 
 describe('DataExportsPage', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
+    mockGetUserFromAuthOrRedirect.mockResolvedValue({
+      id: 'user-1',
+      google_user_email: 'export-user@example.com',
+      is_admin: false,
+    });
   });
 
-  it('redirects unauthenticated visitors to sign in and returns them to data exports', async () => {
+  it('redirects unauthenticated visitors before evaluating the flag', async () => {
     mockGetUserFromAuthOrRedirect.mockRejectedValue(new Error('NEXT_REDIRECT'));
     const { default: DataExportsPage } = await import('./page');
 
@@ -24,15 +43,52 @@ describe('DataExportsPage', () => {
     expect(mockGetUserFromAuthOrRedirect).toHaveBeenCalledWith(
       '/users/sign_in?callbackPath=/data-exports'
     );
+    expect(mockIsCloudDataExportUIEnabled).not.toHaveBeenCalled();
   });
 
-  it('renders for a signed-in non-admin user', async () => {
-    mockGetUserFromAuthOrRedirect.mockResolvedValue({ id: 'user-1', is_admin: false });
+  it('preserves the page for an enabled non-admin user', async () => {
+    mockIsCloudDataExportUIEnabled.mockResolvedValue(true);
     const { default: DataExportsPage } = await import('./page');
 
-    await expect(DataExportsPage()).resolves.toBeTruthy();
-    expect(mockGetUserFromAuthOrRedirect).toHaveBeenCalledWith(
-      '/users/sign_in?callbackPath=/data-exports'
-    );
+    const html = renderToStaticMarkup(await DataExportsPage());
+
+    expect(html).toContain('Export controls');
+    expect(html).toContain('Deletion support');
+    expect(mockIsCloudDataExportUIEnabled).toHaveBeenCalledWith('export-user@example.com');
+  });
+
+  it.each([false, undefined])('rejects direct access when the flag is %s', async enabled => {
+    mockIsCloudDataExportUIEnabled.mockResolvedValue(enabled);
+    const { default: DataExportsPage } = await import('./page');
+
+    await expect(DataExportsPage()).rejects.toThrow('NEXT_NOT_FOUND');
+  });
+
+  it('does not render while the flag evaluation is pending', async () => {
+    const flag = Promise.withResolvers<boolean>();
+    mockIsCloudDataExportUIEnabled.mockReturnValue(flag.promise);
+    const { default: DataExportsPage } = await import('./page');
+    const rendered = jest.fn();
+    const result = DataExportsPage().then(rendered);
+
+    await Promise.resolve();
+    expect(mockIsCloudDataExportUIEnabled).toHaveBeenCalled();
+    expect(rendered).not.toHaveBeenCalled();
+
+    flag.resolve(false);
+    await expect(result).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(rendered).not.toHaveBeenCalled();
+  });
+
+  it('does not bypass the flag for staff', async () => {
+    mockGetUserFromAuthOrRedirect.mockResolvedValue({
+      id: 'admin-1',
+      google_user_email: 'staff@example.com',
+      is_admin: true,
+    });
+    mockIsCloudDataExportUIEnabled.mockResolvedValue(false);
+    const { default: DataExportsPage } = await import('./page');
+
+    await expect(DataExportsPage()).rejects.toThrow('NEXT_NOT_FOUND');
   });
 });

--- a/apps/web/src/app/(app)/data-exports/page.tsx
+++ b/apps/web/src/app/(app)/data-exports/page.tsx
@@ -1,4 +1,3 @@
-import { notFound } from 'next/navigation';
 import { getUserFromAuthOrRedirect } from '@/lib/user/server';
 import { isCloudDataExportUIEnabled } from '@/lib/user-data-export-ui';
 import { PageLayout } from '@/components/PageLayout';
@@ -7,16 +6,18 @@ import { RequestDataDeletionCard } from './RequestDataDeletionCard';
 
 export default async function DataExportsPage() {
   const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/data-exports');
-  if ((await isCloudDataExportUIEnabled(user.google_user_email)) !== true) {
-    notFound();
-  }
+  const exportUIEnabled = (await isCloudDataExportUIEnabled(user.google_user_email)) === true;
 
   return (
     <PageLayout
-      title="Data exports"
-      subtitle="Request and download a copy of the data stored with your Kilo account."
+      title={exportUIEnabled ? 'Data exports' : 'Data deletion'}
+      subtitle={
+        exportUIEnabled
+          ? 'Request and download a copy of the data stored with your Kilo account.'
+          : 'Request deletion of your Kilo account and its data through our support team.'
+      }
     >
-      <DataExportsClient />
+      {exportUIEnabled && <DataExportsClient />}
       <RequestDataDeletionCard />
     </PageLayout>
   );

--- a/apps/web/src/app/(app)/data-exports/page.tsx
+++ b/apps/web/src/app/(app)/data-exports/page.tsx
@@ -1,10 +1,15 @@
+import { notFound } from 'next/navigation';
 import { getUserFromAuthOrRedirect } from '@/lib/user/server';
+import { isCloudDataExportUIEnabled } from '@/lib/user-data-export-ui';
 import { PageLayout } from '@/components/PageLayout';
 import { DataExportsClient } from './DataExportsClient';
 import { RequestDataDeletionCard } from './RequestDataDeletionCard';
 
 export default async function DataExportsPage() {
-  await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/data-exports');
+  const user = await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/data-exports');
+  if ((await isCloudDataExportUIEnabled(user.google_user_email)) !== true) {
+    notFound();
+  }
 
   return (
     <PageLayout

--- a/apps/web/src/lib/user-data-export-ui.test.ts
+++ b/apps/web/src/lib/user-data-export-ui.test.ts
@@ -1,0 +1,62 @@
+import { isCloudDataExportUIEnabled } from './user-data-export-ui';
+
+jest.mock('@/lib/posthog', () => ({
+  __esModule: true,
+  default: () => ({ getFeatureFlag: (...args: unknown[]) => mockGetFeatureFlag(...args) }),
+}));
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+  startSpan: async (_context: unknown, callback: () => Promise<unknown>) => callback(),
+}));
+
+const mockGetFeatureFlag = jest.fn();
+
+describe('cloud data export UI flag', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses the same email distinct ID as browser PostHog identification', async () => {
+    mockGetFeatureFlag.mockResolvedValue(true);
+
+    await expect(isCloudDataExportUIEnabled('export-user@example.com')).resolves.toBe(true);
+    expect(mockGetFeatureFlag).toHaveBeenCalledWith(
+      'cloud-data-export-ui',
+      'export-user@example.com'
+    );
+  });
+
+  it.each([false, undefined, 'enabled'])('fails closed for %s', async value => {
+    mockGetFeatureFlag.mockResolvedValue(value);
+
+    await expect(isCloudDataExportUIEnabled('export-user@example.com')).resolves.toBe(false);
+  });
+
+  it('fails closed on PostHog errors', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetFeatureFlag.mockRejectedValue(new Error('PostHog unavailable'));
+
+    try {
+      await expect(isCloudDataExportUIEnabled('export-user@example.com')).resolves.toBe(false);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('does not fall back to an anonymous or shared identity', async () => {
+    await expect(isCloudDataExportUIEnabled('')).resolves.toBe(false);
+    expect(mockGetFeatureFlag).not.toHaveBeenCalled();
+  });
+
+  it('does not bypass the flag in development', async () => {
+    const env = jest.replaceProperty(process, 'env', { ...process.env, NODE_ENV: 'development' });
+    mockGetFeatureFlag.mockResolvedValue(undefined);
+
+    try {
+      await expect(isCloudDataExportUIEnabled('export-user@example.com')).resolves.toBe(false);
+      expect(mockGetFeatureFlag).toHaveBeenCalled();
+    } finally {
+      env.restore();
+    }
+  });
+});

--- a/apps/web/src/lib/user-data-export-ui.ts
+++ b/apps/web/src/lib/user-data-export-ui.ts
@@ -1,0 +1,9 @@
+import 'server-only';
+
+import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
+
+export async function isCloudDataExportUIEnabled(email: string): Promise<boolean> {
+  if (!email) return false;
+
+  return isReleaseToggleEnabled('cloud-data-export-ui', email);
+}

--- a/apps/web/src/routers/user-exports-router.test.ts
+++ b/apps/web/src/routers/user-exports-router.test.ts
@@ -1,4 +1,9 @@
 import { TRPCError } from '@trpc/server';
+import { isCloudDataExportUIEnabled } from '@/lib/user-data-export-ui';
+
+jest.mock('@/lib/user-data-export-ui', () => ({
+  isCloudDataExportUIEnabled: jest.fn(async () => false),
+}));
 import { eq, sql } from 'drizzle-orm';
 import { DOWNLOAD_CODE_LENGTH } from '@/app/(app)/data-exports/data-export-contract';
 import { db } from '@/lib/drizzle';
@@ -10,7 +15,7 @@ import {
   type User,
 } from '@kilocode/db/schema';
 import { createCallerForUser } from '@/routers/test-utils';
-import { __test__ } from '@/routers/user-exports-router';
+import { __test__, userExportsRouter } from '@/routers/user-exports-router';
 import { createTestOrganization } from '@/tests/helpers/organization.helper';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 
@@ -122,6 +127,38 @@ async function requestCode(kiloUserId: string, exportId: string) {
   const { challengeId } = await caller.userExports.requestDownloadCode({ exportId });
   return { caller, challengeId, code: lastEmailedCode() };
 }
+
+describe('user export UI access', () => {
+  it('rejects token authentication before evaluating UI eligibility', async () => {
+    const caller = userExportsRouter.createCaller({ user: stranger, authViaToken: true });
+
+    await expect(caller.uiAccess()).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(isCloudDataExportUIEnabled).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    'evaluates %s for the authenticated email, not the user ID',
+    async enabled => {
+      jest.mocked(isCloudDataExportUIEnabled).mockResolvedValueOnce(enabled);
+      const caller = await createCallerForUser(stranger.id);
+
+      await expect(caller.userExports.uiAccess()).resolves.toEqual({
+        enabled,
+        email: stranger.google_user_email,
+      });
+      expect(isCloudDataExportUIEnabled).toHaveBeenCalledWith(stranger.google_user_email);
+    }
+  );
+
+  it('keeps existing export APIs available when the UI flag is off', async () => {
+    const caller = await createCallerForUser(stranger.id);
+    await expect(caller.userExports.uiAccess()).resolves.toMatchObject({ enabled: false });
+    await expect(caller.userExports.request()).resolves.toMatchObject({
+      subjectType: 'user',
+      status: 'queued',
+    });
+  });
+});
 
 describe('user exports router guards and serialization', () => {
   it('rejects API-token authentication for data export procedures', () => {

--- a/apps/web/src/routers/user-exports-router.ts
+++ b/apps/web/src/routers/user-exports-router.ts
@@ -17,6 +17,7 @@ import {
 } from '@/lib/auth/data-export-download-codes';
 import { db } from '@/lib/drizzle';
 import { sendDataExportDownloadCodeEmail } from '@/lib/email';
+import { isCloudDataExportUIEnabled } from '@/lib/user-data-export-ui';
 import { baseProcedure, createTRPCRouter, type TRPCContext } from '@/lib/trpc/init';
 import {
   ORGANIZATION_EXPORT_ROLES,
@@ -419,6 +420,14 @@ function downloadCodeError(result: Exclude<ReserveDownloadCodeResult, 'ok'>): TR
 }
 
 export const userExportsRouter = createTRPCRouter({
+  uiAccess: baseProcedure.query(async ({ ctx }) => {
+    requireWebSession(ctx.authViaToken);
+    return {
+      enabled: await isCloudDataExportUIEnabled(ctx.user.google_user_email),
+      email: ctx.user.google_user_email,
+    };
+  }),
+
   request: baseProcedure.mutation(async ({ ctx }) => {
     requireWebSession(ctx.authViaToken);
     const row = await createExportRequest({ kiloUserId: ctx.user.id, organizationId: null });


### PR DESCRIPTION
## Summary

- Gate the shared personal/organization sidebar's **Request data export** entry and direct `/data-exports` access with the existing `cloud-data-export-ui` PostHog flag. Only literal `true` enables the UI; disabled, unresolved, multivariate, and error results fail closed.
- Share the existing strict server-side release-toggle evaluation between the page and an authenticated `userExports.uiAccess` query, targeting the account email to match browser PostHog identification. Hide stale results belonging to another account and keep the sidebar's standalone Storybook view provider-free.
- Preserve all existing authentication, organization authorization, export APIs, admin recovery, and background processing. No remote PostHog flag was created or changed.

## Verification


## Visual Changes


## Reviewer Notes

- Review the shared email-based targeting contract and fail-closed behavior, including pending queries, failed refreshes, and cached results for a different account. There is no development or staff bypass.
- The page-level server gate covers bookmarks and existing ready-email links before export controls mount. This is deliberately a customer-UI rollout, not an API/job kill switch; admin health/recovery and existing authorization checks remain untouched.
- flag is enabled for all kilo address - and off everyone else. The feature flag in posthog support explicit email check/list - only member currently is my personal address
