### PR TITLE
feat(admin): add GitHub organization installation lookup

### DIFF
--- a/apps/web/src/app/admin/components/AppSidebar.tsx
+++ b/apps/web/src/app/admin/components/AppSidebar.tsx
@@ -32,6 +32,7 @@ import {
   Route,
   Tags,
   Trash2,
+  Github,
 } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import { usePathname } from 'next/navigation';
@@ -162,6 +163,11 @@ const financialItems: MenuItem[] = [
 ];
 
 const productEngineeringItems: MenuItem[] = [
+  {
+    title: () => 'Integrations',
+    url: '/admin/integrations',
+    icon: () => <Github />,
+  },
   {
     title: () => 'KiloClaw',
     url: '/admin/kiloclaw',

--- a/apps/web/src/app/admin/integrations/GitHubInstallationLookup.test.ts
+++ b/apps/web/src/app/admin/integrations/GitHubInstallationLookup.test.ts
@@ -1,0 +1,113 @@
+import React from 'react';
+import { describe, expect, it } from '@jest/globals';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { GitHubOrganizationInstallationLookupResult } from '@/lib/admin/github-installation-lookup';
+import { GitHubInstallationLookupResult, LocalAssociationTable } from './GitHubInstallationLookup';
+
+const result = {
+  organization: 'acme-tools',
+  checkedAt: '2026-09-03T14:00:00.000Z',
+  apps: [
+    {
+      appType: 'standard',
+      status: 'installed',
+      installation: {
+        id: '123',
+        accountId: '456',
+        accountLogin: 'acme-tools',
+        accountType: 'Organization',
+        suspendedAt: null,
+        repositorySelection: 'selected',
+      },
+    },
+    { appType: 'lite', status: 'unknown', reason: 'request_timeout' },
+  ],
+  records: [
+    {
+      id: 'actual-record',
+      appType: 'standard',
+      installationId: '123',
+      accountLogin: 'acme-tools',
+      accountId: '456',
+      status: 'active',
+      suspendedAt: null,
+      authInvalid: false,
+      updatedAt: '2026-09-03T13:00:00.000Z',
+      owner: { type: 'organization', id: 'org/id', name: 'Acme Tools' },
+      association: 'actual',
+    },
+    {
+      id: 'candidate-record',
+      appType: null,
+      installationId: null,
+      accountLogin: null,
+      accountId: null,
+      status: null,
+      suspendedAt: '2026-09-02T13:00:00.000Z',
+      authInvalid: true,
+      updatedAt: '2026-09-03T12:00:00.000Z',
+      owner: { type: 'user', id: 'user/id', name: null },
+      association: 'candidate',
+    },
+    {
+      id: 'unlinked-record',
+      appType: 'lite',
+      installationId: '789',
+      accountLogin: 'other-account',
+      accountId: '987',
+      status: 'pending',
+      suspendedAt: null,
+      authInvalid: false,
+      updatedAt: '2026-09-03T11:00:00.000Z',
+      owner: null,
+      association: 'candidate',
+    },
+  ],
+  recordsTruncated: true,
+} satisfies GitHubOrganizationInstallationLookupResult;
+
+describe('GitHubInstallationLookupResult', () => {
+  it('renders live state separately from local records and preserves operational anomalies', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(GitHubInstallationLookupResult, { result })
+    );
+
+    expect(html).toContain('Live GitHub App checks');
+    expect(html).toContain('Installed');
+    expect(html).toContain('Repository scope');
+    expect(html).toContain('selected');
+    expect(html).toContain('Unknown');
+    expect(html).toContain('Local recorded associations');
+    expect(html).toContain('Actual match');
+    expect(html).toContain('Candidate match');
+    expect(html).toContain('Authentication invalid');
+    expect(html).toContain('No owner linked');
+    expect(html).toContain('Results truncated');
+    expect(html).toContain('/admin/organizations/org%2Fid');
+    expect(html).toContain('/admin/users/user%2Fid');
+  });
+
+  it('does not present an ambiguous GitHub 404 as a confirmed uninstall', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(GitHubInstallationLookupResult, {
+        result: {
+          ...result,
+          apps: [{ appType: 'standard', status: 'not_found', reason: 'not_found_for_app' }],
+          records: [],
+        },
+      })
+    );
+
+    expect(html).toContain('No installation found');
+    expect(html).toContain('organization may not exist or may have been renamed');
+    expect(html).toContain('does not confirm an uninstall');
+    expect(html).not.toContain('Not installed');
+  });
+
+  it('renders a specific empty local-record state without inferring a global installation state', () => {
+    const html = renderToStaticMarkup(React.createElement(LocalAssociationTable, { records: [] }));
+
+    expect(html).toContain('No local association records matched this lookup.');
+    expect(html).not.toContain('Not installed');
+  });
+});

