### PR TITLE
fix(openrouter): preserve standard provider model pricing

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/fetch-provider-models.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/fetch-provider-models.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { fetchModelsForProvider } from '@/lib/ai-gateway/providers/openrouter/fetch-provider-models';
+import { getModelDisplayPricing } from '@/lib/ai-gateway/providers/openrouter/display-pricing';
+import type {
+  OpenRouterModel,
+  OpenRouterProvider,
+} from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+
+const provider: OpenRouterProvider = {
+  name: 'OpenAI',
+  displayName: 'OpenAI',
+  slug: 'openai',
+  dataPolicy: { training: false, retainsPrompts: true, canPublish: false },
+};
+
+function model(variant: string | null | undefined): OpenRouterModel {
+  return {
+    slug: 'openai/gpt-5.6-sol',
+    name: 'OpenAI: GPT-5.6 Sol',
+    author: 'openai',
+    description: '',
+    context_length: 1_050_000,
+    input_modalities: ['text', 'image', 'file'],
+    output_modalities: ['text'],
+    group: 'GPT',
+    updated_at: '2026-09-04T00:00:00.000Z',
+    endpoint: {
+      provider_display_name: 'OpenAI',
+      variant,
+      is_free: false,
+      pricing:
+        variant === 'batch'
+          ? { prompt: '0.000001', completion: '0.000005', discount: 0.5 }
+          : { prompt: '0.000002', completion: '0.00001', discount: 0.5 },
+      data_policy: { training: false, retainsPrompts: true },
+    },
+  };
+}
+
+function mockModels(models: OpenRouterModel[]) {
+  return jest.spyOn(globalThis, 'fetch').mockResolvedValue(Response.json({ data: { models } }));
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('fetchModelsForProvider', () => {
+  it.each([false, true])(
+    'keeps standard pricing for duplicate slugs regardless of order (batch first: %s)',
+    async batchFirst => {
+      const standard = model('standard');
+      const batch = model('batch');
+      mockModels(batchFirst ? [batch, standard] : [standard, batch]);
+
+      const models = await fetchModelsForProvider(provider);
+
+      expect(models).toEqual([standard]);
+      expect(getModelDisplayPricing(models[0]?.endpoint?.pricing)).toEqual({
+        prompt: '0.000004000000',
+        completion: '0.000020000000',
+      });
+    }
+  );
+
+  it('excludes batch-only models rather than advertising unsupported pricing', async () => {
+    mockModels([model('batch')]);
+
+    expect(await fetchModelsForProvider(provider)).toEqual([]);
+  });
+
+  it.each([undefined, null, 'free', 'extended'])('preserves variant %s', async variant => {
+    const entry = model(variant);
+    mockModels([entry]);
+
+    expect(await fetchModelsForProvider(provider)).toEqual([entry]);
+  });
+
+  it('preserves models without endpoints', async () => {
+    const entry = { ...model(undefined), endpoint: null };
+    mockModels([entry]);
+
+    expect(await fetchModelsForProvider(provider)).toEqual([entry]);
+  });
+
+  it('uses the requested provider and attribution headers', async () => {
+    const mockFetch = mockModels([]);
+
+    await fetchModelsForProvider({ ...provider, name: 'Amazon Bedrock' });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://openrouter.ai/api/frontend/v1/models/find?providers=Amazon+Bedrock&fmt=cards',
+      {
+        method: 'GET',
+        headers: { 'HTTP-Referer': 'https://kilocode.ai', 'X-Title': 'Kilo Code' },
+      }
+    );
+  });
+
+  it('rejects upstream errors instead of returning an empty model list', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, {
+        status: 503,
+        statusText: 'Service Unavailable',
+      })
+    );
+
+    await expect(fetchModelsForProvider(provider)).rejects.toThrow(
+      'Failed to fetch models for provider OpenAI: 503 Service Unavailable'
+    );
+  });
+
+  it('rejects malformed model data', async () => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(Response.json({ data: { models: [{ slug: 'openai/gpt-5.6-sol' }] } }));
+
+    await expect(fetchModelsForProvider(provider)).rejects.toThrow();
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/fetch-provider-models.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/fetch-provider-models.ts
@@ -1,0 +1,43 @@
+import {
+  OpenRouterSearchResponse,
+  type OpenRouterModel,
+  type OpenRouterProvider,
+} from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attribution-headers';
+
+export async function fetchModelsForProvider(
+  provider: OpenRouterProvider
+): Promise<OpenRouterModel[]> {
+  console.log(`Fetching models for provider: ${provider.name} (${provider.slug})`);
+
+  const searchParams = new URLSearchParams({
+    providers: provider.name,
+    fmt: 'cards',
+  });
+
+  console.log(
+    'GET',
+    `https://openrouter.ai/api/frontend/v1/models/find?${searchParams.toString()}`
+  );
+
+  const response = await fetch(
+    `https://openrouter.ai/api/frontend/v1/models/find?${searchParams}`,
+    {
+      method: 'GET',
+      headers: ATTRIBUTION_HEADERS,
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch models for provider ${provider.name}: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const data = await response.json().then(d => OpenRouterSearchResponse.parse(d));
+  const models = data.data.models.filter(model => model.endpoint?.variant !== 'batch');
+
+  console.log(`  Found ${models.length} models for provider ${provider.name}`);
+
+  return models;
+}

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -11,10 +11,8 @@ import type {
   OpenRouterModel,
   OpenRouterProvider,
 } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
-import {
-  OpenRouterProvidersResponse,
-  OpenRouterSearchResponse,
-} from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+import { OpenRouterProvidersResponse } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+import { fetchModelsForProvider } from '@/lib/ai-gateway/providers/openrouter/fetch-provider-models';
 import { modelsByProvider } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
 import { desc, lt, sql } from 'drizzle-orm';
@@ -150,43 +148,6 @@ async function fetchProviders(): Promise<OpenRouterProvider[]> {
   console.log(`Found ${providers.length} providers from endpoint`);
 
   return providers;
-}
-
-async function fetchModelsForProvider(provider: OpenRouterProvider): Promise<OpenRouterModel[]> {
-  console.log(`Fetching models for provider: ${provider.name} (${provider.slug})`);
-
-  // Use the frontend API endpoint with provider filter
-  const searchParams = new URLSearchParams({
-    providers: provider.name,
-    fmt: 'cards',
-  });
-
-  console.log(
-    'GET',
-    `https://openrouter.ai/api/frontend/v1/models/find?${searchParams.toString()}`
-  );
-
-  const response = await fetch(
-    `https://openrouter.ai/api/frontend/v1/models/find?${searchParams}`,
-    {
-      method: 'GET',
-      headers: ATTRIBUTION_HEADERS,
-    }
-  );
-
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch models for provider ${provider.name}: ${response.status} ${response.statusText}`
-    );
-  }
-
-  const data = await response.json().then(d => OpenRouterSearchResponse.parse(d));
-
-  console.log(`  Found ${data.data.models.length} models for provider ${provider.name}`);
-
-  // Note: Models still contain redundant provider info in endpoint.provider_info, etc.
-  // This is now available in the comprehensive providers array, but we keep it for compatibility
-  return data.data.models;
 }
 
 async function syncProviders(

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1901,6 +1901,7 @@ export const OpenRouterBaseModel = z.object({
 export type OpenRouterEndpoint = z.infer<typeof OpenRouterEndpoint>;
 export const OpenRouterEndpoint = z.object({
   provider_display_name: z.string(),
+  variant: z.string().nullish(),
   is_free: z.boolean(),
   pricing: OpenRouterPricing,
   data_policy: z


### PR DESCRIPTION
## Summary
- Preserve the frontend endpoint variant and exclude batch entries before provider model injection and deduplication.
- OpenRouter returns standard and batch entries for `openai/gpt-5.6-sol` with the same model slug. The later batch entry previously overwrote standard pricing, producing the flex-like price shown in Providers & Models.
- Extract the provider fetch boundary for regression coverage of duplicate ordering, batch-only models, legacy/null metadata, HTTP failures, and existing display-discount handling.

## Verification
- Inspected the live public endpoints API and the frontend provider feed. Confirmed the frontend standard entry has $2/$10 raw per-million prices and the batch entry $1/$5, both with a 0.5 discount.
- No manual browser testing; the supplied screenshot could not be retrieved. This change targets snapshot ingestion rather than presentation.

## Visual Changes
No layout changes. The displayed price will use the standard entry after the next successful provider sync following deployment.

## Reviewer Notes
- Existing discount reversal is unchanged: the example standard endpoint displays $4/$20 per million under current pricing policy.
- Formatting, focused lint, database package typecheck, and git diff whitespace checks passed locally. Web typecheck reached the sandbox two-minute limit during the prerequisite tRPC build. Local Node is 22; the repository requires 24.
- Test execution is delegated to CI as requested. Added regression tests; no local test suites were run.
- No database migration is needed; the optional variant is part of the JSON validation contract.