### PR TITLE
feat(mobile): show pull request sidebar metadata

### DIFF
--- a/apps/mobile/src/components/pr-review/full-surface-states.mounted.test.tsx
+++ b/apps/mobile/src/components/pr-review/full-surface-states.mounted.test.tsx
@@ -79,7 +79,14 @@ vi.mock('@/components/ui/button', () => ({ Button: 'Button' }));
 vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
 vi.mock('@/components/ui/icons', () => ({
   CheckCheck: 'CheckCheck',
+  CircleCheck: 'CircleCheck',
+  CircleDot: 'CircleDot',
+  CircleX: 'CircleX',
+  Clock: 'Clock',
   GitPullRequest: 'GitPullRequest',
+  MessageSquare: 'MessageSquare',
+  UserRound: 'UserRound',
+  Users: 'Users',
 }));
 vi.mock('@/lib/config', () => ({ WEB_BASE_URL: 'https://example.test' }));
 vi.mock('@/lib/hooks/use-theme-colors', () => ({ useThemeColors: () => ({}) }));
@@ -136,7 +143,22 @@ describe('PR Overview full-body states', () => {
   );
 
   it('keeps cached overview content and its refresh control after a transient failure', async () => {
-    query.data = { title: 'Saved title', headSha: '1234567', counts: {}, bodyMarkdown: '' };
+    query.data = {
+      title: 'Saved title',
+      headSha: '1234567',
+      counts: {},
+      bodyMarkdown: '',
+      state: 'open',
+      createdAt: '2026-03-01T12:00:00Z',
+      updatedAt: '2026-03-02T09:30:00Z',
+      closedAt: null,
+      mergedAt: null,
+      mergedBy: null,
+      labels: [],
+      assignees: [],
+      reviewers: [],
+      linkedIssues: [],
+    };
     const { renderer, unmount } = await renderWithProviders(
       createElement(PrReviewOverview, overviewProps)
     );

--- a/apps/mobile/src/components/pr-review/pr-review-meta-parts.test.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-meta-parts.test.tsx
@@ -1,0 +1,159 @@
+// The sidebar metadata sections render only what GitHub reported: an empty
+// array draws no heading, and a reviewer's state picks both its icon and its
+// theme-color token (Lucide icons take `color`, never a Tailwind class).
+
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to test React/RN structure under vitest */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import type * as ReactI18next from 'react-i18next';
+
+import { lightColors } from '@/lib/hooks/use-theme-colors';
+import { type PrOverviewDto } from '@/lib/pr-review/merge/merge-blocked-reasons';
+
+import { PrOverviewMeta } from './pr-review-meta-parts';
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  View: 'View',
+  useColorScheme: () => 'light',
+}));
+
+vi.mock('expo-router', () => ({ DarkTheme: {}, DefaultTheme: {} }));
+vi.mock('expo-web-browser', () => ({ openBrowserAsync: vi.fn() }));
+
+vi.mock('react-i18next', async importOriginal => {
+  const actual = await importOriginal<typeof ReactI18next>();
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  };
+});
+
+vi.mock('@/components/ui/icons', () => ({
+  CircleCheck: 'CircleCheck',
+  CircleDot: 'CircleDot',
+  CircleX: 'CircleX',
+  Clock: 'Clock',
+  MessageSquare: 'MessageSquare',
+  UserRound: 'UserRound',
+  Users: 'Users',
+}));
+
+vi.mock('@/components/ui/image', () => ({ Image: 'Image' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+
+function overview(overrides: Partial<PrOverviewDto> = {}): PrOverviewDto {
+  // Only the fields PrOverviewMeta reads; the rest of the DTO is irrelevant here.
+  const dto: Pick<
+    PrOverviewDto,
+    | 'assignees'
+    | 'closedAt'
+    | 'createdAt'
+    | 'labels'
+    | 'linkedIssues'
+    | 'mergedAt'
+    | 'mergedBy'
+    | 'reviewers'
+    | 'state'
+    | 'updatedAt'
+  > = {
+    state: 'open',
+    createdAt: '2026-03-01T12:00:00Z',
+    updatedAt: '2026-03-02T09:30:00Z',
+    closedAt: null,
+    mergedAt: null,
+    mergedBy: null,
+    labels: [],
+    assignees: [],
+    reviewers: [],
+    linkedIssues: [],
+    ...overrides,
+  };
+  return dto as PrOverviewDto;
+}
+
+function render(dto: PrOverviewDto) {
+  const rendered: { current: TestRenderer.ReactTestRenderer | null } = { current: null };
+  act(() => {
+    rendered.current = TestRenderer.create(createElement(PrOverviewMeta, { overview: dto }));
+  });
+  if (!rendered.current) {
+    throw new Error('render produced no tree');
+  }
+  return rendered.current;
+}
+
+describe('PrOverviewMeta', () => {
+  it('draws only the timeline line when GitHub reported no sidebar metadata', () => {
+    const renderer = render(overview());
+    // The timeline is the single Text; no section heading icon is mounted.
+    expect(renderer.root.findAll(node => String(node.type) === 'Users')).toHaveLength(0);
+    expect(renderer.root.findAll(node => String(node.type) === 'UserRound')).toHaveLength(0);
+    expect(renderer.root.findAll(node => String(node.type) === 'CircleDot')).toHaveLength(0);
+  });
+
+  it('paints a label chip with GitHub’s own color and a readable text color', () => {
+    const renderer = render(overview({ labels: [{ name: 'bug', color: 'd73a4a' }] }));
+    const chip = renderer.root.find(
+      node =>
+        String(node.type) === 'View' &&
+        (node.props.style as { backgroundColor?: string } | undefined)?.backgroundColor ===
+          '#d73a4a'
+    );
+    expect(chip).toBeDefined();
+    const label = renderer.root.find(
+      node => String(node.type) === 'Text' && node.props.children === 'bug'
+    );
+    expect(label.props.style).toEqual({ color: '#ffffff' });
+  });
+
+  it('falls back to the neutral chip when the label color is not a hex triplet', () => {
+    const renderer = render(overview({ labels: [{ name: 'odd', color: 'nope' }] }));
+    const label = renderer.root.find(
+      node => String(node.type) === 'Text' && node.props.children === 'odd'
+    );
+    expect(label.props.style).toBeUndefined();
+    expect(label.props.className).toContain('text-foreground');
+  });
+
+  it('gives each reviewer state its own icon and theme color token', () => {
+    const renderer = render(
+      overview({
+        reviewers: [
+          { login: 'ada', avatarUrl: null, state: 'APPROVED' },
+          { login: 'grace', avatarUrl: null, state: 'CHANGES_REQUESTED' },
+          { login: 'ken', avatarUrl: null, state: 'PENDING' },
+        ],
+      })
+    );
+    const approved = renderer.root.find(node => String(node.type) === 'CircleCheck');
+    expect(approved.props.color).toBe(lightColors.good);
+    const changes = renderer.root.find(node => String(node.type) === 'CircleX');
+    expect(changes.props.color).toBe(lightColors.destructive);
+    const pending = renderer.root.find(node => String(node.type) === 'Clock');
+    expect(pending.props.color).toBe(lightColors.mutedForeground);
+  });
+
+  it('opens a linked issue in the browser', async () => {
+    const { openBrowserAsync } = await import('expo-web-browser');
+    const renderer = render(
+      overview({
+        linkedIssues: [
+          {
+            number: 42,
+            title: 'Flux capacitor leaks',
+            url: 'https://github.com/kilo/flux/issues/42',
+            closed: false,
+          },
+        ],
+      })
+    );
+    const row = renderer.root.find(node => String(node.type) === 'Pressable');
+    act(() => {
+      (row.props.onPress as () => void)();
+    });
+    expect(openBrowserAsync).toHaveBeenCalledWith('https://github.com/kilo/flux/issues/42');
+  });
+});

--- a/apps/mobile/src/components/pr-review/pr-review-meta-parts.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-meta-parts.tsx
@@ -1,0 +1,204 @@
+// The sidebar metadata GitHub shows beside a pull request: when it opened and
+// last moved, its labels, its reviewers and their verdicts, its assignees, and
+// the issues it closes. Every section hides itself when GitHub reports nothing,
+// so a bare PR renders exactly what it does today.
+
+import * as WebBrowser from 'expo-web-browser';
+import { useTranslation } from 'react-i18next';
+import { Pressable, View } from 'react-native';
+
+import {
+  CircleCheck,
+  CircleDot,
+  CircleX,
+  Clock,
+  type LucideIcon,
+  MessageSquare,
+  UserRound,
+  Users,
+} from '@/components/ui/icons';
+import { PrAvatar } from '@/components/pr-review/pr-review-overview-parts';
+import { Text } from '@/components/ui/text';
+import { type ThemeColors, useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { type PrOverviewDto } from '@/lib/pr-review/merge/merge-blocked-reasons';
+import {
+  buildPrTimeline,
+  labelChipColors,
+  type PrReviewerState,
+  reviewerStateLabelKey,
+  reviewerStateTone,
+  type ReviewerTone,
+} from '@/lib/pr-review/overview-meta';
+import { cn, parseTimestamp, timeAgo } from '@/lib/utils';
+
+// Lucide icons do not take a `className` color, so each tone names a theme
+// color token instead of a Tailwind text class.
+const REVIEWER_TONE_COLOR = {
+  good: 'good',
+  destructive: 'destructive',
+  muted: 'mutedForeground',
+} satisfies Record<ReviewerTone, keyof ThemeColors>;
+
+const REVIEWER_TONE_CLASS = {
+  good: 'text-good',
+  destructive: 'text-destructive',
+  muted: 'text-muted-foreground',
+} satisfies Record<ReviewerTone, string>;
+
+// Icons live here, not in the pure selector module: `merge-blocked-reasons.ts`
+// keeps lucide out of the plain-Node test path for the same reason.
+const REVIEWER_STATE_ICON = {
+  APPROVED: CircleCheck,
+  CHANGES_REQUESTED: CircleX,
+  COMMENTED: MessageSquare,
+  DISMISSED: MessageSquare,
+  PENDING: Clock,
+} satisfies Record<PrReviewerState, LucideIcon>;
+
+function SectionHeading({ icon: Icon, label }: Readonly<{ icon?: LucideIcon; label: string }>) {
+  const colors = useThemeColors();
+  return (
+    <View className="flex-row items-center gap-1.5">
+      {Icon ? <Icon size={12} color={colors.mutedForeground} /> : null}
+      <Text variant="eyebrow" className="uppercase tracking-wide text-muted-foreground">
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+/** "Opened 3 days ago · Updated 2 hours ago" — one line, always present. */
+function PrTimelineLine({ overview }: Readonly<{ overview: PrOverviewDto }>) {
+  const { t } = useTranslation();
+  const parts = buildPrTimeline(overview).map(entry =>
+    t(entry.labelKey, { time: timeAgo(parseTimestamp(entry.iso)), login: entry.login ?? '' })
+  );
+  return (
+    <Text variant="muted" className="text-sm">
+      {parts.join(' · ')}
+    </Text>
+  );
+}
+
+function PrLabelChips({ labels }: Readonly<{ labels: PrOverviewDto['labels'] }>) {
+  return (
+    <View className="flex-row flex-wrap gap-1.5">
+      {labels.map(label => {
+        const chip = labelChipColors(label.color);
+        return (
+          <View
+            key={label.name}
+            className={cn('rounded-full px-2.5 py-1', chip ? undefined : 'bg-secondary')}
+            style={chip ? { backgroundColor: chip.background } : undefined}
+          >
+            <Text
+              className={cn('text-xs font-medium', chip ? undefined : 'text-foreground')}
+              style={chip ? { color: chip.text } : undefined}
+            >
+              {label.name}
+            </Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function PrReviewersSection({ reviewers }: Readonly<{ reviewers: PrOverviewDto['reviewers'] }>) {
+  const colors = useThemeColors();
+  const { t } = useTranslation();
+  return (
+    <View className="gap-2">
+      <SectionHeading icon={Users} label={t('prReview.overview.reviewers')} />
+      {reviewers.map(reviewer => {
+        const tone = reviewerStateTone(reviewer.state);
+        const StateIcon = REVIEWER_STATE_ICON[reviewer.state];
+        const stateLabel = t(reviewerStateLabelKey(reviewer.state));
+        return (
+          <View key={reviewer.login} accessible className="flex-row items-center gap-2">
+            <PrAvatar avatarUrl={reviewer.avatarUrl} />
+            <Text className="flex-1 text-sm text-foreground" numberOfLines={1}>
+              {reviewer.login}
+            </Text>
+            <StateIcon size={14} color={colors[REVIEWER_TONE_COLOR[tone]]} />
+            <Text className={cn('text-xs', REVIEWER_TONE_CLASS[tone])}>{stateLabel}</Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function PrAssigneesRow({ assignees }: Readonly<{ assignees: PrOverviewDto['assignees'] }>) {
+  const { t } = useTranslation();
+  return (
+    <View className="gap-2">
+      <SectionHeading icon={UserRound} label={t('prReview.overview.assignees')} />
+      <View className="flex-row flex-wrap items-center gap-x-3 gap-y-1.5">
+        {assignees.map(assignee => (
+          <View key={assignee.login} className="flex-row items-center gap-1.5">
+            <PrAvatar avatarUrl={assignee.avatarUrl} />
+            <Text className="text-sm text-foreground" numberOfLines={1}>
+              {assignee.login}
+            </Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function PrLinkedIssues({ issues }: Readonly<{ issues: PrOverviewDto['linkedIssues'] }>) {
+  const colors = useThemeColors();
+  const { t } = useTranslation();
+  return (
+    <View className="gap-2">
+      <SectionHeading icon={CircleDot} label={t('prReview.overview.linkedIssues')} />
+      {issues.map(issue => {
+        const Icon = issue.closed ? CircleCheck : CircleDot;
+        return (
+          <Pressable
+            key={issue.number}
+            accessibilityRole="link"
+            accessibilityLabel={t('prReview.overview.openIssueA11y', { number: issue.number })}
+            onPress={() => {
+              void WebBrowser.openBrowserAsync(issue.url);
+            }}
+            className="min-h-11 flex-row items-center gap-2 active:opacity-70"
+          >
+            <Icon size={14} color={issue.closed ? colors.mutedForeground : colors.good} />
+            <Text variant="mono" className="text-[13px] text-muted-foreground">
+              #{issue.number}
+            </Text>
+            <Text className="flex-1 text-sm text-foreground" numberOfLines={1}>
+              {issue.title}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+/**
+ * Every sidebar block, in GitHub's own order. `reviewers` and `linkedIssues`
+ * come from the overview's GraphQL leg, which degrades to empty on a GraphQL
+ * failure — an empty section renders nothing rather than an empty heading.
+ */
+export function PrOverviewMeta({ overview }: Readonly<{ overview: PrOverviewDto }>) {
+  const { t } = useTranslation();
+  return (
+    <View className="gap-4">
+      <PrTimelineLine overview={overview} />
+      {overview.labels.length > 0 ? (
+        <View className="gap-2">
+          <SectionHeading label={t('prReview.overview.labels')} />
+          <PrLabelChips labels={overview.labels} />
+        </View>
+      ) : null}
+      {overview.reviewers.length > 0 ? <PrReviewersSection reviewers={overview.reviewers} /> : null}
+      {overview.assignees.length > 0 ? <PrAssigneesRow assignees={overview.assignees} /> : null}
+      {overview.linkedIssues.length > 0 ? <PrLinkedIssues issues={overview.linkedIssues} /> : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/pr-review/pr-review-overview-parts.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-overview-parts.tsx
@@ -102,6 +102,25 @@ export function PrStateChip({ descriptor }: Readonly<{ descriptor: PrStateChipDe
   );
 }
 
+/**
+ * A GitHub account's avatar at the size every PR-review row uses. Falls back
+ * to the muted circle when GitHub reports no avatar, so the row never jumps.
+ */
+export function PrAvatar({ avatarUrl }: Readonly<{ avatarUrl: string | null }>) {
+  if (!avatarUrl) {
+    return <View className="size-6 rounded-full bg-muted" />;
+  }
+  return (
+    <Image
+      source={{ uri: avatarUrl }}
+      className="size-6 rounded-full"
+      transition={0}
+      cachePolicy="memory"
+      accessibilityIgnoresInvertColors
+    />
+  );
+}
+
 export function PrAuthorRow({
   author,
 }: Readonly<{ author: { login: string; avatarUrl: string | null } | null }>) {
@@ -109,7 +128,7 @@ export function PrAuthorRow({
   if (!author) {
     return (
       <View className="flex-row items-center gap-2">
-        <View className="size-6 rounded-full bg-muted" />
+        <PrAvatar avatarUrl={null} />
         <Text variant="muted" className="text-sm">
           {t('prReview.overview.unknownAuthor')}
         </Text>
@@ -118,17 +137,7 @@ export function PrAuthorRow({
   }
   return (
     <View className="flex-row items-center gap-2">
-      {author.avatarUrl ? (
-        <Image
-          source={{ uri: author.avatarUrl }}
-          className="size-6 rounded-full"
-          transition={0}
-          cachePolicy="memory"
-          accessibilityIgnoresInvertColors
-        />
-      ) : (
-        <View className="size-6 rounded-full bg-muted" />
-      )}
+      <PrAvatar avatarUrl={author.avatarUrl} />
       <Text className="text-sm font-medium text-foreground" numberOfLines={1}>
         {author.login}
       </Text>

--- a/apps/mobile/src/components/pr-review/pr-review-overview.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-overview.tsx
@@ -11,6 +11,7 @@ import { DetailScreenScrollView } from '@/components/detail-screen';
 import { EmptyState } from '@/components/empty-state';
 import { QueryError } from '@/components/query-error';
 import { MarkdownText } from '@/components/agents/markdown-text';
+import { PrOverviewMeta } from '@/components/pr-review/pr-review-meta-parts';
 import { PrReviewChecksSection } from '@/components/pr-review/pr-review-checks-section';
 import { PrMergeSection } from '@/components/pr-review/merge/pr-merge-section';
 import {
@@ -211,6 +212,8 @@ export function PrReviewOverview({
           deletions={data.counts.deletions}
         />
       </View>
+
+      <PrOverviewMeta overview={data} />
 
       <View className="gap-2">
         <Text variant="eyebrow" className="uppercase tracking-wide text-muted-foreground">

--- a/apps/mobile/src/components/pr-review/pr-review-screen.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-screen.tsx
@@ -237,7 +237,11 @@ export function PrReviewScreen({ owner, repo, number }: PrReviewScreenProps) {
         }
       />
       <View className="px-4 pb-2 pt-3">
-        <PrReviewTabSelector activeTab={tab} onChange={setTab} />
+        <PrReviewTabSelector
+          activeTab={tab}
+          onChange={setTab}
+          discussionCount={pr.data?.commentCount}
+        />
       </View>
       {body}
     </View>

--- a/apps/mobile/src/components/pr-review/pr-review-tab-selector.test.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-tab-selector.test.tsx
@@ -1,0 +1,62 @@
+// The Discussion tab carries a comment-count badge so an empty discussion is
+// visible without opening the tab. No count (the PR query is still loading) and
+// a zero count both draw nothing — a "0" badge is noise, not information.
+
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to test React/RN structure under vitest */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import type * as ReactI18next from 'react-i18next';
+
+import { type PrReviewTabId, PrReviewTabSelector } from './pr-review-tab-selector';
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  View: 'View',
+  useColorScheme: () => 'light',
+}));
+
+vi.mock('expo-haptics', () => ({ selectionAsync: vi.fn() }));
+vi.mock('expo-router', () => ({ DarkTheme: {}, DefaultTheme: {} }));
+
+vi.mock('react-i18next', async importOriginal => {
+  const actual = await importOriginal<typeof ReactI18next>();
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  };
+});
+
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+
+function badges(discussionCount: number | undefined) {
+  const rendered: { current: TestRenderer.ReactTestRenderer | null } = { current: null };
+  act(() => {
+    rendered.current = TestRenderer.create(
+      createElement(PrReviewTabSelector, {
+        activeTab: 'overview',
+        onChange: vi.fn<(tab: PrReviewTabId) => void>(),
+        discussionCount,
+      })
+    );
+  });
+  if (!rendered.current) {
+    throw new Error('render produced no tree');
+  }
+  return rendered.current.root
+    .findAll(node => String(node.type) === 'Text')
+    .map(node => node.props.children)
+    .filter(child => typeof child === 'string' && !child.startsWith('prReview.'));
+}
+
+describe('PrReviewTabSelector', () => {
+  it('shows the comment count on the Discussion tab', () => {
+    expect(badges(12)).toEqual(['12']);
+  });
+
+  it('draws no badge while the count is unknown or zero', () => {
+    expect(badges(undefined)).toEqual([]);
+    expect(badges(0)).toEqual([]);
+  });
+});

--- a/apps/mobile/src/components/pr-review/pr-review-tab-selector.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-tab-selector.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { Pressable, View } from 'react-native';
 
 import { Text } from '@/components/ui/text';
+import { i18n } from '@/i18n';
+import { formatNumber } from '@/lib/format';
 import { cn } from '@/lib/utils';
 
 export type PrReviewTabId = 'overview' | 'files' | 'discussion';
@@ -16,6 +18,12 @@ const TABS = [
 type PrReviewTabSelectorProps = {
   activeTab: PrReviewTabId;
   onChange: (tab: PrReviewTabId) => void;
+  /**
+   * Conversation plus review comments. Rendered as a badge on the Discussion
+   * tab so an empty discussion is visible without opening it; omitted (or 0)
+   * while the PR query is still loading, which draws no badge.
+   */
+  discussionCount?: number;
 };
 
 /**
@@ -24,12 +32,20 @@ type PrReviewTabSelectorProps = {
  * S6b (Files body) and S7b (Discussion body) only ever render their
  * respective tab bodies — the parent screen owns the tab state.
  */
-export function PrReviewTabSelector({ activeTab, onChange }: PrReviewTabSelectorProps) {
+export function PrReviewTabSelector({
+  activeTab,
+  onChange,
+  discussionCount,
+}: PrReviewTabSelectorProps) {
   const { t } = useTranslation();
   return (
     <View accessibilityRole="tablist" className="flex-row gap-1 rounded-lg bg-secondary p-1">
       {TABS.map(tab => {
         const active = tab.id === activeTab;
+        const badge =
+          tab.id === 'discussion' && discussionCount && discussionCount > 0
+            ? formatNumber(discussionCount, i18n.language)
+            : null;
         return (
           <Pressable
             key={tab.id}
@@ -47,14 +63,21 @@ export function PrReviewTabSelector({ activeTab, onChange }: PrReviewTabSelector
               active && 'bg-card shadow-sm shadow-[#0000000D]'
             )}
           >
-            <Text
-              className={cn(
-                'text-sm',
-                active ? 'font-semibold text-foreground' : 'text-muted-foreground'
-              )}
-            >
-              {t(tab.labelKey)}
-            </Text>
+            <View className="flex-row items-center gap-1.5">
+              <Text
+                className={cn(
+                  'text-sm',
+                  active ? 'font-semibold text-foreground' : 'text-muted-foreground'
+                )}
+              >
+                {t(tab.labelKey)}
+              </Text>
+              {badge ? (
+                <View className="min-w-5 rounded-full bg-muted px-1.5 py-0.5">
+                  <Text className="text-center text-[11px] text-muted-foreground">{badge}</Text>
+                </View>
+              ) : null}
+            </View>
           </Pressable>
         );
       })}

--- a/apps/mobile/src/i18n/locales/af.json
+++ b/apps/mobile/src/i18n/locales/af.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "lêer",
       "file": "lêers",
-      "file_other": "lêers"
+      "file_other": "lêers",
+      "openedAgo": "Geopen {{time}}",
+      "updatedAgo": "Opgedateer {{time}}",
+      "mergedAgo": "Saamgevoeg {{time}}",
+      "mergedByAgo": "Saamgevoeg deur {{login}} {{time}}",
+      "closedAgo": "Gesluit {{time}}",
+      "labels": "Etikette",
+      "reviewers": "Resensente",
+      "assignees": "Toegewysdes",
+      "linkedIssues": "Gekoppelde kwessies",
+      "reviewApproved": "Goedgekeur",
+      "reviewChangesRequested": "Veranderinge versoek",
+      "reviewCommented": "Kommentaar gelewer",
+      "reviewPending": "Wag vir resensie",
+      "openIssueA11y": "Open kwessie #{{number}} op GitHub",
+      "reviewDismissed": "Verwerp"
     },
     "pendingComment": {
       "editOutdatedA11y": "Wysig uitgediende hangende kommentaar op {{location}}",

--- a/apps/mobile/src/i18n/locales/am.json
+++ b/apps/mobile/src/i18n/locales/am.json
@@ -550,7 +550,22 @@
       "commit_other": "መግባቶች",
       "file_one": "ፋይል",
       "file": "ፋይሎች",
-      "file_other": "ፋይሎች"
+      "file_other": "ፋይሎች",
+      "openedAgo": "የተከፈተው {{time}}",
+      "updatedAgo": "የተዘመነው {{time}}",
+      "mergedAgo": "ተዋህዷል {{time}}",
+      "mergedByAgo": "በ{{login}} የተዋሃደው {{time}}",
+      "closedAgo": "ተዘግቷል {{time}}",
+      "labels": "መለያዎች",
+      "reviewers": "ገምጋሚዎች",
+      "assignees": "ተመዳቢዎች",
+      "linkedIssues": "የተገናኙ ጉዳዮች",
+      "reviewApproved": "ጸድቋል",
+      "reviewChangesRequested": "ለውጦች ተጠይቀዋል",
+      "reviewCommented": "አስተያየት ተሰጥቷል",
+      "reviewPending": "ግምገማ በመጠባበቅ ላይ",
+      "openIssueA11y": "ጉዳይ #{{number}} በGitHub ላይ ክፈት",
+      "reviewDismissed": "ተወግዷል"
     },
     "pendingComment": {
       "editOutdatedA11y": "በ{{location}} ላይ ያለ ያረጀ በመጠባበቅ ላይ ያለ አስተያየት አስተካክል",

--- a/apps/mobile/src/i18n/locales/ar.json
+++ b/apps/mobile/src/i18n/locales/ar.json
@@ -2970,7 +2970,22 @@
       "file_zero": "لا ملفات",
       "file_two": "ملفّان",
       "file_few": "ملفات",
-      "file_many": "ملفًا"
+      "file_many": "ملفًا",
+      "openedAgo": "فُتح {{time}}",
+      "updatedAgo": "حُدّث {{time}}",
+      "mergedAgo": "تم الدمج {{time}}",
+      "mergedByAgo": "دمجه {{login}} {{time}}",
+      "closedAgo": "مغلق {{time}}",
+      "labels": "التسميات",
+      "reviewers": "المراجعون",
+      "assignees": "المكلَّفون",
+      "linkedIssues": "المشكلات المرتبطة",
+      "reviewApproved": "موافق عليه",
+      "reviewChangesRequested": "طُلبت تغييرات",
+      "reviewCommented": "علّق",
+      "reviewPending": "بانتظار المراجعة",
+      "openIssueA11y": "افتح المشكلة #{{number}} على GitHub",
+      "reviewDismissed": "مرفوض"
     },
     "pendingComment": {
       "allQueuedHint": "ستُرسل جميع التعليقات في طلب مجمّع واحد.",

--- a/apps/mobile/src/i18n/locales/az.json
+++ b/apps/mobile/src/i18n/locales/az.json
@@ -550,7 +550,22 @@
       "commit_other": "commit",
       "file_one": "fayl",
       "file": "fayl",
-      "file_other": "fayl"
+      "file_other": "fayl",
+      "openedAgo": "Açılıb {{time}}",
+      "updatedAgo": "Yenilənib {{time}}",
+      "mergedAgo": "Mergeləndi {{time}}",
+      "mergedByAgo": "{{login}} tərəfindən birləşdirilib {{time}}",
+      "closedAgo": "Bağlıdır {{time}}",
+      "labels": "Etiketlər",
+      "reviewers": "Baxış keçirənlər",
+      "assignees": "Təyin olunanlar",
+      "linkedIssues": "Bağlı məsələlər",
+      "reviewApproved": "Təsdiqlənib",
+      "reviewChangesRequested": "Dəyişikliklər tələb olunub",
+      "reviewCommented": "Şərh yazılıb",
+      "reviewPending": "Baxış gözlənilir",
+      "openIssueA11y": "#{{number}} məsələsini GitHub-da aç",
+      "reviewDismissed": "Rədd edilib"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} üzərində köhnəlmiş gözləyən şərhi redaktə et",

--- a/apps/mobile/src/i18n/locales/be.json
+++ b/apps/mobile/src/i18n/locales/be.json
@@ -564,7 +564,22 @@
       "commit_few": "каміты",
       "commit_many": "камітаў",
       "file_few": "файлы",
-      "file_many": "файлаў"
+      "file_many": "файлаў",
+      "openedAgo": "Адкрыта {{time}}",
+      "updatedAgo": "Абноўлена {{time}}",
+      "mergedAgo": "Зліта {{time}}",
+      "mergedByAgo": "Аб'яднаў {{login}} {{time}}",
+      "closedAgo": "Закрыты {{time}}",
+      "labels": "Меткі",
+      "reviewers": "Рэцэнзенты",
+      "assignees": "Прызначаныя",
+      "linkedIssues": "Звязаныя задачы",
+      "reviewApproved": "Ухвалена",
+      "reviewChangesRequested": "Запытаны змены",
+      "reviewCommented": "Пракаменціравана",
+      "reviewPending": "Чакае рэцэнзіі",
+      "openIssueA11y": "Адкрыць задачу #{{number}} на GitHub",
+      "reviewDismissed": "Адхілена"
     },
     "pendingComment": {
       "editOutdatedA11y": "Рэдагаваць састарэлы чакаючы каментар на {{location}}",

--- a/apps/mobile/src/i18n/locales/bg.json
+++ b/apps/mobile/src/i18n/locales/bg.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "файл",
       "file": "файлове",
-      "file_other": "файлове"
+      "file_other": "файлове",
+      "openedAgo": "Отворено {{time}}",
+      "updatedAgo": "Обновено {{time}}",
+      "mergedAgo": "Обединено {{time}}",
+      "mergedByAgo": "Слято от {{login}} {{time}}",
+      "closedAgo": "Затворено {{time}}",
+      "labels": "Етикети",
+      "reviewers": "Рецензенти",
+      "assignees": "Възложени",
+      "linkedIssues": "Свързани задачи",
+      "reviewApproved": "Одобрено",
+      "reviewChangesRequested": "Заявени промени",
+      "reviewCommented": "Коментирано",
+      "reviewPending": "Очаква преглед",
+      "openIssueA11y": "Отвори задача #{{number}} в GitHub",
+      "reviewDismissed": "Отхвърлено"
     },
     "pendingComment": {
       "editOutdatedA11y": "Редактирай остарял чакащ коментар на {{location}}",

--- a/apps/mobile/src/i18n/locales/bn.json
+++ b/apps/mobile/src/i18n/locales/bn.json
@@ -550,7 +550,22 @@
       "commit_other": "কমিট",
       "file_one": "ফাইল",
       "file": "ফাইল",
-      "file_other": "ফাইল"
+      "file_other": "ফাইল",
+      "openedAgo": "খোলা হয়েছে {{time}}",
+      "updatedAgo": "হালনাগাদ হয়েছে {{time}}",
+      "mergedAgo": "মার্জ হয়েছে {{time}}",
+      "mergedByAgo": "{{login}} মার্জ করেছেন {{time}}",
+      "closedAgo": "বন্ধ {{time}}",
+      "labels": "লেবেল",
+      "reviewers": "পর্যালোচক",
+      "assignees": "নিযুক্ত ব্যক্তি",
+      "linkedIssues": "সংযুক্ত ইস্যু",
+      "reviewApproved": "অনুমোদিত",
+      "reviewChangesRequested": "পরিবর্তন চাওয়া হয়েছে",
+      "reviewCommented": "মন্তব্য করা হয়েছে",
+      "reviewPending": "পর্যালোচনার অপেক্ষায়",
+      "openIssueA11y": "GitHub-এ ইস্যু #{{number}} খুলুন",
+      "reviewDismissed": "খারিজ করা হয়েছে"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}}-এ পুরাতন মুলতুবি মন্তব্য সম্পাদনা করুন",

--- a/apps/mobile/src/i18n/locales/bs.json
+++ b/apps/mobile/src/i18n/locales/bs.json
@@ -557,7 +557,22 @@
       "file": "datoteke",
       "file_other": "datoteke",
       "commit_few": "commita",
-      "file_few": "datoteke"
+      "file_few": "datoteke",
+      "openedAgo": "Otvoreno {{time}}",
+      "updatedAgo": "Ažurirano {{time}}",
+      "mergedAgo": "Spojeno {{time}}",
+      "mergedByAgo": "Spojio {{login}} {{time}}",
+      "closedAgo": "Zatvoreno {{time}}",
+      "labels": "Oznake",
+      "reviewers": "Recenzenti",
+      "assignees": "Dodijeljeni",
+      "linkedIssues": "Povezani problemi",
+      "reviewApproved": "Odobreno",
+      "reviewChangesRequested": "Tražene izmjene",
+      "reviewCommented": "Komentarisano",
+      "reviewPending": "Čeka recenziju",
+      "openIssueA11y": "Otvori problem #{{number}} na GitHubu",
+      "reviewDismissed": "Odbijeno"
     },
     "pendingComment": {
       "editOutdatedA11y": "Uredi zastarjeli komentar na čekanju na {{location}}",

--- a/apps/mobile/src/i18n/locales/ca.json
+++ b/apps/mobile/src/i18n/locales/ca.json
@@ -557,7 +557,22 @@
       "file": "fitxers",
       "file_other": "fitxers",
       "commit_many": "commits",
-      "file_many": "fitxers"
+      "file_many": "fitxers",
+      "openedAgo": "Obert {{time}}",
+      "updatedAgo": "Actualitzat {{time}}",
+      "mergedAgo": "Fusionada {{time}}",
+      "mergedByAgo": "Fusionat per {{login}} {{time}}",
+      "closedAgo": "Tancada {{time}}",
+      "labels": "Etiquetes",
+      "reviewers": "Revisors",
+      "assignees": "Assignats",
+      "linkedIssues": "Incidències vinculades",
+      "reviewApproved": "Aprovat",
+      "reviewChangesRequested": "Canvis sol·licitats",
+      "reviewCommented": "Comentat",
+      "reviewPending": "Pendent de revisió",
+      "openIssueA11y": "Obre la incidència #{{number}} a GitHub",
+      "reviewDismissed": "Descartat"
     },
     "pendingComment": {
       "editOutdatedA11y": "Edita el comentari pendent desactualitzat a {{location}}",

--- a/apps/mobile/src/i18n/locales/ckb.json
+++ b/apps/mobile/src/i18n/locales/ckb.json
@@ -550,7 +550,22 @@
       "commit_other": "کۆمیتەکان",
       "file_one": "فایل",
       "file": "فایلەکان",
-      "file_other": "فایلەکان"
+      "file_other": "فایلەکان",
+      "openedAgo": "کرایەوە {{time}}",
+      "updatedAgo": "نوێکرایەوە {{time}}",
+      "mergedAgo": "تێکەڵ کرا {{time}}",
+      "mergedByAgo": "{{login}} تێکەڵی کرد {{time}}",
+      "closedAgo": "داخراو {{time}}",
+      "labels": "پێناسەکان",
+      "reviewers": "پێداچوونەوەکاران",
+      "assignees": "دیاریکراوان",
+      "linkedIssues": "کێشە بەستراوەکان",
+      "reviewApproved": "پەسەندکرا",
+      "reviewChangesRequested": "گۆڕانکاری داواکرا",
+      "reviewCommented": "لێدوان درا",
+      "reviewPending": "چاوەڕێی پێداچوونەوە",
+      "openIssueA11y": "کێشەی #{{number}} لە GitHub بکەرەوە",
+      "reviewDismissed": "لابراو"
     },
     "pendingComment": {
       "editOutdatedA11y": "دەستکاریکردنی بۆچوونی چاوەڕوانی بەسەرچوو لەسەر {{location}}",

--- a/apps/mobile/src/i18n/locales/cs.json
+++ b/apps/mobile/src/i18n/locales/cs.json
@@ -564,7 +564,22 @@
       "commit_few": "commity",
       "commit_many": "commitů",
       "file_few": "soubory",
-      "file_many": "souborů"
+      "file_many": "souborů",
+      "openedAgo": "Otevřeno {{time}}",
+      "updatedAgo": "Aktualizováno {{time}}",
+      "mergedAgo": "Sloučeno {{time}}",
+      "mergedByAgo": "Sloučil {{login}} {{time}}",
+      "closedAgo": "Uzavřeno {{time}}",
+      "labels": "Štítky",
+      "reviewers": "Recenzenti",
+      "assignees": "Přiřazení",
+      "linkedIssues": "Propojené úkoly",
+      "reviewApproved": "Schváleno",
+      "reviewChangesRequested": "Vyžádány změny",
+      "reviewCommented": "Okomentováno",
+      "reviewPending": "Čeká na recenzi",
+      "openIssueA11y": "Otevřít úkol #{{number}} na GitHubu",
+      "reviewDismissed": "Zavrženo"
     },
     "pendingComment": {
       "editOutdatedA11y": "Upravit zastaralý čekající komentář na {{location}}",

--- a/apps/mobile/src/i18n/locales/cy.json
+++ b/apps/mobile/src/i18n/locales/cy.json
@@ -578,7 +578,22 @@
       "file_zero": "ffeil",
       "file_two": "ffeil",
       "file_few": "ffeil",
-      "file_many": "ffeiliau"
+      "file_many": "ffeiliau",
+      "openedAgo": "Agorwyd {{time}}",
+      "updatedAgo": "Diweddarwyd {{time}}",
+      "mergedAgo": "Wedi'i gyfuno {{time}}",
+      "mergedByAgo": "Cyfunwyd gan {{login}} {{time}}",
+      "closedAgo": "Ar gau {{time}}",
+      "labels": "Labeli",
+      "reviewers": "Adolygwyr",
+      "assignees": "Neilltuwyd i",
+      "linkedIssues": "Materion cysylltiedig",
+      "reviewApproved": "Cymeradwywyd",
+      "reviewChangesRequested": "Gofynnwyd am newidiadau",
+      "reviewCommented": "Sylwadwyd",
+      "reviewPending": "Yn aros am adolygiad",
+      "openIssueA11y": "Agor mater #{{number}} ar GitHub",
+      "reviewDismissed": "Wedi'i ddiystyru"
     },
     "pendingComment": {
       "editOutdatedA11y": "Golygu sylw ar y gweill hen ffasiwn ar {{location}}",

--- a/apps/mobile/src/i18n/locales/da.json
+++ b/apps/mobile/src/i18n/locales/da.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "fil",
       "file": "filer",
-      "file_other": "filer"
+      "file_other": "filer",
+      "openedAgo": "Åbnet {{time}}",
+      "updatedAgo": "Opdateret {{time}}",
+      "mergedAgo": "Flettet {{time}}",
+      "mergedByAgo": "Flettet af {{login}} {{time}}",
+      "closedAgo": "Lukket {{time}}",
+      "labels": "Etiketter",
+      "reviewers": "Anmeldere",
+      "assignees": "Tildelte",
+      "linkedIssues": "Tilknyttede sager",
+      "reviewApproved": "Godkendt",
+      "reviewChangesRequested": "Ændringer ønsket",
+      "reviewCommented": "Kommenteret",
+      "reviewPending": "Afventer gennemgang",
+      "openIssueA11y": "Åbn sag #{{number}} på GitHub",
+      "reviewDismissed": "Afvist"
     },
     "pendingComment": {
       "editOutdatedA11y": "Rediger forældet ventende kommentar på {{location}}",

--- a/apps/mobile/src/i18n/locales/de.json
+++ b/apps/mobile/src/i18n/locales/de.json
@@ -2890,7 +2890,22 @@
       "stateOpenApproved": "Offen · Genehmigt",
       "stateOpenChangesRequested": "Offen · Änderungen angefordert",
       "stateOpenReviewRequired": "Offen · Review erforderlich",
-      "unknownAuthor": "Unbekannter Autor"
+      "unknownAuthor": "Unbekannter Autor",
+      "openedAgo": "Geöffnet {{time}}",
+      "updatedAgo": "Aktualisiert {{time}}",
+      "mergedAgo": "Zusammengeführt {{time}}",
+      "mergedByAgo": "Zusammengeführt von {{login}} {{time}}",
+      "closedAgo": "Geschlossen {{time}}",
+      "labels": "Labels",
+      "reviewers": "Prüfer",
+      "assignees": "Zuständige",
+      "linkedIssues": "Verknüpfte Vorgänge",
+      "reviewApproved": "Genehmigt",
+      "reviewChangesRequested": "Änderungen erbeten",
+      "reviewCommented": "Kommentiert",
+      "reviewPending": "Wartet auf Prüfung",
+      "openIssueA11y": "Vorgang #{{number}} auf GitHub öffnen",
+      "reviewDismissed": "Verworfen"
     },
     "pendingComment": {
       "allQueuedHint": "Alle Kommentare werden in einer einzigen gebündelten Anfrage gesendet.",

--- a/apps/mobile/src/i18n/locales/el.json
+++ b/apps/mobile/src/i18n/locales/el.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "αρχείο",
       "file": "αρχεία",
-      "file_other": "αρχεία"
+      "file_other": "αρχεία",
+      "openedAgo": "Άνοιξε {{time}}",
+      "updatedAgo": "Ενημερώθηκε {{time}}",
+      "mergedAgo": "Συγχωνεύτηκε {{time}}",
+      "mergedByAgo": "Συγχωνεύτηκε από τον {{login}} {{time}}",
+      "closedAgo": "Κλειστό {{time}}",
+      "labels": "Ετικέτες",
+      "reviewers": "Κριτές",
+      "assignees": "Ανατέθηκε σε",
+      "linkedIssues": "Συνδεδεμένα ζητήματα",
+      "reviewApproved": "Εγκρίθηκε",
+      "reviewChangesRequested": "Ζητήθηκαν αλλαγές",
+      "reviewCommented": "Σχολιάστηκε",
+      "reviewPending": "Σε αναμονή κριτικής",
+      "openIssueA11y": "Άνοιγμα ζητήματος #{{number}} στο GitHub",
+      "reviewDismissed": "Απορρίφθηκε"
     },
     "pendingComment": {
       "editOutdatedA11y": "Επεξεργασία ξεπερασμένου εκκρεμούς σχολίου στο {{location}}",

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "file",
       "file": "files",
-      "file_other": "files"
+      "file_other": "files",
+      "openedAgo": "Opened {{time}}",
+      "updatedAgo": "Updated {{time}}",
+      "mergedAgo": "Merged {{time}}",
+      "mergedByAgo": "Merged by {{login}} {{time}}",
+      "closedAgo": "Closed {{time}}",
+      "labels": "Labels",
+      "reviewers": "Reviewers",
+      "assignees": "Assignees",
+      "linkedIssues": "Linked issues",
+      "reviewApproved": "Approved",
+      "reviewChangesRequested": "Changes requested",
+      "reviewCommented": "Commented",
+      "reviewDismissed": "Dismissed",
+      "reviewPending": "Awaiting review",
+      "openIssueA11y": "Open issue #{{number}} on GitHub"
     },
     "pendingComment": {
       "editOutdatedA11y": "Edit outdated pending comment on {{location}}",

--- a/apps/mobile/src/i18n/locales/es.json
+++ b/apps/mobile/src/i18n/locales/es.json
@@ -2910,7 +2910,22 @@
       "stateOpenReviewRequired": "Abierta · Revisión necesaria",
       "unknownAuthor": "Autor desconocido",
       "commit_many": "commits",
-      "file_many": "archivos"
+      "file_many": "archivos",
+      "openedAgo": "Abierto {{time}}",
+      "updatedAgo": "Actualizado {{time}}",
+      "mergedAgo": "Fusionada {{time}}",
+      "mergedByAgo": "Fusionado por {{login}} {{time}}",
+      "closedAgo": "Cerrada {{time}}",
+      "labels": "Etiquetas",
+      "reviewers": "Revisores",
+      "assignees": "Asignados",
+      "linkedIssues": "Incidencias vinculadas",
+      "reviewApproved": "Aprobado",
+      "reviewChangesRequested": "Cambios solicitados",
+      "reviewCommented": "Comentado",
+      "reviewPending": "Pendiente de revisión",
+      "openIssueA11y": "Abrir incidencia #{{number}} en GitHub",
+      "reviewDismissed": "Descartado"
     },
     "pendingComment": {
       "allQueuedHint": "Todos los comentarios se enviarán en una única solicitud por lotes.",

--- a/apps/mobile/src/i18n/locales/et.json
+++ b/apps/mobile/src/i18n/locales/et.json
@@ -550,7 +550,22 @@
       "commit_other": "commit'i",
       "file_one": "fail",
       "file": "faili",
-      "file_other": "faili"
+      "file_other": "faili",
+      "openedAgo": "Avatud {{time}}",
+      "updatedAgo": "Uuendatud {{time}}",
+      "mergedAgo": "Ühendatud {{time}}",
+      "mergedByAgo": "Liitis {{login}} {{time}}",
+      "closedAgo": "Suletud {{time}}",
+      "labels": "Sildid",
+      "reviewers": "Ülevaatajad",
+      "assignees": "Määratud",
+      "linkedIssues": "Seotud teemad",
+      "reviewApproved": "Kinnitatud",
+      "reviewChangesRequested": "Muudatusi soovitud",
+      "reviewCommented": "Kommenteeritud",
+      "reviewPending": "Ootab ülevaatust",
+      "openIssueA11y": "Ava teema #{{number}} GitHubis",
+      "reviewDismissed": "Kõrvale jäetud"
     },
     "pendingComment": {
       "editOutdatedA11y": "Muuda aegunud ootel kommentaari asukohas {{location}}",

--- a/apps/mobile/src/i18n/locales/eu.json
+++ b/apps/mobile/src/i18n/locales/eu.json
@@ -550,7 +550,22 @@
       "commit_other": "commit",
       "file_one": "fitxategi",
       "file": "fitxategi",
-      "file_other": "fitxategi"
+      "file_other": "fitxategi",
+      "openedAgo": "Irekita {{time}}",
+      "updatedAgo": "Eguneratua {{time}}",
+      "mergedAgo": "Batuta {{time}}",
+      "mergedByAgo": "{{login}} erabiltzaileak bateratua {{time}}",
+      "closedAgo": "Itxita {{time}}",
+      "labels": "Etiketak",
+      "reviewers": "Berrikusleak",
+      "assignees": "Esleituak",
+      "linkedIssues": "Lotutako arazoak",
+      "reviewApproved": "Onartua",
+      "reviewChangesRequested": "Aldaketak eskatuta",
+      "reviewCommented": "Iruzkindua",
+      "reviewPending": "Berrikuspenaren zain",
+      "openIssueA11y": "Ireki #{{number}} arazoa GitHuben",
+      "reviewDismissed": "Baztertuta"
     },
     "pendingComment": {
       "editOutdatedA11y": "Editatu {{location}}-ko iruzkin zaharkitua",

--- a/apps/mobile/src/i18n/locales/fa.json
+++ b/apps/mobile/src/i18n/locales/fa.json
@@ -550,7 +550,22 @@
       "commit_other": "commit",
       "file_one": "فایل",
       "file": "فایل",
-      "file_other": "فایل"
+      "file_other": "فایل",
+      "openedAgo": "باز شده {{time}}",
+      "updatedAgo": "به‌روزرسانی شده {{time}}",
+      "mergedAgo": "ادغام شد {{time}}",
+      "mergedByAgo": "ادغام‌شده توسط {{login}} {{time}}",
+      "closedAgo": "بسته {{time}}",
+      "labels": "برچسب‌ها",
+      "reviewers": "بازبین‌ها",
+      "assignees": "واگذارشدگان",
+      "linkedIssues": "مسائل مرتبط",
+      "reviewApproved": "تأیید شد",
+      "reviewChangesRequested": "تغییرات درخواست شد",
+      "reviewCommented": "نظر داده شد",
+      "reviewPending": "در انتظار بازبینی",
+      "openIssueA11y": "باز کردن مسئله #{{number}} در GitHub",
+      "reviewDismissed": "رد شده"
     },
     "pendingComment": {
       "editOutdatedA11y": "ویرایش نظر قدیمی در انتظار روی {{location}}",

--- a/apps/mobile/src/i18n/locales/fi.json
+++ b/apps/mobile/src/i18n/locales/fi.json
@@ -550,7 +550,22 @@
       "commit_other": "commitia",
       "file_one": "tiedosto",
       "file": "tiedostoa",
-      "file_other": "tiedostoa"
+      "file_other": "tiedostoa",
+      "openedAgo": "Avattu {{time}}",
+      "updatedAgo": "Päivitetty {{time}}",
+      "mergedAgo": "Yhdistetty {{time}}",
+      "mergedByAgo": "Yhdistänyt {{login}} {{time}}",
+      "closedAgo": "Suljettu {{time}}",
+      "labels": "Tunnisteet",
+      "reviewers": "Katselmoijat",
+      "assignees": "Vastuuhenkilöt",
+      "linkedIssues": "Linkitetyt tiketit",
+      "reviewApproved": "Hyväksytty",
+      "reviewChangesRequested": "Muutoksia pyydetty",
+      "reviewCommented": "Kommentoitu",
+      "reviewPending": "Odottaa katselmointia",
+      "openIssueA11y": "Avaa tiketti #{{number}} GitHubissa",
+      "reviewDismissed": "Hylätty"
     },
     "pendingComment": {
       "editOutdatedA11y": "Muokkaa vanhentunutta odottavaa kommenttia kohteessa {{location}}",

--- a/apps/mobile/src/i18n/locales/fil.json
+++ b/apps/mobile/src/i18n/locales/fil.json
@@ -550,7 +550,22 @@
       "commit_other": "mga commit",
       "file_one": "file",
       "file": "mga file",
-      "file_other": "mga file"
+      "file_other": "mga file",
+      "openedAgo": "Binuksan {{time}}",
+      "updatedAgo": "In-update {{time}}",
+      "mergedAgo": "Na-merge {{time}}",
+      "mergedByAgo": "Isinama ni {{login}} {{time}}",
+      "closedAgo": "Sarado {{time}}",
+      "labels": "Mga label",
+      "reviewers": "Mga tagasuri",
+      "assignees": "Mga naatasan",
+      "linkedIssues": "Mga naka-link na isyu",
+      "reviewApproved": "Naaprubahan",
+      "reviewChangesRequested": "Humiling ng mga pagbabago",
+      "reviewCommented": "May komento",
+      "reviewPending": "Naghihintay ng pagsusuri",
+      "openIssueA11y": "Buksan ang isyu #{{number}} sa GitHub",
+      "reviewDismissed": "Na-dismiss"
     },
     "pendingComment": {
       "editOutdatedA11y": "I-edit ang lumang nakabinbing komento sa {{location}}",

--- a/apps/mobile/src/i18n/locales/fr.json
+++ b/apps/mobile/src/i18n/locales/fr.json
@@ -2910,7 +2910,22 @@
       "stateOpenReviewRequired": "Ouverte · Revue requise",
       "unknownAuthor": "Auteur inconnu",
       "commit_many": "commits",
-      "file_many": "fichiers"
+      "file_many": "fichiers",
+      "openedAgo": "Ouverte {{time}}",
+      "updatedAgo": "Mise à jour {{time}}",
+      "mergedAgo": "Fusionnée {{time}}",
+      "mergedByAgo": "Fusionnée par {{login}} {{time}}",
+      "closedAgo": "Fermée {{time}}",
+      "labels": "Étiquettes",
+      "reviewers": "Relecteurs",
+      "assignees": "Assignés",
+      "linkedIssues": "Tickets liés",
+      "reviewApproved": "Approuvée",
+      "reviewChangesRequested": "Modifications demandées",
+      "reviewCommented": "Commentée",
+      "reviewPending": "En attente de relecture",
+      "openIssueA11y": "Ouvrir le ticket #{{number}} sur GitHub",
+      "reviewDismissed": "Ignoré"
     },
     "pendingComment": {
       "allQueuedHint": "Tous les commentaires seront envoyés dans une seule requête groupée.",

--- a/apps/mobile/src/i18n/locales/ga.json
+++ b/apps/mobile/src/i18n/locales/ga.json
@@ -571,7 +571,22 @@
       "commit_many": "tiomantais",
       "file_two": "chomhad",
       "file_few": "chomhad",
-      "file_many": "comhaid"
+      "file_many": "comhaid",
+      "openedAgo": "Oscailte {{time}}",
+      "updatedAgo": "Nuashonraithe {{time}}",
+      "mergedAgo": "Cumascaithe {{time}}",
+      "mergedByAgo": "Cumaiscthe ag {{login}} {{time}}",
+      "closedAgo": "Dúnta {{time}}",
+      "labels": "Lipéid",
+      "reviewers": "Athbhreithneoirí",
+      "assignees": "Sannaithe",
+      "linkedIssues": "Ceisteanna nasctha",
+      "reviewApproved": "Ceadaithe",
+      "reviewChangesRequested": "Iarradh athruithe",
+      "reviewCommented": "Trácht déanta",
+      "reviewPending": "Ag fanacht le hathbhreithniú",
+      "openIssueA11y": "Oscail ceist #{{number}} ar GitHub",
+      "reviewDismissed": "Díbithe"
     },
     "pendingComment": {
       "editOutdatedA11y": "Cuir trácht seanchaithe ar feitheamh in eagar ar {{location}}",

--- a/apps/mobile/src/i18n/locales/gl.json
+++ b/apps/mobile/src/i18n/locales/gl.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "arquivo",
       "file": "arquivos",
-      "file_other": "arquivos"
+      "file_other": "arquivos",
+      "openedAgo": "Aberto {{time}}",
+      "updatedAgo": "Actualizado {{time}}",
+      "mergedAgo": "Fusionado {{time}}",
+      "mergedByAgo": "Fusionado por {{login}} {{time}}",
+      "closedAgo": "Pechado {{time}}",
+      "labels": "Etiquetas",
+      "reviewers": "Revisores",
+      "assignees": "Asignados",
+      "linkedIssues": "Incidencias vinculadas",
+      "reviewApproved": "Aprobado",
+      "reviewChangesRequested": "Cambios solicitados",
+      "reviewCommented": "Comentado",
+      "reviewPending": "Á espera de revisión",
+      "openIssueA11y": "Abrir incidencia #{{number}} en GitHub",
+      "reviewDismissed": "Descartado"
     },
     "pendingComment": {
       "editOutdatedA11y": "Editar comentario pendente desactualizado en {{location}}",

--- a/apps/mobile/src/i18n/locales/gu.json
+++ b/apps/mobile/src/i18n/locales/gu.json
@@ -550,7 +550,22 @@
       "commit_other": "કમિટ્સ",
       "file_one": "ફાઇલ",
       "file": "ફાઇલો",
-      "file_other": "ફાઇલો"
+      "file_other": "ફાઇલો",
+      "openedAgo": "ખોલવામાં આવ્યું {{time}}",
+      "updatedAgo": "અપડેટ થયું {{time}}",
+      "mergedAgo": "મર્જ થયું {{time}}",
+      "mergedByAgo": "{{login}} દ્વારા મર્જ થયું {{time}}",
+      "closedAgo": "બંધ {{time}}",
+      "labels": "લેબલ",
+      "reviewers": "સમીક્ષકો",
+      "assignees": "સોંપાયેલા",
+      "linkedIssues": "જોડાયેલા મુદ્દા",
+      "reviewApproved": "મંજૂર",
+      "reviewChangesRequested": "ફેરફારો માંગ્યા",
+      "reviewCommented": "ટિપ્પણી કરી",
+      "reviewPending": "સમીક્ષાની રાહ જુએ છે",
+      "openIssueA11y": "GitHub પર મુદ્દો #{{number}} ખોલો",
+      "reviewDismissed": "કાઢી નાખેલ"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} પર જૂની બાકી ટિપ્પણી સંપાદિત કરો",

--- a/apps/mobile/src/i18n/locales/ha.json
+++ b/apps/mobile/src/i18n/locales/ha.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "fayil",
       "file": "fayiloli",
-      "file_other": "fayiloli"
+      "file_other": "fayiloli",
+      "openedAgo": "An buɗe {{time}}",
+      "updatedAgo": "An sabunta {{time}}",
+      "mergedAgo": "An haɗa {{time}}",
+      "mergedByAgo": "{{login}} ya haɗa {{time}}",
+      "closedAgo": "An rufe {{time}}",
+      "labels": "Alamomi",
+      "reviewers": "Masu duba",
+      "assignees": "Waɗanda aka ba wa aiki",
+      "linkedIssues": "Batutuwa masu alaƙa",
+      "reviewApproved": "An amince",
+      "reviewChangesRequested": "An nemi canje-canje",
+      "reviewCommented": "An yi sharhi",
+      "reviewPending": "Ana jiran dubawa",
+      "openIssueA11y": "Buɗe batu #{{number}} a GitHub",
+      "reviewDismissed": "An watsar"
     },
     "pendingComment": {
       "editOutdatedA11y": "Gyara tsokacin da ke jira na tsoho a {{location}}",

--- a/apps/mobile/src/i18n/locales/he.json
+++ b/apps/mobile/src/i18n/locales/he.json
@@ -2910,7 +2910,22 @@
       "stateOpenReviewRequired": "פתוח · נדרשת סקירה",
       "unknownAuthor": "מחבר לא ידוע",
       "commit_two": "commits",
-      "file_two": "קבצים"
+      "file_two": "קבצים",
+      "openedAgo": "נפתחה {{time}}",
+      "updatedAgo": "עודכנה {{time}}",
+      "mergedAgo": "מוזג {{time}}",
+      "mergedByAgo": "מוזגה על ידי {{login}} {{time}}",
+      "closedAgo": "סגור {{time}}",
+      "labels": "תוויות",
+      "reviewers": "סוקרים",
+      "assignees": "אחראים",
+      "linkedIssues": "סוגיות מקושרות",
+      "reviewApproved": "אושרה",
+      "reviewChangesRequested": "התבקשו שינויים",
+      "reviewCommented": "הוגשה תגובה",
+      "reviewPending": "ממתינה לסקירה",
+      "openIssueA11y": "פתח סוגיה #{{number}} ב-GitHub",
+      "reviewDismissed": "נדחה"
     },
     "pendingComment": {
       "allQueuedHint": "כל התגובות יישלחו בבקשה אצווה אחת.",

--- a/apps/mobile/src/i18n/locales/hi.json
+++ b/apps/mobile/src/i18n/locales/hi.json
@@ -2890,7 +2890,22 @@
       "stateOpenApproved": "खुला · स्वीकृत",
       "stateOpenChangesRequested": "खुला · परिवर्तन अनुरोधित",
       "stateOpenReviewRequired": "खुला · समीक्षा आवश्यक",
-      "unknownAuthor": "अज्ञात लेखक"
+      "unknownAuthor": "अज्ञात लेखक",
+      "openedAgo": "खोला गया {{time}}",
+      "updatedAgo": "अपडेट किया गया {{time}}",
+      "mergedAgo": "मर्ज हो गया {{time}}",
+      "mergedByAgo": "{{login}} ने मर्ज किया {{time}}",
+      "closedAgo": "बंद {{time}}",
+      "labels": "लेबल",
+      "reviewers": "समीक्षक",
+      "assignees": "सौंपे गए",
+      "linkedIssues": "जुड़े हुए मुद्दे",
+      "reviewApproved": "स्वीकृत",
+      "reviewChangesRequested": "बदलाव मांगे गए",
+      "reviewCommented": "टिप्पणी की गई",
+      "reviewPending": "समीक्षा की प्रतीक्षा",
+      "openIssueA11y": "GitHub पर मुद्दा #{{number}} खोलें",
+      "reviewDismissed": "खारिज किया गया"
     },
     "pendingComment": {
       "allQueuedHint": "सभी टिप्पणियाँ एक ही बैच अनुरोध में भेजी जाएँगी।",

--- a/apps/mobile/src/i18n/locales/hr.json
+++ b/apps/mobile/src/i18n/locales/hr.json
@@ -557,7 +557,22 @@
       "file": "datoteka",
       "file_other": "datoteka",
       "commit_few": "commita",
-      "file_few": "datoteke"
+      "file_few": "datoteke",
+      "openedAgo": "Otvoreno {{time}}",
+      "updatedAgo": "Ažurirano {{time}}",
+      "mergedAgo": "Spojeno {{time}}",
+      "mergedByAgo": "Spojio {{login}} {{time}}",
+      "closedAgo": "Zatvoreno {{time}}",
+      "labels": "Oznake",
+      "reviewers": "Recenzenti",
+      "assignees": "Dodijeljeni",
+      "linkedIssues": "Povezani problemi",
+      "reviewApproved": "Odobreno",
+      "reviewChangesRequested": "Tražene izmjene",
+      "reviewCommented": "Komentirano",
+      "reviewPending": "Čeka recenziju",
+      "openIssueA11y": "Otvori problem #{{number}} na GitHubu",
+      "reviewDismissed": "Odbaceno"
     },
     "pendingComment": {
       "editOutdatedA11y": "Uredi zastarjeli čekajući komentar na {{location}}",

--- a/apps/mobile/src/i18n/locales/ht.json
+++ b/apps/mobile/src/i18n/locales/ht.json
@@ -550,7 +550,22 @@
       "commit_other": "komit",
       "file_one": "fichye",
       "file": "fichye",
-      "file_other": "fichye"
+      "file_other": "fichye",
+      "openedAgo": "Ouvri {{time}}",
+      "updatedAgo": "Mete ajou {{time}}",
+      "mergedAgo": "Fizyonnen {{time}}",
+      "mergedByAgo": "{{login}} fizyone li {{time}}",
+      "closedAgo": "Fèmen {{time}}",
+      "labels": "Etikèt",
+      "reviewers": "Moun k ap revize",
+      "assignees": "Moun ki responsab",
+      "linkedIssues": "Pwoblèm ki lye",
+      "reviewApproved": "Apwouve",
+      "reviewChangesRequested": "Chanjman mande",
+      "reviewCommented": "Komante",
+      "reviewPending": "Ap tann revizyon",
+      "openIssueA11y": "Ouvri pwoblèm #{{number}} sou GitHub",
+      "reviewDismissed": "Rejte"
     },
     "pendingComment": {
       "editOutdatedA11y": "Modifye kòmantè an patant demode sou {{location}}",

--- a/apps/mobile/src/i18n/locales/hu.json
+++ b/apps/mobile/src/i18n/locales/hu.json
@@ -550,7 +550,22 @@
       "commit_other": "commit",
       "file_one": "fájl",
       "file": "fájl",
-      "file_other": "fájl"
+      "file_other": "fájl",
+      "openedAgo": "Megnyitva {{time}}",
+      "updatedAgo": "Frissítve {{time}}",
+      "mergedAgo": "Összevonva {{time}}",
+      "mergedByAgo": "Egyesítette: {{login}} {{time}}",
+      "closedAgo": "Lezárva {{time}}",
+      "labels": "Címkék",
+      "reviewers": "Értékelők",
+      "assignees": "Felelősök",
+      "linkedIssues": "Kapcsolt hibajegyek",
+      "reviewApproved": "Jóváhagyva",
+      "reviewChangesRequested": "Változtatásokat kértek",
+      "reviewCommented": "Hozzászólva",
+      "reviewPending": "Értékelésre vár",
+      "openIssueA11y": "#{{number}} hibajegy megnyitása a GitHubon",
+      "reviewDismissed": "Elvetve"
     },
     "pendingComment": {
       "editOutdatedA11y": "Elavult függőben lévő megjegyzés szerkesztése itt: {{location}}",

--- a/apps/mobile/src/i18n/locales/hy.json
+++ b/apps/mobile/src/i18n/locales/hy.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "ֆայլ",
       "file": "ֆայլեր",
-      "file_other": "ֆայլեր"
+      "file_other": "ֆայլեր",
+      "openedAgo": "Բացվել է {{time}}",
+      "updatedAgo": "Թարմացվել է {{time}}",
+      "mergedAgo": "Միավորված {{time}}",
+      "mergedByAgo": "Միաձուլել է {{login}}-ը {{time}}",
+      "closedAgo": "Փակ {{time}}",
+      "labels": "Պիտակներ",
+      "reviewers": "Գրախոսներ",
+      "assignees": "Նշանակվածներ",
+      "linkedIssues": "Կապված խնդիրներ",
+      "reviewApproved": "Հաստատված է",
+      "reviewChangesRequested": "Փոփոխություններ են պահանջվել",
+      "reviewCommented": "Մեկնաբանված է",
+      "reviewPending": "Սպասում է գրախոսության",
+      "openIssueA11y": "Բացել #{{number}} խնդիրը GitHub-ում",
+      "reviewDismissed": "Մերժված"
     },
     "pendingComment": {
       "editOutdatedA11y": "Խմբագրել հնացած սպասվող մեկնաբանությունը {{location}} վայրում",

--- a/apps/mobile/src/i18n/locales/id.json
+++ b/apps/mobile/src/i18n/locales/id.json
@@ -2890,7 +2890,22 @@
       "stateOpenApproved": "Terbuka · Disetujui",
       "stateOpenChangesRequested": "Terbuka · Perubahan diminta",
       "stateOpenReviewRequired": "Terbuka · Tinjauan diperlukan",
-      "unknownAuthor": "Penulis tidak diketahui"
+      "unknownAuthor": "Penulis tidak diketahui",
+      "openedAgo": "Dibuka {{time}}",
+      "updatedAgo": "Diperbarui {{time}}",
+      "mergedAgo": "Digabungkan {{time}}",
+      "mergedByAgo": "Digabungkan oleh {{login}} {{time}}",
+      "closedAgo": "Ditutup {{time}}",
+      "labels": "Label",
+      "reviewers": "Peninjau",
+      "assignees": "Penerima tugas",
+      "linkedIssues": "Isu tertaut",
+      "reviewApproved": "Disetujui",
+      "reviewChangesRequested": "Perubahan diminta",
+      "reviewCommented": "Dikomentari",
+      "reviewPending": "Menunggu tinjauan",
+      "openIssueA11y": "Buka isu #{{number}} di GitHub",
+      "reviewDismissed": "Diabaikan"
     },
     "pendingComment": {
       "allQueuedHint": "Semua komentar akan dikirim dalam satu permintaan sekaligus.",

--- a/apps/mobile/src/i18n/locales/ig.json
+++ b/apps/mobile/src/i18n/locales/ig.json
@@ -550,7 +550,22 @@
       "commit_other": "commit",
       "file_one": "faịlụ",
       "file": "faịlụ",
-      "file_other": "faịlụ"
+      "file_other": "faịlụ",
+      "openedAgo": "Emepere ya {{time}}",
+      "updatedAgo": "Emelitere ya {{time}}",
+      "mergedAgo": "Ejikọtara {{time}}",
+      "mergedByAgo": "{{login}} jikọtara ya {{time}}",
+      "closedAgo": "Emechiri {{time}}",
+      "labels": "Akara",
+      "reviewers": "Ndị nyocha",
+      "assignees": "Ndị e kenyere ọrụ",
+      "linkedIssues": "Okwu ejikọtara",
+      "reviewApproved": "Akwadoro ya",
+      "reviewChangesRequested": "Arịọrọ mgbanwe",
+      "reviewCommented": "Ekwuru okwu",
+      "reviewPending": "Na-echere nyocha",
+      "openIssueA11y": "Mepee okwu #{{number}} na GitHub",
+      "reviewDismissed": "Ekagburu"
     },
     "pendingComment": {
       "editOutdatedA11y": "Dezie nkọwa na-echere ochie na {{location}}",

--- a/apps/mobile/src/i18n/locales/is.json
+++ b/apps/mobile/src/i18n/locales/is.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "skrá",
       "file": "skrár",
-      "file_other": "skrár"
+      "file_other": "skrár",
+      "openedAgo": "Opnað {{time}}",
+      "updatedAgo": "Uppfært {{time}}",
+      "mergedAgo": "Sameinað {{time}}",
+      "mergedByAgo": "{{login}} sameinaði {{time}}",
+      "closedAgo": "Lokað {{time}}",
+      "labels": "Merki",
+      "reviewers": "Yfirlesarar",
+      "assignees": "Ábyrgðaraðilar",
+      "linkedIssues": "Tengd mál",
+      "reviewApproved": "Samþykkt",
+      "reviewChangesRequested": "Óskað eftir breytingum",
+      "reviewCommented": "Athugasemd gerð",
+      "reviewPending": "Bíður yfirlestrar",
+      "openIssueA11y": "Opna mál #{{number}} á GitHub",
+      "reviewDismissed": "Vísað frá"
     },
     "pendingComment": {
       "editOutdatedA11y": "Breyta úreltri biðandi athugasemd á {{location}}",

--- a/apps/mobile/src/i18n/locales/it.json
+++ b/apps/mobile/src/i18n/locales/it.json
@@ -2910,7 +2910,22 @@
       "stateOpenReviewRequired": "Aperta · Revisione richiesta",
       "unknownAuthor": "Autore sconosciuto",
       "commit_many": "commit",
-      "file_many": "file"
+      "file_many": "file",
+      "openedAgo": "Aperta {{time}}",
+      "updatedAgo": "Aggiornata {{time}}",
+      "mergedAgo": "Unita {{time}}",
+      "mergedByAgo": "Unita da {{login}} {{time}}",
+      "closedAgo": "Chiusa {{time}}",
+      "labels": "Etichette",
+      "reviewers": "Revisori",
+      "assignees": "Assegnatari",
+      "linkedIssues": "Problemi collegati",
+      "reviewApproved": "Approvata",
+      "reviewChangesRequested": "Modifiche richieste",
+      "reviewCommented": "Commentata",
+      "reviewPending": "In attesa di revisione",
+      "openIssueA11y": "Apri il problema #{{number}} su GitHub",
+      "reviewDismissed": "Ignorato"
     },
     "pendingComment": {
       "allQueuedHint": "Tutti i commenti verranno inviati in un'unica richiesta in batch.",

--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -2890,7 +2890,22 @@
       "stateOpenApproved": "オープン · 承認済み",
       "stateOpenChangesRequested": "オープン · 変更リクエストあり",
       "stateOpenReviewRequired": "オープン · レビューが必要",
-      "unknownAuthor": "不明な作成者"
+      "unknownAuthor": "不明な作成者",
+      "openedAgo": "作成 {{time}}",
+      "updatedAgo": "更新 {{time}}",
+      "mergedAgo": "まーじずみ {{time}}",
+      "mergedByAgo": "{{login}} がマージ {{time}}",
+      "closedAgo": "くろーずずみ {{time}}",
+      "labels": "ラベル",
+      "reviewers": "レビュー担当者",
+      "assignees": "担当者",
+      "linkedIssues": "関連イシュー",
+      "reviewApproved": "承認済み",
+      "reviewChangesRequested": "変更を要求",
+      "reviewCommented": "コメント済み",
+      "reviewPending": "レビュー待ち",
+      "openIssueA11y": "GitHub でイシュー #{{number}} を開く",
+      "reviewDismissed": "却下済み"
     },
     "pendingComment": {
       "allQueuedHint": "すべてのコメントは1つのバッチリクエストで送信されます。",

--- a/apps/mobile/src/i18n/locales/ka.json
+++ b/apps/mobile/src/i18n/locales/ka.json
@@ -550,7 +550,22 @@
       "commit_other": "commit",
       "file_one": "ფაილი",
       "file": "ფაილი",
-      "file_other": "ფაილი"
+      "file_other": "ფაილი",
+      "openedAgo": "გაიხსნა {{time}}",
+      "updatedAgo": "განახლდა {{time}}",
+      "mergedAgo": "შერწყმულია {{time}}",
+      "mergedByAgo": "შეარწყა {{login}}-მა {{time}}",
+      "closedAgo": "დახურულია {{time}}",
+      "labels": "იარლიყები",
+      "reviewers": "მიმომხილველები",
+      "assignees": "პასუხისმგებლები",
+      "linkedIssues": "დაკავშირებული საკითხები",
+      "reviewApproved": "დამტკიცებულია",
+      "reviewChangesRequested": "მოთხოვნილია ცვლილებები",
+      "reviewCommented": "დაკომენტარებულია",
+      "reviewPending": "ელოდება მიმოხილვას",
+      "openIssueA11y": "გახსენი საკითხი #{{number}} GitHub-ზე",
+      "reviewDismissed": "გაუქმებულია"
     },
     "pendingComment": {
       "editOutdatedA11y": "მოძველებული მოლოდინის კომენტარის რედაქტირება {{location}}-ზე",

--- a/apps/mobile/src/i18n/locales/kk.json
+++ b/apps/mobile/src/i18n/locales/kk.json
@@ -550,7 +550,22 @@
       "commit_other": "commitтер",
       "file_one": "файл",
       "file": "файлдар",
-      "file_other": "файлдар"
+      "file_other": "файлдар",
+      "openedAgo": "Ашылды {{time}}",
+      "updatedAgo": "Жаңартылды {{time}}",
+      "mergedAgo": "Біріктірілді {{time}}",
+      "mergedByAgo": "{{login}} біріктірді {{time}}",
+      "closedAgo": "Жабық {{time}}",
+      "labels": "Белгілер",
+      "reviewers": "Қараушылар",
+      "assignees": "Тағайындалғандар",
+      "linkedIssues": "Байланысты мәселелер",
+      "reviewApproved": "Мақұлданды",
+      "reviewChangesRequested": "Өзгертулер сұралды",
+      "reviewCommented": "Пікір қалдырылды",
+      "reviewPending": "Қарауды күтуде",
+      "openIssueA11y": "GitHub-та #{{number}} мәселесін ашу",
+      "reviewDismissed": "Болдырылды"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} бойынша ескірген күтілудегі пікірді өңдеу",

--- a/apps/mobile/src/i18n/locales/km.json
+++ b/apps/mobile/src/i18n/locales/km.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "ឯកសារ",
       "file": "ឯកសារ",
-      "file_other": "ឯកសារ"
+      "file_other": "ឯកសារ",
+      "openedAgo": "បើក {{time}}",
+      "updatedAgo": "ធ្វើបច្ចុប្បន្នភាព {{time}}",
+      "mergedAgo": "បានបញ្ចូល {{time}}",
+      "mergedByAgo": "{{login}} បានបញ្ចូលគ្នា {{time}}",
+      "closedAgo": "បានបិទ {{time}}",
+      "labels": "ស្លាក",
+      "reviewers": "អ្នកត្រួតពិនិត្យ",
+      "assignees": "អ្នកទទួលបន្ទុក",
+      "linkedIssues": "បញ្ហាដែលភ្ជាប់",
+      "reviewApproved": "បានអនុម័ត",
+      "reviewChangesRequested": "បានស្នើសុំការផ្លាស់ប្ដូរ",
+      "reviewCommented": "បានផ្ដល់មតិ",
+      "reviewPending": "កំពុងរង់ចាំការត្រួតពិនិត្យ",
+      "openIssueA11y": "បើកបញ្ហា #{{number}} នៅលើ GitHub",
+      "reviewDismissed": "បានបដិសេធ"
     },
     "pendingComment": {
       "editOutdatedA11y": "កែសម្រួលអត្ថាធិប្បាយរង់ចាំហួសសម័យនៅ {{location}}",

--- a/apps/mobile/src/i18n/locales/kn.json
+++ b/apps/mobile/src/i18n/locales/kn.json
@@ -550,7 +550,22 @@
       "commit_other": "ಕಮಿಟ್‌ಗಳು",
       "file_one": "ಫೈಲ್",
       "file": "ಫೈಲ್‌ಗಳು",
-      "file_other": "ಫೈಲ್‌ಗಳು"
+      "file_other": "ಫೈಲ್‌ಗಳು",
+      "openedAgo": "ತೆರೆಯಲಾಗಿದೆ {{time}}",
+      "updatedAgo": "ನವೀಕರಿಸಲಾಗಿದೆ {{time}}",
+      "mergedAgo": "ವಿಲೀನಗೊಳಿಸಲಾಗಿದೆ {{time}}",
+      "mergedByAgo": "{{login}} ವಿಲೀನಗೊಳಿಸಿದ್ದಾರೆ {{time}}",
+      "closedAgo": "ಮುಚ್ಚಲಾಗಿದೆ {{time}}",
+      "labels": "ಲೇಬಲ್‌ಗಳು",
+      "reviewers": "ಪರಿಶೀಲಕರು",
+      "assignees": "ನಿಯೋಜಿತರು",
+      "linkedIssues": "ಸಂಬಂಧಿತ ಸಮಸ್ಯೆಗಳು",
+      "reviewApproved": "ಅನುಮೋದಿಸಲಾಗಿದೆ",
+      "reviewChangesRequested": "ಬದಲಾವಣೆಗಳನ್ನು ಕೋರಲಾಗಿದೆ",
+      "reviewCommented": "ಕಾಮೆಂಟ್ ಮಾಡಲಾಗಿದೆ",
+      "reviewPending": "ಪರಿಶೀಲನೆಗಾಗಿ ಕಾಯುತ್ತಿದೆ",
+      "openIssueA11y": "GitHub ನಲ್ಲಿ ಸಮಸ್ಯೆ #{{number}} ತೆರೆಯಿರಿ",
+      "reviewDismissed": "ತೆಗೆದುಹಾಕಲಾಗಿದೆ"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} ನಲ್ಲಿ ಹಳೆಯ ಬಾಕಿ ಕಾಮೆಂಟ್ ಸಂಪಾದಿಸಿ",

--- a/apps/mobile/src/i18n/locales/ko.json
+++ b/apps/mobile/src/i18n/locales/ko.json
@@ -2890,7 +2890,22 @@
       "stateOpenApproved": "열림 · 승인됨",
       "stateOpenChangesRequested": "열림 · 변경 요청됨",
       "stateOpenReviewRequired": "열림 · 리뷰 필요",
-      "unknownAuthor": "알 수 없는 작성자"
+      "unknownAuthor": "알 수 없는 작성자",
+      "openedAgo": "열림 {{time}}",
+      "updatedAgo": "업데이트됨 {{time}}",
+      "mergedAgo": "병합됨 {{time}}",
+      "mergedByAgo": "{{login}} 님이 병합함 {{time}}",
+      "closedAgo": "닫힘 {{time}}",
+      "labels": "라벨",
+      "reviewers": "검토자",
+      "assignees": "담당자",
+      "linkedIssues": "연결된 이슈",
+      "reviewApproved": "승인됨",
+      "reviewChangesRequested": "변경 요청됨",
+      "reviewCommented": "댓글 남김",
+      "reviewPending": "검토 대기 중",
+      "openIssueA11y": "GitHub에서 이슈 #{{number}} 열기",
+      "reviewDismissed": "해제됨"
     },
     "pendingComment": {
       "allQueuedHint": "모든 댓글은 단일 일괄 요청으로 전송됩니다.",

--- a/apps/mobile/src/i18n/locales/lo.json
+++ b/apps/mobile/src/i18n/locales/lo.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "ໄຟລ໌",
       "file": "ໄຟລ໌",
-      "file_other": "ໄຟລ໌"
+      "file_other": "ໄຟລ໌",
+      "openedAgo": "ເປີດ {{time}}",
+      "updatedAgo": "ອັບເດດ {{time}}",
+      "mergedAgo": "Merge ແລ້ວ {{time}}",
+      "mergedByAgo": "{{login}} ລວມແລ້ວ {{time}}",
+      "closedAgo": "ປິດ {{time}}",
+      "labels": "ປ້າຍກຳກັບ",
+      "reviewers": "ຜູ້ກວດສອບ",
+      "assignees": "ຜູ້ຮັບຜິດຊອບ",
+      "linkedIssues": "ບັນຫາທີ່ເຊື່ອມໂຍງ",
+      "reviewApproved": "ອະນຸມັດແລ້ວ",
+      "reviewChangesRequested": "ຮ້ອງຂໍການປ່ຽນແປງ",
+      "reviewCommented": "ໄດ້ໃຫ້ຄຳເຫັນ",
+      "reviewPending": "ລໍຖ້າການກວດສອບ",
+      "openIssueA11y": "ເປີດບັນຫາ #{{number}} ໃນ GitHub",
+      "reviewDismissed": "ຖືກປິດ"
     },
     "pendingComment": {
       "editOutdatedA11y": "ແກ້ໄຂຄຳເຫັນທີ່ລໍຖ້າທີ່ລ້າສະໄໝໃສ່ {{location}}",

--- a/apps/mobile/src/i18n/locales/lt.json
+++ b/apps/mobile/src/i18n/locales/lt.json
@@ -564,7 +564,22 @@
       "commit_few": "įsipareigojimai",
       "commit_many": "įsipareigojimų",
       "file_few": "failai",
-      "file_many": "failų"
+      "file_many": "failų",
+      "openedAgo": "Atidaryta {{time}}",
+      "updatedAgo": "Atnaujinta {{time}}",
+      "mergedAgo": "Sujungta {{time}}",
+      "mergedByAgo": "Suliejo {{login}} {{time}}",
+      "closedAgo": "Uždaryta {{time}}",
+      "labels": "Žymos",
+      "reviewers": "Peržiūrėtojai",
+      "assignees": "Priskirtieji",
+      "linkedIssues": "Susietos problemos",
+      "reviewApproved": "Patvirtinta",
+      "reviewChangesRequested": "Paprašyta pakeitimų",
+      "reviewCommented": "Pakomentuota",
+      "reviewPending": "Laukiama peržiūros",
+      "openIssueA11y": "Atverti problemą #{{number}} GitHub'e",
+      "reviewDismissed": "Atmesta"
     },
     "pendingComment": {
       "editOutdatedA11y": "Redaguoti pasenusį laukiantį komentarą {{location}}",

--- a/apps/mobile/src/i18n/locales/lv.json
+++ b/apps/mobile/src/i18n/locales/lv.json
@@ -557,7 +557,22 @@
       "file": "faili",
       "file_other": "faili",
       "commit_zero": "commits",
-      "file_zero": "failu"
+      "file_zero": "failu",
+      "openedAgo": "Atvērts {{time}}",
+      "updatedAgo": "Atjaunināts {{time}}",
+      "mergedAgo": "Apvienots {{time}}",
+      "mergedByAgo": "Sapludināja {{login}} {{time}}",
+      "closedAgo": "Slēgts {{time}}",
+      "labels": "Etiķetes",
+      "reviewers": "Recenzenti",
+      "assignees": "Atbildīgie",
+      "linkedIssues": "Saistītie pieteikumi",
+      "reviewApproved": "Apstiprināts",
+      "reviewChangesRequested": "Pieprasītas izmaiņas",
+      "reviewCommented": "Komentēts",
+      "reviewPending": "Gaida recenziju",
+      "openIssueA11y": "Atvērt pieteikumu #{{number}} vietnē GitHub",
+      "reviewDismissed": "Noraidīts"
     },
     "pendingComment": {
       "editOutdatedA11y": "Rediģēt novecojušo gaidīto komentāru uz {{location}}",

--- a/apps/mobile/src/i18n/locales/mg.json
+++ b/apps/mobile/src/i18n/locales/mg.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "rakitra",
       "file": "rakitra",
-      "file_other": "rakitra"
+      "file_other": "rakitra",
+      "openedAgo": "Nosokafana {{time}}",
+      "updatedAgo": "Nohavaozina {{time}}",
+      "mergedAgo": "Nampirina {{time}}",
+      "mergedByAgo": "Nakamban'i {{login}} {{time}}",
+      "closedAgo": "Mihidy {{time}}",
+      "labels": "Marika",
+      "reviewers": "Mpandinika",
+      "assignees": "Voatendry",
+      "linkedIssues": "Olana mifandray",
+      "reviewApproved": "Nankatoavina",
+      "reviewChangesRequested": "Nangatahana fanovana",
+      "reviewCommented": "Nanome hevitra",
+      "reviewPending": "Miandry fandinihana",
+      "openIssueA11y": "Sokafy ny olana #{{number}} ao amin'ny GitHub",
+      "reviewDismissed": "Voala"
     },
     "pendingComment": {
       "editOutdatedA11y": "Hanova hevitra miandry lany daty ao amin'ny {{location}}",

--- a/apps/mobile/src/i18n/locales/mi.json
+++ b/apps/mobile/src/i18n/locales/mi.json
@@ -550,7 +550,22 @@
       "commit_other": "ngā commit",
       "file_one": "kōnae",
       "file": "ngā kōnae",
-      "file_other": "ngā kōnae"
+      "file_other": "ngā kōnae",
+      "openedAgo": "I whakatuwherahia {{time}}",
+      "updatedAgo": "I whakahoutia {{time}}",
+      "mergedAgo": "Kua whakakotahitia {{time}}",
+      "mergedByAgo": "Nā {{login}} i whakakotahi {{time}}",
+      "closedAgo": "Kua kati {{time}}",
+      "labels": "Ngā tapanga",
+      "reviewers": "Ngā kaiarotake",
+      "assignees": "Ngā kaiwhiwhi mahi",
+      "linkedIssues": "Ngā take honoa",
+      "reviewApproved": "Kua whakaaetia",
+      "reviewChangesRequested": "I tonoa he panonitanga",
+      "reviewCommented": "Kua tākupu",
+      "reviewPending": "E tatari ana ki te arotake",
+      "openIssueA11y": "Huakina te take #{{number}} i GitHub",
+      "reviewDismissed": "Kua whakakorea"
     },
     "pendingComment": {
       "editOutdatedA11y": "Whakatika i te kōrero tawhito e tatari ana ki {{location}}",

--- a/apps/mobile/src/i18n/locales/mk.json
+++ b/apps/mobile/src/i18n/locales/mk.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "датотека",
       "file": "датотеки",
-      "file_other": "датотеки"
+      "file_other": "датотеки",
+      "openedAgo": "Отворено {{time}}",
+      "updatedAgo": "Ажурирано {{time}}",
+      "mergedAgo": "Споено {{time}}",
+      "mergedByAgo": "Споено од {{login}} {{time}}",
+      "closedAgo": "Затворено {{time}}",
+      "labels": "Ознаки",
+      "reviewers": "Рецензенти",
+      "assignees": "Задолжени",
+      "linkedIssues": "Поврзани проблеми",
+      "reviewApproved": "Одобрено",
+      "reviewChangesRequested": "Побарани промени",
+      "reviewCommented": "Коментирано",
+      "reviewPending": "Чека рецензија",
+      "openIssueA11y": "Отвори проблем #{{number}} на GitHub",
+      "reviewDismissed": "Отфрлен"
     },
     "pendingComment": {
       "editOutdatedA11y": "Уреди застарен коментар што чека на {{location}}",

--- a/apps/mobile/src/i18n/locales/ml.json
+++ b/apps/mobile/src/i18n/locales/ml.json
@@ -550,7 +550,22 @@
       "commit_other": "കമ്മിറ്റുകൾ",
       "file_one": "ഫയൽ",
       "file": "ഫയലുകൾ",
-      "file_other": "ഫയലുകൾ"
+      "file_other": "ഫയലുകൾ",
+      "openedAgo": "തുറന്നത് {{time}}",
+      "updatedAgo": "പുതുക്കിയത് {{time}}",
+      "mergedAgo": "മെർജ് ചെയ്തു {{time}}",
+      "mergedByAgo": "{{login}} ലയിപ്പിച്ചത് {{time}}",
+      "closedAgo": "അടച്ചു {{time}}",
+      "labels": "ലേബലുകൾ",
+      "reviewers": "അവലോകകർ",
+      "assignees": "ചുമതലപ്പെടുത്തിയവർ",
+      "linkedIssues": "ബന്ധിപ്പിച്ച പ്രശ്നങ്ങൾ",
+      "reviewApproved": "അംഗീകരിച്ചു",
+      "reviewChangesRequested": "മാറ്റങ്ങൾ ആവശ്യപ്പെട്ടു",
+      "reviewCommented": "അഭിപ്രായം രേഖപ്പെടുത്തി",
+      "reviewPending": "അവലോകനത്തിനായി കാത്തിരിക്കുന്നു",
+      "openIssueA11y": "GitHub-ൽ പ്രശ്നം #{{number}} തുറക്കുക",
+      "reviewDismissed": "നിരസിച്ചു"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}}-ലെ കാലഹരണപ്പെട്ട തീർച്ചയാകാത്ത അഭിപ്രായം എഡിറ്റ് ചെയ്യുക",

--- a/apps/mobile/src/i18n/locales/mn.json
+++ b/apps/mobile/src/i18n/locales/mn.json
@@ -550,7 +550,22 @@
       "commit_other": "commit",
       "file_one": "файл",
       "file": "файл",
-      "file_other": "файл"
+      "file_other": "файл",
+      "openedAgo": "Нээгдсэн {{time}}",
+      "updatedAgo": "Шинэчлэгдсэн {{time}}",
+      "mergedAgo": "Нэгтгэсэн {{time}}",
+      "mergedByAgo": "{{login}} нэгтгэсэн {{time}}",
+      "closedAgo": "Хаалттай {{time}}",
+      "labels": "Шошго",
+      "reviewers": "Хянагчид",
+      "assignees": "Хариуцагчид",
+      "linkedIssues": "Холбоотой асуудлууд",
+      "reviewApproved": "Батлагдсан",
+      "reviewChangesRequested": "Өөрчлөлт хүссэн",
+      "reviewCommented": "Сэтгэгдэл үлдээсэн",
+      "reviewPending": "Хяналт хүлээж байна",
+      "openIssueA11y": "GitHub дээр #{{number}} асуудлыг нээх",
+      "reviewDismissed": "Хасагдсан"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} дээрх хуучирсан хүлээгдэж буй сэтгэгдлийг засах",

--- a/apps/mobile/src/i18n/locales/mr.json
+++ b/apps/mobile/src/i18n/locales/mr.json
@@ -550,7 +550,22 @@
       "commit_other": "कमिट्स",
       "file_one": "फाइल",
       "file": "फाइल्स",
-      "file_other": "फाइल्स"
+      "file_other": "फाइल्स",
+      "openedAgo": "उघडले {{time}}",
+      "updatedAgo": "अद्ययावत केले {{time}}",
+      "mergedAgo": "मर्ज केले {{time}}",
+      "mergedByAgo": "{{login}} यांनी विलीन केले {{time}}",
+      "closedAgo": "बंद {{time}}",
+      "labels": "लेबल",
+      "reviewers": "समीक्षक",
+      "assignees": "नियुक्त व्यक्ती",
+      "linkedIssues": "जोडलेले मुद्दे",
+      "reviewApproved": "मंजूर",
+      "reviewChangesRequested": "बदल मागवले",
+      "reviewCommented": "टिप्पणी केली",
+      "reviewPending": "समीक्षेच्या प्रतीक्षेत",
+      "openIssueA11y": "GitHub वर मुद्दा #{{number}} उघडा",
+      "reviewDismissed": "रद्द केलेले"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} वरील कालबाह्य प्रलंबित टिप्पणी संपादित करा",

--- a/apps/mobile/src/i18n/locales/ms.json
+++ b/apps/mobile/src/i18n/locales/ms.json
@@ -550,7 +550,22 @@
       "commit_other": "komit",
       "file_one": "fail",
       "file": "fail",
-      "file_other": "fail"
+      "file_other": "fail",
+      "openedAgo": "Dibuka {{time}}",
+      "updatedAgo": "Dikemas kini {{time}}",
+      "mergedAgo": "Digabung {{time}}",
+      "mergedByAgo": "Digabungkan oleh {{login}} {{time}}",
+      "closedAgo": "Ditutup {{time}}",
+      "labels": "Label",
+      "reviewers": "Penyemak",
+      "assignees": "Penerima tugasan",
+      "linkedIssues": "Isu berkaitan",
+      "reviewApproved": "Diluluskan",
+      "reviewChangesRequested": "Perubahan diminta",
+      "reviewCommented": "Diulas",
+      "reviewPending": "Menunggu semakan",
+      "openIssueA11y": "Buka isu #{{number}} di GitHub",
+      "reviewDismissed": "Diketepikan"
     },
     "pendingComment": {
       "editOutdatedA11y": "Edit komen tertunda yang usang pada {{location}}",

--- a/apps/mobile/src/i18n/locales/mt.json
+++ b/apps/mobile/src/i18n/locales/mt.json
@@ -571,7 +571,22 @@
       "commit_many": "commit",
       "file_two": "fajls",
       "file_few": "fajls",
-      "file_many": "fajl"
+      "file_many": "fajl",
+      "openedAgo": "Infetħet {{time}}",
+      "updatedAgo": "Aġġornata {{time}}",
+      "mergedAgo": "Ffuż {{time}}",
+      "mergedByAgo": "Ingħaqdet minn {{login}} {{time}}",
+      "closedAgo": "Magħluq {{time}}",
+      "labels": "Tikketti",
+      "reviewers": "Reviżuri",
+      "assignees": "Assenjati",
+      "linkedIssues": "Kwistjonijiet marbuta",
+      "reviewApproved": "Approvata",
+      "reviewChangesRequested": "Intalbu bidliet",
+      "reviewCommented": "Ikkummentata",
+      "reviewPending": "Tistenna reviżjoni",
+      "openIssueA11y": "Iftaħ il-kwistjoni #{{number}} fuq GitHub",
+      "reviewDismissed": "Mwarrab"
     },
     "pendingComment": {
       "editOutdatedA11y": "Editja l-kument pendenti skadut fuq {{location}}",

--- a/apps/mobile/src/i18n/locales/my.json
+++ b/apps/mobile/src/i18n/locales/my.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "ဖိုင်",
       "file": "ဖိုင်များ",
-      "file_other": "ဖိုင်များ"
+      "file_other": "ဖိုင်များ",
+      "openedAgo": "ဖွင့်ခဲ့သည် {{time}}",
+      "updatedAgo": "မွမ်းမံခဲ့သည် {{time}}",
+      "mergedAgo": "ပေါင်းစည်းပြီးပါပြီ {{time}}",
+      "mergedByAgo": "{{login}} က ပေါင်းစည်းခဲ့သည် {{time}}",
+      "closedAgo": "ပိတ်ထား {{time}}",
+      "labels": "အညွှန်းများ",
+      "reviewers": "စိစစ်သူများ",
+      "assignees": "တာဝန်ခံများ",
+      "linkedIssues": "ချိတ်ဆက်ထားသော ကိစ္စများ",
+      "reviewApproved": "အတည်ပြုပြီး",
+      "reviewChangesRequested": "ပြောင်းလဲမှုများ တောင်းဆိုထားသည်",
+      "reviewCommented": "မှတ်ချက်ပေးထားသည်",
+      "reviewPending": "စိစစ်မှု စောင့်ဆိုင်းနေသည်",
+      "openIssueA11y": "GitHub တွင် ကိစ္စ #{{number}} ကို ဖွင့်ပါ",
+      "reviewDismissed": "ဖျက်သိမ်းပြီး"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} တွင် ခေတ်နောက်ကျသော ဆိုင်းငံ့မှတ်ချက် တည်းဖြတ်ပါ",

--- a/apps/mobile/src/i18n/locales/nb.json
+++ b/apps/mobile/src/i18n/locales/nb.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "fil",
       "file": "filer",
-      "file_other": "filer"
+      "file_other": "filer",
+      "openedAgo": "Åpnet {{time}}",
+      "updatedAgo": "Oppdatert {{time}}",
+      "mergedAgo": "Flettet {{time}}",
+      "mergedByAgo": "Slått sammen av {{login}} {{time}}",
+      "closedAgo": "Lukket {{time}}",
+      "labels": "Etiketter",
+      "reviewers": "Vurderere",
+      "assignees": "Ansvarlige",
+      "linkedIssues": "Tilknyttede saker",
+      "reviewApproved": "Godkjent",
+      "reviewChangesRequested": "Endringer bedt om",
+      "reviewCommented": "Kommentert",
+      "reviewPending": "Venter på vurdering",
+      "openIssueA11y": "Åpne sak #{{number}} på GitHub",
+      "reviewDismissed": "Avvist"
     },
     "pendingComment": {
       "editOutdatedA11y": "Rediger utdatert ventende kommentar på {{location}}",

--- a/apps/mobile/src/i18n/locales/ne.json
+++ b/apps/mobile/src/i18n/locales/ne.json
@@ -550,7 +550,22 @@
       "commit_other": "कमिटहरू",
       "file_one": "फाइल",
       "file": "फाइलहरू",
-      "file_other": "फाइलहरू"
+      "file_other": "फाइलहरू",
+      "openedAgo": "खोलिएको {{time}}",
+      "updatedAgo": "अद्यावधिक गरिएको {{time}}",
+      "mergedAgo": "मर्ज गरियो {{time}}",
+      "mergedByAgo": "{{login}} ले मर्ज गरेको {{time}}",
+      "closedAgo": "बन्द {{time}}",
+      "labels": "लेबलहरू",
+      "reviewers": "समीक्षकहरू",
+      "assignees": "जिम्मेवारहरू",
+      "linkedIssues": "जोडिएका मुद्दाहरू",
+      "reviewApproved": "स्वीकृत",
+      "reviewChangesRequested": "परिवर्तन अनुरोध गरियो",
+      "reviewCommented": "टिप्पणी गरियो",
+      "reviewPending": "समीक्षाको प्रतीक्षामा",
+      "openIssueA11y": "GitHub मा मुद्दा #{{number}} खोल्नुहोस्",
+      "reviewDismissed": "खारेज गरियो"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} मा पुरानो प्रतीक्षामा रहेको टिप्पणी सम्पादन गर्नुहोस्",

--- a/apps/mobile/src/i18n/locales/nl.json
+++ b/apps/mobile/src/i18n/locales/nl.json
@@ -2890,7 +2890,22 @@
       "stateOpenApproved": "Open · Goedgekeurd",
       "stateOpenChangesRequested": "Open · Wijzigingen aangevraagd",
       "stateOpenReviewRequired": "Open · Review vereist",
-      "unknownAuthor": "Onbekende auteur"
+      "unknownAuthor": "Onbekende auteur",
+      "openedAgo": "Geopend {{time}}",
+      "updatedAgo": "Bijgewerkt {{time}}",
+      "mergedAgo": "Samengevoegd {{time}}",
+      "mergedByAgo": "Samengevoegd door {{login}} {{time}}",
+      "closedAgo": "Gesloten {{time}}",
+      "labels": "Labels",
+      "reviewers": "Beoordelaars",
+      "assignees": "Toegewezenen",
+      "linkedIssues": "Gekoppelde issues",
+      "reviewApproved": "Goedgekeurd",
+      "reviewChangesRequested": "Wijzigingen gevraagd",
+      "reviewCommented": "Becommentarieerd",
+      "reviewPending": "Wacht op beoordeling",
+      "openIssueA11y": "Issue #{{number}} openen op GitHub",
+      "reviewDismissed": "Afgewezen"
     },
     "pendingComment": {
       "allQueuedHint": "Alle opmerkingen worden in één gebundeld verzoek verzonden.",

--- a/apps/mobile/src/i18n/locales/om.json
+++ b/apps/mobile/src/i18n/locales/om.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "faayilii",
       "file": "faayiloota",
-      "file_other": "faayiloota"
+      "file_other": "faayiloota",
+      "openedAgo": "Banameera {{time}}",
+      "updatedAgo": "Haaromsameera {{time}}",
+      "mergedAgo": "Maksame {{time}}",
+      "mergedByAgo": "{{login}} walitti make {{time}}",
+      "closedAgo": "Cufame {{time}}",
+      "labels": "Asxaawwan",
+      "reviewers": "Qorattoota",
+      "assignees": "Itti gaafatamtoota",
+      "linkedIssues": "Rakkoolee walqabatan",
+      "reviewApproved": "Mirkanaa'eera",
+      "reviewChangesRequested": "Jijjiiramni gaafatameera",
+      "reviewCommented": "Yaadni kennameera",
+      "reviewPending": "Qorannoo eeggachaa jira",
+      "openIssueA11y": "Rakkoo #{{number}} GitHub irratti bani",
+      "reviewDismissed": "Dhiifame"
     },
     "pendingComment": {
       "editOutdatedA11y": "Yaada eeggate dheeraa {{location}} irratti gulaali",

--- a/apps/mobile/src/i18n/locales/or.json
+++ b/apps/mobile/src/i18n/locales/or.json
@@ -550,7 +550,22 @@
       "commit_other": "କମିଟ୍",
       "file_one": "ଫାଇଲ୍",
       "file": "ଫାଇଲ୍",
-      "file_other": "ଫାଇଲଗୁଡ଼ିକ"
+      "file_other": "ଫାଇଲଗୁଡ଼ିକ",
+      "openedAgo": "ଖୋଲାଯାଇଛି {{time}}",
+      "updatedAgo": "ଅଦ୍ୟତନ କରାଯାଇଛି {{time}}",
+      "mergedAgo": "ମର୍ଜ୍ ହେଲା {{time}}",
+      "mergedByAgo": "{{login}} ମିଶ୍ରଣ କରିଛନ୍ତି {{time}}",
+      "closedAgo": "ବନ୍ଦ {{time}}",
+      "labels": "ଲେବଲ୍",
+      "reviewers": "ସମୀକ୍ଷକ",
+      "assignees": "ନ୍ୟସ୍ତ ବ୍ୟକ୍ତି",
+      "linkedIssues": "ସଂଯୁକ୍ତ ସମସ୍ୟା",
+      "reviewApproved": "ଅନୁମୋଦିତ",
+      "reviewChangesRequested": "ପରିବର୍ତ୍ତନ ଅନୁରୋଧ କରାଯାଇଛି",
+      "reviewCommented": "ମନ୍ତବ୍ୟ ଦିଆଯାଇଛି",
+      "reviewPending": "ସମୀକ୍ଷା ଅପେକ୍ଷାରେ",
+      "openIssueA11y": "GitHub ରେ ସମସ୍ୟା #{{number}} ଖୋଲନ୍ତୁ",
+      "reviewDismissed": "ଖାରଜ ହୋଇଛି"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} ରେ ଅପ୍ରଚଳିତ ବାକି ମନ୍ତବ୍ୟ ସମ୍ପାଦନ କରନ୍ତୁ",

--- a/apps/mobile/src/i18n/locales/pa.json
+++ b/apps/mobile/src/i18n/locales/pa.json
@@ -550,7 +550,22 @@
       "commit_other": "ਕਮਿਟ",
       "file_one": "ਫਾਈਲ",
       "file": "ਫਾਈਲਾਂ",
-      "file_other": "ਫਾਈਲਾਂ"
+      "file_other": "ਫਾਈਲਾਂ",
+      "openedAgo": "ਖੋਲ੍ਹਿਆ ਗਿਆ {{time}}",
+      "updatedAgo": "ਅੱਪਡੇਟ ਕੀਤਾ ਗਿਆ {{time}}",
+      "mergedAgo": "ਮਰਜ ਹੋਈ {{time}}",
+      "mergedByAgo": "{{login}} ਨੇ ਮਰਜ ਕੀਤਾ {{time}}",
+      "closedAgo": "ਬੰਦ {{time}}",
+      "labels": "ਲੇਬਲ",
+      "reviewers": "ਸਮੀਖਿਅਕ",
+      "assignees": "ਸੌਂਪੇ ਗਏ",
+      "linkedIssues": "ਜੁੜੇ ਮੁੱਦੇ",
+      "reviewApproved": "ਮਨਜ਼ੂਰ",
+      "reviewChangesRequested": "ਤਬਦੀਲੀਆਂ ਮੰਗੀਆਂ",
+      "reviewCommented": "ਟਿੱਪਣੀ ਕੀਤੀ",
+      "reviewPending": "ਸਮੀਖਿਆ ਦੀ ਉਡੀਕ",
+      "openIssueA11y": "GitHub ਉੱਤੇ ਮੁੱਦਾ #{{number}} ਖੋਲ੍ਹੋ",
+      "reviewDismissed": "ਖਾਰਜ ਕੀਤਾ ਗਿਆ"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} 'ਤੇ ਪੁਰਾਣੀ ਲੰਬਿਤ ਟਿੱਪਣੀ ਸੰਪਾਦਿਤ ਕਰੋ",

--- a/apps/mobile/src/i18n/locales/pl.json
+++ b/apps/mobile/src/i18n/locales/pl.json
@@ -2930,7 +2930,22 @@
       "commit_few": "commity",
       "commit_many": "commitów",
       "file_few": "pliki",
-      "file_many": "plików"
+      "file_many": "plików",
+      "openedAgo": "Otwarto {{time}}",
+      "updatedAgo": "Zaktualizowano {{time}}",
+      "mergedAgo": "Scalony {{time}}",
+      "mergedByAgo": "Scalone przez {{login}} {{time}}",
+      "closedAgo": "Zamknięty {{time}}",
+      "labels": "Etykiety",
+      "reviewers": "Recenzenci",
+      "assignees": "Przypisani",
+      "linkedIssues": "Powiązane zgłoszenia",
+      "reviewApproved": "Zatwierdzono",
+      "reviewChangesRequested": "Poproszono o zmiany",
+      "reviewCommented": "Skomentowano",
+      "reviewPending": "Oczekuje na recenzję",
+      "openIssueA11y": "Otwórz zgłoszenie #{{number}} w GitHub",
+      "reviewDismissed": "Odrzucone"
     },
     "pendingComment": {
       "allQueuedHint": "Wszystkie komentarze zostaną wysłane w jednym zbiorczym żądaniu.",

--- a/apps/mobile/src/i18n/locales/ps.json
+++ b/apps/mobile/src/i18n/locales/ps.json
@@ -550,7 +550,22 @@
       "commit_other": "کمټونه",
       "file_one": "فایل",
       "file": "فایلونه",
-      "file_other": "فایلونه"
+      "file_other": "فایلونه",
+      "openedAgo": "پرانیستل شوی {{time}}",
+      "updatedAgo": "تازه شوی {{time}}",
+      "mergedAgo": "یوځای شو {{time}}",
+      "mergedByAgo": "{{login}} یوځای کړ {{time}}",
+      "closedAgo": "تړل شوی {{time}}",
+      "labels": "نښې",
+      "reviewers": "بیاکتونکي",
+      "assignees": "ګمارل شوي",
+      "linkedIssues": "تړل شوې مسئلې",
+      "reviewApproved": "تصویب شوی",
+      "reviewChangesRequested": "بدلونونه غوښتل شوي",
+      "reviewCommented": "تبصره وشوه",
+      "reviewPending": "د بیاکتنې په تمه",
+      "openIssueA11y": "په GitHub کې مسئله #{{number}} پرانیزئ",
+      "reviewDismissed": "له پامه غورځول شوی"
     },
     "pendingComment": {
       "editOutdatedA11y": "په {{location}} زوړ په انتظار تبصره سمه کړئ",

--- a/apps/mobile/src/i18n/locales/pt-BR.json
+++ b/apps/mobile/src/i18n/locales/pt-BR.json
@@ -2910,7 +2910,22 @@
       "stateOpenReviewRequired": "Aberto · Revisão necessária",
       "unknownAuthor": "Autor desconhecido",
       "commit_many": "commits",
-      "file_many": "arquivos"
+      "file_many": "arquivos",
+      "openedAgo": "Aberto {{time}}",
+      "updatedAgo": "Atualizado {{time}}",
+      "mergedAgo": "Mesclado {{time}}",
+      "mergedByAgo": "Mesclado por {{login}} {{time}}",
+      "closedAgo": "Fechado {{time}}",
+      "labels": "Etiquetas",
+      "reviewers": "Revisores",
+      "assignees": "Responsáveis",
+      "linkedIssues": "Issues vinculadas",
+      "reviewApproved": "Aprovado",
+      "reviewChangesRequested": "Alterações solicitadas",
+      "reviewCommented": "Comentado",
+      "reviewPending": "Aguardando revisão",
+      "openIssueA11y": "Abrir issue #{{number}} no GitHub",
+      "reviewDismissed": "Dispensado"
     },
     "pendingComment": {
       "allQueuedHint": "Todos os comentários serão enviados em uma única solicitação em lote.",

--- a/apps/mobile/src/i18n/locales/pt.json
+++ b/apps/mobile/src/i18n/locales/pt.json
@@ -557,7 +557,22 @@
       "file": "ficheiros",
       "file_other": "ficheiros",
       "commit_many": "commits",
-      "file_many": "ficheiros"
+      "file_many": "ficheiros",
+      "openedAgo": "Aberto {{time}}",
+      "updatedAgo": "Atualizado {{time}}",
+      "mergedAgo": "Fundido {{time}}",
+      "mergedByAgo": "Integrado por {{login}} {{time}}",
+      "closedAgo": "Fechado {{time}}",
+      "labels": "Etiquetas",
+      "reviewers": "Revisores",
+      "assignees": "Responsáveis",
+      "linkedIssues": "Problemas associados",
+      "reviewApproved": "Aprovado",
+      "reviewChangesRequested": "Alterações solicitadas",
+      "reviewCommented": "Comentado",
+      "reviewPending": "A aguardar revisão",
+      "openIssueA11y": "Abrir problema #{{number}} no GitHub",
+      "reviewDismissed": "Dispensada"
     },
     "pendingComment": {
       "editOutdatedA11y": "Editar comentário pendente desatualizado em {{location}}",

--- a/apps/mobile/src/i18n/locales/ro.json
+++ b/apps/mobile/src/i18n/locales/ro.json
@@ -557,7 +557,22 @@
       "file": "fișiere",
       "file_other": "fișiere",
       "commit_few": "commit-uri",
-      "file_few": "fișiere"
+      "file_few": "fișiere",
+      "openedAgo": "Deschis {{time}}",
+      "updatedAgo": "Actualizat {{time}}",
+      "mergedAgo": "Fuzionat {{time}}",
+      "mergedByAgo": "Îmbinat de {{login}} {{time}}",
+      "closedAgo": "Închis {{time}}",
+      "labels": "Etichete",
+      "reviewers": "Recenzenți",
+      "assignees": "Responsabili",
+      "linkedIssues": "Probleme asociate",
+      "reviewApproved": "Aprobat",
+      "reviewChangesRequested": "Modificări solicitate",
+      "reviewCommented": "Comentat",
+      "reviewPending": "În așteptarea recenziei",
+      "openIssueA11y": "Deschide problema #{{number}} pe GitHub",
+      "reviewDismissed": "Respinsă"
     },
     "pendingComment": {
       "editOutdatedA11y": "Editează comentariul învechit în așteptare pe {{location}}",

--- a/apps/mobile/src/i18n/locales/ru.json
+++ b/apps/mobile/src/i18n/locales/ru.json
@@ -2930,7 +2930,22 @@
       "commit_few": "коммита",
       "commit_many": "коммитов",
       "file_few": "файла",
-      "file_many": "файлов"
+      "file_many": "файлов",
+      "openedAgo": "Открыт {{time}}",
+      "updatedAgo": "Обновлён {{time}}",
+      "mergedAgo": "Объединен {{time}}",
+      "mergedByAgo": "Объединил {{login}} {{time}}",
+      "closedAgo": "Закрыт {{time}}",
+      "labels": "Метки",
+      "reviewers": "Рецензенты",
+      "assignees": "Ответственные",
+      "linkedIssues": "Связанные задачи",
+      "reviewApproved": "Одобрено",
+      "reviewChangesRequested": "Запрошены изменения",
+      "reviewCommented": "Прокомментировано",
+      "reviewPending": "Ожидает рецензии",
+      "openIssueA11y": "Открыть задачу #{{number}} на GitHub",
+      "reviewDismissed": "Отклонено"
     },
     "pendingComment": {
       "allQueuedHint": "Все комментарии будут отправлены одним пакетным запросом.",

--- a/apps/mobile/src/i18n/locales/si.json
+++ b/apps/mobile/src/i18n/locales/si.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "ගොනුව",
       "file": "ගොනු",
-      "file_other": "ගොනු"
+      "file_other": "ගොනු",
+      "openedAgo": "විවෘත කළේ {{time}}",
+      "updatedAgo": "යාවත්කාලීන කළේ {{time}}",
+      "mergedAgo": "ඒකාබද්ධ කරන ලදී {{time}}",
+      "mergedByAgo": "{{login}} ඒකාබද්ධ කළේ {{time}}",
+      "closedAgo": "වසා ඇත {{time}}",
+      "labels": "ලේබල",
+      "reviewers": "සමාලෝචකයෝ",
+      "assignees": "පවරන ලද අය",
+      "linkedIssues": "සම්බන්ධිත ගැටලු",
+      "reviewApproved": "අනුමත කළා",
+      "reviewChangesRequested": "වෙනස්කම් ඉල්ලා ඇත",
+      "reviewCommented": "අදහස් දක්වා ඇත",
+      "reviewPending": "සමාලෝචනය බලාපොරොත්තුවෙන්",
+      "openIssueA11y": "GitHub හි #{{number}} ගැටලුව විවෘත කරන්න",
+      "reviewDismissed": "ඉවතලා ඇත"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} මත යල් පැන ගිය අත්හිටුවන ලද අදහස සංස්කරණය කරන්න",

--- a/apps/mobile/src/i18n/locales/sk.json
+++ b/apps/mobile/src/i18n/locales/sk.json
@@ -564,7 +564,22 @@
       "commit_few": "commity",
       "commit_many": "commitov",
       "file_few": "súbory",
-      "file_many": "súborov"
+      "file_many": "súborov",
+      "openedAgo": "Otvorené {{time}}",
+      "updatedAgo": "Aktualizované {{time}}",
+      "mergedAgo": "Zlúčené {{time}}",
+      "mergedByAgo": "Zlúčil {{login}} {{time}}",
+      "closedAgo": "Zatvorené {{time}}",
+      "labels": "Štítky",
+      "reviewers": "Recenzenti",
+      "assignees": "Pridelení",
+      "linkedIssues": "Prepojené úlohy",
+      "reviewApproved": "Schválené",
+      "reviewChangesRequested": "Vyžiadané zmeny",
+      "reviewCommented": "Okomentované",
+      "reviewPending": "Čaká na recenziu",
+      "openIssueA11y": "Otvoriť úlohu #{{number}} na GitHube",
+      "reviewDismissed": "Odmietnuté"
     },
     "pendingComment": {
       "editOutdatedA11y": "Upraviť zastaraný čakajúci komentár na {{location}}",

--- a/apps/mobile/src/i18n/locales/sl.json
+++ b/apps/mobile/src/i18n/locales/sl.json
@@ -564,7 +564,22 @@
       "commit_two": "commit-a",
       "commit_few": "commit-i",
       "file_two": "datoteki",
-      "file_few": "datoteke"
+      "file_few": "datoteke",
+      "openedAgo": "Odprto {{time}}",
+      "updatedAgo": "Posodobljeno {{time}}",
+      "mergedAgo": "Združeno {{time}}",
+      "mergedByAgo": "Združil {{login}} {{time}}",
+      "closedAgo": "Zaprto {{time}}",
+      "labels": "Oznake",
+      "reviewers": "Pregledovalci",
+      "assignees": "Dodeljeni",
+      "linkedIssues": "Povezane težave",
+      "reviewApproved": "Odobreno",
+      "reviewChangesRequested": "Zahtevane spremembe",
+      "reviewCommented": "Komentirano",
+      "reviewPending": "Čaka na pregled",
+      "openIssueA11y": "Odpri težavo #{{number}} na GitHubu",
+      "reviewDismissed": "Zavrženo"
     },
     "pendingComment": {
       "editOutdatedA11y": "Uredi zastareli čakajoči komentar na {{location}}",

--- a/apps/mobile/src/i18n/locales/so.json
+++ b/apps/mobile/src/i18n/locales/so.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "fayl",
       "file": "faylal",
-      "file_other": "faylal"
+      "file_other": "faylal",
+      "openedAgo": "La furay {{time}}",
+      "updatedAgo": "La cusbooneysiiyay {{time}}",
+      "mergedAgo": "Waa la daray {{time}}",
+      "mergedByAgo": "{{login}} ayaa isku daray {{time}}",
+      "closedAgo": "Waa xiran {{time}}",
+      "labels": "Calaamado",
+      "reviewers": "Dib-u-eegayaal",
+      "assignees": "Loo xilsaaray",
+      "linkedIssues": "Arrimo xiriirsan",
+      "reviewApproved": "La ansixiyay",
+      "reviewChangesRequested": "Isbeddello la codsaday",
+      "reviewCommented": "Faallo la bixiyay",
+      "reviewPending": "Sugaya dib-u-eegis",
+      "openIssueA11y": "Fur arrinta #{{number}} ee GitHub",
+      "reviewDismissed": "Waa la xiray"
     },
     "pendingComment": {
       "editOutdatedA11y": "Faallada sugaysa ee duugga ah wax ka beddel {{location}}",

--- a/apps/mobile/src/i18n/locales/sq.json
+++ b/apps/mobile/src/i18n/locales/sq.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "skedar",
       "file": "skedarë",
-      "file_other": "skedarë"
+      "file_other": "skedarë",
+      "openedAgo": "Hapur {{time}}",
+      "updatedAgo": "Përditësuar {{time}}",
+      "mergedAgo": "E shkrirë {{time}}",
+      "mergedByAgo": "Bashkuar nga {{login}} {{time}}",
+      "closedAgo": "E mbyllur {{time}}",
+      "labels": "Etiketat",
+      "reviewers": "Rishikuesit",
+      "assignees": "Të ngarkuarit",
+      "linkedIssues": "Çështje të lidhura",
+      "reviewApproved": "Miratuar",
+      "reviewChangesRequested": "Kërkuar ndryshime",
+      "reviewCommented": "Komentuar",
+      "reviewPending": "Në pritje të rishikimit",
+      "openIssueA11y": "Hap çështjen #{{number}} në GitHub",
+      "reviewDismissed": "E hedhur poshtë"
     },
     "pendingComment": {
       "editOutdatedA11y": "Redakto komentin në pritje të vjetëruar te {{location}}",

--- a/apps/mobile/src/i18n/locales/sr.json
+++ b/apps/mobile/src/i18n/locales/sr.json
@@ -557,7 +557,22 @@
       "file": "datoteke",
       "file_other": "datoteke",
       "commit_few": "commita",
-      "file_few": "datoteke"
+      "file_few": "datoteke",
+      "openedAgo": "Otvoreno {{time}}",
+      "updatedAgo": "Ažurirano {{time}}",
+      "mergedAgo": "Spojeno {{time}}",
+      "mergedByAgo": "Spojio {{login}} {{time}}",
+      "closedAgo": "Zatvoreno {{time}}",
+      "labels": "Oznake",
+      "reviewers": "Recenzenti",
+      "assignees": "Zaduženi",
+      "linkedIssues": "Povezani problemi",
+      "reviewApproved": "Odobreno",
+      "reviewChangesRequested": "Zatražene izmene",
+      "reviewCommented": "Komentarisano",
+      "reviewPending": "Čeka recenziju",
+      "openIssueA11y": "Otvori problem #{{number}} na GitHubu",
+      "reviewDismissed": "Odbijeno"
     },
     "pendingComment": {
       "editOutdatedA11y": "Izmeni zastareli čekajući komentar na {{location}}",

--- a/apps/mobile/src/i18n/locales/sv.json
+++ b/apps/mobile/src/i18n/locales/sv.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "fil",
       "file": "filer",
-      "file_other": "filer"
+      "file_other": "filer",
+      "openedAgo": "Öppnad {{time}}",
+      "updatedAgo": "Uppdaterad {{time}}",
+      "mergedAgo": "Sammanfogad {{time}}",
+      "mergedByAgo": "Sammanfogad av {{login}} {{time}}",
+      "closedAgo": "Stängd {{time}}",
+      "labels": "Etiketter",
+      "reviewers": "Granskare",
+      "assignees": "Ansvariga",
+      "linkedIssues": "Länkade ärenden",
+      "reviewApproved": "Godkänd",
+      "reviewChangesRequested": "Ändringar begärda",
+      "reviewCommented": "Kommenterad",
+      "reviewPending": "Väntar på granskning",
+      "openIssueA11y": "Öppna ärende #{{number}} på GitHub",
+      "reviewDismissed": "Avskriven"
     },
     "pendingComment": {
       "editOutdatedA11y": "Redigera föråldrad väntande kommentar på {{location}}",

--- a/apps/mobile/src/i18n/locales/sw.json
+++ b/apps/mobile/src/i18n/locales/sw.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "faili",
       "file": "faili",
-      "file_other": "faili"
+      "file_other": "faili",
+      "openedAgo": "Ilifunguliwa {{time}}",
+      "updatedAgo": "Ilisasishwa {{time}}",
+      "mergedAgo": "Imeunganishwa {{time}}",
+      "mergedByAgo": "Iliunganishwa na {{login}} {{time}}",
+      "closedAgo": "Imefungwa {{time}}",
+      "labels": "Lebo",
+      "reviewers": "Wakaguzi",
+      "assignees": "Waliopewa jukumu",
+      "linkedIssues": "Masuala yaliyounganishwa",
+      "reviewApproved": "Imeidhinishwa",
+      "reviewChangesRequested": "Mabadiliko yameombwa",
+      "reviewCommented": "Imetolewa maoni",
+      "reviewPending": "Inasubiri ukaguzi",
+      "openIssueA11y": "Fungua suala #{{number}} kwenye GitHub",
+      "reviewDismissed": "Imefutwa"
     },
     "pendingComment": {
       "editOutdatedA11y": "Hariri maoni ya zamani ya kusubiri kwenye {{location}}",

--- a/apps/mobile/src/i18n/locales/ta.json
+++ b/apps/mobile/src/i18n/locales/ta.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "கோப்பு",
       "file": "கோப்புகள்",
-      "file_other": "கோப்புகள்"
+      "file_other": "கோப்புகள்",
+      "openedAgo": "திறக்கப்பட்டது {{time}}",
+      "updatedAgo": "புதுப்பிக்கப்பட்டது {{time}}",
+      "mergedAgo": "இணைக்கப்பட்டது {{time}}",
+      "mergedByAgo": "{{login}} இணைத்தார் {{time}}",
+      "closedAgo": "மூடப்பட்டது {{time}}",
+      "labels": "லேபிள்கள்",
+      "reviewers": "மதிப்பாய்வாளர்கள்",
+      "assignees": "ஒதுக்கப்பட்டவர்கள்",
+      "linkedIssues": "இணைக்கப்பட்ட சிக்கல்கள்",
+      "reviewApproved": "அங்கீகரிக்கப்பட்டது",
+      "reviewChangesRequested": "மாற்றங்கள் கோரப்பட்டன",
+      "reviewCommented": "கருத்து தெரிவிக்கப்பட்டது",
+      "reviewPending": "மதிப்பாய்வுக்காகக் காத்திருக்கிறது",
+      "openIssueA11y": "GitHub இல் சிக்கல் #{{number}} ஐத் திறக்கவும்",
+      "reviewDismissed": "நிராகரிக்கப்பட்டது"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} இல் காலாவதியான நிலுவை கருத்தைத் திருத்து",

--- a/apps/mobile/src/i18n/locales/te.json
+++ b/apps/mobile/src/i18n/locales/te.json
@@ -550,7 +550,22 @@
       "commit_other": "కమిట్లు",
       "file_one": "ఫైల్",
       "file": "ఫైల్లు",
-      "file_other": "ఫైల్లు"
+      "file_other": "ఫైల్లు",
+      "openedAgo": "తెరవబడింది {{time}}",
+      "updatedAgo": "నవీకరించబడింది {{time}}",
+      "mergedAgo": "మెర్జ్ అయింది {{time}}",
+      "mergedByAgo": "{{login}} విలీనం చేశారు {{time}}",
+      "closedAgo": "మూసివేయబడింది {{time}}",
+      "labels": "లేబుళ్లు",
+      "reviewers": "సమీక్షకులు",
+      "assignees": "కేటాయించినవారు",
+      "linkedIssues": "అనుసంధానిత సమస్యలు",
+      "reviewApproved": "ఆమోదించబడింది",
+      "reviewChangesRequested": "మార్పులు కోరబడ్డాయి",
+      "reviewCommented": "వ్యాఖ్యానించబడింది",
+      "reviewPending": "సమీక్ష కోసం వేచి ఉంది",
+      "openIssueA11y": "GitHub లో సమస్య #{{number}} తెరవండి",
+      "reviewDismissed": "తోసివేయబడింది"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}}పై పాత పెండింగ్ వ్యాఖ్యను సవరించండి",

--- a/apps/mobile/src/i18n/locales/th.json
+++ b/apps/mobile/src/i18n/locales/th.json
@@ -550,7 +550,22 @@
       "commit_other": "commits",
       "file_one": "ไฟล์",
       "file": "ไฟล์",
-      "file_other": "ไฟล์"
+      "file_other": "ไฟล์",
+      "openedAgo": "เปิดเมื่อ {{time}}",
+      "updatedAgo": "อัปเดตเมื่อ {{time}}",
+      "mergedAgo": "รวมแล้ว {{time}}",
+      "mergedByAgo": "{{login}} ผสานเมื่อ {{time}}",
+      "closedAgo": "ปิดแล้ว {{time}}",
+      "labels": "ป้ายกำกับ",
+      "reviewers": "ผู้ตรวจทาน",
+      "assignees": "ผู้รับผิดชอบ",
+      "linkedIssues": "ปัญหาที่เชื่อมโยง",
+      "reviewApproved": "อนุมัติแล้ว",
+      "reviewChangesRequested": "ขอให้แก้ไข",
+      "reviewCommented": "แสดงความคิดเห็นแล้ว",
+      "reviewPending": "รอการตรวจทาน",
+      "openIssueA11y": "เปิดปัญหา #{{number}} บน GitHub",
+      "reviewDismissed": "ละเว้นแล้ว"
     },
     "pendingComment": {
       "editOutdatedA11y": "แก้ไขความคิดเห็นที่รอดำเนินการที่ล้าสมัยบน {{location}}",

--- a/apps/mobile/src/i18n/locales/tr.json
+++ b/apps/mobile/src/i18n/locales/tr.json
@@ -2890,7 +2890,22 @@
       "stateOpenApproved": "Açık · Onaylandı",
       "stateOpenChangesRequested": "Açık · Değişiklik istendi",
       "stateOpenReviewRequired": "Açık · İnceleme gerekli",
-      "unknownAuthor": "Bilinmeyen yazar"
+      "unknownAuthor": "Bilinmeyen yazar",
+      "openedAgo": "Açıldı {{time}}",
+      "updatedAgo": "Güncellendi {{time}}",
+      "mergedAgo": "Birleştirildi {{time}}",
+      "mergedByAgo": "{{login}} birleştirdi {{time}}",
+      "closedAgo": "Kapalı {{time}}",
+      "labels": "Etiketler",
+      "reviewers": "İnceleyenler",
+      "assignees": "Atananlar",
+      "linkedIssues": "Bağlantılı sorunlar",
+      "reviewApproved": "Onaylandı",
+      "reviewChangesRequested": "Değişiklik istendi",
+      "reviewCommented": "Yorum yapıldı",
+      "reviewPending": "İnceleme bekliyor",
+      "openIssueA11y": "GitHub'da #{{number}} sorununu aç",
+      "reviewDismissed": "Yok sayıldı"
     },
     "pendingComment": {
       "allQueuedHint": "Tüm yorumlar tek bir toplu istekte gönderilecek.",

--- a/apps/mobile/src/i18n/locales/uk.json
+++ b/apps/mobile/src/i18n/locales/uk.json
@@ -2930,7 +2930,22 @@
       "commit_few": "коміти",
       "commit_many": "комітів",
       "file_few": "файли",
-      "file_many": "файлів"
+      "file_many": "файлів",
+      "openedAgo": "Відкрито {{time}}",
+      "updatedAgo": "Оновлено {{time}}",
+      "mergedAgo": "Злито {{time}}",
+      "mergedByAgo": "Об'єднав {{login}} {{time}}",
+      "closedAgo": "Закрито {{time}}",
+      "labels": "Мітки",
+      "reviewers": "Рецензенти",
+      "assignees": "Відповідальні",
+      "linkedIssues": "Пов'язані задачі",
+      "reviewApproved": "Схвалено",
+      "reviewChangesRequested": "Запитано зміни",
+      "reviewCommented": "Прокоментовано",
+      "reviewPending": "Очікує рецензії",
+      "openIssueA11y": "Відкрити задачу #{{number}} на GitHub",
+      "reviewDismissed": "Відхилено"
     },
     "pendingComment": {
       "allQueuedHint": "Усі коментарі буде надіслано одним пакетним запитом.",

--- a/apps/mobile/src/i18n/locales/ur.json
+++ b/apps/mobile/src/i18n/locales/ur.json
@@ -550,7 +550,22 @@
       "commit_other": "کمیٹیں",
       "file_one": "فائل",
       "file": "فائلیں",
-      "file_other": "فائلیں"
+      "file_other": "فائلیں",
+      "openedAgo": "کھولا گیا {{time}}",
+      "updatedAgo": "اپ ڈیٹ ہوا {{time}}",
+      "mergedAgo": "مرج شدہ {{time}}",
+      "mergedByAgo": "{{login}} نے ضم کیا {{time}}",
+      "closedAgo": "بند {{time}}",
+      "labels": "لیبل",
+      "reviewers": "جائزہ لینے والے",
+      "assignees": "تفویض کردہ",
+      "linkedIssues": "منسلک مسائل",
+      "reviewApproved": "منظور شدہ",
+      "reviewChangesRequested": "تبدیلیاں طلب کی گئیں",
+      "reviewCommented": "تبصرہ کیا گیا",
+      "reviewPending": "جائزے کا منتظر",
+      "openIssueA11y": "GitHub پر مسئلہ #{{number}} کھولیں",
+      "reviewDismissed": "مسترد کیا گیا"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} پر پرانا زیر التوا تبصرہ ترمیم کریں",

--- a/apps/mobile/src/i18n/locales/uz.json
+++ b/apps/mobile/src/i18n/locales/uz.json
@@ -550,7 +550,22 @@
       "commit_other": "commit",
       "file_one": "fayl",
       "file": "fayl",
-      "file_other": "fayl"
+      "file_other": "fayl",
+      "openedAgo": "Ochilgan {{time}}",
+      "updatedAgo": "Yangilangan {{time}}",
+      "mergedAgo": "Birlashtirildi {{time}}",
+      "mergedByAgo": "{{login}} birlashtirdi {{time}}",
+      "closedAgo": "Yopilgan {{time}}",
+      "labels": "Yorliqlar",
+      "reviewers": "Ko'rib chiquvchilar",
+      "assignees": "Mas'ullar",
+      "linkedIssues": "Bog'langan masalalar",
+      "reviewApproved": "Tasdiqlangan",
+      "reviewChangesRequested": "O'zgarishlar so'ralgan",
+      "reviewCommented": "Izoh qoldirilgan",
+      "reviewPending": "Ko'rib chiqish kutilmoqda",
+      "openIssueA11y": "GitHub'da #{{number}} masalasini ochish",
+      "reviewDismissed": "Rad etilgan"
     },
     "pendingComment": {
       "editOutdatedA11y": "{{location}} dagi eskirgan kutilayotgan izohni tahrirlash",

--- a/apps/mobile/src/i18n/locales/vi.json
+++ b/apps/mobile/src/i18n/locales/vi.json
@@ -2890,7 +2890,22 @@
       "stateOpenApproved": "Đang mở · Đã phê duyệt",
       "stateOpenChangesRequested": "Đang mở · Đã yêu cầu thay đổi",
       "stateOpenReviewRequired": "Đang mở · Cần đánh giá",
-      "unknownAuthor": "Tác giả không xác định"
+      "unknownAuthor": "Tác giả không xác định",
+      "openedAgo": "Đã mở {{time}}",
+      "updatedAgo": "Đã cập nhật {{time}}",
+      "mergedAgo": "Đã hợp nhất {{time}}",
+      "mergedByAgo": "{{login}} đã gộp {{time}}",
+      "closedAgo": "Đã đóng {{time}}",
+      "labels": "Nhãn",
+      "reviewers": "Người đánh giá",
+      "assignees": "Người phụ trách",
+      "linkedIssues": "Vấn đề liên kết",
+      "reviewApproved": "Đã phê duyệt",
+      "reviewChangesRequested": "Đã yêu cầu thay đổi",
+      "reviewCommented": "Đã bình luận",
+      "reviewPending": "Đang chờ đánh giá",
+      "openIssueA11y": "Mở vấn đề #{{number}} trên GitHub",
+      "reviewDismissed": "Đã bỏ qua"
     },
     "pendingComment": {
       "allQueuedHint": "Tất cả các bình luận sẽ được gửi trong một yêu cầu gộp duy nhất.",

--- a/apps/mobile/src/i18n/locales/yo.json
+++ b/apps/mobile/src/i18n/locales/yo.json
@@ -550,7 +550,22 @@
       "commit_other": "awọn iṣẹ",
       "file_one": "faili",
       "file": "àwọn fáìlì",
-      "file_other": "àwọn fáìlì"
+      "file_other": "àwọn fáìlì",
+      "openedAgo": "Ṣí {{time}}",
+      "updatedAgo": "Ṣàtúnṣe {{time}}",
+      "mergedAgo": "Ti darapọ {{time}}",
+      "mergedByAgo": "{{login}} darapọ̀ mọ́ ọn {{time}}",
+      "closedAgo": "Tí a pa {{time}}",
+      "labels": "Àwọn àmì",
+      "reviewers": "Àwọn olùyẹ̀wò",
+      "assignees": "Àwọn tí a yàn",
+      "linkedIssues": "Àwọn ọ̀rọ̀ tí a so pọ̀",
+      "reviewApproved": "Ti fọwọ́sí",
+      "reviewChangesRequested": "Wọ́n béèrè àwọn àyípadà",
+      "reviewCommented": "Ti sọ̀rọ̀",
+      "reviewPending": "Ń dúró de àyẹ̀wò",
+      "openIssueA11y": "Ṣí ọ̀rọ̀ #{{number}} lórí GitHub",
+      "reviewDismissed": "Ti fi silẹ"
     },
     "pendingComment": {
       "editOutdatedA11y": "Ṣatunkọ asọye idaduro atijọ lori {{location}}",

--- a/apps/mobile/src/i18n/locales/zh-Hans.json
+++ b/apps/mobile/src/i18n/locales/zh-Hans.json
@@ -2890,7 +2890,22 @@
       "stateOpenApproved": "打开 · 已批准",
       "stateOpenChangesRequested": "打开 · 已请求更改",
       "stateOpenReviewRequired": "打开 · 需要审查",
-      "unknownAuthor": "未知作者"
+      "unknownAuthor": "未知作者",
+      "openedAgo": "创建于 {{time}}",
+      "updatedAgo": "更新于 {{time}}",
+      "mergedAgo": "已合并 {{time}}",
+      "mergedByAgo": "由 {{login}} 合并 {{time}}",
+      "closedAgo": "已关闭 {{time}}",
+      "labels": "标签",
+      "reviewers": "审查者",
+      "assignees": "指派人",
+      "linkedIssues": "关联的议题",
+      "reviewApproved": "已批准",
+      "reviewChangesRequested": "已请求修改",
+      "reviewCommented": "已评论",
+      "reviewPending": "等待审查",
+      "openIssueA11y": "在 GitHub 上打开议题 #{{number}}",
+      "reviewDismissed": "已忽略"
     },
     "pendingComment": {
       "allQueuedHint": "所有评论将在一次批量请求中发送。",

--- a/apps/mobile/src/i18n/locales/zh-Hant.json
+++ b/apps/mobile/src/i18n/locales/zh-Hant.json
@@ -2890,7 +2890,22 @@
       "stateOpenApproved": "開啟 · 已核准",
       "stateOpenChangesRequested": "開啟 · 要求變更",
       "stateOpenReviewRequired": "開啟 · 需要審查",
-      "unknownAuthor": "未知作者"
+      "unknownAuthor": "未知作者",
+      "openedAgo": "建立於 {{time}}",
+      "updatedAgo": "更新於 {{time}}",
+      "mergedAgo": "已合併 {{time}}",
+      "mergedByAgo": "由 {{login}} 合併 {{time}}",
+      "closedAgo": "已關閉 {{time}}",
+      "labels": "標籤",
+      "reviewers": "審查者",
+      "assignees": "指派人",
+      "linkedIssues": "關聯的議題",
+      "reviewApproved": "已核准",
+      "reviewChangesRequested": "已要求修改",
+      "reviewCommented": "已評論",
+      "reviewPending": "等待審查",
+      "openIssueA11y": "在 GitHub 上開啟議題 #{{number}}",
+      "reviewDismissed": "已忽略"
     },
     "pendingComment": {
       "allQueuedHint": "所有留言會以單一批次要求傳送。",

--- a/apps/mobile/src/i18n/locales/zu.json
+++ b/apps/mobile/src/i18n/locales/zu.json
@@ -550,7 +550,22 @@
       "commit_other": "ama-commit",
       "file_one": "ifayela",
       "file": "amafayela",
-      "file_other": "amafayela"
+      "file_other": "amafayela",
+      "openedAgo": "Kuvuliwe {{time}}",
+      "updatedAgo": "Kubuyekeziwe {{time}}",
+      "mergedAgo": "Kuyahlanganisiwe {{time}}",
+      "mergedByAgo": "Kuhlanganiswe ngu-{{login}} {{time}}",
+      "closedAgo": "Kuvaliwe {{time}}",
+      "labels": "Amalebula",
+      "reviewers": "Ababuyekezi",
+      "assignees": "Abelwe",
+      "linkedIssues": "Izinkinga ezixhunyiwe",
+      "reviewApproved": "Kugunyaziwe",
+      "reviewChangesRequested": "Kuceliwe izinguquko",
+      "reviewCommented": "Kuphawuliwe",
+      "reviewPending": "Kulindele ukubuyekezwa",
+      "openIssueA11y": "Vula inkinga #{{number}} ku-GitHub",
+      "reviewDismissed": "Ichithiwe"
     },
     "pendingComment": {
       "editOutdatedA11y": "Hlela amazwana alindile aphelelwe yisikhathi ku-{{location}}",

--- a/apps/mobile/src/lib/pr-review/overview-meta.test.ts
+++ b/apps/mobile/src/lib/pr-review/overview-meta.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPrTimeline, labelChipColors, reviewerStateTone } from './overview-meta';
+
+type TimelineInput = Parameters<typeof buildPrTimeline>[0];
+
+function pr(overrides: Partial<TimelineInput> = {}): TimelineInput {
+  return {
+    state: 'open',
+    createdAt: '2026-03-01T12:00:00Z',
+    updatedAt: '2026-03-02T09:30:00Z',
+    closedAt: null,
+    mergedAt: null,
+    mergedBy: null,
+    ...overrides,
+  };
+}
+
+describe('buildPrTimeline', () => {
+  it('reports the last update for an open pull request', () => {
+    expect(buildPrTimeline(pr())).toEqual([
+      { id: 'opened', labelKey: 'prReview.overview.openedAgo', iso: '2026-03-01T12:00:00Z' },
+      { id: 'updated', labelKey: 'prReview.overview.updatedAgo', iso: '2026-03-02T09:30:00Z' },
+    ]);
+  });
+
+  it('names the merge actor when GitHub reports one', () => {
+    const entries = buildPrTimeline(
+      pr({
+        state: 'merged',
+        mergedAt: '2026-03-03T10:00:00Z',
+        closedAt: '2026-03-03T10:00:00Z',
+        mergedBy: { login: 'hubot', avatarUrl: null },
+      })
+    );
+    expect(entries[1]).toEqual({
+      id: 'merged',
+      labelKey: 'prReview.overview.mergedByAgo',
+      iso: '2026-03-03T10:00:00Z',
+      login: 'hubot',
+    });
+  });
+
+  it('drops the actor from the merge entry when GitHub omits it', () => {
+    const entries = buildPrTimeline(
+      pr({ state: 'merged', mergedAt: '2026-03-03T10:00:00Z', mergedBy: null })
+    );
+    expect(entries[1]).toEqual({
+      id: 'merged',
+      labelKey: 'prReview.overview.mergedAgo',
+      iso: '2026-03-03T10:00:00Z',
+    });
+  });
+
+  it('falls back to the closed entry when a merged pull request has no merge time', () => {
+    const entries = buildPrTimeline(
+      pr({ state: 'merged', mergedAt: null, closedAt: '2026-03-03T10:00:00Z' })
+    );
+    expect(entries[1]?.id).toBe('closed');
+  });
+
+  it('falls back to the updated entry when a closed pull request has no close time', () => {
+    expect(buildPrTimeline(pr({ state: 'closed', closedAt: null }))[1]?.id).toBe('updated');
+  });
+
+  it('reports the close time for a closed pull request', () => {
+    const entries = buildPrTimeline(pr({ state: 'closed', closedAt: '2026-03-04T08:00:00Z' }));
+    expect(entries[1]).toEqual({
+      id: 'closed',
+      labelKey: 'prReview.overview.closedAgo',
+      iso: '2026-03-04T08:00:00Z',
+    });
+  });
+});
+
+describe('labelChipColors', () => {
+  it('writes dark text on a light label', () => {
+    expect(labelChipColors('d4c5f9')).toEqual({ background: '#d4c5f9', text: '#1f2328' });
+  });
+
+  it('writes white text on a dark label', () => {
+    expect(labelChipColors('0e8a16')).toEqual({ background: '#0e8a16', text: '#ffffff' });
+  });
+
+  it('rejects anything that is not a six-digit hex', () => {
+    expect(labelChipColors('')).toBeNull();
+    expect(labelChipColors('#d73a4a')).toBeNull();
+    expect(labelChipColors('fff')).toBeNull();
+    expect(labelChipColors('zzzzzz')).toBeNull();
+  });
+});
+
+describe('reviewerStateTone', () => {
+  it('separates the two states that change the merge outcome', () => {
+    expect(reviewerStateTone('APPROVED')).toBe('good');
+    expect(reviewerStateTone('CHANGES_REQUESTED')).toBe('destructive');
+    expect(reviewerStateTone('COMMENTED')).toBe('muted');
+    expect(reviewerStateTone('PENDING')).toBe('muted');
+  });
+});

--- a/apps/mobile/src/lib/pr-review/overview-meta.ts
+++ b/apps/mobile/src/lib/pr-review/overview-meta.ts
@@ -1,0 +1,105 @@
+// Pure selectors for the PR overview's sidebar metadata — the timeline line,
+// label chip colors, and the reviewer-state label lookup. No React, no
+// react-query, no expo modules, so the tests load in plain Node (the same
+// split `merge-blocked-reasons.ts` uses).
+
+import { type PrOverviewDto } from '@/lib/pr-review/merge/merge-blocked-reasons';
+
+export type PrReviewerState = PrOverviewDto['reviewers'][number]['state'];
+
+// Literal keys, never a template: the catalog check scans the source for the
+// keys a lookup passes on, and a computed key is invisible to it.
+const REVIEWER_STATE_LABEL_KEYS = {
+  APPROVED: 'prReview.overview.reviewApproved',
+  CHANGES_REQUESTED: 'prReview.overview.reviewChangesRequested',
+  COMMENTED: 'prReview.overview.reviewCommented',
+  DISMISSED: 'prReview.overview.reviewDismissed',
+  PENDING: 'prReview.overview.reviewPending',
+} satisfies Record<PrReviewerState, string>;
+
+export type ReviewerTone = 'good' | 'destructive' | 'muted';
+
+const REVIEWER_STATE_TONES = {
+  APPROVED: 'good',
+  CHANGES_REQUESTED: 'destructive',
+  COMMENTED: 'muted',
+  DISMISSED: 'muted',
+  PENDING: 'muted',
+} satisfies Record<PrReviewerState, ReviewerTone>;
+
+export function reviewerStateLabelKey(state: PrReviewerState): string {
+  return REVIEWER_STATE_LABEL_KEYS[state];
+}
+
+export function reviewerStateTone(state: PrReviewerState): ReviewerTone {
+  return REVIEWER_STATE_TONES[state];
+}
+
+export type PrTimelineEntry = {
+  /** Stable list key, and the reason this entry exists. */
+  id: 'opened' | 'merged' | 'closed' | 'updated';
+  labelKey: string;
+  /** ISO timestamp the caller renders through `timeAgo`. */
+  iso: string;
+  /** Present only on a merge whose actor GitHub reported. */
+  login?: string;
+};
+
+type PrTimelineInput = Pick<
+  PrOverviewDto,
+  'state' | 'createdAt' | 'updatedAt' | 'closedAt' | 'mergedAt' | 'mergedBy'
+>;
+
+/**
+ * The two-part timeline line: when the PR opened, then the one event that
+ * describes where it stands now. An open PR reports its last update; a merged
+ * or closed PR reports that instead, because "updated" after a merge is noise.
+ *
+ * A merged PR whose `mergedAt` GitHub omitted falls back to the closed or
+ * updated entry rather than rendering a blank time.
+ */
+export function buildPrTimeline(pr: PrTimelineInput): PrTimelineEntry[] {
+  const entries: PrTimelineEntry[] = [
+    { id: 'opened', labelKey: 'prReview.overview.openedAgo', iso: pr.createdAt },
+  ];
+
+  if (pr.state === 'merged' && pr.mergedAt) {
+    entries.push(
+      pr.mergedBy
+        ? {
+            id: 'merged',
+            labelKey: 'prReview.overview.mergedByAgo',
+            iso: pr.mergedAt,
+            login: pr.mergedBy.login,
+          }
+        : { id: 'merged', labelKey: 'prReview.overview.mergedAgo', iso: pr.mergedAt }
+    );
+    return entries;
+  }
+  if (pr.state !== 'open' && pr.closedAt) {
+    entries.push({ id: 'closed', labelKey: 'prReview.overview.closedAgo', iso: pr.closedAt });
+    return entries;
+  }
+  entries.push({ id: 'updated', labelKey: 'prReview.overview.updatedAgo', iso: pr.updatedAt });
+  return entries;
+}
+
+/**
+ * Readable text color for a GitHub label swatch. GitHub stores the chip
+ * background as a bare 6-digit hex and leaves the foreground to the client;
+ * perceived luminance picks near-black on a light chip and white on a dark one.
+ *
+ * Returns null for anything that is not a 6-digit hex, so the caller can fall
+ * back to the theme's neutral chip instead of drawing an unreadable one.
+ */
+export function labelChipColors(color: string): { background: string; text: string } | null {
+  if (!/^[0-9a-fA-F]{6}$/.test(color)) {
+    return null;
+  }
+  const red = Number.parseInt(color.slice(0, 2), 16);
+  const green = Number.parseInt(color.slice(2, 4), 16);
+  const blue = Number.parseInt(color.slice(4, 6), 16);
+  // ITU-R BT.601 luma, the same weighting GitHub's own label contrast uses.
+  const luma = (0.299 * red + 0.587 * green + 0.114 * blue) / 255;
+  return { background: `#${color}`, text: luma > 0.6 ? '#1f2328' : '#ffffff' };
+}

--- a/apps/web/src/lib/github-pr-review/dtos.ts
+++ b/apps/web/src/lib/github-pr-review/dtos.ts
@@ -9,6 +9,29 @@ export const GitHubPrReviewAuthorSchema = z
   })
   .strict();
 
+/** A reviewer's latest state on the PR, or PENDING when only a request exists. */
+export const GitHubPrReviewReviewerSchema = GitHubPrReviewAuthorSchema.extend({
+  state: z.enum(['APPROVED', 'CHANGES_REQUESTED', 'COMMENTED', 'DISMISSED', 'PENDING']),
+});
+
+/** A repository label. `color` is GitHub's 6-digit hex WITHOUT the leading `#`. */
+export const GitHubPrReviewLabelSchema = z
+  .object({
+    name: z.string().min(1),
+    color: z.string(),
+  })
+  .strict();
+
+/** An issue this PR closes when it merges — GitHub's "Development" sidebar box. */
+export const GitHubPrReviewLinkedIssueSchema = z
+  .object({
+    number: z.number().int().positive(),
+    title: z.string(),
+    url: z.string().url(),
+    closed: z.boolean(),
+  })
+  .strict();
+
 export const GitHubPrReviewOverviewSchema = z
   .object({
     number: z.number().int().positive(),
@@ -39,6 +62,19 @@ export const GitHubPrReviewOverviewSchema = z
       })
       .nullable(),
     reviewDecision: z.enum(['REVIEW_REQUIRED', 'APPROVED', 'CHANGES_REQUESTED']).nullable(),
+    labels: z.array(GitHubPrReviewLabelSchema),
+    assignees: z.array(GitHubPrReviewAuthorSchema),
+    // Empty when the GraphQL enrichment leg degraded — the overview still
+    // renders, it just omits the reviewer and linked-issue rows.
+    reviewers: z.array(GitHubPrReviewReviewerSchema),
+    linkedIssues: z.array(GitHubPrReviewLinkedIssueSchema),
+    createdAt: z.string().min(1),
+    updatedAt: z.string().min(1),
+    closedAt: z.string().nullable(),
+    mergedAt: z.string().nullable(),
+    mergedBy: GitHubPrReviewAuthorSchema.nullable(),
+    /** Conversation comments plus review comments — the Discussion tab badge. */
+    commentCount: z.number().int().nonnegative(),
     repo: z
       .object({
         allowMergeCommit: z.boolean(),

--- a/apps/web/src/lib/github-pr-review/mappers.test.ts
+++ b/apps/web/src/lib/github-pr-review/mappers.test.ts
@@ -25,6 +25,8 @@ describe('buildOverviewDto', () => {
     mergeable: true,
     mergeable_state: 'clean',
     auto_merge: { merge_method: 'squash' },
+    created_at: '2026-03-01T12:00:00Z',
+    updated_at: '2026-03-02T09:30:00Z',
   };
 
   it('returns overview DTO with all required fields populated', () => {
@@ -91,6 +93,136 @@ describe('buildOverviewDto', () => {
     expect(dto.author).toBeNull();
     expect(dto.reviewDecision).toBeNull();
     expect(dto.repo.viewerLogin).toBeNull();
+  });
+
+  it('maps labels, assignees, timestamps, merged-by and the comment count from REST', () => {
+    const dto = buildOverviewDto({
+      pr: {
+        ...basePr,
+        merged: true,
+        labels: [
+          { name: 'bug', color: 'd73a4a' },
+          { name: 'no-color', color: null },
+          { name: null, color: 'ffffff' },
+        ],
+        assignees: [{ login: 'octocat', avatar_url: 'https://avatars.example/octocat' }, null],
+        closed_at: '2026-03-03T10:00:00Z',
+        merged_at: '2026-03-03T10:00:00Z',
+        merged_by: { login: 'hubot', avatar_url: 'https://avatars.example/hubot' },
+        comments: 4,
+        review_comments: 7,
+      },
+      repo: {},
+      graphQl: { repository: { pullRequest: { reviewDecision: null } }, viewer: null },
+      viewer: null,
+    });
+    // A label without a name is dropped; a null color falls back to empty.
+    expect(dto.labels).toEqual([
+      { name: 'bug', color: 'd73a4a' },
+      { name: 'no-color', color: '' },
+    ]);
+    expect(dto.assignees).toEqual([
+      { login: 'octocat', avatarUrl: 'https://avatars.example/octocat' },
+    ]);
+    expect(dto.createdAt).toBe('2026-03-01T12:00:00Z');
+    expect(dto.updatedAt).toBe('2026-03-02T09:30:00Z');
+    expect(dto.closedAt).toBe('2026-03-03T10:00:00Z');
+    expect(dto.mergedAt).toBe('2026-03-03T10:00:00Z');
+    expect(dto.mergedBy).toEqual({ login: 'hubot', avatarUrl: 'https://avatars.example/hubot' });
+    expect(dto.commentCount).toBe(11);
+  });
+
+  it('defaults every REST-sourced sidebar field when GitHub omits it', () => {
+    const dto = buildOverviewDto({
+      pr: basePr,
+      repo: {},
+      graphQl: null,
+      viewer: null,
+    });
+    expect(dto.labels).toEqual([]);
+    expect(dto.assignees).toEqual([]);
+    expect(dto.closedAt).toBeNull();
+    expect(dto.mergedAt).toBeNull();
+    expect(dto.mergedBy).toBeNull();
+    expect(dto.commentCount).toBe(0);
+    // A degraded GraphQL leg must not blank the overview.
+    expect(dto.reviewers).toEqual([]);
+    expect(dto.linkedIssues).toEqual([]);
+  });
+
+  it('lists submitted reviewers first and requested-only reviewers as PENDING', () => {
+    const dto = buildOverviewDto({
+      pr: basePr,
+      repo: {},
+      graphQl: {
+        repository: {
+          pullRequest: {
+            reviewDecision: 'CHANGES_REQUESTED',
+            latestReviews: {
+              nodes: [
+                { state: 'APPROVED', author: { login: 'ada', avatarUrl: 'https://a.example/ada' } },
+                { state: 'CHANGES_REQUESTED', author: { login: 'grace', avatarUrl: null } },
+                // An unknown state and a null author are both skipped.
+                { state: 'SOMETHING_NEW', author: { login: 'linus', avatarUrl: null } },
+                { state: 'COMMENTED', author: null },
+                null,
+              ],
+            },
+            reviewRequests: {
+              nodes: [
+                { requestedReviewer: { login: 'ken', avatarUrl: null } },
+                // Already reviewed — keeps the submitted verdict, no PENDING row.
+                { requestedReviewer: { login: 'ada', avatarUrl: 'https://a.example/ada' } },
+                // A requested TEAM resolves to null and is dropped.
+                { requestedReviewer: null },
+              ],
+            },
+          },
+        },
+        viewer: { login: 'octocat' },
+      },
+      viewer: { login: 'octocat' },
+    });
+    expect(dto.reviewers).toEqual([
+      { login: 'ada', avatarUrl: 'https://a.example/ada', state: 'APPROVED' },
+      { login: 'grace', avatarUrl: null, state: 'CHANGES_REQUESTED' },
+      { login: 'ken', avatarUrl: null, state: 'PENDING' },
+    ]);
+  });
+
+  it('maps the issues the PR closes', () => {
+    const dto = buildOverviewDto({
+      pr: basePr,
+      repo: {},
+      graphQl: {
+        repository: {
+          pullRequest: {
+            reviewDecision: null,
+            closingIssuesReferences: {
+              nodes: [
+                {
+                  number: 42,
+                  title: 'Flux capacitor leaks',
+                  url: 'https://github.com/kilo/flux/issues/42',
+                  closed: false,
+                },
+                null,
+              ],
+            },
+          },
+        },
+        viewer: null,
+      },
+      viewer: null,
+    });
+    expect(dto.linkedIssues).toEqual([
+      {
+        number: 42,
+        title: 'Flux capacitor leaks',
+        url: 'https://github.com/kilo/flux/issues/42',
+        closed: false,
+      },
+    ]);
   });
 });
 

--- a/apps/web/src/lib/github-pr-review/mappers.ts
+++ b/apps/web/src/lib/github-pr-review/mappers.ts
@@ -23,6 +23,9 @@ import {
   type GitHubPrReviewOverview,
 } from './dtos';
 
+type OverviewReviewer = GitHubPrReviewOverview['reviewers'][number];
+type OverviewAuthor = GitHubPrReviewOverview['author'];
+
 export type PullRequestRestData = {
   number: number;
   title: string;
@@ -41,6 +44,15 @@ export type PullRequestRestData = {
   mergeable: boolean | null;
   mergeable_state?: string | null;
   auto_merge?: { merge_method?: string | null } | null;
+  labels?: { name?: string | null; color?: string | null }[] | null;
+  assignees?: ({ login: string; avatar_url: string } | null)[] | null;
+  created_at: string;
+  updated_at: string;
+  closed_at?: string | null;
+  merged_at?: string | null;
+  merged_by?: { login: string; avatar_url: string } | null;
+  comments?: number | null;
+  review_comments?: number | null;
 };
 
 export type RepoRestData = {
@@ -55,10 +67,21 @@ export type RepoRestData = {
 
 export type ViewerInfo = { login: string } | null;
 
+type GraphQlActor = { login: string; avatarUrl?: string | null } | null;
+
 export type OverviewGraphQlData = {
   repository: {
     pullRequest: {
       reviewDecision: string | null;
+      latestReviews?: {
+        nodes?: ({ state: string; author: GraphQlActor } | null)[] | null;
+      } | null;
+      reviewRequests?: {
+        nodes?: ({ requestedReviewer: GraphQlActor } | null)[] | null;
+      } | null;
+      closingIssuesReferences?: {
+        nodes?: ({ number: number; title: string; url: string; closed: boolean } | null)[] | null;
+      } | null;
     } | null;
   } | null;
   viewer: { login: string } | null;
@@ -69,6 +92,79 @@ function normalizeReviewDecision(value: string | null): GitHubPrReviewOverview['
     return value;
   }
   return null;
+}
+
+/** REST `{ login, avatar_url }` -> the DTO author shape, or null when unusable. */
+function restAuthor(
+  user: { login: string; avatar_url: string } | null | undefined
+): OverviewAuthor {
+  if (!user) {
+    return null;
+  }
+  const parsed = GitHubPrReviewAuthorSchema.safeParse({
+    login: user.login,
+    avatarUrl: user.avatar_url,
+  });
+  return parsed.success ? parsed.data : null;
+}
+
+const REVIEW_STATES = new Set<OverviewReviewer['state']>([
+  'APPROVED',
+  'CHANGES_REQUESTED',
+  'COMMENTED',
+  'DISMISSED',
+  'PENDING',
+]);
+
+function normalizeReviewState(value: string): OverviewReviewer['state'] | null {
+  return REVIEW_STATES.has(value as OverviewReviewer['state'])
+    ? (value as OverviewReviewer['state'])
+    : null;
+}
+
+/**
+ * One row per reviewer, in GitHub's own sidebar order: everyone who has
+ * already submitted a review (their LATEST state) first, then everyone who is
+ * only requested, as PENDING. A login that appears in both keeps its submitted
+ * state — GitHub re-requests a review without discarding the old verdict.
+ *
+ * `requestedReviewer` is null for a requested TEAM (the query selects only the
+ * `User` inline fragment), and such an entry is skipped rather than guessed at.
+ */
+function buildReviewers(
+  pullRequest: NonNullable<NonNullable<OverviewGraphQlData>['repository']>['pullRequest']
+): OverviewReviewer[] {
+  const reviewers: OverviewReviewer[] = [];
+  const seen = new Set<string>();
+
+  const push = (actor: GraphQlActor, state: OverviewReviewer['state']) => {
+    if (!actor || seen.has(actor.login)) {
+      return;
+    }
+    const parsed = GitHubPrReviewAuthorSchema.safeParse({
+      login: actor.login,
+      avatarUrl: actor.avatarUrl ?? null,
+    });
+    if (!parsed.success) {
+      return;
+    }
+    seen.add(actor.login);
+    reviewers.push({ ...parsed.data, state });
+  };
+
+  for (const node of pullRequest?.latestReviews?.nodes ?? []) {
+    if (!node) {
+      continue;
+    }
+    const state = normalizeReviewState(node.state);
+    if (state) {
+      push(node.author, state);
+    }
+  }
+  for (const node of pullRequest?.reviewRequests?.nodes ?? []) {
+    push(node?.requestedReviewer ?? null, 'PENDING');
+  }
+  return reviewers;
 }
 
 const GitHubRestUserSchema = z
@@ -85,18 +181,13 @@ export function buildOverviewDto(args: {
   viewer: ViewerInfo;
 }): GitHubPrReviewOverview {
   const { pr, repo, graphQl, viewer } = args;
+  const pullRequest = graphQl?.repository?.pullRequest ?? null;
   const state: GitHubPrReviewOverview['state'] = pr.merged
     ? 'merged'
     : pr.state === 'open'
       ? 'open'
       : 'closed';
-  const authorParsed = pr.user
-    ? GitHubPrReviewAuthorSchema.safeParse({
-        login: pr.user.login,
-        avatarUrl: pr.user.avatar_url,
-      })
-    : null;
-  const author = authorParsed?.success ? authorParsed.data : null;
+  const author = restAuthor(pr.user);
   const headRepoFullName = pr.head.repo?.full_name ?? null;
   const isCrossRepo = Boolean(
     pr.base.repo?.full_name && headRepoFullName && pr.base.repo.full_name !== headRepoFullName
@@ -125,9 +216,24 @@ export function buildOverviewDto(args: {
     mergeable: pr.mergeable,
     mergeableState: pr.mergeable_state ?? null,
     autoMerge,
-    reviewDecision: normalizeReviewDecision(
-      graphQl?.repository?.pullRequest?.reviewDecision ?? null
+    reviewDecision: normalizeReviewDecision(pullRequest?.reviewDecision ?? null),
+    labels: (pr.labels ?? []).flatMap(label =>
+      label?.name ? [{ name: label.name, color: label.color ?? '' }] : []
     ),
+    assignees: (pr.assignees ?? []).flatMap(user => {
+      const parsed = restAuthor(user);
+      return parsed ? [parsed] : [];
+    }),
+    reviewers: buildReviewers(pullRequest),
+    linkedIssues: (pullRequest?.closingIssuesReferences?.nodes ?? []).flatMap(node =>
+      node ? [{ number: node.number, title: node.title, url: node.url, closed: node.closed }] : []
+    ),
+    createdAt: pr.created_at,
+    updatedAt: pr.updated_at,
+    closedAt: pr.closed_at ?? null,
+    mergedAt: pr.merged_at ?? null,
+    mergedBy: restAuthor(pr.merged_by),
+    commentCount: (pr.comments ?? 0) + (pr.review_comments ?? 0),
     repo: {
       allowMergeCommit: Boolean(repo.allow_merge_commit),
       allowSquashMerge: Boolean(repo.allow_squash_merge),

--- a/apps/web/src/routers/github-pr-review-router.test.ts
+++ b/apps/web/src/routers/github-pr-review-router.test.ts
@@ -1206,6 +1206,8 @@ describe('githubPrReviewRouter.getPullRequest and listChecks parallel legs (P2-G
     mergeable: true,
     mergeable_state: 'clean',
     auto_merge: null,
+    created_at: '2026-03-01T12:00:00Z',
+    updated_at: '2026-03-02T09:30:00Z',
   };
 
   const overviewRepoData = {

--- a/apps/web/src/routers/github-pr-review-router.ts
+++ b/apps/web/src/routers/github-pr-review-router.ts
@@ -27,6 +27,7 @@ import {
   buildReviewThreadsResult,
   sliceFileLines,
   type GraphQlInboxNode,
+  type OverviewGraphQlData,
 } from '@/lib/github-pr-review/mappers';
 import {
   CONVERSATION_COMMENTS_MAX_PAGES,
@@ -220,11 +221,44 @@ const AutoMergeInput = ownerRepoSchema
   })
   .strict();
 
+// Overview enrichment: the aggregate review decision plus the three sidebar
+// boxes REST cannot answer — per-reviewer state, pending review requests, and
+// the issues this PR closes. `latestReviews` returns ONE node per reviewer
+// (their newest review), which is exactly what GitHub's own sidebar lists.
+// Only the `User` inline fragment is selected on `requestedReviewer`: a
+// requested team has no login or avatar and is dropped by the mapper.
 const PULL_REQUEST_FRAGMENT_QUERY = /* GraphQL */ `
   query PrReviewDecision($owner: String!, $name: String!, $number: Int!) {
     repository(owner: $owner, name: $name) {
       pullRequest(number: $number) {
         reviewDecision
+        latestReviews(first: 25) {
+          nodes {
+            state
+            author {
+              login
+              avatarUrl
+            }
+          }
+        }
+        reviewRequests(first: 25) {
+          nodes {
+            requestedReviewer {
+              ... on User {
+                login
+                avatarUrl
+              }
+            }
+          }
+        }
+        closingIssuesReferences(first: 10) {
+          nodes {
+            number
+            title
+            url
+            closed
+          }
+        }
       }
     }
     viewer {
@@ -1425,12 +1459,10 @@ async function runMergeWrite(
   }
 }
 
-type OverviewGraphQl = {
-  repository: {
-    pullRequest: { reviewDecision: string | null } | null;
-  } | null;
-  viewer: { login: string } | null;
-};
+// Mirrors PULL_REQUEST_FRAGMENT_QUERY. `OverviewGraphQlData` (mappers.ts) owns
+// the field-by-field shape; this alias keeps the fetch helper's return type in
+// step with it without restating the selection twice.
+type OverviewGraphQl = NonNullable<OverviewGraphQlData>;
 
 // GraphQL enrichment for the overview (reviewDecision + viewer.login). It keeps
 // its own try/catch: a TRPCError and any raw 401 are rethrown so


### PR DESCRIPTION
## What

The PR review Overview showed the title, author, refs and counts only. A reviewer could not see who else is reviewing, what the labels are, or how old the pull request is without opening GitHub.

This adds the sidebar metadata GitHub itself shows beside a pull request:

- **Timeline line** — when the pull request opened, and when it last moved (merged by whom, closed, or last updated).
- **Labels** — painted in GitHub's own colors, with a text color picked by luma so the chip stays readable.
- **Reviewers** — each reviewer's own state: approved, changes requested, commented, dismissed, or awaiting review. Only the aggregate `reviewDecision` was visible before, so "am I the one blocking this?" was unanswerable.
- **Assignees**.
- **Linked issues** — the issues the pull request closes. Each row opens the issue on GitHub.
- **Comment count** — a badge on the Discussion tab, so an empty discussion is visible without opening the tab.

Every section hides itself when GitHub reports nothing, so a bare pull request renders exactly what it does today.

## Cost

No extra GitHub request.

- `octokit.pulls.get` already returned the labels, assignees, timestamps, `merged_by` and comment counts. `buildOverviewDto` dropped them.
- The reviewers and linked issues are new fields on `PULL_REQUEST_FRAGMENT_QUERY`, the overview GraphQL query the same request already issued.

The GraphQL leg degrades to `null` on failure, so `reviewers` and `linkedIssues` come back empty and the overview still renders.

## Tests

- `mappers.test.ts`: labels/assignees/timestamps/merged-by/comment-count mapping, the all-omitted defaults, reviewer ordering (submitted verdicts first, requested-only as `PENDING`, a requested team dropped), and linked issues.
- `overview-meta.test.ts`: the timeline branches and the label contrast function.
- `pr-review-meta-parts.test.tsx`: empty sections draw nothing, the chip colors, the per-state reviewer icon and theme token, and the linked-issue tap.
- `pr-review-tab-selector.test.tsx`: the badge appears for a count and not for zero or unknown.
- `github-pr-review-graphql-schema.test.ts` validates the extended query against GitHub's published GraphQL SDL.

Ran: `lint-all.sh`, `typecheck-all.sh`, mobile `test` / `check:i18n` / `check:classes` / `check:unused`, and the web `github-pr-review` suites.

## Verified end to end

Against the local stack with the hermetic GitHub API stub, on an iOS simulator, in light and dark:

- `kilo-stub/discussion-mixed#1` renders every section and the `Discussion 9` badge.
- `kilo-stub/discussion-empty#3` renders the timeline line only — no empty headings, no badge.

## i18n

15 new keys under `prReview.overview`, translated across all 87 catalogs. `mergedAgo` and `closedAgo` reuse each catalog's own `stateMerged` / `stateClosed` wording, and `reviewDismissed` reuses its existing "Dismissed" translation, so the catalog check's one-wording-per-string rule holds.
