### PR TITLE
fix(git-token-service): allow GitHub npm registry capabilities

### DIFF
--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -1195,11 +1195,17 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
   });
 
   it.each([
-    ['POST', 'https://api.github.com/graphql'],
-    ['GET', 'https://github.com/acme/other.git/info/refs?service=git-upload-pack'],
+    ['POST', 'https://api.github.com/graphql', 'repository_mismatch'],
+    [
+      'GET',
+      'https://github.com/acme/other.git/info/refs?service=git-upload-pack',
+      'repository_mismatch',
+    ],
+    ['GET', 'https://npm.pkg.github.com/@acme/design', 'upstream_host_not_allowed'],
+    ['GET', 'https://npm.pkg.github.com/@acme%2fdesign', 'invalid_upstream_url'],
   ] as const)(
     'keeps legacy unbound GitHub capabilities repository-confined for %s %s',
-    async (requestMethod, requestUrl) => {
+    async (requestMethod, requestUrl, reason) => {
       const service = createService();
       const issued = await service.issueGitHubSessionCapability({
         githubRepo: 'acme/repo',
@@ -1215,7 +1221,7 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
           requestMethod,
           requestUrl,
         })
-      ).resolves.toEqual({ success: false, reason: 'repository_mismatch' });
+      ).resolves.toEqual({ success: false, reason });
       expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
     }
   );
@@ -1335,6 +1341,8 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
     ['GET', 'https://api.github.com/user/repos'],
     ['DELETE', 'https://api.github.com/repos/acme/other/issues/42/comments/1'],
     ['GET', 'https://api.github.com/repos/acme/repo/contents/src%2Findex.ts'],
+    ['GET', 'https://npm.pkg.github.com/@acme%2fdesign'],
+    ['GET', 'https://npm.pkg.github.com/download/@acme/design/1.0.0/package.tgz'],
     ['POST', 'https://uploads.github.com/repos/acme/other/releases/1/assets?name=asset.zip'],
     ['POST', 'https://github.com/acme/other.git/info/lfs/objects/batch'],
   ] as const)(
@@ -1427,6 +1435,8 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
     ['GET', 'https://api.github.com/user/repos'],
     ['DELETE', 'https://api.github.com/repos/acme/other/issues/42/comments/1'],
     ['GET', 'https://api.github.com/repos/acme/repo/contents/src%2Findex.ts'],
+    ['GET', 'https://npm.pkg.github.com/@acme%2fdesign'],
+    ['GET', 'https://npm.pkg.github.com/download/@acme/design/1.0.0/package.tgz'],
     ['POST', 'https://uploads.github.com/repos/acme/other/releases/1/assets?name=asset.zip'],
     ['GET', 'https://github.com/acme/other.git/info/refs?service=git-upload-pack'],
   ] as const)(
@@ -1483,6 +1493,11 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
     ],
     ['GET', 'https://api.github.com:8443/user/repos', 'upstream_host_not_allowed'],
     ['GET', 'https://api.github.com/user/repos#fragment', 'invalid_upstream_url'],
+    ['GET', 'http://npm.pkg.github.com/@acme%2fdesign', 'invalid_upstream_url'],
+    ['GET', 'https://attacker@npm.pkg.github.com/@acme%2fdesign', 'invalid_upstream_url'],
+    ['GET', 'https://npm.pkg.github.com/@acme%2fdesign#fragment', 'invalid_upstream_url'],
+    ['GET', 'https://npm.pkg.github.com:8443/@acme%2fdesign', 'upstream_host_not_allowed'],
+    ['GET', 'https://npm.pkg.github.com.evil.example/@acme%2fdesign', 'upstream_host_not_allowed'],
   ] as const)(
     'rejects unsafe upstream request %s %s without forwarding authorization',
     async (requestMethod, requestUrl, reason) => {
@@ -1507,28 +1522,34 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
     }
   );
 
