### PR TITLE
feat(admin): release conflicting email addresses

### DIFF
--- a/apps/web/src/app/admin/components/UserAdmin/ReleaseEmailAddressButton.test.ts
+++ b/apps/web/src/app/admin/components/UserAdmin/ReleaseEmailAddressButton.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { QueryClient, QueryClientProvider, type UseMutationOptions } from '@tanstack/react-query';
+import { createRequire } from 'node:module';
+import React, { act, createElement, useContext, type ComponentProps, type ReactNode } from 'react';
+import type { createRoot as createReactRoot, Root } from 'react-dom/client';
+import type { ReleaseEmailAddressButton as ReleaseEmailAddressButtonComponent } from './ReleaseEmailAddressButton';
+
+type ReleaseEmailInput = { userId: string; expectedEmail: string };
+type ReleaseEmailMutationOptions = UseMutationOptions<void, Error, ReleaseEmailInput>;
+
+const mockReleaseEmailAddress = jest.fn<(input: ReleaseEmailInput) => Promise<void>>();
+const mockRefresh = jest.fn();
+const mockToast = { success: jest.fn(), error: jest.fn() };
+
+const mockTrpc = {
+  admin: {
+    users: {
+      releaseEmailAddress: {
+        mutationOptions: (options?: ReleaseEmailMutationOptions) => ({
+          ...options,
+          mutationFn: mockReleaseEmailAddress,
+        }),
+      },
+    },
+  },
+};
+
+const AlertDialogContext = React.createContext<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+} | null>(null);
+
+function useAlertDialogContext() {
+  const context = useContext(AlertDialogContext);
+  if (!context) throw new Error('Alert dialog context missing');
+  return context;
+}
+
+jest.mock('@/lib/trpc/utils', () => ({ useTRPC: () => mockTrpc }));
+jest.mock('next/navigation', () => ({ useRouter: () => ({ refresh: mockRefresh }) }));
+jest.mock('sonner', () => ({ toast: mockToast }));
+jest.mock('@/components/ui/alert-dialog', () => ({
+  AlertDialog: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: ReactNode;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  }) => createElement(AlertDialogContext.Provider, { value: { open, onOpenChange } }, children),
+  AlertDialogTrigger: ({
+    children,
+  }: {
+    children: React.ReactElement<ComponentProps<'button'>>;
+  }) => {
+    const { onOpenChange } = useAlertDialogContext();
+    return React.cloneElement(children, { onClick: () => onOpenChange(true) });
+  },
+  AlertDialogContent: ({ children }: { children: ReactNode }) => {
+    const { open, onOpenChange } = useAlertDialogContext();
+    if (!open) return null;
+    return createElement(
+      'div',
+      {
+        role: 'alertdialog',
+        tabIndex: -1,
+        onKeyDown: event => event.key === 'Escape' && onOpenChange(false),
+      },
+      createElement('button', {
+        'aria-label': 'Dismiss dialog overlay',
+        onClick: () => onOpenChange(false),
+      }),
+      children
+    );
+  },
+  AlertDialogHeader: ({ children }: { children: ReactNode }) =>
+    createElement('div', null, children),
+  AlertDialogFooter: ({ children }: { children: ReactNode }) =>
+    createElement('div', null, children),
+  AlertDialogTitle: ({ children }: { children: ReactNode }) => createElement('h2', null, children),
+  AlertDialogDescription: ({ children }: { children: ReactNode }) =>
+    createElement('p', null, children),
+  AlertDialogCancel: ({ children, onClick, ...props }: ComponentProps<'button'>) => {
+    const { onOpenChange } = useAlertDialogContext();
+    return createElement(
+      'button',
+      {
+        ...props,
+        onClick: event => {
+          onClick?.(event);
+          onOpenChange(false);
+        },
+      },
+      children
+    );
+  },
+  AlertDialogAction: ({ children, ...props }: ComponentProps<'button'>) =>
+    createElement('button', props, children),
+}));
+
+type LinkedomModule = {
+  parseHTML: (
+    html: string,
+    globals: { location: URL }
+  ) => { window: typeof globalThis; document: Document };
+};
+
+function installDom() {
+  const requireFromHere = createRequire(__filename);
+  const { window, document } = (requireFromHere('linkedom') as LinkedomModule).parseHTML(
+    '<!doctype html><html><body><div id="root"></div></body></html>',
+    { location: new URL('http://localhost/') }
+  );
+  const container = document.getElementById('root');
+  if (!container) throw new Error('React root missing');
+  const globals = {
+    window,
+    document,
+    HTMLElement: window.HTMLElement,
+    HTMLButtonElement: window.HTMLButtonElement,
+    Element: window.Element,
+    Node: window.Node,
+    Text: window.Text,
+    Comment: window.Comment,
+    DocumentFragment: window.DocumentFragment,
+    Document: window.Document,
+    SVGElement: window.SVGElement,
+    Event: window.Event,
+    CustomEvent: window.CustomEvent,
+    navigator: window.navigator,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  };
+  const previous = new Map(
+    Object.keys(globals).map(name => [name, Object.getOwnPropertyDescriptor(globalThis, name)])
+  );
+  for (const [name, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  }
+  return {
+    container,
+    cleanup: () => {
+      for (const [name, descriptor] of previous) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else Reflect.deleteProperty(globalThis, name);
+      }
+    },
+  };
+}
+
+async function settle(action: () => void) {
+  await act(async () => {
+    action();
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+  });
+}
+
+describe('ReleaseEmailAddressButton', () => {
+  let dom: ReturnType<typeof installDom>;
+  let root: Root;
+  let queryClient: QueryClient;
+  let createRoot: typeof createReactRoot;
+  let ReleaseEmailAddressButton: typeof ReleaseEmailAddressButtonComponent;
+
+  function button(text: string) {
+    const found = Array.from(dom.container.querySelectorAll('button')).find(
+      candidate => candidate.textContent?.trim() === text
+    );
+    if (!found) throw new Error(`Button missing: ${text}`);
+    return found;
+  }
+
+  function dialog() {
+    return dom.container.querySelector('[role="alertdialog"]');
+  }
+
+  function dialogButton(text: string) {
+    const found = Array.from(dialog()?.querySelectorAll('button') ?? []).find(
+      candidate => candidate.textContent?.trim() === text
+    );
+    if (!found) throw new Error(`Dialog button missing: ${text}`);
+    return found;
+  }
+
+  function openDialog() {
+    act(() => button('Release email address').click());
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockReleaseEmailAddress.mockReset().mockResolvedValue(undefined);
+    dom = installDom();
+    ({ createRoot } = await import('react-dom/client'));
+    ({ ReleaseEmailAddressButton } = await import('./ReleaseEmailAddressButton'));
+    queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false, gcTime: Infinity } },
+    });
+    act(() => {
+      root = createRoot(dom.container);
+      root.render(
+        createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          createElement(ReleaseEmailAddressButton, {
+            userId: 'User/Original-Case',
+            email: 'Original.Case+duplicate@example.com',
+          })
+        )
+      );
+    });
+  });
+
+  afterEach(() => {
+    try {
+      act(() => root?.unmount());
+      queryClient?.clear();
+    } finally {
+      dom?.cleanup();
+    }
+  });
+
+  it('opens for confirmation and cancel makes no request', () => {
+    openDialog();
+    expect(dialog()?.textContent).toContain('loses email sign-in and email delivery');
+    expect(dialog()?.textContent).toContain('does not merge accounts');
+    expect(dialog()?.textContent).toContain('or revoke access');
+
+    act(() => button('Cancel').click());
+
+    expect(mockReleaseEmailAddress).not.toHaveBeenCalled();
+    expect(dialog()).toBeNull();
+  });
+
+  it('submits the exact user ID and original-case email only after confirmation', async () => {
+    openDialog();
+    await settle(() => dialogButton('Release email address').click());
+
+    expect(mockReleaseEmailAddress.mock.calls[0]?.[0]).toEqual({
+      userId: 'User/Original-Case',
+      expectedEmail: 'Original.Case+duplicate@example.com',
+    });
+  });
+
+  it('disables confirmation and blocks overlay or Escape dismissal while pending', async () => {
+    const release = Promise.withResolvers<void>();
+    mockReleaseEmailAddress.mockReturnValueOnce(release.promise);
+    openDialog();
+    await settle(() => dialogButton('Release email address').click());
+
+    expect(dialogButton('Releasing email address...').disabled).toBe(true);
+    expect(dialogButton('Cancel').disabled).toBe(true);
+    act(() => {
+      const overlay = dialog()?.querySelector('[aria-label="Dismiss dialog overlay"]');
+      if (!(overlay instanceof HTMLButtonElement)) throw new Error('Dismiss overlay missing');
+      overlay.click();
+    });
+    act(() => {
+      const escape = new Event('keydown', { bubbles: true });
+      Object.defineProperty(escape, 'key', { value: 'Escape' });
+      dialog()?.dispatchEvent(escape);
+    });
+    act(() => dialogButton('Releasing email address...').click());
+
+    expect(dialog()).not.toBeNull();
+    expect(mockReleaseEmailAddress).toHaveBeenCalledTimes(1);
+  });
+
+  it('toasts, refreshes, and closes on success but remains open on failure', async () => {
+    const success = Promise.withResolvers<void>();
+    mockReleaseEmailAddress.mockReturnValueOnce(success.promise);
+    openDialog();
+    await settle(() => dialogButton('Release email address').click());
+    await settle(() => success.resolve());
+
+    expect(mockToast.success).toHaveBeenCalledWith('Email address released');
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(dialog()).toBeNull();
+
+    mockReleaseEmailAddress.mockRejectedValueOnce(new Error('Address changed'));
+    openDialog();
+    await settle(() => dialogButton('Release email address').click());
+
+    expect(mockToast.error).toHaveBeenCalledWith('Could not release email address', {
+      description: 'Address changed',
+    });
+    expect(dialog()).not.toBeNull();
+  });
+});

