### PR TITLE
fix(mobile): resolve prebuilt Expo modules only on disk

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -262,6 +262,7 @@ const config: ExpoConfig = {
       },
     ],
     './plugins/withAndroidManifestFix',
+    './plugins/withAndroidExpoModuleRepos',
     // Declares the app's languages on the widget extension, which expo-widgets
     // leaves English-only. This must be registered BEFORE 'expo-widgets':
     // dangerous mods run in reverse registration order, so the earlier entry

--- a/apps/mobile/plugins/withAndroidExpoModuleRepos.js
+++ b/apps/mobile/plugins/withAndroidExpoModuleRepos.js
@@ -1,0 +1,47 @@
+const { withProjectBuildGradle } = require('expo/config-plugins');
+
+const MARKER = 'kilo-prebuilt-expo-modules';
+
+/**
+ * Prebuilt Expo modules ship as AARs inside each package, and
+ * expo-modules-autolinking serves them from a `local-maven-repo` file
+ * repository per package. Their coordinates (`*:expo.modules.*`) exist nowhere
+ * else, so every remote repository answers 404 for them.
+ *
+ * Gradle treats a 404 as "keep looking" but any other HTTP error as fatal. When
+ * a remote repository is consulted first and rate-limits the lookup, all 35
+ * modules fail at once and the build dies even though the AARs are on disk.
+ * Maven Central returned 429 to an EAS builder on 2026-09-03 and did exactly
+ * that.
+ *
+ * Excluding the coordinates from every remote repository keeps the lookups on
+ * disk, where they always resolve.
+ */
+const REPOSITORY_FILTER = `
+// ${MARKER}: prebuilt Expo module AARs live only in the per-package
+// local-maven-repo directories. Remote repositories 404 for them, and a
+// rate-limited 404 (429) is fatal to the whole build, so never ask remotely.
+allprojects {
+  repositories.all { repo ->
+    if (repo instanceof org.gradle.api.artifacts.repositories.MavenArtifactRepository
+        && repo.url.scheme != 'file') {
+      repo.content { content ->
+        content.excludeModuleByRegex('.*', 'expo\\\\.modules\\\\..*')
+      }
+    }
+  }
+}
+`;
+
+function withAndroidExpoModuleRepos(config) {
+  return withProjectBuildGradle(config, config => {
+    if (config.modResults.language !== 'groovy') {
+      throw new Error('withAndroidExpoModuleRepos supports only Groovy build.gradle');
+    }
+    if (config.modResults.contents.includes(MARKER)) return config;
+    config.modResults.contents += REPOSITORY_FILTER;
+    return config;
+  });
+}
+
+module.exports = withAndroidExpoModuleRepos;


### PR DESCRIPTION
Fixes the Android build in the `kilo-app Release` run [33773162034](https://github.com/Kilo-Org/cloud/actions/runs/33773162034/job/100722763307).

## What broke

The Android EAS build failed with 35 identical errors:

```
> Could not resolve expo.modules.ui:expo.modules.ui:57.0.12.
   > Could not GET '.../expo.modules.ui-57.0.12.pom'. Received status code 429 from server: Too Many Requests
```

## Root cause

The 37 prebuilt Expo modules ship their AARs inside the npm packages.
`expo-modules-autolinking` serves them from a `local-maven-repo` directory per
package, and their coordinates exist in no remote repository:

```
repo.maven.apache.org/maven2/expo/modules/ui/expo.modules.ui/57.0.12/...pom            → 404
repo.maven.apache.org/maven2/host/exp/exponent/expo.modules.application/57.0.2/...pom  → 404
```

EAS consults a remote repository before the local ones. Gradle treats a 404 as
"keep looking", so it fell through to the local repo and every build up to
2026-09-02 passed. Maven Central answered 429 on 2026-09-03. Gradle treats any
other HTTP error as fatal, so all 35 modules failed at once and
`:app:bundleRelease` died.

Nothing in this repository changed. The last green build has the same 37
prebuilt modules.

This is an upstream bug in `expo-modules-autolinking`
(`ProjectExtension.kt:23`): it registers the local repositories with
`content { includeVersion(...) }`, which states that the repository serves those
coordinates but not that it is the only one. `repositories.exclusiveContent { }`
is the primitive that closes the hole.

## The change

`withAndroidExpoModuleRepos` excludes `*:expo.modules.*` from every remote
repository, so the lookups stay on disk where they always resolve. It also
saves 35 HTTP requests per Android build.

## Verification

A local mirror in front of every other repository, returning 429 for
`expo.modules` paths and 404 for the rest, reproduces the failure. Both runs use
real `expo prebuild` output:

| | `:app:bundleRelease --dry-run` |
| --- | --- |
| before | `BUILD FAILED` — the same 35 `Could not resolve expo.modules.*` errors as CI |
| after | `BUILD SUCCESSFUL` — the mirror logs zero `expo.modules` requests |

A full local `:app:bundleRelease` against the real repositories is green:
1596 tasks, `app-release.aab` written. `pnpm format`, `typecheck`, `lint`,
`check:unused` and `assert:config` all pass.

## Out of scope

Two other release runs failed today for unrelated reasons: run
[33763937780](https://github.com/Kilo-Org/cloud/actions/runs/33763937780) failed
at **Submit iOS** after both builds finished, and run
[33760516671](https://github.com/Kilo-Org/cloud/actions/runs/33760516671) failed
inside `eas build` after one minute.