### PR TITLE
fix(github): stop mislabeling user-connect state failures

### DIFF
--- a/apps/web/src/app/api/integrations/github/user-connect/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/github/user-connect/callback/route.test.ts
@@ -1,0 +1,292 @@
+import { createHash } from 'node:crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { captureException, captureMessage } from '@sentry/nextjs';
+import { getUserFromAuth } from '@/lib/user/server';
+import { redisClient } from '@/lib/redis';
+import { createGitHubUserAuthorizationState } from '@/lib/integrations/platforms/github/user-authorization-state';
+import { exchangeAndStoreGitHubUserAuthorization } from '@/lib/integrations/platforms/github/user-authorization';
+import { GET } from './route';
+
+jest.mock('@/lib/config.server', () => ({ NEXTAUTH_SECRET: 'synthetic-oauth-signing-secret' }));
+jest.mock('@/lib/constants', () => ({ APP_URL: 'https://app.example.test' }));
+jest.mock('@/lib/user/server', () => ({ getUserFromAuth: jest.fn() }));
+jest.mock('@/lib/redis', () => ({ redisClient: { set: jest.fn(), getdel: jest.fn() } }));
+jest.mock('@/lib/integrations/platforms/github/user-authorization', () => ({
+  exchangeAndStoreGitHubUserAuthorization: jest.fn(),
+}));
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn(), captureMessage: jest.fn() }));
+
+const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
+const mockedExchange = jest.mocked(exchangeAndStoreGitHubUserAuthorization);
+const mockedRedisGetDel = jest.mocked(redisClient.getdel);
+const mockedRedisSet = jest.mocked(redisClient.set);
+const mockedCaptureMessage = jest.mocked(captureMessage);
+const mockedCaptureException = jest.mocked(captureException);
+const userId = 'oauth/synthetic-callback-user';
+const code = 'synthetic-code';
+
+function makeRequest(params: Record<string, string> = {}): NextRequest {
+  const url = new URL('/api/integrations/github/user-connect/callback', 'https://app.example.test');
+  url.search = new URLSearchParams(params).toString();
+  return new NextRequest(url);
+}
+
+function expectRedirect(response: Response, key: 'error' | 'success', value: string) {
+  expect(response.status).toBe(307);
+  const url = new URL(response.headers.get('location') ?? '');
+  expect(url.origin).toBe('https://app.example.test');
+  expect(url.pathname).toBe('/integrations/github');
+  expect(Object.fromEntries(url.searchParams)).toEqual({ [key]: value, flow: 'user-connect' });
+}
+
+describe('GET /api/integrations/github/user-connect/callback', () => {
+  const verifiers = new Map<string, string>();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    verifiers.clear();
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: { id: userId },
+      authFailedResponse: null,
+    } as Awaited<ReturnType<typeof getUserFromAuth>>);
+    mockedRedisSet.mockImplementation(async (key, value) => {
+      if (typeof value !== 'string') throw new Error('Expected a string verifier');
+      verifiers.set(key, value);
+      return 'OK';
+    });
+    mockedRedisGetDel.mockImplementation(async key => {
+      const verifier = verifiers.get(key) ?? null;
+      verifiers.delete(key);
+      return verifier;
+    });
+    mockedExchange.mockResolvedValue({ status: 'connected', githubLogin: 'synthetic-login' });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('redirects an unauthenticated callback before state consumption', async () => {
+    const { state } = await createGitHubUserAuthorizationState(userId);
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: null,
+      authFailedResponse: NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401 }
+      ),
+    });
+    const response = await GET(makeRequest({ code, state }));
+    expect(response.headers.get('location')).toBe('https://app.example.test/users/sign_in');
+    expect(mockedRedisGetDel).not.toHaveBeenCalled();
+    expect(mockedExchange).not.toHaveBeenCalled();
+    expect(mockedCaptureMessage).not.toHaveBeenCalled();
+  });
+
+  test('handles provider cancellation without consuming or logging provider data', async () => {
+    const { state } = await createGitHubUserAuthorizationState(userId);
+    expectRedirect(
+      await GET(makeRequest({ code, state, error: 'synthetic-sensitive-provider-error' })),
+      'error',
+      'authorization_cancelled'
+    );
+    expect(mockedRedisGetDel).not.toHaveBeenCalled();
+    expect(mockedExchange).not.toHaveBeenCalled();
+    expect(mockedCaptureMessage).not.toHaveBeenCalled();
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  test.each([undefined, '', 'invalid code', 'x'.repeat(2049)])(
+    'leaves the verifier available after a missing or malformed code (case %#)',
+    async invalidCode => {
+      const { state } = await createGitHubUserAuthorizationState(userId);
+      const params: Record<string, string> = { state };
+      if (invalidCode !== undefined) params.code = invalidCode;
+      expectRedirect(await GET(makeRequest(params)), 'error', 'missing_code');
+      expect(mockedRedisGetDel).not.toHaveBeenCalled();
+      expect(mockedExchange).not.toHaveBeenCalled();
+      expect(mockedCaptureMessage).not.toHaveBeenCalled();
+      expectRedirect(await GET(makeRequest({ code, state })), 'success', 'user_connected');
+      expect(mockedExchange).toHaveBeenCalledWith({
+        kiloUserId: userId,
+        code,
+        codeVerifier: mockedRedisSet.mock.calls[0][1],
+      });
+    }
+  );
+
+  test('rejects missing state even when a code is present', async () => {
+    expectRedirect(await GET(makeRequest({ code })), 'error', 'invalid_state');
+    expect(mockedRedisGetDel).not.toHaveBeenCalled();
+    expect(mockedExchange).not.toHaveBeenCalled();
+    expect(mockedCaptureMessage).toHaveBeenCalledWith(
+      'GitHub user authorization callback invalid state',
+      {
+        level: 'warning',
+        tags: {
+          endpoint: 'github/user-connect/callback',
+          stage: 'consume_state',
+          reason: 'state_missing',
+        },
+        extra: { hasCode: true, hasState: false, stateHash: null, hasProviderError: false },
+      }
+    );
+  });
+
+  test('rejects tampered state without consuming or exchanging', async () => {
+    const { state } = await createGitHubUserAuthorizationState(userId);
+    expectRedirect(
+      await GET(makeRequest({ code, state: `${state}tampered` })),
+      'error',
+      'invalid_state'
+    );
+    expect(mockedRedisGetDel).not.toHaveBeenCalled();
+    expect(mockedExchange).not.toHaveBeenCalled();
+    expect(mockedCaptureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ tags: expect.objectContaining({ reason: 'signature_invalid' }) })
+    );
+  });
+
+  test('rejects expired state before consuming storage', async () => {
+    jest.useFakeTimers();
+    const { state } = await createGitHubUserAuthorizationState(userId);
+    jest.advanceTimersByTime(601_000);
+    expectRedirect(await GET(makeRequest({ code, state })), 'error', 'invalid_state');
+    expect(mockedRedisGetDel).not.toHaveBeenCalled();
+    expect(mockedExchange).not.toHaveBeenCalled();
+    expect(mockedCaptureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ tags: expect.objectContaining({ reason: 'state_expired' }) })
+    );
+  });
+
+  test('routes a different authenticated account to account-mismatch recovery', async () => {
+    const { state } = await createGitHubUserAuthorizationState('oauth/synthetic-other-account');
+    expectRedirect(await GET(makeRequest({ code, state })), 'error', 'account_mismatch');
+    expect(mockedRedisGetDel).not.toHaveBeenCalled();
+    expect(mockedExchange).not.toHaveBeenCalled();
+    expect(mockedCaptureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ tags: expect.objectContaining({ reason: 'user_mismatch' }) })
+    );
+  });
+
+  test('classifies missing verifier separately from storage failures', async () => {
+    const { state } = await createGitHubUserAuthorizationState(userId);
+    verifiers.clear();
+    expectRedirect(await GET(makeRequest({ code, state })), 'error', 'invalid_state');
+    expect(mockedExchange).not.toHaveBeenCalled();
+    expect(mockedCaptureMessage).toHaveBeenCalledWith(
+      'GitHub user authorization callback invalid state',
+      {
+        level: 'warning',
+        tags: {
+          endpoint: 'github/user-connect/callback',
+          stage: 'consume_state',
+          reason: 'verifier_missing',
+        },
+        extra: {
+          hasCode: true,
+          hasState: true,
+          stateHash: createHash('sha256').update(state).digest('hex').slice(0, 8),
+          hasProviderError: false,
+        },
+      }
+    );
+  });
+
+  test.each([
+    new DOMException('synthetic-sensitive-timeout', 'TimeoutError'),
+    new Error('synthetic-sensitive-redis-details'),
+  ])('reports a storage failure safely without exchange or GETDEL retry', async error => {
+    const { state } = await createGitHubUserAuthorizationState(userId);
+    const verifier = mockedRedisSet.mock.calls[0][1];
+    mockedRedisGetDel.mockRejectedValueOnce(error);
+    expectRedirect(await GET(makeRequest({ code, state })), 'error', 'connection_failed');
+    expect(mockedRedisGetDel).toHaveBeenCalledTimes(1);
+    expect(mockedExchange).not.toHaveBeenCalled();
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+    expect(mockedCaptureMessage).toHaveBeenCalledTimes(1);
+    expect(mockedCaptureMessage).toHaveBeenCalledWith(
+      'GitHub user authorization callback storage failure',
+      {
+        level: 'error',
+        tags: {
+          endpoint: 'github/user-connect/callback',
+          stage: 'consume_state',
+          reason: 'storage_unavailable',
+        },
+        extra: {
+          hasCode: true,
+          hasState: true,
+          stateHash: createHash('sha256').update(state).digest('hex').slice(0, 8),
+          hasProviderError: false,
+        },
+      }
+    );
+    const telemetry = JSON.stringify(mockedCaptureMessage.mock.calls);
+    for (const sensitive of [code, state, verifier, userId, error.message]) {
+      expect(telemetry).not.toContain(sensitive);
+    }
+  });
+
+  test('exchanges a valid callback exactly once under concurrent requests', async () => {
+    const { state } = await createGitHubUserAuthorizationState(userId);
+    const results = await Promise.all([
+      GET(makeRequest({ code, state })),
+      GET(makeRequest({ code, state })),
+    ]);
+    expectRedirect(results[0], 'success', 'user_connected');
+    expectRedirect(results[1], 'error', 'invalid_state');
+    expect(mockedExchange).toHaveBeenCalledTimes(1);
+    expect(mockedExchange).toHaveBeenCalledWith({
+      kiloUserId: userId,
+      code,
+      codeVerifier: mockedRedisSet.mock.calls[0][1],
+    });
+  });
+
+  test.each([
+    'already_connected_to_another_account',
+    'disconnect_existing_identity_first',
+  ] as const)('preserves authorization conflict redirects: %s', async status => {
+    const { state } = await createGitHubUserAuthorizationState(userId);
+    mockedExchange.mockResolvedValueOnce({ status });
+    expectRedirect(await GET(makeRequest({ code, state })), 'error', status);
+  });
+
+  test('sanitizes unexpected exchange errors and records the stage', async () => {
+    const { state } = await createGitHubUserAuthorizationState(userId);
+    const sensitiveError = `synthetic-exchange-secret ${code} ${state} ${userId}`;
+    mockedExchange.mockRejectedValueOnce(new Error(sensitiveError));
+    expectRedirect(await GET(makeRequest({ code, state })), 'error', 'connection_failed');
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      new Error('GitHub user authorization callback failed'),
+      {
+        tags: {
+          endpoint: 'github/user-connect/callback',
+          stage: 'exchange_and_store_authorization',
+          reason: 'operation_failed',
+        },
+        extra: {
+          hasCode: true,
+          hasState: true,
+          stateHash: createHash('sha256').update(state).digest('hex').slice(0, 8),
+          hasProviderError: false,
+        },
+      }
+    );
+    const telemetry = JSON.stringify(mockedCaptureException.mock.calls, (_key, value: unknown) =>
+      value instanceof Error ? { message: value.message, stack: value.stack } : value
+    );
+    for (const sensitive of [
+      sensitiveError,
+      code,
+      state,
+      userId,
+      mockedRedisSet.mock.calls[0][1],
+    ]) {
+      expect(telemetry).not.toContain(sensitive);
+    }
+  });
+});