--- a/apps/web/src/app/admin/components/UserAdmin/ReleaseEmailAddressButton.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/ReleaseEmailAddressButton.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { useTRPC } from '@/lib/trpc/utils';
+
+export function ReleaseEmailAddressButton({ userId, email }: { userId: string; email: string }) {
+  const [open, setOpen] = useState(false);
+  const trpc = useTRPC();
+  const router = useRouter();
+  const releaseEmailAddress = useMutation(
+    trpc.admin.users.releaseEmailAddress.mutationOptions({
+      onSuccess: () => {
+        toast.success('Email address released');
+        setOpen(false);
+        router.refresh();
+      },
+      onError: error => {
+        toast.error('Could not release email address', { description: error.message });
+      },
+    })
+  );
+  const isPending = releaseEmailAddress.isPending;
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!isPending) setOpen(nextOpen);
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogTrigger asChild>
+        <Button size="sm" variant="destructive" disabled={isPending}>
+          Release email address
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Release email address</AlertDialogTitle>
+          <AlertDialogDescription>
+            Release <span className="font-mono break-all text-foreground">{email}</span> from
+            account <span className="font-mono break-all text-foreground">{userId}</span>? This
+            replaces the account email with a non-deliverable address, so this duplicate account
+            loses email sign-in and email delivery. It does not merge accounts, change billing or
+            subscriptions, or revoke access.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={() => releaseEmailAddress.mutate({ userId, expectedEmail: email })}
+            disabled={isPending}
+          >
+            {isPending ? 'Releasing email address...' : 'Release email address'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminTabbedSections.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminTabbedSections.tsx
@@ -19,6 +19,7 @@ import { UserAdminOrganizations } from './UserAdminOrganizations';
 import { UserAdminKiloPass } from './UserAdminKiloPass';
 import { UserAdminKiloClaw } from './UserAdminKiloClaw';
 import { UserAdminGastown } from './UserAdminGastown';
+import { ReleaseEmailAddressButton } from './ReleaseEmailAddressButton';
 
 const VALID_TABS = ['billing', 'organizations', 'kiloclaw', 'gastown', 'admin-tools'] as const;
 type Tab = (typeof VALID_TABS)[number];
@@ -108,6 +109,7 @@ export function UserAdminTabbedSections(
             <UserAdminNotes {...user} />
             <UserAdminStytchFingerprints {...user} />
             <UserAdminReferrals kilo_user_id={user.id} />
+            <ReleaseEmailAddressButton userId={user.id} email={user.google_user_email} />
             <UserAdminGdprRemoval {...user} />
           </div>
         </TabsContent>

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -1954,7 +1954,8 @@ async function getEmailAccountCandidates(email: string) {
 
 export async function getCrossAccountEmailConflicts(
   emails: string[],
-  currentUserId: string
+  currentUserId: string,
+  database: typeof db | DrizzleTransaction = db
 ): Promise<Map<string, boolean>> {
   const uniqueEmails = [...new Set(emails)];
   if (uniqueEmails.length === 0) return new Map();
@@ -1962,7 +1963,7 @@ export async function getCrossAccountEmailConflicts(
   const lowerEmails = [...new Set(uniqueEmails.map(email => email.toLowerCase().trim()))];
   const normalizedEmails = [...new Set(uniqueEmails.map(normalizeEmail))];
   const [linkedProviderMatches, primaryEmailMatches] = await Promise.all([
-    db
+    database
       .select({ email: user_auth_provider.email })
       .from(user_auth_provider)
       .where(
@@ -1971,7 +1972,7 @@ export async function getCrossAccountEmailConflicts(
           ne(user_auth_provider.kilo_user_id, currentUserId)
         )
       ),
-    db
+    database
       .select({
         normalizedEmail: kilocode_users.normalized_email,
         primaryEmail: kilocode_users.google_user_email,

--- a/apps/web/src/routers/admin-router.test.ts
+++ b/apps/web/src/routers/admin-router.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from '@jest/globals';
 import { eq } from 'drizzle-orm';
-import { kilocode_users } from '@kilocode/db/schema';
+import { kilocode_users, organizations, user_auth_provider } from '@kilocode/db/schema';
 import {
   createDeletionInProgressBlockedReason,
   createSoftDeletedBlockedReason,
@@ -8,6 +8,9 @@ import {
 import { db } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createCallerForUser } from '@/routers/test-utils';
+import { getAllUserProviders } from '@/lib/user';
+import { hosted_domain_specials } from '@/lib/auth/constants';
+import { createOrganization } from '@/lib/organizations/organizations';
 
 async function getBlockState(id: string) {
   return db.query.kilocode_users.findFirst({
@@ -134,5 +137,311 @@ describe('admin.users.updateBlockStatus', () => {
     expect(after?.blocked_at).not.toBeNull();
     expect(after?.blocked_by_kilo_user_id).toBe(admin.id);
     expect(after?.api_token_pepper).toBe('deleted-pepper');
+  });
+});
+
+describe('admin.users.releaseEmailAddress', () => {
+  test.each([false, true])(
+    'releases a rowless duplicate with normalized email stored: %s and preserves the retained account',
+    async hasNormalizedEmail => {
+      const email = `Retained.${crypto.randomUUID()}@example.com`;
+      const normalizedEmail = email.toLowerCase();
+      const admin = await insertTestUser({ is_admin: true });
+      const retained = await insertTestUser({
+        id: crypto.randomUUID(),
+        google_user_email: email,
+        normalized_email: normalizedEmail,
+        hosted_domain: hosted_domain_specials.email,
+      });
+      const duplicate = await insertTestUser({
+        id: hasNormalizedEmail ? crypto.randomUUID() : 'rowless-email-account',
+        google_user_email: email.toUpperCase(),
+        normalized_email: hasNormalizedEmail ? normalizedEmail : null,
+        email_domain: 'example.com',
+        hosted_domain: hosted_domain_specials.email,
+        api_token_pepper: 'unchanged-key',
+      });
+
+      await expect(getAllUserProviders(normalizedEmail)).resolves.toEqual({
+        kind: 'ambiguous',
+      });
+
+      const caller = await createCallerForUser(admin.id);
+      await expect(
+        caller.admin.users.releaseEmailAddress({
+          userId: duplicate.id,
+          expectedEmail: duplicate.google_user_email,
+        })
+      ).resolves.toEqual({ success: true });
+
+      const released = await db.query.kilocode_users.findFirst({
+        where: eq(kilocode_users.id, duplicate.id),
+      });
+      expect(released).toBeDefined();
+      if (!released) throw new Error('Released user not found');
+      expect(released).toEqual({
+        ...duplicate,
+        google_user_email: expect.stringMatching(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}@released\.invalid$/
+        ),
+        normalized_email: null,
+        email_domain: 'released.invalid',
+        updated_at: expect.any(String),
+      });
+      await expect(
+        db.query.kilocode_users.findFirst({ where: eq(kilocode_users.id, retained.id) })
+      ).resolves.toEqual(retained);
+      await expect(getAllUserProviders(normalizedEmail)).resolves.toMatchObject({
+        kind: 'found',
+        user: { kiloUserId: retained.id },
+      });
+    }
+  );
+
+  test('refuses a duplicate with a linked provider without changing its email', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const duplicate = await insertTestUser({
+      google_user_email: 'linked-duplicate@example.com',
+      normalized_email: 'linked-duplicate@example.com',
+    });
+    await insertTestUser({ normalized_email: 'linked-duplicate@example.com' });
+    await db.insert(user_auth_provider).values({
+      kilo_user_id: duplicate.id,
+      provider: 'google',
+      provider_account_id: `google-${duplicate.id}`,
+      email: duplicate.google_user_email,
+      avatar_url: '',
+      hosted_domain: null,
+    });
+
+    const caller = await createCallerForUser(admin.id);
+    await expect(
+      caller.admin.users.releaseEmailAddress({
+        userId: duplicate.id,
+        expectedEmail: duplicate.google_user_email,
+      })
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: expect.stringMatching(/linked provider/),
+    });
+
+    await expect(
+      db.query.kilocode_users.findFirst({ where: eq(kilocode_users.id, duplicate.id) })
+    ).resolves.toMatchObject({ google_user_email: 'linked-duplicate@example.com' });
+  });
+
+  test('rejects a stale confirmation without changing the account', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const duplicate = await insertTestUser({
+      google_user_email: 'stale-original@example.com',
+      normalized_email: 'stale-original@example.com',
+    });
+    await insertTestUser({ normalized_email: 'stale-current@example.com' });
+    await db
+      .update(kilocode_users)
+      .set({
+        google_user_email: 'stale-current@example.com',
+        normalized_email: 'stale-current@example.com',
+      })
+      .where(eq(kilocode_users.id, duplicate.id));
+
+    const caller = await createCallerForUser(admin.id);
+    await expect(
+      caller.admin.users.releaseEmailAddress({
+        userId: duplicate.id,
+        expectedEmail: 'stale-original@example.com',
+      })
+    ).rejects.toMatchObject({ code: 'CONFLICT', message: expect.stringMatching(/changed/) });
+
+    await expect(
+      db.query.kilocode_users.findFirst({ where: eq(kilocode_users.id, duplicate.id) })
+    ).resolves.toMatchObject({
+      google_user_email: 'stale-current@example.com',
+      normalized_email: 'stale-current@example.com',
+    });
+  });
+
+  test('refuses an account with a non-email inferred login method', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const duplicate = await insertTestUser({
+      google_user_email: 'inferred-google@example.com',
+      normalized_email: 'inferred-google@example.com',
+      hosted_domain: hosted_domain_specials.non_workspace_google_account,
+    });
+    await insertTestUser({ normalized_email: 'inferred-google@example.com' });
+
+    const caller = await createCallerForUser(admin.id);
+    await expect(
+      caller.admin.users.releaseEmailAddress({
+        userId: duplicate.id,
+        expectedEmail: duplicate.google_user_email,
+      })
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: expect.stringMatching(/inferred email/),
+    });
+  });
+
+  test('requires a current cross-account email conflict', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const target = await insertTestUser({
+      hosted_domain: hosted_domain_specials.email,
+      normalized_email: 'no-conflict@example.com',
+    });
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(
+      caller.admin.users.releaseEmailAddress({
+        userId: target.id,
+        expectedEmail: target.google_user_email,
+      })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringMatching(/does not conflict/),
+    });
+
+    await expect(
+      db.query.kilocode_users.findFirst({ where: eq(kilocode_users.id, target.id) })
+    ).resolves.toMatchObject({ google_user_email: target.google_user_email });
+  });
+
+  test('serializes simultaneous releases for the same normalized email', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const first = await insertTestUser({
+      id: crypto.randomUUID(),
+      google_user_email: 'First.Candidate@gmail.com',
+      normalized_email: 'firstcandidate@gmail.com',
+      hosted_domain: hosted_domain_specials.email,
+    });
+    const second = await insertTestUser({
+      id: crypto.randomUUID(),
+      google_user_email: 'FIRSTCANDIDATE@gmail.com',
+      normalized_email: 'firstcandidate@gmail.com',
+      hosted_domain: hosted_domain_specials.email,
+    });
+    const caller = await createCallerForUser(admin.id);
+    const results = await Promise.allSettled([
+      caller.admin.users.releaseEmailAddress({
+        userId: first.id,
+        expectedEmail: first.google_user_email,
+      }),
+      caller.admin.users.releaseEmailAddress({
+        userId: second.id,
+        expectedEmail: second.google_user_email,
+      }),
+    ]);
+
+    expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    const rejected = results.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    );
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.reason).toMatchObject({ code: 'BAD_REQUEST' });
+    const candidates = await db
+      .select({ id: kilocode_users.id })
+      .from(kilocode_users)
+      .where(eq(kilocode_users.normalized_email, 'firstcandidate@gmail.com'));
+    expect(candidates).toHaveLength(1);
+    expect([first.id, second.id]).toContain(candidates[0]?.id);
+  });
+
+  test('refuses self-targeting and missing users', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(
+      caller.admin.users.releaseEmailAddress({
+        userId: admin.id,
+        expectedEmail: admin.google_user_email,
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: expect.stringMatching(/own email/) });
+    await expect(
+      caller.admin.users.releaseEmailAddress({
+        userId: 'missing-release-email-user',
+        expectedEmail: 'missing@example.com',
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND', message: 'User not found' });
+  });
+
+  test.each([
+    ['deleting', createDeletionInProgressBlockedReason(new Date())],
+    ['deleted', createSoftDeletedBlockedReason(new Date())],
+  ])('refuses a %s user', async (_state, blocked_reason) => {
+    const admin = await insertTestUser({ is_admin: true });
+    const target = await insertTestUser({
+      google_user_email: `release-${crypto.randomUUID()}@example.com`,
+      hosted_domain: hosted_domain_specials.email,
+      blocked_reason,
+    });
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(
+      caller.admin.users.releaseEmailAddress({
+        userId: target.id,
+        expectedEmail: target.google_user_email,
+      })
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: expect.stringMatching(/deleted or deleting/),
+    });
+  });
+
+  test('refuses an already released email address', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const target = await insertTestUser({
+      google_user_email: `${crypto.randomUUID()}@released.invalid`,
+      normalized_email: null,
+      email_domain: 'released.invalid',
+      hosted_domain: hosted_domain_specials.email,
+    });
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(
+      caller.admin.users.releaseEmailAddress({
+        userId: target.id,
+        expectedEmail: target.google_user_email,
+      })
+    ).rejects.toMatchObject({ code: 'CONFLICT', message: 'Email address is already released' });
+  });
+
+  test('refuses an email address managed by organization SSO', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const organization = await createOrganization(
+      `Release email SSO ${crypto.randomUUID()}`,
+      admin.id
+    );
+    await db
+      .update(organizations)
+      .set({ sso_domain: 'sso-release.example.com' })
+      .where(eq(organizations.id, organization.id));
+    const target = await insertTestUser({
+      google_user_email: 'member@sso-release.example.com',
+      normalized_email: 'member@sso-release.example.com',
+      hosted_domain: hosted_domain_specials.email,
+    });
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(
+      caller.admin.users.releaseEmailAddress({
+        userId: target.id,
+        expectedEmail: target.google_user_email,
+      })
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: expect.stringMatching(/organization SSO/),
+    });
+  });
+
+  test('requires admin access', async () => {
+    const nonAdmin = await insertTestUser({ is_admin: false });
+    const target = await insertTestUser();
+    const caller = await createCallerForUser(nonAdmin.id);
+
+    await expect(
+      caller.admin.users.releaseEmailAddress({
+        userId: target.id,
+        expectedEmail: target.google_user_email,
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: 'Admin access required' });
   });
 });

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -98,7 +98,12 @@ import {
   min,
 } from 'drizzle-orm';
 import type { InferColumnsDataTypes } from 'drizzle-orm';
