### PR TITLE
feat(mobile): rotate in-progress review status icon

### DIFF
--- a/apps/mobile/src/components/code-reviewer/review-detail-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/code-reviewer/review-detail-screen.mounted.test.tsx
@@ -35,6 +35,7 @@ const queryErrors = vi.hoisted(() => ({
 const buttons = vi.hoisted(() => ({
   rendered: [] as { children?: unknown; onPress?: () => void }[],
 }));
+const spinningIcons = vi.hoisted(() => ({ rendered: [] as { spinning?: boolean }[] }));
 
 const viewRenders = vi.hoisted(() => ({
   list: [] as { style?: unknown; className?: string; children?: unknown }[],
@@ -82,8 +83,14 @@ vi.mock('react-native', () => ({
 vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 24, bottom: 34, left: 0, right: 0 }),
 }));
-vi.mock('@/components/ui/icons', () => ({ Share: 'Share' }));
+vi.mock('@/components/ui/icons', () => ({ Loader2: 'Loader2', Share: 'Share' }));
 vi.mock('@/lib/hooks/use-theme-colors', () => ({ useThemeColors: () => ({}) }));
+vi.mock('@/components/ui/spinning-icon', () => ({
+  SpinningIcon: (props: { spinning?: boolean }) => {
+    spinningIcons.rendered.push(props);
+    return null;
+  },
+}));
 vi.mock('react-native-reanimated', () => ({
   default: { View: 'Animated.View' },
   FadeIn: { duration: vi.fn() },
@@ -288,6 +295,7 @@ beforeEach(() => {
   detail.refetch.mockClear();
   queryErrors.errors = [];
   buttons.rendered = [];
+  spinningIcons.rendered = [];
   viewRenders.list = [];
   modalRenders.list = [];
   nativePlatform.OS = 'ios';
@@ -319,6 +327,26 @@ beforeEach(() => {
 });
 
 describe('ReviewDetailScreen outcome-first order', () => {
+  it.each([
+    ['pending', true],
+    ['queued', true],
+    ['running', true],
+    ['completed', false],
+    ['failed', false],
+    ['cancelled', false],
+    ['interrupted', false],
+  ])('rotates the status icon for %s only while the review is in progress', (status, spinning) => {
+    detail.data = {
+      success: true,
+      review: makeReview({ status }),
+      tokenUsage: { input: 0, output: 0 },
+    };
+
+    renderScreen();
+
+    expect(spinningIcons.rendered).toEqual([expect.objectContaining({ spinning })]);
+  });
+
   it('leads with conclusion, then findings, council, gate, then metadata', () => {
     detail.data = {
       success: true,

--- a/apps/mobile/src/components/code-reviewer/review-detail-screen.tsx
+++ b/apps/mobile/src/components/code-reviewer/review-detail-screen.tsx
@@ -9,6 +9,7 @@ import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 
 import {
   isCancellableReviewStatus,
+  isInFlightReviewStatus,
   isRetriggerableReviewStatus,
 } from '@kilocode/app-shared/code-review';
 import { fromMicrodollars } from '@kilocode/app-shared/utils';
@@ -24,7 +25,9 @@ import {
 import { QueryError } from '@/components/query-error';
 import { ScreenHeader } from '@/components/screen-header';
 import { Button } from '@/components/ui/button';
+import { Loader2 } from '@/components/ui/icons';
 import { Skeleton } from '@/components/ui/skeleton';
+import { SpinningIcon } from '@/components/ui/spinning-icon';
 import { Text } from '@/components/ui/text';
 import { TabScreenScrollView } from '@/components/tab-screen';
 import { i18n } from '@/i18n';
@@ -34,6 +37,7 @@ import { reviewerPlatformLabel } from '@/lib/code-reviewer-config';
 import { openExternalUrl } from '@/lib/external-link';
 import { formatMoney, formatNumber } from '@/lib/format';
 import { useCancelReview, useRetriggerReview, useReviewDetail } from '@/lib/hooks/use-code-reviews';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { getPrReviewPath } from '@/lib/profile-agent-navigation';
 import { cn, parseTimestamp, timeAgo } from '@/lib/utils';
 
@@ -71,6 +75,7 @@ export function ReviewDetailScreen({
 }: Readonly<{ scope: string; reviewId: string }>) {
   const router = useRouter();
   const { t } = useTranslation();
+  const colors = useThemeColors();
   const prReviewEnabled = useFeatureFlag(FEATURE_FLAG_PR_REVIEW, true);
   const { data, isLoading, isError, isFetching, error, refetch } = useReviewDetail(reviewId);
   const cancelReview = useCancelReview(scope);
@@ -165,7 +170,15 @@ export function ReviewDetailScreen({
 
         {/* Conclusion: the outcome leads — status first, then the failure reason. */}
         <View className="gap-2">
-          <Text className={cn('text-sm font-semibold', meta.className)}>{meta.label}</Text>
+          <View className="flex-row items-center gap-1.5">
+            <SpinningIcon
+              icon={Loader2}
+              size={14}
+              color={colors.mutedForeground}
+              spinning={isInFlightReviewStatus(review.status)}
+            />
+            <Text className={cn('text-sm font-semibold', meta.className)}>{meta.label}</Text>
+          </View>
           {review.error_message ? (
             <View className="rounded-lg bg-danger-tile-bg p-3">
               <Text className="text-xs text-destructive">{review.error_message}</Text>


### PR DESCRIPTION
## What changed

- The review page rotates its status icon for pending, queued, and running reviews.
- The status icon stays still for completed, failed, cancelled, and interrupted reviews.
- The status icon uses the existing motion behavior, including reduced-motion support.

## Why

Users can now distinguish an active review from a finished or failed review.

## Verification

- Driver checks: 4 checks passed after round 1
- mobile: typecheck + unit + i18n gates passed
- mobile-device: 1 shard(s) over 1 device(s): CEB47290-FE68-4B66-9A70-98C3F21E4FFB
- mobile-device: login probe passed on 1 device(s); app signed in
- mobile-device: verifier passed
- mobile-device: spot check clean

**The login screenshot shows the verify-code screen used by the device check.**

![login-shots/01-login-verify-code.png](https://github.com/user-attachments/assets/bf26987b-15bf-46a0-a51d-eee8ad30cad2)

**The login screenshot shows the pre-existing Refreshing bar and spinner over the verify-code form.**

![login-shots/01-login-request-code.png](https://github.com/user-attachments/assets/1c272138-e189-4a57-9b60-1347bcf26cba)

**The review page screenshot shows the status icon beside the in-progress review status.**

![e2e-mobile-app/e1-review-page.png](https://github.com/user-attachments/assets/13512bbc-9ac9-4a39-b375-2f0e7f4ae9db)

**The recent reviews screenshot shows the review entry used for the live scenario.**

![e2e-mobile-app/e1-recent-reviews.png](https://github.com/user-attachments/assets/75dd9017-9c51-4b2b-97a9-94a9ab0dbdc1)

## Notes for the reviewer

The static screenshot shows the icon. The unit check verifies rotation for each active and final status.

## Pre-existing UX defects observed (not changed here)
- 01-login-request-code.png — A "Refreshing..." bar and spinner overlay the verify-code form.