### PR TITLE
fix(mobile): stop Android Fabric crash on session navigation

### DIFF
--- a/apps/mobile/src/components/agents/session-detail-content.test.ts
+++ b/apps/mobile/src/components/agents/session-detail-content.test.ts
@@ -83,6 +83,17 @@ vi.mock('expo-router', () => ({
     },
   }),
 }));
+// `useStackSafeReplace` owns the push + post-transition stack cleanup that keeps
+// Android Fabric alive (KILO-APP-25); its own mechanics are covered in
+// src/lib/navigation/stack-safe-replace.mounted.test.tsx. Here it stands in for
+// the navigation call so these assertions stay about the resulting route list.
+vi.mock('@/lib/navigation/stack-safe-replace', () => ({
+  useStackSafeReplace: () => ({
+    replace: (href: string) => {
+      navigationRoutes.splice(-1, 1, href);
+    },
+  }),
+}));
 vi.mock('expo-keep-awake', () => ({ useKeepAwake: vi.fn() }));
 vi.mock('expo-haptics', () => ({
   notificationAsync: vi.fn(),

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -33,6 +33,7 @@ import {
 import { createAndNavigateAgentSession } from '@/components/agents/create-and-navigate-agent-session';
 import { exitRemoteSessionWithFeedback } from '@/components/agents/exit-remote-session-with-feedback';
 import { restartAgentSession } from '@/components/agents/restart-agent-session';
+import { useStackSafeReplace } from '@/lib/navigation/stack-safe-replace';
 import { MessageBubble } from '@/components/agents/message-bubble';
 import { MessageDetailsSheet } from '@/components/agents/message-details-sheet';
 import { ModelPickerSelectionScopeProvider } from '@/components/agents/model-selector';
@@ -183,6 +184,9 @@ export function SessionDetailContent({
   const manager = useSessionManager();
   const { t } = useTranslation();
   const router = useRouter();
+  // Session-route navigation only: `replace` in one native-stack commit crashes
+  // Android Fabric (KILO-APP-25). Other `router` uses here are unaffected.
+  const sessionRouter = useStackSafeReplace();
   const [childSessionSheet, setChildSessionSheet] = useState<ChildSessionSheetMountState>({
     sheet: null,
     visible: false,
@@ -1293,27 +1297,27 @@ export function SessionDetailContent({
     // tick, and the agents tab refetches on focus.
     const result = await createAndNavigateAgentSession({
       create: manager.createRemoteSession.bind(manager),
-      router,
+      router: sessionRouter,
       organizationId,
       onError: message => {
         toast.error(message);
       },
     });
     return result.success;
-  }, [manager, router, organizationId]);
+  }, [manager, sessionRouter, organizationId]);
 
   const handleRestartSession = useCallback(async () => {
     const result = await restartAgentSession({
       create: manager.createRemoteSession.bind(manager),
       exit: manager.exitRemoteSession.bind(manager),
-      router,
+      router: sessionRouter,
       organizationId,
       onError: message => {
         toast.error(message);
       },
     });
     return result.success;
-  }, [manager, router, organizationId]);
+  }, [manager, sessionRouter, organizationId]);
 
   const handleExitSession = useCallback(
     async (

--- a/apps/mobile/src/components/agents/session-detail-queue.test.ts
+++ b/apps/mobile/src/components/agents/session-detail-queue.test.ts
@@ -135,6 +135,14 @@ vi.mock('expo-router', () => ({
   useIsFocused: () => true,
   useRouter: () => ({ replace: vi.fn() }),
 }));
+
+// `useStackSafeReplace` owns the push + post-transition stack cleanup that keeps
+// Android Fabric alive (KILO-APP-25); its own mechanics are covered in
+// src/lib/navigation/stack-safe-replace.mounted.test.tsx. Here it stands in for
+// the navigation call so these assertions stay about the destination href.
+vi.mock('@/lib/navigation/stack-safe-replace', () => ({
+  useStackSafeReplace: () => ({ replace: vi.fn() }),
+}));
 vi.mock('expo-keep-awake', () => ({
   useKeepAwake: vi.fn(),
 }));

--- a/apps/mobile/src/components/agents/session-detail-routes.ts
+++ b/apps/mobile/src/components/agents/session-detail-routes.ts
@@ -33,10 +33,14 @@ export function getAgentSessionPath(
 
 /**
  * Replace the current route with the canonical agent-chat detail for the new
- * session. Using `replace` (not `push`) means the previous session route is
- * not on the stack, so the system back gesture does not return to it. The
- * route-keyed `AgentSessionProvider` recreates the manager for the new id, so
- * the caller does not switch the current manager before navigation.
+ * session. Replacing (not pushing) means the previous route is not left on the
+ * stack, so the system back gesture does not return to it. The route-keyed
+ * `AgentSessionProvider` recreates the manager for the new id, so the caller
+ * does not switch the current manager before navigation.
+ *
+ * Pass `useStackSafeReplace()` as the router: a literal `router.replace` swaps
+ * both screens in one native-stack commit, which crashes Android Fabric with
+ * `addViewAt: failed to insert view` (Sentry KILO-APP-25).
  */
 export function replaceWithAgentSession(
   router: AgentSessionRouterLike,

--- a/apps/mobile/src/components/agents/use-continue-cloud-create.test.ts
+++ b/apps/mobile/src/components/agents/use-continue-cloud-create.test.ts
@@ -30,6 +30,14 @@ vi.mock('expo-router', () => ({
   useRouter: () => ({ replace: routerReplace, push: routerPush }),
 }));
 
+// `useStackSafeReplace` owns the push + post-transition stack cleanup that keeps
+// Android Fabric alive (KILO-APP-25); its own mechanics are covered in
+// src/lib/navigation/stack-safe-replace.mounted.test.tsx. Here it stands in for
+// the navigation call so these assertions stay about the destination href.
+vi.mock('@/lib/navigation/stack-safe-replace', () => ({
+  useStackSafeReplace: () => ({ replace: routerReplace }),
+}));
+
 vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({}),
 }));

--- a/apps/mobile/src/components/agents/use-continue-cloud-create.ts
+++ b/apps/mobile/src/components/agents/use-continue-cloud-create.ts
@@ -1,12 +1,12 @@
 // Performs one `prepareSession` clone for the Cloud Agent Continue entry: a
 // hoisted operation key, a safe-retry outbox row, and post-success navigation.
 import { useCallback } from 'react';
-import { useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { type KiloSessionId } from '@kilocode/cloud-agent-sdk';
 import * as Haptics from 'expo-haptics';
 
 import { type AgentMode, normalizeAgentMode } from '@/components/agents/mode-normalize';
+import { useStackSafeReplace } from '@/lib/navigation/stack-safe-replace';
 import {
   type NewSessionRepository,
   type RepositoryPlatform,
@@ -29,7 +29,7 @@ export function useContinueCloudCreate(
   dest: { repository: NewSessionRepository | null; model: string; variant: string },
   mode: string
 ) => Promise<void> {
-  const router = useRouter();
+  const router = useStackSafeReplace();
   const queryClient = useQueryClient();
   const trpc = useTRPC();
   // P1-A-08b: cloud prepares and remote spawns are different intents, so each

--- a/apps/mobile/src/components/agents/use-new-session-creator.test.ts
+++ b/apps/mobile/src/components/agents/use-new-session-creator.test.ts
@@ -28,6 +28,14 @@ vi.mock('expo-router', () => ({
   useRouter: () => ({ replace: routerReplace }),
 }));
 
+// `useStackSafeReplace` owns the push + post-transition stack cleanup that keeps
+// Android Fabric alive (KILO-APP-25); its own mechanics are covered in
+// src/lib/navigation/stack-safe-replace.mounted.test.tsx. Here it stands in for
+// the navigation call so these assertions stay about the destination href.
+vi.mock('@/lib/navigation/stack-safe-replace', () => ({
+  useStackSafeReplace: () => ({ replace: routerReplace }),
+}));
+
 vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({}),
 }));

--- a/apps/mobile/src/components/agents/use-new-session-creator.ts
+++ b/apps/mobile/src/components/agents/use-new-session-creator.ts
@@ -1,5 +1,4 @@
 import { type RefObject, useCallback, useRef } from 'react';
-import { useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { generateMessageId } from '@kilocode/cloud-agent-sdk/message-id';
 import * as Haptics from 'expo-haptics';
@@ -14,6 +13,7 @@ import {
 import { resolveNewSessionPromptForCreate } from '@/components/agents/new-session-prompt-state';
 import { isCloudPrepareRetryableError } from '@/components/agents/mobile-session-manager';
 import { replaceWithAgentSession } from '@/components/agents/session-detail-routes';
+import { useStackSafeReplace } from '@/lib/navigation/stack-safe-replace';
 import { invalidateAgentSessionQueries } from '@/lib/agent-session-cache';
 import { captureEvent, SESSION_CREATED_EVENT } from '@/lib/analytics/posthog';
 import { useHoistedOperationKey } from '@/lib/operation-key';
@@ -81,7 +81,7 @@ export function useNewSessionCreator({
   autoCommit,
   profileId,
 }: UseNewSessionCreatorInput): UseNewSessionCreatorResult {
-  const router = useRouter();
+  const router = useStackSafeReplace();
   const queryClient = useQueryClient();
   const trpc = useTRPC();
   const promptRef = useRef('');

--- a/apps/mobile/src/components/agents/use-remote-spawn-dispatch.test.ts
+++ b/apps/mobile/src/components/agents/use-remote-spawn-dispatch.test.ts
@@ -44,6 +44,14 @@ vi.mock('expo-router', () => ({
   useRouter: () => ({ replace: routerReplace }),
 }));
 
+// `useStackSafeReplace` owns the push + post-transition stack cleanup that keeps
+// Android Fabric alive (KILO-APP-25); its own mechanics are covered in
+// src/lib/navigation/stack-safe-replace.mounted.test.tsx. Here it stands in for
+// the navigation call so these assertions stay about the destination href.
+vi.mock('@/lib/navigation/stack-safe-replace', () => ({
+  useStackSafeReplace: () => ({ replace: routerReplace }),
+}));
+
 vi.mock('sonner-native', () => ({
   toast: { error: toastErrorMock },
 }));

--- a/apps/mobile/src/components/agents/use-remote-spawn-dispatch.ts
+++ b/apps/mobile/src/components/agents/use-remote-spawn-dispatch.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { type Href, useRouter } from 'expo-router';
+import { type Href } from 'expo-router';
 import { toast } from 'sonner-native';
 import { type ModelSelection } from '@kilocode/cloud-agent-sdk';
 
 import { getSpawnedAgentSessionPath } from '@/components/agents/session-detail-routes';
+import { useStackSafeReplace } from '@/lib/navigation/stack-safe-replace';
 import { i18n } from '@/i18n';
 import { type InstancePickerInstance } from '@/lib/picker-bridge';
 import {
@@ -175,7 +176,7 @@ export function useRemoteSpawnDispatch({
   onSpawnFailed,
   onSpawnReady,
 }: UseRemoteSpawnDispatchArgs): UseRemoteSpawnDispatchResult {
-  const router = useRouter();
+  const router = useStackSafeReplace();
   // Route param is frozen at navigation: missing param means personal, not
   // "inherit live context". `?? null` so undefined does not fall through to
   // `useOrganization()` after a later org switch (share-gate keeps zero-arg

--- a/apps/mobile/src/lib/navigation/stack-safe-replace.mounted.test.tsx
+++ b/apps/mobile/src/lib/navigation/stack-safe-replace.mounted.test.tsx
@@ -1,0 +1,224 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (node env, no jsdom); its React 19 deprecation notice points to the DOM-based Testing Library, which cannot render this app's non-DOM tree. See src/test/render-with-providers.tsx. */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useStackSafeReplace } from './stack-safe-replace';
+
+type Route = { key: string; name: string };
+type State = { routes: Route[]; index: number };
+
+const pushMock = vi.hoisted(() => vi.fn());
+const replaceMock = vi.hoisted(() => vi.fn());
+const resetMock = vi.hoisted(() => vi.fn());
+
+type Nav = { state: State; transitionEnd: (() => void) | undefined };
+
+const nav = vi.hoisted<Nav>(() => ({ state: { routes: [], index: 0 }, transitionEnd: undefined }));
+
+vi.mock('expo-router', () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  useNavigation: () => ({
+    addListener: (event: string, listener: () => void) => {
+      if (event === 'transitionEnd') {
+        nav.transitionEnd = listener;
+      }
+      return () => {
+        nav.transitionEnd = undefined;
+      };
+    },
+    getState: () => nav.state,
+    reset: resetMock,
+  }),
+}));
+
+let latestReplace: ((href: string) => void) | undefined = undefined;
+
+function Harness() {
+  const router = useStackSafeReplace();
+  latestReplace = router.replace as (href: string) => void;
+  return null;
+}
+
+function mount() {
+  const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+  act(() => {
+    ref.current = TestRenderer.create(createElement(Harness));
+  });
+  if (!ref.current) {
+    throw new Error('harness did not render');
+  }
+  return ref.current;
+}
+
+function setStack(routes: Route[], index: number) {
+  nav.state = { routes, index };
+}
+
+describe('useStackSafeReplace', () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    replaceMock.mockReset();
+    resetMock.mockReset();
+    nav.transitionEnd = undefined;
+    latestReplace = undefined;
+    setStack(
+      [
+        { key: 'tabs-1', name: '(tabs)' },
+        { key: 'new-1', name: 'agent-chat/new' },
+      ],
+      1
+    );
+  });
+
+  it('pushes instead of replacing, so the stack never swaps both screens at once', () => {
+    const renderer = mount();
+
+    latestReplace?.('/(app)/agent-chat/ses_1');
+
+    // A literal `replace` is what crashes Android Fabric (KILO-APP-25).
+    expect(replaceMock).not.toHaveBeenCalled();
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    expect(pushMock).toHaveBeenCalledWith('/(app)/agent-chat/ses_1');
+    // Nothing is removed yet: the push transition is still running.
+    expect(resetMock).not.toHaveBeenCalled();
+
+    act(() => {
+      renderer.unmount();
+    });
+  });
+
+  it('drops the source route once the push transition has ended', () => {
+    const renderer = mount();
+
+    latestReplace?.('/(app)/agent-chat/ses_1');
+    setStack(
+      [
+        { key: 'tabs-1', name: '(tabs)' },
+        { key: 'new-1', name: 'agent-chat/new' },
+        { key: 'session-1', name: 'agent-chat/[session-id]' },
+      ],
+      2
+    );
+
+    act(() => {
+      nav.transitionEnd?.();
+    });
+
+    expect(resetMock).toHaveBeenCalledTimes(1);
+    // The end state is the one `replace` produces: the source route is gone and
+    // the destination is focused, so back skips past it.
+    expect(resetMock.mock.calls[0]?.[0]).toEqual({
+      routes: [
+        { key: 'tabs-1', name: '(tabs)' },
+        { key: 'session-1', name: 'agent-chat/[session-id]' },
+      ],
+      index: 1,
+    });
+
+    act(() => {
+      renderer.unmount();
+    });
+  });
+
+  it('removes the route it started from, not another route of the same name', () => {
+    setStack(
+      [
+        { key: 'new-1', name: 'agent-chat/new' },
+        { key: 'new-2', name: 'agent-chat/new' },
+      ],
+      1
+    );
+    const renderer = mount();
+
+    latestReplace?.('/(app)/agent-chat/ses_1');
+    setStack(
+      [
+        { key: 'new-1', name: 'agent-chat/new' },
+        { key: 'new-2', name: 'agent-chat/new' },
+        { key: 'session-1', name: 'agent-chat/[session-id]' },
+      ],
+      2
+    );
+
+    act(() => {
+      nav.transitionEnd?.();
+    });
+
+    expect(resetMock.mock.calls[0]?.[0]).toEqual({
+      routes: [
+        { key: 'new-1', name: 'agent-chat/new' },
+        { key: 'session-1', name: 'agent-chat/[session-id]' },
+      ],
+      index: 1,
+    });
+
+    act(() => {
+      renderer.unmount();
+    });
+  });
+
+  it('is one-shot: an unrelated later transition does not touch the stack', () => {
+    const renderer = mount();
+
+    latestReplace?.('/(app)/agent-chat/ses_1');
+    setStack(
+      [
+        { key: 'tabs-1', name: '(tabs)' },
+        { key: 'new-1', name: 'agent-chat/new' },
+        { key: 'session-1', name: 'agent-chat/[session-id]' },
+      ],
+      2
+    );
+    act(() => {
+      nav.transitionEnd?.();
+    });
+    expect(resetMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      nav.transitionEnd?.();
+    });
+    expect(resetMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      renderer.unmount();
+    });
+  });
+
+  it('leaves the stack alone when the source route is already gone', () => {
+    const renderer = mount();
+
+    latestReplace?.('/(app)/agent-chat/ses_1');
+    // The user left another way, so `new-1` is no longer on the stack: a reset
+    // here would drop a route the navigation never owned.
+    setStack([{ key: 'tabs-1', name: '(tabs)' }], 0);
+
+    act(() => {
+      nav.transitionEnd?.();
+    });
+
+    expect(resetMock).not.toHaveBeenCalled();
+
+    act(() => {
+      renderer.unmount();
+    });
+  });
+
+  it('leaves the stack alone when the source route is the only one left', () => {
+    setStack([{ key: 'new-1', name: 'agent-chat/new' }], 0);
+    const renderer = mount();
+
+    latestReplace?.('/(app)/agent-chat/ses_1');
+
+    act(() => {
+      nav.transitionEnd?.();
+    });
+
+    // Resetting to an empty route list would tear down the navigator.
+    expect(resetMock).not.toHaveBeenCalled();
+
+    act(() => {
+      renderer.unmount();
+    });
+  });
+});

--- a/apps/mobile/src/lib/navigation/stack-safe-replace.ts
+++ b/apps/mobile/src/lib/navigation/stack-safe-replace.ts
@@ -1,0 +1,69 @@
+import { type Href, type NativeStackNavigationProp, useNavigation, useRouter } from 'expo-router';
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * The `router.replace` call signature, so helpers that already take a router
+ * (`replaceWithAgentSession` and friends) accept this hook's result unchanged.
+ */
+export type StackSafeReplaceRouter = {
+  replace: (href: Href) => void;
+};
+
+/**
+ * A `router.replace` that the Android native stack survives.
+ *
+ * `router.replace` removes the current screen and inserts the next one in a
+ * single native-stack commit. On Android, react-native-screens reparents a view
+ * the outgoing screen still owns during that commit and Fabric throws
+ * `addViewAt: failed to insert view [...] The specified child already has a
+ * parent` (Sentry KILO-APP-25). A plain `push` and a plain `pop` each commit
+ * cleanly; only the combined swap breaks.
+ *
+ * So push, then drop the route we came from once its transition has ended. That
+ * route is no longer the visible screen by then, so removing it animates nothing
+ * and commits on its own. The end state is the one `replace` produces: the source
+ * screen is gone and back skips past it.
+ *
+ * Waiting for `transitionEnd` is what makes the second commit safe. The earlier
+ * form of this pushed and then reset the stack one frame later, which landed the
+ * second commit while the push was still animating and crashed the same way.
+ *
+ * The removal is keyed on the route focused when the navigation started, so a
+ * duplicate route name elsewhere in the stack is never dropped by mistake.
+ */
+export function useStackSafeReplace(): StackSafeReplaceRouter {
+  const router = useRouter();
+  const navigation = useNavigation<NativeStackNavigationProp<Record<string, undefined>>>();
+  const pendingRouteKeyRef = useRef<string | null>(null);
+
+  useEffect(
+    () =>
+      navigation.addListener('transitionEnd', () => {
+        const routeKey = pendingRouteKeyRef.current;
+        if (routeKey === null) {
+          return;
+        }
+        pendingRouteKeyRef.current = null;
+        const state = navigation.getState();
+        const routes = state.routes.filter(route => route.key !== routeKey);
+        // The route is already gone (the user left another way), or it is the
+        // only one left: leave the stack alone rather than commit a bad reset.
+        if (routes.length === state.routes.length || routes.length === 0) {
+          return;
+        }
+        navigation.reset({ ...state, routes, index: routes.length - 1 });
+      }),
+    [navigation]
+  );
+
+  const replace = useCallback(
+    (href: Href) => {
+      const state = navigation.getState();
+      pendingRouteKeyRef.current = state.routes[state.index]?.key ?? null;
+      router.push(href);
+    },
+    [navigation, router]
+  );
+
+  return { replace };
+}


### PR DESCRIPTION
Fixes Sentry [KILO-APP-25](https://kilo-code.sentry.io/issues/?query=KILO-APP-25): `addViewAt: failed to insert view [...] The specified child already has a parent`.

## Cause

`router.replace` removes the current screen and inserts the next one in a single native-stack commit. On Android, react-native-screens reparents a view the outgoing screen still owns during that commit, and Fabric throws. A plain `push` and a plain `pop` each commit cleanly; only the combined swap breaks.

Two earlier attempts missed this. #5306 changed a push + reset into a `replace`, and #5431 turned off clipped subviews. Neither removed the single-commit swap.

## Fix

`useStackSafeReplace` in `apps/mobile/src/lib/navigation/stack-safe-replace.ts`: push, then drop the source route once its transition has ended. By then the source route is not the visible screen, so the removal animates nothing and commits on its own. The end state matches `replace`: the source screen is gone and back skips past it.

Waiting for `transitionEnd` is what makes the second commit safe. A push plus a reset one frame later lands the second commit mid-animation and crashes the same way.

Every session-route navigation now goes through the hook: new session create, continue-cloud create, remote spawn dispatch, and the create and restart paths in the session detail screen. Other `router` uses in those files are untouched.

## Verification

Emulator-5554, Android 16, local stack. Repro is the New coding task flow through Start session.

| Navigation | Result |
| --- | --- |
| `router.replace` new -> `[session-id]` (before) | crash, signature byte-identical to Sentry |
| `router.replace` new -> `(tabs)/(2_agents)` (before) | crash |
| `router.push` new -> `[session-id]` | no crash |
| `animation: 'none'` on `[session-id]` | crash, so not an animation issue |
| this fix | no crash; back lands past the create form |

`stack-safe-replace.mounted.test.tsx` covers the push, the keyed removal, the one-shot behaviour, and the two cases that must not reset the stack.

Checks: `pnpm format`, `pnpm typecheck`, `pnpm lint`, `pnpm check:unused`, `pnpm test` (8546 passed), and root `scripts/lint-all.sh`.

https://claude.ai/code/session_01AGsBUddy4TP7xqJ58X8xiY