-import { findUsersByIds, findUserById } from '@/lib/user';
+import {
+  findUsersByIds,
+  findUserById,
+  getCrossAccountEmailConflicts,
+  inferRowlessAuthProviders,
+} from '@/lib/user';
 import { blockUser } from '@/lib/user/block';
 import { reportEvents } from '@/lib/ai-gateway/abuse-service';
 import { getBlobContent } from '@/lib/r2/cli-sessions';
@@ -125,7 +130,7 @@ import { recomputeUserBalances } from '@/lib/user/recompute-balances';
 import { getStripeInvoices } from '@/lib/stripe';
 import { client as stripeClient } from '@/lib/stripe-client';
 import { resolveSsoAuthorityForDomain } from '@/lib/organizations/organization-sso-policy';
-import { getLowerDomainFromEmail } from '@/lib/utils';
+import { getLowerDomainFromEmail, normalizeEmail } from '@/lib/utils';
 import { cancelAndRefundKiloPassForUser } from '@/lib/kilo-pass/cancel-and-refund';
 import { KILOCLAW_EARLYBIRD_EXPIRY_DATE } from '@/lib/kiloclaw/constants';
 import {
@@ -318,6 +323,13 @@ const CheckKiloPassSchema = z.object({
 const ResetToMagicLinkLoginSchema = z.object({
   userId: z.string(),
 });
+
+const ReleaseEmailAddressSchema = z.object({
+  userId: z.string().min(1),
+  expectedEmail: z.string().min(1),
+});
+
+const RELEASED_EMAIL_DOMAIN = 'released.invalid';
 
 const UpdateUserBlockStatusSchema = z.object({
   userId: z.string(),
@@ -675,6 +687,151 @@ export const adminRouter = createTRPCRouter({
         await db
           .delete(user_auth_provider)
           .where(eq(user_auth_provider.kilo_user_id, input.userId));
+
+        return successResult();
+      }),
+
+    releaseEmailAddress: adminProcedure
+      .input(ReleaseEmailAddressSchema)
+      .mutation(async ({ input, ctx }) => {
+        if (input.userId === ctx.user.id) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Administrators cannot release their own email address',
+          });
+        }
+
+        await db.transaction(async tx => {
+          await tx.execute(
+            sql`SELECT pg_advisory_xact_lock(hashtextextended(${`release-email:${normalizeEmail(input.expectedEmail)}`}, 0))`
+          );
+
+          const [user] = await tx
+            .select({
+              id: kilocode_users.id,
+              googleUserEmail: kilocode_users.google_user_email,
+              emailDomain: kilocode_users.email_domain,
+              hostedDomain: kilocode_users.hosted_domain,
+              blockedReason: kilocode_users.blocked_reason,
+            })
+            .from(kilocode_users)
+            .where(eq(kilocode_users.id, input.userId))
+            .for('update')
+            .limit(1);
+
+          if (!user) {
+            throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+          }
+          if (user.googleUserEmail !== input.expectedEmail) {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: 'Email address changed. Reload the user before releasing it.',
+            });
+          }
+          if (isGoneOrDeletingBlockedReason(user.blockedReason)) {
+            throw new TRPCError({
+              code: 'FORBIDDEN',
+              message: 'Cannot release an email address for a deleted or deleting user',
+            });
+          }
+          if (
+            user.emailDomain === RELEASED_EMAIL_DOMAIN ||
+            user.googleUserEmail.toLowerCase().endsWith(`@${RELEASED_EMAIL_DOMAIN}`)
+          ) {
+            throw new TRPCError({ code: 'CONFLICT', message: 'Email address is already released' });
+          }
+
+          const [linkedProvider] = await tx
+            .select({ provider: user_auth_provider.provider })
+            .from(user_auth_provider)
+            .where(eq(user_auth_provider.kilo_user_id, user.id))
+            .limit(1);
+          if (linkedProvider) {
+            throw new TRPCError({
+              code: 'FORBIDDEN',
+              message: 'Cannot release an email address from an account with a linked provider',
+            });
+          }
+          const inferredProviders = inferRowlessAuthProviders({
+            id: user.id,
+            hosted_domain: user.hostedDomain,
+          });
+          if (inferredProviders.length !== 1 || inferredProviders[0] !== 'email') {
+            throw new TRPCError({
+              code: 'FORBIDDEN',
+              message: 'Cannot release an account without inferred email authentication',
+            });
+          }
+
+          const domain = getLowerDomainFromEmail(user.googleUserEmail);
+          if (!domain) {
+            throw new TRPCError({
+              code: 'FORBIDDEN',
+              message: 'Cannot release an account without an email-based identity',
+            });
+          }
+          const ssoAuthority = await resolveSsoAuthorityForDomain(domain, tx);
+          if (ssoAuthority.status !== 'not_required') {
+            throw new TRPCError({
+              code: 'FORBIDDEN',
+              message: 'Cannot release an email address managed by organization SSO',
+            });
+          }
+
+          const conflicts = await getCrossAccountEmailConflicts(
+            [user.googleUserEmail],
+            user.id,
+            tx
+          );
+          if (!conflicts.get(user.googleUserEmail)) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'Email address does not conflict with another account',
+            });
+          }
+
+          const [released] = await tx
+            .update(kilocode_users)
+            .set({
+              google_user_email: `${crypto.randomUUID()}@${RELEASED_EMAIL_DOMAIN}`,
+              normalized_email: null,
+              email_domain: RELEASED_EMAIL_DOMAIN,
+              updated_at: new Date().toISOString(),
+            })
+            .where(
+              and(
+                eq(kilocode_users.id, user.id),
+                eq(kilocode_users.google_user_email, input.expectedEmail),
+                sql`NOT EXISTS (
+                  SELECT 1 FROM ${user_auth_provider}
+                  WHERE ${user_auth_provider.kilo_user_id} = ${kilocode_users.id}
+                )`,
+                sql`EXISTS (
+                  SELECT 1 FROM ${user_auth_provider} AS conflicting_provider
+                  WHERE lower(conflicting_provider.email) = lower(${user.googleUserEmail})
+                    AND conflicting_provider.kilo_user_id <> ${user.id}
+                  UNION ALL
+                  SELECT 1 FROM ${kilocode_users} AS conflicting_user
+                  WHERE conflicting_user.id <> ${user.id}
+                    AND (
+                      conflicting_user.normalized_email = ${normalizeEmail(user.googleUserEmail)}
+                      OR (
+                        conflicting_user.normalized_email IS NULL
+                        AND lower(conflicting_user.google_user_email) = lower(${user.googleUserEmail})
+                      )
+                    )
+                )`
+              )
+            )
+            .returning({ id: kilocode_users.id });
+
+          if (!released) {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: 'Account changed while releasing the email address. Reload and try again.',
+            });
+          }
+        });
 
         return successResult();
       }),