-  it('rejects unsafe selected-user destinations before resolving authorization', async () => {
-    const service = createService();
-    const issued = await service.issueGitHubSessionCapability({
-      githubRepo: 'acme/repo',
-      userId: 'user_1',
-      outboundContainerId,
-      allowUserAuthorization: true,
-    });
-    if (!issued.success) throw new Error('Expected successful issuance');
-    expect(issued.source).toBe('user');
-    serviceMocks.selectUserAuthorization.mockClear();
-
-    await expect(
-      service.redeemGitHubSessionCapability({
-        capability: issued.capability,
+  it.each([
+    'https://github.com.evil.example/graphql',
+    'https://npm.pkg.github.com.evil.example/@acme%2fdesign',
+  ])(
+    'rejects unsafe selected-user destination %s before resolving authorization',
+    async requestUrl => {
+      const service = createService();
+      const issued = await service.issueGitHubSessionCapability({
+        githubRepo: 'acme/repo',
+        userId: 'user_1',
         outboundContainerId,
-        requestMethod: 'POST',
-        requestUrl: 'https://github.com.evil.example/graphql',
-      })
-    ).resolves.toEqual({ success: false, reason: 'upstream_host_not_allowed' });
-    expect(serviceMocks.selectUserAuthorization).not.toHaveBeenCalled();
-  });
+        allowUserAuthorization: true,
+      });
+      if (!issued.success) throw new Error('Expected successful issuance');
+      expect(issued.source).toBe('user');
+      serviceMocks.selectUserAuthorization.mockClear();
+
+      await expect(
+        service.redeemGitHubSessionCapability({
+          capability: issued.capability,
+          outboundContainerId,
+          requestMethod: 'POST',
+          requestUrl,
+        })
+      ).resolves.toEqual({ success: false, reason: 'upstream_host_not_allowed' });
+      expect(serviceMocks.selectUserAuthorization).not.toHaveBeenCalled();
+    }
+  );
 
   it('rejects user-source redemption rather than falling back to installation authorization', async () => {
     const service = createService();

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -416,7 +416,11 @@ function validateGitHubCapabilityUpstream(
   if (url.protocol !== 'https:') return 'invalid_upstream_url';
   if (url.username || url.password || url.hash) return 'invalid_upstream_url';
   if (url.port !== '') return 'upstream_host_not_allowed';
-  if (!['api.github.com', 'uploads.github.com', 'github.com'].includes(url.hostname)) {
+  if (
+    !['api.github.com', 'uploads.github.com', 'github.com', 'npm.pkg.github.com'].includes(
+      url.hostname
+    )
+  ) {
     return 'upstream_host_not_allowed';
   }
   return null;


### PR DESCRIPTION
## Summary
- Allow only the exact `npm.pkg.github.com` destination for bound (v2) managed GitHub capability requests.
- Preserve HTTPS, default-port, userinfo, fragment, container-binding, identity, and credential-source checks. Legacy v1 behavior is unchanged.
- Add regression coverage for scoped npm metadata and package-download URLs using both installation and selected-user credentials, unsafe registry destinations, and legacy rejection.

## Verification
- Confirmed the four new acceptance cases fail with `upstream_host_not_allowed` before the allowlist change.
- `pnpm --filter cloudflare-git-token-service test` — 627 tests passed across 24 files.
- `pnpm --filter cloudflare-git-token-service typecheck` — passed.
- `pnpm --filter cloudflare-git-token-service lint` — passed, no warnings.
- `pnpm format services/git-token-service/src/index.ts services/git-token-service/src/index.test.ts` and `git diff --check` — passed.

## Scope and limitations
This removes our proxy destination rejection; it does not establish that GitHub Packages accepts the underlying GitHub App installation or user token. Tests use synthetic fixture credentials, not live registry authentication. Private-package installation remains unverified. No deployment, credential provisioning, automatic npm configuration, or legacy capability expansion is included.