--- a/apps/web/src/app/api/integrations/github/user-connect/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/user-connect/callback/route.ts
@@ -10,6 +10,7 @@ import { exchangeAndStoreGitHubUserAuthorization } from '@/lib/integrations/plat
 function redirectWithStatus(key: 'success' | 'error', value: string): NextResponse {
   const target = new URL('/integrations/github', APP_URL);
   target.searchParams.set(key, value);
+  target.searchParams.set('flow', 'user-connect');
   return NextResponse.redirect(target);
 }
 
@@ -19,7 +20,7 @@ function safeCallbackContext(searchParams: URLSearchParams) {
     hasCode: Boolean(searchParams.get('code')),
     hasState: Boolean(state),
     stateHash: state ? createHash('sha256').update(state).digest('hex').slice(0, 8) : null,
-    providerError: searchParams.get('error'),
+    hasProviderError: Boolean(searchParams.get('error')),
   };
 }
 
@@ -28,20 +29,10 @@ function validOAuthCode(code: string | null): string | null {
   return code;
 }
 
-function logDevelopmentCallbackFailure(stage: string, searchParams: URLSearchParams): void {
-  if (process.env.NODE_ENV !== 'development') return;
-  const context = safeCallbackContext(searchParams);
-  console.error('[GitHub user authorization callback debug]', {
-    stage,
-    hasCode: context.hasCode,
-    hasState: context.hasState,
-    stateHash: context.stateHash,
-    hasProviderError: Boolean(context.providerError),
-  });
-}
+type CallbackStage = 'authenticate_user' | 'consume_state' | 'exchange_and_store_authorization';
 
 export async function GET(request: NextRequest) {
-  let stage = 'authenticate_user';
+  let stage: CallbackStage = 'authenticate_user';
   try {
     const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
     if (authFailedResponse) {
@@ -53,20 +44,31 @@ export async function GET(request: NextRequest) {
       return redirectWithStatus('error', 'authorization_cancelled');
     }
 
-    stage = 'consume_state';
-    const state = await consumeGitHubUserAuthorizationState(searchParams.get('state'), user.id);
-    if (!state) {
-      captureMessage('GitHub user authorization callback invalid state', {
-        level: 'warning',
-        tags: { endpoint: 'github/user-connect/callback' },
-        extra: safeCallbackContext(searchParams),
-      });
-      return redirectWithStatus('error', 'invalid_state');
-    }
-
     const code = validOAuthCode(searchParams.get('code'));
     if (!code) {
       return redirectWithStatus('error', 'missing_code');
+    }
+
+    stage = 'consume_state';
+    const state = await consumeGitHubUserAuthorizationState(searchParams.get('state'), user.id);
+    if (state.status === 'storage_error') {
+      captureMessage('GitHub user authorization callback storage failure', {
+        level: 'error',
+        tags: { endpoint: 'github/user-connect/callback', stage, reason: state.reason },
+        extra: safeCallbackContext(searchParams),
+      });
+      return redirectWithStatus('error', 'connection_failed');
+    }
+    if (state.status === 'invalid') {
+      captureMessage('GitHub user authorization callback invalid state', {
+        level: 'warning',
+        tags: { endpoint: 'github/user-connect/callback', stage, reason: state.reason },
+        extra: safeCallbackContext(searchParams),
+      });
+      return redirectWithStatus(
+        'error',
+        state.reason === 'user_mismatch' ? 'account_mismatch' : 'invalid_state'
+      );
     }
 
     stage = 'exchange_and_store_authorization';
@@ -80,10 +82,9 @@ export async function GET(request: NextRequest) {
     }
 
     return redirectWithStatus('success', 'user_connected');
-  } catch (error) {
-    logDevelopmentCallbackFailure(stage, request.nextUrl.searchParams);
-    captureException(error, {
-      tags: { endpoint: 'github/user-connect/callback' },
+  } catch {
+    captureException(new Error('GitHub user authorization callback failed'), {
+      tags: { endpoint: 'github/user-connect/callback', stage, reason: 'operation_failed' },
       extra: safeCallbackContext(request.nextUrl.searchParams),
     });
     return redirectWithStatus('error', 'connection_failed');

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.test.ts
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.test.ts
@@ -1,4 +1,56 @@
-import { buildAppReturnOutcomeView } from './GitHubIntegrationDetails';
+import {
+  buildAppReturnOutcomeView,
+  getGitHubUserConnectionErrorMessage,
+} from './GitHubIntegrationDetails';
+
+jest.mock('@/lib/config.server', () => ({ NEXTAUTH_SECRET: 'synthetic-oauth-signing-secret' }));
+
+describe('GitHub user-connect recovery copy', () => {
+  test.each([
+    'invalid_state',
+    'connection_failed',
+    'account_mismatch',
+    'authorization_cancelled',
+    'missing_code',
+  ])('provides an actionable recovery for user-connect error %s only', error => {
+    expect(getGitHubUserConnectionErrorMessage(error, 'user-connect')).toMatch(/new connection/);
+    expect(getGitHubUserConnectionErrorMessage(error, null)).toBeNull();
+    expect(getGitHubUserConnectionErrorMessage(error, 'installation')).toBeNull();
+  });
+
+  test('acknowledges cancellation and provides a fresh-start path', () => {
+    expect(getGitHubUserConnectionErrorMessage('authorization_cancelled', 'user-connect')).toBe(
+      'GitHub account authorization was cancelled. Start a new connection when you are ready.'
+    );
+  });
+
+  test('explains an incomplete provider response without exposing an internal status code', () => {
+    expect(getGitHubUserConnectionErrorMessage('missing_code', 'user-connect')).toBe(
+      'GitHub did not return a valid authorization code. Start a new connection.'
+    );
+  });
+
+  test('does not claim missing verifier state necessarily expired', () => {
+    expect(getGitHubUserConnectionErrorMessage('invalid_state', 'user-connect')).not.toMatch(
+      /expired/i
+    );
+  });
+
+  test('explains the account binding without naming an account', () => {
+    expect(getGitHubUserConnectionErrorMessage('account_mismatch', 'user-connect')).toBe(
+      'Sign in to the Kilo account that started this GitHub connection, then start a new connection.'
+    );
+  });
+
+  test.each([
+    undefined,
+    'installation_failed',
+    'install_state_user_mismatch',
+    'not_installation_admin',
+  ])('leaves unrelated error presentation unchanged: %s', error => {
+    expect(getGitHubUserConnectionErrorMessage(error, 'user-connect')).toBeNull();
+  });
+});
 
 describe('GitHubIntegrationDetails fromApp outcome CTA behavior', () => {
   it('success: Continue back to /cloud/sessions with github_install=success', () => {

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -120,6 +120,27 @@ export function buildAppReturnOutcomeView(input: {
   };
 }
 
+export function getGitHubUserConnectionErrorMessage(
+  error: string | undefined,
+  flow: string | null
+): string | null {
+  if (flow !== 'user-connect') return null;
+  switch (error) {
+    case 'authorization_cancelled':
+      return 'GitHub account authorization was cancelled. Start a new connection when you are ready.';
+    case 'missing_code':
+      return 'GitHub did not return a valid authorization code. Start a new connection.';
+    case 'invalid_state':
+      return 'This GitHub account connection attempt is no longer valid. Start a new connection.';
+    case 'connection_failed':
+      return 'We could not complete your GitHub account connection. Start a new connection and try again.';
+    case 'account_mismatch':
+      return 'Sign in to the Kilo account that started this GitHub connection, then start a new connection.';
+    default:
+      return null;
+  }
+}
+
 function GitHubIntegrationOutcomeToasts({
   success,
   userConnectionSuccess,
@@ -170,7 +191,11 @@ function GitHubIntegrationOutcomeToasts({
     } else if (error === 'install_state_user_mismatch') {
       // Handled by the fromApp fallback card or non-app mismatch landing.
     } else if (error) {
-      toast.error(`GitHub connection failed: ${error}`);
+      const userConnectionMessage = getGitHubUserConnectionErrorMessage(
+        error,
+        new URLSearchParams(window.location.search).get('flow')
+      );
+      toast.error(userConnectionMessage ?? `GitHub connection failed: ${error}`);
     }
   }, [success, userConnectionSuccess, error, pendingApproval, existingPendingOrg]);
 

--- a/apps/web/src/lib/integrations/oauth-state.test.ts
+++ b/apps/web/src/lib/integrations/oauth-state.test.ts
@@ -1,6 +1,114 @@
-import { createOAuthState, verifyOAuthState } from './oauth-state';
+import { createHmac } from 'node:crypto';
+import { NEXTAUTH_SECRET } from '@/lib/config.server';
+import { createOAuthState, verifyOAuthState, verifyOAuthStateDetailed } from './oauth-state';
+
+jest.mock('@/lib/config.server', () => ({ NEXTAUTH_SECRET: 'synthetic-oauth-signing-secret' }));
+
+function signPayload(payload: string, secret = NEXTAUTH_SECRET): string {
+  const encoded = Buffer.from(payload).toString('base64url');
+  return `${encoded}.${createHmac('sha256', secret).update(encoded).digest('base64url')}`;
+}
 
 describe('oauth state', () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ now: new Date('2026-01-01T00:00:00Z') });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test.each([null, ''])('classifies missing state: %s', state => {
+    expect(verifyOAuthStateDetailed(state)).toEqual({ status: 'invalid', reason: 'state_missing' });
+    expect(verifyOAuthState(state)).toBeNull();
+  });
+
+  test('classifies a malformed envelope', () => {
+    expect(verifyOAuthStateDetailed('not-a-signed-state')).toEqual({
+      status: 'invalid',
+      reason: 'state_malformed',
+    });
+    expect(verifyOAuthState('not-a-signed-state')).toBeNull();
+  });
+
+  test('rejects tampered payloads and signatures', () => {
+    const state = createOAuthState('user_synthetic', 'oauth/synthetic');
+    const [payload, signature] = state.split('.');
+    for (const tampered of [`${payload}A.${signature}`, `${payload}.invalid`]) {
+      expect(verifyOAuthStateDetailed(tampered)).toEqual({
+        status: 'invalid',
+        reason: 'signature_invalid',
+      });
+      expect(verifyOAuthState(tampered)).toBeNull();
+    }
+  });
+
+  test('rejects state signed with a different secret', () => {
+    const state = signPayload('{}', 'different-synthetic-secret');
+    expect(verifyOAuthStateDetailed(state)).toEqual({
+      status: 'invalid',
+      reason: 'signature_invalid',
+    });
+    expect(verifyOAuthState(state)).toBeNull();
+  });
+
+  test.each([
+    'not-json',
+    'null',
+    '[]',
+    '{}',
+    JSON.stringify({ owner: 1, uid: 'synthetic', iat: 0, nonce: 'nonce' }),
+    JSON.stringify({ owner: 'synthetic', uid: 1, iat: 0, nonce: 'nonce' }),
+    JSON.stringify({ owner: 'synthetic', uid: 'synthetic', iat: '0', nonce: 'nonce' }),
+    JSON.stringify({ owner: 'synthetic', uid: 'synthetic', iat: 0 }),
+    JSON.stringify({ owner: 'synthetic', uid: 'synthetic', iat: 0, nonce: '' }),
+    '{"owner":"synthetic","uid":"synthetic","iat":1e309,"nonce":"nonce"}',
+  ])('rejects signed malformed payload: %s', payload => {
+    const state = signPayload(payload);
+    expect(verifyOAuthStateDetailed(state)).toEqual({
+      status: 'invalid',
+      reason: 'state_malformed',
+    });
+    expect(verifyOAuthState(state)).toBeNull();
+  });
+
+  test('accepts the TTL boundary and rejects state one second later', () => {
+    const state = createOAuthState('user_synthetic', 'oauth/synthetic');
+    jest.advanceTimersByTime(600_000);
+    expect(verifyOAuthStateDetailed(state)).toEqual({
+      status: 'valid',
+      state: { owner: 'user_synthetic', userId: 'oauth/synthetic' },
+    });
+    expect(verifyOAuthState(state)).toEqual({ owner: 'user_synthetic', userId: 'oauth/synthetic' });
+    jest.advanceTimersByTime(1_000);
+    expect(verifyOAuthStateDetailed(state)).toEqual({ status: 'invalid', reason: 'state_expired' });
+    expect(verifyOAuthState(state)).toBeNull();
+  });
+
+  test('rejects state issued in the future', () => {
+    const now = Date.now();
+    const state = createOAuthState('user_synthetic', 'oauth/synthetic');
+    jest.setSystemTime(now - 1_000);
+    expect(verifyOAuthStateDetailed(state)).toEqual({
+      status: 'invalid',
+      reason: 'state_from_future',
+    });
+    expect(verifyOAuthState(state)).toBeNull();
+  });
+
+  test('keeps ignoring non-string optional return paths', () => {
+    const state = signPayload(
+      JSON.stringify({
+        owner: 'user_synthetic',
+        uid: 'oauth/synthetic',
+        iat: Date.now() / 1000,
+        nonce: 'nonce',
+        returnTo: 123,
+      })
+    );
+    expect(verifyOAuthState(state)).toEqual({ owner: 'user_synthetic', userId: 'oauth/synthetic' });
+  });
+
   test('round-trips a validated return path', () => {
     const state = createOAuthState('user_123', 'user_123', '/claw/new?step=linear');
 

--- a/apps/web/src/lib/integrations/oauth-state.ts
+++ b/apps/web/src/lib/integrations/oauth-state.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 import crypto from 'node:crypto';
+import { z } from 'zod';
 import { NEXTAUTH_SECRET } from '@/lib/config.server';
 import { validateReturnPath } from '@/lib/integrations/validate-return-path';
 
@@ -80,10 +81,34 @@ export type VerifiedOAuthState = {
  * invalid, or the token has expired.
  */
 export function verifyOAuthState(state: string | null): VerifiedOAuthState | null {
-  if (!state) return null;
+  const result = verifyOAuthStateDetailed(state);
+  return result.status === 'valid' ? result.state : null;
+}
+
+export type OAuthStateVerificationFailureReason =
+  | 'state_missing'
+  | 'state_malformed'
+  | 'signature_invalid'
+  | 'state_expired'
+  | 'state_from_future';
+
+export type OAuthStateVerificationResult =
+  | { status: 'valid'; state: VerifiedOAuthState }
+  | { status: 'invalid'; reason: OAuthStateVerificationFailureReason };
+
+const OAuthStatePayloadSchema = z.object({
+  owner: z.string(),
+  uid: z.string(),
+  iat: z.number().finite(),
+  nonce: z.string().min(1),
+  returnTo: z.unknown().optional(),
+});
+
+export function verifyOAuthStateDetailed(state: string | null): OAuthStateVerificationResult {
+  if (!state) return { status: 'invalid', reason: 'state_missing' };
 
   const dotIndex = state.indexOf('.');
-  if (dotIndex === -1) return null;
+  if (dotIndex === -1) return { status: 'invalid', reason: 'state_malformed' };
 
   const payload = state.slice(0, dotIndex);
   const providedSig = state.slice(dotIndex + 1);
@@ -96,31 +121,29 @@ export function verifyOAuthState(state: string | null): VerifiedOAuthState | nul
     providedSigBytes.length !== expectedSigBytes.length ||
     !crypto.timingSafeEqual(providedSigBytes, expectedSigBytes)
   ) {
-    return null;
+    return { status: 'invalid', reason: 'signature_invalid' };
   }
 
+  let data: z.infer<typeof OAuthStatePayloadSchema>;
   try {
-    const data = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as {
-      owner?: string;
-      uid?: string;
-      iat?: number;
-      nonce?: string;
-      returnTo?: string;
-    };
-    if (typeof data.owner !== 'string' || typeof data.uid !== 'string') return null;
-
-    // Enforce TTL: reject tokens that are too old or have no timestamp
-    if (typeof data.iat !== 'number') return null;
-    const ageSeconds = Math.floor(Date.now() / 1000) - data.iat;
-    if (ageSeconds < 0 || ageSeconds > OAUTH_STATE_TTL_SECONDS) return null;
-
-    // Require nonce to be present (guards against old-format tokens)
-    if (typeof data.nonce !== 'string' || data.nonce.length === 0) return null;
-
-    const returnTo = typeof data.returnTo === 'string' ? validateReturnPath(data.returnTo) : null;
-
-    return { owner: data.owner, userId: data.uid, ...(returnTo ? { returnTo } : {}) };
+    const parsed = OAuthStatePayloadSchema.safeParse(
+      JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'))
+    );
+    if (!parsed.success) return { status: 'invalid', reason: 'state_malformed' };
+    data = parsed.data;
   } catch {
-    return null;
+    return { status: 'invalid', reason: 'state_malformed' };
   }
+
+  const ageSeconds = Math.floor(Date.now() / 1000) - data.iat;
+  if (ageSeconds < 0) return { status: 'invalid', reason: 'state_from_future' };
+  if (ageSeconds > OAUTH_STATE_TTL_SECONDS) {
+    return { status: 'invalid', reason: 'state_expired' };
+  }
+
+  const returnTo = typeof data.returnTo === 'string' ? validateReturnPath(data.returnTo) : null;
+  return {
+    status: 'valid',
+    state: { owner: data.owner, userId: data.uid, ...(returnTo ? { returnTo } : {}) },
+  };
 }

--- a/apps/web/src/lib/integrations/platforms/github/user-authorization-state.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/user-authorization-state.test.ts
@@ -1,56 +1,193 @@
 import { createHash } from 'node:crypto';
 import { redisClient } from '@/lib/redis';
+import { createOAuthState } from '@/lib/integrations/oauth-state';
 import {
   consumeGitHubUserAuthorizationState,
   createGitHubUserAuthorizationState,
 } from './user-authorization-state';
 
+jest.mock('@/lib/config.server', () => ({ NEXTAUTH_SECRET: 'synthetic-oauth-signing-secret' }));
 jest.mock('@/lib/redis', () => ({
   redisClient: { set: jest.fn(), getdel: jest.fn() },
 }));
 
 const mockedRedisGetDel = jest.mocked(redisClient.getdel);
 const mockedRedisSet = jest.mocked(redisClient.set);
+const userId = 'oauth/synthetic-user';
+
+function stateWithPayload(payload: string): string {
+  return createOAuthState(
+    `github-user-authorization:${Buffer.from(payload).toString('base64url')}`,
+    userId
+  );
+}
 
 describe('GitHub user authorization state', () => {
+  const verifiers = new Map<string, string>();
+
   beforeEach(() => {
-    jest.clearAllMocks();
-    mockedRedisSet.mockResolvedValue('OK');
+    jest.resetAllMocks();
+    verifiers.clear();
+    mockedRedisSet.mockImplementation(async (key, value) => {
+      if (typeof value !== 'string') throw new Error('Expected a string verifier');
+      verifiers.set(key, value);
+      return 'OK';
+    });
+    mockedRedisGetDel.mockImplementation(async key => {
+      const value = verifiers.get(key) ?? null;
+      verifiers.delete(key);
+      return value;
+    });
   });
 
-  test('round-trips a single-use PKCE verifier bound to the Kilo user', async () => {
-    const created = await createGitHubUserAuthorizationState('user_123');
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('round-trips a single-use PKCE verifier bound to a non-UUID Kilo user', async () => {
+    const created = await createGitHubUserAuthorizationState(userId);
     const codeVerifier = mockedRedisSet.mock.calls[0][1];
-    if (typeof codeVerifier !== 'string') {
-      throw new Error('Expected Redis PKCE value to be a string');
-    }
-    mockedRedisGetDel.mockResolvedValueOnce(codeVerifier).mockResolvedValueOnce(null);
+    if (typeof codeVerifier !== 'string') throw new Error('Expected a string verifier');
 
     expect(created.codeChallenge).toBe(
       createHash('sha256').update(codeVerifier).digest('base64url')
     );
-    await expect(consumeGitHubUserAuthorizationState(created.state, 'user_123')).resolves.toEqual({
+    expect(mockedRedisSet).toHaveBeenCalledWith(
+      expect.stringMatching(/^auth-pkce:github-user:/),
+      codeVerifier,
+      { ex: 605 }
+    );
+    await expect(consumeGitHubUserAuthorizationState(created.state, userId)).resolves.toEqual({
+      status: 'consumed',
       codeVerifier,
     });
-    await expect(
-      consumeGitHubUserAuthorizationState(created.state, 'user_123')
-    ).resolves.toBeNull();
+    expect(mockedRedisGetDel).toHaveBeenCalledWith(mockedRedisSet.mock.calls[0][0]);
+    await expect(consumeGitHubUserAuthorizationState(created.state, userId)).resolves.toEqual({
+      status: 'invalid',
+      reason: 'verifier_missing',
+    });
   });
 
   test('does not consume a verifier for a different signed-in user', async () => {
-    const created = await createGitHubUserAuthorizationState('user_owner');
-
+    const created = await createGitHubUserAuthorizationState(userId);
     await expect(
-      consumeGitHubUserAuthorizationState(created.state, 'user_other')
-    ).resolves.toBeNull();
+      consumeGitHubUserAuthorizationState(created.state, 'oauth/synthetic-other')
+    ).resolves.toEqual({
+      status: 'invalid',
+      reason: 'user_mismatch',
+    });
     expect(mockedRedisGetDel).not.toHaveBeenCalled();
+    await expect(consumeGitHubUserAuthorizationState(created.state, userId)).resolves.toMatchObject(
+      { status: 'consumed' }
+    );
+  });
+
+  test('validates the flow before touching storage', async () => {
+    await expect(
+      consumeGitHubUserAuthorizationState(createOAuthState('other-flow', userId), userId)
+    ).resolves.toEqual({
+      status: 'invalid',
+      reason: 'flow_mismatch',
+    });
+    expect(mockedRedisGetDel).not.toHaveBeenCalled();
+  });
+
+  test.each(['not-json', 'null', '{}', '{"verifierRef":""}', '{"verifierRef":1}'])(
+    'classifies invalid reference payload without touching storage: %s',
+    async payload => {
+      await expect(
+        consumeGitHubUserAuthorizationState(stateWithPayload(payload), userId)
+      ).resolves.toEqual({
+        status: 'invalid',
+        reason: 'payload_invalid',
+      });
+      expect(mockedRedisGetDel).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each([
+    [null, 'state_missing'],
+    ['malformed', 'state_malformed'],
+    ['payload.signature', 'signature_invalid'],
+  ])('does not consume storage for invalid signed state: %s', async (state, reason) => {
+    await expect(consumeGitHubUserAuthorizationState(state, userId)).resolves.toEqual({
+      status: 'invalid',
+      reason,
+    });
+    expect(mockedRedisGetDel).not.toHaveBeenCalled();
+  });
+
+  test('rejects expired state before storage access', async () => {
+    jest.useFakeTimers();
+    const created = await createGitHubUserAuthorizationState(userId);
+    jest.advanceTimersByTime(601_000);
+    await expect(consumeGitHubUserAuthorizationState(created.state, userId)).resolves.toEqual({
+      status: 'invalid',
+      reason: 'state_expired',
+    });
+    expect(mockedRedisGetDel).not.toHaveBeenCalled();
+  });
+
+  test('keeps independently started same-account flows independent', async () => {
+    const first = await createGitHubUserAuthorizationState(userId);
+    const second = await createGitHubUserAuthorizationState(userId);
+    expect(first.state).not.toBe(second.state);
+    expect(mockedRedisSet.mock.calls[0][0]).not.toBe(mockedRedisSet.mock.calls[1][0]);
+    const results = await Promise.all([
+      consumeGitHubUserAuthorizationState(second.state, userId),
+      consumeGitHubUserAuthorizationState(first.state, userId),
+    ]);
+    expect(results).toEqual([
+      { status: 'consumed', codeVerifier: mockedRedisSet.mock.calls[1][1] },
+      { status: 'consumed', codeVerifier: mockedRedisSet.mock.calls[0][1] },
+    ]);
+  });
+
+  test('consumes one state exactly once under concurrent callbacks', async () => {
+    const created = await createGitHubUserAuthorizationState(userId);
+    const results = await Promise.all([
+      consumeGitHubUserAuthorizationState(created.state, userId),
+      consumeGitHubUserAuthorizationState(created.state, userId),
+    ]);
+    expect(results.filter(result => result.status === 'consumed')).toHaveLength(1);
+    expect(results.filter(result => result.status === 'invalid')).toEqual([
+      { status: 'invalid', reason: 'verifier_missing' },
+    ]);
+  });
+
+  test.each([
+    new DOMException('synthetic-sensitive-timeout', 'TimeoutError'),
+    new Error('synthetic-sensitive-storage-failure'),
+  ])('classifies storage exceptions without exposing or retrying them', async error => {
+    const created = await createGitHubUserAuthorizationState(userId);
+    mockedRedisGetDel.mockRejectedValueOnce(error);
+    await expect(consumeGitHubUserAuthorizationState(created.state, userId)).resolves.toEqual({
+      status: 'storage_error',
+      reason: 'storage_unavailable',
+    });
+    expect(mockedRedisGetDel).toHaveBeenCalledTimes(1);
+  });
+
+  test('classifies an absent verifier without claiming expiration or replay', async () => {
+    const created = await createGitHubUserAuthorizationState(userId);
+    verifiers.clear();
+    await expect(consumeGitHubUserAuthorizationState(created.state, userId)).resolves.toEqual({
+      status: 'invalid',
+      reason: 'verifier_missing',
+    });
   });
 
   test('fails closed if transient PKCE storage is unavailable', async () => {
     mockedRedisSet.mockResolvedValue(null);
-
-    await expect(createGitHubUserAuthorizationState('user_123')).rejects.toThrow(
+    await expect(createGitHubUserAuthorizationState(userId)).rejects.toThrow(
       'configured transient state storage'
+    );
+  });
+
+  test('does not return authorization state after a failed storage write', async () => {
+    mockedRedisSet.mockRejectedValueOnce(new Error('synthetic-write-failed'));
+    await expect(createGitHubUserAuthorizationState(userId)).rejects.toThrow(
+      'synthetic-write-failed'
     );
   });
 });

--- a/apps/web/src/lib/integrations/platforms/github/user-authorization-state.ts
+++ b/apps/web/src/lib/integrations/platforms/github/user-authorization-state.ts
@@ -5,7 +5,8 @@ import { z } from 'zod';
 import {
   createOAuthState,
   OAUTH_STATE_TTL_SECONDS,
-  verifyOAuthState,
+  verifyOAuthStateDetailed,
+  type OAuthStateVerificationFailureReason,
 } from '@/lib/integrations/oauth-state';
 import { redisClient } from '@/lib/redis';
 import { githubUserAuthorizationPkceRedisKey } from '@/lib/redis-keys';
@@ -42,27 +43,52 @@ export async function createGitHubUserAuthorizationState(
   return { state, codeChallenge };
 }
 
+export type GitHubUserAuthorizationStateResult =
+  | { status: 'consumed'; codeVerifier: string }
+  | {
+      status: 'invalid';
+      reason:
+        | OAuthStateVerificationFailureReason
+        | 'user_mismatch'
+        | 'flow_mismatch'
+        | 'payload_invalid'
+        | 'verifier_missing';
+    }
+  | { status: 'storage_error'; reason: 'storage_unavailable' };
+
 export async function consumeGitHubUserAuthorizationState(
   state: string | null,
   sessionUserId: string
-): Promise<{ codeVerifier: string } | null> {
-  const verified = verifyOAuthState(state);
-  if (!verified || verified.userId !== sessionUserId || !verified.owner.startsWith(STATE_PREFIX)) {
-    return null;
+): Promise<GitHubUserAuthorizationStateResult> {
+  const verified = verifyOAuthStateDetailed(state);
+  if (verified.status === 'invalid') return verified;
+  if (verified.state.userId !== sessionUserId) {
+    return { status: 'invalid', reason: 'user_mismatch' };
+  }
+  if (!verified.state.owner.startsWith(STATE_PREFIX)) {
+    return { status: 'invalid', reason: 'flow_mismatch' };
   }
 
-  const encodedPayload = verified.owner.slice(STATE_PREFIX.length);
+  const encodedPayload = verified.state.owner.slice(STATE_PREFIX.length);
+  let verifierRef: string;
   try {
     const parsed = StatePayloadSchema.safeParse(
       JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8'))
     );
-    if (!parsed.success) return null;
-
-    const codeVerifier = await redisClient.getdel<string>(
-      githubUserAuthorizationPkceRedisKey(parsed.data.verifierRef)
-    );
-    return codeVerifier ? { codeVerifier } : null;
+    if (!parsed.success) return { status: 'invalid', reason: 'payload_invalid' };
+    verifierRef = parsed.data.verifierRef;
   } catch {
-    return null;
+    return { status: 'invalid', reason: 'payload_invalid' };
+  }
+
+  try {
+    const codeVerifier = await redisClient.getdel<string>(
+      githubUserAuthorizationPkceRedisKey(verifierRef)
+    );
+    return codeVerifier
+      ? { status: 'consumed', codeVerifier }
+      : { status: 'invalid', reason: 'verifier_missing' };
+  } catch {
+    return { status: 'storage_error', reason: 'storage_unavailable' };
   }
 }


### PR DESCRIPTION
## Summary

- Address KILOCODE-WEB-24SY by distinguishing invalid OAuth state, missing one-time verifiers, account/flow mismatch, and Redis storage failures instead of reporting all failures as invalid state.
- Validate the authorization code before consuming the PKCE verifier, preserve the nullable shared verification API, and report only allowlisted callback diagnostics.
- Add user-connect-scoped recovery messages and regression coverage without changing GitHub App installation setup/retry flows, TTLs, or single-use semantics.

## Verification

No manual browser or live GitHub OAuth testing was performed. Verification used isolated synthetic-data tests and static checks; no live Redis/PostgreSQL services or production credentials were accessed.

## Visual Changes

Copy-only changes; no layout or styling changes. Screenshots were not captured.

| Before | After |
|---|---|
| Raw user-connect error status codes | Actionable fresh-connection, cancellation, and account-mismatch guidance |
| Installation error presentation | Unchanged; new copy requires `flow=user-connect` |

## Reviewer Notes

- Independent static review of the complete diff and surrounding code is clean. The first review requested recovery copy for cancellation and missing-code outcomes; both were fixed and a fresh review reported no blocking findings.
- Automated verification: four isolated Jest suites, **83 tests passed**; targeted oxlint on all eight changed files, **0 warnings/errors**; `pnpm exec tsgo --noEmit -p apps/web/tsconfig.json`, **passed**; changed-file formatting and `git diff --check`, **passed**; `pnpm install --frozen-lockfile`, **passed**.
- Jest reused the existing configuration through an external temporary config, disabling global/worker database setup. The selected suites use synthetic signing configuration and atomic in-memory Redis fakes; no database resets were performed. This is not full-repository validation.
- Preserve HMAC/user binding and a single atomic `GETDEL` with no retries. Missing verifiers do not prove expiry or replay. The original production occurrence's exact cause remains unproven; this fixes confirmed error-classification and consumption-order defects.
- Only the eight intended implementation/test files are included; no dependency or lockfile changes.
