### PR TITLE
fix(github): recover expired GitHub install callback state

### DIFF
--- a/apps/web/src/app/api/integrations/github/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.test.ts
@@ -110,7 +110,7 @@ const INSTALL_STATE_TOKEN = 'valid-database-token-for-callback-tests';
 
 beforeEach(() => {
   mockedConsumeInstallState.mockReset();
-  mockedConsumeInstallState.mockResolvedValue({ status: 'unusable' });
+  mockedConsumeInstallState.mockResolvedValue({ status: 'unusable', reason: 'not_found' });
   mockedUpsertPlatformIntegrationForOwner.mockResolvedValue({ ok: true });
   mockedExchangeGitHubOAuthCode.mockResolvedValue({
     id: GITHUB_USER_ID,
@@ -183,7 +183,7 @@ describe('GET /api/integrations/github/callback bot link flow', () => {
     );
 
     expect(response.status).toBe(307);
-    expectRedirectLocation(response, '/');
+    expectRedirectLocation(response, '/github-app?error=install_state_invalid');
     expect(mockedExchangeGitHubOAuthCode).not.toHaveBeenCalled();
     expect(mockedLinkKiloUser).not.toHaveBeenCalled();
   });
@@ -412,15 +412,13 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
       created_at: new Date().toISOString(),
     };
     mockedConsumeInstallState.mockImplementation(async (token: string) => {
-      return token === DB_TOKEN ? { status: 'success', state: mockRow } : { status: 'unusable' };
+      return token === DB_TOKEN
+        ? { status: 'success', state: mockRow }
+        : { status: 'unusable', reason: 'not_found' };
     });
 
     const { GET } = await import('./route');
 
-    // If a producer erroneously sends a suffixed state, consumeInstallState
-    // receives the full suffix. The real DB returns null because it stores
-    // only the bare token. The callback must redirect to the home page
-    // instead of proceeding with the install.
     const suffixed = `${DB_TOKEN}|return=${encodeURIComponent('/github-app')}`;
     const response = await GET(
       makeRequest(
@@ -429,7 +427,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
     );
 
     expect(response.status).toBe(307);
-    expectRedirectLocation(response, '/');
+    expectRedirectLocation(response, '/github-app?error=install_state_invalid');
     expect(mockedConsumeInstallState).toHaveBeenCalledWith(suffixed, USER_ID);
     expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
   });
@@ -538,7 +536,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
         expect.anything()
       );
       const replayed = await GET(makeRequest(callbackPath));
-      expectRedirectLocation(replayed, '/');
+      expectRedirectLocation(replayed, '/github-app?error=install_state_invalid');
       expect(mockedUpsertPlatformIntegrationForOwner).toHaveBeenCalledTimes(1);
     } finally {
       await db.delete(kilocode_users).where(eq(kilocode_users.id, initiatorId));
@@ -560,22 +558,40 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
     expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
   });
 