--- a/apps/web/src/app/admin/integrations/GitHubInstallationLookup.tsx
+++ b/apps/web/src/app/admin/integrations/GitHubInstallationLookup.tsx
@@ -1,0 +1,339 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import type { GitHubOrganizationInstallationLookupResult } from '@/lib/admin/github-installation-lookup';
+import { normalizeGitHubOrganizationLogin } from '@/lib/admin/github-installation-lookup-input';
+import { useTRPC } from '@/lib/trpc/utils';
+import Link from 'next/link';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+type LookupResult = GitHubOrganizationInstallationLookupResult;
+type LookupApp = LookupResult['apps'][number];
+type LookupRecord = LookupResult['records'][number];
+
+export function GitHubInstallationLookup() {
+  const trpc = useTRPC();
+  const [organization, setOrganization] = useState('');
+  const [inputError, setInputError] = useState<string | null>(null);
+  const lookup = useMutation(
+    trpc.admin.github.lookupOrganizationInstallation.mutationOptions({ retry: false })
+  );
+  const result = inputError || lookup.isPending || lookup.isError ? undefined : lookup.data;
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    try {
+      const normalizedOrganization = normalizeGitHubOrganizationLogin(organization);
+      setInputError(null);
+      lookup.mutate({ organization: normalizedOrganization });
+    } catch {
+      setInputError('Enter a valid GitHub organization login.');
+    }
+  }
+
+  return (
+    <div className="flex w-full max-w-7xl flex-col gap-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-bold">Integrations</h2>
+        <p className="text-muted-foreground max-w-3xl">
+          Check GitHub App installations for an organization and compare the live response with
+          locally recorded associations.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>GitHub organization lookup</CardTitle>
+          <CardDescription>
+            Enter a GitHub organization login, @mention, or github.com organization URL. This check
+            runs only when submitted.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <form
+            className="flex flex-col gap-3 sm:flex-row sm:items-end"
+            onSubmit={onSubmit}
+            noValidate
+          >
+            <div className="flex min-w-0 flex-1 flex-col gap-2">
+              <Label htmlFor="github-organization">GitHub organization</Label>
+              <Input
+                id="github-organization"
+                name="github-organization"
+                autoComplete="off"
+                autoCapitalize="none"
+                spellCheck={false}
+                maxLength={256}
+                disabled={lookup.isPending}
+                placeholder="acme-tools"
+                value={organization}
+                onChange={event => {
+                  setOrganization(event.target.value);
+                  if (inputError) setInputError(null);
+                }}
+                aria-describedby={inputError ? 'github-organization-error' : undefined}
+                aria-invalid={inputError ? true : undefined}
+              />
+              {inputError ? (
+                <p id="github-organization-error" className="text-destructive text-sm" role="alert">
+                  {inputError}
+                </p>
+              ) : null}
+            </div>
+            <Button type="submit" className="sm:min-w-32" disabled={lookup.isPending}>
+              {lookup.isPending ? 'Checking…' : 'Check installation'}
+            </Button>
+          </form>
+
+          {lookup.isPending ? <p role="status">Checking GitHub and local associations…</p> : null}
+          {lookup.isError ? (
+            <Alert variant="destructive">
+              <AlertTitle>Lookup unavailable</AlertTitle>
+              <AlertDescription>
+                Unable to check this organization. Submit again to retry.
+              </AlertDescription>
+            </Alert>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      {result ? <GitHubInstallationLookupResult result={result} /> : null}
+    </div>
+  );
+}
+
+export function GitHubInstallationLookupResult({ result }: { result: LookupResult }) {
+  return (
+    <div className="flex flex-col gap-6">
+      <section className="space-y-3" aria-labelledby="live-installations-heading">
+        <div className="flex flex-col justify-between gap-1 sm:flex-row sm:items-baseline">
+          <div>
+            <h3 id="live-installations-heading" className="text-lg font-semibold">
+              Live GitHub App checks
+            </h3>
+            <p className="text-muted-foreground text-sm">
+              GitHub responses for <span className="font-mono">{result.organization}</span>. Checked{' '}
+              {formatTimestamp(result.checkedAt)}.
+            </p>
+          </div>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {result.apps.map(app => (
+            <LiveInstallationCard key={app.appType} app={app} />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-3" aria-labelledby="local-records-heading">
+        <div className="space-y-1">
+          <h3 id="local-records-heading" className="text-lg font-semibold">
+            Local recorded associations
+          </h3>
+          <p className="text-muted-foreground max-w-4xl text-sm">
+            Actual matches share the live installation’s app type, installation ID and account ID.
+            Candidates match a recorded login or ID but are not confirmed live associations. Records
+            may be stale, and deleted installations are not retained. No local record does not mean
+            the app is uninstalled.
+          </p>
+        </div>
+        {result.recordsTruncated ? (
+          <Alert variant="warning">
+            <AlertTitle>Results truncated</AlertTitle>
+            <AlertDescription>
+              Only the first 100 local association records are shown.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+        <LocalAssociationTable records={result.records} />
+      </section>
+    </div>
+  );
+}
+
+function LiveInstallationCard({ app }: { app: LookupApp }) {
+  const installation = app.installation;
+  const status = liveStatus(app);
+
+  return (
+    <Card>
+      <CardHeader className="gap-2">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="capitalize">{app.appType} app</CardTitle>
+          <StatusBadge status={status} />
+        </div>
+        <CardDescription>{liveDetail(app)}</CardDescription>
+      </CardHeader>
+      {installation ? (
+        <CardContent>
+          <dl className="grid gap-x-4 gap-y-3 text-sm sm:grid-cols-2">
+            <Detail label="Installation ID" value={installation.id} mono />
+            <Detail label="Account" value={installation.accountLogin} />
+            <Detail label="Account ID" value={installation.accountId} mono />
+            <Detail label="Account type" value={installation.accountType} />
+            <Detail label="Repository scope" value={installation.repositorySelection} />
+            <Detail
+              label="Suspended"
+              value={installation.suspendedAt ? formatTimestamp(installation.suspendedAt) : 'No'}
+            />
+          </dl>
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+}
+
+export function LocalAssociationTable({ records }: { records: LookupRecord[] }) {
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Association</TableHead>
+            <TableHead>Owner</TableHead>
+            <TableHead>App and installation</TableHead>
+            <TableHead>GitHub account</TableHead>
+            <TableHead>Local state</TableHead>
+            <TableHead>Updated</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {records.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={6} className="text-muted-foreground h-24 text-center">
+                No local association records matched this lookup.
+              </TableCell>
+            </TableRow>
+          ) : (
+            records.map(record => <LocalAssociationRow key={record.id} record={record} />)
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function LocalAssociationRow({ record }: { record: LookupRecord }) {
+  return (
+    <TableRow>
+      <TableCell className="min-w-36 align-top">
+        <Badge variant={record.association === 'actual' ? 'new' : 'secondary'}>
+          {record.association === 'actual' ? 'Actual match' : 'Candidate match'}
+        </Badge>
+        <div className="text-muted-foreground mt-2 font-mono text-xs break-all">{record.id}</div>
+      </TableCell>
+      <TableCell className="min-w-48 align-top text-sm">{renderOwner(record.owner)}</TableCell>
+      <TableCell className="min-w-48 align-top text-sm">
+        <div>{record.appType ?? 'App type not recorded'}</div>
+        <div className="text-muted-foreground mt-1 font-mono text-xs">
+          {record.installationId ?? 'Installation ID not recorded'}
+        </div>
+      </TableCell>
+      <TableCell className="min-w-48 align-top text-sm">
+        <div>{record.accountLogin ?? 'Account login not recorded'}</div>
+        <div className="text-muted-foreground mt-1 font-mono text-xs">
+          {record.accountId ?? 'Account ID not recorded'}
+        </div>
+      </TableCell>
+      <TableCell className="min-w-52 align-top text-sm">
+        <div className="flex flex-wrap gap-1.5">
+          <Badge variant="outline">{record.status ?? 'Status not recorded'}</Badge>
+          {record.authInvalid ? <Badge variant="destructive">Authentication invalid</Badge> : null}
+          {record.suspendedAt ? <Badge variant="destructive">Suspended</Badge> : null}
+        </div>
+        {record.suspendedAt ? (
+          <div className="text-muted-foreground mt-2 text-xs">
+            Suspended {formatTimestamp(record.suspendedAt)}
+          </div>
+        ) : null}
+      </TableCell>
+      <TableCell className="text-muted-foreground min-w-40 align-top text-sm">
+        {formatTimestamp(record.updatedAt)}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function Detail({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-muted-foreground text-xs">{label}</dt>
+      <dd className={mono ? 'mt-1 font-mono text-xs break-all' : 'mt-1 break-words'}>{value}</dd>
+    </div>
+  );
+}
+
+function renderOwner(owner: LookupRecord['owner']) {
+  if (!owner) return <span className="text-muted-foreground">No owner linked</span>;
+
+  const href =
+    owner.type === 'user'
+      ? `/admin/users/${encodeURIComponent(owner.id)}`
+      : `/admin/organizations/${encodeURIComponent(owner.id)}`;
+  const type = owner.type === 'user' ? 'Personal' : 'Organization';
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Badge variant="outline">{type}</Badge>
+      <Link href={href} className="text-link hover:text-link-hover break-words">
+        {owner.name ?? 'Unnamed owner'}
+      </Link>
+      <span className="text-muted-foreground font-mono text-xs break-all">{owner.id}</span>
+    </div>
+  );
+}
+
+function liveStatus(app: LookupApp) {
+  if (app.reason === 'suspended') return 'suspended';
+  return app.status;
+}
+
+function liveDetail(app: LookupApp) {
+  if (app.reason === 'suspended') return 'GitHub reports this installation as suspended.';
+  if (app.status === 'installed') return 'GitHub reports an active installation record.';
+  if (app.status === 'not_found') {
+    return 'GitHub returned no installation for this app and login. The organization may not exist or may have been renamed. This does not confirm an uninstall.';
+  }
+  switch (app.reason) {
+    case 'app_not_configured':
+      return 'This app is not configured in this environment. Its installation state is unknown.';
+    case 'authentication_failed':
+      return 'GitHub refused this app’s lookup. Its installation state is unknown.';
+    case 'request_timeout':
+      return 'GitHub did not respond in time. Submit again to retry.';
+    default:
+      return 'The live installation state could not be determined. Submit again to retry.';
+  }
+}
+
+function StatusBadge({ status }: { status: 'installed' | 'suspended' | 'not_found' | 'unknown' }) {
+  const labels = {
+    installed: 'Installed',
+    suspended: 'Suspended',
+    not_found: 'No installation found',
+    unknown: 'Unknown',
+  };
+  const variant =
+    status === 'installed' ? 'new' : status === 'suspended' ? 'destructive' : 'secondary';
+
+  return <Badge variant={variant}>{labels[status]}</Badge>;
+}
+
+function formatTimestamp(value: string) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'Not available' : date.toLocaleString();
+}

--- a/apps/web/src/app/admin/integrations/page.tsx
+++ b/apps/web/src/app/admin/integrations/page.tsx
@@ -1,0 +1,17 @@
+import AdminPage from '@/app/admin/components/AdminPage';
+import { BreadcrumbItem, BreadcrumbPage } from '@/components/ui/breadcrumb';
+import { GitHubInstallationLookup } from './GitHubInstallationLookup';
+
+const breadcrumbs = (
+  <BreadcrumbItem>
+    <BreadcrumbPage>Integrations</BreadcrumbPage>
+  </BreadcrumbItem>
+);
+
+export default function IntegrationsPage() {
+  return (
+    <AdminPage breadcrumbs={breadcrumbs}>
+      <GitHubInstallationLookup />
+    </AdminPage>
+  );
+}

--- a/apps/web/src/lib/admin/github-installation-lookup-input.test.ts
+++ b/apps/web/src/lib/admin/github-installation-lookup-input.test.ts
@@ -1,0 +1,30 @@
+import { GitHubOrganizationInstallationLookupInputSchema } from './github-installation-lookup-input';
+
+describe('GitHubOrganizationInstallationLookupInputSchema', () => {
+  test.each([
+    [' Acme-Tools ', 'acme-tools'],
+    ['@Acme-Tools', 'acme-tools'],
+    ['https://github.com/Acme-Tools/', 'acme-tools'],
+  ])('normalizes %s', (organization, expected) => {
+    expect(GitHubOrganizationInstallationLookupInputSchema.parse({ organization })).toEqual({
+      organization: expected,
+    });
+  });
+
+  test.each([
+    'github.com/acme',
+    'https://github.com/acme/path',
+    'https://github.com@attacker.invalid/acme',
+    'https://github.com:443/acme',
+    'https://github.com/acme?x=1',
+    'https://github.com/acme#fragment',
+    '-acme',
+    'acme-',
+    'acme--tools',
+    'a'.repeat(40),
+  ])('rejects invalid organization login %s', organization => {
+    expect(() => GitHubOrganizationInstallationLookupInputSchema.parse({ organization })).toThrow(
+      'Enter a valid GitHub organization login'
+    );
+  });
+});

--- a/apps/web/src/lib/admin/github-installation-lookup-input.ts
+++ b/apps/web/src/lib/admin/github-installation-lookup-input.ts
@@ -1,0 +1,41 @@
+import * as z from 'zod';
+
+const githubOrganizationLogin = /^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$/;
+const githubOrganizationUrl = /^https:\/\/github\.com\/([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\/?$/;
+
+export const GitHubOrganizationInstallationLookupInputSchema = z
+  .object({
+    organization: z.string().max(256).trim().min(1),
+  })
+  .transform(({ organization }, ctx) => {
+    const normalized = tryNormalizeGitHubOrganizationLogin(organization);
+    if (!normalized) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['organization'],
+        message: 'Enter a valid GitHub organization login',
+      });
+      return z.NEVER;
+    }
+    return { organization: normalized };
+  });
+
+export type GitHubOrganizationInstallationLookupInput = z.infer<
+  typeof GitHubOrganizationInstallationLookupInputSchema
+>;
+
+function tryNormalizeGitHubOrganizationLogin(value: string): string | null {
+  let login = value.trim();
+  const urlMatch = githubOrganizationUrl.exec(login);
+  if (urlMatch?.[1]) login = urlMatch[1];
+  else if (login.startsWith('@')) login = login.slice(1);
+
+  if (login.length > 39 || !githubOrganizationLogin.test(login)) return null;
+  return login.toLowerCase();
+}
+
+export function normalizeGitHubOrganizationLogin(value: string): string {
+  const normalized = tryNormalizeGitHubOrganizationLogin(value);
+  if (!normalized) throw new Error('Enter a valid GitHub organization login');
+  return normalized;
+}

--- a/apps/web/src/lib/admin/github-installation-lookup-upstream.test.ts
+++ b/apps/web/src/lib/admin/github-installation-lookup-upstream.test.ts
@@ -1,0 +1,112 @@
+const mockRequest = jest.fn();
+const mockAuth = jest.fn();
+const mockCreateAppAuth = jest.fn();
+const mockGetGitHubAppCredentials = jest.fn();
+
+jest.mock('@octokit/auth-app', () => ({
+  createAppAuth: (...args: unknown[]) => mockCreateAppAuth(...args),
+}));
+jest.mock('@octokit/rest', () => ({
+  Octokit: jest.fn(() => ({ request: (...args: unknown[]) => mockRequest(...args) })),
+}));
+jest.mock('@/lib/integrations/platforms/github/app-selector', () => ({
+  getGitHubAppCredentials: (...args: unknown[]) => mockGetGitHubAppCredentials(...args),
+}));
+
+import { lookupGitHubOrganizationInstallationForApp } from './github-installation-lookup';
+
+const credentials = {
+  appId: '123',
+  privateKey: 'private-key',
+  clientId: '',
+  clientSecret: '',
+  appName: 'KiloConnect',
+  webhookSecret: '',
+};
+
+describe('lookupGitHubOrganizationInstallationForApp', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetGitHubAppCredentials.mockReturnValue(credentials);
+    mockCreateAppAuth.mockReturnValue(mockAuth);
+    mockAuth.mockResolvedValue({ token: 'app-jwt' });
+  });
+
+  test('uses app authentication and the organization-only installation endpoint', async () => {
+    mockRequest.mockResolvedValue({
+      data: {
+        id: 101,
+        account: { id: 501, login: 'acme', type: 'Organization' },
+        suspended_at: null,
+        repository_selection: 'all',
+      },
+    });
+
+    await expect(lookupGitHubOrganizationInstallationForApp('standard', 'acme')).resolves.toEqual({
+      appType: 'standard',
+      status: 'installed',
+      installation: {
+        id: '101',
+        accountId: '501',
+        accountLogin: 'acme',
+        accountType: 'Organization',
+        suspendedAt: null,
+        repositorySelection: 'all',
+      },
+    });
+    expect(mockAuth).toHaveBeenCalledWith({ type: 'app' });
+    expect(mockRequest).toHaveBeenCalledWith(
+      'GET /orgs/{org}/installation',
+      expect.objectContaining({ org: 'acme' })
+    );
+  });
+
+  test.each([
+    [401, 'authentication_failed'],
+    [403, 'authentication_failed'],
+    [429, 'upstream_error'],
+    [500, 'upstream_error'],
+    [404, 'not_found_for_app'],
+  ] as const)('maps HTTP %s to safe %s', async (status, reason) => {
+    mockRequest.mockRejectedValue({ status, message: 'secret upstream response' });
+
+    const result = await lookupGitHubOrganizationInstallationForApp('lite', 'acme');
+
+    expect(result).toEqual({
+      appType: 'lite',
+      status: status === 404 ? 'not_found' : 'unknown',
+      reason,
+    });
+    expect(JSON.stringify(result)).not.toContain('secret upstream response');
+  });
+
+  test('maps aborted requests and malformed account payloads to unknown', async () => {
+    mockRequest.mockRejectedValueOnce(new DOMException('aborted', 'AbortError'));
+    await expect(lookupGitHubOrganizationInstallationForApp('standard', 'acme')).resolves.toEqual({
+      appType: 'standard',
+      status: 'unknown',
+      reason: 'request_timeout',
+    });
+
+    mockRequest.mockResolvedValueOnce({
+      data: { id: 101, account: { id: 501, login: 'acme', type: 'User' } },
+    });
+    await expect(lookupGitHubOrganizationInstallationForApp('standard', 'acme')).resolves.toEqual({
+      appType: 'standard',
+      status: 'unknown',
+      reason: 'malformed_response',
+    });
+  });
+
+  test('does not request GitHub when app configuration is unavailable', async () => {
+    mockGetGitHubAppCredentials.mockReturnValue({ ...credentials, appId: '' });
+
+    await expect(lookupGitHubOrganizationInstallationForApp('standard', 'acme')).resolves.toEqual({
+      appType: 'standard',
+      status: 'unknown',
+      reason: 'app_not_configured',
+    });
+    expect(mockCreateAppAuth).not.toHaveBeenCalled();
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/admin/github-installation-lookup.db.test.ts
+++ b/apps/web/src/lib/admin/github-installation-lookup.db.test.ts
@@ -1,0 +1,301 @@
+import { db } from '@/lib/drizzle';
+import { createTestOrganization } from '@/tests/helpers/organization.helper';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { kilocode_users, organizations, platform_integrations } from '@kilocode/db/schema';
+import { asc, inArray } from 'drizzle-orm';
+import { findGitHubOrganizationInstallationRecords } from './github-installation-lookup';
+
+const createdIntegrationIds: string[] = [];
+const createdOrganizationIds: string[] = [];
+const createdUserIds: string[] = [];
+
+async function createUser(id = `oauth/github/${crypto.randomUUID()}`) {
+  const user = await insertTestUser({ id });
+  createdUserIds.push(user.id);
+  return user;
+}
+
+async function createOrganization() {
+  const user = await createUser();
+  const organization = await createTestOrganization(`Lookup ${crypto.randomUUID()}`, user.id, 0);
+  createdOrganizationIds.push(organization.id);
+  return organization;
+}
+
+async function insertIntegration(
+  values: Omit<
+    typeof platform_integrations.$inferInsert,
+    'owned_by_user_id' | 'owned_by_organization_id'
+  > &
+    (
+      | { owned_by_user_id: string; owned_by_organization_id?: never }
+      | { owned_by_organization_id: string; owned_by_user_id?: never }
+    )
+) {
+  const [integration] = await db.insert(platform_integrations).values(values).returning();
+  createdIntegrationIds.push(integration.id);
+  return integration;
+}
+
+afterEach(async () => {
+  if (createdIntegrationIds.length > 0) {
+    await db
+      .delete(platform_integrations)
+      .where(inArray(platform_integrations.id, createdIntegrationIds));
+  }
+  if (createdOrganizationIds.length > 0) {
+    await db.delete(organizations).where(inArray(organizations.id, createdOrganizationIds));
+  }
+  if (createdUserIds.length > 0) {
+    await db.delete(kilocode_users).where(inArray(kilocode_users.id, createdUserIds));
+  }
+  createdIntegrationIds.length = 0;
+  createdOrganizationIds.length = 0;
+  createdUserIds.length = 0;
+});
+
+describe('findGitHubOrganizationInstallationRecords', () => {
+  test('returns an exact case-insensitive match for a personal integration owned by an arbitrary OAuth user ID', async () => {
+    const user = await createUser('oauth/github/123456789');
+    const integration = await insertIntegration({
+      owned_by_user_id: user.id,
+      platform: 'github',
+      integration_type: 'app',
+      platform_installation_id: `personal-installation-${crypto.randomUUID()}`,
+      platform_account_id: 'personal-account',
+      platform_account_login: 'Personal-Account',
+      integration_status: 'active',
+    });
+
+    await expect(
+      findGitHubOrganizationInstallationRecords({
+        organization: 'personal-account',
+        installationIds: [],
+        accountIds: [],
+      })
+    ).resolves.toMatchObject({
+      recordsTruncated: false,
+      records: [
+        {
+          id: integration.id,
+          owner: { type: 'user', id: user.id, name: 'Test User' },
+          association: 'candidate',
+        },
+      ],
+    });
+  });
+
+  test('returns an organization owner name without projecting owner email or integration metadata', async () => {
+    const organization = await createOrganization();
+    const integration = await insertIntegration({
+      owned_by_organization_id: organization.id,
+      platform: 'github',
+      integration_type: 'app',
+      platform_installation_id: `organization-installation-${crypto.randomUUID()}`,
+      platform_account_id: 'organization-account',
+      platform_account_login: 'Acme-Tools',
+      integration_status: 'active',
+      metadata: { privateEmail: 'should-not-be-projected@example.com' },
+    });
+
+    const result = await findGitHubOrganizationInstallationRecords({
+      organization: 'acme-tools',
+      installationIds: [],
+      accountIds: [],
+    });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0]).toMatchObject({
+      id: integration.id,
+      owner: { type: 'organization', id: organization.id, name: organization.name },
+    });
+    expect(Object.keys(result.records[0]).sort()).toEqual([
+      'accountId',
+      'accountLogin',
+      'appType',
+      'association',
+      'authInvalid',
+      'id',
+      'installationId',
+      'owner',
+      'status',
+      'suspendedAt',
+      'updatedAt',
+    ]);
+    expect(result.records[0]).not.toHaveProperty('metadata');
+    expect(result.records[0].owner).not.toHaveProperty('email');
+  });
+
+  test('finds a renamed account through matched live installation and account IDs', async () => {
+    const organization = await createOrganization();
+    const integration = await insertIntegration({
+      owned_by_organization_id: organization.id,
+      platform: 'github',
+      integration_type: 'app',
+      platform_installation_id: 'live-installation-id',
+      platform_account_id: 'live-account-id',
+      platform_account_login: 'former-acme-name',
+      integration_status: 'active',
+    });
+
+    await expect(
+      findGitHubOrganizationInstallationRecords({
+        organization: 'acme-tools',
+        installationIds: ['live-installation-id'],
+        accountIds: ['live-account-id'],
+      })
+    ).resolves.toMatchObject({ records: [expect.objectContaining({ id: integration.id })] });
+  });
+
+  test('preserves standard and lite records with shared live account IDs', async () => {
+    const organization = await createOrganization();
+    const [standard, lite] = await Promise.all(
+      (['standard', 'lite'] as const).map(github_app_type =>
+        insertIntegration({
+          owned_by_organization_id: organization.id,
+          platform: 'github',
+          integration_type: 'app',
+          github_app_type,
+          platform_installation_id: `${github_app_type}-installation-${crypto.randomUUID()}`,
+          platform_account_id: 'shared-live-account',
+          platform_account_login: 'Acme-Tools',
+          integration_status: 'active',
+        })
+      )
+    );
+
+    const result = await findGitHubOrganizationInstallationRecords({
+      organization: 'unrelated-name',
+      installationIds: [],
+      accountIds: ['shared-live-account'],
+    });
+
+    expect(result.records).toHaveLength(2);
+    expect(result.records.map(record => [record.id, record.appType])).toEqual(
+      expect.arrayContaining([
+        [standard.id, 'standard'],
+        [lite.id, 'lite'],
+      ])
+    );
+  });
+
+  test('returns legacy null-app, pending, and suspended GitHub records', async () => {
+    const organization = await createOrganization();
+    const legacy = await insertIntegration({
+      owned_by_organization_id: organization.id,
+      platform: 'github',
+      integration_type: 'app',
+      github_app_type: null,
+      platform_installation_id: `legacy-installation-${crypto.randomUUID()}`,
+      platform_account_id: 'legacy-account',
+      platform_account_login: 'Acme-Tools',
+      integration_status: 'active',
+    });
+    const pending = await insertIntegration({
+      owned_by_organization_id: organization.id,
+      platform: 'github',
+      integration_type: 'app',
+      platform_account_id: 'pending-account',
+      platform_account_login: 'not-the-requested-name',
+      integration_status: 'pending',
+    });
+    const suspended = await insertIntegration({
+      owned_by_organization_id: organization.id,
+      platform: 'github',
+      integration_type: 'app',
+      platform_installation_id: `suspended-installation-${crypto.randomUUID()}`,
+      platform_account_id: 'suspended-account',
+      platform_account_login: 'acme-tools',
+      integration_status: 'suspended',
+      suspended_at: '2026-09-03 15:00:00+00',
+    });
+
+    const result = await findGitHubOrganizationInstallationRecords({
+      organization: 'acme-tools',
+      installationIds: [],
+      accountIds: ['pending-account'],
+    });
+
+    expect(result.records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: legacy.id, appType: null, status: 'active' }),
+        expect.objectContaining({ id: pending.id, installationId: null, status: 'pending' }),
+        expect.objectContaining({
+          id: suspended.id,
+          status: 'suspended',
+          suspendedAt: '2026-09-03T15:00:00.000Z',
+        }),
+      ])
+    );
+  });
+
+  test('excludes non-GitHub records and login substring matches', async () => {
+    const organization = await createOrganization();
+    await Promise.all([
+      insertIntegration({
+        owned_by_organization_id: organization.id,
+        platform: 'gitlab',
+        integration_type: 'oauth',
+        platform_installation_id: `gitlab-installation-${crypto.randomUUID()}`,
+        platform_account_login: 'Acme-Tools',
+      }),
+      insertIntegration({
+        owned_by_organization_id: organization.id,
+        platform: 'github',
+        integration_type: 'app',
+        platform_installation_id: `substring-installation-${crypto.randomUUID()}`,
+        platform_account_login: 'Acme-Tools-Archived',
+      }),
+    ]);
+
+    await expect(
+      findGitHubOrganizationInstallationRecords({
+        organization: 'acme-tools',
+        installationIds: [],
+        accountIds: [],
+      })
+    ).resolves.toEqual({ records: [], recordsTruncated: false });
+  });
+
+  test('returns the first 100 records in ID order, reports truncation, and does not mutate rows', async () => {
+    const user = await createUser();
+    const integrations = await db
+      .insert(platform_integrations)
+      .values(
+        Array.from({ length: 101 }, (_, index) => ({
+          owned_by_user_id: user.id,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: `bulk-installation-${index}-${crypto.randomUUID()}`,
+          platform_account_id: `bulk-account-${index}`,
+          platform_account_login: 'Acme-Tools',
+          integration_status: 'active',
+        }))
+      )
+      .returning({ id: platform_integrations.id, updatedAt: platform_integrations.updated_at });
+    createdIntegrationIds.push(...integrations.map(integration => integration.id));
+    const expected = await db
+      .select({ id: platform_integrations.id, updatedAt: platform_integrations.updated_at })
+      .from(platform_integrations)
+      .where(inArray(platform_integrations.id, createdIntegrationIds))
+      .orderBy(asc(platform_integrations.id));
+
+    const result = await findGitHubOrganizationInstallationRecords({
+      organization: 'acme-tools',
+      installationIds: [],
+      accountIds: [],
+    });
+
+    expect(result.recordsTruncated).toBe(true);
+    expect(result.records.map(record => record.id)).toEqual(
+      expected.slice(0, 100).map(row => row.id)
+    );
+    await expect(
+      db
+        .select({ id: platform_integrations.id, updatedAt: platform_integrations.updated_at })
+        .from(platform_integrations)
+        .where(inArray(platform_integrations.id, createdIntegrationIds))
+        .orderBy(asc(platform_integrations.id))
+    ).resolves.toEqual(expected);
+  });
+});

--- a/apps/web/src/lib/admin/github-installation-lookup.test.ts
+++ b/apps/web/src/lib/admin/github-installation-lookup.test.ts
@@ -1,0 +1,108 @@
+import {
+  lookupGitHubOrganizationInstallation,
+  type GitHubOrganizationInstallationLookupResult,
+} from './github-installation-lookup';
+
+const checkedAt = new Date('2026-09-03T15:00:00.000Z');
+
+function record(
+  overrides: Partial<GitHubOrganizationInstallationLookupResult['records'][number]> = {}
+): GitHubOrganizationInstallationLookupResult['records'][number] {
+  return {
+    id: 'record-1',
+    appType: 'standard',
+    installationId: '101',
+    accountLogin: 'acme',
+    accountId: '501',
+    status: 'active',
+    suspendedAt: null,
+    authInvalid: false,
+    updatedAt: checkedAt.toISOString(),
+    owner: { type: 'organization', id: 'owner-1', name: 'Acme' },
+    association: 'candidate',
+    ...overrides,
+  };
+}
+
+function installed(appType: 'standard' | 'lite', id = '101', accountId = '501') {
+  return {
+    appType,
+    status: 'installed' as const,
+    installation: {
+      id,
+      accountId,
+      accountLogin: 'acme',
+      accountType: 'Organization',
+      suspendedAt: null,
+      repositorySelection: 'all',
+    },
+  };
+}
+
+describe('lookupGitHubOrganizationInstallation', () => {
+  test('checks both apps, returns bounded local candidates, and marks only exact app/id/account matches actual', async () => {
+    const getInstallation = jest.fn(async (appType: 'standard' | 'lite') =>
+      appType === 'standard'
+        ? installed('standard')
+        : { appType, status: 'not_found' as const, reason: 'not_found_for_app' as const }
+    );
+    const findRecords = jest.fn().mockResolvedValue({
+      records: [
+        record(),
+        record({ id: 'legacy', appType: null }),
+        record({ id: 'wrong-app', appType: 'lite' }),
+      ],
+      recordsTruncated: true,
+    });
+
+    const result = await lookupGitHubOrganizationInstallation('acme', {
+      getInstallation,
+      findRecords,
+      now: () => checkedAt,
+    });
+
+    expect(getInstallation).toHaveBeenCalledTimes(2);
+    expect(findRecords).toHaveBeenCalledWith({
+      organization: 'acme',
+      installationIds: ['101'],
+      accountIds: ['501'],
+    });
+    expect(result).toMatchObject({
+      organization: 'acme',
+      checkedAt: checkedAt.toISOString(),
+      recordsTruncated: true,
+      apps: [installed('standard'), { appType: 'lite', status: 'not_found' }],
+    });
+    expect(result.records.map(item => item.association)).toEqual(['actual', 'actual', 'candidate']);
+  });
+
+  test('retains an unknown app result and does not claim global absence', async () => {
+    const result = await lookupGitHubOrganizationInstallation('acme', {
+      getInstallation: async appType =>
+        appType === 'standard'
+          ? { appType, status: 'not_found', reason: 'not_found_for_app' }
+          : { appType, status: 'unknown', reason: 'request_timeout' },
+      findRecords: async () => ({ records: [], recordsTruncated: false }),
+      now: () => checkedAt,
+    });
+
+    expect(result.apps).toEqual([
+      { appType: 'standard', status: 'not_found', reason: 'not_found_for_app' },
+      { appType: 'lite', status: 'unknown', reason: 'request_timeout' },
+    ]);
+  });
+
+  test('returns only safe upstream reason codes', async () => {
+    const upstreamMessage = 'token secret-value failed at internal-host';
+    const result = await lookupGitHubOrganizationInstallation('acme', {
+      getInstallation: async appType => ({ appType, status: 'unknown', reason: 'upstream_error' }),
+      findRecords: async () => ({ records: [record()], recordsTruncated: false }),
+      now: () => checkedAt,
+    });
+
+    expect(JSON.stringify(result)).not.toContain(upstreamMessage);
+    expect(
+      result.apps.every(app => app.status === 'unknown' && app.reason === 'upstream_error')
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/lib/admin/github-installation-lookup.ts
+++ b/apps/web/src/lib/admin/github-installation-lookup.ts
@@ -1,0 +1,260 @@
+import 'server-only';
+import { createAppAuth } from '@octokit/auth-app';
+import { Octokit } from '@octokit/rest';
+import { and, asc, eq, ilike, inArray, or } from 'drizzle-orm';
+import { db } from '@/lib/drizzle';
+import { kilocode_users, organizations, platform_integrations } from '@kilocode/db/schema';
+import {
+  getGitHubAppCredentials,
+  type GitHubAppType,
+} from '@/lib/integrations/platforms/github/app-selector';
+import * as z from 'zod';
+
+const APP_TYPES = ['standard', 'lite'] as const;
+const MAX_RECORDS = 100;
+const REQUEST_TIMEOUT_MS = 8_000;
+
+const InstallationSchema = z.object({
+  id: z.number().int().positive(),
+  account: z.object({
+    id: z.number().int().positive(),
+    login: z.string().min(1),
+    type: z.string().min(1),
+  }),
+  suspended_at: z.string().nullable(),
+  repository_selection: z.string().min(1),
+});
+
+type LookupReason =
+  | 'not_found_for_app'
+  | 'app_not_configured'
+  | 'authentication_failed'
+  | 'request_timeout'
+  | 'upstream_error'
+  | 'malformed_response';
+
+export type GitHubOrganizationInstallationLookupResult = {
+  organization: string;
+  checkedAt: string;
+  apps: Array<{
+    appType: GitHubAppType;
+    status: 'installed' | 'not_found' | 'unknown';
+    reason?: LookupReason | 'suspended';
+    installation?: {
+      id: string;
+      accountId: string;
+      accountLogin: string;
+      accountType: string;
+      suspendedAt: string | null;
+      repositorySelection: string;
+    };
+  }>;
+  records: Array<{
+    id: string;
+    appType: string | null;
+    installationId: string | null;
+    accountLogin: string | null;
+    accountId: string | null;
+    status: string | null;
+    suspendedAt: string | null;
+    authInvalid: boolean;
+    updatedAt: string;
+    owner: { type: 'user' | 'organization'; id: string; name: string | null } | null;
+    association: 'actual' | 'candidate';
+  }>;
+  recordsTruncated: boolean;
+};
+
+type LocalRecord = GitHubOrganizationInstallationLookupResult['records'][number];
+
+type Dependencies = {
+  getInstallation: (
+    appType: GitHubAppType,
+    organization: string
+  ) => Promise<GitHubOrganizationInstallationLookupResult['apps'][number]>;
+  findRecords: (input: {
+    organization: string;
+    installationIds: string[];
+    accountIds: string[];
+  }) => Promise<{ records: LocalRecord[]; recordsTruncated: boolean }>;
+  now: () => Date;
+};
+
+function toIso(value: string | null): string | null {
+  return value ? new Date(value).toISOString() : null;
+}
+
+function getGitHubAppConfig(appType: GitHubAppType) {
+  try {
+    const credentials = getGitHubAppCredentials(appType);
+    return credentials.appId && credentials.privateKey
+      ? { appId: credentials.appId, privateKey: credentials.privateKey }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function reasonForError(error: unknown): LookupReason {
+  if (error instanceof DOMException && error.name === 'AbortError') return 'request_timeout';
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    const status = error.status;
+    if (status === 401 || status === 403) return 'authentication_failed';
+  }
+  return 'upstream_error';
+}
+
+export async function lookupGitHubOrganizationInstallationForApp(
+  appType: GitHubAppType,
+  organization: string
+): Promise<GitHubOrganizationInstallationLookupResult['apps'][number]> {
+  const config = getGitHubAppConfig(appType);
+  if (!config) return { appType, status: 'unknown', reason: 'app_not_configured' };
+
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, REQUEST_TIMEOUT_MS);
+  try {
+    const auth = createAppAuth(config);
+    const { token } = await auth({ type: 'app' });
+    const octokit = new Octokit({
+      auth: token,
+      log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    });
+    const response = await octokit.request('GET /orgs/{org}/installation', {
+      org: organization,
+      request: { signal: controller.signal },
+    });
+    const parsed = InstallationSchema.safeParse(response.data);
+    if (!parsed.success || parsed.data.account.type !== 'Organization') {
+      return { appType, status: 'unknown', reason: 'malformed_response' };
+    }
+    const installation = parsed.data;
+    return {
+      appType,
+      status: 'installed',
+      ...(installation.suspended_at ? { reason: 'suspended' as const } : {}),
+      installation: {
+        id: installation.id.toString(),
+        accountId: installation.account.id.toString(),
+        accountLogin: installation.account.login,
+        accountType: installation.account.type,
+        suspendedAt: toIso(installation.suspended_at),
+        repositorySelection: installation.repository_selection,
+      },
+    };
+  } catch (error) {
+    if (timedOut) return { appType, status: 'unknown', reason: 'request_timeout' };
+    if (typeof error === 'object' && error !== null && 'status' in error && error.status === 404) {
+      return { appType, status: 'not_found', reason: 'not_found_for_app' };
+    }
+    return { appType, status: 'unknown', reason: reasonForError(error) };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function findGitHubOrganizationInstallationRecords(input: {
+  organization: string;
+  installationIds: string[];
+  accountIds: string[];
+}): Promise<{ records: LocalRecord[]; recordsTruncated: boolean }> {
+  const matchConditions = [ilike(platform_integrations.platform_account_login, input.organization)];
+  if (input.installationIds.length > 0) {
+    matchConditions.push(
+      inArray(platform_integrations.platform_installation_id, input.installationIds)
+    );
+  }
+  if (input.accountIds.length > 0) {
+    matchConditions.push(inArray(platform_integrations.platform_account_id, input.accountIds));
+  }
+
+  const rows = await db
+    .select({
+      id: platform_integrations.id,
+      appType: platform_integrations.github_app_type,
+      installationId: platform_integrations.platform_installation_id,
+      accountLogin: platform_integrations.platform_account_login,
+      accountId: platform_integrations.platform_account_id,
+      status: platform_integrations.integration_status,
+      suspendedAt: platform_integrations.suspended_at,
+      authInvalidAt: platform_integrations.auth_invalid_at,
+      updatedAt: platform_integrations.updated_at,
+      userId: kilocode_users.id,
+      userName: kilocode_users.google_user_name,
+      organizationId: organizations.id,
+      organizationName: organizations.name,
+    })
+    .from(platform_integrations)
+    .leftJoin(kilocode_users, eq(platform_integrations.owned_by_user_id, kilocode_users.id))
+    .leftJoin(organizations, eq(platform_integrations.owned_by_organization_id, organizations.id))
+    .where(and(eq(platform_integrations.platform, 'github'), or(...matchConditions)))
+    .orderBy(asc(platform_integrations.id))
+    .limit(MAX_RECORDS + 1);
+
+  return {
+    records: rows.slice(0, MAX_RECORDS).map(row => ({
+      id: row.id,
+      appType: row.appType,
+      installationId: row.installationId,
+      accountLogin: row.accountLogin,
+      accountId: row.accountId,
+      status: row.status,
+      suspendedAt: toIso(row.suspendedAt),
+      authInvalid: row.authInvalidAt !== null,
+      updatedAt: new Date(row.updatedAt).toISOString(),
+      owner: row.userId
+        ? { type: 'user', id: row.userId, name: row.userName }
+        : row.organizationId
+          ? { type: 'organization', id: row.organizationId, name: row.organizationName }
+          : null,
+      association: 'candidate',
+    })),
+    recordsTruncated: rows.length > MAX_RECORDS,
+  };
+}
+
+const defaultDependencies: Dependencies = {
+  getInstallation: lookupGitHubOrganizationInstallationForApp,
+  findRecords: findGitHubOrganizationInstallationRecords,
+  now: () => new Date(),
+};
+
+export async function lookupGitHubOrganizationInstallation(
+  organization: string,
+  dependencies: Dependencies = defaultDependencies
+): Promise<GitHubOrganizationInstallationLookupResult> {
+  const apps = await Promise.all(
+    APP_TYPES.map(appType => dependencies.getInstallation(appType, organization))
+  );
+  const installations = apps.flatMap(app => (app.installation ? [app.installation] : []));
+  const local = await dependencies.findRecords({
+    organization,
+    installationIds: installations.map(installation => installation.id),
+    accountIds: installations.map(installation => installation.accountId),
+  });
+  const records: LocalRecord[] = local.records.map(record => {
+    const liveInstallation = apps.find(
+      app =>
+        app.installation &&
+        app.appType === (record.appType ?? 'standard') &&
+        app.installation.id === record.installationId &&
+        app.installation.accountId === record.accountId
+    )?.installation;
+    return {
+      ...record,
+      association: liveInstallation ? ('actual' as const) : ('candidate' as const),
+    };
+  });
+
+  return {
+    organization,
+    checkedAt: dependencies.now().toISOString(),
+    apps,
+    records,
+    recordsTruncated: local.recordsTruncated,
+  };
+}

--- a/apps/web/src/routers/admin-github-router.test.ts
+++ b/apps/web/src/routers/admin-github-router.test.ts
@@ -1,10 +1,14 @@
 import { createCallerForUser } from '@/routers/test-utils';
+import { createCallerFactory } from '@/lib/trpc/init';
+import { rootRouter } from '@/routers/root-router';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { User } from '@kilocode/db/schema';
 import {
   getKilocodeRepoOpenPullRequestsSummary,
   getKilocodeRepoRecentlyClosedExternalPRs,
 } from '@/lib/github/open-pull-request-counts';
+import { lookupGitHubOrganizationInstallation } from '@/lib/admin/github-installation-lookup';
+import { setAdminAccessSinkForTest } from '@/lib/admin/admin-access-log';
 
 jest.mock('@/lib/github/open-pull-request-counts', () => ({
   getKilocodeRepoOpenPullRequestCounts: jest.fn(),
@@ -14,8 +18,16 @@ jest.mock('@/lib/github/open-pull-request-counts', () => ({
   ALL_REPO_IDS: ['kilocode', 'cloud', 'kilo-marketplace', 'kilocode-legacy'],
 }));
 
+jest.mock('@/lib/admin/github-installation-lookup', () => ({
+  lookupGitHubOrganizationInstallation: jest.fn(),
+}));
+
 let regularUser: User;
 let adminUser: User;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('admin.github.getKilocodeOpenPullRequestCounts', () => {
   beforeAll(async () => {
@@ -38,6 +50,97 @@ describe('admin.github.getKilocodeOpenPullRequestCounts', () => {
     await expect(caller.admin.github.getKilocodeOpenPullRequestCounts()).rejects.toThrow(
       'Admin access required'
     );
+  });
+});
+
+describe('admin.github.lookupOrganizationInstallation', () => {
+  it('denies anonymous callers before a lookup', async () => {
+    const createCaller = createCallerFactory(rootRouter);
+    const caller = createCaller({ user: null } as never);
+
+    await expect(
+      caller.admin.github.lookupOrganizationInstallation({ organization: 'acme' })
+    ).rejects.toThrow();
+    expect(lookupGitHubOrganizationInstallation).not.toHaveBeenCalled();
+  });
+
+  it('denies non-admin callers before a lookup', async () => {
+    const caller = await createCallerForUser(regularUser.id);
+
+    await expect(
+      caller.admin.github.lookupOrganizationInstallation({ organization: 'acme' })
+    ).rejects.toThrow('Admin access required');
+    expect(lookupGitHubOrganizationInstallation).not.toHaveBeenCalled();
+  });
+
+  it('normalizes input and delegates only for an admin', async () => {
+    const response = {
+      organization: 'acme',
+      checkedAt: new Date().toISOString(),
+      apps: [],
+      records: [],
+      recordsTruncated: false,
+    };
+    (lookupGitHubOrganizationInstallation as jest.Mock).mockResolvedValue(response);
+
+    const caller = await createCallerForUser(adminUser.id);
+    await expect(
+      caller.admin.github.lookupOrganizationInstallation({
+        organization: 'https://github.com/acme/',
+      })
+    ).resolves.toEqual(response);
+    expect(lookupGitHubOrganizationInstallation).toHaveBeenCalledWith('acme');
+  });
+
+  it('returns a generic error when the database lookup fails', async () => {
+    const sentinel = 'SELECT secret FROM platform_integrations WHERE account = acme';
+    (lookupGitHubOrganizationInstallation as jest.Mock).mockRejectedValue(new Error(sentinel));
+    const caller = await createCallerForUser(adminUser.id);
+
+    const error = await caller.admin.github
+      .lookupOrganizationInstallation({ organization: 'acme' })
+      .catch(error => error);
+
+    expect(error).toHaveProperty('message', 'GitHub installation lookup failed');
+    expect(error.message).not.toContain(sentinel);
+    expect(error.cause).toBeUndefined();
+  });
+
+  it('preserves admin guard auditing without lookup input or results', async () => {
+    const sink = jest.fn();
+    setAdminAccessSinkForTest(sink);
+    (lookupGitHubOrganizationInstallation as jest.Mock).mockResolvedValue({
+      organization: 'private-lookup-target',
+      records: [{ id: 'private-lookup-result' }],
+    });
+
+    try {
+      const caller = await createCallerForUser(adminUser.id);
+      await caller.admin.github.lookupOrganizationInstallation({
+        organization: 'private-lookup-target',
+      });
+      expect(sink).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'admin_guard',
+          route: 'admin.github.lookupOrganizationInstallation',
+          method: 'mutation',
+          target: null,
+        })
+      );
+      expect(JSON.stringify(sink.mock.calls)).not.toContain('private-lookup-target');
+      expect(JSON.stringify(sink.mock.calls)).not.toContain('private-lookup-result');
+    } finally {
+      setAdminAccessSinkForTest(null);
+    }
+  });
+
+  it('rejects invalid input without calling the lookup', async () => {
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(
+      caller.admin.github.lookupOrganizationInstallation({ organization: 'acme--tools' })
+    ).rejects.toThrow('Enter a valid GitHub organization login');
+    expect(lookupGitHubOrganizationInstallation).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -142,6 +142,8 @@ import {
   getKilocodeRepoRecentlyMergedExternalPRs,
   ALL_REPO_IDS,
 } from '@/lib/github/open-pull-request-counts';
+import { GitHubOrganizationInstallationLookupInputSchema } from '@/lib/admin/github-installation-lookup-input';
+import { lookupGitHubOrganizationInstallation } from '@/lib/admin/github-installation-lookup';
 
 const SyncResponseSchema = z.object({
   success: z.boolean(),
@@ -508,6 +510,18 @@ export const adminRouter = createTRPCRouter({
   impactReferrals: adminImpactReferralsRouter,
   webhookTriggers: adminWebhookTriggersRouter,
   github: createTRPCRouter({
+    lookupOrganizationInstallation: adminProcedure
+      .input(GitHubOrganizationInstallationLookupInputSchema)
+      .mutation(async ({ input }) => {
+        try {
+          return await lookupGitHubOrganizationInstallation(input.organization);
+        } catch {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'GitHub installation lookup failed',
+          });
+        }
+      }),
     getKilocodeOpenPullRequestCounts: adminProcedure.query(async () => {
       return getKilocodeRepoOpenPullRequestCounts({ ttlMs: 2 * 60_000 });
     }),


### PR DESCRIPTION
## Summary

- Add an employee-only Integrations page under Product & Engineering with exact GitHub organization-name, @mention, or organization-URL lookup.
- Check the Standard and Lite GitHub Apps independently, and show installation details plus linked Kilo personal accounts or organizations using existing admin detail links.
- Separate live GitHub evidence from potentially stale local associations, including suspension, pending records, missing owners, multiple records, and bounded-result truncation. A GitHub 404 is reported as no installation found, not a confirmed uninstall.
- Reuse existing server-side admin authorization and audit conventions. Lookup is read-only, uses POST to keep search input out of request URLs, and returns minimal fields with sanitized failures. No new dependencies or schema changes.

## Verification

- [x] Browser-checked the local Integrations page using synthetic identities and fixtures only.
- [x] Checked invalid input, normalization, real local unknown-configuration/empty-record responses, and mocked installed/suspended/not-found responses.
- [x] Checked loading controls, stale-result hiding, safe errors, retry, and encoded owner links.
- [x] Checked responsive layouts at 375px, 900px, and 1440px.
- [x] Verified actual HTTP rejection of anonymous callers (401) and non-admin callers (403).

## Visual Changes

New Product & Engineering navigation entry and Integrations lookup page. Screenshots omitted as requested.

## Reviewer Notes

- Independent read-only review and re-review completed with no remaining feature-specific blockers. Review prompted narrower wording for ambiguous GitHub 404 responses.
- GitHub 404 does not establish whether the organization exists or was renamed. Local records are never treated as authoritative installation status. Live GitHub installation responses were mocked during validation; no production records were used.
- Automated validation passed: `pnpm --filter web lint`, `pnpm --filter web typecheck`, changed-file formatting checks, and `git diff --check`.
- `pnpm --filter web test --runInBand github-installation-lookup admin-github-router GitHubInstallationLookup`: 6 suites, 46 tests passed, including authorization, audit privacy, error redaction, normalization, and database association/query-bound coverage. Database tests used an isolated worktree database prepared with `pnpm test:db`.
- Typecheck completed with nonblocking Rollup external-dependency warnings.