### PR TITLE
ci(kilo-app): bump the app version after a store submission

### DIFF
--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -240,8 +240,23 @@ jobs:
     steps:
       - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
 
+      # An open bump PR already carries the next version. A second one would
+      # bump to the same number and conflict with it.
+      - name: Look for an open bump PR
+        id: pending
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OPEN=$(gh pr list --state open --limit 100 --json headRefName \
+            --jq '[.[] | select(.headRefName | startswith("kilo-app-version-bump-"))] | length')
+          if [ "$OPEN" != "0" ]; then
+            echo "::warning::A kilo-app version bump PR is already open — not opening another. Merge it to release the next version."
+          fi
+          echo "open=$OPEN" >> "$GITHUB_OUTPUT"
+
       - name: Bump patch version
         id: bump
+        if: steps.pending.outputs.open == '0'
         working-directory: apps/mobile
         run: |
           OLD=$(sed -n "s/^  version: '\([0-9][0-9.]*\)',$/\1/p" app.config.ts)
@@ -256,6 +271,7 @@ jobs:
           echo "new=$NEW" >> "$GITHUB_OUTPUT"
 
       - name: Push bump branch
+        if: steps.pending.outputs.open == '0'
         run: |
           NEW="${{ steps.bump.outputs.new }}"
           git config user.name "github-actions[bot]"
@@ -267,6 +283,7 @@ jobs:
           git push -fu origin "kilo-app-version-bump-$NEW"
 
       - name: Open bump PR
+        if: steps.pending.outputs.open == '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -31,6 +31,9 @@ jobs:
   check-changes:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 5
+    permissions:
+      contents: read # read the release tags
+      pull-requests: read # look for an open bump PR
     outputs:
       should_build: ${{ steps.check.outputs.should_build }}
     steps:
@@ -40,7 +43,21 @@ jobs:
 
       - name: Check for changes since last release
         id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # An open bump PR means main still holds the version that was already
+          # submitted. Building it submits that version again, so wait for the
+          # merge. This gate is before the manual-run override on purpose: a
+          # store submission of an already-released version fails either way.
+          OPEN=$(gh pr list --state open --limit 100 --json headRefName \
+            --jq '[.[] | select(.headRefName | startswith("kilo-app-version-bump-"))] | length')
+          if [ "$OPEN" != "0" ]; then
+            echo "::warning::A kilo-app version bump PR is open — skipping the release. Merge it, then release again."
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # A manual run is the override: build and submit whatever main holds.
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             echo "Manual run — building regardless of changes"
@@ -247,23 +264,8 @@ jobs:
     steps:
       - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
 
-      # An open bump PR already carries the next version. A second one would
-      # bump to the same number and conflict with it.
-      - name: Look for an open bump PR
-        id: pending
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          OPEN=$(gh pr list --state open --limit 100 --json headRefName \
-            --jq '[.[] | select(.headRefName | startswith("kilo-app-version-bump-"))] | length')
-          if [ "$OPEN" != "0" ]; then
-            echo "::warning::A kilo-app version bump PR is already open — not opening another. Merge it to release the next version."
-          fi
-          echo "open=$OPEN" >> "$GITHUB_OUTPUT"
-
       - name: Bump patch version
         id: bump
-        if: steps.pending.outputs.open == '0'
         working-directory: apps/mobile
         run: |
           OLD=$(sed -n "s/^  version: '\([0-9][0-9.]*\)',$/\1/p" app.config.ts)
@@ -278,7 +280,6 @@ jobs:
           echo "new=$NEW" >> "$GITHUB_OUTPUT"
 
       - name: Push bump branch
-        if: steps.pending.outputs.open == '0'
         run: |
           NEW="${{ steps.bump.outputs.new }}"
           git config user.name "github-actions[bot]"
@@ -290,7 +291,6 @@ jobs:
           git push -fu origin "kilo-app-version-bump-$NEW"
 
       - name: Open bump PR
-        if: steps.pending.outputs.open == '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -67,19 +67,6 @@ jobs:
             fi
           fi
 
-          # If main still carries the version that the last release submitted, the
-          # bump PR is not merged yet. Wait for it: building now submits the same
-          # version twice. Merging the bump PR runs this workflow again and picks
-          # these changes up, so nothing is lost.
-          read_version() { sed -n "s/^  version: '\([0-9][0-9.]*\)',$/\1/p"; }
-          PREV_VERSION=$(git show "$LAST_TAG":apps/mobile/app.config.ts | read_version)
-          CUR_VERSION=$(read_version < apps/mobile/app.config.ts)
-          if [ -n "$PREV_VERSION" ] && [ "$PREV_VERSION" = "$CUR_VERSION" ]; then
-            echo "::warning::Version $CUR_VERSION was already submitted at $LAST_TAG — skipping the build. Merge the open kilo-app-version-bump PR; the release resumes on the next push to main."
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           if [ -z "$CHANGES" ]; then
             echo "No changes since $LAST_TAG — skipping build"
             echo "should_build=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -319,5 +319,4 @@ jobs:
             --title "chore(kilo-app): bump version to $NEW" \
             --body-file /tmp/bump-pr-body.md \
             --assignee iscekic \
