### PR TITLE
fix(cloud-agent): refine skill and subagent chat rows

### DIFF
--- a/apps/web/src/components/cloud-agent-next/ChildSessionSection.tsx
+++ b/apps/web/src/components/cloud-agent-next/ChildSessionSection.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { useState, type ReactNode } from 'react';
-import { ChevronRight, ChevronDown, Bot, Loader2 } from 'lucide-react';
+import { ChevronRight, ChevronDown, Bot, CornerDownRight } from 'lucide-react';
+import { StatusSpinner } from '@/components/shared/StatusSpinner';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
 import type { KiloSessionId } from '@kilocode/cloud-agent-sdk';
 import type { SubtaskPart, StoredMessage, ToolPart, Part } from './types';
 import { isMessageStreaming, isToolPart } from './types';
@@ -38,10 +40,6 @@ type ChildSessionSectionProps = {
   onOpenChildSession?: OpenChildSession;
 };
 
-/**
- * ChildSessionSection - Compact task row that opens Cloud Agent child transcripts in a drawer.
- * Consumers without a drawer callback retain the existing inline child transcript fallback.
- */
 export function ChildSessionSection({
   subtaskPart,
   taskToolPart,
@@ -56,11 +54,11 @@ export function ChildSessionSection({
   const description = subtaskPart?.description || getTaskDescription(taskToolPart);
   const agent = subtaskPart?.agent || getTaskAgent(taskToolPart);
   const taskStatus = taskToolPart?.state?.status;
+  const isCompleted = taskStatus === 'completed';
   const isRunning = taskStatus === 'running' || taskStatus === 'pending';
   const latestTool = isRunning ? getLatestToolActivity(childMessages) : undefined;
   const agentLabel = agent ? agent.charAt(0).toUpperCase() + agent.slice(1) : undefined;
-  const activity = latestTool ? `Latest: ${latestTool}` : undefined;
-  const progress = activity ?? (taskStatus === 'pending' ? 'Delegating...' : 'Working...');
+  const progress = latestTool ?? (taskStatus === 'pending' ? 'Delegating...' : 'Working...');
   const statusLabel =
     taskStatus === 'completed' ? 'Completed' : taskStatus === 'error' ? 'Failed' : undefined;
   const toolCount = childMessages.reduce(
@@ -83,22 +81,52 @@ export function ChildSessionSection({
     }
   };
 
+  const summary = (statusLabel || toolCount > 0) && (
+    <span className="flex shrink-0 items-center gap-2 font-normal whitespace-nowrap">
+      {statusLabel && (
+        <span className={taskStatus === 'error' ? 'text-destructive' : undefined}>
+          {statusLabel}
+        </span>
+      )}
+      {statusLabel && toolCount > 0 && <span aria-hidden="true">·</span>}
+      {toolCount > 0 && (
+        <span className="tabular-nums">
+          {toolCount} {toolCount === 1 ? 'tool call' : 'tool calls'}
+        </span>
+      )}
+    </span>
+  );
+
   const rowContent = (
     <>
-      {isRunning ? (
-        <Loader2 className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none" />
-      ) : (
-        <Bot className="size-3.5 shrink-0" />
-      )}
-      <span className="flex min-w-0 flex-1 flex-col gap-0.5 text-left">
-        <span className="flex min-w-0 items-center gap-2">
-          <span className="truncate" title={description}>
+      <span className="flex min-w-0 items-center gap-2">
+        {isRunning ? (
+          <StatusSpinner
+            className="size-4 shrink-0 motion-reduce:[&_rect]:animate-none!"
+            title={taskStatus === 'pending' ? 'Delegating' : 'Working'}
+          />
+        ) : (
+          <Bot className="size-4 shrink-0" aria-hidden="true" />
+        )}
+        <span
+          className={cn(
+            'flex min-w-0 flex-1 items-center gap-x-2 gap-y-1',
+            !isCompleted && 'flex-wrap'
+          )}
+        >
+          <span
+            className={cn('min-w-0 font-normal', isCompleted ? 'truncate' : 'wrap-anywhere')}
+            title={description}
+          >
             {description || 'Subagent task'}
           </span>
           {agentLabel && (
             <Badge
               variant="outline"
-              className="max-w-[35%] shrink-0 px-1.5 py-0 text-xs font-normal"
+              className={cn(
+                'px-1.5 py-0 text-xs font-normal',
+                isCompleted ? 'max-w-[45%] shrink-0' : 'max-w-full'
+              )}
             >
               <span className="truncate" title={agentLabel}>
                 {agentLabel}
@@ -106,51 +134,51 @@ export function ChildSessionSection({
             </Badge>
           )}
         </span>
-        {isRunning && (
-          <span className="truncate font-normal" title={progress}>
-            {progress}
-          </span>
-        )}
+        {isCompleted && summary}
+        {isInteractive &&
+          (canExpandInline && isExpanded ? (
+            <ChevronDown className="text-muted-foreground size-4 shrink-0" aria-hidden="true" />
+          ) : (
+            <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden="true" />
+          ))}
       </span>
-      {(statusLabel || toolCount > 0) && (
-        <span className="flex shrink-0 items-center gap-2 font-normal">
-          {statusLabel && (
-            <span className={taskStatus === 'error' ? 'text-destructive' : undefined}>
-              {statusLabel}
+      {!isCompleted && (isRunning || statusLabel || toolCount > 0) && (
+        <span className="text-muted-foreground ml-6 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 font-normal">
+          {isRunning && (
+            <span className="flex min-w-0 items-center gap-2">
+              {latestTool && <CornerDownRight className="size-4 shrink-0" aria-hidden="true" />}
+              <span className="truncate" title={progress}>
+                {progress}
+              </span>
             </span>
           )}
-          {statusLabel && toolCount > 0 && <span aria-hidden="true">·</span>}
-          {toolCount > 0 && (
-            <span className="tabular-nums">
-              {toolCount} {toolCount === 1 ? 'tool call' : 'tool calls'}
-            </span>
-          )}
+          {summary}
         </span>
       )}
-      {isInteractive &&
-        (canExpandInline && isExpanded ? (
-          <ChevronDown className="size-3.5 shrink-0" />
-        ) : (
-          <ChevronRight className="size-3.5 shrink-0" />
-        ))}
     </>
   );
 
   return (
-    <div className="text-muted-foreground min-w-0 text-xs">
+    <div className="text-muted-foreground min-w-0 py-1 text-xs">
       {isInteractive ? (
         <Button
           variant="ghost"
+          size={null}
           onClick={handleOpen}
           aria-busy={isRunning || undefined}
           aria-haspopup={canOpenDrawer ? 'dialog' : undefined}
           aria-expanded={canExpandInline ? isExpanded : undefined}
-          className="hover:bg-muted/40 h-auto min-h-6 w-full items-center justify-start gap-2 px-2 py-1 text-left text-xs pointer-coarse:min-h-11"
+          className="hover:bg-muted/40 h-auto min-h-8 w-full flex-col items-stretch justify-center gap-1 px-2 py-2 text-left text-xs whitespace-normal pointer-coarse:min-h-11"
         >
           {rowContent}
         </Button>
       ) : (
-        <div className="flex min-h-6 w-full items-center gap-2 px-2 py-1">{rowContent}</div>
+        <div
+          aria-busy={isRunning || undefined}
+          className="flex min-h-8 w-full flex-col justify-center gap-1 px-2 py-2 pointer-coarse:min-h-11"
+        >
+          {rowContent}
+        </div>
       )}
 
       {isExpanded && inlineRenderPart && (

--- a/apps/web/src/components/cloud-agent-next/ConversationMessages.test.ts
+++ b/apps/web/src/components/cloud-agent-next/ConversationMessages.test.ts
@@ -553,8 +553,9 @@ describe('ConversationMessages', () => {
     const childControl = renderedButtons.find(button => button.includes('Inspect the parser'));
     expect(childControl).toContain('>Explore<');
     expect(childControl).not.toContain('explore Agent');
-    expect(childControl).toContain('Latest: Read parser.ts');
-    expect(childControl).toContain('parser.ts');
+    expect(childControl).toMatch(/<title>Working<\/title>[\s\S]*Inspect the parser/);
+    expect(childControl).toContain('>Read parser.ts<');
+    expect(childControl).not.toContain('Latest:');
     expect(childControl).toContain('2 tool calls');
     expect(childControl).toContain('aria-busy="true"');
     expect(childControl).not.toContain('aria-expanded=');
@@ -621,8 +622,8 @@ describe('ConversationMessages', () => {
         });
       const html = render();
 
-      expect(html).toContain(`Latest: Read package.json${status === 'error' ? ' (failed)' : ''}`);
-      expect(html).not.toContain('Latest: Shell');
+      expect(html).toContain(`>Read package.json${status === 'error' ? ' (failed)' : ''}<`);
+      expect(html).not.toContain('Shell pnpm');
       expect(html).not.toContain('Working...');
       expect(html).toContain('2 tool calls');
       expect(html).toContain('aria-busy="true"');
@@ -638,8 +639,8 @@ describe('ConversationMessages', () => {
         ])
       );
       const next = render();
-      expect(next).toContain('Latest: Read README.md');
-      expect(next).not.toContain('Latest: Read package.json');
+      expect(next).toContain('>Read README.md<');
+      expect(next).not.toContain('Read package.json');
       expect(next).toContain('3 tool calls');
       expect(next).toContain('aria-busy="true"');
     }
@@ -657,6 +658,8 @@ describe('ConversationMessages', () => {
       ]);
 
       expect(html).toContain(status === 'pending' ? 'Delegating...' : 'Working...');
+      expect(html).toContain(`<title>${status === 'pending' ? 'Delegating' : 'Working'}</title>`);
+      expect(html).toContain('aria-busy="true"');
       expect(html).not.toContain('0 tool calls');
       expect(html).not.toContain('Completed');
     }
@@ -690,7 +693,8 @@ describe('ConversationMessages', () => {
     expect(buttons(html)).toEqual([expect.stringContaining('Inspect the parser')]);
     expect(buttons(html)[0]).toContain('>Explore<');
     expect(buttons(html)[0]).toContain('Completed');
-    expect(buttons(html)[0]).not.toContain('Latest:');
+    expect(buttons(html)[0]).not.toContain('<title>Working</title>');
+    expect(buttons(html)[0]).not.toContain('>Shell pnpm<');
     expect(buttons(html)[0]).toContain('1 tool call');
     expect(buttons(html)[0]).not.toContain('1 tool calls');
     expect(buttons(html)[0]).not.toContain('aria-busy="true"');

--- a/apps/web/src/components/cloud-agent-next/SkillToolCard.tsx
+++ b/apps/web/src/components/cloud-agent-next/SkillToolCard.tsx
@@ -1,3 +1,5 @@
+import { BookOpen, Loader2, XCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import type { ToolPart } from './types';
 
 type SkillToolCardProps = {
@@ -8,24 +10,39 @@ export function SkillToolCard({ toolPart }: SkillToolCardProps) {
   const state = toolPart.state;
   const name = state.input.name || ('metadata' in state && state.metadata?.name);
   const skillName = typeof name === 'string' && name ? name : 'skill';
-  const skillLabel = `Skill "${skillName}"`;
   const isLoading = state.status === 'pending' || state.status === 'running';
 
-  if (state.status === 'error') {
-    return (
-      <div className="text-destructive flex min-w-0 items-baseline gap-2 px-1 py-0.5 font-mono text-sm">
-        <span className="shrink-0">→</span>
-        <span className="shrink-0">{skillLabel}</span>
-        <span className="truncate">{state.error ?? 'Failed to load skill'}</span>
-      </div>
-    );
-  }
-
   return (
-    <div className="text-muted-foreground flex min-w-0 items-center gap-2 px-1 py-0.5 font-mono text-sm">
-      <span className="shrink-0">→</span>
-      <span className="truncate">{skillLabel}</span>
-      {isLoading && <span className="animate-pulse">...</span>}
+    <div
+      data-tool-card
+      aria-busy={isLoading || undefined}
+      className={cn(
+        'text-muted-foreground flex min-h-6 min-w-0 items-center gap-2 px-2 py-1 text-xs',
+        state.status === 'error' && 'text-destructive'
+      )}
+    >
+      {isLoading ? (
+        <Loader2
+          className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none"
+          aria-hidden="true"
+        />
+      ) : state.status === 'error' ? (
+        <XCircle className="size-3.5 shrink-0" aria-hidden="true" />
+      ) : (
+        <BookOpen className="size-3.5 shrink-0" aria-hidden="true" />
+      )}
+      <span className="shrink-0">Skill</span>
+      <span aria-hidden="true" className="text-muted-foreground/60">
+        ·
+      </span>
+      <span className="min-w-0 truncate font-mono" title={skillName}>
+        {skillName}
+      </span>
+      {state.status === 'error' && (
+        <span className="min-w-0 truncate" title={state.error}>
+          {state.error ?? 'Failed to load skill'}
+        </span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Match skill calls to standard tool rows while keeping skill contents hidden.
- Give subagents subtle spacing and regular-weight text, with single-line completed summaries.
- Use the existing moving-squares spinner on active subagent headings and an indented branch arrow before the latest tool.
- Preserve status/counts, drawer and inline controls, keyboard focus, and reduced-motion support.

## Verification

- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- 154 passing tests across `tool-card-parity`, `ConversationMessages`, and `message-presentation` using the repository Jest config without database setup hooks.
- Formatting on changed files and `git diff --check`.
- Browser component fixtures at 320, 375, 768, and 1440px: layout/overflow, loading and completion transitions, keyboard controls, and reduced motion.

Browser verification used isolated component fixtures, not a live-agent end-to-end session.

## Screenshot

Desktop component fixture using the production components and styles.

![Cloud Agent chat UI at 1440px](https://github.com/user-attachments/assets/6726506b-b5fb-4d33-9338-9986313560de)