### PR TITLE
fix(mobile): keep the glanceable surfaces current and one Live Activity card

### DIFF
--- a/apps/mobile/src/components/agents/remote-session-row.tsx
+++ b/apps/mobile/src/components/agents/remote-session-row.tsx
@@ -3,6 +3,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
+import { glanceableStatusKind } from '@kilocode/app-shared/glanceable-agents-snapshot';
+
 import { buildActiveSessionsTrayInput } from '@/lib/active-sessions-live';
 import { currentAuthEpoch, isCurrentAuthEpoch } from '@/lib/auth/auth-epoch';
 import { isSignOutActive } from '@/lib/auth/sign-out-state';
@@ -233,6 +235,7 @@ export function RemoteSessionRow({
             remoteMeta(session)
           )}
           live
+          statusKind={glanceableStatusKind(session.status)}
           needsInput={needsInput}
           metaWhileLive
           platformIcon={platformIcon}

--- a/apps/mobile/src/components/agents/session-row.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/session-row.mounted.test.tsx
@@ -62,7 +62,7 @@ vi.mock('@/components/icons/slack-icon', () => ({ SlackIcon: 'SlackIcon' }));
 vi.mock('@/components/ui/directional-icons', () => ({ DirectionalChevronRight: 'Chevron' }));
 vi.mock('@/components/ui/agent-badge', () => ({ AgentBadge: 'AgentBadge' }));
 vi.mock('@/components/ui/eyebrow', () => ({ Eyebrow: 'Eyebrow' }));
-vi.mock('@/components/ui/status-dot', () => ({ StatusDot: 'StatusDot' }));
+vi.mock('@/components/ui/session-status-icon', () => ({ SessionStatusIcon: 'SessionStatusIcon' }));
 vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
 vi.mock('@/components/ui/skeleton', () => ({ Skeleton: 'Skeleton' }));
 vi.mock('@/components/rename-modal', () => ({ RenameModal: 'RenameModal' }));
