### PR TITLE
feat(byok): read synced model lists from the PostgreSQL replica

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/model-list.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/model-list.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
 import { direct_byok_model_lists } from '@kilocode/db/schema';
 import type { SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
@@ -13,13 +13,14 @@ jest.mock('@/lib/drizzle', () => ({
 }));
 jest.mock('@/lib/redis', () => ({ redisClient: { get: jest.fn() } }));
 
-const mockLimit = jest.fn<(limit: number) => Promise<{ models: unknown }[]>>();
-const mockWhere = jest.fn<(condition: SQL) => { limit: typeof mockLimit }>();
-const mockFrom = jest.fn<(table: typeof direct_byok_model_lists) => { where: typeof mockWhere }>();
+const mockLimit = jest.fn<Promise<{ models: unknown }[]>, [limit: number]>();
+const mockWhere = jest.fn<{ limit: typeof mockLimit }, [condition: SQL]>();
+const mockFrom = jest.fn<{ where: typeof mockWhere }, [table: typeof direct_byok_model_lists]>();
 const { readDb: mockReadDb } = jest.requireMock<{
   readDb: {
     select: jest.Mock<
-      (fields: { models: typeof direct_byok_model_lists.models }) => { from: typeof mockFrom }
+      { from: typeof mockFrom },
+      [fields: { models: typeof direct_byok_model_lists.models }]
     >;
   };
 }>('@/lib/drizzle');

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/model-list.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/model-list.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { direct_byok_model_lists } from '@kilocode/db/schema';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { db, readDb } from '@/lib/drizzle';
+import { redisClient } from '@/lib/redis';
+import { cachedEnhancedDirectByokModelList } from './model-list';
+import type { DirectByokModel } from './types';
+
+jest.mock('@/lib/drizzle', () => ({
+  db: { select: jest.fn() },
+  readDb: { select: jest.fn() },
+}));
+jest.mock('@/lib/redis', () => ({ redisClient: { get: jest.fn() } }));
+
+const mockReplicaSelect = jest.mocked(readDb.select);
+const mockLimit = jest.fn<(limit: number) => Promise<{ models: unknown }[]>>();
+const mockWhere = jest.fn<(condition: SQL) => { limit: typeof mockLimit }>();
+const mockFrom = jest.fn();
+const ttl = 600_000;
+
+function model(id: string, overrides: Partial<DirectByokModel> = {}): DirectByokModel {
+  return { id, name: id, context_length: 4096, max_completion_tokens: 1024, ...overrides };
+}
+
+const recommended = model('recommended', { flags: ['vision'] });
+const recommendedModels: ReadonlyArray<DirectByokModel> = [recommended];
+const failures = [
+  { name: 'malformed JSONB', failure: [model('valid'), { id: 'invalid' }] },
+  { name: 'null JSONB', failure: null },
+  { name: 'replica read error', failure: new Error('replica unavailable') },
+];
+let now: number;
+let getModels: ReturnType<typeof cachedEnhancedDirectByokModelList>;
+
+function failNextRead(failure: unknown) {
+  if (failure instanceof Error) {
+    mockLimit.mockRejectedValueOnce(failure);
+  } else {
+    mockLimit.mockResolvedValueOnce([{ models: failure }]);
+  }
+}
+
+function expectProviderReads(...providerIds: string[]) {
+  expect(mockReplicaSelect.mock.calls).toEqual(
+    providerIds.map(() => [{ models: direct_byok_model_lists.models }])
+  );
+  expect(mockFrom.mock.calls).toEqual(providerIds.map(() => [direct_byok_model_lists]));
+  expect(mockLimit.mock.calls).toEqual(providerIds.map(() => [1]));
+  expect(mockWhere.mock.calls.map(([condition]) => new PgDialect().sqlToQuery(condition))).toEqual(
+    providerIds.map(providerId =>
+      expect.objectContaining({
+        sql: '"direct_byok_model_lists"."provider_id" = $1',
+        params: [providerId],
+      })
+    )
+  );
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  now = 1_000_000;
+  jest.spyOn(Date, 'now').mockImplementation(() => now);
+  mockLimit.mockResolvedValue([]);
+  mockWhere.mockReturnValue({ limit: mockLimit });
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockReplicaSelect.mockReturnValue({ from: mockFrom } as ReturnType<typeof readDb.select>);
+  getModels = cachedEnhancedDirectByokModelList({ providerId: 'codestral', recommendedModels });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  expect(db.select).not.toHaveBeenCalled();
+  expect(redisClient.get).not.toHaveBeenCalled();
+});
+
+describe('cachedEnhancedDirectByokModelList', () => {
+  test.each([
+    { name: 'missing row', rows: [] },
+    { name: 'empty list', rows: [{ models: [] }] },
+  ])('enhances recommendations for a $name using only the replica', async ({ rows }) => {
+    mockLimit.mockResolvedValueOnce(rows);
+
+    const result = await getModels();
+
+    expect(result).toStrictEqual([
+      { ...recommended, flags: ['vision', 'recommended'], variants: undefined },
+    ]);
+    expect(result).not.toBe(recommendedModels);
+    expect(recommended.flags).toEqual(['vision']);
+    now += ttl - 1;
+    await expect(getModels()).resolves.toBe(result);
+    expectProviderReads('codestral');
+  });
+
+  test('merges ordered metadata, deduplicated flags and variant precedence', async () => {
+    const syncedVariants = { high: { reasoning: { effort: 'high' as const } } };
+    const beta = model('beta', {
+      name: 'Curated beta',
+      flags: ['vision', 'vision', 'recommended'],
+    });
+    const alpha = model('alpha', { variants: { curated: { reasoning: { enabled: false } } } });
+    const empty = model('empty', { variants: {} });
+    const zeta = model('zeta', { flags: [] });
+    const gamma = model('gamma', { flags: ['reasoning', 'reasoning'] });
+    const curated = [beta, alpha, empty, model('beta', { name: 'Discarded recommendation' })];
+    const synced = [
+      zeta,
+      model('beta', {
+        name: 'Synced beta',
+        context_length: 9999,
+        max_completion_tokens: 8888,
+        flags: ['reasoning'],
+        variants: { low: { reasoning: { effort: 'low' } } },
+      }),
+      model('alpha', { variants: syncedVariants }),
+      model('beta', { variants: syncedVariants }),
+      model('empty', { variants: syncedVariants }),
+      model('zeta', { name: 'Discarded synced duplicate' }),
+      gamma,
+    ];
+    const originalCurated = structuredClone(curated);
+    const originalSynced = structuredClone(synced);
+    const getMerged = cachedEnhancedDirectByokModelList({
+      providerId: 'codestral',
+      recommendedModels: curated,
+    });
+    mockLimit.mockResolvedValueOnce([{ models: synced }]);
+
+    await expect(getMerged()).resolves.toStrictEqual([
+      { ...beta, flags: ['vision', 'recommended'], variants: syncedVariants },
+      { ...alpha, flags: ['recommended'] },
+      { ...empty, flags: ['recommended'] },
+      { ...zeta, flags: undefined, variants: undefined },
+      { ...gamma, flags: ['reasoning'], variants: undefined },
+    ]);
+    expect(curated).toStrictEqual(originalCurated);
+    expect(synced).toStrictEqual(originalSynced);
+    expectProviderReads('codestral');
+  });
+
+  test.each(failures)('falls back on cold $name and retries', async ({ failure }) => {
+    failNextRead(failure);
+
+    await expect(getModels()).resolves.toBe(recommendedModels);
+    expect(recommended.flags).toEqual(['vision']);
+    expectProviderReads('codestral');
+
+    mockLimit.mockResolvedValueOnce([{ models: [model('recovered')] }]);
+    const recovered = await getModels();
+    expect(recovered).toStrictEqual([
+      { ...recommended, flags: ['vision', 'recommended'], variants: undefined },
+      { ...model('recovered'), flags: undefined, variants: undefined },
+    ]);
+    await expect(getModels()).resolves.toBe(recovered);
+    expectProviderReads('codestral', 'codestral');
+  });
+
+  test.each(failures)('retains last-good on warm $name and retries', async ({ failure }) => {
+    mockLimit.mockResolvedValueOnce([{ models: [model('last-good')] }]);
+    const lastGood = await getModels();
+    expect(lastGood.map(entry => entry.id)).toEqual(['recommended', 'last-good']);
+
+    now += ttl - 1;
+    await expect(getModels()).resolves.toBe(lastGood);
+    expectProviderReads('codestral');
+
+    now += 1;
+    failNextRead(failure);
+    await expect(getModels()).resolves.toBe(lastGood);
+    expectProviderReads('codestral', 'codestral');
+
+    mockLimit.mockResolvedValueOnce([{ models: [model('recovered')] }]);
+    const recovered = await getModels();
+    expect(recovered.map(entry => entry.id)).toEqual(['recommended', 'recovered']);
+    expect(recovered).not.toBe(lastGood);
+    expectProviderReads('codestral', 'codestral', 'codestral');
+
+    now += ttl - 1;
+    await expect(getModels()).resolves.toBe(recovered);
+    expectProviderReads('codestral', 'codestral', 'codestral');
+    now += 1;
+    mockLimit.mockResolvedValueOnce([{ models: [model('refreshed')] }]);
+    expect((await getModels()).map(entry => entry.id)).toEqual(['recommended', 'refreshed']);
+    expectProviderReads('codestral', 'codestral', 'codestral', 'codestral');
+  });
+
+  test('isolates provider predicates, cached models, expiry and stale fallback', async () => {
+    const kimiRecommendation = model('recommended', { name: 'Kimi recommendation' });
+    const getKimi = cachedEnhancedDirectByokModelList({
+      providerId: 'kimi-coding',
+      recommendedModels: [kimiRecommendation],
+    });
+    mockLimit.mockResolvedValueOnce([{ models: [model('shared', { name: 'Codestral model' })] }]);
+    const codestral = await getModels();
+    expect(codestral.map(entry => entry.name)).toEqual(['recommended', 'Codestral model']);
+
+    now += 100;
+    mockLimit.mockResolvedValueOnce([{ models: [model('shared', { name: 'Kimi model' })] }]);
+    const kimi = await getKimi();
+    expect(kimi.map(entry => entry.name)).toEqual(['Kimi recommendation', 'Kimi model']);
+    await expect(getModels()).resolves.toBe(codestral);
+    expectProviderReads('codestral', 'kimi-coding');
+
+    now += ttl - 100;
+    mockLimit.mockRejectedValueOnce(new Error('codestral read failed'));
+    await expect(getModels()).resolves.toBe(codestral);
+    await expect(getKimi()).resolves.toBe(kimi);
+    expectProviderReads('codestral', 'kimi-coding', 'codestral');
+
+    mockLimit.mockResolvedValueOnce([{ models: [model('recovered')] }]);
+    expect((await getModels()).map(entry => entry.id)).toEqual(['recommended', 'recovered']);
+    await expect(getKimi()).resolves.toBe(kimi);
+    expectProviderReads('codestral', 'kimi-coding', 'codestral', 'codestral');
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/model-list.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/model-list.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globa
 import { direct_byok_model_lists } from '@kilocode/db/schema';
 import type { SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
-import { db, readDb } from '@/lib/drizzle';
+import { db } from '@/lib/drizzle';
 import { redisClient } from '@/lib/redis';
 import { cachedEnhancedDirectByokModelList } from './model-list';
 import type { DirectByokModel } from './types';
@@ -13,10 +13,17 @@ jest.mock('@/lib/drizzle', () => ({
 }));
 jest.mock('@/lib/redis', () => ({ redisClient: { get: jest.fn() } }));
 
-const mockReplicaSelect = jest.mocked(readDb.select);
 const mockLimit = jest.fn<(limit: number) => Promise<{ models: unknown }[]>>();
 const mockWhere = jest.fn<(condition: SQL) => { limit: typeof mockLimit }>();
-const mockFrom = jest.fn();
+const mockFrom = jest.fn<(table: typeof direct_byok_model_lists) => { where: typeof mockWhere }>();
+const { readDb: mockReadDb } = jest.requireMock<{
+  readDb: {
+    select: jest.Mock<
+      (fields: { models: typeof direct_byok_model_lists.models }) => { from: typeof mockFrom }
+    >;
+  };
+}>('@/lib/drizzle');
+const mockReplicaSelect = mockReadDb.select;
 const ttl = 600_000;
 
 function model(id: string, overrides: Partial<DirectByokModel> = {}): DirectByokModel {
@@ -64,7 +71,7 @@ beforeEach(() => {
   mockLimit.mockResolvedValue([]);
   mockWhere.mockReturnValue({ limit: mockLimit });
   mockFrom.mockReturnValue({ where: mockWhere });
-  mockReplicaSelect.mockReturnValue({ from: mockFrom } as ReturnType<typeof readDb.select>);
+  mockReplicaSelect.mockReturnValue({ from: mockFrom });
   getModels = cachedEnhancedDirectByokModelList({ providerId: 'codestral', recommendedModels });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/model-list.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/model-list.test.ts
@@ -142,8 +142,8 @@ describe('cachedEnhancedDirectByokModelList', () => {
       { ...zeta, flags: undefined, variants: undefined },
       { ...gamma, flags: ['reasoning'], variants: undefined },
     ]);
-    expect(curated).toStrictEqual(originalCurated);
-    expect(synced).toStrictEqual(originalSynced);
+    expect(curated).toEqual(originalCurated);
+    expect(synced).toEqual(originalSynced);
     expectProviderReads('codestral');
   });
 

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/model-list.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/model-list.ts
@@ -4,8 +4,9 @@ import {
 } from '@/lib/ai-gateway/providers/direct-byok/types';
 import type { DirectUserByokInferenceProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import { createCachedFetch } from '@/lib/cached-fetch';
-import { redisClient } from '@/lib/redis';
-import { directByokModelsRedisKey } from '@/lib/redis-keys';
+import { readDb } from '@/lib/drizzle';
+import { direct_byok_model_lists } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
 
 type CachedEnhancedModelListOptions = {
   providerId: DirectUserByokInferenceProviderId;
@@ -17,13 +18,17 @@ export function cachedEnhancedDirectByokModelList({
   recommendedModels,
 }: CachedEnhancedModelListOptions) {
   return createCachedFetch<ReadonlyArray<DirectByokModel>>(
-    async () =>
-      enhanceDirectByokModelList({
+    async () => {
+      const [row] = await readDb
+        .select({ models: direct_byok_model_lists.models })
+        .from(direct_byok_model_lists)
+        .where(eq(direct_byok_model_lists.provider_id, providerId))
+        .limit(1);
+      return enhanceDirectByokModelList({
         recommendedModels,
-        remainingModels: DirectByokModelArraySchema.parse(
-          JSON.parse((await redisClient.get<string>(directByokModelsRedisKey(providerId))) ?? '[]')
-        ),
-      }),
+        remainingModels: DirectByokModelArraySchema.parse(row ? row.models : []),
+      });
+    },
     600_000,
     recommendedModels
   );

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
@@ -407,7 +407,9 @@ describe('syncDirectByokModels database snapshots', () => {
   }
 
   function expectCachedModels(models: DirectByokModel[]) {
-    const cachedModels = redisSet.mock.calls.find(([key]) => key === providerKey)?.[1];
+    const cachedWrite = redisSet.mock.calls.find(([key]) => key === providerKey);
+    expect(cachedWrite?.[2]).toEqual({ ex: 604_800 });
+    const cachedModels = cachedWrite?.[1];
     if (typeof cachedModels !== 'string') {
       throw new Error('Expected a Redis SET with a serialized model list');
     }
@@ -447,6 +449,10 @@ describe('syncDirectByokModels database snapshots', () => {
       normalizedModels.length
     );
     expectCachedModels(normalizedModels);
+    expect(redisSet).toHaveBeenCalledTimes(Object.keys(counts).length);
+    for (const [, , options] of redisSet.mock.calls) {
+      expect(options).toEqual({ ex: 604_800 });
+    }
 
     const snapshots = await db.select().from(direct_byok_model_lists);
     expect(snapshots.map(row => row.provider_id).sort()).toEqual(Object.keys(counts).sort());
@@ -501,7 +507,7 @@ describe('syncDirectByokModels database snapshots', () => {
     expect(snapshot.models).toStrictEqual([]);
     expect(new Date(snapshot.synced_at).toISOString()).not.toBe(oldSyncedAt);
     expect(counts[providerId]).toBe(0);
-    expect(redisSet).toHaveBeenCalledWith(providerKey, '[]');
+    expect(redisSet).toHaveBeenCalledWith(providerKey, '[]', { ex: 604_800 });
   });
 
   test('rejects an upstream failure without replacing the last successful snapshot', async () => {

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -336,7 +336,9 @@ async function syncProvider(fetcher: ProviderFetcher, ctx: SyncContext): Promise
       set: { models, synced_at },
     });
 
-  await redisClient.set(directByokModelsRedisKey(fetcher.providerId), JSON.stringify(models));
+  await redisClient.set(directByokModelsRedisKey(fetcher.providerId), JSON.stringify(models), {
+    ex: 7 * 24 * 60 * 60,
+  });
   return models.length;
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #5853.

- Replace the shared direct-BYOK model-list Redis reader with a provider-filtered query of `direct_byok_model_lists.models` through the existing regional `readDb` client. This covers all synced direct-BYOK providers.
- Validate persisted JSONB and preserve the ten-minute in-process cache, recommendation ordering/deduplication, variant precedence, and last-known-good fallback. Missing snapshots still serve recommendations; no Redis read fallback is introduced.
- Keep PostgreSQL upserts and Redis mirroring in the existing sync flow. Every Redis write now sets `EX 604800` (seven days), including refreshes and empty catalogs.
- Leave unrelated gateway metadata caches unchanged. No schema migration is required.

## Verification
- Focused lint, changed-file formatting, and whitespace checks passed.
- Added replica-only query, provider isolation, merge, cache expiry, malformed JSONB, outage, and recovery coverage. Updated sync tests to assert seven-day TTLs for every provider and subsequent refreshes.
- CI tests, typecheck, lint, formatting, migration checks, build, and extension E2E passed. Tests ran in CI only; the local web typecheck had exceeded the sandbox time limit.
- Read-only and automated PR reviews found no issues. CI-discovered test mock typing/hoisting and cross-realm fixture comparisons were fixed in follow-up commits.

## Rollout
The existing provider sync must have populated PostgreSQL snapshots from #5853. PostgreSQL catalogs remain durable; only the compatibility Redis mirror expires.

