### PR TITLE
feat(admin): add confirmed GitHub App uninstall

### DIFF
--- a/apps/web/src/app/admin/integrations/GitHubInstallationLookup.test.ts
+++ b/apps/web/src/app/admin/integrations/GitHubInstallationLookup.test.ts
@@ -2,7 +2,12 @@ import React from 'react';
 import { describe, expect, it } from '@jest/globals';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { GitHubOrganizationInstallationLookupResult } from '@/lib/admin/github-installation-lookup';
-import { GitHubInstallationLookupResult, LocalAssociationTable } from './GitHubInstallationLookup';
+import {
+  getUninstallTarget,
+  GitHubInstallationLookupResult,
+  LocalAssociationTable,
+  uninstallConfirmationCopy,
+} from './GitHubInstallationLookup';
 
 const result = {
   organization: 'acme-tools',
@@ -24,7 +29,7 @@ const result = {
   ],
   records: [
     {
-      id: 'actual-record',
+      id: '123e4567-e89b-42d3-a456-426614174000',
       appType: 'standard',
       installationId: '123',
       accountLogin: 'acme-tools',
@@ -33,7 +38,11 @@ const result = {
       suspendedAt: null,
       authInvalid: false,
       updatedAt: '2026-09-03T13:00:00.000Z',
-      owner: { type: 'organization', id: 'org/id', name: 'Acme Tools' },
+      owner: {
+        type: 'organization',
+        id: '223e4567-e89b-42d3-a456-426614174000',
+        name: 'Acme Tools',
+      },
       association: 'actual',
     },
     {
@@ -83,7 +92,7 @@ describe('GitHubInstallationLookupResult', () => {
     expect(html).toContain('Authentication invalid');
     expect(html).toContain('No owner linked');
     expect(html).toContain('Results truncated');
-    expect(html).toContain('/admin/organizations/org%2Fid');
+    expect(html).toContain('/admin/organizations/223e4567-e89b-42d3-a456-426614174000');
     expect(html).toContain('/admin/users/user%2Fid');
   });
 
@@ -109,5 +118,81 @@ describe('GitHubInstallationLookupResult', () => {
 
     expect(html).toContain('No local association records matched this lookup.');
     expect(html).not.toContain('Not installed');
+  });
+
+  it('only enables the install-wide action for a live, actual record with complete identity', () => {
+    const target = getUninstallTarget(result, result.records[0]);
+    const candidateTarget = getUninstallTarget(result, result.records[1]);
+    const ownerlessTarget = getUninstallTarget(result, result.records[2]);
+    const html = renderToStaticMarkup(
+      React.createElement(GitHubInstallationLookupResult, {
+        result,
+        onUninstall: () => {},
+      })
+    );
+
+    expect(target).toMatchObject({
+      appType: 'standard',
+      installationId: '123',
+      accountId: '456',
+      owner: { type: 'organization', id: '223e4567-e89b-42d3-a456-426614174000' },
+    });
+    expect(candidateTarget).toBeNull();
+    expect(ownerlessTarget).toBeNull();
+    expect(html).toContain('Uninstall GitHub App');
+    expect(html).toContain('Not eligible');
+  });
+
+  it('allows suspended actual installations and preserves arbitrary OAuth owner IDs', () => {
+    const suspendedResult = {
+      ...result,
+      records: [
+        {
+          ...result.records[0],
+          owner: { type: 'user' as const, id: 'oauth|github|9/with:any-id', name: 'OAuth user' },
+          suspendedAt: '2026-09-03T13:00:00.000Z',
+        },
+      ],
+      apps: [
+        {
+          ...result.apps[0],
+          reason: 'suspended' as const,
+          installation: {
+            ...result.apps[0].installation!,
+            suspendedAt: '2026-09-03T13:00:00.000Z',
+          },
+        },
+        result.apps[1],
+      ],
+    } satisfies GitHubOrganizationInstallationLookupResult;
+
+    expect(getUninstallTarget(suspendedResult, suspendedResult.records[0])).toMatchObject({
+      owner: { type: 'user', id: 'oauth|github|9/with:any-id' },
+    });
+  });
+
+  it('refuses duplicate effective app associations and unknown live checks', () => {
+    const duplicateResult = {
+      ...result,
+      records: [
+        result.records[0],
+        { ...result.records[0], id: '323e4567-e89b-42d3-a456-426614174000', appType: null },
+      ],
+    };
+    expect(getUninstallTarget(duplicateResult, duplicateResult.records[0])).toBeNull();
+    expect(getUninstallTarget({ ...result, apps: [] }, result.records[0])).toBeNull();
+  });
+
+  it('uses irreversible confirmation copy that names the access impact and recovery path', () => {
+    expect(uninstallConfirmationCopy.description).toContain(
+      'This removes the GitHub App installation from GitHub.'
+    );
+    expect(uninstallConfirmationCopy.impact).toContain(
+      'All repositories served by this GitHub installation lose app access.'
+    );
+    expect(uninstallConfirmationCopy.impact).toContain('Kilo history and settings are retained.');
+    expect(uninstallConfirmationCopy.impact).toContain(
+      'Reinstall the app through GitHub to restore access.'
+    );
   });
 });

--- a/apps/web/src/app/admin/integrations/GitHubInstallationLookup.tsx
+++ b/apps/web/src/app/admin/integrations/GitHubInstallationLookup.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import type { GitHubOrganizationInstallationLookupResult } from '@/lib/admin/github-installation-lookup';
 import { normalizeGitHubOrganizationLogin } from '@/lib/admin/github-installation-lookup-input';
+import { GitHubInstallationUninstallInputSchema } from '@/lib/admin/github-installation-uninstall-input';
 import { useTRPC } from '@/lib/trpc/utils';
 import Link from 'next/link';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -12,6 +13,16 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import {
   Table,
   TableBody,
@@ -24,22 +35,149 @@ import {
 type LookupResult = GitHubOrganizationInstallationLookupResult;
 type LookupApp = LookupResult['apps'][number];
 type LookupRecord = LookupResult['records'][number];
+export type UninstallTarget = {
+  integrationId: string;
+  installationId: string;
+  accountId: string;
+  appType: 'standard' | 'lite';
+  owner: NonNullable<LookupRecord['owner']>;
+  accountLogin: string;
+};
+
+export const uninstallConfirmationCopy = {
+  description:
+    'This removes the GitHub App installation from GitHub. It cannot be undone from Kilo.',
+  impact:
+    'All repositories served by this GitHub installation lose app access. Kilo history and settings are retained. Reinstall the app through GitHub to restore access.',
+};
+
+function isPositiveDecimalString(value: string | null): value is string {
+  return value !== null && /^[1-9]\d*$/.test(value);
+}
+
+export function getUninstallTarget(
+  result: LookupResult,
+  record: LookupRecord
+): UninstallTarget | null {
+  if (
+    record.association !== 'actual' ||
+    !record.owner ||
+    !isPositiveDecimalString(record.installationId) ||
+    !isPositiveDecimalString(record.accountId)
+  ) {
+    return null;
+  }
+
+  const appType = record.appType ?? 'standard';
+  if (appType !== 'standard' && appType !== 'lite') return null;
+  if (
+    result.records.filter(
+      candidate =>
+        (candidate.appType ?? 'standard') === appType &&
+        candidate.installationId === record.installationId
+    ).length !== 1
+  ) {
+    return null;
+  }
+
+  const installation = result.apps.find(
+    app =>
+      app.appType === appType &&
+      app.status === 'installed' &&
+      app.installation?.id === record.installationId &&
+      app.installation.accountId === record.accountId
+  )?.installation;
+
+  if (!installation) return null;
+
+  const target: UninstallTarget = {
+    integrationId: record.id,
+    installationId: record.installationId,
+    accountId: record.accountId,
+    appType,
+    owner: record.owner,
+    accountLogin: installation.accountLogin,
+  };
+
+  return GitHubInstallationUninstallInputSchema.safeParse({
+    ...target,
+    owner: { type: target.owner.type, id: target.owner.id },
+    confirmation: target.installationId,
+  }).success
+    ? target
+    : null;
+}
 
 export function GitHubInstallationLookup() {
   const trpc = useTRPC();
   const [organization, setOrganization] = useState('');
   const [inputError, setInputError] = useState<string | null>(null);
+  const [result, setResult] = useState<LookupResult>();
+  const [submittedOrganization, setSubmittedOrganization] = useState<string>();
+  const [uninstallTarget, setUninstallTarget] = useState<UninstallTarget | null>(null);
+  const [uninstallConfirmation, setUninstallConfirmation] = useState('');
+  const [uninstallSuccess, setUninstallSuccess] = useState<string | null>(null);
+  const [uninstalledIntegrationId, setUninstalledIntegrationId] = useState<string | null>(null);
+  const [refreshingAfterUninstall, setRefreshingAfterUninstall] = useState(false);
   const lookup = useMutation(
-    trpc.admin.github.lookupOrganizationInstallation.mutationOptions({ retry: false })
+    trpc.admin.github.lookupOrganizationInstallation.mutationOptions({
+      retry: false,
+      onSuccess: data => {
+        setResult(data);
+        setRefreshingAfterUninstall(false);
+      },
+      onError: () => {
+        setResult(undefined);
+        if (refreshingAfterUninstall) {
+          setUninstallSuccess(
+            previous =>
+              `${previous ?? 'GitHub uninstall confirmed.'} The refreshed lookup could not be loaded. Refresh before taking another action.`
+          );
+          setRefreshingAfterUninstall(false);
+        }
+      },
+    })
   );
-  const result = inputError || lookup.isPending || lookup.isError ? undefined : lookup.data;
+  const uninstall = useMutation(
+    trpc.admin.github.uninstallOrganizationInstallation.mutationOptions({
+      retry: false,
+      onSuccess: response => {
+        const organizationToRefresh = submittedOrganization;
+        setUninstallTarget(null);
+        setUninstallConfirmation('');
+        setResult(undefined);
+        setUninstalledIntegrationId(uninstallTarget?.integrationId ?? null);
+        setUninstallSuccess(
+          response.localCleanup === 'pending'
+            ? 'GitHub App was uninstalled, but local cleanup is not confirmed. The deletion webhook normally reconciles this. Refresh the lookup; manual investigation is needed if the record remains.'
+            : 'GitHub App was uninstalled and local cleanup completed.'
+        );
+        if (organizationToRefresh) {
+          setRefreshingAfterUninstall(true);
+          lookup.mutate({ organization: organizationToRefresh });
+        }
+      },
+      onError: () => {
+        setResult(undefined);
+      },
+    })
+  );
+  const lookupBlocked = uninstall.isPending;
 
   function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (lookup.isPending || uninstall.isPending) return;
+    setResult(undefined);
 
     try {
       const normalizedOrganization = normalizeGitHubOrganizationLogin(organization);
       setInputError(null);
+      setUninstallSuccess(null);
+      setUninstallTarget(null);
+      setUninstallConfirmation('');
+      setUninstalledIntegrationId(null);
+      setResult(undefined);
+      setSubmittedOrganization(normalizedOrganization);
       lookup.mutate({ organization: normalizedOrganization });
     } catch {
       setInputError('Enter a valid GitHub organization login.');
@@ -79,7 +217,7 @@ export function GitHubInstallationLookup() {
                 autoCapitalize="none"
                 spellCheck={false}
                 maxLength={256}
-                disabled={lookup.isPending}
+                disabled={lookup.isPending || lookupBlocked}
                 placeholder="acme-tools"
                 value={organization}
                 onChange={event => {
@@ -95,7 +233,11 @@ export function GitHubInstallationLookup() {
                 </p>
               ) : null}
             </div>
-            <Button type="submit" className="sm:min-w-32" disabled={lookup.isPending}>
+            <Button
+              type="submit"
+              className="sm:min-w-32"
+              disabled={lookup.isPending || lookupBlocked}
+            >
               {lookup.isPending ? 'Checking…' : 'Check installation'}
             </Button>
           </form>
@@ -109,15 +251,77 @@ export function GitHubInstallationLookup() {
               </AlertDescription>
             </Alert>
           ) : null}
+          {uninstallSuccess ? (
+            <Alert>
+              <AlertTitle>GitHub uninstall confirmed</AlertTitle>
+              <AlertDescription>{uninstallSuccess}</AlertDescription>
+            </Alert>
+          ) : null}
         </CardContent>
       </Card>
 
-      {result ? <GitHubInstallationLookupResult result={result} /> : null}
+      {result ? (
+        <GitHubInstallationLookupResult
+          result={result}
+          uninstallPending={uninstall.isPending}
+          unavailableIntegrationId={uninstalledIntegrationId}
+          onUninstall={target => {
+            uninstall.reset();
+            setUninstallConfirmation('');
+            setUninstallTarget(target);
+          }}
+        />
+      ) : null}
+      <UninstallGitHubAppDialog
+        target={uninstallTarget}
+        confirmation={uninstallConfirmation}
+        isPending={uninstall.isPending}
+        error={
+          uninstall.isError
+            ? 'GitHub App uninstall could not be confirmed. Close this dialog and refresh the lookup before trying again.'
+            : null
+        }
+        onConfirmationChange={setUninstallConfirmation}
+        onOpenChange={open => {
+          if (!open && !uninstall.isPending) {
+            setUninstallTarget(null);
+            setUninstallConfirmation('');
+          }
+        }}
+        onConfirm={() => {
+          if (
+            uninstall.isPending ||
+            uninstall.isError ||
+            !uninstallTarget ||
+            uninstallConfirmation !== uninstallTarget.installationId
+          ) {
+            return;
+          }
+          uninstall.mutate({
+            integrationId: uninstallTarget.integrationId,
+            installationId: uninstallTarget.installationId,
+            accountId: uninstallTarget.accountId,
+            appType: uninstallTarget.appType,
+            owner: { type: uninstallTarget.owner.type, id: uninstallTarget.owner.id },
+            confirmation: uninstallTarget.installationId,
+          });
+        }}
+      />
     </div>
   );
 }
 
-export function GitHubInstallationLookupResult({ result }: { result: LookupResult }) {
+export function GitHubInstallationLookupResult({
+  result,
+  onUninstall,
+  uninstallPending = false,
+  unavailableIntegrationId,
+}: {
+  result: LookupResult;
+  onUninstall?: (target: UninstallTarget) => void;
+  uninstallPending?: boolean;
+  unavailableIntegrationId?: string | null;
+}) {
   return (
     <div className="flex flex-col gap-6">
       <section className="space-y-3" aria-labelledby="live-installations-heading">
@@ -159,7 +363,13 @@ export function GitHubInstallationLookupResult({ result }: { result: LookupResul
             </AlertDescription>
           </Alert>
         ) : null}
-        <LocalAssociationTable records={result.records} />
+        <LocalAssociationTable
+          result={result}
+          records={result.records}
+          onUninstall={onUninstall}
+          uninstallPending={uninstallPending}
+          unavailableIntegrationId={unavailableIntegrationId}
+        />
       </section>
     </div>
   );
@@ -197,7 +407,19 @@ function LiveInstallationCard({ app }: { app: LookupApp }) {
   );
 }
 
-export function LocalAssociationTable({ records }: { records: LookupRecord[] }) {
+export function LocalAssociationTable({
+  result,
+  records,
+  onUninstall,
+  uninstallPending = false,
+  unavailableIntegrationId,
+}: {
+  result?: LookupResult;
+  records: LookupRecord[];
+  onUninstall?: (target: UninstallTarget) => void;
+  uninstallPending?: boolean;
+  unavailableIntegrationId?: string | null;
+}) {
   return (
     <div className="overflow-x-auto rounded-lg border">
       <Table>
@@ -209,17 +431,33 @@ export function LocalAssociationTable({ records }: { records: LookupRecord[] }) 
             <TableHead>GitHub account</TableHead>
             <TableHead>Local state</TableHead>
             <TableHead>Updated</TableHead>
+            {onUninstall ? <TableHead className="text-right">Action</TableHead> : null}
           </TableRow>
         </TableHeader>
         <TableBody>
           {records.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={6} className="text-muted-foreground h-24 text-center">
+              <TableCell
+                colSpan={onUninstall ? 7 : 6}
+                className="text-muted-foreground h-24 text-center"
+              >
                 No local association records matched this lookup.
               </TableCell>
             </TableRow>
           ) : (
-            records.map(record => <LocalAssociationRow key={record.id} record={record} />)
+            records.map(record => (
+              <LocalAssociationRow
+                key={record.id}
+                record={record}
+                uninstallTarget={
+                  result && record.id !== unavailableIntegrationId
+                    ? getUninstallTarget(result, record)
+                    : null
+                }
+                uninstallPending={uninstallPending}
+                onUninstall={onUninstall}
+              />
+            ))
           )}
         </TableBody>
       </Table>
@@ -227,7 +465,17 @@ export function LocalAssociationTable({ records }: { records: LookupRecord[] }) 
   );
 }
 
-function LocalAssociationRow({ record }: { record: LookupRecord }) {
+function LocalAssociationRow({
+  record,
+  uninstallTarget,
+  uninstallPending,
+  onUninstall,
+}: {
+  record: LookupRecord;
+  uninstallTarget: UninstallTarget | null;
+  uninstallPending: boolean;
+  onUninstall?: (target: UninstallTarget) => void;
+}) {
   return (
     <TableRow>
       <TableCell className="min-w-36 align-top">
@@ -264,7 +512,112 @@ function LocalAssociationRow({ record }: { record: LookupRecord }) {
       <TableCell className="text-muted-foreground min-w-40 align-top text-sm">
         {formatTimestamp(record.updatedAt)}
       </TableCell>
+      {onUninstall ? (
+        <TableCell className="min-w-40 align-top text-right">
+          {uninstallTarget ? (
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={uninstallPending}
+              onClick={() => onUninstall(uninstallTarget)}
+            >
+              Uninstall GitHub App
+            </Button>
+          ) : (
+            <span className="text-muted-foreground text-xs">Not eligible</span>
+          )}
+        </TableCell>
+      ) : null}
     </TableRow>
+  );
+}
+
+export function UninstallGitHubAppDialog({
+  target,
+  confirmation,
+  isPending,
+  error,
+  onConfirmationChange,
+  onOpenChange,
+  onConfirm,
+}: {
+  target: UninstallTarget | null;
+  confirmation: string;
+  isPending: boolean;
+  error: string | null;
+  onConfirmationChange: (value: string) => void;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  const canConfirm = target !== null && confirmation === target.installationId;
+
+  return (
+    <AlertDialog open={target !== null} onOpenChange={onOpenChange}>
+      <AlertDialogContent
+        className="sm:max-w-xl"
+        aria-busy={isPending}
+        onEscapeKeyDown={event => {
+          if (isPending) event.preventDefault();
+        }}
+        onPointerDownOutside={event => {
+          if (isPending) event.preventDefault();
+        }}
+      >
+        <AlertDialogHeader>
+          <AlertDialogTitle>Uninstall GitHub App?</AlertDialogTitle>
+          <AlertDialogDescription>{uninstallConfirmationCopy.description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        {target ? (
+          <div className="space-y-4 text-sm">
+            <dl className="grid gap-x-4 gap-y-3 rounded-lg border bg-muted/30 p-3 sm:grid-cols-2">
+              <Detail label="GitHub App" value={`${target.appType} app`} />
+              <Detail label="GitHub login" value={target.accountLogin} />
+              <Detail label="Installation ID" value={target.installationId} mono />
+              <Detail label="Kilo owner" value={`${target.owner.type}: ${target.owner.id}`} mono />
+            </dl>
+            <Alert variant="destructive">
+              <AlertTitle>Repository access will stop</AlertTitle>
+              <AlertDescription>{uninstallConfirmationCopy.impact}</AlertDescription>
+            </Alert>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="github-installation-uninstall-confirmation">
+                Type installation ID <span className="font-mono">{target.installationId}</span> to
+                confirm
+              </Label>
+              <Input
+                id="github-installation-uninstall-confirmation"
+                value={confirmation}
+                onChange={event => onConfirmationChange(event.target.value)}
+                disabled={isPending}
+                autoComplete="off"
+                maxLength={16}
+                inputMode="numeric"
+                aria-describedby={error ? 'github-installation-uninstall-error' : undefined}
+              />
+            </div>
+            {error ? (
+              <p
+                id="github-installation-uninstall-error"
+                className="text-destructive text-sm"
+                role="alert"
+              >
+                {error}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            disabled={isPending || error !== null || !canConfirm}
+            onClick={onConfirm}
+          >
+            {isPending ? 'Uninstalling GitHub App…' : 'Uninstall GitHub App'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 

--- a/apps/web/src/lib/admin/github-installation-uninstall-input.test.ts
+++ b/apps/web/src/lib/admin/github-installation-uninstall-input.test.ts
@@ -1,0 +1,38 @@
+import { GitHubInstallationUninstallInputSchema } from './github-installation-uninstall-input';
+
+const input = {
+  integrationId: '12345678-1234-4234-9234-123456789abc',
+  installationId: '123',
+  accountId: '456',
+  appType: 'standard' as const,
+  owner: { type: 'user' as const, id: 'oauth/github|arbitrary-user-id' },
+  confirmation: '123',
+};
+
+describe('GitHubInstallationUninstallInputSchema', () => {
+  test('accepts arbitrary user owner IDs and organization IDs', () => {
+    expect(GitHubInstallationUninstallInputSchema.parse(input)).toEqual(input);
+    expect(
+      GitHubInstallationUninstallInputSchema.parse({
+        ...input,
+        owner: { type: 'organization', id: '12345678-1234-4234-9234-123456789abd' },
+      })
+    ).toEqual(
+      expect.objectContaining({
+        owner: { type: 'organization', id: '12345678-1234-4234-9234-123456789abd' },
+      })
+    );
+  });
+
+  test.each([
+    { installationId: '0' },
+    { installationId: '01' },
+    { installationId: '9007199254740992' },
+    { accountId: '-1' },
+    { confirmation: '124' },
+  ])('rejects unsafe destructive input %#', invalid => {
+    expect(GitHubInstallationUninstallInputSchema.safeParse({ ...input, ...invalid }).success).toBe(
+      false
+    );
+  });
+});

--- a/apps/web/src/lib/admin/github-installation-uninstall-input.ts
+++ b/apps/web/src/lib/admin/github-installation-uninstall-input.ts
@@ -1,0 +1,34 @@
+import * as z from 'zod';
+
+const positiveSafeDecimal = z
+  .string()
+  .max(16)
+  .regex(/^[1-9]\d*$/)
+  .refine(value => Number.isSafeInteger(Number(value)));
+
+export const GitHubInstallationUninstallInputSchema = z
+  .object({
+    integrationId: z.uuid(),
+    installationId: positiveSafeDecimal,
+    accountId: positiveSafeDecimal,
+    appType: z.enum(['standard', 'lite']),
+    owner: z
+      .object({
+        type: z.enum(['user', 'organization']),
+        id: z.string().min(1).max(1024),
+      })
+      .superRefine((owner, ctx) => {
+        if (owner.type === 'organization' && !z.uuid().safeParse(owner.id).success) {
+          ctx.addIssue({ code: 'custom', path: ['id'], message: 'Organization ID must be a UUID' });
+        }
+      }),
+    confirmation: z.string(),
+  })
+  .refine(input => input.confirmation === input.installationId, {
+    path: ['confirmation'],
+    message: 'Confirmation must match the installation ID',
+  });
+
+export type GitHubInstallationUninstallInput = z.infer<
+  typeof GitHubInstallationUninstallInputSchema
+>;

--- a/apps/web/src/lib/admin/github-installation-uninstall.test.ts
+++ b/apps/web/src/lib/admin/github-installation-uninstall.test.ts
@@ -1,0 +1,350 @@
+import { cleanupDbForTest, db } from '@/lib/drizzle';
+import { createTestOrganization } from '@/tests/helpers/organization.helper';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import {
+  kilocode_users,
+  agent_configs,
+  organization_audit_logs,
+  organizations,
+  platform_integrations,
+  user_admin_notes,
+} from '@kilocode/db/schema';
+import { eq, sql } from 'drizzle-orm';
+import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
+import { verifyAndDeleteGitHubOrganizationInstallation } from '@/lib/integrations/platforms/github/adapter';
+import { uninstallGitHubOrganizationInstallation } from './github-installation-uninstall';
+
+const mockBotInitialize = jest.fn<Promise<void>, []>();
+const mockBotGetState = jest.fn<unknown, []>();
+const mockUnlinkTeamKiloUsers = jest.fn<Promise<number>, []>();
+
+jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
+  verifyAndDeleteGitHubOrganizationInstallation: jest.fn(),
+}));
+
+jest.mock('@/lib/organizations/organization-audit-logs', () => {
+  const actual = jest.requireActual('@/lib/organizations/organization-audit-logs');
+  return { ...actual, createAuditLog: jest.fn(actual.createAuditLog) };
+});
+
+jest.mock('@/lib/bot', () => ({
+  bot: {
+    initialize: () => mockBotInitialize(),
+    getState: () => mockBotGetState(),
+  },
+}));
+
+jest.mock('@/lib/bot-identity', () => ({
+  unlinkTeamKiloUsers: () => mockUnlinkTeamKiloUsers(),
+}));
+
+const upstream = jest.mocked(verifyAndDeleteGitHubOrganizationInstallation);
+const audit = jest.mocked(createAuditLog);
+
+async function integration(owner: { userId?: string; organizationId?: string }, overrides = {}) {
+  const [row] = await db
+    .insert(platform_integrations)
+    .values({
+      platform: 'github',
+      integration_type: 'app',
+      owned_by_user_id: owner.userId,
+      owned_by_organization_id: owner.organizationId,
+      platform_installation_id: '123',
+      platform_account_id: '456',
+      github_app_type: 'standard',
+      integration_status: 'active',
+      ...overrides,
+    })
+    .returning();
+  return row!;
+}
+
+function request(
+  row: { id: string },
+  owner: { type: 'user' | 'organization'; id: string },
+  overrides = {}
+) {
+  return {
+    integrationId: row.id,
+    installationId: '123',
+    accountId: '456',
+    appType: 'standard' as const,
+    owner,
+    confirmation: '123',
+    ...overrides,
+  };
+}
+
+describe('uninstallGitHubOrganizationInstallation', () => {
+  beforeEach(async () => {
+    await cleanupDbForTest();
+    upstream.mockReset();
+    upstream.mockResolvedValue();
+    audit.mockReset();
+    audit.mockImplementation(
+      jest.requireActual('@/lib/organizations/organization-audit-logs').createAuditLog
+    );
+    mockBotInitialize.mockResolvedValue();
+    mockBotGetState.mockReturnValue({});
+    mockUnlinkTeamKiloUsers.mockResolvedValue(0);
+  });
+
+  test.each([{ is_admin: false }, { blocked_reason: 'blocked' }])(
+    'rejects a currently inactive admin before upstream work: %j',
+    async change => {
+      const actor = await insertTestUser({ is_admin: true });
+      const owner = await insertTestUser();
+      const row = await integration({ userId: owner.id });
+      await db.update(kilocode_users).set(change).where(eq(kilocode_users.id, actor.id));
+
+      await expect(
+        uninstallGitHubOrganizationInstallation({
+          input: request(row, { type: 'user', id: owner.id }),
+          actor: { id: actor.id, email: actor.google_user_email, name: actor.google_user_name },
+        })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(upstream).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each([
+    { owner: { type: 'user' as const, id: 'other' } },
+    { accountId: '999' },
+    { installationId: '999', confirmation: '999' },
+    { appType: 'lite' as const },
+  ])('rejects stale snapshot before upstream work', async override => {
+    const actor = await insertTestUser({ is_admin: true });
+    const owner = await insertTestUser();
+    const row = await integration({ userId: owner.id });
+    await expect(
+      uninstallGitHubOrganizationInstallation({
+        input: request(row, { type: 'user', id: owner.id }, override),
+        actor: { id: actor.id, email: actor.google_user_email, name: actor.google_user_name },
+      })
+    ).rejects.toThrow('Refresh before retrying');
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  test('deletes only selected user association and preserves sibling and audit attribution', async () => {
+    const actor = await insertTestUser({ is_admin: true });
+    const owner = await insertTestUser({ id: 'oauth/github|owner' });
+    const row = await integration({ userId: owner.id });
+    const sibling = await integration({ userId: owner.id }, { platform_installation_id: '789' });
+    await expect(
+      uninstallGitHubOrganizationInstallation({
+        input: request(row, { type: 'user', id: owner.id }),
+        actor: { id: actor.id, email: actor.google_user_email, name: actor.google_user_name },
+      })
+    ).resolves.toEqual({ status: 'uninstalled', localCleanup: 'complete' });
+    expect(
+      await db.query.platform_integrations.findFirst({
+        where: eq(platform_integrations.id, row.id),
+      })
+    ).toBeUndefined();
+    expect(
+      await db.query.platform_integrations.findFirst({
+        where: eq(platform_integrations.id, sibling.id),
+      })
+    ).toBeDefined();
+    const notes = await db
+      .select()
+      .from(user_admin_notes)
+      .where(eq(user_admin_notes.kilo_user_id, owner.id));
+    expect(notes).toHaveLength(2);
+    expect(notes.every(note => note.admin_kilo_user_id === actor.id)).toBe(true);
+  });
+
+  test('supports legacy standard association and preserves organization resources', async () => {
+    const actor = await insertTestUser({ is_admin: true });
+    const owner = await insertTestUser();
+    const org = await createTestOrganization('Uninstall test org', owner.id, 0);
+    const row = await integration({ organizationId: org.id }, { github_app_type: null });
+    const [config] = await db
+      .insert(agent_configs)
+      .values({
+        owned_by_organization_id: org.id,
+        agent_type: 'code_review',
+        platform: 'github',
+        config: {},
+        created_by: owner.id,
+      })
+      .returning();
+    await uninstallGitHubOrganizationInstallation({
+      input: request(row, { type: 'organization', id: org.id }),
+      actor: { id: actor.id, email: actor.google_user_email, name: actor.google_user_name },
+    });
+    expect(
+      await db.query.organizations.findFirst({ where: eq(organizations.id, org.id) })
+    ).toBeDefined();
+    expect(
+      await db.query.agent_configs.findFirst({ where: eq(agent_configs.id, config!.id) })
+    ).toBeDefined();
+    const audits = await db
+      .select()
+      .from(organization_audit_logs)
+      .where(eq(organization_audit_logs.organization_id, org.id));
+    expect(audits).toHaveLength(2);
+    expect(
+      audits.every(audit => audit.actor_id === actor.id && audit.message.includes(row.id))
+    ).toBe(true);
+  });
+
+  test.each([401, 403, 404, 'timeout'])(
+    'leaves local association on upstream %s',
+    async failure => {
+      const actor = await insertTestUser({ is_admin: true });
+      const owner = await insertTestUser();
+      const row = await integration({ userId: owner.id });
+      upstream.mockRejectedValue({ status: failure });
+      await expect(
+        uninstallGitHubOrganizationInstallation({
+          input: request(row, { type: 'user', id: owner.id }),
+          actor: { id: actor.id, email: actor.google_user_email, name: actor.google_user_name },
+        })
+      ).rejects.toThrow('Refresh before retrying');
+      expect(
+        await db.query.platform_integrations.findFirst({
+          where: eq(platform_integrations.id, row.id),
+        })
+      ).toBeDefined();
+    }
+  );
+
+  test('rejects effective duplicate legacy rows before upstream deletion', async () => {
+    const actor = await insertTestUser({ is_admin: true });
+    const owner = await insertTestUser();
+    const row = await integration({ userId: owner.id });
+    const otherOwner = await insertTestUser();
+    await integration({ userId: otherOwner.id }, { github_app_type: null });
+    await expect(
+      uninstallGitHubOrganizationInstallation({
+        input: request(row, { type: 'user', id: owner.id }),
+        actor: { id: actor.id, email: actor.google_user_email, name: actor.google_user_name },
+      })
+    ).rejects.toThrow('Refresh before retrying');
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  test('serializes admin revocation and target reassignment during upstream deletion', async () => {
+    const actor = await insertTestUser({ is_admin: true });
+    const owner = await insertTestUser();
+    const replacementOwner = await insertTestUser();
+    const row = await integration({ userId: owner.id });
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    upstream.mockImplementation(async () => {
+      entered.resolve();
+      await release.promise;
+    });
+    const uninstall = uninstallGitHubOrganizationInstallation({
+      input: request(row, { type: 'user', id: owner.id }),
+      actor: { id: actor.id, email: actor.google_user_email, name: actor.google_user_name },
+    });
+
+    try {
+      await Promise.race([
+        entered.promise,
+        uninstall.then(() => {
+          throw new Error('Uninstall completed without the expected upstream gate');
+        }),
+      ]);
+      await expect(
+        db.transaction(async tx => {
+          await tx.execute(sql`SET LOCAL lock_timeout = '100ms'`);
+          await tx
+            .update(kilocode_users)
+            .set({ is_admin: false })
+            .where(eq(kilocode_users.id, actor.id));
+        })
+      ).rejects.toThrow();
+      await expect(
+        db.transaction(async tx => {
+          await tx.execute(sql`SET LOCAL lock_timeout = '100ms'`);
+          await tx
+            .update(platform_integrations)
+            .set({ owned_by_user_id: replacementOwner.id })
+            .where(eq(platform_integrations.id, row.id));
+        })
+      ).rejects.toThrow();
+    } finally {
+      release.resolve();
+      await uninstall;
+    }
+    expect(upstream).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns pending and retains local row when confirmed cleanup transaction fails', async () => {
+    const actor = await insertTestUser({ is_admin: true });
+    const owner = await insertTestUser();
+    const org = await createTestOrganization('Uninstall pending org', owner.id, 0);
+    const row = await integration({ organizationId: org.id });
+    audit.mockImplementationOnce(
+      jest.requireActual('@/lib/organizations/organization-audit-logs').createAuditLog
+    );
+    audit.mockRejectedValueOnce(new Error('final audit private database error'));
+    audit.mockImplementationOnce(
+      jest.requireActual('@/lib/organizations/organization-audit-logs').createAuditLog
+    );
+
+    await expect(
+      uninstallGitHubOrganizationInstallation({
+        input: request(row, { type: 'organization', id: org.id }),
+        actor: { id: actor.id, email: actor.google_user_email, name: actor.google_user_name },
+      })
+    ).resolves.toEqual({ status: 'uninstalled', localCleanup: 'pending' });
+    expect(
+      await db.query.platform_integrations.findFirst({
+        where: eq(platform_integrations.id, row.id),
+      })
+    ).toBeDefined();
+    const audits = await db
+      .select()
+      .from(organization_audit_logs)
+      .where(eq(organization_audit_logs.organization_id, org.id));
+    expect(audits.map(entry => entry.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('uninstall attempted'),
+        expect.stringContaining('confirmed; local cleanup pending'),
+      ])
+    );
+  });
+
+  test('standard deletion webhook reconciles a legacy row retained after local cleanup rolls back', async () => {
+    const actor = await insertTestUser({ is_admin: true });
+    const owner = await insertTestUser();
+    const org = await createTestOrganization('Uninstall webhook reconciliation org', owner.id, 0);
+    const row = await integration({ organizationId: org.id }, { github_app_type: null });
+    audit.mockImplementationOnce(
+      jest.requireActual('@/lib/organizations/organization-audit-logs').createAuditLog
+    );
+    audit.mockRejectedValueOnce(new Error('final audit private database error'));
+    audit.mockImplementationOnce(
+      jest.requireActual('@/lib/organizations/organization-audit-logs').createAuditLog
+    );
+
+    await expect(
+      uninstallGitHubOrganizationInstallation({
+        input: request(row, { type: 'organization', id: org.id }),
+        actor: { id: actor.id, email: actor.google_user_email, name: actor.google_user_name },
+      })
+    ).resolves.toEqual({ status: 'uninstalled', localCleanup: 'pending' });
+    expect(
+      await db.query.platform_integrations.findFirst({
+        where: eq(platform_integrations.id, row.id),
+      })
+    ).toBeDefined();
+
+    const { handleInstallationDeleted } =
+      await import('@/lib/integrations/platforms/github/webhook-handlers/installation-handler');
+    await handleInstallationDeleted(
+      { action: 'deleted', installation: { id: 123 } } as never,
+      'standard'
+    );
+
+    expect(
+      await db.query.platform_integrations.findFirst({
+        where: eq(platform_integrations.id, row.id),
+      })
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/admin/github-installation-uninstall.ts
+++ b/apps/web/src/lib/admin/github-installation-uninstall.ts
@@ -1,0 +1,215 @@
+import 'server-only';
+
+import { and, eq, isNull, or } from 'drizzle-orm';
+import { TRPCError } from '@trpc/server';
+import { db, type DrizzleTransaction } from '@/lib/drizzle';
+import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
+import { verifyAndDeleteGitHubOrganizationInstallation } from '@/lib/integrations/platforms/github/adapter';
+import { kilocode_users, platform_integrations, user_admin_notes } from '@kilocode/db/schema';
+import type { GitHubInstallationUninstallInput } from './github-installation-uninstall-input';
+
+const RETRY_MESSAGE =
+  'GitHub installation uninstall could not be confirmed. Refresh before retrying.';
+
+type Actor = { id: string; email: string; name: string | null };
+type LocalRecord = {
+  id: string;
+  ownerType: 'user' | 'organization';
+  ownerId: string;
+  appType: 'standard' | 'lite';
+  installationId: string;
+  accountId: string;
+};
+
+function uninstallError(code: 'BAD_REQUEST' | 'FORBIDDEN' | 'CONFLICT' = 'CONFLICT') {
+  return new TRPCError({ code, message: RETRY_MESSAGE });
+}
+
+type AuditStatus = 'attempted' | 'confirmed' | 'unconfirmed' | 'confirmed; local cleanup pending';
+
+function auditMessage(record: LocalRecord, status: AuditStatus) {
+  return `GitHub ${record.appType} App integration ${record.id} installation ${record.installationId} (${record.accountId}) uninstall ${status}.`;
+}
+
+async function writeAudit(
+  executor: typeof db | DrizzleTransaction,
+  actor: Actor,
+  record: LocalRecord,
+  status: AuditStatus
+) {
+  if (record.ownerType === 'organization') {
+    const audit = {
+      organization_id: record.ownerId,
+      action: 'organization.settings.change',
+      actor_id: actor.id,
+      actor_email: actor.email,
+      actor_name: actor.name,
+      message: auditMessage(record, status),
+    } as const;
+    if (executor === db) await createAuditLog(audit);
+    else await createAuditLog({ ...audit, tx: executor as DrizzleTransaction });
+    return;
+  }
+  await executor.insert(user_admin_notes).values({
+    kilo_user_id: record.ownerId,
+    admin_kilo_user_id: actor.id,
+    note_content: auditMessage(record, status),
+  });
+}
+
+async function tryWriteAudit(params: { actor: Actor; record: LocalRecord; status: AuditStatus }) {
+  try {
+    await writeAudit(db, params.actor, params.record, params.status);
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+function recordMatchesInput(record: LocalRecord, input: GitHubInstallationUninstallInput) {
+  return (
+    record.id === input.integrationId &&
+    record.ownerType === input.owner.type &&
+    record.ownerId === input.owner.id &&
+    record.appType === input.appType &&
+    record.installationId === input.installationId &&
+    record.accountId === input.accountId
+  );
+}
+
+async function lockRecord(tx: DrizzleTransaction, input: GitHubInstallationUninstallInput) {
+  const rows = await tx
+    .select({
+      id: platform_integrations.id,
+      platform: platform_integrations.platform,
+      userId: platform_integrations.owned_by_user_id,
+      organizationId: platform_integrations.owned_by_organization_id,
+      appType: platform_integrations.github_app_type,
+      installationId: platform_integrations.platform_installation_id,
+      accountId: platform_integrations.platform_account_id,
+    })
+    .from(platform_integrations)
+    .where(eq(platform_integrations.id, input.integrationId))
+    .for('update');
+  const row = rows[0];
+  if (
+    !row ||
+    row.platform !== 'github' ||
+    !row.installationId ||
+    !row.accountId ||
+    (!row.userId && !row.organizationId) ||
+    (row.userId && row.organizationId)
+  ) {
+    throw uninstallError();
+  }
+  const record: LocalRecord = {
+    id: row.id,
+    ownerType: row.userId ? 'user' : 'organization',
+    ownerId: row.userId ?? row.organizationId ?? '',
+    appType: row.appType ?? 'standard',
+    installationId: row.installationId,
+    accountId: row.accountId,
+  };
+  if (!recordMatchesInput(record, input)) throw uninstallError();
+  return record;
+}
+
+async function rejectEffectiveDuplicates(tx: DrizzleTransaction, record: LocalRecord) {
+  const rows = await tx
+    .select({ id: platform_integrations.id })
+    .from(platform_integrations)
+    .where(
+      and(
+        eq(platform_integrations.platform, 'github'),
+        eq(platform_integrations.platform_installation_id, record.installationId),
+        record.appType === 'standard'
+          ? or(
+              eq(platform_integrations.github_app_type, 'standard'),
+              isNull(platform_integrations.github_app_type)
+            )
+          : eq(platform_integrations.github_app_type, 'lite')
+      )
+    )
+    .limit(2);
+  if (rows.length !== 1 || rows[0]?.id !== record.id) throw uninstallError();
+}
+
+async function requireFreshActiveAdmin(tx: DrizzleTransaction, actorId: string) {
+  const [admin] = await tx
+    .select({ isAdmin: kilocode_users.is_admin, blockedReason: kilocode_users.blocked_reason })
+    .from(kilocode_users)
+    .where(eq(kilocode_users.id, actorId))
+    .limit(1)
+    .for('share');
+  if (!admin || !admin.isAdmin || admin.blockedReason !== null) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'Admin access required' });
+  }
+}
+
+export async function uninstallGitHubOrganizationInstallation(params: {
+  input: GitHubInstallationUninstallInput;
+  actor: Actor;
+}): Promise<{ status: 'uninstalled'; localCleanup: 'complete' | 'pending' }> {
+  let record: LocalRecord;
+  try {
+    record = await db.transaction(async tx => {
+      await requireFreshActiveAdmin(tx, params.actor.id);
+      return lockRecord(tx, params.input);
+    });
+  } catch (error) {
+    if (error instanceof TRPCError) throw error;
+    throw uninstallError();
+  }
+
+  try {
+    await writeAudit(db, params.actor, record, 'attempted');
+  } catch {
+    throw uninstallError();
+  }
+
+  let upstreamDeleted = false;
+  try {
+    await db.transaction(async tx => {
+      await requireFreshActiveAdmin(tx, params.actor.id);
+      const locked = await lockRecord(tx, params.input);
+      await rejectEffectiveDuplicates(tx, locked);
+      await verifyAndDeleteGitHubOrganizationInstallation({
+        installationId: locked.installationId,
+        accountId: locked.accountId,
+        appType: locked.appType,
+      });
+      upstreamDeleted = true;
+      const deleted = await tx
+        .delete(platform_integrations)
+        .where(
+          and(
+            eq(platform_integrations.id, locked.id),
+            eq(platform_integrations.platform, 'github'),
+            eq(platform_integrations.platform_installation_id, locked.installationId),
+            eq(platform_integrations.platform_account_id, locked.accountId),
+            locked.appType === 'standard'
+              ? or(
+                  eq(platform_integrations.github_app_type, 'standard'),
+                  isNull(platform_integrations.github_app_type)
+                )
+              : eq(platform_integrations.github_app_type, 'lite')
+          )
+        );
+      if ((deleted.rowCount ?? 0) !== 1) throw uninstallError();
+      await writeAudit(tx, params.actor, locked, 'confirmed');
+    });
+    return { status: 'uninstalled', localCleanup: 'complete' };
+  } catch (error) {
+    if (error instanceof TRPCError && error.code === 'FORBIDDEN') throw error;
+    if (upstreamDeleted) {
+      await tryWriteAudit({
+        actor: params.actor,
+        record,
+        status: 'confirmed; local cleanup pending',
+      });
+      return { status: 'uninstalled', localCleanup: 'pending' };
+    }
+    await tryWriteAudit({ actor: params.actor, record, status: 'unconfirmed' });
+    throw uninstallError();
+  }
+}

--- a/apps/web/src/lib/integrations/db/platform-integrations.test.ts
+++ b/apps/web/src/lib/integrations/db/platform-integrations.test.ts
@@ -4,6 +4,7 @@ import { platform_integrations, kilocode_users, organizations } from '@kilocode/
 import { and, eq } from 'drizzle-orm';
 import {
   deleteIntegration,
+  deleteGitHubInstallationRecords,
   deleteIntegrationForOwner,
   createPendingIntegration,
   findIntegrationByInstallationId,
@@ -513,6 +514,124 @@ describe('upsertPlatformIntegrationForOwner', () => {
       expect(rows).toHaveLength(1);
       expect(rows[0].platform_installation_id).toBe(siblingInstallId);
       expect(rows[0].github_app_type).toBe('lite');
+    });
+
+    test('deleteGitHubInstallationRecords deletes all effective standard rows for one installation', async () => {
+      await db.insert(platform_integrations).values([
+        {
+          owned_by_user_id: userId,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: destructiveInstallId,
+          platform_account_id: '1000',
+          platform_account_login: 'user-standard',
+          repository_access: 'all',
+          integration_status: 'active',
+          github_app_type: 'standard',
+        },
+        {
+          owned_by_user_id: otherUserId,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: destructiveInstallId,
+          platform_account_id: '2000',
+          platform_account_login: 'user-legacy-standard',
+          repository_access: 'all',
+          integration_status: 'active',
+          github_app_type: null,
+        },
+        {
+          owned_by_organization_id: orgId,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: destructiveInstallId,
+          platform_account_id: '3000',
+          platform_account_login: 'org-lite',
+          repository_access: 'all',
+          integration_status: 'active',
+          github_app_type: 'lite',
+        },
+        {
+          owned_by_organization_id: otherOrgId,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: siblingInstallId,
+          platform_account_id: '4000',
+          platform_account_login: 'org-unrelated-standard',
+          repository_access: 'all',
+          integration_status: 'active',
+          github_app_type: 'standard',
+        },
+      ]);
+
+      await deleteGitHubInstallationRecords(destructiveInstallId, 'standard');
+
+      expect(await getRowsByInstallId()).toEqual([
+        expect.objectContaining({
+          platform_installation_id: destructiveInstallId,
+          github_app_type: 'lite',
+        }),
+      ]);
+      expect(
+        await db
+          .select()
+          .from(platform_integrations)
+          .where(eq(platform_integrations.platform_installation_id, siblingInstallId))
+      ).toEqual([
+        expect.objectContaining({
+          github_app_type: 'standard',
+          owned_by_organization_id: otherOrgId,
+        }),
+      ]);
+    });
+
+    test('deleteGitHubInstallationRecords deletes only lite rows for a lite webhook', async () => {
+      await db.insert(platform_integrations).values([
+        {
+          owned_by_user_id: userId,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: destructiveInstallId,
+          platform_account_id: '1000',
+          platform_account_login: 'user-standard',
+          repository_access: 'all',
+          integration_status: 'active',
+          github_app_type: 'standard',
+        },
+        {
+          owned_by_user_id: otherUserId,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: destructiveInstallId,
+          platform_account_id: '2000',
+          platform_account_login: 'user-legacy-standard',
+          repository_access: 'all',
+          integration_status: 'active',
+          github_app_type: null,
+        },
+        {
+          owned_by_organization_id: orgId,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: destructiveInstallId,
+          platform_account_id: '3000',
+          platform_account_login: 'org-lite',
+          repository_access: 'all',
+          integration_status: 'active',
+          github_app_type: 'lite',
+        },
+      ]);
+
+      await deleteGitHubInstallationRecords(destructiveInstallId, 'lite');
+
+      const rows = await getRowsByInstallId();
+      expect(rows).toHaveLength(2);
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ github_app_type: 'standard' }),
+          expect.objectContaining({ github_app_type: null }),
+        ])
+      );
     });
 
     test('suspendIntegration with app type leaves the owner sibling app-type row active', async () => {

--- a/apps/web/src/lib/integrations/db/platform-integrations.ts
+++ b/apps/web/src/lib/integrations/db/platform-integrations.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/drizzle';
 import { platform_integrations } from '@kilocode/db/schema';
-import { eq, and, isNull, asc, desc, sql } from 'drizzle-orm';
+import { eq, and, or, isNull, asc, desc, sql } from 'drizzle-orm';
 import type {
   GitHubRequester,
   IntegrationPermissions,
@@ -361,6 +361,29 @@ export async function deleteIntegration(
   }
 
   await db.delete(platform_integrations).where(and(...conditions));
+}
+
+export async function deleteGitHubInstallationRecords(
+  installationId: string,
+  githubAppType: GitHubAppType
+) {
+  const appTypeCondition =
+    githubAppType === 'standard'
+      ? or(
+          eq(platform_integrations.github_app_type, githubAppType),
+          isNull(platform_integrations.github_app_type)
+        )
+      : eq(platform_integrations.github_app_type, githubAppType);
+
+  await db
+    .delete(platform_integrations)
+    .where(
+      and(
+        eq(platform_integrations.platform, PLATFORM.GITHUB),
+        eq(platform_integrations.platform_installation_id, installationId),
+        appTypeCondition
+      )
+    );
 }
 
 /**

--- a/apps/web/src/lib/integrations/platforms/github/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.ts
@@ -117,6 +117,54 @@ export async function deleteGitHubInstallation(
   });
 }
 
+export async function verifyAndDeleteGitHubOrganizationInstallation(params: {
+  installationId: string;
+  accountId: string;
+  appType: GitHubAppType;
+}): Promise<void> {
+  const credentials = getGitHubAppCredentials(params.appType);
+  if (!credentials.appId || !credentials.privateKey)
+    throw new Error('GitHub App credentials unavailable');
+  const installationId = Number(params.installationId);
+  const accountId = Number(params.accountId);
+  if (!Number.isSafeInteger(installationId) || !Number.isSafeInteger(accountId)) {
+    throw new Error('GitHub installation identity unavailable');
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8_000);
+  try {
+    const auth = createAppAuth({ appId: credentials.appId, privateKey: credentials.privateKey });
+    const { token } = await auth({ type: 'app' });
+    const octokit = new Octokit({
+      auth: token,
+      log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    });
+    const installation = await octokit.apps.getInstallation({
+      installation_id: installationId,
+      request: { signal: controller.signal },
+    });
+    const account = installation.data.account;
+    if (
+      installation.data.id !== installationId ||
+      account?.id !== accountId ||
+      !account ||
+      !('type' in account) ||
+      account.type !== 'Organization' ||
+      (installation.data.app_id !== undefined &&
+        installation.data.app_id.toString() !== credentials.appId)
+    ) {
+      throw new Error('GitHub installation identity mismatch');
+    }
+    const deleted = await octokit.apps.deleteInstallation({
+      installation_id: installationId,
+      request: { signal: controller.signal },
+    });
+    if (deleted.status !== 204) throw new Error('GitHub installation deletion not confirmed');
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 type GitHubRepository = {
   id: number;
   name: string;

--- a/apps/web/src/lib/integrations/platforms/github/adapter.uninstall.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.uninstall.test.ts
@@ -1,0 +1,128 @@
+jest.mock('@octokit/auth-app', () => ({ createAppAuth: jest.fn() }));
+jest.mock('@octokit/rest', () => ({
+  Octokit: jest.fn(),
+}));
+jest.mock('./app-selector', () => ({ getGitHubAppCredentials: jest.fn() }));
+
+import { createAppAuth } from '@octokit/auth-app';
+import { Octokit } from '@octokit/rest';
+import { getGitHubAppCredentials } from './app-selector';
+import { verifyAndDeleteGitHubOrganizationInstallation } from './adapter';
+
+const mockGetInstallation = jest.fn();
+const mockDeleteInstallation = jest.fn();
+const mockAuth = jest.fn();
+
+describe('verifyAndDeleteGitHubOrganizationInstallation', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    jest.mocked(createAppAuth).mockReturnValue(mockAuth as never);
+    jest.mocked(Octokit).mockImplementation(
+      () =>
+        ({
+          apps: {
+            getInstallation: mockGetInstallation,
+            deleteInstallation: mockDeleteInstallation,
+          },
+        }) as never
+    );
+    jest.mocked(getGitHubAppCredentials).mockReturnValue({
+      appId: '42',
+      privateKey: 'private-key',
+    } as never);
+    mockAuth.mockResolvedValue({ token: 'app-token' });
+    mockGetInstallation.mockResolvedValue({
+      data: { id: 123, app_id: 42, account: { id: 456, type: 'Organization' } },
+    });
+    mockDeleteInstallation.mockResolvedValue({ status: 204 });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('gets the exact app installation before deleting it with silent logging', async () => {
+    await verifyAndDeleteGitHubOrganizationInstallation({
+      installationId: '123',
+      accountId: '456',
+      appType: 'standard',
+    });
+    expect(mockGetInstallation).toHaveBeenCalledWith(
+      expect.objectContaining({ installation_id: 123 })
+    );
+    expect(mockDeleteInstallation).toHaveBeenCalledWith(
+      expect.objectContaining({ installation_id: 123 })
+    );
+    expect(Octokit).toHaveBeenCalledWith(
+      expect.objectContaining({ log: expect.objectContaining({ debug: expect.any(Function) }) })
+    );
+    const options = jest.mocked(Octokit).mock.calls[0]?.[0] as {
+      log: { error: (message: string) => void };
+    };
+    expect(() => options.log.error('private-key app-token')).not.toThrow();
+  });
+
+  test.each([
+    { id: 999, app_id: 42, account: { id: 456, type: 'Organization' } },
+    { id: 123, app_id: 42, account: { id: 999, type: 'Organization' } },
+    { id: 123, app_id: 42, account: { id: 456, type: 'User' } },
+    { id: 123, app_id: 999, account: { id: 456, type: 'Organization' } },
+  ])('refuses mismatched upstream identity', async data => {
+    mockGetInstallation.mockResolvedValue({ data });
+    await expect(
+      verifyAndDeleteGitHubOrganizationInstallation({
+        installationId: '123',
+        accountId: '456',
+        appType: 'standard',
+      })
+    ).rejects.toThrow('identity mismatch');
+    expect(mockDeleteInstallation).not.toHaveBeenCalled();
+  });
+
+  test('rejects unavailable credentials and non-204 delete responses', async () => {
+    jest.mocked(getGitHubAppCredentials).mockReturnValue({ appId: '', privateKey: '' } as never);
+    await expect(
+      verifyAndDeleteGitHubOrganizationInstallation({
+        installationId: '123',
+        accountId: '456',
+        appType: 'lite',
+      })
+    ).rejects.toThrow('credentials unavailable');
+    mockDeleteInstallation.mockResolvedValue({ status: 202 });
+    jest.mocked(getGitHubAppCredentials).mockReturnValue({
+      appId: '42',
+      privateKey: 'private-key',
+    } as never);
+    await expect(
+      verifyAndDeleteGitHubOrganizationInstallation({
+        installationId: '123',
+        accountId: '456',
+        appType: 'lite',
+      })
+    ).rejects.toThrow('deletion not confirmed');
+  });
+
+  test('aborts both upstream calls at the bounded deadline', async () => {
+    jest.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    mockGetInstallation.mockImplementation(({ request }) => {
+      signal = request.signal;
+      return new Promise((_, reject) => {
+        request.signal.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError'))
+        );
+      });
+    });
+    const result = verifyAndDeleteGitHubOrganizationInstallation({
+      installationId: '123',
+      accountId: '456',
+      appType: 'standard',
+    });
+    void result.catch(() => {});
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(8_000);
+    expect(signal?.aborted).toBe(true);
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/installation-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/installation-handler.test.ts
@@ -25,24 +25,8 @@ const mockFindIntegrationByInstallationId =
       appType: GitHubAppType
     ) => Promise<GitHubIntegrationRow | null>
   >();
-const mockDeleteIntegration =
-  jest.fn<
-    (
-      organizationId: string,
-      platform: string,
-      appType: GitHubAppType,
-      installationId?: string
-    ) => Promise<void>
-  >();
-const mockDeleteIntegrationForOwner =
-  jest.fn<
-    (
-      owner: GitHubOwner,
-      platform: string,
-      appType: GitHubAppType,
-      installationId?: string
-    ) => Promise<void>
-  >();
+const mockDeleteGitHubInstallationRecords =
+  jest.fn<(installationId: string, appType: GitHubAppType) => Promise<void>>();
 const mockSuspendIntegration =
   jest.fn<
     (
@@ -104,18 +88,8 @@ jest.mock('@/lib/integrations/db/platform-integrations', () => ({
     appType: GitHubAppType
   ) => mockFindIntegrationByInstallationId(platform, installationId, appType),
   autoCompleteInstallation: jest.fn(),
-  deleteIntegration: (
-    organizationId: string,
-    platform: string,
-    appType: GitHubAppType,
-    installationId?: string
-  ) => mockDeleteIntegration(organizationId, platform, appType, installationId),
-  deleteIntegrationForOwner: (
-    owner: GitHubOwner,
-    platform: string,
-    appType: GitHubAppType,
-    installationId?: string
-  ) => mockDeleteIntegrationForOwner(owner, platform, appType, installationId),
+  deleteGitHubInstallationRecords: (installationId: string, appType: GitHubAppType) =>
+    mockDeleteGitHubInstallationRecords(installationId, appType),
   suspendIntegration: (
     organizationId: string,
     platform: string,
@@ -219,39 +193,25 @@ describe('handleInstallationDeleted', () => {
     mockBotInitialize.mockResolvedValue(undefined);
     mockBotGetState.mockReturnValue({});
     mockUnlinkTeamKiloUsers.mockResolvedValue(0);
-    mockDeleteIntegration.mockResolvedValue(undefined);
-    mockDeleteIntegrationForOwner.mockResolvedValue(undefined);
+    mockDeleteGitHubInstallationRecords.mockResolvedValue(undefined);
   });
 
   it('standard app deletion unlinks bot identities and passes the app type', async () => {
-    mockFindIntegrationByInstallationId.mockResolvedValue(orgIntegration);
-
     const response = await handleInstallationDeleted(deletedPayload, 'standard');
 
     expect(response.status).toBe(200);
-    expect(mockFindIntegrationByInstallationId).toHaveBeenCalledWith('github', '98765', 'standard');
     expect(mockBotInitialize).toHaveBeenCalled();
     expect(mockUnlinkTeamKiloUsers).toHaveBeenCalledWith(expect.anything(), 'github', '98765');
-    expect(mockDeleteIntegration).toHaveBeenCalledWith('org_1', 'github', 'standard', '98765');
-    expect(mockDeleteIntegrationForOwner).not.toHaveBeenCalled();
+    expect(mockDeleteGitHubInstallationRecords).toHaveBeenCalledWith('98765', 'standard');
   });
 
   it('lite app deletion does not unlink bot identities and passes the app type', async () => {
-    mockFindIntegrationByInstallationId.mockResolvedValue(userIntegration);
-
     const response = await handleInstallationDeleted(deletedPayload, 'lite');
 
     expect(response.status).toBe(200);
-    expect(mockFindIntegrationByInstallationId).toHaveBeenCalledWith('github', '98765', 'lite');
     expect(mockBotInitialize).not.toHaveBeenCalled();
     expect(mockUnlinkTeamKiloUsers).not.toHaveBeenCalled();
-    expect(mockDeleteIntegrationForOwner).toHaveBeenCalledWith(
-      { type: 'user', id: 'user_1' },
-      'github',
-      'lite',
-      '98765'
-    );
-    expect(mockDeleteIntegration).not.toHaveBeenCalled();
+    expect(mockDeleteGitHubInstallationRecords).toHaveBeenCalledWith('98765', 'lite');
   });
 });
 

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/installation-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/installation-handler.ts
@@ -6,11 +6,10 @@ import {
   findIntegrationByInstallationId,
   suspendIntegration,
   unsuspendIntegration,
-  deleteIntegration,
+  deleteGitHubInstallationRecords,
   autoCompleteInstallation,
   suspendIntegrationForOwner,
   unsuspendIntegrationForOwner,
-  deleteIntegrationForOwner,
   updateRepositoriesForIntegration,
 } from '@/lib/integrations/db/platform-integrations';
 import { fetchGitHubRepositories } from '../adapter';
@@ -133,15 +132,6 @@ export async function handleInstallationDeleted(
 ) {
   const installationIdStr = payload.installation.id.toString();
 
-  // Find and delete the integration (whether completed or pending). The
-  // webhook is signed by a specific GitHub App, so scope the lookup by app
-  // type to avoid deleting the other app's row for the same installation ID.
-  const integrationToDelete = await findIntegrationByInstallationId(
-    PLATFORM.GITHUB,
-    installationIdStr,
-    appType
-  );
-
   try {
     // The bot identity store has no app-type dimension and the lite app has no
     // bot-link flow, so only the standard app unlinks team bot identities.
@@ -156,34 +146,7 @@ export async function handleInstallationDeleted(
     });
   }
 
-  if (integrationToDelete) {
-    // Determine owner from the integration record
-    if (integrationToDelete.owned_by_organization_id) {
-      await deleteIntegration(
-        integrationToDelete.owned_by_organization_id,
-        PLATFORM.GITHUB,
-        appType,
-        installationIdStr
-      );
-      logExceptInTest('Deleted organization installation:', {
-        installation_id: installationIdStr,
-        owned_by_organization_id: integrationToDelete.owned_by_organization_id,
-      });
-    } else if (integrationToDelete.owned_by_user_id) {
-      await deleteIntegrationForOwner(
-        { type: 'user', id: integrationToDelete.owned_by_user_id },
-        PLATFORM.GITHUB,
-        appType,
-        installationIdStr
-      );
-      logExceptInTest('Deleted user installation:', {
-        installation_id: installationIdStr,
-        owned_by_user_id: integrationToDelete.owned_by_user_id,
-      });
-    } else {
-      console.error('Integration found but has no owner:', integrationToDelete.id);
-    }
-  }
+  await deleteGitHubInstallationRecords(installationIdStr, appType);
 
   return NextResponse.json({ message: 'Installation removed' }, { status: 200 });
 }

--- a/apps/web/src/routers/admin-github-router.test.ts
+++ b/apps/web/src/routers/admin-github-router.test.ts
@@ -8,6 +8,7 @@ import {
   getKilocodeRepoRecentlyClosedExternalPRs,
 } from '@/lib/github/open-pull-request-counts';
 import { lookupGitHubOrganizationInstallation } from '@/lib/admin/github-installation-lookup';
+import { uninstallGitHubOrganizationInstallation } from '@/lib/admin/github-installation-uninstall';
 import { setAdminAccessSinkForTest } from '@/lib/admin/admin-access-log';
 
 jest.mock('@/lib/github/open-pull-request-counts', () => ({
@@ -20,6 +21,10 @@ jest.mock('@/lib/github/open-pull-request-counts', () => ({
 
 jest.mock('@/lib/admin/github-installation-lookup', () => ({
   lookupGitHubOrganizationInstallation: jest.fn(),
+}));
+
+jest.mock('@/lib/admin/github-installation-uninstall', () => ({
+  uninstallGitHubOrganizationInstallation: jest.fn(),
 }));
 
 let regularUser: User;
@@ -141,6 +146,51 @@ describe('admin.github.lookupOrganizationInstallation', () => {
       caller.admin.github.lookupOrganizationInstallation({ organization: 'acme--tools' })
     ).rejects.toThrow('Enter a valid GitHub organization login');
     expect(lookupGitHubOrganizationInstallation).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin.github.uninstallOrganizationInstallation', () => {
+  const input = {
+    integrationId: '12345678-1234-4234-9234-123456789abc',
+    installationId: '123',
+    accountId: '456',
+    appType: 'standard' as const,
+    owner: { type: 'user' as const, id: 'oauth/github|arbitrary-user-id' },
+    confirmation: '123',
+  };
+
+  it('denies anonymous callers before local or upstream work', async () => {
+    const createCaller = createCallerFactory(rootRouter);
+    const caller = createCaller({ user: null } as never);
+
+    await expect(caller.admin.github.uninstallOrganizationInstallation(input)).rejects.toThrow();
+    expect(uninstallGitHubOrganizationInstallation).not.toHaveBeenCalled();
+  });
+
+  it('denies non-admin callers before local or upstream work', async () => {
+    const caller = await createCallerForUser(regularUser.id);
+
+    await expect(caller.admin.github.uninstallOrganizationInstallation(input)).rejects.toThrow(
+      'Admin access required'
+    );
+    expect(uninstallGitHubOrganizationInstallation).not.toHaveBeenCalled();
+  });
+
+  it('passes the exact, client-safe snapshot to the guarded helper', async () => {
+    (uninstallGitHubOrganizationInstallation as jest.Mock).mockResolvedValue({
+      status: 'uninstalled',
+      localCleanup: 'complete',
+    });
+    const caller = await createCallerForUser(adminUser.id);
+
+    await expect(caller.admin.github.uninstallOrganizationInstallation(input)).resolves.toEqual({
+      status: 'uninstalled',
+      localCleanup: 'complete',
+    });
+    expect(uninstallGitHubOrganizationInstallation).toHaveBeenCalledWith({
+      input,
+      actor: expect.objectContaining({ id: adminUser.id }),
+    });
   });
 });
 

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -145,6 +145,8 @@ import {
 } from '@/lib/github/open-pull-request-counts';
 import { GitHubOrganizationInstallationLookupInputSchema } from '@/lib/admin/github-installation-lookup-input';
 import { lookupGitHubOrganizationInstallation } from '@/lib/admin/github-installation-lookup';
+import { GitHubInstallationUninstallInputSchema } from '@/lib/admin/github-installation-uninstall-input';
+import { uninstallGitHubOrganizationInstallation } from '@/lib/admin/github-installation-uninstall';
 
 const SyncResponseSchema = z.object({
   success: z.boolean(),
@@ -522,6 +524,18 @@ export const adminRouter = createTRPCRouter({
             message: 'GitHub installation lookup failed',
           });
         }
+      }),
+    uninstallOrganizationInstallation: adminProcedure
+      .input(GitHubInstallationUninstallInputSchema)
+      .mutation(async ({ ctx, input }) => {
+        return uninstallGitHubOrganizationInstallation({
+          input,
+          actor: {
+            id: ctx.user.id,
+            email: ctx.user.google_user_email,
+            name: ctx.user.google_user_name,
+          },
+        });
       }),
     getKilocodeOpenPullRequestCounts: adminProcedure.query(async () => {
       return getKilocodeRepoOpenPullRequestCounts({ ttlMs: 2 * 60_000 });


### PR DESCRIPTION
## Summary

Follow-up to #5861.

- Add an employee-admin **Uninstall GitHub App** action for verified, locally associated GitHub organization installations. Require the exact installation ID as confirmation and explain repository-access impact and retained Kilo history/settings.
- Recheck current admin access and the selected owner/app/installation/account snapshot under database locks, then verify the upstream installation by ID before deleting it. Only GitHub 204 permits local cleanup; permission errors, missing installations, and timeouts remain unconfirmed.
- Persist owner-specific attempt/outcome audits, distinguish confirmed GitHub deletion from incomplete local cleanup, and prevent immediate retries using stale lookup results.
- Reconcile signed installation-deleted webhooks by exact installation and app scope, including legacy standard-app records with null app type, without touching Lite or sibling installations.
- No schema changes, new dependencies, customer-admin permissions, local-only disconnect, or user OAuth-grant revocation.

## Verification

- [x] Browser-checked with synthetic local identities and mocked destructive responses; no real GitHub installations were removed.
- [x] Checked typed confirmation, safe cancellation, exact target submission, pending-state locks, and refreshing the submitted organization rather than edited input.
- [x] Checked error retry lockout, stale-action removal, and preservation of partial-cleanup warnings when refresh fails.
- [x] Checked confirmation-dialog layouts at 375px, 900px, and 1440px.
- [x] Verified actual HTTP rejection of anonymous callers (401) and non-admin callers (403).

## Visual Changes

New uninstall action on eligible association rows, destructive confirmation dialog, and outcome feedback. Screenshots omitted as requested.

## Reviewer Notes

- Independent static review and re-review completed without remaining feature-specific blockers. Findings drove authorization locking, duplicate detection, retry lockout, and legacy webhook reconciliation fixes.
- Only verified local associations are eligible; orphan installations and uncertain/candidate records do not get destructive controls. Existing agent settings and history are retained.
- GitHub and PostgreSQL are not atomic. A confirmed uninstall with failed local cleanup is reported explicitly; the deletion webhook normally reconciles it, with manual investigation required if the row persists.
- Completed focused automated runs: uninstall/UI/router/adapter tests (5 suites, 50 tests) and lifecycle/database/uninstall tests (3 suites, 50 tests; overlapping coverage). Tests include stale identities, revoked/blocked admins, lock serialization, 401/403/404/timeouts, partial cleanup, audit attribution, legacy records, and sibling preservation.
- Formatting, web lint, and diff whitespace checks passed. The final typecheck found Jest mock-signature errors in the added test; those signatures were corrected afterward. No further check was run after the request to stop testing.
- Broader combined test attempts timed out or were interrupted and are not claimed as passing. All DB-backed checks used the isolated worktree database prepared with `pnpm test:db`.