-  test('rejects a replayed (already consumed) token', async () => {
-    mockedConsumeInstallState.mockResolvedValue({ status: 'unusable' });
+  test.each(['consumed', 'expired', 'not_found', 'unavailable'] as const)(
+    'recovers a %s token without OAuth or installation writes',
+    async reason => {
+      mockedConsumeInstallState.mockResolvedValue({ status: 'unusable', reason });
 
-    const { GET } = await import('./route');
-    const response = await GET(
-      makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${DB_TOKEN}`
-      ) as never
-    );
+      const { GET } = await import('./route');
+      const response = await GET(
+        makeRequest(
+          `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${DB_TOKEN}&code=synthetic-oauth-code&organizationId=untrusted-org&fromApp=1`
+        ) as never
+      );
 
-    // Replayed tokens fall through to unrecognized state
-    expect(response.status).toBe(307);
-    expectRedirectLocation(response, '/');
-    expect(mockedConsumeInstallState).toHaveBeenCalledWith(DB_TOKEN, USER_ID);
-    expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(307);
+      expectRedirectLocation(response, '/github-app?error=install_state_invalid');
+      expect(mockedConsumeInstallState).toHaveBeenCalledWith(DB_TOKEN, USER_ID);
+      expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
+      expect(mockedExchangeGitHubOAuthCode).not.toHaveBeenCalled();
+      expect(mockedCreateAppAuth).not.toHaveBeenCalled();
+      const { createPendingIntegration } =
+        await import('@/lib/integrations/db/platform-integrations');
+      expect(createPendingIntegration).not.toHaveBeenCalled();
+      expect(mockedCaptureMessage).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          level: reason === 'expired' || reason === 'consumed' ? 'info' : 'warning',
+          extra: expect.objectContaining({ stateClass: 'install_token', rejectionReason: reason }),
+        })
+      );
+      const diagnostics = JSON.stringify(mockedCaptureMessage.mock.calls);
+      for (const value of [DB_TOKEN, USER_ID, INSTALLATION_ID]) {
+        expect(diagnostics).not.toContain(value);
+      }
+    }
+  );
 
   test('treats a prefixed state as opaque when it matches a database token', async () => {
     const PREFIXED_DB_TOKEN = `user_${DB_TOKEN}`;
@@ -985,7 +1001,7 @@ describe('GET /api/integrations/github/callback plaintext state rejection', () =
       authFailedResponse: null,
     } as never);
     mockedVerifyGitHubBotLinkState.mockReturnValue(null);
-    mockedConsumeInstallState.mockResolvedValue({ status: 'unusable' });
+    mockedConsumeInstallState.mockResolvedValue({ status: 'unusable', reason: 'not_found' });
   });
 
   test.each(['org_', 'user_'])('always rejects %s prefixed plaintext state', async prefix => {
@@ -997,7 +1013,7 @@ describe('GET /api/integrations/github/callback plaintext state rejection', () =
     );
 
     expect(response.status).toBe(307);
-    expectRedirectLocation(response, '/');
+    expectRedirectLocation(response, '/github-app?error=install_state_invalid');
     expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
     expect(mockedExchangeGitHubOAuthCode).not.toHaveBeenCalled();
     expect(mockedCreateAppAuth).not.toHaveBeenCalled();
@@ -1231,7 +1247,7 @@ describe('GET /api/integrations/github/callback Sentry redaction', () => {
       authFailedResponse: null,
     } as never);
     mockedVerifyGitHubBotLinkState.mockReturnValue(null);
-    mockedConsumeInstallState.mockResolvedValue({ status: 'unusable' });
+    mockedConsumeInstallState.mockResolvedValue({ status: 'unusable', reason: 'not_found' });
     mockedCreateAppAuth.mockReturnValue(
       jest.fn(async () => ({ token: 'github-app-token' })) as never
     );
@@ -1257,7 +1273,7 @@ describe('GET /api/integrations/github/callback Sentry redaction', () => {
 
   test('unrecognized-state warning does not include the raw state token', async () => {
     const RAW_TOKEN = `sentry-redaction-unknown-${Date.now()}`;
-    mockedConsumeInstallState.mockResolvedValue({ status: 'unusable' });
+    mockedConsumeInstallState.mockResolvedValue({ status: 'unusable', reason: 'not_found' });
 
     const { GET } = await import('./route');
     const response = await GET(
@@ -1267,15 +1283,15 @@ describe('GET /api/integrations/github/callback Sentry redaction', () => {
     );
 
     expect(response.status).toBe(307);
-    expectRedirectLocation(response, '/');
+    expectRedirectLocation(response, '/github-app?error=install_state_invalid');
     expect(mockedCaptureMessage).toHaveBeenCalled();
     const serializedMessage = JSON.stringify(mockedCaptureMessage.mock.calls);
     // The raw state is a bearer token and must never reach Sentry.
     expect(serializedMessage).not.toContain(RAW_TOKEN);
-    // Safe diagnostics survive: state class, reason, and the callback ids.
     expect(serializedMessage).toContain('install_token');
     expect(serializedMessage).toContain('state_not_bot_link_or_install_token');
-    expect(serializedMessage).toContain(INSTALLATION_ID);
+    expect(serializedMessage).not.toContain(INSTALLATION_ID);
+    expect(serializedMessage).toContain('not_found');
   });
 
   test('catch-path exception does not include the raw state token', async () => {

--- a/apps/web/src/app/api/integrations/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.ts
@@ -33,7 +33,10 @@ import { bot } from '@/lib/bot';
 import { isOrganizationMember } from '@/lib/organizations/organizations';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { APP_URL } from '@/lib/constants';
-import { consumeInstallState } from '@/lib/integrations/github/install-state';
+import {
+  consumeInstallState,
+  type InstallStateRejectionReason,
+} from '@/lib/integrations/github/install-state';
 import { ORGANIZATION_MANAGE_ROLES } from '@kilocode/app-shared/organizations';
 
 const appendQueryParam = (path: string, queryParam: string): string =>
@@ -149,6 +152,7 @@ export async function GET(request: NextRequest) {
     const installationId = searchParams.get('installation_id') ?? '';
     const setupAction = searchParams.get('setup_action');
     const rawState = searchParams.get('state');
+    let rejectionReason: InstallStateRejectionReason | 'missing' = 'missing';
 
     // 3. Atomically consume a database-backed install state before attempting
     // bot-link parsing. Database tokens are opaque and unambiguous once found.
@@ -171,6 +175,8 @@ export async function GET(request: NextRequest) {
         return NextResponse.redirect(new URL(`/github-app?${query}`, APP_URL));
       }
 
+      rejectionReason = result.reason;
+
       // 4. Bot-link callback hand-off. Bot-link state tokens use a signed
       // dot-separated format and never collide with database tokens, which are
       // base64url (no dots).
@@ -180,17 +186,24 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    captureMessage('GitHub callback with unrecognized state', {
-      level: 'warning',
-      tags: { endpoint: 'github/callback', source: 'github_app_installation' },
-      extra: {
-        installationId,
-        setupAction,
-        stateClass: classifyInstallState(rawState),
-        reason: 'state_not_bot_link_or_install_token',
-      },
-    });
-    return NextResponse.redirect(new URL('/', APP_URL));
+    const expectedRejection = rejectionReason === 'expired' || rejectionReason === 'consumed';
+    captureMessage(
+      expectedRejection
+        ? 'GitHub callback with unusable install state'
+        : 'GitHub callback with unrecognized state',
+      {
+        level: expectedRejection ? 'info' : 'warning',
+        tags: { endpoint: 'github/callback', source: 'github_app_installation', rejectionReason },
+        extra: {
+          hasInstallationId: Boolean(installationId),
+          setupAction,
+          stateClass: classifyInstallState(rawState),
+          reason: 'state_not_bot_link_or_install_token',
+          rejectionReason,
+        },
+      }
+    );
+    return NextResponse.redirect(new URL('/github-app?error=install_state_invalid', APP_URL));
   } catch (error) {
     console.error('Error handling GitHub App callback:', error);
 

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.test.ts
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.test.ts
@@ -1,6 +1,9 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import {
   buildAppReturnOutcomeView,
   getGitHubUserConnectionErrorMessage,
+  GitHubIntegrationDetails,
 } from './GitHubIntegrationDetails';
 
 jest.mock('@/lib/config.server', () => ({ NEXTAUTH_SECRET: 'synthetic-oauth-signing-secret' }));
@@ -50,6 +53,149 @@ describe('GitHub user-connect recovery copy', () => {
   ])('leaves unrelated error presentation unchanged: %s', error => {
     expect(getGitHubUserConnectionErrorMessage(error, 'user-connect')).toBeNull();
   });
+});
+
+const mockMint = jest.fn();
+const mockButtons: Array<{ children?: React.ReactNode; onClick?: () => Promise<void> }> = [];
+
+jest.mock('@/lib/trpc/utils', () => ({
+  useTRPC: () => ({
+    githubApps: Object.fromEntries(
+      [
+        'getAppType',
+        'getInstallation',
+        'checkUserPendingInstallation',
+        'getUserAuthorization',
+        'connectUserAuthorization',
+        'disconnectUserAuthorization',
+        'uninstallApp',
+        'cancelPendingInstallation',
+        'refreshInstallation',
+        'updateModel',
+        'mintInstallState',
+      ].map(name => [name, { queryOptions: () => ({}), mutationOptions: () => ({}) }])
+    ),
+  }),
+}));
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQuery: () => ({ data: undefined, isLoading: false, refetch: jest.fn() }),
+  useMutation: () => ({ mutateAsync: mockMint, isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}));
+jest.mock('@/app/api/organizations/hooks', () => ({ useOrganizationWithMembers: () => ({}) }));
+jest.mock('@/app/api/openrouter/hooks', () => ({ useModelSelectorList: () => ({}) }));
+jest.mock('@/components/ui/confirm', () => ({ useConfirm: () => jest.fn() }));
+jest.mock('./DevAddGitHubInstallationCard', () => ({ DevAddGitHubInstallationCard: () => null }));
+jest.mock('./OrganizationGitHubInstallations', () => ({
+  OrganizationGitHubInstallations: () => null,
+}));
+jest.mock('@/components/ui/button', () => ({
+  Button: (props: { children?: React.ReactNode; onClick?: () => Promise<void> }) => {
+    mockButtons.push(props);
+    return jest.requireActual<typeof React>('react').createElement('button', null, props.children);
+  },
+}));
+
+describe('GitHubIntegrationDetails installation setup recovery', () => {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  const open = jest.fn();
+  const location = { href: '' };
+
+  beforeEach(() => {
+    mockButtons.length = 0;
+    mockMint.mockReset().mockResolvedValue({ token: 'fresh-install-token' });
+    open.mockReset();
+    location.href = '';
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: { open, location } });
+  });
+
+  afterEach(() => {
+    if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+    else Reflect.deleteProperty(globalThis, 'window');
+  });
+
+  function action(label: string) {
+    const button = mockButtons.find(button =>
+      renderToStaticMarkup(React.createElement(React.Fragment, null, button.children)).includes(
+        label
+      )
+    );
+    if (!button?.onClick) throw new Error(`Missing action: ${label}`);
+    return button.onClick;
+  }
+
+  test('uses pre-minted state once and sends repeated clicks to neutral recovery without reminting', async () => {
+    renderToStaticMarkup(
+      React.createElement(GitHubIntegrationDetails, {
+        installState: 'original-install-token',
+        fromApp: true,
+        appReturnPath: '/cloud/sessions',
+        organizationId: 'synthetic-organization',
+      })
+    );
+    const setup = action('Open GitHub setup');
+    await Promise.all([setup(), setup(), setup()]);
+    expect(open).toHaveBeenCalledTimes(1);
+    const opened = new URL(open.mock.calls[0][0]);
+    expect(opened.searchParams.get('state')).toBe('original-install-token');
+    expect(mockMint).not.toHaveBeenCalled();
+    expect(location.href).toBe('/github-app?error=install_state_invalid&fromApp=1');
+    expect(location.href).not.toContain('original-install-token');
+    expect(location.href).not.toContain('synthetic-organization');
+  });
+
+  test('a retry carrying pre-minted state cannot silently mint for a changed browser account', async () => {
+    renderToStaticMarkup(
+      React.createElement(GitHubIntegrationDetails, {
+        installState: 'original-install-token',
+        fromApp: true,
+        appReturnPath: '/cloud/sessions',
+        error: 'installation_failed',
+      })
+    );
+    await action('Try again')();
+    expect(mockMint).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+    expect(location.href).toBe('/github-app?error=install_state_invalid&fromApp=1');
+  });
+
+  test('an explicit retry without pre-minted state mints a fresh token', async () => {
+    renderToStaticMarkup(
+      React.createElement(GitHubIntegrationDetails, {
+        fromApp: true,
+        appReturnPath: '/cloud/sessions',
+        error: 'installation_failed',
+      })
+    );
+    await action('Try again')();
+    expect(mockMint).toHaveBeenCalledWith({
+      organizationId: undefined,
+      returnTo: '/cloud/sessions',
+    });
+    expect(new URL(open.mock.calls[0][0]).searchParams.get('state')).toBe('fresh-install-token');
+  });
+
+  test.each([true, false])(
+    'invalid-state landing explains recovery without inferring an owner (fromApp: %s)',
+    fromApp => {
+      const html = renderToStaticMarkup(
+        React.createElement(GitHubIntegrationDetails, {
+          error: 'install_state_invalid',
+          fromApp,
+          organizationId: 'untrusted-organization',
+        })
+      );
+      expect(html).toContain('Restart GitHub setup');
+      expect(html).toContain('has expired, has already been used, or is invalid');
+      expect(html).toContain(
+        fromApp ? '/cloud/sessions?error=install_state_unusable' : '/integrations'
+      );
+      expect(html).not.toContain('untrusted-organization');
+      expect(mockMint).not.toHaveBeenCalled();
+      expect(open).not.toHaveBeenCalled();
+    }
+  );
 });
 
 describe('GitHubIntegrationDetails fromApp outcome CTA behavior', () => {

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -15,7 +15,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import Link from 'next/link';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { DevAddGitHubInstallationCard } from './DevAddGitHubInstallationCard';
@@ -203,6 +203,31 @@ function GitHubIntegrationOutcomeToasts({
 }
 
 export function GitHubIntegrationDetails(props: GitHubIntegrationDetailsProps) {
+  if (props.error === 'install_state_invalid') {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Restart GitHub setup</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-muted-foreground text-sm">
+            This setup link has expired, has already been used, or is invalid. Start GitHub setup
+            again from the Kilo account and organization you want to connect.
+          </p>
+          <Button asChild>
+            <Link
+              href={
+                props.fromApp ? '/cloud/sessions?error=install_state_unusable' : '/integrations'
+              }
+            >
+              {props.fromApp ? 'Return to Kilo App' : 'Open integration settings'}
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
   return (
     <>
       <GitHubIntegrationOutcomeToasts {...props} />
@@ -282,6 +307,7 @@ function GitHubIntegrationDetailsContent({
   // Track selected model
   const [selectedModel, setSelectedModel] = useState<string>('');
   const installationDetectedRef = useRef(false);
+  const launchedInstallStates = useRef(new Set<string>());
 
   const { data: onboardingAppType } = useQuery({
     ...trpc.githubApps.getAppType.queryOptions(input),
@@ -446,6 +472,11 @@ function GitHubIntegrationDetailsContent({
       // second mint.  The state token is the raw database token; it must be
       // passed to GitHub exactly as received.
       if (installState) {
+        if (launchedInstallStates.current.has(installState)) {
+          window.location.href = `/github-app?error=install_state_invalid${fromApp ? '&fromApp=1' : ''}`;
+          return;
+        }
+        launchedInstallStates.current.add(installState);
         const installUrl = `https://github.com/apps/${githubAppName}/installations/new?state=${encodeURIComponent(buildGitHubInstallState(installState))}`;
         window.open(installUrl, '_blank', 'noopener,noreferrer');
         return;
@@ -473,6 +504,10 @@ function GitHubIntegrationDetailsContent({
    * token was consumed by the callback.  A retry must never reuse it.
    */
   const handleAppRetry = async () => {
+    if (installState) {
+      window.location.href = `/github-app?error=install_state_invalid${fromApp ? '&fromApp=1' : ''}`;
+      return;
+    }
     try {
       const result = await mintInstallState.mutateAsync({
         organizationId: organizationId ?? undefined,

--- a/apps/web/src/lib/integrations/github/install-state.test.ts
+++ b/apps/web/src/lib/integrations/github/install-state.test.ts
@@ -118,7 +118,10 @@ describe('install-state', () => {
       if (first.status !== 'success') throw new Error('Expected successful consumption');
       expect(first.state).toEqual(await readState(token));
       expect(first.state.consumed_at).not.toBeNull();
-      await expect(consumeInstallState(token, testUserId)).resolves.toEqual({ status: 'unusable' });
+      await expect(consumeInstallState(token, testUserId)).resolves.toEqual({
+        status: 'unusable',
+        reason: 'consumed',
+      });
     });
 
     test('a foreign callback cannot burn state before the initiator consumes it', async () => {
@@ -134,7 +137,10 @@ describe('install-state', () => {
         status: 'success',
         state: { kilo_user_id: testUserId },
       });
-      await expect(consumeInstallState(token, testUserId)).resolves.toEqual({ status: 'unusable' });
+      await expect(consumeInstallState(token, testUserId)).resolves.toEqual({
+        status: 'unusable',
+        reason: 'consumed',
+      });
     });
 
     test('a session change after valid preflight does not authorize consumption', async () => {
@@ -166,6 +172,7 @@ describe('install-state', () => {
         consumeInstallState(token, testUserId),
       ]);
       expect(results.map(result => result.status).sort()).toEqual(['success', 'unusable']);
+      expect(results).toContainEqual({ status: 'unusable', reason: 'consumed' });
     });
   });
 
@@ -186,11 +193,52 @@ describe('install-state', () => {
         const before = kind === 'unknown' ? null : await readState(token);
         for (const userId of [testUserId, otherUserId]) {
           await expect(checkInstallState(token, userId)).resolves.toEqual({ status: 'unusable' });
-          await expect(consumeInstallState(token, userId)).resolves.toEqual({ status: 'unusable' });
+          await expect(consumeInstallState(token, userId)).resolves.toEqual({
+            status: 'unusable',
+            reason: kind === 'unknown' ? 'not_found' : kind,
+          });
         }
         if (before) expect(await readState(token)).toEqual(before);
       }
     );
+  });
+
+  test('does not claim a deleted expired token was never issued', async () => {
+    const token = await mintState();
+    await db
+      .update(github_install_states)
+      .set({ expires_at: sql`NOW() - INTERVAL '1 second'` })
+      .where(eq(github_install_states.token, token));
+    await expect(consumeInstallState(token, testUserId)).resolves.toEqual({
+      status: 'unusable',
+      reason: 'expired',
+    });
+    await cleanupExpiredInstallStates();
+    await expect(consumeInstallState(token, testUserId)).resolves.toEqual({
+      status: 'unusable',
+      reason: 'not_found',
+    });
+  });
+
+  test('rejects the expiry boundary without consuming and prioritizes an observed consumption', async () => {
+    const token = await mintState();
+    await db
+      .update(github_install_states)
+      .set({ expires_at: sql`NOW()` })
+      .where(eq(github_install_states.token, token));
+    await expect(consumeInstallState(token, testUserId)).resolves.toEqual({
+      status: 'unusable',
+      reason: 'expired',
+    });
+    expect((await readState(token)).consumed_at).toBeNull();
+    await db
+      .update(github_install_states)
+      .set({ consumed_at: sql`NOW()` })
+      .where(eq(github_install_states.token, token));
+    await expect(consumeInstallState(token, testUserId)).resolves.toEqual({
+      status: 'unusable',
+      reason: 'consumed',
+    });
   });
 
   describe('cleanupExpiredInstallStates', () => {

--- a/apps/web/src/lib/integrations/github/install-state.ts
+++ b/apps/web/src/lib/integrations/github/install-state.ts
@@ -52,10 +52,12 @@ export type InstallStatePreflightResult =
   | InstallStateUserMismatch
   | UnusableInstallState;
 
+export type InstallStateRejectionReason = 'consumed' | 'expired' | 'not_found' | 'unavailable';
+
 export type ConsumeInstallStateResult =
   | { status: 'success'; state: GitHubInstallState }
   | InstallStateUserMismatch
-  | UnusableInstallState;
+  | { status: 'unusable'; reason: InstallStateRejectionReason };
 
 export async function checkInstallState(
   token: string,
@@ -109,8 +111,30 @@ export async function consumeInstallState(
   const state = result[0];
   if (state) return { status: 'success', state };
 
-  const diagnostic = await checkInstallState(token, userId);
-  return diagnostic.status === 'user_mismatch' ? diagnostic : { status: 'unusable' };
+  const [diagnostic] = await db
+    .select({
+      userId: github_install_states.kilo_user_id,
+      ownerType: github_install_states.owner_type,
+      ownerId: github_install_states.owner_id,
+      returnTo: github_install_states.return_to,
+      consumed: sql<boolean>`${github_install_states.consumed_at} IS NOT NULL`,
+      expired: sql<boolean>`${github_install_states.expires_at} <= NOW()`,
+    })
+    .from(github_install_states)
+    .where(eq(github_install_states.token, token))
+    .limit(1);
+
+  if (!diagnostic) return { status: 'unusable', reason: 'not_found' };
+  if (diagnostic.consumed) return { status: 'unusable', reason: 'consumed' };
+  if (diagnostic.expired) return { status: 'unusable', reason: 'expired' };
+  if (diagnostic.userId !== userId) {
+    return {
+      status: 'user_mismatch',
+      returnTo: diagnostic.returnTo,
+      organizationId: diagnostic.ownerType === 'org' ? diagnostic.ownerId : null,
+    };
+  }
+  return { status: 'unusable', reason: 'unavailable' };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Recover rejected GitHub installation callbacks with an explicit restart page instead of a silent home redirect. Addresses KILOCODE-WEB-27ME.
- Preserve PR #5884's atomic, presenting-user-bound consume and preflight. Add primary-database diagnostics for observable consumed, expired, and not-found states, plus an unavailable fallback; deleted rows are not claimed to be never-issued tokens.
- Separate rejection reasons from state shape and lower known expiry/replay events to informational severity. New rejection diagnostics omit raw tokens and installation identifiers.
- Prevent repeated setup clicks from resending pre-minted state. Send those attempts to neutral recovery rather than silently minting for a potentially different browser account. Explicit retries without pre-minted state still mint fresh state.

## Verification

- [ ] Manual browser/GitHub installation flow not run. Verification used isolated PostgreSQL-backed tests, rendered component/handler tests, static analysis, and independent review; no production access or deployment was needed.

## Visual Changes

| Before | After |
|---|---|
| Rejected callbacks silently redirected home. Repeated mobile-handoff setup clicks reused the original token. | A restart card explains expired/already-used/invalid setup links and directs users to integration settings or back to the Kilo App. Repeated pre-minted attempts enter this neutral recovery. |

Screenshots were not captured. The recovery markup and setup/retry handlers are covered by automated tests; no unrelated UI or user-connect error mapping was changed.

## Reviewer Notes

- **Stacked on #5884:** base `research/sentry-27q2-github-install`; inherited commit `da656f8e6` is unchanged. Only six 27ME files are included.
- Independent Task static review of the complete diff and surrounding code returned **CLEAN**. The final snapshot was reconfirmed clean after deleting two stale test comments. No actionable findings were rejected or left open.
- Automated verification: **87 tests passed across four suites** (`install-state`, GitHub callback route, `GitHubIntegrationDetails`, and the unchanged `/github-app` preflight suite).
- Tests ran with `pnpm --filter web test --runInBand --silent --globalSetup=<temporary isolated setup> --runTestsByPath src/lib/integrations/github/install-state.test.ts src/app/api/integrations/github/callback/route.test.ts src/components/integrations/GitHubIntegrationDetails.test.ts src/app/github-app/page.test.ts`. The temporary setup calls the repository global setup, then pins `POSTGRES_URL` to a dedicated localhost database `kilo_test_sentry_27me` and disables replica URLs. Jest resets only its dedicated `kilo_test_sentry_27me-1` worker database.
- `pnpm format` on the six changed files and `git diff --check` passed.
- `pnpm exec oxlint --config .oxlintrc.json` on the six changed files passed with zero warnings/errors.
- `pnpm exec tsgo --noEmit -p apps/web/tsconfig.json` passed. This is targeted verification, **not full-repository validation**.
- No stale/legacy state acceptance, TTL increase, schema migration, user-connect mapping changes, merge, or deployment.
