### PR TITLE
chore(ai-gateway): update latest Gemini Flash to 3.8

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/google.ts
+++ b/apps/web/src/lib/ai-gateway/providers/google.ts
@@ -25,6 +25,6 @@ export const GEMINI_PRO_CURRENT_MODEL_ID = 'google/gemini-3.1-pro-preview';
 
 export const GEMINI_PRO_CURRENT_VERCEL_MODEL_ID = GEMINI_PRO_CURRENT_MODEL_ID;
 
-export const GEMINI_FLASH_CURRENT_MODEL_ID = 'google/gemini-3.6-flash';
+export const GEMINI_FLASH_CURRENT_MODEL_ID = 'google/gemini-3.8-flash';
 
 export const GEMINI_FLASH_CURRENT_VERCEL_MODEL_ID = GEMINI_FLASH_CURRENT_MODEL_ID;


### PR DESCRIPTION
## Summary

- Point `~google/gemini-flash-latest` to `google/gemini-3.8-flash` instead of 3.6.
- Keep the Vercel model ID derived from the shared constant; leave independent BYOK probes and historical model mappings unchanged.

## Verification

No manual runtime tests were run: this is a one-line model alias update, and tests are delegated to CI as requested.

## Visual Changes

N/A

## Reviewer Notes

Existing alias-mapping coverage consumes the current model constant. Local formatting, targeted oxlint, and `git diff --check` passed. `pnpm typecheck --changes-only` exceeded the environment's two-minute command limit without completing; the environment also reports Node 22 instead of the required Node 24. CI will provide test and full static-check results.