### PR TITLE
fix(mobile): rotate pending PR check icons

### DIFF
--- a/apps/mobile/src/components/pr-review/pr-review-checks-section.mounted.test.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-checks-section.mounted.test.tsx
@@ -1,0 +1,119 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the repository's native-free mounted test tool. */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SpinningIcon } from '@/components/ui/spinning-icon';
+import { PrReviewChecksSection } from './pr-review-checks-section';
+
+const query = vi.hoisted(() => ({
+  data: {
+    checkRuns: [
+      {
+        name: 'Running',
+        status: 'in_progress',
+        conclusion: null,
+        appName: null,
+        detailsUrl: null,
+      },
+      {
+        name: 'Queued',
+        status: 'queued',
+        conclusion: null,
+        appName: null,
+        detailsUrl: null,
+      },
+      {
+        name: 'Passed',
+        status: 'completed',
+        conclusion: 'success',
+        appName: null,
+        detailsUrl: null,
+      },
+      {
+        name: 'Failed',
+        status: 'completed',
+        conclusion: 'failure',
+        appName: null,
+        detailsUrl: null,
+      },
+    ],
+    rollup: { total: 4, success: 1, failure: 1, pending: 2, skipped: 0 },
+  },
+  isLoading: false,
+  isError: false,
+  isFetching: false,
+  refetch: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({ useQuery: () => query }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-native', () => ({ Pressable: 'Pressable', View: 'View' }));
+vi.mock('@/components/ui/button', () => ({ Button: 'Button' }));
+vi.mock('@/components/ui/icons', () => ({
+  AlertTriangle: 'AlertTriangle',
+  CheckCircle2: 'CheckCircle2',
+  Circle: 'Circle',
+  ExternalLink: 'ExternalLink',
+  Loader2: 'Loader2',
+  MinusCircle: 'MinusCircle',
+  XCircle: 'XCircle',
+}));
+vi.mock('@/components/ui/spinning-icon', () => ({ SpinningIcon: 'SpinningIcon' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/components/pr-review/pr-review-reconnect-notice', () => ({
+  PrReviewReconnectNotice: 'PrReviewReconnectNotice',
+}));
+vi.mock('@/i18n', () => ({ i18n: { language: 'en', t: (key: string) => key } }));
+vi.mock('@/lib/format', () => ({
+  formatList: (parts: string[]) => parts.join(', '),
+  formatNumber: String,
+}));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({
+    destructive: 'red',
+    foreground: 'black',
+    good: 'green',
+    mutedForeground: 'gray',
+    warn: 'orange',
+  }),
+}));
+vi.mock('@/lib/external-link', () => ({ openExternalUrl: vi.fn() }));
+vi.mock('@/lib/pr-review/classify-pr-review-query-state', () => ({
+  classifyPrReviewQueryState: () => ({ kind: 'retryable' }),
+}));
+vi.mock('@/lib/trpc', () => ({
+  useTRPC: () => ({ githubPrReview: { listChecks: { queryOptions: () => ({}) } } }),
+}));
+
+describe('PrReviewChecksSection check status icons', () => {
+  it('rotates pending check icons but not finished check icons', () => {
+    const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+    act(() => {
+      ref.current = TestRenderer.create(
+        createElement(PrReviewChecksSection, {
+          owner: 'org',
+          repo: 'repo',
+          number: 1,
+          headSha: 'head',
+        })
+      );
+    });
+    const renderer = ref.current;
+    if (!renderer) {
+      throw new Error('renderer was not created');
+    }
+
+    expect(renderer.root.findAllByType(SpinningIcon)).toHaveLength(2);
+    expect(renderer.root.findAllByType(SpinningIcon).map(node => node.props.icon)).toEqual([
+      'Loader2',
+      'Loader2',
+    ]);
+    expect(renderer.root.findAll(node => String(node.type) === 'CheckCircle2')).toHaveLength(1);
+    expect(renderer.root.findAll(node => String(node.type) === 'XCircle')).toHaveLength(1);
+
+    act(() => {
+      renderer.unmount();
+    });
+  });
+});

--- a/apps/mobile/src/components/pr-review/pr-review-checks-section.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-checks-section.tsx
@@ -15,6 +15,7 @@ import { Pressable, View } from 'react-native';
 
 import { PrReviewReconnectNotice } from '@/components/pr-review/pr-review-reconnect-notice';
 import { Button } from '@/components/ui/button';
+import { SpinningIcon } from '@/components/ui/spinning-icon';
 import { Text } from '@/components/ui/text';
 import { i18n } from '@/i18n';
 import { formatList, formatNumber } from '@/lib/format';
@@ -99,7 +100,11 @@ function CheckRow({ run }: Readonly<{ run: CheckRun }>) {
 
   const body = (
     <View className={cn('flex-row items-center gap-3 px-4 py-3', 'min-h-11')}>
-      <Icon size={16} color={iconColor} />
+      {tone === 'pending' ? (
+        <SpinningIcon icon={Icon} size={16} color={iconColor} />
+      ) : (
+        <Icon size={16} color={iconColor} />
+      )}
       <View className="flex-1 gap-0.5">
         <Text className="text-sm font-medium" numberOfLines={1}>
           {run.name}


### PR DESCRIPTION
## Changelog for users

- In-progress and queued pull request check icons now rotate.
- Completed and failed check icons remain static.
- Reduced Motion disables pending icon rotation.

## Changelog for maintainers

- Pull request check rows reuse the shared spinning icon for pending states.
- A mounted test protects pending and finished icon behavior.

## Changes by area

### Pull request checks

Pending checks use the existing motion token and Reduced Motion behavior. Finished checks keep their static status icons.

### Test coverage

The mounted check section test verifies rotating pending icons and static success and failure icons.

## E2E proof

- Driver checks: 5 checks passed after round 3
- Section `mobile-app` verification output:
  - mobile: gates cached for c44907723ff0cc368345f310ead01df16ebaa556 (skipped)
  - mobile-device: 2 shard(s) over 2 device(s): B6F4F8DE-8DBF-41E2-9114-908DADAD1B68 CEB47290-FE68-4B66-9A70-98C3F21E4FFB
  - mobile-device: login probe passed on 2 device(s); app signed in
  - mobile-device: verifier passed
  - mobile-device: spot check clean

**The check status list shows the expected icon behavior for each status.**

https://github.com/user-attachments/assets/c2732db7-b240-4187-8990-a946b5181704

**Pending check icons rotate while their jobs remain unfinished.**

https://github.com/user-attachments/assets/255b05d5-33f8-4449-b0c9-1be9f25397c8

**Finished check icons remain static after completion or failure.**

https://github.com/user-attachments/assets/b3ac8f0a-7cef-4959-a5f6-93840491f72b

**Reduced Motion stops the pending check icon rotation.**

https://github.com/user-attachments/assets/496e0303-9ec7-468c-a343-0b861af2b0ff

**Pending check icons rotate during the full device scenario.**

https://github.com/user-attachments/assets/ded53b6c-6b45-401d-b47a-92980dbed6d4

**The check status view respects the Reduced Motion setting.**

https://github.com/user-attachments/assets/1e893262-fc25-4d43-a566-056c95fceaa7
