### PR TITLE
fix(github): bind install-state consume to presenting user

### DIFF
--- a/apps/web/src/app/api/integrations/github/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.test.ts
@@ -9,6 +9,15 @@ import { linkKiloUser } from '@/lib/bot-identity';
 import { bot } from '@/lib/bot';
 import { failureResult } from '@/lib/maybe-result';
 import { consumeInstallState } from '@/lib/integrations/github/install-state';
+import type * as InstallStateModule from '@/lib/integrations/github/install-state';
+import { db } from '@/lib/drizzle';
+import {
+  github_install_states,
+  kilocode_users,
+  type GitHubInstallState,
+} from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
 import {
   findIntegrationByInstallationId,
   upsertPlatformIntegrationForOwner,
@@ -25,15 +34,6 @@ jest.mock('@/lib/user/server');
 jest.mock('@/lib/bot/github-link-state');
 jest.mock('@/lib/bot-identity');
 jest.mock('@/lib/integrations/platforms/github/adapter');
-jest.mock('@/lib/drizzle', () => ({
-  db: {
-    select: jest.fn(() => ({
-      from: jest.fn(() => ({
-        where: jest.fn(async () => []),
-      })),
-    })),
-  },
-}));
 jest.mock('@/lib/bot', () => ({
   bot: {
     initialize: jest.fn(async () => undefined),
@@ -98,13 +98,20 @@ const mockedCaptureException = jest.mocked(captureException);
 const mockedCaptureMessage = jest.mocked(captureMessage);
 const mockedEnsureOrganizationAccess = jest.mocked(ensureOrganizationAccess);
 
-const USER_ID = '034489e8-19e0-4479-9d69-2edad719e847';
-const OTHER_USER_ID = 'c00b91a1-6959-4b04-9ef8-e8d37b340f4a';
+function mockConsumedInstallState(state: GitHubInstallState) {
+  mockedConsumeInstallState.mockResolvedValue({ status: 'success', state });
+}
+
+const USER_ID = 'oauth/test-callback-alice';
+const OTHER_USER_ID = 'test-callback-bob';
 const GITHUB_USER_ID = '12345';
 const INSTALLATION_ID = '98765';
 const INSTALL_STATE_TOKEN = 'valid-database-token-for-callback-tests';
 
 beforeEach(() => {
+  mockedConsumeInstallState.mockReset();
+  mockedConsumeInstallState.mockResolvedValue({ status: 'unusable' });
+  mockedUpsertPlatformIntegrationForOwner.mockResolvedValue({ ok: true });
   mockedExchangeGitHubOAuthCode.mockResolvedValue({
     id: GITHUB_USER_ID,
     login: 'octocat',
@@ -282,7 +289,7 @@ describe('GET /api/integrations/github/callback installation flow', () => {
           },
         }) as never
     );
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: INSTALL_STATE_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',
@@ -355,7 +362,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
   });
 
   test('completes a callback using a valid database-minted token', async () => {
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',
@@ -379,7 +386,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
     // The token consumed by the callback must be bare — no return suffix.
     expect(DB_TOKEN).not.toContain('|');
     expect(DB_TOKEN).not.toContain('return');
-    expect(mockedConsumeInstallState).toHaveBeenCalledWith(DB_TOKEN);
+    expect(mockedConsumeInstallState).toHaveBeenCalledWith(DB_TOKEN, USER_ID);
     expect(mockedUpsertPlatformIntegrationForOwner).toHaveBeenCalledWith(
       { type: 'user', id: USER_ID },
       expect.objectContaining({
@@ -393,7 +400,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
   test('consumes a bare token and rejects suffixed tokens (producer-shaped state)', async () => {
     // Simulate the real DB: only the bare token returns a row.
     // A suffixed token never matches the stored bare token.
-    const mockRow: Awaited<ReturnType<typeof consumeInstallState>> = {
+    const mockRow: GitHubInstallState = {
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',
@@ -405,7 +412,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
       created_at: new Date().toISOString(),
     };
     mockedConsumeInstallState.mockImplementation(async (token: string) => {
-      return token === DB_TOKEN ? mockRow : null;
+      return token === DB_TOKEN ? { status: 'success', state: mockRow } : { status: 'unusable' };
     });
 
     const { GET } = await import('./route');
@@ -423,21 +430,15 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
 
     expect(response.status).toBe(307);
     expectRedirectLocation(response, '/');
-    expect(mockedConsumeInstallState).toHaveBeenCalledWith(suffixed);
+    expect(mockedConsumeInstallState).toHaveBeenCalledWith(suffixed, USER_ID);
     expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
   });
 
-  test('rejects a token consumed by a different user (foreign state)', async () => {
+  test('rejects foreign state before any GitHub or integration side effects', async () => {
     mockedConsumeInstallState.mockResolvedValue({
-      token: DB_TOKEN,
-      kilo_user_id: OTHER_USER_ID,
-      owner_type: 'org',
-      owner_id: 'org-123',
-      github_app_type: 'standard',
-      return_to: null,
-      expires_at: new Date(Date.now() + 300_000).toISOString(),
-      consumed_at: null,
-      created_at: new Date().toISOString(),
+      status: 'user_mismatch',
+      organizationId: 'test-organization',
+      returnTo: null,
     });
 
     const { GET } = await import('./route');
@@ -449,22 +450,30 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
 
     expect(response.status).toBe(307);
     expectRedirectLocation(response, '/github-app?error=install_state_user_mismatch');
-    expect(mockedConsumeInstallState).toHaveBeenCalledWith(DB_TOKEN);
+    expect(mockedConsumeInstallState).toHaveBeenCalledWith(DB_TOKEN, USER_ID);
     expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
+    expect(mockedExchangeGitHubOAuthCode).not.toHaveBeenCalled();
+    expect(mockedCreateAppAuth).not.toHaveBeenCalled();
+    expect(mockedOctokit).not.toHaveBeenCalled();
+    expect(mockedAssertUserAdministersInstallation).not.toHaveBeenCalled();
+    expect(mockedVerifyGitHubBotLinkState).not.toHaveBeenCalled();
+    const { createPendingIntegration } =
+      await import('@/lib/integrations/db/platform-integrations');
+    expect(createPendingIntegration).not.toHaveBeenCalled();
+    expect(mockedCaptureMessage).toHaveBeenCalledWith(
+      'GitHub install state presented by different user',
+      {
+        level: 'warning',
+        tags: { endpoint: 'github/callback', source: 'install_state_user_mismatch' },
+      }
+    );
   });
 
   test('redirects with fromApp=1 when user mismatch on app-initiated state', async () => {
     mockedConsumeInstallState.mockResolvedValue({
-      token: DB_TOKEN,
-      kilo_user_id: OTHER_USER_ID,
-      owner_type: 'user',
-      owner_id: OTHER_USER_ID,
-      github_app_type: 'standard',
-      // App-initiated: return_to is /cloud/sessions (starts with /cloud/)
-      return_to: '/cloud/sessions',
-      expires_at: new Date(Date.now() + 300_000).toISOString(),
-      consumed_at: null,
-      created_at: new Date().toISOString(),
+      status: 'user_mismatch',
+      organizationId: null,
+      returnTo: '/cloud/sessions',
     });
 
     const { GET } = await import('./route');
@@ -476,12 +485,83 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
 
     expect(response.status).toBe(307);
     expectRedirectLocation(response, '/github-app?error=install_state_user_mismatch&fromApp=1');
-    expect(mockedConsumeInstallState).toHaveBeenCalledWith(DB_TOKEN);
+    expect(mockedConsumeInstallState).toHaveBeenCalledWith(DB_TOKEN, USER_ID);
+    expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
+  });
+
+  test('a callback after a session switch leaves real state usable by its initiator', async () => {
+    const stateModule = jest.requireActual<typeof InstallStateModule>(
+      '@/lib/integrations/github/install-state'
+    );
+    const initiatorId = `oauth/callback-db-${randomUUID()}`;
+    await db.insert(kilocode_users).values({
+      id: initiatorId,
+      google_user_email: `callback-db-${randomUUID()}@example.com`,
+      google_user_name: 'Test Initiator',
+      google_user_image_url: '',
+      stripe_customer_id: 'cus_test_callback',
+    });
+    try {
+      const token = await stateModule.createInstallState({
+        kiloUserId: initiatorId,
+        ownerType: 'user',
+        ownerId: initiatorId,
+        githubAppType: 'standard',
+        returnTo: '/cloud/sessions',
+      });
+      await expect(stateModule.checkInstallState(token, initiatorId)).resolves.toEqual({
+        status: 'valid',
+      });
+      mockedConsumeInstallState.mockImplementation(stateModule.consumeInstallState);
+      const { GET } = await import('./route');
+      const callbackPath = `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${token}&code=test-code`;
+      const rejected = await GET(makeRequest(callbackPath));
+      expectRedirectLocation(rejected, '/github-app?error=install_state_user_mismatch&fromApp=1');
+      const [state] = await db
+        .select({ consumedAt: github_install_states.consumed_at })
+        .from(github_install_states)
+        .where(eq(github_install_states.token, token));
+      expect(state).toEqual({ consumedAt: null });
+      expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
+      expect(mockedExchangeGitHubOAuthCode).not.toHaveBeenCalled();
+      expect(mockedOctokit).not.toHaveBeenCalled();
+
+      mockedGetUserFromAuth.mockResolvedValue({
+        user: { id: initiatorId, google_user_email: 'test@example.com', google_user_name: 'Test' },
+        authFailedResponse: null,
+      } as never);
+      const accepted = await GET(makeRequest(callbackPath));
+      expectRedirectLocation(accepted, '/github-app?fromApp=1&github_install=success');
+      expect(mockedUpsertPlatformIntegrationForOwner).toHaveBeenCalledTimes(1);
+      expect(mockedUpsertPlatformIntegrationForOwner).toHaveBeenCalledWith(
+        { type: 'user', id: initiatorId },
+        expect.anything()
+      );
+      const replayed = await GET(makeRequest(callbackPath));
+      expectRedirectLocation(replayed, '/');
+      expect(mockedUpsertPlatformIntegrationForOwner).toHaveBeenCalledTimes(1);
+    } finally {
+      await db.delete(kilocode_users).where(eq(kilocode_users.id, initiatorId));
+    }
+  });
+
+  test('preserves organization recovery context for an app-initiated mismatch', async () => {
+    mockedConsumeInstallState.mockResolvedValue({
+      status: 'user_mismatch',
+      organizationId: 'test-organization',
+      returnTo: '/cloud/sessions',
+    });
+    const { GET } = await import('./route');
+    const response = await GET(makeRequest(`/api/integrations/github/callback?state=${DB_TOKEN}`));
+    expectRedirectLocation(
+      response,
+      '/github-app?error=install_state_user_mismatch&fromApp=1&organizationId=test-organization'
+    );
     expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
   });
 
   test('rejects a replayed (already consumed) token', async () => {
-    mockedConsumeInstallState.mockResolvedValue(null);
+    mockedConsumeInstallState.mockResolvedValue({ status: 'unusable' });
 
     const { GET } = await import('./route');
     const response = await GET(
@@ -493,13 +573,13 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
     // Replayed tokens fall through to unrecognized state
     expect(response.status).toBe(307);
     expectRedirectLocation(response, '/');
-    expect(mockedConsumeInstallState).toHaveBeenCalledWith(DB_TOKEN);
+    expect(mockedConsumeInstallState).toHaveBeenCalledWith(DB_TOKEN, USER_ID);
     expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
   });
 
   test('treats a prefixed state as opaque when it matches a database token', async () => {
     const PREFIXED_DB_TOKEN = `user_${DB_TOKEN}`;
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: PREFIXED_DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'org',
@@ -520,7 +600,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
 
     expect(response.status).toBe(307);
     expectRedirectLocation(response, '/github-app?github_install=success');
-    expect(mockedConsumeInstallState).toHaveBeenCalledWith(PREFIXED_DB_TOKEN);
+    expect(mockedConsumeInstallState).toHaveBeenCalledWith(PREFIXED_DB_TOKEN, USER_ID);
     // The owner always comes from the database row, never from token contents.
     expect(mockedUpsertPlatformIntegrationForOwner).toHaveBeenCalledWith(
       { type: 'org', id: 'org-db-owner' },
@@ -534,7 +614,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
   });
 
   test('revalidates organization management access before storing an installation', async () => {
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'org',
@@ -559,7 +639,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
   });
 
   test('handles a database-minted token with returnTo', async () => {
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'org',
@@ -591,7 +671,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
   });
 
   test('redirects to /github-app fallback (not /cloud/sessions) for app-initiated success', async () => {
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',
@@ -618,7 +698,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
   });
 
   test('redirects to /github-app fallback for app-initiated pending approval', async () => {
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',
@@ -649,7 +729,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
 
   test('rejects non-/cloud/ returnTo as non-app (no fallback redirect)', async () => {
     // A non-app returnTo must not trigger the /github-app fallback.
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'org',
@@ -681,7 +761,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
   });
 
   test('app-initiated installation_already_claimed redirects to /github-app fallback', async () => {
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',
@@ -709,7 +789,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
   });
 
   test('app-initiated missing_installation_id redirects to /github-app fallback', async () => {
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',
@@ -734,7 +814,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
   });
 
   test('app-initiated installation_not_found redirects to /github-app fallback', async () => {
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',
@@ -771,7 +851,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
   });
 
   test('ambiguous app-initiated pending request returns successful pending no-op', async () => {
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',
@@ -797,7 +877,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
   test('app-initiated org success preserves organizationId on redirect', async () => {
     const ORG_ID = 'org-789';
     mockedUpsertPlatformIntegrationForOwner.mockResolvedValue({ ok: true });
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'org',
@@ -830,7 +910,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
 
   test('app-initiated user success omits organizationId', async () => {
     mockedUpsertPlatformIntegrationForOwner.mockResolvedValue({ ok: true });
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',
@@ -856,7 +936,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
 
   test('app-initiated org pending approval preserves organizationId', async () => {
     const ORG_ID = 'org-pending';
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'org',
@@ -905,7 +985,7 @@ describe('GET /api/integrations/github/callback plaintext state rejection', () =
       authFailedResponse: null,
     } as never);
     mockedVerifyGitHubBotLinkState.mockReturnValue(null);
-    mockedConsumeInstallState.mockResolvedValue(null);
+    mockedConsumeInstallState.mockResolvedValue({ status: 'unusable' });
   });
 
   test.each(['org_', 'user_'])('always rejects %s prefixed plaintext state', async prefix => {
@@ -940,7 +1020,7 @@ describe('GET /api/integrations/github/callback admin proof', () => {
       authFailedResponse: null,
     } as never);
     mockedVerifyGitHubBotLinkState.mockReturnValue(null);
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: INSTALL_STATE_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',
@@ -1067,7 +1147,7 @@ describe('GET /api/integrations/github/callback admin proof', () => {
 
   test('redirects when multiple installations are disabled for the organization', async () => {
     const organizationId = '00000000-0000-4000-8000-000000000001';
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: INSTALL_STATE_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'org',
@@ -1151,7 +1231,7 @@ describe('GET /api/integrations/github/callback Sentry redaction', () => {
       authFailedResponse: null,
     } as never);
     mockedVerifyGitHubBotLinkState.mockReturnValue(null);
-    mockedConsumeInstallState.mockResolvedValue(null);
+    mockedConsumeInstallState.mockResolvedValue({ status: 'unusable' });
     mockedCreateAppAuth.mockReturnValue(
       jest.fn(async () => ({ token: 'github-app-token' })) as never
     );
@@ -1177,7 +1257,7 @@ describe('GET /api/integrations/github/callback Sentry redaction', () => {
 
   test('unrecognized-state warning does not include the raw state token', async () => {
     const RAW_TOKEN = `sentry-redaction-unknown-${Date.now()}`;
-    mockedConsumeInstallState.mockResolvedValue(null);
+    mockedConsumeInstallState.mockResolvedValue({ status: 'unusable' });
 
     const { GET } = await import('./route');
     const response = await GET(
@@ -1200,7 +1280,7 @@ describe('GET /api/integrations/github/callback Sentry redaction', () => {
 
   test('catch-path exception does not include the raw state token', async () => {
     const RAW_TOKEN = `sentry-redaction-catch-${Date.now()}`;
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: RAW_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',
@@ -1244,7 +1324,7 @@ describe('GET /api/integrations/github/callback Sentry redaction', () => {
 
   test('missing-installation diagnostic does not include the raw state token or params', async () => {
     const RAW_TOKEN = `missing-installation-${Date.now()}`;
-    mockedConsumeInstallState.mockResolvedValue({
+    mockConsumedInstallState({
       token: RAW_TOKEN,
       kilo_user_id: USER_ID,
       owner_type: 'user',

--- a/apps/web/src/app/api/integrations/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.ts
@@ -153,9 +153,22 @@ export async function GET(request: NextRequest) {
     // 3. Atomically consume a database-backed install state before attempting
     // bot-link parsing. Database tokens are opaque and unambiguous once found.
     if (rawState) {
-      const installRow = await consumeInstallState(rawState);
-      if (installRow) {
-        return await handleNewInstallFlow(request, user, installRow, installationId, setupAction);
+      const result = await consumeInstallState(rawState, user.id);
+      if (result.status === 'success') {
+        return await handleNewInstallFlow(request, user, result.state, installationId, setupAction);
+      }
+      if (result.status === 'user_mismatch') {
+        captureMessage('GitHub install state presented by different user', {
+          level: 'warning',
+          tags: { endpoint: 'github/callback', source: 'install_state_user_mismatch' },
+        });
+        const isAppInitiated = result.returnTo?.startsWith('/cloud/') === true;
+        const query = new URLSearchParams({ error: 'install_state_user_mismatch' });
+        if (isAppInitiated) {
+          query.set('fromApp', '1');
+          if (result.organizationId) query.set('organizationId', result.organizationId);
+        }
+        return NextResponse.redirect(new URL(`/github-app?${query}`, APP_URL));
       }
 
       // 4. Bot-link callback hand-off. Bot-link state tokens use a signed
@@ -167,7 +180,6 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // 5. Both bot-link verification and database consumption returned null.
     captureMessage('GitHub callback with unrecognized state', {
       level: 'warning',
       tags: { endpoint: 'github/callback', source: 'github_app_installation' },
@@ -202,10 +214,6 @@ export async function GET(request: NextRequest) {
   }
 }
 
-/**
- * New database-backed install flow. The state was atomically consumed.
- * Verify the user matches and run the install flow using row data.
- */
 async function handleNewInstallFlow(
   request: NextRequest,
   user: { id: string; google_user_email: string; google_user_name: string },
@@ -213,31 +221,6 @@ async function handleNewInstallFlow(
   installationId: string,
   setupAction: string | null
 ): Promise<Response> {
-  // Verify user identity — a state minted for another user must never be usable.
-  if (installRow.kilo_user_id !== user.id) {
-    captureMessage('GitHub install state consumed by different user', {
-      level: 'warning',
-      tags: { endpoint: 'github/callback', source: 'install_state_user_mismatch' },
-      extra: {
-        tokenUserId: installRow.kilo_user_id,
-        callbackUserId: user.id,
-        installationId,
-      },
-    });
-    // Redirect to the integration page with a specific error so the UI can
-    // display the corrective message.  If the flow was started from the app
-    // (return_to is set to an app route like /cloud/sessions) include fromApp=1
-    // so the /github-app fallback triggers.
-    const returnTo = installRow.return_to;
-    const isAppInitiated = returnTo?.startsWith('/cloud/') === true;
-    const organizationId =
-      installRow.owner_type === 'org' ? `&organizationId=${installRow.owner_id}` : '';
-    const mismatchQuery = isAppInitiated
-      ? `error=install_state_user_mismatch&fromApp=1${organizationId}`
-      : 'error=install_state_user_mismatch';
-    return NextResponse.redirect(new URL(appendQueryParam('/github-app', mismatchQuery), APP_URL));
-  }
-
   const ownerType = installRow.owner_type as Owner['type'];
   const ownerId = installRow.owner_id;
   const owner: Owner = { type: ownerType, id: ownerId };

--- a/apps/web/src/app/github-app/page.test.ts
+++ b/apps/web/src/app/github-app/page.test.ts
@@ -1,0 +1,117 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import GitHubAppPage from './page';
+import { GitHubIntegrationDetails } from '@/components/integrations/GitHubIntegrationDetails';
+import { checkInstallState } from '@/lib/integrations/github/install-state';
+import { getUserFromAuthOrRedirect } from '@/lib/user/server';
+
+jest.mock('@/components/integrations/GitHubIntegrationDetails', () => ({
+  GitHubIntegrationDetails: jest.fn(() => React.createElement('button', null, 'Open GitHub setup')),
+}));
+jest.mock('@/lib/integrations/github/install-state', () => ({
+  checkInstallState: jest.fn(),
+}));
+jest.mock('@/lib/user/server', () => ({
+  getUserFromAuthOrRedirect: jest.fn(),
+}));
+
+const mockedCheckInstallState = jest.mocked(checkInstallState);
+const mockedGetUser = jest.mocked(getUserFromAuthOrRedirect);
+const mockedDetails = jest.mocked(GitHubIntegrationDetails);
+const browserUserId = 'oauth/test-browser-alice';
+const token = 'test-preminted-install-state';
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  mockedGetUser.mockResolvedValue({ id: browserUserId } as Awaited<
+    ReturnType<typeof getUserFromAuthOrRedirect>
+  >);
+  mockedCheckInstallState.mockResolvedValue({ status: 'valid' });
+  mockedDetails.mockImplementation(() => React.createElement('button', null, 'Open GitHub setup'));
+});
+
+async function renderPage(search: Record<string, string> = {}) {
+  return renderToStaticMarkup(await GitHubAppPage({ searchParams: Promise.resolve(search) }));
+}
+
+describe('GitHubAppPage install-state preflight', () => {
+  test('forwards matching pre-minted state unchanged after checking the browser user', async () => {
+    const html = await renderPage({
+      installState: token,
+      fromApp: '1',
+      organizationId: 'test-org',
+    });
+    expect(mockedCheckInstallState).toHaveBeenCalledWith(token, browserUserId);
+    expect(html).toContain('Open GitHub setup');
+    expect(mockedDetails.mock.calls[0][0]).toMatchObject({
+      installState: token,
+      fromApp: true,
+      organizationId: 'test-org',
+      appReturnPath: `/github-app?organizationId=test-org&installState=${token}&fromApp=1`,
+    });
+  });
+
+  test.each(['1', '0'])(
+    'blocks foreign state without mounting the installation component (fromApp=%s)',
+    async fromApp => {
+      mockedCheckInstallState.mockResolvedValue({
+        status: 'user_mismatch',
+        organizationId: 'test-org',
+        returnTo: '/cloud/sessions',
+      });
+      const html = await renderPage({ installState: token, fromApp });
+      expect(html).toContain('Account mismatch');
+      expect(html).not.toContain('Open GitHub setup');
+      expect(html).not.toContain(token);
+      expect(html).not.toContain('test-org');
+      expect(mockedDetails).not.toHaveBeenCalled();
+      expect(html).toContain(fromApp === '1' ? 'Return to Kilo App' : 'Go to dashboard');
+    }
+  );
+
+  test.each(['expired-state', 'consumed-state', 'unknown-state', ''])(
+    'shows restart recovery for unusable state %j',
+    async installState => {
+      mockedCheckInstallState.mockResolvedValue({ status: 'unusable' });
+      const html = await renderPage({ installState, fromApp: '1' });
+      expect(mockedCheckInstallState).toHaveBeenCalledWith(installState, browserUserId);
+      expect(html).toContain('Restart GitHub setup');
+      expect(html).toContain('/cloud/sessions?error=install_state_unusable');
+      expect(html).not.toContain('Open GitHub setup');
+      expect(mockedDetails).not.toHaveBeenCalled();
+    }
+  );
+
+  test('query-string success and pending outcomes cannot bypass a failed preflight', async () => {
+    mockedCheckInstallState.mockResolvedValue({ status: 'unusable' });
+    const html = await renderPage({
+      installState: token,
+      fromApp: '1',
+      github_install: 'success',
+      pending_approval: 'true',
+    });
+    expect(html).toContain('Restart GitHub setup');
+    expect(mockedDetails).not.toHaveBeenCalled();
+  });
+
+  test('does not preflight ordinary web setup or callback outcomes without pre-minted state', async () => {
+    await renderPage({ fromApp: '1', error: 'install_state_user_mismatch' });
+    expect(mockedCheckInstallState).not.toHaveBeenCalled();
+    expect(mockedDetails.mock.calls[0][0]).toMatchObject({
+      installState: undefined,
+      error: 'install_state_user_mismatch',
+    });
+  });
+
+  test('authenticates before preflight and preserves the original handoff through sign-in', async () => {
+    mockedGetUser.mockRejectedValue(new Error('test sign-in redirect'));
+    await expect(renderPage({ installState: token, fromApp: '1' })).rejects.toThrow(
+      'test sign-in redirect'
+    );
+    expect(mockedGetUser).toHaveBeenCalledWith(
+      `/users/sign_in?callbackPath=${encodeURIComponent(`/github-app?installState=${token}&fromApp=1`)}`
+    );
+    expect(mockedCheckInstallState).not.toHaveBeenCalled();
+    expect(mockedDetails).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/github-app/page.test.ts
+++ b/apps/web/src/app/github-app/page.test.ts
@@ -66,6 +66,50 @@ describe('GitHubAppPage install-state preflight', () => {
       expect(html).not.toContain('test-org');
       expect(mockedDetails).not.toHaveBeenCalled();
       expect(html).toContain(fromApp === '1' ? 'Return to Kilo App' : 'Go to dashboard');
+      expect(html).toContain(
+        fromApp === '1' ? 'href="/cloud/sessions?error=install_state_user_mismatch"' : 'href="/"'
+      );
+      expect(html).not.toContain('organizationId');
+    }
+  );
+
+  test.each(['user_mismatch', 'unusable'] as const)(
+    'preserves only the encoded query organization in app recovery for %s',
+    async status => {
+      mockedCheckInstallState.mockResolvedValue(
+        status === 'user_mismatch'
+          ? { status, organizationId: 'foreign-state-org', returnTo: '/cloud/sessions' }
+          : { status }
+      );
+      const html = await renderPage({
+        installState: token,
+        fromApp: '1',
+        organizationId: 'query org&scope=other',
+      });
+      const error =
+        status === 'user_mismatch' ? 'install_state_user_mismatch' : 'install_state_unusable';
+      expect(html).toContain(
+        `href="/cloud/sessions?error=${error}&amp;organizationId=query%20org%26scope%3Dother"`
+      );
+      expect(html).not.toContain('foreign-state-org');
+      expect(mockedDetails).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each(['user_mismatch', 'unusable'] as const)(
+    'keeps dashboard recovery free of organization parameters for %s',
+    async status => {
+      mockedCheckInstallState.mockResolvedValue(
+        status === 'user_mismatch'
+          ? { status, organizationId: 'foreign-state-org', returnTo: '/cloud/sessions' }
+          : { status }
+      );
+      const html = await renderPage({ installState: token, organizationId: 'query-org' });
+      expect(html).toContain('href="/"');
+      expect(html).not.toContain('organizationId');
+      expect(html).not.toContain('foreign-state-org');
+      expect(html).not.toContain('query-org');
+      expect(mockedDetails).not.toHaveBeenCalled();
     }
   );
 

--- a/apps/web/src/app/github-app/page.tsx
+++ b/apps/web/src/app/github-app/page.tsx
@@ -60,6 +60,9 @@ export default async function GitHubAppPage({
   const blocked = preflight && preflight.status !== 'valid';
   const mismatch = preflight?.status === 'user_mismatch';
   const recoveryError = mismatch ? 'install_state_user_mismatch' : 'install_state_unusable';
+  const recoveryOrgParam = search.organizationId
+    ? `&organizationId=${encodeURIComponent(search.organizationId)}`
+    : '';
 
   return (
     <main className="min-h-screen bg-background px-4 py-5 sm:px-6">
@@ -86,7 +89,11 @@ export default async function GitHubAppPage({
                   : 'This setup link has expired, has already been used, or is invalid. Return to Kilo and start GitHub setup again.'}
               </p>
               <Button asChild variant="outline">
-                <Link href={isFromApp ? `/cloud/sessions?error=${recoveryError}` : '/'}>
+                <Link
+                  href={
+                    isFromApp ? `/cloud/sessions?error=${recoveryError}${recoveryOrgParam}` : '/'
+                  }
+                >
                   {isFromApp ? 'Return to Kilo App' : 'Go to dashboard'}
                 </Link>
               </Button>

--- a/apps/web/src/app/github-app/page.tsx
+++ b/apps/web/src/app/github-app/page.tsx
@@ -1,6 +1,11 @@
+import React from 'react';
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 import { GitHubIntegrationDetails } from '@/components/integrations/GitHubIntegrationDetails';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { checkInstallState } from '@/lib/integrations/github/install-state';
 import { getUserFromAuthOrRedirect } from '@/lib/user/server';
 
 export const metadata: Metadata = {
@@ -47,7 +52,14 @@ export default async function GitHubAppPage({
   const installState = search.installState;
   const returnPath = getGitHubAppReturnPath(search.organizationId, installState, search.fromApp);
 
-  await getUserFromAuthOrRedirect(`/users/sign_in?callbackPath=${encodeURIComponent(returnPath)}`);
+  const user = await getUserFromAuthOrRedirect(
+    `/users/sign_in?callbackPath=${encodeURIComponent(returnPath)}`
+  );
+  const preflight =
+    installState !== undefined ? await checkInstallState(installState, user.id) : null;
+  const blocked = preflight && preflight.status !== 'valid';
+  const mismatch = preflight?.status === 'user_mismatch';
+  const recoveryError = mismatch ? 'install_state_user_mismatch' : 'install_state_unusable';
 
   return (
     <main className="min-h-screen bg-background px-4 py-5 sm:px-6">
@@ -62,18 +74,38 @@ export default async function GitHubAppPage({
           </p>
         </header>
 
-        <GitHubIntegrationDetails
-          organizationId={search.organizationId}
-          installState={installState}
-          fromApp={isFromApp}
-          success={search.github_install === 'success' || search.success === 'installed'}
-          error={search.error}
-          pendingApproval={
-            search.github_pending_approval === 'true' || search.pending_approval === 'true'
-          }
-          existingPendingOrg={search.org}
-          appReturnPath={isFromApp ? returnPath : undefined}
-        />
+        {blocked ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>{mismatch ? 'Account mismatch' : 'Restart GitHub setup'}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-muted-foreground text-sm">
+                {mismatch
+                  ? 'This connection was started by a different Kilo account. Sign in with the account that started it, then restart setup.'
+                  : 'This setup link has expired, has already been used, or is invalid. Return to Kilo and start GitHub setup again.'}
+              </p>
+              <Button asChild variant="outline">
+                <Link href={isFromApp ? `/cloud/sessions?error=${recoveryError}` : '/'}>
+                  {isFromApp ? 'Return to Kilo App' : 'Go to dashboard'}
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <GitHubIntegrationDetails
+            organizationId={search.organizationId}
+            installState={installState}
+            fromApp={isFromApp}
+            success={search.github_install === 'success' || search.success === 'installed'}
+            error={search.error}
+            pendingApproval={
+              search.github_pending_approval === 'true' || search.pending_approval === 'true'
+            }
+            existingPendingOrg={search.org}
+            appReturnPath={isFromApp ? returnPath : undefined}
+          />
+        )}
       </div>
     </main>
   );

--- a/apps/web/src/lib/integrations/github/install-state.test.ts
+++ b/apps/web/src/lib/integrations/github/install-state.test.ts
@@ -1,191 +1,212 @@
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { randomUUID } from 'node:crypto';
 import { db } from '@/lib/drizzle';
 import { github_install_states, kilocode_users } from '@kilocode/db/schema';
-import { eq, sql } from 'drizzle-orm';
+import { eq, inArray, sql } from 'drizzle-orm';
 import {
   createInstallState,
+  checkInstallState,
   consumeInstallState,
   cleanupExpiredInstallStates,
 } from './install-state';
 
-describe('install-state', () => {
-  const testUserId = 'test-install-user-' + Date.now();
-  const testUserEmail = `test-install-${Date.now()}@example.com`;
+const testUserId = `oauth/install-state-alice-${randomUUID()}`;
+const otherUserId = `install-state-bob-${randomUUID()}`;
 
+async function mintState() {
+  return createInstallState({
+    kiloUserId: testUserId,
+    ownerType: 'org',
+    ownerId: 'test-organization',
+    githubAppType: 'lite',
+    returnTo: '/cloud/sessions',
+  });
+}
+
+async function readState(token: string) {
+  const [state] = await db
+    .select()
+    .from(github_install_states)
+    .where(eq(github_install_states.token, token));
+  if (!state) throw new Error('Expected test state to exist');
+  return state;
+}
+
+describe('install-state', () => {
   beforeEach(async () => {
-    await db.insert(kilocode_users).values({
-      id: testUserId,
-      google_user_email: testUserEmail,
-      google_user_name: 'Test Install User',
-      google_user_image_url: 'https://example.com/avatar.jpg',
-      stripe_customer_id: 'cus_test_install',
-    });
+    await db.insert(kilocode_users).values(
+      [testUserId, otherUserId].map((id, index) => ({
+        id,
+        google_user_email: `install-state-${index}-${randomUUID()}@example.com`,
+        google_user_name: 'Test Install User',
+        google_user_image_url: 'https://example.com/avatar.jpg',
+        stripe_customer_id: `cus_test_install_${index}`,
+      }))
+    );
   });
 
   afterEach(async () => {
     await db
       .delete(github_install_states)
-      .where(eq(github_install_states.kilo_user_id, testUserId));
-    await db.delete(kilocode_users).where(eq(kilocode_users.id, testUserId));
+      .where(inArray(github_install_states.kilo_user_id, [testUserId, otherUserId]));
+    await db.delete(kilocode_users).where(inArray(kilocode_users.id, [testUserId, otherUserId]));
   });
 
   describe('createInstallState', () => {
-    test('creates a row and returns a base64url token', async () => {
-      const token = await createInstallState({
-        kiloUserId: testUserId,
-        ownerType: 'org',
-        ownerId: 'org-1',
-        githubAppType: 'standard',
-        returnTo: '/github-app',
+    test('stores an opaque token with its initiating user and installation context', async () => {
+      const token = await mintState();
+      expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      const state = await readState(token);
+      expect(state).toMatchObject({
+        token,
+        kilo_user_id: testUserId,
+        owner_type: 'org',
+        owner_id: 'test-organization',
+        github_app_type: 'lite',
+        return_to: '/cloud/sessions',
+        consumed_at: null,
       });
-
-      expect(token).toBeTruthy();
-      expect(typeof token).toBe('string');
-      // 32 random bytes base64url-encoded = 43 characters (no padding)
-      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(new Date(state.expires_at).getTime()).toBeGreaterThan(Date.now());
+      expect(new Date(state.expires_at).getTime()).toBeLessThanOrEqual(Date.now() + 600_000);
     });
 
-    test('stores the row in the database', async () => {
+    test('stores personal ownership and a null return path', async () => {
       const token = await createInstallState({
         kiloUserId: testUserId,
         ownerType: 'user',
         ownerId: testUserId,
-        githubAppType: 'lite',
+        githubAppType: 'standard',
+      });
+      expect(await readState(token)).toMatchObject({
+        owner_type: 'user',
+        owner_id: testUserId,
+        return_to: null,
+      });
+      await expect(checkInstallState(token, otherUserId)).resolves.toEqual({
+        status: 'user_mismatch',
+        organizationId: null,
         returnTo: null,
       });
+    });
+  });
 
-      const rows = await db
-        .select()
-        .from(github_install_states)
-        .where(eq(github_install_states.token, token));
+  describe('checkInstallState', () => {
+    test('checks a matching user without consuming or returning the stored row', async () => {
+      const token = await mintState();
+      await expect(checkInstallState(token, testUserId)).resolves.toEqual({ status: 'valid' });
+      await expect(checkInstallState(token, testUserId)).resolves.toEqual({ status: 'valid' });
+      expect((await readState(token)).consumed_at).toBeNull();
+    });
 
-      expect(rows).toHaveLength(1);
-      expect(rows[0].kilo_user_id).toBe(testUserId);
-      expect(rows[0].owner_type).toBe('user');
-      expect(rows[0].owner_id).toBe(testUserId);
-      expect(rows[0].github_app_type).toBe('lite');
-      expect(rows[0].return_to).toBeNull();
-      expect(rows[0].consumed_at).toBeNull();
-      expect(rows[0].expires_at).toBeTruthy();
+    test('reports only recovery context for a different user without mutating state', async () => {
+      const token = await mintState();
+      const before = await readState(token);
+      await expect(checkInstallState(token, otherUserId)).resolves.toEqual({
+        status: 'user_mismatch',
+        organizationId: 'test-organization',
+        returnTo: '/cloud/sessions',
+      });
+      expect(await readState(token)).toEqual(before);
     });
   });
 
   describe('consumeInstallState', () => {
-    test('consumes a fresh token exactly once', async () => {
-      const token = await createInstallState({
-        kiloUserId: testUserId,
-        ownerType: 'org',
-        ownerId: 'org-2',
-        githubAppType: 'standard',
-      });
-
-      const first = await consumeInstallState(token);
-      expect(first).not.toBeNull();
-      expect(first!.token).toBe(token);
-      expect(first!.consumed_at).toBeTruthy();
-
-      const second = await consumeInstallState(token);
-      expect(second).toBeNull();
+    test('consumes a matching arbitrary-string user token exactly once and returns its row', async () => {
+      const token = await mintState();
+      const first = await consumeInstallState(token, testUserId);
+      expect(first.status).toBe('success');
+      if (first.status !== 'success') throw new Error('Expected successful consumption');
+      expect(first.state).toEqual(await readState(token));
+      expect(first.state.consumed_at).not.toBeNull();
+      await expect(consumeInstallState(token, testUserId)).resolves.toEqual({ status: 'unusable' });
     });
 
-    test('returns null for an unknown token', async () => {
-      const result = await consumeInstallState('nonexistent-token');
-      expect(result).toBeNull();
+    test('a foreign callback cannot burn state before the initiator consumes it', async () => {
+      const token = await mintState();
+      const before = await readState(token);
+      await expect(consumeInstallState(token, otherUserId)).resolves.toEqual({
+        status: 'user_mismatch',
+        organizationId: 'test-organization',
+        returnTo: '/cloud/sessions',
+      });
+      expect(await readState(token)).toEqual(before);
+      await expect(consumeInstallState(token, testUserId)).resolves.toMatchObject({
+        status: 'success',
+        state: { kilo_user_id: testUserId },
+      });
+      await expect(consumeInstallState(token, testUserId)).resolves.toEqual({ status: 'unusable' });
     });
 
-    test('returns null for an expired token', async () => {
-      // Insert a token with an already-past expires_at
-      const expiredToken = 'expired-test-token-' + Date.now();
-      await db.insert(github_install_states).values({
-        token: expiredToken,
-        kilo_user_id: testUserId,
-        owner_type: 'user',
-        owner_id: testUserId,
-        github_app_type: 'standard',
-        expires_at: new Date(Date.now() - 1000).toISOString(),
+    test('a session change after valid preflight does not authorize consumption', async () => {
+      const token = await mintState();
+      await expect(checkInstallState(token, testUserId)).resolves.toEqual({ status: 'valid' });
+      await expect(consumeInstallState(token, otherUserId)).resolves.toMatchObject({
+        status: 'user_mismatch',
       });
-
-      const result = await consumeInstallState(expiredToken);
-      expect(result).toBeNull();
+      expect((await readState(token)).consumed_at).toBeNull();
     });
 
-    test('returns null for a consumed token', async () => {
-      const token = await createInstallState({
-        kiloUserId: testUserId,
-        ownerType: 'org',
-        ownerId: 'org-3',
-        githubAppType: 'standard',
-      });
+    test.each([true, false])(
+      'only the initiator wins concurrent consumption (foreign first: %s)',
+      async foreignFirst => {
+        const token = await mintState();
+        const users = foreignFirst ? [otherUserId, testUserId] : [testUserId, otherUserId];
+        const results = await Promise.all(users.map(userId => consumeInstallState(token, userId)));
+        expect(results[users.indexOf(testUserId)].status).toBe('success');
+        expect(['user_mismatch', 'unusable']).toContain(results[users.indexOf(otherUserId)].status);
+        expect(results.filter(result => result.status === 'success')).toHaveLength(1);
+        expect((await readState(token)).consumed_at).not.toBeNull();
+      }
+    );
 
-      // Pre-consume by setting consumed_at directly
-      await db
-        .update(github_install_states)
-        .set({ consumed_at: sql`NOW()` })
-        .where(eq(github_install_states.token, token));
-
-      const result = await consumeInstallState(token);
-      expect(result).toBeNull();
-    });
-
-    test('returns the full row with all fields', async () => {
-      const token = await createInstallState({
-        kiloUserId: testUserId,
-        ownerType: 'org',
-        ownerId: 'org-4',
-        githubAppType: 'lite',
-        returnTo: '/some/path',
-      });
-
-      const row = await consumeInstallState(token);
-      expect(row).not.toBeNull();
-      expect(row!.kilo_user_id).toBe(testUserId);
-      expect(row!.owner_type).toBe('org');
-      expect(row!.owner_id).toBe('org-4');
-      expect(row!.github_app_type).toBe('lite');
-      expect(row!.return_to).toBe('/some/path');
+    test('concurrent matching callbacks consume state exactly once', async () => {
+      const token = await mintState();
+      const results = await Promise.all([
+        consumeInstallState(token, testUserId),
+        consumeInstallState(token, testUserId),
+      ]);
+      expect(results.map(result => result.status).sort()).toEqual(['success', 'unusable']);
     });
   });
 
+  describe('unusable states', () => {
+    test.each(['unknown', 'expired', 'consumed'])(
+      '%s state is unusable for either user',
+      async kind => {
+        const token = kind === 'unknown' ? 'nonexistent-test-token' : await mintState();
+        if (kind === 'expired') {
+          await db
+            .update(github_install_states)
+            .set({ expires_at: sql`NOW() - INTERVAL '1 second'` })
+            .where(eq(github_install_states.token, token));
+        }
+        if (kind === 'consumed') {
+          await consumeInstallState(token, testUserId);
+        }
+        const before = kind === 'unknown' ? null : await readState(token);
+        for (const userId of [testUserId, otherUserId]) {
+          await expect(checkInstallState(token, userId)).resolves.toEqual({ status: 'unusable' });
+          await expect(consumeInstallState(token, userId)).resolves.toEqual({ status: 'unusable' });
+        }
+        if (before) expect(await readState(token)).toEqual(before);
+      }
+    );
+  });
+
   describe('cleanupExpiredInstallStates', () => {
-    test('deletes expired rows', async () => {
-      // Insert an already-expired row
-      await db.insert(github_install_states).values({
-        token: 'cleanup-expired-' + Date.now(),
-        kilo_user_id: testUserId,
-        owner_type: 'user',
-        owner_id: testUserId,
-        github_app_type: 'standard',
-        expires_at: new Date(Date.now() - 60_000).toISOString(),
-      });
-
-      const deleted = await cleanupExpiredInstallStates();
-      expect(deleted).toBeGreaterThanOrEqual(1);
-
-      // Verify the expired row is gone
+    test('deletes expired rows and retains live rows', async () => {
+      const expired = await mintState();
+      const live = await mintState();
+      await db
+        .update(github_install_states)
+        .set({ expires_at: sql`NOW() - INTERVAL '1 second'` })
+        .where(eq(github_install_states.token, expired));
+      expect(await cleanupExpiredInstallStates()).toBeGreaterThanOrEqual(1);
       const remaining = await db
-        .select()
+        .select({ token: github_install_states.token })
         .from(github_install_states)
         .where(eq(github_install_states.kilo_user_id, testUserId));
-
-      expect(remaining.filter(r => r.expires_at <= new Date().toISOString())).toHaveLength(0);
-    });
-
-    test('does not delete non-expired rows', async () => {
-      const token = await createInstallState({
-        kiloUserId: testUserId,
-        ownerType: 'org',
-        ownerId: 'org-5',
-        githubAppType: 'standard',
-      });
-
-      await cleanupExpiredInstallStates();
-
-      const rows = await db
-        .select()
-        .from(github_install_states)
-        .where(eq(github_install_states.token, token));
-
-      expect(rows).toHaveLength(1);
+      expect(remaining).toEqual([{ token: live }]);
     });
   });
 });

--- a/apps/web/src/lib/integrations/github/install-state.ts
+++ b/apps/web/src/lib/integrations/github/install-state.ts
@@ -39,15 +39,36 @@ export async function createInstallState(params: CreateInstallStateParams): Prom
   return token;
 }
 
-/**
- * Atomically consumes a GitHub install state token.
- * A single UPDATE ... WHERE consumed_at IS NULL AND expires_at > NOW() RETURNING *.
- * Returns null if the token is already consumed, expired, or unknown.
- */
-export async function consumeInstallState(token: string): Promise<GitHubInstallState | null> {
-  const result = await db
-    .update(github_install_states)
-    .set({ consumed_at: sql`NOW()` })
+type InstallStateUserMismatch = {
+  status: 'user_mismatch';
+  returnTo: string | null;
+  organizationId: string | null;
+};
+
+type UnusableInstallState = { status: 'unusable' };
+
+export type InstallStatePreflightResult =
+  | { status: 'valid' }
+  | InstallStateUserMismatch
+  | UnusableInstallState;
+
+export type ConsumeInstallStateResult =
+  | { status: 'success'; state: GitHubInstallState }
+  | InstallStateUserMismatch
+  | UnusableInstallState;
+
+export async function checkInstallState(
+  token: string,
+  userId: string
+): Promise<InstallStatePreflightResult> {
+  const [state] = await db
+    .select({
+      userId: github_install_states.kilo_user_id,
+      ownerType: github_install_states.owner_type,
+      ownerId: github_install_states.owner_id,
+      returnTo: github_install_states.return_to,
+    })
+    .from(github_install_states)
     .where(
       and(
         eq(github_install_states.token, token),
@@ -55,9 +76,41 @@ export async function consumeInstallState(token: string): Promise<GitHubInstallS
         sql`${github_install_states.expires_at} > NOW()`
       )
     )
+    .limit(1);
+
+  if (!state) return { status: 'unusable' };
+  if (state.userId !== userId) {
+    return {
+      status: 'user_mismatch',
+      returnTo: state.returnTo,
+      organizationId: state.ownerType === 'org' ? state.ownerId : null,
+    };
+  }
+  return { status: 'valid' };
+}
+
+export async function consumeInstallState(
+  token: string,
+  userId: string
+): Promise<ConsumeInstallStateResult> {
+  const result = await db
+    .update(github_install_states)
+    .set({ consumed_at: sql`NOW()` })
+    .where(
+      and(
+        eq(github_install_states.token, token),
+        eq(github_install_states.kilo_user_id, userId),
+        isNull(github_install_states.consumed_at),
+        sql`${github_install_states.expires_at} > NOW()`
+      )
+    )
     .returning();
 
-  return result[0] ?? null;
+  const state = result[0];
+  if (state) return { status: 'success', state };
+
+  const diagnostic = await checkInstallState(token, userId);
+  return diagnostic.status === 'user_mismatch' ? diagnostic : { status: 'unusable' };
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes KILOCODE-WEB-27Q2.

- Bind atomic GitHub install-state consumption to the authenticated presenting user, preserving state when another account presents it.
- Return explicit success, user-mismatch, and unusable outcomes; diagnostic reads never authorize installation.
- Add non-consuming browser-user preflight for pre-minted state and show recovery instead of installation controls for mismatched or unusable links.
- Preserve callback authorization, bot-link dispatch, expiry, organization management checks, GitHub admin proof, and cross-owner protection.
- Add database, callback, concurrency, replay, and landing-page regression coverage. Remove account identifiers from mismatch diagnostic extras.

## Verification

No manual browser/device or live GitHub installation testing was performed. Verification used targeted database/callback tests and server-rendered landing-page tests; automated check results are listed under Reviewer Notes. No full-repository validation is claimed.

## Visual Changes

The existing GitHub landing page now renders a recovery card instead of installation controls when pre-minted state fails preflight. Matching-state and ordinary callback rendering remain unchanged. Screenshots were not captured; recovery rendering and absence of installation controls are covered by server-rendered tests.

| Before | After |
|---|---|
| Pre-minted state could reach installation controls under a different browser account or after becoming unusable. | Account-mismatch or restart-setup recovery is shown before installation controls are mounted. |

## Reviewer Notes

- Independent read-only static review of the complete six-file diff and surrounding code returned **clean: no remaining blocking findings** before commit or publication. No findings were rejected.
- `GitHubIntegrationDetails.tsx` is intentionally untouched; its recovery-copy and pre-minted-token-reuse work belongs to the separate 27ME task.
- No schema migration, silent remint, organization-based user-matching exception, merge, or deployment.
- Automated checks passed:
  - `pnpm format apps/web/src/lib/integrations/github/install-state.ts apps/web/src/lib/integrations/github/install-state.test.ts apps/web/src/app/api/integrations/github/callback/route.ts apps/web/src/app/api/integrations/github/callback/route.test.ts apps/web/src/app/github-app/page.tsx apps/web/src/app/github-app/page.test.ts`
  - `git diff --check` and `git diff --cached --check`
  - Targeted Jest execution: `pnpm --filter web test --runInBand --silent --globalSetup "$ISOLATED_JEST_SETUP" --runTestsByPath src/lib/integrations/github/install-state.test.ts src/app/api/integrations/github/callback/route.test.ts src/app/github-app/page.test.ts` — **3 suites, 63 tests passed**. The external setup wrapper runs the normal global setup and selects a dedicated local test database before worker setup; it prevents resetting the shared default worker database. PostgreSQL was already healthy, so `pnpm test:db` was not needed.
  - `pnpm --filter web lint` — zero warnings/errors.
  - `pnpm --filter web typecheck` — passed; declaration bundling emitted existing external-dependency warnings.
- All new fixtures are synthetic. No production identifiers or raw incident logs are included.