@@ -159,7 +159,7 @@ describe('StoredSessionRow live speech', () => {
     const nonliveLabel =
       'Fix login bug, feature/live, pull request 42, CLI, and cost 12 cents, 5 minutes ago';
     expect(button?.props.accessibilityLabel).toBe(nonliveLabel);
-    expect(hosts(renderer, 'StatusDot')).toHaveLength(0);
+    expect(hosts(renderer, 'SessionStatusIcon')).toHaveLength(0);
     expect(texts(renderer)).toContain('$0.12 · 5 MINUTES AGO');
 
     act(() => {
@@ -169,7 +169,9 @@ describe('StoredSessionRow live speech', () => {
     expect(button?.props.accessibilityLabel).toBe(
       'Fix login bug, LIVE, feature/live, pull request 42, CLI, and cost 12 cents, 5 minutes ago'
     );
-    expect(hosts(renderer, 'StatusDot').map(dot => dot.props)).toEqual([{ tone: 'good' }]);
+    expect(hosts(renderer, 'SessionStatusIcon').map(glyph => glyph.props)).toEqual([
+      { kind: 'running' },
+    ]);
     expect(texts(renderer)).toContain('$0.12 · 5 MINUTES AGO');
     expect(texts(renderer)).toContain('feature/live · #42');
 
@@ -177,7 +179,7 @@ describe('StoredSessionRow live speech', () => {
       renderer.update(row({ ...props, live: false }));
     });
     expect(button?.props.accessibilityLabel).toBe(nonliveLabel);
-    expect(hosts(renderer, 'StatusDot')).toHaveLength(0);
+    expect(hosts(renderer, 'SessionStatusIcon')).toHaveLength(0);
   });
 
   it('updates an existing live row to localized speech and locale-aware list composition', async () => {
@@ -195,7 +197,7 @@ describe('StoredSessionRow live speech', () => {
       'Fix login bug, EN DIRECTO, CLI y hace 5 minutos'
     );
     expect(texts(renderer)).toContain('HACE 5 MINUTOS');
-    expect(hosts(renderer, 'StatusDot')).toHaveLength(1);
+    expect(hosts(renderer, 'SessionStatusIcon')).toHaveLength(1);
   });
 
   it.each(['question', 'permission'])(
@@ -207,8 +209,8 @@ describe('StoredSessionRow live speech', () => {
       expect(hosts(renderer, 'Pressable')[0]?.props.accessibilityLabel).toBe(
         'Fix login bug, needs input, feature/live, and CLI'
       );
-      expect(hosts(renderer, 'StatusDot').map(dot => dot.props)).toEqual([
-        { tone: 'warn', pulse: true },
+      expect(hosts(renderer, 'SessionStatusIcon').map(glyph => glyph.props)).toEqual([
+        { kind: 'needsInput' },
       ]);
       expect(texts(renderer)).toContain('NEEDS INPUT');
       expect(texts(renderer)).not.toContain('$0.12 · 5 MINUTES AGO');
@@ -261,7 +263,9 @@ describe('StoredSessionRow live speech', () => {
         'Fix login bug, LIVE, feature/live, CLI, and cost 12 cents, 5 minutes ago'
       );
       expect(texts(renderer)).toContain('$0.12 · 5 MINUTES AGO');
-      expect(hosts(renderer, 'StatusDot').map(dot => dot.props)).toEqual([{ tone: 'good' }]);
+      expect(hosts(renderer, 'SessionStatusIcon').map(glyph => glyph.props)).toEqual([
+        { kind: 'running' },
+      ]);
       expect(button.props.onLongPress).toBeUndefined();
       const { onPress } = button.props as Pick<Parameters<typeof StoredSessionRow>[0], 'onPress'>;
       act(onPress);

--- a/apps/mobile/src/components/agents/session-row.tsx
+++ b/apps/mobile/src/components/agents/session-row.tsx
@@ -5,6 +5,8 @@ import { Platform, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 
+import { glanceableStatusKind } from '@kilocode/app-shared/glanceable-agents-snapshot';
+
 import { RenameModal } from '@/components/rename-modal';
 import { SessionRow } from '@/components/ui/session-row';
 import { type AgentSessionSortBy, getAgentSessionTimestamp } from '@/lib/agent-session-sort';
@@ -219,6 +221,7 @@ export function StoredSessionRow({
           subtitle={subtitle}
           meta={visibleMeta}
           live={live}
+          statusKind={session.status === null ? null : glanceableStatusKind(session.status)}
           metaWhileLive={metaWhileLive}
           needsInput={needsInput}
           platformIcon={platformIcon}

--- a/apps/mobile/src/components/home/agent-sessions-section.test.ts
+++ b/apps/mobile/src/components/home/agent-sessions-section.test.ts
@@ -63,7 +63,7 @@ vi.mock('@/lib/a11y/announcing-toast', () => ({
   announcingToast: { error: vi.fn(), success: vi.fn() },
 }));
 vi.mock('@/components/ui/agent-badge', () => ({ AgentBadge: 'AgentBadge' }));
-vi.mock('@/components/ui/status-dot', () => ({ StatusDot: 'StatusDot' }));
+vi.mock('@/components/ui/session-status-icon', () => ({ SessionStatusIcon: 'SessionStatusIcon' }));
 vi.mock('@/components/ui/directional-icons', () => ({ DirectionalChevronRight: 'ChevronRight' }));
 vi.mock('@/components/home/section-header', () => ({ SectionHeader: 'SectionHeader' }));
 vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
@@ -190,18 +190,19 @@ describe('Home live section', () => {
   });
 
   it.each([
-    ['running', 'good', false],
-    ['question', 'warn', true],
+    ['running', 'running', false],
+    ['idle', 'idle', false],
+    ['question', 'needsInput', true],
   ] as const)(
     'keeps the real %s badge when the phone disconnects',
-    async (status, tone, needsInput) => {
+    async (status, kind, needsInput) => {
       const sessions = { ...settled, activeSessions: [{ ...session('a1'), status }] };
       await render(sessions);
       const row = node('RemoteSessionRow');
       connectivity.offline = true;
       await render(sessions);
       expect(node('RemoteSessionRow')).toBe(row);
-      expect(node('StatusDot').props.tone).toBe(tone);
+      expect(node('SessionStatusIcon').props.kind).toBe(kind);
       expect(nodes('Text').some(text => text.children.includes('NEEDS INPUT'))).toBe(needsInput);
       expect(nodes('Text').some(text => text.children.includes('No internet connection'))).toBe(
         true

--- a/apps/mobile/src/components/ui/session-row.mounted.test.tsx
+++ b/apps/mobile/src/components/ui/session-row.mounted.test.tsx
@@ -15,7 +15,7 @@ vi.mock('react-native', () => ({
 }));
 vi.mock('@rn-primitives/slot', () => ({ Text: 'Slot.Text' }));
 vi.mock('@/components/ui/agent-badge', () => ({ AgentBadge: 'AgentBadge' }));
-vi.mock('@/components/ui/status-dot', () => ({ StatusDot: 'StatusDot' }));
+vi.mock('@/components/ui/session-status-icon', () => ({ SessionStatusIcon: 'SessionStatusIcon' }));
 vi.mock('@/components/ui/directional-icons', () => ({ DirectionalChevronRight: 'ChevronRight' }));
 vi.mock('@/lib/hooks/use-theme-colors', () => ({
   useThemeColors: () => ({ mutedSoft: '#777777' }),
@@ -82,7 +82,7 @@ describe('SessionRow mounted layout', () => {
     expect(text.children).toEqual([meta]);
 
     if (live) {
-      const cluster = root.findByProps({ tone: 'good' }).parent;
+      const cluster = root.findByProps({ kind: 'running' }).parent;
       expect((cluster?.props.className as string | undefined)?.split(' ')).toEqual(
         expect.arrayContaining(['shrink', 'min-w-0'])
       );
@@ -98,7 +98,7 @@ describe('SessionRow mounted layout', () => {
     props: Partial<Props>;
     visibleMeta: boolean;
     needsInput: boolean;
-    tone: 'good' | 'warn' | null;
+    kind: 'needsInput' | 'running' | 'idle' | null;
     icon: boolean;
   }>([
     {
@@ -106,7 +106,7 @@ describe('SessionRow mounted layout', () => {
       props: { live: true, needsInput: true, meta, metaWhileLive: true, platformIcon },
       visibleMeta: false,
       needsInput: true,
-      tone: 'warn',
+      kind: 'needsInput',
       icon: false,
     },
     {
@@ -114,7 +114,7 @@ describe('SessionRow mounted layout', () => {
       props: { needsInput: true },
       visibleMeta: false,
       needsInput: true,
-      tone: 'warn',
+      kind: 'needsInput',
       icon: false,
     },
     {
@@ -122,7 +122,7 @@ describe('SessionRow mounted layout', () => {
       props: { live: true, meta, metaWhileLive: true, platformIcon },
       visibleMeta: true,
       needsInput: false,
-      tone: 'good',
+      kind: 'running',
       icon: true,
     },
     {
@@ -130,7 +130,7 @@ describe('SessionRow mounted layout', () => {
       props: { live: true, meta, platformIcon },
       visibleMeta: false,
       needsInput: false,
-      tone: 'good',
+      kind: 'running',
       icon: true,
     },
     {
@@ -138,7 +138,15 @@ describe('SessionRow mounted layout', () => {
       props: { live: true, metaWhileLive: true },
       visibleMeta: false,
       needsInput: false,
-      tone: 'good',
+      kind: 'running',
+      icon: false,
+    },
+    {
+      name: 'live but idle',
+      props: { live: true, statusKind: 'idle', meta, metaWhileLive: true },
+      visibleMeta: true,
+      needsInput: false,
+      kind: 'idle',
       icon: false,
     },
     {
@@ -146,7 +154,7 @@ describe('SessionRow mounted layout', () => {
       props: { meta },
       visibleMeta: true,
       needsInput: false,
-      tone: null,
+      kind: null,
       icon: false,
     },
     {
@@ -154,7 +162,7 @@ describe('SessionRow mounted layout', () => {
       props: { meta, platformIcon },
       visibleMeta: true,
       needsInput: false,
-      tone: null,
+      kind: null,
       icon: true,
     },
     {
@@ -162,7 +170,7 @@ describe('SessionRow mounted layout', () => {
       props: { platformIcon },
       visibleMeta: false,
       needsInput: false,
-      tone: null,
+      kind: null,
       icon: true,
     },
     {
@@ -170,7 +178,7 @@ describe('SessionRow mounted layout', () => {
       props: {},
       visibleMeta: false,
       needsInput: false,
-      tone: null,
+      kind: null,
       icon: false,
     },
   ])('preserves $name', test => {
@@ -179,10 +187,8 @@ describe('SessionRow mounted layout', () => {
     expect(texts.some(node => node.children.includes(meta))).toBe(test.visibleMeta);
     expect(texts.some(node => node.children.includes('NEEDS INPUT'))).toBe(test.needsInput);
     expect(root.findAllByProps({ testID: 'platform-icon' })).toHaveLength(test.icon ? 1 : 0);
-    const dots = root.findAll(node => Object.is(node.type, 'StatusDot'));
-    expect(dots.map(dot => ({ tone: dot.props.tone, pulse: Boolean(dot.props.pulse) }))).toEqual(
-      test.tone ? [{ tone: test.tone, pulse: test.needsInput }] : []
-    );
+    const glyphs = root.findAll(node => Object.is(node.type, 'SessionStatusIcon'));
+    expect(glyphs.map(glyph => glyph.props.kind)).toEqual(test.kind ? [test.kind] : []);
     expect(root.findAll(node => Object.is(node.type, 'Pressable'))).toHaveLength(0);
   });
 

--- a/apps/mobile/src/components/ui/session-row.tsx
+++ b/apps/mobile/src/components/ui/session-row.tsx
@@ -3,10 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { DirectionalChevronRight } from '@/components/ui/directional-icons';
 import { Pressable, View } from 'react-native';
 
+import { type GlanceableStatusKind } from '@kilocode/app-shared/glanceable-agents-snapshot';
+
 import { AgentBadge } from '@/components/ui/agent-badge';
 import { Eyebrow } from '@/components/ui/eyebrow';
 import { selectSessionRowEyebrowRight } from '@/components/ui/session-row-eyebrow-right';
-import { StatusDot } from '@/components/ui/status-dot';
+import { SessionStatusIcon } from '@/components/ui/session-status-icon';
 import { Text } from '@/components/ui/text';
 import { agentColor } from '@/lib/agent-color';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
@@ -19,10 +21,17 @@ type SessionRowProps = {
   /** Small mono line shown below the title (e.g. git branch). */
   subtitle?: string | null;
   meta?: string;
-  /** When true, renders a good-tone StatusDot in the eyebrow. */
+  /** When true, renders the session's status glyph in the eyebrow. */
   live?: boolean;
   /**
-   * When true, replaces the live dot / meta with a pulsing warn-tone dot
+   * What the session is doing, from the shared status map. Picks between the
+   * working and idle glyphs on a live row; `needsInput` is driven by the flag
+   * below, which the attention-ack rules own. Absent falls back to working,
+   * which is what every live row drew before the idle glyph existed.
+   */
+  statusKind?: GlanceableStatusKind | null;
+  /**
+   * When true, replaces the status glyph / meta with the needs-input glyph
    * and a `NEEDS INPUT` label. Highest priority in the eyebrow row.
    */
   needsInput?: boolean;
@@ -65,6 +74,7 @@ export function SessionRow({
   subtitle,
   meta,
   live,
+  statusKind = null,
   needsInput = false,
   metaWhileLive = false,
   platformIcon,
@@ -77,6 +87,7 @@ export function SessionRow({
   const { t } = useTranslation();
   const color = agentColor(agentLabel);
   const dimStrip = !live && !needsInput;
+  const liveKind: GlanceableStatusKind = statusKind === 'idle' ? 'idle' : 'running';
 
   const eyebrowDecision = selectSessionRowEyebrowRight({
     needsInput,
@@ -90,7 +101,7 @@ export function SessionRow({
   if (eyebrowDecision.kind === 'needs-input') {
     branchContent = (
       <View className="flex-row items-center gap-1.5">
-        <StatusDot tone="warn" pulse />
+        <SessionStatusIcon kind="needsInput" />
         <Text variant="mono" className="shrink text-xs text-warn">
           {t('sessionRow.needsInput')}
         </Text>
@@ -99,7 +110,7 @@ export function SessionRow({
   } else if (eyebrowDecision.kind === 'live-and-meta') {
     branchContent = (
       <View className="min-w-0 shrink flex-row items-center gap-1.5">
-        <StatusDot tone="good" />
+        <SessionStatusIcon kind={liveKind} />
         <Text
           variant="mono"
           className="shrink text-xs text-ink2"
@@ -111,7 +122,7 @@ export function SessionRow({
       </View>
     );
   } else if (eyebrowDecision.kind === 'live') {
-    branchContent = <StatusDot tone="good" />;
+    branchContent = <SessionStatusIcon kind={liveKind} />;
   } else if (eyebrowDecision.kind === 'meta' && meta) {
     branchContent = (
       <Text

--- a/apps/mobile/src/components/ui/session-status-icon.tsx
+++ b/apps/mobile/src/components/ui/session-status-icon.tsx
@@ -1,0 +1,29 @@
+import { type GlanceableStatusKind } from '@kilocode/app-shared/glanceable-agents-snapshot';
+
+import { AlertCircle, Circle } from '@/components/ui/icons';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+
+type SessionStatusIconProps = {
+  kind: GlanceableStatusKind;
+};
+
+/**
+ * The session's state as one glyph, the same three the Live Activity and the
+ * widgets draw: an exclamation circle for a wait, a filled disc for work
+ * in progress, a hollow ring for a connected agent doing nothing. The shapes
+ * differ as well as the colors, so the state reads without color.
+ *
+ * Sized to the platform icon beside it in the eyebrow, not to the dot it
+ * replaced, so the cluster keeps one optical weight.
+ */
+export function SessionStatusIcon({ kind }: Readonly<SessionStatusIconProps>) {
+  const colors = useThemeColors();
+
+  if (kind === 'needsInput') {
+    return <AlertCircle size={12} color={colors.warn} />;
+  }
+  if (kind === 'running') {
+    return <Circle size={12} color={colors.good} fill={colors.good} />;
+  }
+  return <Circle size={12} color={colors.mutedSoft} />;
+}

--- a/apps/mobile/src/glanceable-ios/adopt-activity.ts
+++ b/apps/mobile/src/glanceable-ios/adopt-activity.ts
@@ -1,0 +1,41 @@
+import * as SecureStore from 'expo-secure-store';
+
+import { getLastGlanceableSnapshot, restorePersistedGlanceable } from '@/lib/glanceable/persist';
+import { ACTIVE_USER_ID_KEY, ORGANIZATION_STORAGE_KEY } from '@/lib/storage-keys';
+
+import { adoptNativeActivity } from './ios-sink';
+
+async function readKey(key: string): Promise<string | null> {
+  try {
+    return await SecureStore.getItemAsync(key);
+  } catch {
+    // An unavailable keychain only costs this adoption; the publisher retries.
+    return null;
+  }
+}
+
+/**
+ * Bind a Live Activity this process did not start.
+ *
+ * A push-to-start raises the card with no JavaScript running, and iOS then
+ * grants the app background run time. The card's update token reaches the
+ * server only once something reads the native instance, so until this runs the
+ * server can neither update nor end that card — it can only raise another one,
+ * and the Lock Screen collects frozen duplicates.
+ *
+ * Runs at import, ahead of any React tree or session query, in the foreground
+ * process and in the headless push process alike. The native read inside also
+ * retires every instance except the adopted one.
+ */
+export async function adoptPushStartedActivity(): Promise<void> {
+  await restorePersistedGlanceable();
+  const snapshot = getLastGlanceableSnapshot();
+  const userId = await readKey(ACTIVE_USER_ID_KEY);
+  if (snapshot === null || userId === null) {
+    return;
+  }
+  adoptNativeActivity(snapshot, {
+    userId,
+    organizationId: await readKey(ORGANIZATION_STORAGE_KEY),
+  });
+}

--- a/apps/mobile/src/glanceable-ios/adopt-activity.ts
+++ b/apps/mobile/src/glanceable-ios/adopt-activity.ts
@@ -1,5 +1,10 @@
 import * as SecureStore from 'expo-secure-store';
 
+// The adoption hands an update token straight to the delivery, and it runs from
+// the root layout's import. The route group that would otherwise install the
+// delivery is evaluated later, so without this side-effect import the token
+// would reach the no-op delivery and the card would stay orphaned.
+import '@/lib/glanceable/delivery-registration';
 import { getLastGlanceableSnapshot, restorePersistedGlanceable } from '@/lib/glanceable/persist';
 import { ACTIVE_USER_ID_KEY, ORGANIZATION_STORAGE_KEY } from '@/lib/storage-keys';
 

--- a/apps/mobile/src/glanceable-ios/ios-sink.test.ts
+++ b/apps/mobile/src/glanceable-ios/ios-sink.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildGlanceableSnapshot,
+  GLANCEABLE_STALE_MS,
   type GlanceableAgentsSnapshot,
 } from '@kilocode/app-shared/glanceable-agents-snapshot';
 import { type GlanceableLiveActivityContentState } from '@kilocode/notifications';
@@ -21,6 +22,7 @@ import {
 
 import {
   _resetIosSinkForTests,
+  adoptNativeActivity,
   clearActivityKitDeniedIfAvailable,
   getActivityKitDenied,
   iosSink,
@@ -658,6 +660,41 @@ describe('iosSink end', () => {
     }
   );
 
+  it('registers the update token of a card this process did not start', async () => {
+    const ended: string[] = [];
+    // Two cards a server that could never reach the first one raised by push.
+    for (const name of ['first', 'second']) {
+      mockState.instances.push({
+        getPushToken: vi.fn().mockResolvedValue(`${name}-token`),
+        end: () => ended.push(name),
+      });
+    }
+
+    adoptNativeActivity(snapshotFor([{ status: 'busy' }]), CTX);
+    await iosSink.waitForNativeTerminal?.();
+
+    expect(delivery.registerTokens).toHaveBeenCalledTimes(1);
+    expect(subscriptions).toContain('activity');
+    // Whichever one survives, the Lock Screen is left holding exactly one card.
+    expect(ended).toHaveLength(1);
+  });
+
+  it('registers nothing when no card is on screen', () => {
+    adoptNativeActivity(snapshotFor([{ status: 'busy' }]), CTX);
+
+    expect(delivery.registerTokens).not.toHaveBeenCalled();
+    expect(mockState.started).toEqual([]);
+  });
+
+  it('leaves a card alone while the in-app switch is off', () => {
+    setLiveActivityEnabledValue(false);
+    mockState.instances.push({ getPushToken: vi.fn().mockResolvedValue('token'), end: vi.fn() });
+
+    adoptNativeActivity(snapshotFor([{ status: 'busy' }]), CTX);
+
+    expect(delivery.registerTokens).not.toHaveBeenCalled();
+  });
+
   it('supersedes a pending terminal intent without ending new-scope work', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
@@ -728,12 +765,11 @@ describe('iosSink widget publish', () => {
       iosSink.publish(snapshot);
 
       expect(mockState.snapshots.length).toBe(1);
-      expect(mockState.timeline).toHaveLength(2);
       expect(mockState.timeline[0]?.props).toMatchObject({
         primaryCount: 1,
         primaryKind: 'running',
       });
-      const expired = mockState.timeline[1];
+      const expired = mockState.timeline.at(-1);
       expect(expired?.date.getTime()).toBe(Date.parse(snapshot.expiresAt));
 
       const expiredProps = expired?.props as GlanceableViewProps;
@@ -744,6 +780,37 @@ describe('iosSink widget publish', () => {
       expect(expiredProps.primaryKind).toBeUndefined();
     }
   );
+
+  it('stops calling happy counts current once a stale window passes with no refresh', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const snapshot = snapshotFor([{ status: 'busy' }]);
+
+    iosSink.publish(snapshot);
+
+    // WidgetKit owns this clock: the app may be force quit, and then no
+    // background wake ever arrives to correct the frame it is showing.
+    expect(mockState.timeline.map(entry => entry.date.getTime())).toEqual([
+      NOW,
+      NOW + GLANCEABLE_STALE_MS,
+      Date.parse(snapshot.expiresAt),
+    ]);
+    expect(mockState.timeline[1]?.props).toMatchObject({
+      statusLine: "Can't update now",
+      primaryCount: 1,
+      primaryKind: 'running',
+    });
+  });
+
+  it('retracts nothing on a surface that asserts no counts', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    iosSink.publish(snapshotFor([]));
+
+    expect(mockState.timeline).toHaveLength(2);
+    expect(mockState.timeline[0]?.props).toMatchObject({ statusLine: 'No work in progress' });
+  });
 
   it.each([
     ['signed_out', 'Sign in to see agents'],

--- a/apps/mobile/src/glanceable-ios/ios-sink.ts
+++ b/apps/mobile/src/glanceable-ios/ios-sink.ts
@@ -31,6 +31,7 @@ import {
   buildExpiredWidgetProps,
   buildGlanceableLiveActivityContentState,
   buildGlanceableViewProps,
+  buildStaleWidgetProps,
   toWidgetProps,
 } from './view-props';
 
@@ -205,6 +206,25 @@ function endNow(
   return pending.length === 0 ? null : settleEnds(pending);
 }
 
+/**
+ * Adopt a card this process did not start and hand its update token to the
+ * server. A push-to-start raises the card with no JavaScript running, so
+ * nothing has read the native instance yet and the server has no way to update
+ * or end it. The native read also retires every instance except the adopted
+ * one, so duplicates an earlier process left behind go with it.
+ */
+export function adoptNativeActivity(
+  snapshot: GlanceableAgentsSnapshot,
+  ctx: GlanceableSinkContext
+): void {
+  if (!getLiveActivityEnabled() || activityKitDeniedState || !refreshActivity()) {
+    return;
+  }
+  if (activity !== null) {
+    getGlanceableDelivery().registerTokens(snapshot, ctx.organizationId, ctx.userId, activity);
+  }
+}
+
 /** True once ActivityKit reported the surface unavailable (see slice psh for the alert). */
 export function getActivityKitDenied(): boolean {
   return activityKitDeniedState;
@@ -244,6 +264,23 @@ export function _resetIosSinkForTests(): void {
   pendingStartAt = 0;
 }
 
+/**
+ * The delayed frame, when there is a claim worth retracting. Counts only: an
+ * empty or waiting surface asserts nothing that can go out of date, and a
+ * `stale` frame after `expiresAt` would only undo the expiry frame behind it.
+ */
+function staleTimelineFrame(
+  snapshot: GlanceableAgentsSnapshot
+): { date: Date; props: Partial<ReturnType<typeof buildGlanceableViewProps>> }[] {
+  if (snapshot.status !== 'happy') {
+    return [];
+  }
+  const staleAt = Date.parse(snapshot.updatedAt) + GLANCEABLE_STALE_MS;
+  return staleAt >= Date.parse(snapshot.expiresAt)
+    ? []
+    : [{ date: new Date(staleAt), props: buildStaleWidgetProps(snapshot, translate) }];
+}
+
 export const iosSink: GlanceableSink = {
   async waitForNativeTerminal() {
     await Promise.all(
@@ -260,6 +297,12 @@ export const iosSink: GlanceableSink = {
     if (snapshot.status !== 'signed_out' && snapshot.status !== 'privacy') {
       ActiveAgentsWidget.updateTimeline([
         { date: new Date(), props },
+        // WidgetKit is the only clock the widget has while the app is not
+        // running: a background wake can be throttled or, after a force quit,
+        // never delivered at all. Hand it the frame that stops asserting the
+        // counts as current, so a widget nothing has refreshed reads as delayed
+        // rather than as fact.
+        ...staleTimelineFrame(snapshot),
         { date: new Date(snapshot.expiresAt), props: buildExpiredWidgetProps(snapshot, translate) },
       ]);
     }

--- a/apps/mobile/src/glanceable-ios/register.ts
+++ b/apps/mobile/src/glanceable-ios/register.ts
@@ -7,6 +7,7 @@ import {
   subscribeLiveActivityEnabled,
 } from '@/lib/glanceable/live-activity-switch';
 
+import { adoptPushStartedActivity } from './adopt-activity';
 import { refreshActiveAgentsLiveActivityCopy } from './active-agents-live-activity';
 import { refreshActiveAgentsWidgetCopy } from './active-agents-widget';
 import { iosSink } from './ios-sink';
@@ -23,6 +24,11 @@ registerGlanceableSink(iosSink);
 // it. Fire and forget: it lands long before the first snapshot arrives, and a
 // failure only costs the logo.
 void ensureWidgetLogo();
+
+// Claim a card raised by a push-to-start before anything else runs. iOS grants
+// this process background run time for exactly that, and the server cannot
+// update or end the card until its update token arrives.
+void adoptPushStartedActivity();
 
 // The layouts bake their copy in at import, when i18n still holds English: the
 // stored language is applied a few ticks later. Re-bake on every language

--- a/apps/mobile/src/glanceable-ios/view-props.ts
+++ b/apps/mobile/src/glanceable-ios/view-props.ts
@@ -83,6 +83,19 @@ export function toWidgetProps(props: GlanceableViewProps): Partial<GlanceableVie
 }
 
 /**
+ * The widget's stale frame: the same counts under the delayed copy, for the
+ * timeline entry that lands once a whole stale window has passed with no
+ * refresh. The counts stay — they are still the last thing the device knew —
+ * and only the claim that they are current is dropped.
+ */
+export function buildStaleWidgetProps(
+  snapshot: GlanceableAgentsSnapshot,
+  translate: (key: string) => string
+): Partial<GlanceableViewProps> {
+  return toWidgetProps(buildGlanceableViewProps({ ...snapshot, status: 'stale' }, {}, translate));
+}
+
+/**
  * The widget's expiry frame: the same snapshot with its counts zeroed and the
  * expired copy, for the timeline entry that lands at `expiresAt`.
  */

--- a/packages/app-shared/src/glanceable-agents-snapshot.ts
+++ b/packages/app-shared/src/glanceable-agents-snapshot.ts
@@ -92,6 +92,25 @@ export type GlanceableSessionRow = {
 /** Statuses that mean the agent waits on the user and cannot go on alone. */
 const NEEDS_INPUT_STATUSES = new Set(['question', 'permission', 'retry']);
 
+/** What a session's status means to a user: the one vocabulary every surface reads. */
+export type GlanceableStatusKind = 'needsInput' | 'running' | 'idle';
+
+/**
+ * Map one session status to the kind the glanceable surfaces and the session
+ * lists both show, or null when the status means nothing to either. The counts
+ * below and the list rows share this map, so a row can never disagree with the
+ * widget beside it.
+ */
+export function glanceableStatusKind(status: string): GlanceableStatusKind | null {
+  if (status === 'busy') {
+    return 'running';
+  }
+  if (NEEDS_INPUT_STATUSES.has(status)) {
+    return 'needsInput';
+  }
+  return status === 'idle' ? 'idle' : null;
+}
+
 /**
  * Map session rows to the three glanceable counts. `busy` → running,
  * `question`/`permission`/`retry` → needs-input, `idle` → idle, and any
@@ -105,28 +124,15 @@ const NEEDS_INPUT_STATUSES = new Set(['question', 'permission', 'retry']);
 export function countGlanceableSessions(
   sessions: readonly GlanceableSessionRow[]
 ): GlanceableCounts {
-  let running = 0;
-  let needsInput = 0;
-  let idle = 0;
+  const counts = { running: 0, needsInput: 0, idle: 0 };
   for (const session of sessions) {
-    switch (session.status) {
-      case 'busy':
-        running += 1;
-        break;
-      case 'question':
-      case 'permission':
-      case 'retry':
-        needsInput += 1;
-        break;
-      case 'idle':
-        idle += 1;
-        break;
-      default:
-        // An unknown status contributes nothing.
-        break;
+    // An unknown status contributes nothing.
+    const kind = glanceableStatusKind(session.status);
+    if (kind !== null) {
+      counts[kind] += 1;
     }
   }
-  return { running, needsInput, idle };
+  return counts;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2979,6 +2979,9 @@ importers:
 
   services/notifications:
     dependencies:
+      '@kilocode/app-shared':
+        specifier: workspace:*
+        version: link:../../packages/app-shared
       '@kilocode/db':
         specifier: workspace:*
         version: link:../../packages/db

--- a/services/notifications/package.json
+++ b/services/notifications/package.json
@@ -21,6 +21,7 @@
     "wrangler": "catalog:"
   },
   "dependencies": {
+    "@kilocode/app-shared": "workspace:*",
     "@kilocode/db": "workspace:*",
     "@kilocode/event-service": "workspace:*",
     "@kilocode/notifications": "workspace:*",

--- a/services/notifications/src/lib/apns-live-activity.ts
+++ b/services/notifications/src/lib/apns-live-activity.ts
@@ -93,6 +93,11 @@ export function buildLiveActivityApnsRequest(
     credentials: ApnsCredentials;
     authorizationJwt: string;
     timestampSeconds: number;
+    /**
+     * Unix seconds after which iOS dims the card as out of date. A push-updated
+     * card must read as unknown once its updates stop, never as current.
+     */
+    staleDateSeconds?: number;
   } & (
     | { event: 'start'; startAlert: LiveActivityAlert }
     | { event: 'update' }
@@ -123,6 +128,9 @@ export function buildLiveActivityApnsRequest(
             }
           : {}),
         'content-state': params.contentState,
+        ...(params.event !== 'end' && params.staleDateSeconds !== undefined
+          ? { 'stale-date': params.staleDateSeconds }
+          : {}),
         ...(params.event === 'end' ? { 'dismissal-date': params.dismissalDateSeconds } : {}),
       },
     }),
@@ -145,12 +153,21 @@ export async function sendLiveActivityApns(params: {
   nowSeconds: number;
   /** Snapshot ordering time, independent of the provider token's signing time. */
   timestampSeconds?: number;
+  /** Unix seconds after which iOS dims a start or update as out of date. */
+  staleDateSeconds?: number;
   /** Recheck the durable generation after signing, before each request. */
   isCurrent?: () => Promise<boolean>;
   /** Persist terminal intent after signing, before the end can reach ActivityKit. */
   beforeEnd?: (token: string) => Promise<boolean>;
-  /** Retire successful ends by registration identity, even after a newer generation. */
+  /**
+   * Retire a token that can no longer reach a card: a successful end, or an
+   * APNs 410 on any event. A 410 means the target is gone, so leaving the row
+   * would keep every later update aimed at a card that no longer exists and
+   * would keep a push-to-start from raising a new one.
+   */
   onEnded?: (token: string) => Promise<void>;
+  /** Record an accepted start so the same token cannot raise a second card. */
+  onStarted?: (token: string) => Promise<void>;
   /** Release only an explicitly rejected end; a lost response leaves delivery uncertain. */
   onEndRejected?: (token: string) => Promise<void>;
   fetchFn?: typeof fetch;
@@ -177,6 +194,7 @@ export async function sendLiveActivityApns(params: {
         credentials: params.credentials,
         authorizationJwt,
         timestampSeconds: params.timestampSeconds ?? params.nowSeconds,
+        staleDateSeconds: params.staleDateSeconds,
       });
       const response = await fetchFn(request.url, {
         method: 'POST',
@@ -184,15 +202,17 @@ export async function sendLiveActivityApns(params: {
         body: request.body,
       });
       if (!response.ok) {
-        if (event === 'end') {
-          // A 410 confirms an inactive target, not a live activity that can recover.
-          if (response.status === 410) await params.onEnded?.(token);
-          else await params.onEndRejected?.(token);
-        }
+        // A 410 confirms an inactive target on every event, not a live activity
+        // that can recover. Retire it, or later updates keep missing and no
+        // start is ever allowed to replace the card they cannot reach.
+        if (response.status === 410) await params.onEnded?.(token);
+        else if (event === 'end') await params.onEndRejected?.(token);
         throw new Error(`APNs rejected the push with status ${response.status}`);
       }
       if (event === 'end') {
         await params.onEnded?.(token);
+      } else if (event === 'start') {
+        await params.onStarted?.(token);
       }
       return true;
     })

--- a/services/notifications/src/lib/glanceable-delivery-deps.ts
+++ b/services/notifications/src/lib/glanceable-delivery-deps.ts
@@ -1,3 +1,4 @@
+import { GLANCEABLE_STALE_MS } from '@kilocode/app-shared/glanceable-agents-snapshot';
 import { getWorkerDb } from '@kilocode/db/client';
 import { user_activity_tokens, user_push_tokens } from '@kilocode/db/schema';
 import { pushDataSchema } from '@kilocode/notifications';
@@ -13,7 +14,7 @@ export function glanceableDeliveryDeps(env: Env): GlanceableDeliveryDeps {
   const getDbForCall = () => (db ??= getWorkerDb(env.HYPERDRIVE.connectionString));
   const iosTargets = new Map<
     string,
-    Pick<typeof user_activity_tokens.$inferSelect, 'id' | 'updated_at'>
+    Pick<typeof user_activity_tokens.$inferSelect, 'id' | 'updated_at' | 'kind'>
   >();
 
   return {
@@ -83,8 +84,10 @@ export function glanceableDeliveryDeps(env: Env): GlanceableDeliveryDeps {
             inArray(user_activity_tokens.kind, ['ios_activity', 'ios_push_to_start'])
           )
         );
+      // Both kinds: an APNs 410 retires whichever registration it names, and a
+      // dead push-to-start row would otherwise keep raising rejected starts.
       for (const row of rows) {
-        if (row.kind === 'ios_activity') iosTargets.set(row.token, row);
+        iosTargets.set(row.token, row);
       }
       return rows.map(row => ({ ...row, kind: row.kind as IosActivityToken['kind'] }));
     },
@@ -95,7 +98,8 @@ export function glanceableDeliveryDeps(env: Env): GlanceableDeliveryDeps {
       timestampSeconds,
       isCurrent,
       beforeEnd,
-      onEndRejected
+      onEndRejected,
+      onStarted
     ) => {
       const credentials = await readApnsCredentials(env);
       if (credentials === null || (isCurrent && !(await isCurrent()))) return;
@@ -106,21 +110,25 @@ export function glanceableDeliveryDeps(env: Env): GlanceableDeliveryDeps {
         startAlert,
         nowSeconds: Math.floor(Date.now() / 1000),
         timestampSeconds,
+        // A card whose updates stop must dim rather than keep asserting counts
+        // the device can no longer confirm. Same window the local sink uses.
+        staleDateSeconds: Math.floor(Date.now() / 1000) + GLANCEABLE_STALE_MS / 1000,
         isCurrent,
         beforeEnd,
         onEndRejected,
+        onStarted,
         onEnded: async token => {
           const target = iosTargets.get(token);
           if (!target) return;
-          // A delayed end must not delete a scope subscription, another activity,
-          // or a registration refreshed since this delivery selected its target.
+          // A delayed end must not delete another activity or a registration
+          // refreshed since this delivery selected its target.
           await getDbForCall()
             .delete(user_activity_tokens)
             .where(
               and(
                 eq(user_activity_tokens.id, target.id),
                 eq(user_activity_tokens.token, token),
-                eq(user_activity_tokens.kind, 'ios_activity'),
+                eq(user_activity_tokens.kind, target.kind),
                 eq(user_activity_tokens.updated_at, target.updated_at)
               )
             );

--- a/services/notifications/src/lib/glanceable-delivery.test.ts
+++ b/services/notifications/src/lib/glanceable-delivery.test.ts
@@ -85,6 +85,7 @@ describe('NotificationsService.refreshGlanceableSessions', () => {
       event: string;
       timestamp: number;
       'dismissal-date'?: number;
+      'stale-date'?: number;
       'content-state': GlanceableApnsContentState;
     };
   };
@@ -606,6 +607,93 @@ describe('NotificationsService.refreshGlanceableSessions', () => {
       needsInputSince: '2026-08-27T10:00:01.000Z',
     });
     expect([...activityRows.keys()]).toEqual(['scope-token']);
+  });
+
+  it('raises one card per push-to-start token, however many refreshes find no activity', async () => {
+    const pem = await generateTestPrivateKeyPem();
+    const { createService, apns } = setupService({
+      privateKey: async () => pem,
+      iosTokens: [{ token: 'scope-token', kind: 'ios_push_to_start' }],
+      response: () => Response.json(freshSnapshot({ running: 1 })),
+    });
+    // Nothing registers an activity token while the app never runs, so without
+    // the fence every refresh would stack another card on the Lock Screen.
+    for (const second of [0, 1, 2]) {
+      vi.mocked(Date.now).mockReturnValue(Date.parse('2026-08-27T10:00:00.000Z') + second * 1000);
+      await createService().refreshGlanceableSessions(personalRefresh);
+    }
+    expect(apns.map(({ token, aps }) => [token, aps.event])).toEqual([['scope-token', 'start']]);
+  });
+
+  it('releases the push-to-start fence once the app adopts the card it raised', async () => {
+    const pem = await generateTestPrivateKeyPem();
+    let current = freshSnapshot({ running: 1 });
+    const { createService, apns, activityRows } = setupService({
+      privateKey: async () => pem,
+      iosTokens: [{ token: 'scope-token', kind: 'ios_push_to_start' }],
+      response: () => Response.json(current),
+    });
+    await createService().refreshGlanceableSessions(personalRefresh);
+    expect(apns.map(({ token, aps }) => [token, aps.event])).toEqual([['scope-token', 'start']]);
+
+    // The app woke, adopted the pushed card, and registered its update token.
+    activityRows.set('activity-token', {
+      id: 'row-adopted',
+      kind: 'ios_activity',
+      updated_at: '2026-08-27 10:00:00+00',
+    });
+    vi.mocked(Date.now).mockReturnValue(Date.parse('2026-08-27T10:00:01.000Z'));
+    current = freshSnapshot({ status: 'empty', running: 0, needsInputSince: null });
+    await createService().refreshGlanceableSessions(personalRefresh);
+    expect([...activityRows.keys()]).toEqual(['scope-token']);
+
+    // That end retired the card, so fresh work may raise another one.
+    vi.mocked(Date.now).mockReturnValue(Date.parse('2026-08-27T10:00:02.000Z'));
+    current = freshSnapshot({ running: 1 });
+    await createService().refreshGlanceableSessions(personalRefresh);
+    expect(apns.map(({ token, aps }) => [token, aps.event])).toEqual([
+      ['scope-token', 'start'],
+      ['activity-token', 'end'],
+      ['scope-token', 'start'],
+    ]);
+  });
+
+  it('retires a token APNs rejects with 410 on an update, not only on an end', async () => {
+    const pem = await generateTestPrivateKeyPem();
+    const { service, activityRows } = setupService({
+      privateKey: async () => pem,
+      iosTokens: [
+        { token: 'scope-token', kind: 'ios_push_to_start' },
+        { token: 'gone-token', kind: 'ios_activity' },
+      ],
+      apnsStatus: token => (token === 'gone-token' ? 410 : 200),
+      response: () => Response.json(freshSnapshot({ running: 1 })),
+    });
+    // A dead activity row would otherwise absorb every update and keep the
+    // push-to-start from raising the card those updates never reach.
+    await service.refreshGlanceableSessions(personalRefresh);
+    expect([...activityRows.keys()]).toEqual(['scope-token']);
+  });
+
+  it('marks every start and update stale after the shared window', async () => {
+    const pem = await generateTestPrivateKeyPem();
+    const { createService, apns, activityRows } = setupService({
+      privateKey: async () => pem,
+      iosTokens: [{ token: 'scope-token', kind: 'ios_push_to_start' }],
+      response: () => Response.json(freshSnapshot({ running: 1 })),
+    });
+    await createService().refreshGlanceableSessions(personalRefresh);
+    activityRows.set('activity-token', {
+      id: 'row-adopted',
+      kind: 'ios_activity',
+      updated_at: '2026-08-27 10:00:00+00',
+    });
+    vi.mocked(Date.now).mockReturnValue(Date.parse('2026-08-27T10:00:01.000Z'));
+    await createService().refreshGlanceableSessions(personalRefresh);
+    expect(apns.map(({ aps }) => [aps.event, aps['stale-date']])).toEqual([
+      ['start', Date.parse('2026-08-27T10:30:00.000Z') / 1000],
+      ['update', Date.parse('2026-08-27T10:30:01.000Z') / 1000],
+    ]);
   });
 
   it('retires only successful ends and preserves failed targets and scope subscriptions', async () => {

--- a/services/notifications/src/lib/glanceable-delivery.ts
+++ b/services/notifications/src/lib/glanceable-delivery.ts
@@ -123,7 +123,8 @@ export type GlanceableDeliveryDeps = {
     timestampSeconds: number,
     isCurrent?: () => Promise<boolean>,
     beforeEnd?: (token: string) => Promise<boolean>,
-    onEndRejected?: (token: string) => Promise<void>
+    onEndRejected?: (token: string) => Promise<void>,
+    onStarted?: (token: string) => Promise<void>
   ) => Promise<void>;
   /** Reserved before reading; do not assign a new timestamp after a delayed send. */
   apnsTimestampSeconds?: number;
@@ -133,6 +134,8 @@ export type GlanceableDeliveryDeps = {
   beforeIosEnd?: (token: string) => Promise<boolean>;
   /** Release the current attempt only after an explicit transport rejection. */
   onIosEndRejected?: (token: string) => Promise<void>;
+  /** Record an accepted push-to-start so the same token cannot raise a second card. */
+  onIosStarted?: (token: string) => Promise<void>;
   listIosExpoTokens: (userId: string, organizationId: string | null) => Promise<ExpoPushToken[]>;
   listAndroidExpoTokens: (
     userId: string,
@@ -182,7 +185,8 @@ export async function deliverGlanceableSnapshot(
       deps.apnsTimestampSeconds ?? Math.floor(Date.parse(snapshot.updatedAt) / 1000),
       deps.isCurrent,
       deps.beforeIosEnd,
-      deps.onIosEndRejected
+      deps.onIosEndRejected,
+      deps.onIosStarted
     );
   }
 

--- a/services/notifications/src/lib/glanceable-refresh.ts
+++ b/services/notifications/src/lib/glanceable-refresh.ts
@@ -32,7 +32,8 @@ export async function refreshGlanceableSnapshot(
   // A card raised by push-to-start carries no update token until the app runs
   // and adopts it, so nothing here can update or end it. Without this fence
   // every later refresh raises another card and the Lock Screen stacks them.
-  const iosStartKey = (token: string) => `glanceable-ios-start:${JSON.stringify(token)}`;
+  const iosStartPrefix = 'glanceable-ios-start:';
+  const iosStartKey = (token: string) => `${iosStartPrefix}${JSON.stringify(token)}`;
   const request = await storage.transaction(async tx => {
     const previous = refreshStateSchema.optional().parse(await tx.get(key));
     const now = Date.now();
@@ -86,7 +87,10 @@ export async function refreshGlanceableSnapshot(
       const tokens = await deps.listIosActivityTokens(userId, organizationId);
       const current = refreshStateSchema.parse(await storage.get(key));
       if (current.revision !== request.revision) return [];
-      const withoutFencedStarts = await dropFencedStarts(tokens, storage, iosStartKey);
+      const withoutFencedStarts = await dropFencedStarts(tokens, storage, {
+        prefix: iosStartPrefix,
+        key: iosStartKey,
+      });
       // Empty work can retry ends. Eligible work excludes every accepted or uncertain end.
       if (!eligible) return withoutFencedStarts;
       const retiring = await Promise.all(
@@ -127,26 +131,29 @@ export async function refreshGlanceableSnapshot(
  * retirement from here and every fence in the scope is released. Otherwise a
  * push-to-start whose fence has not lapsed is removed from the list, which
  * leaves `apnsSendsForTokens` with no start to send.
+ *
+ * Every read also drops the lapsed fences, including those of tokens the device
+ * has since rotated away and will never present again.
  */
 async function dropFencedStarts<T extends { token: string; kind: string }>(
   tokens: readonly T[],
   storage: DurableObjectStorage,
-  iosStartKey: (token: string) => string
+  fence: { prefix: string; key: (token: string) => string }
 ): Promise<T[]> {
+  const held = await storage.list<number>({ prefix: fence.prefix });
   if (tokens.some(({ kind }) => kind === 'ios_activity')) {
-    await storage.delete(tokens.map(({ token }) => iosStartKey(token)));
+    if (held.size > 0) {
+      await storage.delete([...held.keys()]);
+    }
     return [...tokens];
   }
   const now = Date.now();
-  const fenced = await Promise.all(
-    tokens.map(async ({ token, kind }) => {
-      if (kind !== 'ios_push_to_start') return false;
-      const until = await storage.get<number>(iosStartKey(token));
-      if (until === undefined) return false;
-      if (until > now) return true;
-      await storage.delete(iosStartKey(token));
-      return false;
-    })
-  );
-  return tokens.filter((_token, index) => !fenced[index]);
+  const lapsed = [...held].filter(([, until]) => until <= now).map(([key]) => key);
+  if (lapsed.length > 0) {
+    await storage.delete(lapsed);
+  }
+  return tokens.filter(({ token, kind }) => {
+    const until = held.get(fence.key(token));
+    return kind !== 'ios_push_to_start' || until === undefined || until <= now;
+  });
 }

--- a/services/notifications/src/lib/glanceable-refresh.ts
+++ b/services/notifications/src/lib/glanceable-refresh.ts
@@ -1,3 +1,4 @@
+import { GLANCEABLE_SNAPSHOT_EXPIRY_MS } from '@kilocode/app-shared/glanceable-agents-snapshot';
 import { z } from 'zod';
 
 import { deliverGlanceableSnapshot, type GlanceableDeliveryDeps } from './glanceable-delivery';
@@ -28,6 +29,10 @@ export async function refreshGlanceableSnapshot(
   const key = `glanceable:${JSON.stringify([scope.userId, scope.organizationId])}`;
   // Row renewal or temporary absence cannot prove that the native token is live.
   const iosEndPrefix = (token: string) => `glanceable-ios-end:${JSON.stringify(token)}:`;
+  // A card raised by push-to-start carries no update token until the app runs
+  // and adopts it, so nothing here can update or end it. Without this fence
+  // every later refresh raises another card and the Lock Screen stacks them.
+  const iosStartKey = (token: string) => `glanceable-ios-start:${JSON.stringify(token)}`;
   const request = await storage.transaction(async tx => {
     const previous = refreshStateSchema.optional().parse(await tx.get(key));
     const now = Date.now();
@@ -81,16 +86,23 @@ export async function refreshGlanceableSnapshot(
       const tokens = await deps.listIosActivityTokens(userId, organizationId);
       const current = refreshStateSchema.parse(await storage.get(key));
       if (current.revision !== request.revision) return [];
+      const withoutFencedStarts = await dropFencedStarts(tokens, storage, iosStartKey);
       // Empty work can retry ends. Eligible work excludes every accepted or uncertain end.
-      if (!eligible) return tokens;
+      if (!eligible) return withoutFencedStarts;
       const retiring = await Promise.all(
-        tokens.map(async ({ token, kind }) =>
+        withoutFencedStarts.map(async ({ token, kind }) =>
           kind === 'ios_activity'
             ? (await storage.list({ prefix: iosEndPrefix(token), limit: 1 })).size > 0
             : false
         )
       );
-      return tokens.filter((_, index) => !retiring[index]);
+      return withoutFencedStarts.filter((_, index) => !retiring[index]);
+    },
+    onIosStarted: async token => {
+      // Hold the fence for the whole maximum life of the card it raised. An
+      // orphan card cannot be ended remotely, so a second one would simply sit
+      // beside it until ActivityKit dismisses them both.
+      await storage.put(iosStartKey(token), Date.now() + GLANCEABLE_SNAPSHOT_EXPIRY_MS);
     },
     beforeIosEnd: async token => {
       return storage.transaction(async tx => {
@@ -106,4 +118,35 @@ export async function refreshGlanceableSnapshot(
       await storage.delete(`${iosEndPrefix(token)}${key}:${request.revision}`);
     },
   });
+}
+
+/**
+ * Drop the push-to-start tokens that already raised a card nobody has adopted.
+ *
+ * An `ios_activity` row proves the app adopted its card, so it owns duplicate
+ * retirement from here and every fence in the scope is released. Otherwise a
+ * push-to-start whose fence has not lapsed is removed from the list, which
+ * leaves `apnsSendsForTokens` with no start to send.
+ */
+async function dropFencedStarts<T extends { token: string; kind: string }>(
+  tokens: readonly T[],
+  storage: DurableObjectStorage,
+  iosStartKey: (token: string) => string
+): Promise<T[]> {
+  if (tokens.some(({ kind }) => kind === 'ios_activity')) {
+    await storage.delete(tokens.map(({ token }) => iosStartKey(token)));
+    return [...tokens];
+  }
+  const now = Date.now();
+  const fenced = await Promise.all(
+    tokens.map(async ({ token, kind }) => {
+      if (kind !== 'ios_push_to_start') return false;
+      const until = await storage.get<number>(iosStartKey(token));
+      if (until === undefined) return false;
+      if (until > now) return true;
+      await storage.delete(iosStartKey(token));
+      return false;
+    })
+  );
+  return tokens.filter((_token, index) => !fenced[index]);
 }


### PR DESCRIPTION
## Problem

Three reports, one root cause between them:

- The widget, the Live Activity, and the notification showed old values until the app was opened.
- The iOS Lock Screen collected several Live Activity cards.
- A Live Activity sometimes vibrated and expanded on its own.

A push-to-start raises a Live Activity while no JavaScript runs. Nothing read the
native instance, so the server never held an update token for that card. Every
later refresh sent another push-to-start, and each one raised a new card. APNs
requires an `alert` on a push-to-start, and that alert is what lit the screen and
expanded the card. So the stacking and the unprompted expansion are the same bug.

## Changes

**One card, no unprompted expansion**

- The user Durable Object fences a push-to-start token for the maximum life of the
  card it raises. A refresh that finds no update token sends no second start.
- The fence is released as soon as an activity token proves the app adopted the card.
- The iOS sink adopts a card it did not start, at import, inside the background run
  time ActivityKit grants after a push-to-start, and hands the update token to the
  server. The same native read retires any duplicate already on screen.
- An APNs `410` now retires the token it names on every event, not only on an `end`.
  A dead activity row used to absorb every update *and* block the push-to-start that
  would have replaced the card those updates could not reach.

**Honest values instead of stale ones**

- Start and update pushes carry `stale-date`, and the widget timeline carries a
  delayed frame at `updatedAt + 30 min`.
- iOS cannot deliver a background wake to a force-quit app, so a surface can go
  unrefreshed. It now reads as delayed rather than asserting counts the device
  cannot confirm.

**Shared status glyphs**

- `glanceableStatusKind()` in `@kilocode/app-shared` is now the single status map.
  The widget counts and the session list rows both read it, so a row can never
  disagree with the widget beside it.
- The live list and the history list draw the same three glyphs the widget draws:
  needs input, working, idle.

## Verification

- `services/notifications`: 310 tests pass, including four new ones covering the
  fence, the fence release, the `410`-on-update retirement, and the stale date.
  Three of the four fail when the fix is reverted.
- `apps/mobile`: 8968 tests pass. `packages/app-shared`: 370 pass.
- Root `lint-all.sh`, `tsgo` typecheck, `check:unused`, `check:i18n`: clean.

## Known remaining cause of a card replacement

PR #5881 retires a card after a 10 minute idle window. Work that resumes inside
that window dismisses the ended card and starts a replacement, which pops. That
is a trade-off from #5881 and is not changed here.
