### PR TITLE
fix(admin): report GitHub uninstall audit failures

### DIFF
--- a/apps/web/src/lib/admin/github-installation-uninstall.test.ts
+++ b/apps/web/src/lib/admin/github-installation-uninstall.test.ts
@@ -10,6 +10,7 @@ import {
   user_admin_notes,
 } from '@kilocode/db/schema';
 import { eq, sql } from 'drizzle-orm';
+import { captureException } from '@sentry/nextjs';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
 import { verifyAndDeleteGitHubOrganizationInstallation } from '@/lib/integrations/platforms/github/adapter';
 import { uninstallGitHubOrganizationInstallation } from './github-installation-uninstall';
@@ -21,6 +22,8 @@ const mockUnlinkTeamKiloUsers = jest.fn<Promise<number>, []>();
 jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
   verifyAndDeleteGitHubOrganizationInstallation: jest.fn(),
 }));
+
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
 
 jest.mock('@/lib/organizations/organization-audit-logs', () => {
   const actual = jest.requireActual('@/lib/organizations/organization-audit-logs');
@@ -40,6 +43,7 @@ jest.mock('@/lib/bot-identity', () => ({
 
 const upstream = jest.mocked(verifyAndDeleteGitHubOrganizationInstallation);
 const audit = jest.mocked(createAuditLog);
+const sentryCaptureException = jest.mocked(captureException);
 
 async function integration(owner: { userId?: string; organizationId?: string }, overrides = {}) {
   const [row] = await db
@@ -84,6 +88,7 @@ describe('uninstallGitHubOrganizationInstallation', () => {
     audit.mockImplementation(
       jest.requireActual('@/lib/organizations/organization-audit-logs').createAuditLog
     );
+    sentryCaptureException.mockReset();
     mockBotInitialize.mockResolvedValue();
     mockBotGetState.mockReturnValue({});
     mockUnlinkTeamKiloUsers.mockResolvedValue(0);
@@ -271,6 +276,9 @@ describe('uninstallGitHubOrganizationInstallation', () => {
       await uninstall;
     }
     expect(upstream).toHaveBeenCalledTimes(1);
+    await expect(
+      db.update(kilocode_users).set({ is_admin: false }).where(eq(kilocode_users.id, actor.id))
+    ).resolves.toMatchObject({ rowCount: 1 });
   });
 
   test('returns pending and retains local row when confirmed cleanup transaction fails', async () => {
@@ -282,6 +290,7 @@ describe('uninstallGitHubOrganizationInstallation', () => {
       jest.requireActual('@/lib/organizations/organization-audit-logs').createAuditLog
     );
     audit.mockRejectedValueOnce(new Error('final audit private database error'));
+    audit.mockRejectedValueOnce(new Error('fallback audit private database error'));
     audit.mockImplementationOnce(
       jest.requireActual('@/lib/organizations/organization-audit-logs').createAuditLog
     );
@@ -302,11 +311,72 @@ describe('uninstallGitHubOrganizationInstallation', () => {
       .from(organization_audit_logs)
       .where(eq(organization_audit_logs.organization_id, org.id));
     expect(audits.map(entry => entry.message)).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('uninstall attempted'),
-        expect.stringContaining('confirmed; local cleanup pending'),
-      ])
+      expect.arrayContaining([expect.stringContaining('uninstall attempted')])
     );
+    expect(sentryCaptureException).toHaveBeenCalledWith(expect.any(Error), {
+      tags: {
+        operation: 'github-installation-uninstall-audit',
+        audit_status: 'confirmed_local_cleanup_pending',
+      },
+      extra: { integrationId: row.id, ownerType: 'organization' },
+    });
+    expect(sentryCaptureException.mock.calls[0]?.[1]).not.toHaveProperty('result');
+  });
+
+  test('retains the local row and returns a safe error when upstream and fallback audit fail', async () => {
+    const actor = await insertTestUser({ is_admin: true });
+    const owner = await insertTestUser();
+    const org = await createTestOrganization('Uninstall fallback audit failure org', owner.id, 0);
+    const row = await integration({ organizationId: org.id });
+    upstream.mockRejectedValue(new Error('upstream private error'));
+    audit.mockImplementationOnce(
+      jest.requireActual('@/lib/organizations/organization-audit-logs').createAuditLog
+    );
+    audit.mockRejectedValueOnce(new Error('fallback audit private database error'));
+
+    await expect(
+      uninstallGitHubOrganizationInstallation({
+        input: request(row, { type: 'organization', id: org.id }),
+        actor: { id: actor.id, email: actor.google_user_email, name: actor.google_user_name },
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'GitHub installation uninstall could not be confirmed. Refresh before retrying.',
+    });
+    expect(
+      await db.query.platform_integrations.findFirst({
+        where: eq(platform_integrations.id, row.id),
+      })
+    ).toBeDefined();
+    expect(sentryCaptureException).toHaveBeenCalledWith(expect.any(Error), {
+      tags: {
+        operation: 'github-installation-uninstall-audit',
+        audit_status: 'unconfirmed',
+      },
+      extra: { integrationId: row.id, ownerType: 'organization' },
+    });
+    expect(sentryCaptureException.mock.calls[0]?.[1]).not.toHaveProperty('result');
+  });
+
+  test('releases target locks when upstream deletion fails', async () => {
+    const actor = await insertTestUser({ is_admin: true });
+    const owner = await insertTestUser();
+    const replacementOwner = await insertTestUser();
+    const row = await integration({ userId: owner.id });
+    upstream.mockRejectedValue(new Error('upstream private error'));
+
+    await expect(
+      uninstallGitHubOrganizationInstallation({
+        input: request(row, { type: 'user', id: owner.id }),
+        actor: { id: actor.id, email: actor.google_user_email, name: actor.google_user_name },
+      })
+    ).rejects.toThrow('Refresh before retrying');
+    await expect(
+      db
+        .update(platform_integrations)
+        .set({ owned_by_user_id: replacementOwner.id })
+        .where(eq(platform_integrations.id, row.id))
+    ).resolves.toMatchObject({ rowCount: 1 });
   });
 
   test('standard deletion webhook reconciles a legacy row retained after local cleanup rolls back', async () => {

--- a/apps/web/src/lib/admin/github-installation-uninstall.ts
+++ b/apps/web/src/lib/admin/github-installation-uninstall.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { and, eq, isNull, or } from 'drizzle-orm';
+import { captureException } from '@sentry/nextjs';
 import { TRPCError } from '@trpc/server';
 import { db, type DrizzleTransaction } from '@/lib/drizzle';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
@@ -60,10 +61,18 @@ async function writeAudit(
 async function tryWriteAudit(params: { actor: Actor; record: LocalRecord; status: AuditStatus }) {
   try {
     await writeAudit(db, params.actor, params.record, params.status);
-  } catch {
-    return false;
+  } catch (error) {
+    captureException(error, {
+      tags: {
+        operation: 'github-installation-uninstall-audit',
+        audit_status: params.status.replaceAll(/[^a-z]+/g, '_').replaceAll(/^_|_$/g, ''),
+      },
+      extra: {
+        integrationId: params.record.id,
+        ownerType: params.record.ownerType,
+      },
+    });
   }
-  return true;
 }
 
 function recordMatchesInput(record: LocalRecord, input: GitHubInstallationUninstallInput) {
@@ -169,6 +178,7 @@ export async function uninstallGitHubOrganizationInstallation(params: {
 
   let upstreamDeleted = false;
   try {
+    // These transaction-scoped locks auto-release, but intentionally span the bounded remote call to prevent actor revocation or target reassignment.
     await db.transaction(async tx => {
       await requireFreshActiveAdmin(tx, params.actor.id);
       const locked = await lockRecord(tx, params.input);


### PR DESCRIPTION
## Summary

Follow-up to review feedback left after #5864 merged.

- Report best-effort terminal audit failures to Sentry with safe, minimal context instead of swallowing them silently.
- Preserve truthful destructive-operation outcomes: confirmed GitHub deletion still returns local cleanup pending, while unconfirmed upstream deletion remains a safe refresh-before-retry error.
- Document why transaction-scoped actor and integration locks intentionally span the bounded GitHub request.
- Extend concurrency coverage to demonstrate automatic lock release after both successful commit and upstream-failure rollback.

## Why the lock remains

The review suggested replacing the row locks with a single conditional `UPDATE ... WHERE` or subquery. That is not equivalent for this operation because deleting the GitHub App installation is an external, irreversible side effect that happens before the final local database update.

Without locks, this race is possible:

1. The server validates that the employee is still an active admin and that integration A belongs to the expected Kilo owner.
2. Before the GitHub request completes, another transaction revokes the employee admin or reassigns integration A.
3. GitHub deletes the installation.
4. A conditional local update correctly affects zero rows because the database state changed, but it is too late: GitHub already removed the installation for the newly reassigned owner.

The transaction therefore holds:

- `FOR SHARE` on the acting admin row, preventing admin revocation/blocking from committing during the destructive request.
- `FOR UPDATE` on the selected integration row, preventing reassignment or mutation of the target during that request.

PostgreSQL releases both locks automatically when the Drizzle transaction commits or rolls back; there is no manual unlock path to miss. The GitHub operation is bounded by an eight-second timeout, and this endpoint is a low-volume employee-admin action. Tests verify that conflicting updates block while deletion is in flight and proceed after both commit and rollback.

A lock-free implementation would require a larger durable state-machine or outbox design that first claims the installation, commits that claim, performs the GitHub operation, and then reconciles it. A single conditional SQL update alone cannot protect the validation-to-external-delete interval, so the review suggestion was not safe as stated.

## Verification

- [ ] No manual UI verification needed; this changes server-side observability and lock regression coverage only.

## Visual Changes

N/A

## Reviewer Notes

- `pnpm --filter web test --runInBand --runTestsByPath src/lib/admin/github-installation-uninstall.test.ts`: 18 tests passed. Existing missing local Upstash environment warnings were emitted during initialization.
- `pnpm --filter web exec tsgo --noEmit`: passed.
- Focused formatting and `git diff --check`: passed.
- Independent read-only review found no issues.
- Sentry context contains only operation, normalized audit status, integration ID, and owner type. It does not add actor identity, installation/account IDs, credentials, or serialized upstream responses.