### PR DESCRIPTION
## Summary
- Add **Release email address** under a user’s **Admin Tools**, with target email/account confirmation, pending-state protection, and success/error feedback.
- For conflicting accounts with inferred email authentication and no linked providers, atomically replace the primary email with a unique UUID address at `released.invalid`, clear `normalized_email`, and update `email_domain` and `updated_at`.
- Preserve account IDs, balances, memberships, subscriptions, sessions, and API keys. This is neither a merge nor GDPR deletion.

## Safeguards
- Admin-only; refuses self-targeting, missing/deleting/deleted accounts, already-released addresses, linked providers, unsupported inferred authentication, and organization SSO.
- Exact expected-email check protects stale confirmations; a current cross-account conflict is required.
- A normalized-email transaction advisory lock serializes competing release operations so two admins cannot release both sides of the same conflict simultaneously.
- Clearing normalization alone is insufficient because discovery falls back to the primary email; regression tests cover both populated and null normalized-email records, mixed-case addresses, and non-UUID user IDs.

## Validation
- `pnpm --filter web test --runInBand src/routers/admin-router.test.ts src/lib/user/index.test.ts src/app/api/sso/organizations/route.test.ts src/app/admin/components/UserAdmin/ReleaseEmailAddressButton.test.ts` — 4 suites, 184 tests passed.
- `pnpm --filter web typecheck` — passed.
- `pnpm --filter web lint` — passed, no warnings/errors.
- `pnpm format` on all six changed files and `git diff --check` — passed.
- UI interaction tests exercise confirmation, cancellation, exact payload, pending state, and success/error behavior. They mock the dialog layer under Linkedom; no live browser validation was performed.

## Scope and operational notes
- Implemented in a separate worktree; no production accounts were modified.
- Use only on the confirmed duplicate account. Release does not transfer data or stop billing, and there is no undo button.
- This is not a permanent account suspension: sessions remain valid. Unrelated provider-linking transactions do not share the release lock, so a concurrent or later provider link can reintroduce a conflict; recheck discovery after release.
- Uses the Cloud overlay/voice guidance and existing dialog/button primitives; no new design system or database migration.