### PR TITLE
fix(github): accept null installation on uninstall webhook

### DIFF
--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
@@ -1,4 +1,10 @@
 import type { NextRequest } from 'next/server';
+import { captureException, captureMessage } from '@sentry/nextjs';
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
 
 const mockVerifyGitHubWebhookSignature = jest.fn(
   (_payload: string, _signature: string, _appType: string) => true
@@ -399,6 +405,107 @@ describe('handleGitHubWebhook', () => {
     expect(mockHandlePRReviewComment).not.toHaveBeenCalled();
   });
 
+  it.each(['standard', 'lite'] as const)(
+    'ignores installation.deleted with a null installation for the %s app',
+    async appType => {
+      const request = signedGitHubRequest('installation', {
+        action: 'deleted',
+        installation: null,
+        sender: { id: 111, login: 'alice' },
+        organization: { id: 222, login: 'acme' },
+        repositories: [{ id: 333, full_name: 'acme/widgets' }],
+      });
+      request.headers.set('x-github-hook-id', '444');
+      request.headers.set('x-github-hook-installation-target-id', '555');
+      request.headers.set('x-github-hook-installation-target-type', 'integration');
+
+      const response = await handleGitHubWebhook(request, appType);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        message: 'Event ignored: missing installation ID',
+      });
+      expect(mockVerifyGitHubWebhookSignature).toHaveBeenCalledWith(
+        expect.any(String),
+        'sha256=test',
+        appType
+      );
+      expect(mockFindIntegrationByInstallationId).not.toHaveBeenCalled();
+      expect(mockHandleInstallationDeleted).not.toHaveBeenCalled();
+      expect(mockLogWebhookEvent).not.toHaveBeenCalled();
+      expect(mockUpdateWebhookEvent).not.toHaveBeenCalled();
+      expect(captureMessage).not.toHaveBeenCalled();
+      expect(captureException).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects installation.deleted with a null installation when signature verification fails', async () => {
+    mockVerifyGitHubWebhookSignature.mockReturnValue(false);
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('installation', { action: 'deleted', installation: null }),
+      'standard'
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockFindIntegrationByInstallationId).not.toHaveBeenCalled();
+    expect(mockHandleInstallationDeleted).not.toHaveBeenCalled();
+    expect(mockLogWebhookEvent).not.toHaveBeenCalled();
+    expect(mockUpdateWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, {}, { id: '98765' }])(
+    'still rejects malformed installation.deleted installation %j',
+    async installation => {
+      const response = await handleGitHubWebhook(
+        signedGitHubRequest('installation', { action: 'deleted', installation }),
+        'standard'
+      );
+
+      expect(response.status).toBe(400);
+      expect(mockFindIntegrationByInstallationId).not.toHaveBeenCalled();
+      expect(mockHandleInstallationDeleted).not.toHaveBeenCalled();
+      expect(captureMessage).toHaveBeenCalledWith(
+        'Invalid GitHub webhook payload structure',
+        expect.objectContaining({
+          level: 'error',
+          tags: { source: 'github_webhook_validation', event: 'installation.deleted' },
+        })
+      );
+    }
+  );
+
+  it('preserves duplicate installation.deleted handling', async () => {
+    mockLogWebhookEvent.mockResolvedValue({ id: 'we_1', isDuplicate: true });
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('installation', { action: 'deleted', installation: { id: 98765 } }),
+      'standard'
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ message: 'Duplicate event' });
+    expect(mockFindIntegrationByInstallationId).toHaveBeenCalledWith('github', '98765', 'standard');
+    expect(mockLogWebhookEvent).toHaveBeenCalledTimes(1);
+    expect(mockHandleInstallationDeleted).not.toHaveBeenCalled();
+    expect(mockUpdateWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it('routes installation.deleted with a known ID even when no integration is found', async () => {
+    const payload = { action: 'deleted', installation: { id: 98765 } };
+    mockFindIntegrationByInstallationId.mockResolvedValue(null);
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('installation', payload),
+      'standard'
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockHandleInstallationDeleted).toHaveBeenCalledWith(payload, 'standard');
+    expect(mockLogWebhookEvent).not.toHaveBeenCalled();
+    expect(mockUpdateWebhookEvent).not.toHaveBeenCalled();
+  });
+
   it('routes installation.deleted to the handler with the webhook app type', async () => {
     const payload = { action: 'deleted', installation: { id: 98765 } };
 
@@ -412,6 +519,10 @@ describe('handleGitHubWebhook', () => {
     expect(mockHandleInstallationDeleted).toHaveBeenCalledWith(
       expect.objectContaining(payload),
       'lite'
+    );
+    expect(mockUpdateWebhookEvent).toHaveBeenCalledWith(
+      'we_1',
+      expect.objectContaining({ processed: true, handlers_triggered: ['installation_deleted'] })
     );
   });
 

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
@@ -4,7 +4,7 @@ import { captureException, captureMessage } from '@sentry/nextjs';
 import { verifyGitHubWebhookSignature } from '@/lib/integrations/platforms/github/adapter';
 import {
   InstallationCreatedPayloadSchema,
-  InstallationDeletedPayloadSchema,
+  InstallationDeletedWebhookPayloadSchema,
   InstallationSuspendPayloadSchema,
   InstallationUnsuspendPayloadSchema,
   InstallationTargetRenamedPayloadSchema,
@@ -177,7 +177,7 @@ export async function handleGitHubWebhook(
       }
 
       if (action === GITHUB_ACTION.DELETED) {
-        const parseResult = InstallationDeletedPayloadSchema.safeParse(payload);
+        const parseResult = InstallationDeletedWebhookPayloadSchema.safeParse(payload);
         if (!parseResult.success) {
           logExceptInTest(`Invalid installation.deleted payload${logSuffix}:`, parseResult.error);
           captureMessage('Invalid GitHub webhook payload structure', {
@@ -188,8 +188,18 @@ export async function handleGitHubWebhook(
           return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
         }
 
+        const { installation } = parseResult.data;
+        if (installation === null) {
+          logExceptInTest(`Ignoring installation.deleted without an installation ID${logSuffix}`);
+          return NextResponse.json(
+            { message: 'Event ignored: missing installation ID' },
+            { status: 200 }
+          );
+        }
+        const deletedPayload = { ...parseResult.data, installation };
+
         // Get integration before deletion to log the event
-        const installationId = parseResult.data.installation.id.toString();
+        const installationId = installation.id.toString();
         const integration = await findIntegrationByInstallationId(
           PLATFORM.GITHUB,
           installationId,
@@ -202,7 +212,7 @@ export async function handleGitHubWebhook(
             return NextResponse.json({ message: 'Duplicate event' }, { status: 200 });
           }
 
-          const result = await handleInstallationDeleted(parseResult.data, appType);
+          const result = await handleInstallationDeleted(deletedPayload, appType);
 
           // Mark webhook event as processed
           if (logResult.webhookEventId) {
@@ -221,7 +231,7 @@ export async function handleGitHubWebhook(
           return result;
         }
 
-        return await handleInstallationDeleted(parseResult.data, appType);
+        return await handleInstallationDeleted(deletedPayload, appType);
       }
 
       if (action === GITHUB_ACTION.SUSPEND) {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-schemas.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-schemas.test.ts
@@ -1,0 +1,38 @@
+import {
+  InstallationDeletedPayloadSchema,
+  InstallationDeletedWebhookPayloadSchema,
+} from './webhook-schemas';
+
+describe('InstallationDeletedWebhookPayloadSchema', () => {
+  it.each([null, { id: 98765 }])('accepts installation %j', installation => {
+    const payload = { action: 'deleted', installation };
+
+    expect(InstallationDeletedWebhookPayloadSchema.parse(payload)).toEqual(payload);
+  });
+
+  it.each([undefined, {}, { id: '98765' }, { id: null }, '98765', []])(
+    'rejects malformed installation %j',
+    installation => {
+      expect(
+        InstallationDeletedWebhookPayloadSchema.safeParse({ action: 'deleted', installation })
+          .success
+      ).toBe(false);
+    }
+  );
+
+  it('rejects other installation actions', () => {
+    expect(
+      InstallationDeletedWebhookPayloadSchema.safeParse({ action: 'created', installation: null })
+        .success
+    ).toBe(false);
+  });
+
+  it('keeps the cleanup handler payload non-nullable', () => {
+    expect(
+      InstallationDeletedPayloadSchema.safeParse({ action: 'deleted', installation: null }).success
+    ).toBe(false);
+    expect(
+      InstallationDeletedPayloadSchema.parse({ action: 'deleted', installation: { id: 98765 } })
+    ).toEqual({ action: 'deleted', installation: { id: 98765 } });
+  });
+});

--- a/apps/web/src/lib/integrations/platforms/github/webhook-schemas.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-schemas.ts
@@ -55,6 +55,10 @@ export const InstallationDeletedPayloadSchema = z.object({
   sender: GitHubSenderSchema.optional(),
 });
 
+export const InstallationDeletedWebhookPayloadSchema = InstallationDeletedPayloadSchema.extend({
+  installation: InstallationDeletedPayloadSchema.shape.installation.nullable(),
+});
+
 // installation.suspend webhook payload
 export const InstallationSuspendPayloadSchema = z.object({
   action: z.literal('suspend'),


### PR DESCRIPTION
## Summary

- Fix KILOCODE-WEB-238B by accepting the observed `installation.deleted` payload with `installation: null` at the GitHub webhook boundary.
- Return HTTP 200 with an explicit ignored response and an identifier-free informational log. Do not look up an integration, invoke cleanup, persist/mark a successful uninstall, or emit a Sentry error when no installation ID is available.
- Preserve the strict cleanup-handler payload contract, signature verification, app-scoped lookup, known-ID cleanup, and duplicate-delivery behavior.

## Verification

No manual/live webhook tests were run: exercising a real uninstall is destructive. The automated regression tests use synthetic payloads and mocked business dependencies; no production data or database reset was used.

## Visual Changes

N/A

## Reviewer Notes

- GitHub's [installation event and delivery-header documentation](https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation) describes the installation object; the [Octokit deleted-event schema](https://github.com/octokit/webhooks/blob/main/payload-schemas/api.github.com/installation/deleted.schema.json) has no fallback installation ID. The observed null shape differs from the documented object shape. `X-GitHub-Hook-Installation-Target-ID` identifies the webhook resource, not the deleted installation; sender, organization, repository, and hook IDs are not safe substitutes.
- Null deliveries are deliberately acknowledged without cleanup. No claim is made that an unknown integration was uninstalled.
- Independent read-only review of the complete diff and surrounding routing, signature verification, and cleanup code: clean, no actionable findings. Review completed before commit/push/PR.
- Targeted verification only, not full-repository validation:
  - `pnpm install`: passed with normal lifecycle hooks; dependency/rollup warnings only.
  - `pnpm format apps/web/src/lib/integrations/platforms/github/webhook-handler.ts apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts apps/web/src/lib/integrations/platforms/github/webhook-schemas.ts apps/web/src/lib/integrations/platforms/github/webhook-schemas.test.ts`: passed.
  - `git diff --check` and `git diff --cached --check`: passed.
  - `pnpm --filter web typecheck`: passed; rollup external-dependency warnings only.
  - `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/integrations/platforms/github/webhook-handler.ts apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts apps/web/src/lib/integrations/platforms/github/webhook-schemas.ts apps/web/src/lib/integrations/platforms/github/webhook-schemas.test.ts`: passed, zero warnings/errors.
  - `pnpm exec tsx /var/folders/gs/myr74nfn0mj7vm9krth39rwr0000gp/T/kilo/sentry-238b-tests.cts`: 40 tests passed across webhook schemas, webhook routing, and installation handlers. The temporary runner reuses the repository Jest configuration/transforms/mappers, disables `globalSetup` and `setupFilesAfterEnv` to avoid database-reset hooks, loads tracked `.env.test`, and overrides PostgreSQL to an unusable loopback port with replica URLs cleared. Jest reported an existing `silent` configuration warning. Before the routing change, this same runner reproduced both null-delivery failures (expected 200, received 400), with the remaining 38 tests passing.
