### PR TITLE
fix(ai-gateway): send OpenCode Go session headers

### DIFF
--- a/apps/web/src/lib/ai-gateway/providerHash.test.ts
+++ b/apps/web/src/lib/ai-gateway/providerHash.test.ts
@@ -1,7 +1,10 @@
 import { OPENROUTER, VERCEL_AI_GATEWAY } from '@/lib/ai-gateway/providers/provider-definitions';
+import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import {
+  applyTrackingIds,
   generateOpenRouterDownstreamSafetyIdentifier,
   generateProviderSpecificHash,
+  generateProviderSpecificSessionHash,
   generateVercelDownstreamSafetyIdentifier,
 } from './providerHash';
 
@@ -34,6 +37,45 @@ describe('generateProviderSpecificHash', () => {
 
     // Base64 pattern check
     expect(hash).toMatch(/^[A-Za-z0-9+/]+=*$/);
+  });
+});
+
+describe('session tracking identifiers', () => {
+  const userId = 'oauth/test-user';
+  const sessionId = 'conversation-1';
+
+  it('preserves the existing session hash format', () => {
+    expect(generateProviderSpecificSessionHash(userId, sessionId, OPENROUTER)).toBe(
+      generateProviderSpecificHash(userId + '-' + sessionId, OPENROUTER)
+    );
+  });
+
+  const requests: GatewayRequest[] = [
+    { kind: 'chat_completions', body: { model: 'test-model', messages: [] } },
+    { kind: 'messages', body: { model: 'test-model', messages: [], max_tokens: 100 } },
+    { kind: 'responses', body: { model: 'test-model', input: 'Hello' } },
+  ];
+
+  it.each(requests)('uses the shared session hash for $kind tracking', request => {
+    const trackedRequest = structuredClone(request);
+    applyTrackingIds(trackedRequest, OPENROUTER, userId, sessionId);
+
+    const trackedSession =
+      trackedRequest.kind === 'messages'
+        ? trackedRequest.body.session_id
+        : trackedRequest.body.prompt_cache_key;
+    expect(trackedSession).toBe(generateProviderSpecificSessionHash(userId, sessionId, OPENROUTER));
+  });
+
+  it.each(requests)('omits $kind session tracking when the task ID is absent', request => {
+    const trackedRequest = structuredClone(request);
+    applyTrackingIds(trackedRequest, OPENROUTER, userId, null);
+
+    const trackedSession =
+      trackedRequest.kind === 'messages'
+        ? trackedRequest.body.session_id
+        : trackedRequest.body.prompt_cache_key;
+    expect(trackedSession).toBeUndefined();
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providerHash.ts
+++ b/apps/web/src/lib/ai-gateway/providerHash.ts
@@ -25,6 +25,14 @@ export function generateProviderSpecificHash(payload: string, provider: Provider
     .digest('base64');
 }
 
+export function generateProviderSpecificSessionHash(
+  userId: string,
+  sessionId: string,
+  provider: Provider
+): string {
+  return generateProviderSpecificHash(userId + '-' + sessionId, provider);
+}
+
 export function generateOpenRouterDownstreamSafetyIdentifier(userId: string): string {
   return generateProviderSpecificHash(userId, OPENROUTER);
 }
@@ -54,7 +62,7 @@ export function applyTrackingIds(
   taskId: string | null
 ) {
   const userHash = generateProviderSpecificHash(userId, provider);
-  const taskHash = taskId ? generateProviderSpecificHash(userId + '-' + taskId, provider) : '';
+  const taskHash = taskId ? generateProviderSpecificSessionHash(userId, taskId, provider) : '';
   if (request.kind === 'messages') {
     request.body.metadata = { ...request.body.metadata, user_id: userHash };
     if (provider.id === 'openrouter') {

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/index.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { generateText } from 'ai';
+import { COMPATIBLE_USER_AGENT } from './types';
 
 jest.mock('@/lib/drizzle', () => ({
   readDb: {},
@@ -68,6 +70,71 @@ jest.mock('./direct-byok-definitions', () => ({
     },
   ],
 }));
+
+describe('createAiSdkProvider session headers', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockCompletions() {
+    return jest.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      Response.json({
+        id: 'test-completion',
+        object: 'chat.completion',
+        created: 0,
+        model: 'test-model',
+        choices: [
+          { index: 0, message: { role: 'assistant', content: 'Hi' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      })
+    );
+  }
+
+  test('keeps an OpenCode Go probe session stable across SDK retries and isolates new probes', async () => {
+    const { createAiSdkProvider } = await import('.');
+    const { directByokProviders } = await loadDirectByokModule();
+    const provider = { ...directByokProviders[0], id: 'opencode-go' as const };
+    const fetchMock = mockCompletions().mockResolvedValueOnce(
+      new Response('Temporary failure', { status: 500 })
+    );
+    const firstProbe = createAiSdkProvider(provider, 'test-key');
+
+    await generateText({ model: firstProbe('test-model'), prompt: 'Say hi', maxRetries: 1 });
+    await generateText({
+      model: createAiSdkProvider(provider, 'test-key')('test-model'),
+      prompt: 'Say hi',
+      maxRetries: 0,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const headers = fetchMock.mock.calls.map(([, init]) => new Headers(init?.headers));
+    const session = headers[0].get('x-opencode-session');
+    expect(session).toEqual(expect.any(String));
+    expect(session).not.toBe('');
+    expect(headers[1].get('x-opencode-session')).toBe(session);
+    expect(headers[2].get('x-opencode-session')).not.toBe(session);
+    for (const header of headers) {
+      expect(header.get('authorization')).toBe('Bearer test-key');
+      expect(header.get('user-agent')).toBe(COMPATIBLE_USER_AGENT);
+    }
+  });
+
+  test('does not add OpenCode session headers to other direct providers', async () => {
+    const { createAiSdkProvider } = await import('.');
+    const { directByokProviders } = await loadDirectByokModule();
+    const fetchMock = mockCompletions();
+
+    await generateText({
+      model: createAiSdkProvider(directByokProviders[0], 'test-key')('test-model'),
+      prompt: 'Say hi',
+      maxRetries: 0,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(new Headers(fetchMock.mock.calls[0][1]?.headers).has('x-opencode-session')).toBe(false);
+  });
+});
 
 async function loadDirectByokModule() {
   const directByokProviders = (await import('./direct-byok-definitions')).default;

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { type UserByokProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import {
   COMPATIBLE_USER_AGENT,
@@ -126,6 +127,8 @@ export function createAiSdkProvider(directByokProvider: DirectByokProvider, apiK
     baseURL: directByokProvider.base_url,
     apiKey,
     name: 'openaiCompatible',
+    headers:
+      directByokProvider.id === 'opencode-go' ? { 'x-opencode-session': randomUUID() } : undefined,
     fetch: (url, init) => {
       const headers = new Headers(init?.headers);
       headers.set('user-agent', COMPATIBLE_USER_AGENT);

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts
@@ -1,8 +1,108 @@
+import type { GatewayRequest } from '../openrouter/types';
+import type { TransformRequestContext } from '../types';
 import { getAiSdkProvider } from '../model-settings';
 import openCodeGo from './opencode-go';
 
 test('allows the Responses API for OpenCode Go', () => {
   expect(openCodeGo.supported_chat_apis).toContain('responses');
+});
+
+describe('OpenCode Go session headers', () => {
+  const requests: GatewayRequest[] = [
+    { kind: 'chat_completions', body: { model: 'qwen3.7-plus', messages: [] } },
+    { kind: 'messages', body: { model: 'qwen3.7-plus', messages: [], max_tokens: 100 } },
+    { kind: 'responses', body: { model: 'qwen3.7-plus', input: 'Hello' } },
+  ];
+
+  function createContext(
+    overrides: Partial<TransformRequestContext> = {}
+  ): TransformRequestContext {
+    return {
+      provider: {
+        id: 'direct-byok',
+        apiUrl: openCodeGo.base_url,
+        apiUrlOverrides: {},
+        apiKey: 'test-api-key',
+        apiKeyHeader: null,
+        supportedChatApis: openCodeGo.supported_chat_apis,
+        responseTransforms: null,
+        async transformRequest() {},
+      },
+      model: 'opencode-go/qwen3.7-plus',
+      request: requests[0],
+      originalHeaders: {},
+      extraHeaders: {},
+      userByok: null,
+      kilo_user_id: 'oauth/test-user',
+      organization_id: null,
+      session_id: 'conversation-1',
+      ...overrides,
+    };
+  }
+
+  test.each(requests)('adds a stable conversation header for $kind', request => {
+    const first = createContext({ request });
+    const next = createContext({ request });
+    const otherApi = createContext();
+
+    openCodeGo.transformRequest(first);
+    openCodeGo.transformRequest(next);
+    openCodeGo.transformRequest(otherApi);
+
+    const session = first.extraHeaders['x-opencode-session'];
+    expect(session).toEqual(expect.any(String));
+    expect(session).not.toBe('');
+    expect(session).not.toContain(first.kilo_user_id);
+    expect(next.extraHeaders['x-opencode-session']).toBe(session);
+    expect(otherApi.extraHeaders['x-opencode-session']).toBe(session);
+    expect(first.extraHeaders['x-api-key']).toBe(
+      request.kind === 'messages' ? 'test-api-key' : undefined
+    );
+  });
+
+  test.each([
+    { session_id: 'conversation-2' },
+    { kilo_user_id: 'oauth/another-user' },
+    { organization_id: 'another-organization' },
+  ])('isolates sessions when the conversation or owner changes: %j', overrides => {
+    const first = createContext();
+    const other = createContext(overrides);
+
+    openCodeGo.transformRequest(first);
+    openCodeGo.transformRequest(other);
+
+    expect(other.extraHeaders['x-opencode-session']).not.toBe(
+      first.extraHeaders['x-opencode-session']
+    );
+  });
+
+  test('keeps the header stable when the model, API key, or request body changes', () => {
+    const first = createContext();
+    const next = createContext({
+      model: 'opencode-go/minimax-m3',
+      request: { kind: 'responses', body: { model: 'minimax-m3', input: 'Next turn' } },
+      provider: { ...first.provider, apiKey: 'rotated-key' },
+    });
+
+    openCodeGo.transformRequest(first);
+    openCodeGo.transformRequest(next);
+
+    expect(next.extraHeaders['x-opencode-session']).toBe(first.extraHeaders['x-opencode-session']);
+  });
+
+  test('assigns isolated fallback headers when no conversation identifier is available', () => {
+    const first = createContext({ session_id: null });
+    const second = createContext({ session_id: null });
+
+    openCodeGo.transformRequest(first);
+    openCodeGo.transformRequest(second);
+
+    expect(first.extraHeaders['x-opencode-session']).toEqual(expect.any(String));
+    expect(first.extraHeaders['x-opencode-session']).not.toBe('');
+    expect(second.extraHeaders['x-opencode-session']).not.toBe(
+      first.extraHeaders['x-opencode-session']
+    );
+  });
 });
 
 describe('getAiSdkProvider', () => {

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts
@@ -1,4 +1,5 @@
 import { EmptyFraudDetectionHeaders } from '@/lib/utils';
+import { applyTrackingIds } from '@/lib/ai-gateway/providerHash';
 import type { GatewayRequest } from '../openrouter/types';
 import type { TransformRequestContext } from '../types';
 import { getAiSdkProvider } from '../model-settings';
@@ -61,21 +62,33 @@ describe('OpenCode Go session headers', () => {
     );
   });
 
-  test.each([
-    { session_id: 'conversation-2' },
-    { kilo_user_id: 'oauth/another-user' },
-    { organization_id: 'another-organization' },
-  ])('isolates sessions when the conversation or owner changes: %j', overrides => {
-    const first = createContext();
-    const other = createContext(overrides);
+  test.each([{ session_id: 'conversation-2' }, { kilo_user_id: 'oauth/another-user' }])(
+    'isolates sessions when the conversation or user changes: %j',
+    overrides => {
+      const first = createContext();
+      const other = createContext(overrides);
 
-    openCodeGo.transformRequest(first);
-    openCodeGo.transformRequest(other);
+      openCodeGo.transformRequest(first);
+      openCodeGo.transformRequest(other);
 
-    expect(other.extraHeaders['x-opencode-session']).not.toBe(
-      first.extraHeaders['x-opencode-session']
-    );
-  });
+      expect(other.extraHeaders['x-opencode-session']).not.toBe(
+        first.extraHeaders['x-opencode-session']
+      );
+    }
+  );
+
+  test.each(requests.filter(request => request.kind !== 'messages'))(
+    'matches the existing prompt cache key for $kind',
+    request => {
+      const trackedRequest = structuredClone(request);
+      const context = createContext({ request: trackedRequest });
+      applyTrackingIds(trackedRequest, context.provider, context.kilo_user_id, context.session_id);
+
+      openCodeGo.transformRequest(context);
+
+      expect(context.extraHeaders['x-opencode-session']).toBe(trackedRequest.body.prompt_cache_key);
+    }
+  );
 
   test('keeps the header stable when the model, API key, or request body changes', () => {
     const first = createContext();

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts
@@ -1,3 +1,4 @@
+import { EmptyFraudDetectionHeaders } from '@/lib/utils';
 import type { GatewayRequest } from '../openrouter/types';
 import type { TransformRequestContext } from '../types';
 import { getAiSdkProvider } from '../model-settings';
@@ -30,7 +31,7 @@ describe('OpenCode Go session headers', () => {
       },
       model: 'opencode-go/qwen3.7-plus',
       request: requests[0],
-      originalHeaders: {},
+      originalHeaders: EmptyFraudDetectionHeaders,
       extraHeaders: {},
       userByok: null,
       kilo_user_id: 'oauth/test-user',

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+import { generateProviderSpecificHash } from '@/lib/ai-gateway/providerHash';
 import { cachedEnhancedDirectByokModelList } from '@/lib/ai-gateway/providers/direct-byok/model-list';
 import type { DirectByokProvider } from '@/lib/ai-gateway/providers/direct-byok/types';
 
@@ -8,6 +10,14 @@ export default {
   supported_chat_apis: ['chat_completions', 'messages', 'responses'],
   default_ai_sdk_provider: 'openai-compatible',
   transformRequest(context) {
+    context.extraHeaders['x-opencode-session'] = generateProviderSpecificHash(
+      JSON.stringify([
+        context.kilo_user_id,
+        context.organization_id,
+        context.session_id ?? randomUUID(),
+      ]),
+      context.provider
+    );
     if (context.request.kind === 'messages') {
       context.extraHeaders['x-api-key'] = context.provider.apiKey;
     }

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { generateProviderSpecificHash } from '@/lib/ai-gateway/providerHash';
+import { generateProviderSpecificSessionHash } from '@/lib/ai-gateway/providerHash';
 import { cachedEnhancedDirectByokModelList } from '@/lib/ai-gateway/providers/direct-byok/model-list';
 import type { DirectByokProvider } from '@/lib/ai-gateway/providers/direct-byok/types';
 
@@ -10,12 +10,9 @@ export default {
   supported_chat_apis: ['chat_completions', 'messages', 'responses'],
   default_ai_sdk_provider: 'openai-compatible',
   transformRequest(context) {
-    context.extraHeaders['x-opencode-session'] = generateProviderSpecificHash(
-      JSON.stringify([
-        context.kilo_user_id,
-        context.organization_id,
-        context.session_id ?? randomUUID(),
-      ]),
+    context.extraHeaders['x-opencode-session'] = generateProviderSpecificSessionHash(
+      context.kilo_user_id,
+      context.session_id ?? randomUUID(),
       context.provider
     );
     if (context.request.kind === 'messages') {


### PR DESCRIPTION
## Summary

- Send `x-opencode-session` on OpenCode Go Chat Completions, Messages, and Responses requests before upstream begins enforcing it.
- Share `generateProviderSpecificSessionHash` with `applyTrackingIds`, deriving the header from the existing user-scoped conversation ID and preserving all existing tracking IDs. Preserve Messages authentication.
- Give API-key validation probes their own session header, created once per SDK provider so retries reuse it.

## Verification

No manual upstream requests or local tests were run; test execution is delegated to CI as requested.

## Visual Changes

N/A

## Reviewer Notes

- Existing gateway session IDs come from `x-kilocode-taskid`, falling back to `x-kilo-session`.
- When neither conversation identifier exists, use an isolated random fallback rather than omit the required header or merge unrelated conversations. Cross-request stability requires a client conversation ID.
- The shared helper preserves the existing user/session hash format. The OpenCode header matches the prompt-cache key when both use the same conversation ID.
- Regression coverage checks all three APIs, conversation/user isolation, existing tracking compatibility, key/model changes, missing IDs, SDK retries, and unaffected providers.
- Focused lint, formatting, and `git diff --check` passed. Local web typecheck hit the sandbox two-minute timeout during the prerequisite tRPC build; CI completes validation. The sandbox reports Node 22 rather than the required Node 24.
- CI caught a missing typed request-metadata fixture; fixed in a follow-up commit. All checks now pass on the shared-hashing follow-up (144ac058a), including tests, typecheck, lint, build, extension CI, and secret scanning. Automated code review reports no issues; human approval remains required.