-            --reviewer iscekic \
-            || echo "A bump PR for $NEW is already open"
+            --reviewer iscekic

--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -67,6 +67,19 @@ jobs:
             fi
           fi
 
+          # If main still carries the version that the last release submitted, the
+          # bump PR is not merged yet. Wait for it: building now submits the same
+          # version twice. Merging the bump PR runs this workflow again and picks
+          # these changes up, so nothing is lost.
+          read_version() { sed -n "s/^  version: '\([0-9][0-9.]*\)',$/\1/p"; }
+          PREV_VERSION=$(git show "$LAST_TAG":apps/mobile/app.config.ts | read_version)
+          CUR_VERSION=$(read_version < apps/mobile/app.config.ts)
+          if [ -n "$PREV_VERSION" ] && [ "$PREV_VERSION" = "$CUR_VERSION" ]; then
+            echo "::warning::Version $CUR_VERSION was already submitted at $LAST_TAG — skipping the build. Merge the open kilo-app-version-bump PR; the release resumes on the next push to main."
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [ -z "$CHANGES" ]; then
             echo "No changes since $LAST_TAG — skipping build"
             echo "should_build=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -55,6 +55,18 @@ jobs:
           # Check for changes in kilo-app or its direct workspace:* inputs since that tag
           CHANGES=$(git diff --name-only "$LAST_TAG"..HEAD -- apps/mobile/ packages/trpc/ packages/app-shared/ packages/kilo-chat/ packages/kilo-chat-hooks/ packages/event-service/ packages/notifications/ packages/cloud-agent-sdk/ pnpm-lock.yaml)
 
+          # The bump-version job edits the version line after every submission. Its
+          # merged PR must not release the same code again, or every release starts
+          # the next one.
+          if [ "$CHANGES" = "apps/mobile/app.config.ts" ]; then
+            OTHER=$(git diff -U0 "$LAST_TAG"..HEAD -- apps/mobile/app.config.ts | grep '^[+-][^+-]' | grep -cv "^[+-]  version: '" || true)
+            if [ "$OTHER" = "0" ]; then
+              echo "Only the version line changed since $LAST_TAG — skipping build"
+              echo "should_build=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
           if [ -z "$CHANGES" ]; then
             echo "No changes since $LAST_TAG — skipping build"
             echo "should_build=false" >> "$GITHUB_OUTPUT"
@@ -213,3 +225,75 @@ jobs:
           TAG="kilo-app-release/$(date -u +%Y-%m-%d)-$(git rev-parse --short=7 HEAD)"
           git tag "$TAG"
           git push origin "$TAG"
+
+  # A store release needs a version string that was not released before, so the
+  # marketing version is patch-bumped after every successful submission. The
+  # build number is not bumped here; EAS auto-increments it remotely.
+  bump-version:
+    needs: build-and-submit
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    permissions:
+      contents: write # push the bump branch
+      pull-requests: write # open the PR, request the reviewer
+      issues: write # PR assignees are an Issues API operation; pull-requests: write alone does not cover --assignee
+    steps:
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+
+      - name: Bump patch version
+        id: bump
+        working-directory: apps/mobile
+        run: |
+          OLD=$(sed -n "s/^  version: '\([0-9][0-9.]*\)',$/\1/p" app.config.ts)
+          if [ -z "$OLD" ]; then
+            echo "::error::Could not read the version line from apps/mobile/app.config.ts"
+            exit 1
+          fi
+          NEW=$(echo "$OLD" | awk -F. '{print $1"."$2"."$3+1}')
+          sed -i "s/^  version: '$OLD',$/  version: '$NEW',/" app.config.ts
+          echo "Bumped $OLD -> $NEW"
+          echo "old=$OLD" >> "$GITHUB_OUTPUT"
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+
+      - name: Push bump branch
+        run: |
+          NEW="${{ steps.bump.outputs.new }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "kilo-app-version-bump-$NEW"
+          git add apps/mobile/app.config.ts
+          git commit -m "chore(kilo-app): bump version to $NEW"
+          # Force: a re-run rewrites the same single line onto the same branch.
+          git push -fu origin "kilo-app-version-bump-$NEW"
+
+      - name: Open bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW="${{ steps.bump.outputs.new }}"
+          OLD="${{ steps.bump.outputs.old }}"
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          cat > /tmp/bump-pr-body.md <<EOF
+          ## What
+
+          Bumps apps/mobile (kilo-app) version $OLD -> $NEW.
+
+          ## Why
+
+          The kilo-app Release workflow submitted version $OLD to the App Store and to
+          Google Play (run: $RUN_URL). A store release needs a version string that was
+          not released before.
+
+          ## What to do
+
+          1. Required checks show as pending: PRs opened with the default GITHUB_TOKEN
+             do not trigger workflow runs. Close and reopen this PR (or push an empty
+             commit) to start CI.
+          2. Review and merge. Only the version line changed; no product code.
+          EOF
+          gh pr create --base main \
+            --title "chore(kilo-app): bump version to $NEW" \
+            --body-file /tmp/bump-pr-body.md \
+            --assignee iscekic \
+            --reviewer iscekic \
+            || echo "A bump PR for $NEW is already open"

--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -41,6 +41,13 @@ jobs:
       - name: Check for changes since last release
         id: check
         run: |
+          # A manual run is the override: build and submit whatever main holds.
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual run — building regardless of changes"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # Find the latest kilo-app release tag
           LAST_TAG=$(git tag --list 'kilo-app-release/*' --sort=-creatordate | head -n 1)
 

--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -33,7 +33,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read # read the release tags
-      pull-requests: read # look for an open bump PR
     outputs:
       should_build: ${{ steps.check.outputs.should_build }}
     steps:
@@ -43,21 +42,7 @@ jobs:
 
       - name: Check for changes since last release
         id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # An open bump PR means main still holds the version that was already
-          # submitted. Building it submits that version again, so wait for the
-          # merge. This gate is before the manual-run override on purpose: a
-          # store submission of an already-released version fails either way.
-          OPEN=$(gh pr list --state open --limit 100 --json headRefName \
-            --jq '[.[] | select(.headRefName | startswith("kilo-app-version-bump-"))] | length')
-          if [ "$OPEN" != "0" ]; then
-            echo "::warning::A kilo-app version bump PR is open — skipping the release. Merge it, then release again."
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           # A manual run is the override: build and submit whatever main holds.
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             echo "Manual run — building regardless of changes"
@@ -251,10 +236,12 @@ jobs:
           git push origin "$TAG"
 
   # A store release needs a version string that was not released before, so the
-  # marketing version is patch-bumped after every successful submission. The
-  # build number is not bumped here; EAS auto-increments it remotely.
+  # marketing version is patch-bumped for the next one. This runs beside
+  # build-and-submit, not after it: the submission is never blocked on the bump.
+  # The build number is not bumped here; EAS auto-increments it remotely.
   bump-version:
-    needs: build-and-submit
+    needs: [check-changes]
+    if: needs.check-changes.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 10
     permissions:
@@ -264,8 +251,23 @@ jobs:
     steps:
       - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
 
+      # An open bump PR already carries the next version. A second one would
+      # bump to the same number and conflict with it.
+      - name: Look for an open bump PR
+        id: pending
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OPEN=$(gh pr list --state open --limit 100 --json headRefName \
+            --jq '[.[] | select(.headRefName | startswith("kilo-app-version-bump-"))] | length')
+          if [ "$OPEN" != "0" ]; then
+            echo "A kilo-app version bump PR is already open — nothing to open."
+          fi
+          echo "open=$OPEN" >> "$GITHUB_OUTPUT"
+
       - name: Bump patch version
         id: bump
+        if: steps.pending.outputs.open == '0'
         working-directory: apps/mobile
         run: |
           OLD=$(sed -n "s/^  version: '\([0-9][0-9.]*\)',$/\1/p" app.config.ts)
@@ -280,6 +282,7 @@ jobs:
           echo "new=$NEW" >> "$GITHUB_OUTPUT"
 
       - name: Push bump branch
+        if: steps.pending.outputs.open == '0'
         run: |
           NEW="${{ steps.bump.outputs.new }}"
           git config user.name "github-actions[bot]"
@@ -291,6 +294,7 @@ jobs:
           git push -fu origin "kilo-app-version-bump-$NEW"
 
       - name: Open bump PR
+        if: steps.pending.outputs.open == '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -304,9 +308,9 @@ jobs:
 
           ## Why
 
-          The kilo-app Release workflow submitted version $OLD to the App Store and to
-          Google Play (run: $RUN_URL). A store release needs a version string that was
-          not released before.
+          The kilo-app Release workflow is submitting version $OLD to the App Store and
+          to Google Play (run: $RUN_URL). A store release needs a version string that
+          was not released before, so main moves to the next one.
 
           ## What to do
 


### PR DESCRIPTION
## What

The kilo-app Release workflow patch-bumps the app version after a store submission.

- No bump PR open: build, submit to both stores, then open a PR that bumps `version` in `apps/mobile/app.config.ts`.
- A bump PR already open: build and submit as usual, skip the bump steps with a warning. The open PR already carries the next version.

## Why

A store release needs a version string that was not released before. Today the version is edited by hand, so a release can submit a version that was already released.

The build number is untouched. EAS auto-increments it remotely (`appVersionSource: "remote"`).

## Notes

- The bot cannot push to `main` (ruleset `main-reviews`, no bypass actor), so the bump ships as a PR. The job copies the pattern in `.github/workflows/extension-store-release.yml`.
- `check-changes` skips a run whose only change since the last release tag is the version line. Without it, merging a bump PR starts a release of identical code, which bumps again.
- The bump PR's required checks show as pending: PRs opened with the default `GITHUB_TOKEN` start no workflow runs. Close and reopen the bump PR to run CI.

## Test

`sed` and guard logic checked against the real `app.config.ts`: reads `1.0.7`, writes `1.0.8` on one line only; a version-only diff skips; a mixed diff builds.
