### PR TITLE
fix(code-review): stream live transcript and fail reviews the worker never accepted

### DIFF
--- a/apps/mobile/src/components/code-reviewer/review-detail-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/code-reviewer/review-detail-screen.mounted.test.tsx
@@ -668,6 +668,23 @@ describe('ReviewDetailScreen spectator transcript', () => {
     expect(texts).toContain('No transcript for this review.');
   });
 
+  it('shows empty copy, not waiting copy, for a failed review without a session', () => {
+    // The dispatch worker refused the review: the server failed it. The sheet
+    // must leave the "Waiting for the review transcript" state once the status
+    // is terminal, or the user is stranded on an eternal spinner copy.
+    spectatorQueries.streamInfo.data = makeStreamInfo({ status: 'failed' });
+    detail.data = {
+      success: true,
+      review: makeReview({ status: 'failed' }),
+      tokenUsage: { input: 0, output: 0 },
+    };
+
+    const texts = renderScreen(true);
+
+    expect(texts).toContain('No transcript for this review.');
+    expect(texts).not.toContain('Waiting for the review transcript.');
+  });
+
   it('shows empty copy when a completed non-v2 review has stale stream info', () => {
     spectatorQueries.streamInfo.data = makeStreamInfo({ status: 'running', agentVersion: 'v1' });
     detail.data = {

--- a/apps/mobile/src/components/code-reviewer/review-detail-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/code-reviewer/review-detail-screen.mounted.test.tsx
@@ -363,6 +363,33 @@ describe('ReviewDetailScreen outcome-first order', () => {
     expect(texts).toContain('review crashed');
     expect(texts.indexOf('Completed')).toBeLessThan(texts.indexOf('review crashed'));
   });
+
+  it('clamps a multi-kilobyte failure dump so the retry action stays mounted', () => {
+    // A failed admission stores the raw upstream error (a serialized TRPC
+    // stack) in `error_message`. Rendered unclamped it filled the screen and
+    // pushed "Retry review" below the fold (e1-review-status.png), leaving no
+    // visible way out. The failure block must keep a bounded height.
+    statusHelpers.retriggerable = true;
+    const dump = `Dispatch failed: ${'at Object.<anonymous> (worker.js:1:1234)\n'.repeat(60)}`;
+    detail.data = {
+      success: true,
+      review: makeReview({ status: 'failed', error_message: dump }),
+      tokenUsage: { input: 0, output: 0 },
+    };
+
+    const renderer = mountScreen();
+    const texts = collectText(renderer.toJSON());
+    expect(texts).toContain('Retry review');
+
+    const errorNode = renderer.root.findAll(
+      node =>
+        (node.type as string) === 'Text' &&
+        collectText([node.props.children]).some(text => text.includes('Dispatch failed:'))
+    )[0];
+    expect(errorNode).toBeDefined();
+    expect(typeof errorNode?.props.numberOfLines).toBe('number');
+    expect(errorNode?.props.numberOfLines).toBeLessThanOrEqual(4);
+  });
 });
 
 describe('ReviewDetailScreen empty council', () => {
@@ -668,6 +695,23 @@ describe('ReviewDetailScreen spectator transcript', () => {
     expect(texts).toContain('No transcript for this review.');
   });
 
+  it('shows empty copy, not waiting copy, for a failed review without a session', () => {
+    // The dispatch worker refused the review: the server failed it. The sheet
+    // must leave the "Waiting for the review transcript" state once the status
+    // is terminal, or the user is stranded on an eternal spinner copy.
+    spectatorQueries.streamInfo.data = makeStreamInfo({ status: 'failed' });
+    detail.data = {
+      success: true,
+      review: makeReview({ status: 'failed' }),
+      tokenUsage: { input: 0, output: 0 },
+    };
+
+    const texts = renderScreen(true);
+
+    expect(texts).toContain('No transcript for this review.');
+    expect(texts).not.toContain('Waiting for the review transcript.');
+  });
+
   it('shows empty copy when a completed non-v2 review has stale stream info', () => {
     spectatorQueries.streamInfo.data = makeStreamInfo({ status: 'running', agentVersion: 'v1' });
     detail.data = {
@@ -837,6 +881,61 @@ describe('ReviewDetailScreen spectator transcript', () => {
     const afterDrop = sessionListRenders.list.at(-1);
     const afterDropItems = afterDrop?.items as { message?: string }[] | undefined;
     expect(afterDropItems?.[0]?.message).toBe('Execution started');
+  });
+
+  it('renders streamed assistant text while the review is running', async () => {
+    const captured: { onEvent?: (event: unknown) => void } = {};
+    spectatorStream.createReviewSpectatorStream.mockImplementation(
+      (input: { onEvent: (event: unknown) => void }) => {
+        captured.onEvent = input.onEvent;
+        return {
+          connect: vi.fn(),
+          disconnect: vi.fn(),
+          retryReconnect: vi.fn(),
+          destroy: vi.fn(),
+        };
+      }
+    );
+    spectatorQueries.streamInfo.data = makeStreamInfo({
+      status: 'running',
+      cloudAgentSessionId: 'agent-1',
+    });
+    detail.data = {
+      success: true,
+      review: makeReview({ status: 'running' }),
+      tokenUsage: { input: 0, output: 0 },
+    };
+
+    renderScreen(true);
+
+    expect(captured.onEvent).toBeDefined();
+    await act(async () => {
+      captured.onEvent?.({
+        eventId: 1,
+        sessionId: 'agent-1',
+        streamEventType: 'kilocode',
+        timestamp: 't1',
+        data: {
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              id: 'prt_text',
+              sessionID: 'agent-1',
+              messageID: 'msg-1',
+              type: 'text',
+              text: 'Looking at the diff now.',
+              time: { start: 1_787_054_400_000 },
+            },
+          },
+        },
+      });
+      await new Promise<void>(resolve => {
+        setTimeout(resolve, 0);
+      });
+    });
+
+    const items = sessionListRenders.list.at(-1)?.items as { message?: string }[] | undefined;
+    expect(items?.map(item => item.message)).toContain('Looking at the diff now.');
   });
 
   it('keeps a streamed row when the review turns terminal (no skeleton or empty copy)', async () => {

--- a/apps/mobile/src/components/code-reviewer/review-detail-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/code-reviewer/review-detail-screen.mounted.test.tsx
@@ -363,6 +363,33 @@ describe('ReviewDetailScreen outcome-first order', () => {
     expect(texts).toContain('review crashed');
     expect(texts.indexOf('Completed')).toBeLessThan(texts.indexOf('review crashed'));
   });
+
+  it('clamps a multi-kilobyte failure dump so the retry action stays mounted', () => {
+    // A failed admission stores the raw upstream error (a serialized TRPC
+    // stack) in `error_message`. Rendered unclamped it filled the screen and
+    // pushed "Retry review" below the fold (e1-review-status.png), leaving no
+    // visible way out. The failure block must keep a bounded height.
+    statusHelpers.retriggerable = true;
+    const dump = `Dispatch failed: ${'at Object.<anonymous> (worker.js:1:1234)\n'.repeat(60)}`;
+    detail.data = {
+      success: true,
+      review: makeReview({ status: 'failed', error_message: dump }),
+      tokenUsage: { input: 0, output: 0 },
+    };
+
+    const renderer = mountScreen();
+    const texts = collectText(renderer.toJSON());
+    expect(texts).toContain('Retry review');
+
+    const errorNode = renderer.root.findAll(
+      node =>
+        (node.type as string) === 'Text' &&
+        collectText([node.props.children]).some(text => text.includes('Dispatch failed:'))
+    )[0];
+    expect(errorNode).toBeDefined();
+    expect(typeof errorNode?.props.numberOfLines).toBe('number');
+    expect(errorNode?.props.numberOfLines).toBeLessThanOrEqual(4);
+  });
 });
 
 describe('ReviewDetailScreen empty council', () => {

--- a/apps/mobile/src/components/code-reviewer/review-detail-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/code-reviewer/review-detail-screen.mounted.test.tsx
@@ -839,6 +839,61 @@ describe('ReviewDetailScreen spectator transcript', () => {
     expect(afterDropItems?.[0]?.message).toBe('Execution started');
   });
 
+  it('renders streamed assistant text while the review is running', async () => {
+    const captured: { onEvent?: (event: unknown) => void } = {};
+    spectatorStream.createReviewSpectatorStream.mockImplementation(
+      (input: { onEvent: (event: unknown) => void }) => {
+        captured.onEvent = input.onEvent;
+        return {
+          connect: vi.fn(),
+          disconnect: vi.fn(),
+          retryReconnect: vi.fn(),
+          destroy: vi.fn(),
+        };
+      }
+    );
+    spectatorQueries.streamInfo.data = makeStreamInfo({
+      status: 'running',
+      cloudAgentSessionId: 'agent-1',
+    });
+    detail.data = {
+      success: true,
+      review: makeReview({ status: 'running' }),
+      tokenUsage: { input: 0, output: 0 },
+    };
+
+    renderScreen(true);
+
+    expect(captured.onEvent).toBeDefined();
+    await act(async () => {
+      captured.onEvent?.({
+        eventId: 1,
+        sessionId: 'agent-1',
+        streamEventType: 'kilocode',
+        timestamp: 't1',
+        data: {
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              id: 'prt_text',
+              sessionID: 'agent-1',
+              messageID: 'msg-1',
+              type: 'text',
+              text: 'Looking at the diff now.',
+              time: { start: 1_787_054_400_000 },
+            },
+          },
+        },
+      });
+      await new Promise<void>(resolve => {
+        setTimeout(resolve, 0);
+      });
+    });
+
+    const items = sessionListRenders.list.at(-1)?.items as { message?: string }[] | undefined;
+    expect(items?.map(item => item.message)).toContain('Looking at the diff now.');
+  });
+
   it('keeps a streamed row when the review turns terminal (no skeleton or empty copy)', async () => {
     const captured: { onEvent?: (event: unknown) => void } = {};
     spectatorStream.createReviewSpectatorStream.mockImplementation(

--- a/apps/mobile/src/components/code-reviewer/review-detail-screen.tsx
+++ b/apps/mobile/src/components/code-reviewer/review-detail-screen.tsx
@@ -168,7 +168,14 @@ export function ReviewDetailScreen({
           <Text className={cn('text-sm font-semibold', meta.className)}>{meta.label}</Text>
           {review.error_message ? (
             <View className="rounded-lg bg-danger-tile-bg p-3">
-              <Text className="text-xs text-destructive">{review.error_message}</Text>
+              {/* Upstream failures can persist a serialized stack dump here;
+                  unclamped it filled the screen and pushed the retry action
+                  below the fold (e1-review-status.png). Bound the block so
+                  the conclusion keeps a fixed footprint and the actions stay
+                  reachable. */}
+              <Text className="text-xs text-destructive" numberOfLines={4}>
+                {review.error_message}
+              </Text>
             </View>
           ) : null}
         </View>

--- a/apps/mobile/src/components/code-reviewer/review-spectator-rows.test.ts
+++ b/apps/mobile/src/components/code-reviewer/review-spectator-rows.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { type TFunction } from 'i18next';
+import { type CloudAgentEvent } from '@kilocode/cloud-agent-sdk';
 
-import { appendSpectatorRows, type SpectatorRow } from './review-spectator-rows';
+import { i18n } from '@/i18n';
+
+import { appendSpectatorRows, type SpectatorRow, toSpectatorRow } from './review-spectator-rows';
 
 const row = (message: string, key?: string): SpectatorRow => ({
   timestamp: 't',
@@ -8,6 +12,19 @@ const row = (message: string, key?: string): SpectatorRow => ({
   eventType: 'info',
   ...(key === undefined ? {} : { key }),
 });
+
+const t = i18n.t as TFunction;
+
+function kilocodeEvent(properties: Record<string, unknown>): CloudAgentEvent {
+  return {
+    eventId: 1,
+    executionId: 'exec-1',
+    sessionId: 'ses-1',
+    streamEventType: 'kilocode',
+    timestamp: '2026-09-05T12:00:00.000Z',
+    data: { type: 'message.part.updated', properties },
+  };
+}
 
 describe('appendSpectatorRows', () => {
   it('replaces a keyed row and appends unkeyed rows', () => {
@@ -21,5 +38,85 @@ describe('appendSpectatorRows', () => {
   it('keeps every unkeyed row in a batch', () => {
     const rows = appendSpectatorRows([], [row('connected'), row('snapshot'), row('queued')]);
     expect(rows).toHaveLength(3);
+  });
+});
+
+describe('toSpectatorRow text parts', () => {
+  it('renders a canonical live text part that carries no state', () => {
+    // The cloud-agent stream emits text parts as { id, messageID, type, text,
+    // time } with no `state` field while the review runs. Gating these on a
+    // completed state drops every assistant row from the live transcript.
+    const result = toSpectatorRow(
+      kilocodeEvent({
+        part: {
+          id: 'prt_text',
+          sessionID: 'ses-1',
+          messageID: 'msg-1',
+          type: 'text',
+          text: 'Looking at the diff now.',
+          time: { start: 1_787_054_400_000 },
+        },
+      }),
+      t
+    );
+    expect(result).toEqual({
+      timestamp: '2026-09-05T12:00:00.000Z',
+      message: 'Looking at the diff now.',
+      eventType: 'text',
+      key: 'prt_text',
+    });
+  });
+
+  it('renders a completed canonical text part (time.start + time.end, no state)', () => {
+    const result = toSpectatorRow(
+      kilocodeEvent({
+        part: {
+          id: 'prt_text',
+          sessionID: 'ses-1',
+          messageID: 'msg-1',
+          type: 'text',
+          text: 'Review summary',
+          time: { start: 1_787_054_400_000, end: 1_787_054_401_000 },
+        },
+      }),
+      t
+    );
+    expect(result).not.toBeNull();
+    expect(result?.message).toBe('Review summary');
+  });
+
+  it.each(['', '   '])('skips an empty text part: %j', text => {
+    const result = toSpectatorRow(
+      kilocodeEvent({ part: { id: 'prt_text', type: 'text', text } }),
+      t
+    );
+    expect(result).toBeNull();
+  });
+
+  it('updates a streamed text part in place via its part id', () => {
+    const partial = toSpectatorRow(
+      kilocodeEvent({ part: { id: 'prt_text', type: 'text', text: 'Looking at' } }),
+      t
+    );
+    const updated = toSpectatorRow(
+      kilocodeEvent({ part: { id: 'prt_text', type: 'text', text: 'Looking at the diff now.' } }),
+      t
+    );
+    expect(partial).not.toBeNull();
+    expect(updated).not.toBeNull();
+    if (!partial || !updated) {
+      return;
+    }
+    expect(appendSpectatorRows([partial], [updated])).toEqual([updated]);
+  });
+
+  it('still renders a text part that carries a legacy completed state', () => {
+    const result = toSpectatorRow(
+      kilocodeEvent({
+        part: { id: 'prt_text', type: 'text', text: 'Done reading.', state: 'completed' },
+      }),
+      t
+    );
+    expect(result?.message).toBe('Done reading.');
   });
 });

--- a/apps/mobile/src/components/code-reviewer/review-spectator-rows.ts
+++ b/apps/mobile/src/components/code-reviewer/review-spectator-rows.ts
@@ -183,10 +183,10 @@ function toRowFromKilocode(
     }
 
     if (partType === 'text') {
-      const status = partStateStatus(part.state);
-      if (!isCompletedStatus(status)) {
-        return null;
-      }
+      // Canonical stream text parts carry no `state` field while the review
+      // runs (only `time`), so gating on a completed status dropped every
+      // assistant-text row from the live transcript. Render the text and let
+      // the part id replace it in place as it grows (mirrors web #5781).
       const text = asString(part.text);
       const trimmed = text?.trim();
       if (trimmed) {

--- a/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts
+++ b/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts
@@ -52,6 +52,7 @@ import {
   platform_integrations,
   type User,
 } from '@kilocode/db/schema';
+import type { ManualCodeReviewConfig } from '@kilocode/db/schema-types';
 import { eq } from 'drizzle-orm';
 import { or } from 'drizzle-orm';
 import { tryDispatchPendingReviews } from './dispatch-pending-reviews';
@@ -70,6 +71,30 @@ type ReviewOwner = { type: 'user'; id: string } | { type: 'org'; id: string };
 
 function minutesAgo(minutes: number) {
   return new Date(Date.now() - minutes * 60 * 1000).toISOString();
+}
+
+// A manual review carries a `manual_config` parsed by a strict zod schema, so
+// the shape must match `ManualCodeReviewConfigSchema` exactly.
+function manualReviewConfig(): ManualCodeReviewConfig {
+  return {
+    agentConfig: {
+      review_style: 'balanced',
+      focus_areas: [],
+      model_slug: 'anthropic/claude-sonnet-4.6',
+    },
+    instructions: null,
+    outputMode: 'kilo',
+  };
+}
+
+// What undici `fetch` throws when nothing listens behind the worker URL: a
+// `fetch failed` TypeError whose cause carries the ECONNREFUSED code.
+function workerConnectionRefused() {
+  const cause = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:8789'), {
+    code: 'ECONNREFUSED',
+    syscall: 'connect',
+  });
+  return new TypeError('fetch failed', { cause });
 }
 
 function createDeferred<T>() {
@@ -190,6 +215,7 @@ describe('tryDispatchPendingReviews', () => {
     updatedAt,
     startedAt = null,
     platform = 'github',
+    manualConfig = null,
   }: {
     owner: ReviewOwner;
     status: ReviewStatus;
@@ -197,6 +223,7 @@ describe('tryDispatchPendingReviews', () => {
     updatedAt: string;
     startedAt?: string | null;
     platform?: 'github' | 'bitbucket';
+    manualConfig?: ManualCodeReviewConfig | null;
   }) {
     const sequence = reviewSequence++;
 
@@ -218,6 +245,7 @@ describe('tryDispatchPendingReviews', () => {
       started_at: startedAt,
       created_at: createdAt,
       updated_at: updatedAt,
+      manual_config: manualConfig,
     };
   }
 
@@ -1560,6 +1588,103 @@ describe('tryDispatchPendingReviews', () => {
       .limit(1);
     expect(mockGetReviewStatus).toHaveBeenCalledWith(review.id, attempt?.id);
     expect(storedReview?.status).toBe('queued');
+  });
+
+  it('fails a manual review when the worker refuses both the dispatch and the status probe', async () => {
+    const recentTimestamp = minutesAgo(1);
+    const owner = { type: 'user', id: testUser.id } satisfies ReviewOwner;
+    await setTestUserBalance(DEFAULT_TIER_BALANCE_MICRODOLLARS);
+    mockDispatchReview.mockRejectedValue(workerConnectionRefused());
+    mockGetReviewStatus.mockRejectedValue(workerConnectionRefused());
+
+    const [review] = await db
+      .insert(cloud_agent_code_reviews)
+      .values(
+        reviewValues({
+          owner,
+          status: 'pending',
+          createdAt: recentTimestamp,
+          updatedAt: recentTimestamp,
+          manualConfig: manualReviewConfig(),
+        })
+      )
+      .returning({ id: cloud_agent_code_reviews.id });
+
+    if (!review) {
+      throw new Error('Expected review to be inserted');
+    }
+
+    const result = await tryDispatchPendingReviews({
+      type: 'user',
+      id: testUser.id,
+      userId: testUser.id,
+    });
+
+    const storedReview = await getStoredReview(review.id);
+
+    expect(result).toEqual({
+      dispatched: 0,
+      notDispatched: 1,
+      activeCount: 0,
+    });
+    // The connection was refused twice, so the worker never accepted the
+    // review. The waiting user must see a retryable failure, not an eternal
+    // "Queued" with the transcript sheet stuck on "Waiting". upstream_error
+    // is the machine-readable cause (the review worker is the upstream service).
+    expect(storedReview).toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        dispatchReservationId: null,
+        terminalReason: 'upstream_error',
+      })
+    );
+    expect(storedReview?.errorMessage).toContain('could not reach the code review service');
+  });
+
+  it('keeps a webhook review queued when the worker refuses both the dispatch and the status probe', async () => {
+    const recentTimestamp = minutesAgo(1);
+    const owner = { type: 'user', id: testUser.id } satisfies ReviewOwner;
+    await setTestUserBalance(DEFAULT_TIER_BALANCE_MICRODOLLARS);
+    mockDispatchReview.mockRejectedValue(workerConnectionRefused());
+    mockGetReviewStatus.mockRejectedValue(workerConnectionRefused());
+
+    const [review] = await db
+      .insert(cloud_agent_code_reviews)
+      .values(
+        reviewValues({
+          owner,
+          status: 'pending',
+          createdAt: recentTimestamp,
+          updatedAt: recentTimestamp,
+        })
+      )
+      .returning({ id: cloud_agent_code_reviews.id });
+
+    if (!review) {
+      throw new Error('Expected review to be inserted');
+    }
+
+    const result = await tryDispatchPendingReviews({
+      type: 'user',
+      id: testUser.id,
+      userId: testUser.id,
+    });
+
+    const storedReview = await getStoredReview(review.id);
+
+    expect(result).toEqual({
+      dispatched: 0,
+      notDispatched: 1,
+      activeCount: 0,
+    });
+    // Webhook reviews have no user waiting on the screen; the stale-queued
+    // recovery cron re-dispatches them once the worker is back.
+    expect(storedReview).toEqual(
+      expect.objectContaining({
+        status: 'queued',
+        dispatchReservationId: expect.any(String),
+      })
+    );
   });
 
   it('sends the current attempt id to the worker dispatch payload', async () => {

--- a/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
+++ b/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
@@ -107,6 +107,29 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/**
+ * True when a worker call failed because nothing was listening at the worker
+ * URL (TCP connection refused). undici wraps that as a `fetch failed`
+ * TypeError whose cause carries the ECONNREFUSED code. Unlike a timeout, a
+ * refusal is unambiguous: the request never reached the orchestrator, so no
+ * Durable Object can have accepted the review.
+ */
+function isWorkerConnectionRefused(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    if (
+      (current as Error & { code?: unknown }).code === 'ECONNREFUSED' ||
+      current.message.includes('ECONNREFUSED')
+    ) {
+      return true;
+    }
+    current = (current as Error & { cause?: unknown }).cause;
+  }
+  return false;
+}
+
 function getActionRequiredReasonFromError(error: unknown): CodeReviewActionRequiredReason | null {
   if (error instanceof CodeReviewActionRequiredDispatchError) {
     return error.reason;
@@ -608,7 +631,7 @@ async function dispatchReservedReview(reservation: ReservedReview, owner: Owner)
       skipBalanceCheck: true,
     });
   } catch (dispatchError) {
-    errorExceptInTest('[dispatchReview] Worker dispatch failed, leaving review queued', {
+    errorExceptInTest('[dispatchReview] Worker dispatch failed', {
       reviewId: review.id,
       error: dispatchError,
     });
@@ -616,7 +639,13 @@ async function dispatchReservedReview(reservation: ReservedReview, owner: Owner)
       tags: { operation: 'dispatch-review-worker-call' },
       extra: { reviewId: review.id, owner },
     });
-    return handleAmbiguousDispatchFailure(review, owner, attempt.id, dispatchReservationId);
+    return handleAmbiguousDispatchFailure(
+      review,
+      owner,
+      attempt.id,
+      dispatchReservationId,
+      dispatchError
+    );
   }
 
   try {
@@ -652,7 +681,8 @@ async function handleAmbiguousDispatchFailure(
   review: CloudAgentCodeReview,
   owner: Owner,
   attemptId: string,
-  dispatchReservationId: string
+  dispatchReservationId: string,
+  dispatchError: unknown
 ): Promise<boolean> {
   try {
     const workerStatus = await codeReviewWorkerClient.getReviewStatus(review.id, attemptId);
@@ -736,6 +766,45 @@ async function handleAmbiguousDispatchFailure(
     });
     return true;
   } catch (statusError) {
+    if (
+      getManualCodeReviewConfig(review) !== null &&
+      isWorkerConnectionRefused(dispatchError) &&
+      isWorkerConnectionRefused(statusError)
+    ) {
+      // The worker refused the dispatch and then refused the status probe, so
+      // it never accepted this review. A manual review is started by a user
+      // who is watching the detail screen; leaving it `queued` there would
+      // strand them on "Queued" with the transcript sheet stuck on "Waiting
+      // for the review transcript" and no way out. Surface a retryable
+      // failure instead. Webhook reviews keep the stale-queued cron recovery.
+      const errorMessage =
+        'Dispatch failed: could not reach the code review service. ' +
+        'It may be offline — retry the review once it is running.';
+      await updateCodeReviewAttemptForCallback({
+        codeReviewId: review.id,
+        attemptId,
+        status: 'failed',
+        errorMessage,
+        terminalReason: 'upstream_error',
+        completedAt: new Date(),
+      });
+      await failReservedQueuedReview(
+        review.id,
+        dispatchReservationId,
+        errorMessage,
+        'upstream_error'
+      );
+      errorExceptInTest(
+        '[dispatchReview] Worker refused dispatch and status probe, failing manual review',
+        {
+          reviewId: review.id,
+          attemptId,
+          error: dispatchError,
+        }
+      );
+      return false;
+    }
+
     errorExceptInTest('[dispatchReview] Worker status probe failed, leaving review queued', {
       reviewId: review.id,
       error: statusError,

--- a/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
+++ b/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
@@ -1245,15 +1245,68 @@ export class SandboxSession extends DurableObject<Env> {
   }
 
   async replayPreparedInitialMessage(
-    _request: LegacyRegisteredInitialAdmissionRequest
+    request: LegacyRegisteredInitialAdmissionRequest
   ): Promise<SessionMessageAdmissionResult | undefined> {
-    return undefined;
+    const metadata = await this.getMetadata();
+    const messageId = metadata?.initialMessage?.id;
+    if (!messageId || !(await this.hasMessageAdmission(messageId))) {
+      return undefined;
+    }
+    return this.admitPreparedInitialMessage(request);
   }
 
+  /**
+   * Retained legacy two-step flow (prepareSession + initiateFromKilocodeSessionV2)
+   * on the control plane. The registration stores the canonical initial turn in
+   * metadata without admitting it; initiation resolves that stored turn and
+   * admits it through the same durable queue used by `admitSubmittedMessage`,
+   * mirroring `CloudAgentSession.admitPreparedInitialMessage`. Without this,
+   * every code review fails with 'Prepared admission is legacy-only' whenever
+   * the owner is control-plane enrolled (wrangler dev defaults it to `*`).
+   */
   async admitPreparedInitialMessage(
     _request: LegacyRegisteredInitialAdmissionRequest
   ): Promise<SessionMessageAdmissionResult> {
-    return { success: false, code: 'BAD_REQUEST', error: 'Prepared admission is legacy-only' };
+    const metadata = await this.getMetadata();
+    if (!metadata) return { success: false, code: 'NOT_FOUND', error: 'Session not found' };
+    const initialMessage = metadata.initialMessage;
+    if (!initialMessage?.id) {
+      return { success: false, code: 'BAD_REQUEST', error: 'No prompt provided' };
+    }
+    const turn: AcceptedExecutionTurn | undefined =
+      initialMessage.turn?.type === 'command'
+        ? {
+            type: 'command',
+            messageId: initialMessage.id,
+            command: initialMessage.turn.command,
+            arguments: initialMessage.turn.arguments,
+          }
+        : initialMessage.turn?.type === 'prompt'
+          ? {
+              type: 'prompt',
+              messageId: initialMessage.id,
+              prompt: initialMessage.turn.prompt,
+              ...(initialMessage.turn.attachments
+                ? { attachments: initialMessage.turn.attachments }
+                : {}),
+            }
+          : initialMessage.prompt
+            ? {
+                type: 'prompt',
+                messageId: initialMessage.id,
+                prompt: initialMessage.prompt,
+                ...(initialMessage.attachments ? { attachments: initialMessage.attachments } : {}),
+              }
+            : undefined;
+    if (!turn) return { success: false, code: 'BAD_REQUEST', error: 'No prompt provided' };
+    return this.queueAndDispatch(
+      {
+        turn,
+        agent: metadata.agent,
+        finalization: metadata.finalization,
+      },
+      'initial'
+    );
   }
 
   async alarm(): Promise<void> {

--- a/services/cloud-agent-next/test/integration/kilo-facade-runtime.test.ts
+++ b/services/cloud-agent-next/test/integration/kilo-facade-runtime.test.ts
@@ -1,5 +1,5 @@
 import { SELF, env, runInDurableObject } from 'cloudflare:test';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { registerReadySession } from '../helpers/session-setup.js';
 
 const userId = 'user_facade_runtime';
@@ -53,9 +53,7 @@ function createSseDataReader(response: Response): SseDataReader {
 }
 
 async function configureCurrentProducer(identity: WrapperIdentity): Promise<void> {
-  const session = env.CLOUD_AGENT_SESSION.get(
-    env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${cloudAgentSessionId}`)
-  );
+  const session = sessionStub(userId, cloudAgentSessionId);
   await runInDurableObject(session, async instance => {
     const metadata = await instance.getMetadata();
     if (!metadata) {
@@ -82,9 +80,12 @@ async function connectProducer(identity: WrapperIdentity): Promise<WebSocket> {
     wrapperGeneration: String(identity.wrapperGeneration),
     wrapperConnectionId: identity.wrapperConnectionId,
   });
-  const response = await SELF.fetch(`http://worker.test/kilo-global-feed-test?${query}`, {
-    headers: { Upgrade: 'websocket' },
-  });
+  const response = await SELF.fetch(
+    `http://worker.test/kilo-global-feed-test?${query.toString()}`,
+    {
+      headers: { Upgrade: 'websocket' },
+    }
+  );
   if (response.status !== 101 || !response.webSocket) {
     throw new Error(`Unexpected producer upgrade response: ${response.status}`);
   }
@@ -104,6 +105,40 @@ async function readProducerMarker(): Promise<unknown> {
     state.storage.get(`producer:${cloudAgentSessionId}`)
   );
 }
+
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
 
 describe('UserKiloFacade in the Workers runtime', () => {
   it('routes a public facade request to the user Durable Object', async () => {
@@ -128,9 +163,7 @@ describe('UserKiloFacade in the Workers runtime', () => {
     const extensionUserId = 'user_facade_extension';
     const extensionCloudAgentSessionId = 'agent_facade_extension';
     const extensionKiloSessionId = 'ses_abcdefghijklmnopqrstuvwxyz';
-    const session = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${extensionUserId}:${extensionCloudAgentSessionId}`)
-    );
+    const session = sessionStub(extensionUserId, extensionCloudAgentSessionId);
     await runInDurableObject(session, async instance => {
       await registerReadySession(instance, {
         sessionId: extensionCloudAgentSessionId,
@@ -346,7 +379,7 @@ describe('UserKiloFacade in the Workers runtime', () => {
       wrapperConnectionId: firstIdentity.wrapperConnectionId,
     });
     const staleResponse = await SELF.fetch(
-      `http://worker.test/kilo-global-feed-test?${staleQuery}`,
+      `http://worker.test/kilo-global-feed-test?${staleQuery.toString()}`,
       { headers: { Upgrade: 'websocket' } }
     );
     expect(staleResponse.status).toBe(409);

--- a/services/cloud-agent-next/test/integration/sandbox-terminal.test.ts
+++ b/services/cloud-agent-next/test/integration/sandbox-terminal.test.ts
@@ -297,6 +297,14 @@ async function createFixture(ownerId?: string, organizationId?: string): Promise
       return browser;
     },
     dispose: async () => {
+      // Terminalize the fixture's admitted message and clear its retry alarm. A
+      // message left active keeps session DO supervision running after this file
+      // closes, and its finalization commit log races the vitest worker shutdown
+      // as a pending onUserConsoleLog rejection (EnvironmentTeardownError).
+      await runInDurableObject(sessionStub, async (instance, state) => {
+        await instance.interruptExecution();
+        await state.storage.deleteAlarm();
+      });
       for (const browser of fixture.browsers) {
         if (browser.socket.readyState === 1) browser.socket.close(1000, 'test cleanup');
       }
@@ -1082,5 +1090,20 @@ describe('SandboxSession terminal bridge in the Workers runtime', () => {
     await expect(browser.closed).resolves.toMatchObject({ code: 1009 });
     await expect(wrapper.closed).resolves.toMatchObject({ code: 1009 });
     expect(fixture.errors).toEqual([]);
+  });
+
+  it('leaves no active session work or retry alarm after the fixture is disposed', async () => {
+    const fixture = await createFixture();
+    await fixture.dispose();
+    const session = getSandboxSessionStub(env, fixture.ownerId, fixture.sessionId);
+    await runInDurableObject(session, async (_instance, state) => {
+      const messages = (await state.storage.get('session_messages')) as
+        | { state: string }[]
+        | undefined;
+      expect(
+        messages?.every(message => message.state !== 'accepted' && message.state !== 'queued')
+      ).toBe(true);
+      expect(await state.storage.getAlarm()).toBeNull();
+    });
   });
 });

--- a/services/cloud-agent-next/test/integration/session/admission-recovery.test.ts
+++ b/services/cloud-agent-next/test/integration/session/admission-recovery.test.ts
@@ -13,14 +13,48 @@ import {
   registerReadySession,
 } from '../../helpers/session-setup.js';
 
+// Registered sessions leave dispatch and alarm work in the session DO. Interrupt
+// every session a test touched and clear its alarm, or that work wakes after
+// this file closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        // Fire-and-forget run-state publications continue past the test body;
+        // drain the chained tail so no facade RPC is pending when the worker
+        // closes (EnvironmentTeardownError).
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('partial admission callback snapshot recovery', () => {
   it('retains the admission-time callback target when delivery accepts before state repair', async () => {
     const userId = 'user_partial_callback_repair';
     const sessionId = 'agent_partial_callback_repair';
     const messageId = 'msg_018f1e2d3c4bPartCbAbCdEfGh';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const captured: CallbackJob[] = [];
@@ -125,9 +159,7 @@ function cloneRegistrationInput(
 }
 
 function cloneStub(input: ReturnType<typeof cloneRegistrationInput>) {
-  return env.CLOUD_AGENT_SESSION.get(
-    env.CLOUD_AGENT_SESSION.idFromName(`${input.identity.userId}:${input.identity.sessionId}`)
-  );
+  return sessionStub(input.identity.userId, input.identity.sessionId);
 }
 
 describe('forward-only clone reporting admission', () => {

--- a/services/cloud-agent-next/test/integration/session/callback-notification.test.ts
+++ b/services/cloud-agent-next/test/integration/session/callback-notification.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { env, runInDurableObject } from 'cloudflare:test';
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import type { CloudAgentSession } from '../../../src/persistence/CloudAgentSession.js';
@@ -108,13 +108,46 @@ async function prepareSessionWithCallback(
   expect(prepareResult.success).toBe(true);
 }
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('Callback notification with latest assistant message', () => {
   it('includes lastAssistantMessageText on completed callbacks', async () => {
     const userId = 'user_cb_1';
     const sessionId = 'agent_cb_1';
     const executionId = 'exec_cb_completed' as ExecutionId;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const queue = createCapturedQueue();
 
@@ -152,8 +185,7 @@ describe('Callback notification with latest assistant message', () => {
     const userId = 'user_cb_oversized';
     const sessionId = 'agent_cb_oversized';
     const executionId = 'exec_cb_oversized' as ExecutionId;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
     const assistantText = '😀"\\\n'.repeat(CALLBACK_QUEUE_MAX_SERIALIZED_BYTES);
     const queue = createCapturedQueue();
 
@@ -191,8 +223,7 @@ describe('Callback notification with latest assistant message', () => {
     const userId = 'user_cb_oversized_fixed';
     const sessionId = 'agent_cb_oversized_fixed';
     const executionId = 'exec_cb_oversized_fixed' as ExecutionId;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
     const queue = createCapturedQueue();
 
     await runInDurableObject(stub, async (instance: CloudAgentSession) => {
@@ -223,8 +254,7 @@ describe('Callback notification with latest assistant message', () => {
     const userId = 'user_cb_enqueue_failure';
     const sessionId = 'agent_cb_enqueue_failure';
     const executionId = 'exec_cb_enqueue_failure' as ExecutionId;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     await runInDurableObject(stub, async (instance: CloudAgentSession) => {
       injectCallbackQueue(instance, {
@@ -251,8 +281,7 @@ describe('Callback notification with latest assistant message', () => {
     const userId = 'user_cb_2';
     const sessionId = 'agent_cb_2';
     const executionId = 'exec_cb_failed' as ExecutionId;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const queue = createCapturedQueue();
 
@@ -289,8 +318,7 @@ describe('Callback notification with latest assistant message', () => {
     const userId = 'user_cb_3';
     const sessionId = 'agent_cb_3';
     const executionId = 'exec_cb_interrupted' as ExecutionId;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const queue = createCapturedQueue();
 
@@ -322,8 +350,7 @@ describe('Callback notification with latest assistant message', () => {
     const userId = 'user_cb_4';
     const sessionId = 'agent_cb_4';
     const executionId = 'exec_cb_toolonly' as ExecutionId;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const queue = createCapturedQueue();
 

--- a/services/cloud-agent-next/test/integration/session/callback-outbox.test.ts
+++ b/services/cloud-agent-next/test/integration/session/callback-outbox.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { env, runInDurableObject, listDurableObjectIds } from 'cloudflare:test';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import type { CloudAgentSession } from '../../../src/persistence/CloudAgentSession.js';
 import type { CallbackJob } from '../../../src/callbacks/types.js';
 import {
@@ -42,6 +42,40 @@ function removeCallbackQueue(instance: CloudAgentSession): void {
   ).env.CALLBACK_QUEUE = undefined;
 }
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('callback outbox — missing target or queue', () => {
   beforeEach(async () => {
     const ids = await listDurableObjectIds(env.CLOUD_AGENT_SESSION);
@@ -57,8 +91,7 @@ describe('callback outbox — missing target or queue', () => {
   it('records callbackLastError when callbackTarget is missing on a callback-required message', async () => {
     const userId = 'user_cb_no_target';
     const sessionId = 'agent_cb_no_target';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const queue = createCapturedQueue();
 
@@ -108,8 +141,7 @@ describe('callback outbox — missing target or queue', () => {
   it('records callbackLastError when CALLBACK_QUEUE binding is missing', async () => {
     const userId = 'user_cb_no_queue';
     const sessionId = 'agent_cb_no_queue';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     await runInDurableObject(stub, async instance => {
       removeCallbackQueue(instance);
@@ -155,8 +187,7 @@ describe('callback outbox — missing target or queue', () => {
   it('records callbackRetryAt when queue send throws', async () => {
     const userId = 'user_cb_retry';
     const sessionId = 'agent_cb_retry';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const failingQueue: CapturedQueue = {
       captured: [],
@@ -215,8 +246,7 @@ describe('callback outbox — missing target or queue', () => {
   it('does not record error when callback is not required and target is missing', async () => {
     const userId = 'user_cb_optional';
     const sessionId = 'agent_cb_optional';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     await runInDurableObject(stub, async instance => {
       removeCallbackQueue(instance);
@@ -262,8 +292,7 @@ describe('callback outbox — missing target or queue', () => {
   it('collapses a multi-message idle batch into the last callback-relevant message', async () => {
     const userId = 'user_cb_batch';
     const sessionId = 'agent_cb_batch';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
     const queue = createCapturedQueue();
 
     const result = await runInDurableObject(stub, async instance => {
@@ -348,8 +377,7 @@ describe('callback outbox — missing target or queue', () => {
   it('includes idempotencyKey set to messageId in callback payload', async () => {
     const userId = 'user_cb_idempotency';
     const sessionId = 'agent_cb_idempotency';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const queue = createCapturedQueue();
 

--- a/services/cloud-agent-next/test/integration/session/code-review-ephemeral-sandbox.test.ts
+++ b/services/cloud-agent-next/test/integration/session/code-review-ephemeral-sandbox.test.ts
@@ -1,5 +1,5 @@
 import { env, listDurableObjectIds, runInDurableObject } from 'cloudflare:test';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import { getWrapperLease } from '../../../src/session/wrapper-runtime-state.js';
 import { queueUserMessageInput, registerReadySession } from '../../helpers/session-setup.js';
 
@@ -14,6 +14,40 @@ async function clearSessions(): Promise<void> {
   );
 }
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('Code Reviewer ephemeral sandbox lifecycle', () => {
   beforeEach(async () => {
     await clearSessions();
@@ -23,9 +57,7 @@ describe('Code Reviewer ephemeral sandbox lifecycle', () => {
     const userId = 'user_crv_enabled';
     const sessionId = 'agent_crv_enabled';
     const orgId = 'org_crv_enabled';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -118,9 +150,7 @@ describe('Code Reviewer ephemeral sandbox lifecycle', () => {
       sandboxId,
     }) => {
       const orgId = `org_crv_${status}`;
-      const stub = env.CLOUD_AGENT_SESSION.get(
-        env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-      );
+      const stub = sessionStub(userId, sessionId);
 
       const result = await runInDurableObject(stub, async instance => {
         await registerReadySession(instance, {
@@ -181,9 +211,7 @@ describe('Code Reviewer ephemeral sandbox lifecycle', () => {
     const userId = 'user_crv_shared';
     const sessionId = 'agent_crv_shared';
     const orgId = 'org_crv_shared';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -244,9 +272,7 @@ describe('Code Reviewer ephemeral sandbox lifecycle', () => {
     const userId = 'user_crv_destroy';
     const sessionId = 'agent_crv_destroy';
     const orgId = 'org_crv_destroy';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let destroyCalls = 0;

--- a/services/cloud-agent-next/test/integration/session/deletion-lifecycle.test.ts
+++ b/services/cloud-agent-next/test/integration/session/deletion-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { env, runInDurableObject } from 'cloudflare:test';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import type { AgentSandboxLifecycle } from '../../../src/agent-sandbox/protocol.js';
 import type { CloudAgentSession } from '../../../src/persistence/CloudAgentSession.js';
 import { listPendingSessionMessages } from '../../../src/session/pending-messages.js';
@@ -23,13 +23,45 @@ async function establishOwnedWrapper(
     stopStatus === 'absent' ? { status: 'absent' } : { status: 'still-present', observed: [] };
 }
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('session deletion physical cleanup', () => {
   it('erases Durable Object state after explicit deletion confirms wrapper absence', async () => {
     const userId = 'user_delete_complete';
     const sessionId = 'agent_delete_complete';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -62,9 +94,7 @@ describe('session deletion physical cleanup', () => {
   it('does not erase Durable Object state when explicit deletion cannot confirm wrapper absence', async () => {
     const userId = 'user_delete_pending';
     const sessionId = 'agent_delete_pending';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -102,9 +132,7 @@ describe('session deletion physical cleanup', () => {
   it('deletes quarantined session state without probing its sandbox again', async () => {
     const userId = 'user_delete_quarantined';
     const sessionId = 'agent_delete_quarantined';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -158,9 +186,7 @@ describe('session deletion physical cleanup', () => {
     const userId = 'user_delete_pending_failover';
     const sessionId = 'agent_delete_pending_failover';
     const routeKey = 'usr-000000000000000000000000000000000000000000000000';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -204,9 +230,7 @@ describe('session deletion physical cleanup', () => {
   it('retains physical cleanup backoff while explicit deletion is pending', async () => {
     const userId = 'user_delete_backoff';
     const sessionId = 'agent_delete_backoff';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -236,9 +260,7 @@ describe('session deletion physical cleanup', () => {
   it('rejects new message admission while explicit deletion is pending', async () => {
     const userId = 'user_delete_reject_admission';
     const sessionId = 'agent_delete_reject_admission';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -304,9 +326,7 @@ describe('session deletion physical cleanup', () => {
   it('finishes pending explicit deletion from an alarm after wrapper absence is confirmed', async () => {
     const userId = 'user_delete_alarm_complete';
     const sessionId = 'agent_delete_alarm_complete';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -356,9 +376,7 @@ describe('session deletion physical cleanup', () => {
   it('postpones retention deletion while physical wrapper cleanup remains unresolved', async () => {
     const userId = 'user_ttl_pending';
     const sessionId = 'agent_ttl_pending';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -394,9 +412,7 @@ describe('session deletion physical cleanup', () => {
   it('retains physical cleanup backoff while retention deletion is already pending', async () => {
     const userId = 'user_ttl_backoff';
     const sessionId = 'agent_ttl_backoff';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -435,9 +451,7 @@ describe('session deletion physical cleanup', () => {
   it('retains provider deferred-deletion entries through the payload purge', async () => {
     const userId = 'user_delete_deferred';
     const sessionId = 'agent_delete_deferred';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -476,9 +490,7 @@ describe('session deletion physical cleanup', () => {
   it('writes the deletion fence before provider deletion planning', async () => {
     const userId = 'user_delete_fence';
     const sessionId = 'agent_delete_fence';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const intentDuringPlanning = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {

--- a/services/cloud-agent-next/test/integration/session/derive-cloud-status.test.ts
+++ b/services/cloud-agent-next/test/integration/session/derive-cloud-status.test.ts
@@ -1,5 +1,5 @@
 import { env, runInDurableObject } from 'cloudflare:test';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import type { CloudStatusData } from '../../../src/shared/protocol.js';
 import {
   storePendingSessionMessage,
@@ -22,12 +22,44 @@ function asCloudStatusDerivingInstance(instance: object): CloudStatusDerivingIns
 const MSG_INITIAL_PENDING = 'msg_018f1e2d3c4bAaBbCcDdEeFfHh';
 const userId = 'user_cloud_status_derive';
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('deriveCloudStatus (/stream connected bootstrap)', () => {
   it('reports preparing for an unprepared session with durable pending queued work', async () => {
     const sessionId = 'agent_cloud_status_derive_queued';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const message: PendingSessionMessage = {
       messageId: MSG_INITIAL_PENDING,
@@ -59,9 +91,7 @@ describe('deriveCloudStatus (/stream connected bootstrap)', () => {
 
   it('returns null for a brand-new unprepared session without pending queued work', async () => {
     const sessionId = 'agent_cloud_status_derive_empty';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const cloudStatus = await runInDurableObject(stub, async instance =>
       asCloudStatusDerivingInstance(instance).deriveCloudStatus()
@@ -72,9 +102,7 @@ describe('deriveCloudStatus (/stream connected bootstrap)', () => {
 
   it('reports ready for a prepared session without current runtime execution', async () => {
     const sessionId = 'agent_cloud_status_derive_ready';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const cloudStatus = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {

--- a/services/cloud-agent-next/test/integration/session/derive-queued-messages.test.ts
+++ b/services/cloud-agent-next/test/integration/session/derive-queued-messages.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { env, runInDurableObject } from 'cloudflare:test';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import {
   storePendingSessionMessage,
   type PendingSessionMessage,
@@ -39,12 +39,44 @@ const MSG_INITIATED = 'msg_018f1e2d3c4bVvWwXxYyZz0011';
 
 const userId = 'user_queued_derive';
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('deriveQueuedMessages (/stream connect catch-up)', () => {
   it('does not synthesize metadata fallback while lazy prep is pending', async () => {
     const sessionId = 'agent_queued_derive_1';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const snapshots = await runInDurableObject(stub, async instance => {
       const result = await instance.registerSession(
@@ -67,9 +99,7 @@ describe('deriveQueuedMessages (/stream connect catch-up)', () => {
 
   it('returns every entry in the pending_message:* queue', async () => {
     const sessionId = 'agent_queued_derive_2';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const message: PendingSessionMessage = {
       messageId: MSG_FOLLOWUP,
@@ -95,9 +125,7 @@ describe('deriveQueuedMessages (/stream connect catch-up)', () => {
 
   it('deduplicates the metadata entry when pending_message already has it', async () => {
     const sessionId = 'agent_queued_derive_3';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const snapshots = await runInDurableObject(stub, async instance => {
       await instance.registerSession(
@@ -126,9 +154,7 @@ describe('deriveQueuedMessages (/stream connect catch-up)', () => {
 
   it('suppresses the metadata entry once initiation has begun', async () => {
     const sessionId = 'agent_queued_derive_4';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const snapshots = await runInDurableObject(stub, async instance => {
       await instance.registerSession(
@@ -166,9 +192,7 @@ describe('deriveQueuedMessages (/stream connect catch-up)', () => {
 
   it('returns nothing for a brand-new DO with no metadata or queue', async () => {
     const sessionId = 'agent_queued_derive_5';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const snapshots = await runInDurableObject(stub, async instance =>
       asDerivingInstance(instance).deriveQueuedMessages()
@@ -179,9 +203,7 @@ describe('deriveQueuedMessages (/stream connect catch-up)', () => {
 
   it('rehydrates never-accepted exhausted prompts with queued then failed catch-up data', async () => {
     const sessionId = 'agent_queued_derive_exhausted';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const snapshots = await runInDurableObject(stub, async instance => {
       await putSessionMessageState(instance.ctx.storage, {
@@ -223,9 +245,7 @@ describe('deriveQueuedMessages (/stream connect catch-up)', () => {
 
   it('returns new-path pending message without executionId', async () => {
     const sessionId = 'agent_queued_derive_6';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const message: PendingSessionMessage = {
       messageId: MSG_FOLLOWUP,

--- a/services/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
+++ b/services/cloud-agent-next/test/integration/session/disconnect-and-reaper.test.ts
@@ -1,5 +1,5 @@
 import { env, runInDurableObject } from 'cloudflare:test';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import { storePendingSessionMessage } from '../../../src/session/pending-messages.js';
@@ -10,13 +10,45 @@ import {
 } from '../../../src/session/wrapper-runtime-state.js';
 import type { ExecutionId } from '../../../src/types/ids.js';
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('Disconnect handling and compatibility execution RPCs', () => {
   it('alarm schedules the idle cadence when no current message deadlines exist', async () => {
     const userId = 'user_alarm_idle';
     const sessionId = 'agent_alarm_idle';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       const now = Date.now();
@@ -34,9 +66,7 @@ describe('Disconnect handling and compatibility execution RPCs', () => {
   it('idle cleanup respects accepted wrapper-run messages and pending queue work', async () => {
     const userId = 'user_idle_cleanup';
     const sessionId = 'agent_idle_cleanup';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       const now = Date.now();
@@ -88,9 +118,7 @@ describe('Disconnect handling and compatibility execution RPCs', () => {
   it('idle cleanup preserves a completed wrapper retained for warm fenced reuse', async () => {
     const userId = 'user_idle_warm_reuse';
     const sessionId = 'agent_idle_warm_reuse';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       const now = Date.now();
@@ -139,9 +167,7 @@ describe('Disconnect handling and compatibility execution RPCs', () => {
   it('failExecutionRpc retains the public execution-record failure contract', async () => {
     const userId = 'user_rpc_failure';
     const sessionId = 'agent_rpc_failure';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       const now = Date.now();
@@ -181,9 +207,7 @@ describe('Disconnect handling and compatibility execution RPCs', () => {
   it('failExecutionRpc is idempotent for an already-terminal execution', async () => {
     const userId = 'user_rpc_terminal';
     const sessionId = 'agent_rpc_terminal';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await instance.updateMetadata({ version: 1, sessionId, userId, timestamp: 1 });
@@ -220,9 +244,7 @@ describe('Disconnect handling and compatibility execution RPCs', () => {
   it('failExecutionRpc preserves the custom event type compatibility input', async () => {
     const userId = 'user_rpc_custom';
     const sessionId = 'agent_rpc_custom';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await instance.updateMetadata({ version: 1, sessionId, userId, timestamp: 1 });

--- a/services/cloud-agent-next/test/integration/session/events.test.ts
+++ b/services/cloud-agent-next/test/integration/session/events.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { env, runInDurableObject } from 'cloudflare:test';
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
 import * as z from 'zod';
 import { createEventQueries } from '../../../src/session/queries/events.js';
@@ -25,10 +25,43 @@ const messageUpdatedPayloadSchema = z.object({
   }),
 });
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('Event Storage', () => {
   it('should insert event with RETURNING id', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_1');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_1');
 
     // Access the DO directly and call queries on its sql storage
     // The DO auto-runs migrations in constructor via blockConcurrencyWhile
@@ -52,8 +85,7 @@ describe('Event Storage', () => {
   });
 
   it('should find events by filters with various combinations', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_2');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_2');
 
     const result = await runInDurableObject(stub, async (_instance, state) => {
       const db = drizzle(state.storage, { logger: false });
@@ -139,8 +171,7 @@ describe('Event Storage', () => {
   });
 
   it('should delete events older than timestamp', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_3');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_3');
 
     const result = await runInDurableObject(stub, async (_instance, state) => {
       const db = drizzle(state.storage, { logger: false });
@@ -186,8 +217,7 @@ describe('Event Storage', () => {
   });
 
   it('should maintain sequential event ordering (IDs always increase)', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_4');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_4');
 
     const result = await runInDurableObject(stub, async (_instance, state) => {
       const db = drizzle(state.storage, { logger: false });
@@ -233,8 +263,7 @@ describe('Event Storage', () => {
   });
 
   it('should upsert: insert on first call, update payload on conflict', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_5');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_5');
 
     const result = await runInDurableObject(stub, async (_instance, state) => {
       const db = drizzle(state.storage, { logger: false });
@@ -285,7 +314,7 @@ describe('Event Storage', () => {
   });
 
   it('repairs offline entity mutations below the replay cursor without replaying old execution state', async () => {
-    const stub = env.CLOUD_AGENT_SESSION.getByName('user_1:sess_materialized');
+    const stub = sessionStub('user_1', 'sess_materialized');
     const result = await runInDurableObject(stub, async (_instance, state) => {
       const events = createEventQueries(drizzle(state.storage), state.storage.sql);
       const sessionId = 'sess_materialized' as SessionId;
@@ -433,8 +462,7 @@ describe('Event Storage', () => {
   });
 
   it('should upsert: different entityIds create separate rows', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_6');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_6');
 
     const result = await runInDurableObject(stub, async (_instance, state) => {
       const db = drizzle(state.storage, { logger: false });
@@ -489,8 +517,7 @@ describe('Event Storage', () => {
   });
 
   it('should return latest assistant message by sortable message ID with current parts', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_7');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_7');
 
     const result = await runInDurableObject(stub, async (_instance, state) => {
       const db = drizzle(state.storage, { logger: false });
@@ -600,8 +627,7 @@ describe('Event Storage', () => {
   });
 
   it('should require root-session assistant messages', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_8');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_8');
 
     const result = await runInDurableObject(stub, async (_instance, state) => {
       const db = drizzle(state.storage, { logger: false });
@@ -644,8 +670,7 @@ describe('Event Storage', () => {
   });
 
   it('should select and hydrate an assistant without time.completed', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_9');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_9');
 
     const result = await runInDurableObject(stub, async (_instance, state) => {
       const db = drizzle(state.storage, { logger: false });

--- a/services/cloud-agent-next/test/integration/session/execute-directly-failure.test.ts
+++ b/services/cloud-agent-next/test/integration/session/execute-directly-failure.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { env, runInDurableObject, listDurableObjectIds } from 'cloudflare:test';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import type { FencedWrapperDispatchRequest } from '../../../src/execution/types.js';
@@ -26,6 +26,40 @@ import {
 } from '../../../src/session/session-message-state.js';
 import { queueUserMessageInput, registerReadySession } from '../../helpers/session-setup.js';
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('executeDirectly failure handling', () => {
   beforeEach(async () => {
     const ids = await listDurableObjectIds(env.CLOUD_AGENT_SESSION);
@@ -41,8 +75,7 @@ describe('executeDirectly failure handling', () => {
   it('wrapper heartbeat does not reset the no-output deadline', async () => {
     const userId = 'user_liveness_heartbeat';
     const sessionId = 'agent_liveness_heartbeat';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -102,8 +135,7 @@ describe('executeDirectly failure handling', () => {
   it('meaningful wrapper output pushes the no-output deadline forward', async () => {
     const userId = 'user_liveness_refresh';
     const sessionId = 'agent_liveness_refresh';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -170,9 +202,7 @@ describe('executeDirectly failure handling', () => {
   ) {
     const userId = `user_exec_direct_${keySuffix}`;
     const sessionId = `agent_exec_direct_${keySuffix}`;
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     return runInDurableObject(stub, async (instance, state) => {
       (instance as any).agentRuntime = {
@@ -288,8 +318,7 @@ describe('executeDirectly failure handling', () => {
   it('queued flush pre-start failure retries cleanly with the original execution and message ids', async () => {
     const userId = 'user_exec_direct_fail';
     const sessionId = 'agent_exec_direct_fail';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       let attemptCount = 0;
@@ -425,8 +454,7 @@ describe('handleWrapperTerminalEvent — new-path identity and message preservat
   it('wrapper complete reconciles still-accepted messages instead of stranding them', async () => {
     const userId = 'user_wrapper_complete_identity';
     const sessionId = 'agent_wrapper_complete_identity';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -503,8 +531,7 @@ describe('new-path liveness without executionId', () => {
   it('schedules liveness deadlines for accepted messages and fails them on no-output timeout', async () => {
     const userId = 'user_newpath_liveness';
     const sessionId = 'agent_newpath_liveness';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await registerReadySession(instance, {
@@ -590,8 +617,7 @@ describe('new-path liveness without executionId', () => {
   it('schedules liveness deadlines for accepted messages and fails them on ping timeout', async () => {
     const userId = 'user_newpath_ping';
     const sessionId = 'agent_newpath_ping';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await registerReadySession(instance, {
@@ -683,8 +709,7 @@ describe('hot delivery failure preserves existing wrapper identity', () => {
   it('failed hot delivery does not clear wrapper identity for already accepted work', async () => {
     const userId = 'user_hot_fail_identity';
     const sessionId = 'agent_hot_fail_identity';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       (instance as any).orchestrator = {
@@ -786,8 +811,7 @@ describe('hot delivery failure preserves existing wrapper identity', () => {
   it('failed cold delivery fences its run and retains physical cleanup responsibility', async () => {
     const userId = 'user_cold_fail_identity';
     const sessionId = 'agent_cold_fail_identity';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       (instance as any).orchestrator = {

--- a/services/cloud-agent-next/test/integration/session/execution-id-removal.test.ts
+++ b/services/cloud-agent-next/test/integration/session/execution-id-removal.test.ts
@@ -11,7 +11,7 @@
 
 import { env, runInDurableObject, listDurableObjectIds } from 'cloudflare:test';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import { listPendingSessionMessages } from '../../../src/session/pending-messages.js';
 import {
   listNonTerminalAcceptedMessages,
@@ -25,6 +25,40 @@ import {
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import type { FencedWrapperDispatchRequest } from '../../../src/execution/types.js';
 import { queueUserMessageInput, registerReadySession } from '../../helpers/session-setup.js';
+
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
 
 describe('execution-id removal - queue and start response', () => {
   beforeEach(async () => {
@@ -41,8 +75,7 @@ describe('execution-id removal - queue and start response', () => {
   it('new-path admission result omits executionId', async () => {
     const userId = 'user_noexec_start';
     const sessionId = 'agent_noexec_start';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -78,8 +111,7 @@ describe('execution-id removal - queue and start response', () => {
   it('new-path pending message persists canonical V2 intent without executionId', async () => {
     const userId = 'user_noexec_pending';
     const sessionId = 'agent_noexec_pending';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -136,8 +168,7 @@ describe('execution-id removal - flush does not create execution rows', () => {
   it('new-path flush does not insert an execution metadata row', async () => {
     const userId = 'user_noexec_flush';
     const sessionId = 'agent_noexec_flush';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let capturedPlan: FencedWrapperDispatchRequest | null = null;
@@ -195,9 +226,7 @@ describe('execution-id removal - flush does not create execution rows', () => {
   it('repairs accepted pending residue with one sent event and no wrapper redispatch', async () => {
     const userId = 'user_noexec_sent_repair';
     const sessionId = 'agent_noexec_sent_repair';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, doState) => {
       let dispatches = 0;
@@ -254,9 +283,7 @@ describe('execution-id removal - flush does not create execution rows', () => {
   it('retries sent-event repair from accepted pending residue without wrapper redispatch', async () => {
     const userId = 'user_noexec_sent_retry';
     const sessionId = 'agent_noexec_sent_retry';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, doState) => {
       let dispatches = 0;
@@ -321,8 +348,7 @@ describe('execution-id removal - flush does not create execution rows', () => {
   it('new-path flush delivers message and emits queued and sent events without executionId', async () => {
     const userId = 'user_noexec_result';
     const sessionId = 'agent_noexec_result';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, doState) => {
       (instance as any).orchestrator = {
@@ -409,8 +435,7 @@ describe('execution-id removal - stream events do not expose fake executionIds',
   it('new-path message queued event payload does not contain executionId', async () => {
     const userId = 'user_stream_noexec';
     const sessionId = 'agent_stream_noexec';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, doState) => {
       await registerReadySession(instance, {
@@ -452,8 +477,7 @@ describe('execution-id removal - stream events do not expose fake executionIds',
   it('new-path message terminal events do not expose executionId in payload', async () => {
     const userId = 'user_term_noexec';
     const sessionId = 'agent_term_noexec';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, doState) => {
       await registerReadySession(instance, {
@@ -508,8 +532,7 @@ describe('execution-id removal - stream events do not expose fake executionIds',
   it('new-path pending message interrupted event does not expose executionId when absent', async () => {
     const userId = 'user_intrpt_noex';
     const sessionId = 'agent_intrpt_noex';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, doState) => {
       await registerReadySession(instance, {
@@ -574,8 +597,7 @@ describe('execution-id removal - ingest does not alias wrapperRunId as execution
   it('new-path ingest events do not use wrapperRunId as execution_id in StoredEvent', async () => {
     const userId = 'user_ingest_noexec';
     const sessionId = 'agent_ingest_noexec';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, doState) => {
       await registerReadySession(instance, {

--- a/services/cloud-agent-next/test/integration/session/hot-delivery.test.ts
+++ b/services/cloud-agent-next/test/integration/session/hot-delivery.test.ts
@@ -9,8 +9,7 @@
  */
 
 import { env, runInDurableObject } from 'cloudflare:test';
-import { drizzle } from 'drizzle-orm/durable-sqlite';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { listPendingSessionMessages } from '../../../src/session/pending-messages.js';
 import {
   createPendingSessionMessage,
@@ -31,12 +30,47 @@ import {
 import type { FencedWrapperDispatchRequest } from '../../../src/execution/types.js';
 import { registerReadySession } from '../../helpers/session-setup.js';
 
+// Wrapper-hold and drain scenarios leave alarm and delivery work in the session
+// DO. Interrupt every session a test touched and clear its alarm, or that work
+// wakes after this file closes and its logs race the vitest worker shutdown as
+// pending onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        // Fire-and-forget run-state publications continue past the test body;
+        // drain the chained tail so no facade RPC is pending when the worker
+        // closes (EnvironmentTeardownError).
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('hot delivery — DO integration', () => {
   it('holds a queued follow-up while the current wrapper run finalizes', async () => {
     const userId = 'user_hot_deliv';
     const sessionId = 'agent_hot_deliv';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const followUpMessageId = 'msg_018f1e2d3c4bHotDeliv0001Ab';
 
@@ -139,9 +173,7 @@ describe('hot delivery — DO integration', () => {
   it('normal wrapper completion releases the finalizing hold and drains one follow-up under a fresh run', async () => {
     const userId = 'user_complete_drain';
     const sessionId = 'agent_complete_drain';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
     const currentMessageId = 'msg_018f1e2d3c4bCmplteDrain001';
     const followUpMessageId = 'msg_018f1e2d3c4bCmplteDrain002';
 
@@ -244,9 +276,7 @@ describe('hot delivery — DO integration', () => {
   it('holds pending delivery through physical cleanup and drains after confirmed absence', async () => {
     const userId = 'user_cleanup_hold';
     const sessionId = 'agent_cleanup_hold';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
     const followUpMessageId = 'msg_018f1e2d3c4bCleanupHold001';
 
     const result = await runInDurableObject(stub, async instance => {

--- a/services/cloud-agent-next/test/integration/session/idle-reconciliation.test.ts
+++ b/services/cloud-agent-next/test/integration/session/idle-reconciliation.test.ts
@@ -1,5 +1,5 @@
 import { env, listDurableObjectIds, runInDurableObject } from 'cloudflare:test';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import {
   allocateWrapperRuntimeState,
   getWrapperRuntimeState,
@@ -9,6 +9,40 @@ import {
   putSessionMessageState,
 } from '../../../src/session/session-message-state.js';
 import { registerReadySession } from '../../helpers/session-setup.js';
+
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
 
 describe('idle lifecycle integration', () => {
   beforeEach(async () => {
@@ -25,9 +59,7 @@ describe('idle lifecycle integration', () => {
   it('persists raw root idle without using it as a success boundary', async () => {
     const userId = 'user_idle_no_fallback';
     const sessionId = 'agent_idle_no_fallback';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {

--- a/services/cloud-agent-next/test/integration/session/leases.test.ts
+++ b/services/cloud-agent-next/test/integration/session/leases.test.ts
@@ -10,13 +10,46 @@
  */
 
 import { env, runInDurableObject } from 'cloudflare:test';
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import type { ExecutionId } from '../../../src/types/ids.js';
+
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
 
 describe('Lease Acquisition', () => {
   it('should acquire lease on first attempt', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_1');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_1');
 
     // Use the DO's RPC method directly
     const result = await runInDurableObject(stub, async instance => {
@@ -31,8 +64,7 @@ describe('Lease Acquisition', () => {
   });
 
   it('should reject duplicate lease acquisition when lease is held', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_2');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_2');
 
     const result = await runInDurableObject(stub, async instance => {
       // First acquisition succeeds
@@ -52,8 +84,7 @@ describe('Lease Acquisition', () => {
   });
 
   it('should allow lease acquisition after expiration', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_3');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_3');
 
     // We can't easily simulate time passing in tests, so instead we'll
     // test that acquiring a lease works, then release it, and acquire again
@@ -75,8 +106,7 @@ describe('Lease Acquisition', () => {
   });
 
   it('should extend lease with heartbeat (correct leaseId)', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_4');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_4');
 
     const result = await runInDurableObject(stub, async instance => {
       // Acquire lease
@@ -93,8 +123,7 @@ describe('Lease Acquisition', () => {
   });
 
   it('should reject extension with wrong leaseId', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_5');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_5');
 
     const result = await runInDurableObject(stub, async instance => {
       // Acquire lease
@@ -111,8 +140,7 @@ describe('Lease Acquisition', () => {
   });
 
   it('should release lease on completion', async () => {
-    const id = env.CLOUD_AGENT_SESSION.idFromName('user_1:sess_6');
-    const stub = env.CLOUD_AGENT_SESSION.get(id);
+    const stub = sessionStub('user_1', 'sess_6');
 
     const result = await runInDurableObject(stub, async instance => {
       // Acquire lease

--- a/services/cloud-agent-next/test/integration/session/legacy-callback-enqueue.test.ts
+++ b/services/cloud-agent-next/test/integration/session/legacy-callback-enqueue.test.ts
@@ -1,5 +1,5 @@
 import { env, runInDurableObject } from 'cloudflare:test';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import type { CallbackJob } from '../../../src/callbacks/types.js';
 import { registerReadySession } from '../../helpers/session-setup.js';
 
@@ -14,13 +14,45 @@ function installCallbackQueue(
   ).CALLBACK_QUEUE = { send };
 }
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('legacy execution callback enqueue', () => {
   it('includes legacy executionId and messageId in callback jobs', async () => {
     const userId = 'user_legacy_callback_payload';
     const sessionId = 'agent_legacy_callback_payload';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const jobs = await runInDurableObject(stub, async instance => {
       const sentCallbackJobs: CallbackJob[] = [];
@@ -80,9 +112,7 @@ describe('legacy execution callback enqueue', () => {
   ])('$name in callback jobs', async ({ upstreamBranch, expectedBranch }) => {
     const userId = 'user_legacy_callback_branch';
     const sessionId = `agent_legacy_callback_branch_${upstreamBranch ? 'observed' : 'fallback'}`;
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const jobs = await runInDurableObject(stub, async instance => {
       const sentCallbackJobs: CallbackJob[] = [];
@@ -126,9 +156,7 @@ describe('legacy execution callback enqueue', () => {
   it('leaves the branch absent for historical metadata without either branch', async () => {
     const userId = 'user_legacy_callback_no_branch';
     const sessionId = 'agent_legacy_callback_no_branch';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const jobs = await runInDurableObject(stub, async instance => {
       const sentCallbackJobs: CallbackJob[] = [];
@@ -167,9 +195,7 @@ describe('legacy execution callback enqueue', () => {
   it('adds retryable fallback client errors without parsing legacy error text', async () => {
     const userId = 'user_legacy_callback_error';
     const sessionId = 'agent_legacy_callback_error';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const jobs = await runInDurableObject(stub, async instance => {
       const sentCallbackJobs: CallbackJob[] = [];

--- a/services/cloud-agent-next/test/integration/session/message-result.test.ts
+++ b/services/cloud-agent-next/test/integration/session/message-result.test.ts
@@ -1,6 +1,6 @@
 import { env, listDurableObjectIds, runInDurableObject } from 'cloudflare:test';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import type { CloudAgentSession } from '../../../src/persistence/CloudAgentSession.js';
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import {
@@ -96,6 +96,40 @@ function lifecycleState(
   };
 }
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('CloudAgentSession.getMessageResult', () => {
   beforeEach(async () => {
     const ids = await listDurableObjectIds(env.CLOUD_AGENT_SESSION);
@@ -109,9 +143,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   });
 
   it('returns session-not-found when metadata is absent', async () => {
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName('user_message_result_missing:agent_message_result_missing')
-    );
+    const stub = sessionStub('user_message_result_missing', 'agent_message_result_missing');
 
     await expect(stub.getMessageResult(messageA)).resolves.toEqual({ type: 'session-not-found' });
   });
@@ -119,9 +151,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   it('returns message-not-found when the exact message ID is absent', async () => {
     const userId = 'user_message_result_unknown';
     const sessionId = 'agent_message_result_unknown';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerSession(instance, sessionId, userId);
@@ -134,9 +164,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   it('returns correlated assistant text for an exact completed turn', async () => {
     const userId = 'user_message_result_exact';
     const sessionId = 'agent_message_result_exact';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await registerSession(instance, sessionId, userId);
@@ -184,9 +212,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   it('omits assistant text when a persisted assistant ID belongs to another turn', async () => {
     const userId = 'user_message_result_mismatched_parent';
     const sessionId = 'agent_message_result_mismatched_parent';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await registerSession(instance, sessionId, userId);
@@ -223,9 +249,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   it('omits assistant text when a persisted assistant ID belongs to another Kilo session', async () => {
     const userId = 'user_message_result_mismatched_kilo_session';
     const sessionId = 'agent_message_result_mismatched_kilo_session';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await registerSession(instance, sessionId, userId);
@@ -263,9 +287,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   it('returns a queued recovery result for pending-only compatibility rows', async () => {
     const userId = 'user_message_result_pending';
     const sessionId = 'agent_message_result_pending';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerSession(instance, sessionId, userId);
@@ -297,9 +319,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   it('fails closed when a corrupt lifecycle row has pending compatibility residue', async () => {
     const userId = 'user_message_result_corrupt';
     const sessionId = 'agent_message_result_corrupt';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerSession(instance, sessionId, userId);
@@ -327,9 +347,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   it('fails closed when a lifecycle row embeds another valid message ID', async () => {
     const userId = 'user_message_result_mismatched_identity';
     const sessionId = 'agent_message_result_mismatched_identity';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerSession(instance, sessionId, userId);
@@ -343,9 +361,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   it('returns a safe exact result for current pending rows', async () => {
     const userId = 'user_message_result_current_pending';
     const sessionId = 'agent_message_result_current_pending';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
     const token = 'private-current-pending-token';
 
     const result = await runInDurableObject(stub, async instance => {
@@ -381,9 +397,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   it('does not expose assistant text for a queued turn', async () => {
     const userId = 'user_message_result_queued';
     const sessionId = 'agent_message_result_queued';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await registerSession(instance, sessionId, userId);
@@ -412,9 +426,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   it('omits assistant text for completed rows without an assistant message ID', async () => {
     const userId = 'user_message_result_parent';
     const sessionId = 'agent_message_result_parent';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await registerSession(instance, sessionId, userId);
@@ -453,9 +465,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   it('never exposes sensitive persisted diagnostics', async () => {
     const userId = 'user_message_result_safe';
     const sessionId = 'agent_message_result_safe';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
     const token = 'private-token-like-text';
 
     const result = await runInDurableObject(stub, async instance => {
@@ -488,9 +498,7 @@ describe('CloudAgentSession.getMessageResult', () => {
   it('returns allowlisted structured failure fields', async () => {
     const userId = 'user_message_result_failure';
     const sessionId = 'agent_message_result_failure';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerSession(instance, sessionId, userId);

--- a/services/cloud-agent-next/test/integration/session/message-terminalization.test.ts
+++ b/services/cloud-agent-next/test/integration/session/message-terminalization.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { env, runInDurableObject, listDurableObjectIds } from 'cloudflare:test';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import type { CloudAgentSession } from '../../../src/persistence/CloudAgentSession.js';
@@ -103,6 +103,40 @@ async function seedAssistantMessageWithParent(
   }
 }
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('message terminalization and stream events', () => {
   beforeEach(async () => {
     const ids = await listDurableObjectIds(env.CLOUD_AGENT_SESSION);
@@ -122,9 +156,7 @@ describe('message terminalization and stream events', () => {
       const sessionId = `agent_cancel_report_${failFirstReport}`;
       const messageId = 'msg_018f1e2d3c4bCancelReportAB';
       const acceptedMessageId = 'msg_018f1e2d3c4bCancelActiveAB';
-      const stub = env.CLOUD_AGENT_SESSION.get(
-        env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-      );
+      const stub = sessionStub(userId, sessionId);
       const reports: CloudAgentQueueReport[] = [];
       const callbackQueue = createCapturedQueue();
       const broadcastTypes: string[] = [];
@@ -242,9 +274,7 @@ describe('message terminalization and stream events', () => {
   it('alarm repairs terminal effects without duplicating a durable terminal event', async () => {
     const userId = 'user_term_repair_alarm';
     const sessionId = 'agent_term_repair_alarm';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
     const queue = createCapturedQueue();
 
     const result = await runInDurableObject(stub, async (instance, state) => {
@@ -294,9 +324,7 @@ describe('message terminalization and stream events', () => {
   it('does not emit session lifecycle reports for readiness or deletion', async () => {
     const userId = 'user_runtime_reports';
     const sessionId = 'agent_runtime_reports';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
     const reports: CloudAgentQueueReport[] = [];
 
     await runInDurableObject(stub, async instance => {
@@ -320,9 +348,7 @@ describe('message terminalization and stream events', () => {
   it('terminal ingest reconstructs acceptance before the runtime acceptance hook persists', async () => {
     const userId = 'user_term_before_accept';
     const sessionId = 'agent_term_before_accept';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const reports: CloudAgentQueueReport[] = [];
     const result = await runInDurableObject(stub, async (instance, state) => {
@@ -385,9 +411,7 @@ describe('message terminalization and stream events', () => {
   it('reports a safe insufficient-credit diagnostic for a wrapper failure after activity', async () => {
     const userId = 'user_term_credit_report';
     const sessionId = 'agent_term_credit_report';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
     const reports: CloudAgentQueueReport[] = [];
 
     const message = await runInDurableObject(stub, async instance => {
@@ -451,9 +475,7 @@ describe('message terminalization and stream events', () => {
   it('ignores terminal acceptance reconstruction for a non-current wrapper run', async () => {
     const userId = 'user_term_stale_accept';
     const sessionId = 'agent_term_stale_accept';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -481,9 +503,7 @@ describe('message terminalization and stream events', () => {
   it('alarm preserves a near-term sent-effect repair deadline after accepted pending residue fails', async () => {
     const userId = 'user_term_sent_alarm';
     const sessionId = 'agent_term_sent_alarm';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -526,9 +546,7 @@ describe('message terminalization and stream events', () => {
   it('alarm preserves a near-term terminal-effect repair deadline after terminal insertion fails', async () => {
     const userId = 'user_term_event_alarm';
     const sessionId = 'agent_term_event_alarm';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -566,9 +584,7 @@ describe('message terminalization and stream events', () => {
   it('alarm preserves a near-term callback retry deadline after callback progression fails', async () => {
     const userId = 'user_term_callback_alarm';
     const sessionId = 'agent_term_callback_alarm';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       (
@@ -619,8 +635,7 @@ describe('message terminalization and stream events', () => {
   it('terminalization by messageId emits exactly one cloud.message.completed event', async () => {
     const userId = 'user_term_complete';
     const sessionId = 'agent_term_complete';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await registerReadySession(instance, {
@@ -674,8 +689,7 @@ describe('message terminalization and stream events', () => {
   it('terminalization by messageId emits exactly one cloud.message.failed event', async () => {
     const userId = 'user_term_failed';
     const sessionId = 'agent_term_failed';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await registerReadySession(instance, {
@@ -734,8 +748,7 @@ describe('message terminalization and stream events', () => {
   it('duplicate terminalization does not emit duplicate stream events', async () => {
     const userId = 'user_term_dup';
     const sessionId = 'agent_term_dup';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await registerReadySession(instance, {
@@ -792,8 +805,7 @@ describe('message terminalization and stream events', () => {
   it('duplicate terminalization does not enqueue duplicate callbacks', async () => {
     const userId = 'user_term_dup_cb';
     const sessionId = 'agent_term_dup_cb';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const queue = createCapturedQueue();
 
@@ -855,8 +867,7 @@ describe('message terminalization and stream events', () => {
   it('wrapper complete gate results wait past idle callback finalization and reach the callback job', async () => {
     const userId = 'user_term_gate_callback';
     const sessionId = 'agent_term_gate_callback';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const queue = createCapturedQueue();
     const reports: CloudAgentQueueReport[] = [];
@@ -943,8 +954,7 @@ describe('message terminalization and stream events', () => {
   it('terminalization emits cloud.message.interrupted for interrupted kind', async () => {
     const userId = 'user_term_int';
     const sessionId = 'agent_term_int';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await registerReadySession(instance, {
@@ -1002,8 +1012,7 @@ describe('message terminalization and stream events', () => {
   it('completed callback resolves assistant text by matching parentID, not latest assistant', async () => {
     const userId = 'user_term_corr';
     const sessionId = 'agent_term_corr';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const queue = createCapturedQueue();
 
@@ -1078,8 +1087,7 @@ describe('message terminalization and stream events', () => {
   it('completed callback omits assistant text when no matching parentID reply exists', async () => {
     const userId = 'user_term_missing';
     const sessionId = 'agent_term_missing';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const queue = createCapturedQueue();
 

--- a/services/cloud-agent-next/test/integration/session/pending-messages.test.ts
+++ b/services/cloud-agent-next/test/integration/session/pending-messages.test.ts
@@ -1,6 +1,6 @@
 import { env, runInDurableObject } from 'cloudflare:test';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   PENDING_SESSION_MESSAGE_LIMIT,
   clearPendingSessionMessages,
@@ -41,13 +41,44 @@ const createMessage = (overrides: Partial<PendingSessionMessage>): PendingSessio
   ...overrides,
 });
 
+// Queued and accepted messages leave dispatch and alarm work in the session
+// DO. Interrupt every session a test touched and clear its alarm, or that work
+// wakes after this file closes and its logs race the vitest worker shutdown as
+// pending onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('pending session messages', () => {
   it('lists messages in FIFO key order', async () => {
     const userId = 'user_pending_fifo';
     const sessionId = 'agent_pending_fifo';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const messages = await runInDurableObject(stub, async instance => {
       await storePendingSessionMessage(
@@ -71,9 +102,7 @@ describe('pending session messages', () => {
   it('deletes every matching messageId', async () => {
     const userId = 'user_pending_delete';
     const sessionId = 'agent_pending_delete';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await storePendingSessionMessage(
@@ -113,9 +142,7 @@ describe('pending session messages', () => {
     const sessionId = 'agent_pending_cancel_queued';
     const pendingMessageId = 'msg_018f1e2d3c4bCancelQueuedAA';
     const currentMessageId = 'msg_018f1e2d3c4bCurrentRunABCD';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -192,9 +219,7 @@ describe('pending session messages', () => {
   it('finds by clientRequestId', async () => {
     const userId = 'user_pending_client_request';
     const sessionId = 'agent_pending_client_request';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const found = await runInDurableObject(stub, async instance => {
       await storePendingSessionMessage(
@@ -216,9 +241,7 @@ describe('pending session messages', () => {
   it('ignores invalid stored entries', async () => {
     const userId = 'user_pending_invalid';
     const sessionId = 'agent_pending_invalid';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const messages = await runInDurableObject(stub, async instance => {
       await instance.ctx.storage.put('pending_message:0000000000000001:invalid', {
@@ -241,9 +264,7 @@ describe('pending session messages', () => {
   it('clears valid messages and ignores invalid stored entries', async () => {
     const userId = 'user_pending_clear';
     const sessionId = 'agent_pending_clear';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await instance.ctx.storage.put('pending_message:0000000000000001:invalid', {
@@ -278,9 +299,7 @@ describe('pending session messages', () => {
   it('counts messages up to the queue limit', async () => {
     const userId = 'user_pending_count';
     const sessionId = 'agent_pending_count';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const count = await runInDurableObject(stub, async instance => {
       for (let index = 0; index < PENDING_SESSION_MESSAGE_LIMIT; index++) {
@@ -302,9 +321,7 @@ describe('pending session messages', () => {
   it('refreshes stale past alarms when queue admission schedules pending work', async () => {
     const userId = 'user_pending_stale_alarm';
     const sessionId = 'agent_pending_stale_alarm';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -337,9 +354,7 @@ describe('pending session messages', () => {
   it('pulls a far-future alarm forward when durable pending work already exists', async () => {
     const userId = 'user_pending_reconstruct_alarm';
     const sessionId = 'agent_pending_reconstruct_alarm';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -375,9 +390,7 @@ describe('pending session messages', () => {
   it('pre-arms the next wake-up before alarm work can block', async () => {
     const userId = 'user_pending_alarm_prearm';
     const sessionId = 'agent_pending_alarm_prearm';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let releaseFlush: ((result: { remainingPendingCount: number }) => void) | undefined;
@@ -411,9 +424,7 @@ describe('pending session messages', () => {
   it('flushes one FIFO message on alarm and deletes after orchestrator accepts', async () => {
     const userId = 'user_pending_flush';
     const sessionId = 'agent_pending_flush';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let acceptedMessageId: string | undefined;
@@ -474,9 +485,7 @@ describe('pending session messages', () => {
   it('flushes canonical document attachment descriptors through the durable queue plan', async () => {
     const userId = 'user_pending_flush_attachments';
     const sessionId = 'agent_pending_flush_attachments';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
     const attachments = {
       path: '123e4567-e89b-12d3-a456-426614174000',
       files: ['123e4567-e89b-12d3-a456-426614174001.pdf'],
@@ -529,9 +538,7 @@ describe('pending session messages', () => {
   it('keeps queued messages when flush returns an unsuccessful result without throwing', async () => {
     const userId = 'user_pending_flush_unsuccessful';
     const sessionId = 'agent_pending_flush_unsuccessful';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       instance['executeDirectly'] = async () => ({
@@ -580,9 +587,7 @@ describe('pending session messages', () => {
   it('records a failed flush attempt and schedules a delayed retry', async () => {
     const userId = 'user_pending_flush_fail';
     const sessionId = 'agent_pending_flush_fail';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       (instance as any).orchestrator = {
@@ -630,9 +635,7 @@ describe('pending session messages', () => {
   it('does not consume a delivery attempt while physical wrapper cleanup is still in progress', async () => {
     const userId = 'user_pending_cleanup_gate';
     const sessionId = 'agent_pending_cleanup_gate';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let deliveryAttempts = 0;
@@ -712,9 +715,7 @@ describe('pending session messages', () => {
   it('records a retryable sandbox failure when wrapper authorization discovers required cleanup', async () => {
     const userId = 'user_pending_cleanup_discovery';
     const sessionId = 'agent_pending_cleanup_discovery';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let deliveryAttempts = 0;
@@ -796,9 +797,7 @@ describe('pending session messages', () => {
     const userId = 'user_pending_discovery_recovery';
     const sessionId = 'agent_pending_discovery_recovery';
     const messageId = 'msg_018f1e2d3c4bDiscRecoverAbC';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const sharedFailoverRouteKeys: string[] = [];
@@ -857,9 +856,7 @@ describe('pending session messages', () => {
     const sessionId = 'agent_pending_shared_rotation';
     const messageId = 'msg_018f1e2d3c4bSharedRouteAbC';
     const sandboxId = 'usr-000000000000000000000000000000000000000000000000' as const;
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const failoverRouteKeys: string[] = [];
@@ -940,9 +937,7 @@ describe('pending session messages', () => {
     const userId = 'user_pending_terminalization_repair';
     const sessionId = 'agent_pending_terminalization_repair';
     const messageId = 'msg_018f1e2d3c4bTermRepairABCD';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let deliveryAttempts = 0;
@@ -1050,9 +1045,7 @@ describe('pending session messages', () => {
     const userId = 'user_pending_vercel_disabled';
     const sessionId = 'agent_pending_vercel_disabled';
     const messageId = 'msg_018f1e2d3c4bVercelDisabled';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       instance.env.VERCEL_PROJECT_ID = '';
@@ -1116,9 +1109,7 @@ describe('pending session messages', () => {
   it('exhausts failed flush retries, emits cloud.message.failed, and removes the pending message', async () => {
     const userId = 'user_pending_flush_exhaust';
     const sessionId = 'agent_pending_flush_exhaust';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       (instance as any).orchestrator = {
@@ -1189,9 +1180,7 @@ describe('pending session messages', () => {
   it('interrupt clears pending messages and emits cloud.message.failed for each queued message', async () => {
     const userId = 'user_pending_interrupt_clear';
     const sessionId = 'agent_pending_interrupt_clear';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       await registerReadySession(instance, {
@@ -1284,9 +1273,7 @@ describe('pending session messages', () => {
   it('interrupt with pending-only ignores stranded legacy execution identity', async () => {
     const userId = 'user_pending_interrupt_only';
     const sessionId = 'agent_pending_interrupt_only';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -1332,9 +1319,7 @@ describe('pending session messages', () => {
   it('retains queued pending anchors when the interrupted state write fails', async () => {
     const userId = 'user_pending_interrupt_transition_failure';
     const sessionId = 'agent_pending_interrupt_transition_failure';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -1392,9 +1377,7 @@ describe('pending session messages', () => {
   it('retains accepted wrapper ownership when its interrupted state write fails', async () => {
     const userId = 'user_accepted_interrupt_transition_failure';
     const sessionId = 'agent_accepted_interrupt_transition_failure';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -1458,9 +1441,7 @@ describe('pending session messages', () => {
   it('interrupt remains durable when terminal effects and runtime stop fail once', async () => {
     const userId = 'user_pending_interrupt_failure';
     const sessionId = 'agent_pending_interrupt_failure';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -1542,9 +1523,7 @@ describe('pending session messages', () => {
   it('interrupt with accepted work preserves durable physical cleanup when absence cannot be confirmed', async () => {
     const userId = 'user_pending_interrupt_cleanup';
     const sessionId = 'agent_pending_interrupt_cleanup';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -1594,9 +1573,7 @@ describe('pending session messages', () => {
   it('interrupt with accepted work and no live socket fences and requests current wrapper cleanup', async () => {
     const userId = 'user_pending_interrupt_no_socket';
     const sessionId = 'agent_pending_interrupt_no_socket';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const stopped: string[] = [];
@@ -1653,9 +1630,7 @@ describe('pending session messages', () => {
   it('interrupt with a live fenced socket and no accepted work requests cleanup and fences reuse', async () => {
     const userId = 'user_pending_interrupt_idle_wrapper';
     const sessionId = 'agent_pending_interrupt_idle_wrapper';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const sentCommands: unknown[] = [];
@@ -1711,9 +1686,7 @@ describe('pending session messages', () => {
   it('interrupt fences a live wrapper when immediate kill signaling fails', async () => {
     const userId = 'user_pending_interrupt_signal_failure';
     const sessionId = 'agent_pending_interrupt_signal_failure';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const stopped: string[] = [];
@@ -1765,9 +1738,7 @@ describe('pending session messages', () => {
   it('interrupt with a live fenced socket sends kill then fences accepted work', async () => {
     const userId = 'user_pending_interrupt_active';
     const sessionId = 'agent_pending_interrupt_active';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const sentCommands: unknown[] = [];
@@ -1826,9 +1797,7 @@ describe('pending session messages', () => {
   it('ignores late terminal events from the fenced run after current interrupt', async () => {
     const userId = 'user_pending_interrupt_late';
     const sessionId = 'agent_pending_interrupt_late';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -1868,9 +1837,7 @@ describe('pending session messages', () => {
   it('derives accepted current work health from fenced liveness deadlines', async () => {
     const userId = 'user_pending_health_fence';
     const sessionId = 'agent_pending_health_fence';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await putSessionMessageState(instance.ctx.storage, {
@@ -1908,9 +1875,7 @@ describe('pending session messages', () => {
       const userId = `user_pending_health_${kind}`;
       const sessionId = `agent_pending_health_${kind}`;
       const messageId = 'msg_018f1e2d3c4bHealthInputAbC';
-      const stub = env.CLOUD_AGENT_SESSION.get(
-        env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-      );
+      const stub = sessionStub(userId, sessionId);
 
       const result = await runInDurableObject(stub, async instance => {
         const now = Date.now();
@@ -2007,9 +1972,7 @@ describe('pending session messages', () => {
   it('drains a pending current message while another accepted message shares the fenced wrapper run', async () => {
     const userId = 'user_pending_flush_active';
     const sessionId = 'agent_pending_flush_active';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let callCount = 0;
@@ -2103,9 +2066,7 @@ describe('pending session messages', () => {
   it('metadata-not-ready flush keeps pending and schedules retry', async () => {
     const userId = 'user_pending_not_ready';
     const sessionId = 'agent_pending_not_ready';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await instance.updateMetadata({
@@ -2141,9 +2102,7 @@ describe('pending session messages', () => {
   it('accepted execution completion emits cloud.message.completed with messageId and executionId', async () => {
     const userId = 'user_accepted_completed';
     const sessionId = 'agent_accepted_completed';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -2199,9 +2158,7 @@ describe('pending session messages', () => {
   it('suppressed accepted execution completion skips terminal event and callback enqueue', async () => {
     const userId = 'user_accepted_suppressed';
     const sessionId = 'agent_accepted_suppressed';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const sentCallbackJobs: unknown[] = [];
@@ -2256,9 +2213,7 @@ describe('pending session messages', () => {
   it('accepted execution completion callback includes messageId when present', async () => {
     const userId = 'user_accepted_callback_message';
     const sessionId = 'agent_accepted_callback_message';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const sentCallbackJobs: Array<{
@@ -2323,9 +2278,7 @@ describe('pending session messages', () => {
   it('prepared initial execution completion uses the prepared initialMessageId', async () => {
     const userId = 'user_prepared_initial_completed';
     const sessionId = 'agent_prepared_initial_completed';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       (instance as any).orchestrator = {
@@ -2381,9 +2334,7 @@ describe('pending session messages', () => {
   it('accepted execution failure emits cloud.message.failed with accepted marker', async () => {
     const userId = 'user_accepted_failed';
     const sessionId = 'agent_accepted_failed';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -2432,9 +2383,7 @@ describe('pending session messages', () => {
   it('alarm drains the next pending message through current message acceptance', async () => {
     const userId = 'user_pending_completion';
     const sessionId = 'agent_pending_completion';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const acceptedMessageIds: string[] = [];
@@ -2480,9 +2429,7 @@ describe('pending session messages', () => {
   it('does not redeliver exhausted work when terminal effect processing fails once', async () => {
     const userId = 'user_pending_exhaust_repair';
     const sessionId = 'agent_pending_exhaust_repair';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       let deliveryAttempts = 0;
@@ -2550,9 +2497,7 @@ describe('pending session messages', () => {
   it('does not redeliver after exhausted pending disposition survives terminal state put failure', async () => {
     const userId = 'user_pending_exhaust_state_failure';
     const sessionId = 'agent_pending_exhaust_state_failure';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const callbacks: Array<{ payload: { messageId?: string; status: string } }> = [];
@@ -2635,9 +2580,7 @@ describe('pending session messages', () => {
   it('continues a partially failed multi-message interrupt without dispatching captured work', async () => {
     const userId = 'user_pending_interrupt_batch_failure';
     const sessionId = 'agent_pending_interrupt_batch_failure';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let deliveryAttempts = 0;
@@ -2720,9 +2663,7 @@ describe('pending session messages', () => {
   it('enqueues callback-required delivery exhaustion in the terminalization alarm pass', async () => {
     const userId = 'user_pending_exhaust_callback_progress';
     const sessionId = 'agent_pending_exhaust_callback_progress';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const callbacks: Array<{ payload: { messageId?: string; status: string } }> = [];
@@ -2782,9 +2723,7 @@ describe('pending session messages', () => {
   it('terminalizes session message state when delivery retries exhaust', async () => {
     const userId = 'user_pending_exhaust_terminal';
     const sessionId = 'agent_pending_exhaust_terminal';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       (instance as any).orchestrator = {
@@ -2859,9 +2798,7 @@ describe('pending session messages', () => {
   it('terminalizes session message state when queued message is interrupted', async () => {
     const userId = 'user_pending_interrupt_terminal';
     const sessionId = 'agent_pending_interrupt_terminal';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -2934,9 +2871,7 @@ describe('pending session messages', () => {
   it('rejects reuse of a failed message id and admits a fresh identity', async () => {
     const userId = 'user_pending_retry_terminal';
     const sessionId = 'agent_pending_retry_terminal';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, _state) => {
       (instance as any).orchestrator = {
@@ -3015,9 +2950,7 @@ describe('pending session messages', () => {
   it('callback-required failed delivery is visible to listMessagesWithPendingCallbacks', async () => {
     const userId = 'user_pending_callback_visible';
     const sessionId = 'agent_pending_callback_visible';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async (instance, _state) => {
       (instance as any).orchestrator = {

--- a/services/cloud-agent-next/test/integration/session/prepared-admission-control-plane.test.ts
+++ b/services/cloud-agent-next/test/integration/session/prepared-admission-control-plane.test.ts
@@ -10,15 +10,36 @@
  * "Prepared admission is legacy-only" before a transcript exists.
  */
 import { env, runInDurableObject } from 'cloudflare:test';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 const userId = 'oauth/google:prepared-admission-control-plane';
 const kiloSessionId = 'ses_00000000000000000000000000';
 const sandboxId = `usr-${'a'.repeat(48)}` as const;
 const INITIAL_MESSAGE_ID = 'msg_018f1e2d3c4bPrepAdmitAbCdE';
 
+// Admitted messages leave dispatch and alarm work in the session DO. Interrupt
+// each session after its test, or that work finalizes after this file closes
+// and its logs race the vitest worker shutdown as pending onUserConsoleLog
+// rejections.
+const admittedSessions = new Set<`workspace_${string}`>();
+
+afterEach(async () => {
+  for (const sessionId of admittedSessions) {
+    await runInDurableObject(
+      env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`),
+      async (instance, state) => {
+        await instance.interruptExecution();
+        await state.storage.deleteAlarm();
+      }
+    ).catch(() => undefined);
+  }
+  admittedSessions.clear();
+});
+
 function cloudId(): `workspace_${string}` {
-  return `workspace_${crypto.randomUUID()}`;
+  const sessionId = `workspace_${crypto.randomUUID()}` as const;
+  admittedSessions.add(sessionId);
+  return sessionId;
 }
 
 /** Mirrors `buildSessionRegistrationCommand` for the split flow: the initial

--- a/services/cloud-agent-next/test/integration/session/prepared-admission-control-plane.test.ts
+++ b/services/cloud-agent-next/test/integration/session/prepared-admission-control-plane.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Retained legacy two-step flow (prepareSession + initiateFromKilocodeSessionV2)
+ * on a control-plane session.
+ *
+ * services/code-review-infra still chains the two calls, and wrangler dev
+ * defaults CONTROL_PLANE_IDS=* (ENVIRONMENT.md), so a manual review is
+ * registered as a `workspace_` session on SandboxSession. The legacy DO admits
+ * the stored prepared initial turn via CloudAgentSession.admitPreparedInitialMessage;
+ * the control-plane DO must do the same, or every code review fails with
+ * "Prepared admission is legacy-only" before a transcript exists.
+ */
+import { env, runInDurableObject } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+
+const userId = 'oauth/google:prepared-admission-control-plane';
+const kiloSessionId = 'ses_00000000000000000000000000';
+const sandboxId = `usr-${'a'.repeat(48)}` as const;
+const INITIAL_MESSAGE_ID = 'msg_018f1e2d3c4bPrepAdmitAbCdE';
+
+function cloudId(): `workspace_${string}` {
+  return `workspace_${crypto.randomUUID()}`;
+}
+
+/** Mirrors `buildSessionRegistrationCommand` for the split flow: the initial
+ * turn is stored in metadata and admitted only by a later initiate request. */
+function preparedRegistration(sessionId: `workspace_${string}`) {
+  return {
+    identity: { sessionId, userId },
+    auth: { kiloSessionId, kilocodeToken: 'test-session-token' },
+    agent: { mode: 'code', model: 'test-model' },
+    workspace: { sandboxId, sandboxProvider: 'cloudflare' as const },
+    message: {
+      initialMessageId: INITIAL_MESSAGE_ID,
+      turn: {
+        type: 'prompt' as const,
+        id: INITIAL_MESSAGE_ID,
+        prompt: 'prepared review prompt',
+      },
+    },
+  };
+}
+
+describe('SandboxSession prepared initial admission (control plane)', () => {
+  it('admits the stored prepared initial turn for a control-plane session', async () => {
+    const sessionId = cloudId();
+    const stub = env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`);
+
+    const result = await runInDurableObject(stub, async instance => {
+      await instance.registerSession(preparedRegistration(sessionId));
+      const admission = await instance.admitPreparedInitialMessage({ userId });
+      const messages = (await instance.ctx.storage.get('session_messages')) as
+        | { messageId: string; state: string }[]
+        | undefined;
+      return { admission, messages };
+    });
+
+    expect(result.admission.success).toBe(true);
+    if (!result.admission.success) return;
+    expect(result.admission.messageId).toBe(INITIAL_MESSAGE_ID);
+    expect(result.admission.outcome).toBe('queued');
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages?.[0]?.messageId).toBe(INITIAL_MESSAGE_ID);
+  });
+
+  it('replays the admission for a retry of the same initiate request', async () => {
+    const sessionId = cloudId();
+    const stub = env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`);
+
+    const result = await runInDurableObject(stub, async instance => {
+      await instance.registerSession(preparedRegistration(sessionId));
+      const first = await instance.admitPreparedInitialMessage({ userId });
+      const retry = await instance.admitPreparedInitialMessage({ userId });
+      const messages = (await instance.ctx.storage.get('session_messages')) as
+        | { messageId: string }[]
+        | undefined;
+      return { first, retry, messages };
+    });
+
+    expect(result.first.success).toBe(true);
+    expect(result.retry.success).toBe(true);
+    if (!result.first.success || !result.retry.success) return;
+    expect(result.retry.messageId).toBe(result.first.messageId);
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it('replays an already-admitted initial message from the replay probe', async () => {
+    const sessionId = cloudId();
+    const stub = env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`);
+
+    const result = await runInDurableObject(stub, async instance => {
+      await instance.registerSession(preparedRegistration(sessionId));
+      const before = await instance.replayPreparedInitialMessage({ userId });
+      await instance.admitPreparedInitialMessage({ userId });
+      const after = await instance.replayPreparedInitialMessage({ userId });
+      return { before, after };
+    });
+
+    expect(result.before).toBeUndefined();
+    expect(result.after?.success).toBe(true);
+    if (!result.after || !result.after.success) return;
+    expect(result.after.messageId).toBe(INITIAL_MESSAGE_ID);
+  });
+
+  it('reports no prompt for a prepared session without a stored initial turn', async () => {
+    const sessionId = cloudId();
+    const stub = env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`);
+
+    const result = await runInDurableObject(stub, async instance => {
+      await instance.registerSession({
+        identity: { sessionId, userId },
+        auth: { kiloSessionId, kilocodeToken: 'test-session-token' },
+        agent: { mode: 'code', model: 'test-model' },
+        workspace: { sandboxId, sandboxProvider: 'cloudflare' as const },
+      });
+      return instance.admitPreparedInitialMessage({ userId });
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe('BAD_REQUEST');
+  });
+});

--- a/services/cloud-agent-next/test/integration/session/prepared-admission-control-plane.test.ts
+++ b/services/cloud-agent-next/test/integration/session/prepared-admission-control-plane.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Retained legacy two-step flow (prepareSession + initiateFromKilocodeSessionV2)
+ * on a control-plane session.
+ *
+ * services/code-review-infra still chains the two calls, and wrangler dev
+ * defaults CONTROL_PLANE_IDS=* (ENVIRONMENT.md), so a manual review is
+ * registered as a `workspace_` session on SandboxSession. The legacy DO admits
+ * the stored prepared initial turn via CloudAgentSession.admitPreparedInitialMessage;
+ * the control-plane DO must do the same, or every code review fails with
+ * "Prepared admission is legacy-only" before a transcript exists.
+ */
+import { env, runInDurableObject } from 'cloudflare:test';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const userId = 'oauth/google:prepared-admission-control-plane';
+const kiloSessionId = 'ses_00000000000000000000000000';
+const sandboxId = `usr-${'a'.repeat(48)}` as const;
+const INITIAL_MESSAGE_ID = 'msg_018f1e2d3c4bPrepAdmitAbCdE';
+
+// Admitted messages leave dispatch and alarm work in the session DO. Interrupt
+// each session after its test, or that work finalizes after this file closes
+// and its logs race the vitest worker shutdown as pending onUserConsoleLog
+// rejections.
+const admittedSessions = new Set<`workspace_${string}`>();
+
+afterEach(async () => {
+  for (const sessionId of admittedSessions) {
+    await runInDurableObject(
+      env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`),
+      async (instance, state) => {
+        await instance.interruptExecution();
+        await state.storage.deleteAlarm();
+      }
+    ).catch(() => undefined);
+  }
+  admittedSessions.clear();
+});
+
+function cloudId(): `workspace_${string}` {
+  const sessionId = `workspace_${crypto.randomUUID()}` as const;
+  admittedSessions.add(sessionId);
+  return sessionId;
+}
+
+/** Mirrors `buildSessionRegistrationCommand` for the split flow: the initial
+ * turn is stored in metadata and admitted only by a later initiate request. */
+function preparedRegistration(sessionId: `workspace_${string}`) {
+  return {
+    identity: { sessionId, userId },
+    auth: { kiloSessionId, kilocodeToken: 'test-session-token' },
+    agent: { mode: 'code', model: 'test-model' },
+    workspace: { sandboxId, sandboxProvider: 'cloudflare' as const },
+    message: {
+      initialMessageId: INITIAL_MESSAGE_ID,
+      turn: {
+        type: 'prompt' as const,
+        id: INITIAL_MESSAGE_ID,
+        prompt: 'prepared review prompt',
+      },
+    },
+  };
+}
+
+describe('SandboxSession prepared initial admission (control plane)', () => {
+  it('admits the stored prepared initial turn for a control-plane session', async () => {
+    const sessionId = cloudId();
+    const stub = env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`);
+
+    const result = await runInDurableObject(stub, async instance => {
+      await instance.registerSession(preparedRegistration(sessionId));
+      const admission = await instance.admitPreparedInitialMessage({ userId });
+      const messages = (await instance.ctx.storage.get('session_messages')) as
+        | { messageId: string; state: string }[]
+        | undefined;
+      return { admission, messages };
+    });
+
+    expect(result.admission.success).toBe(true);
+    if (!result.admission.success) return;
+    expect(result.admission.messageId).toBe(INITIAL_MESSAGE_ID);
+    expect(result.admission.outcome).toBe('queued');
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages?.[0]?.messageId).toBe(INITIAL_MESSAGE_ID);
+  });
+
+  it('replays the admission for a retry of the same initiate request', async () => {
+    const sessionId = cloudId();
+    const stub = env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`);
+
+    const result = await runInDurableObject(stub, async instance => {
+      await instance.registerSession(preparedRegistration(sessionId));
+      const first = await instance.admitPreparedInitialMessage({ userId });
+      const retry = await instance.admitPreparedInitialMessage({ userId });
+      const messages = (await instance.ctx.storage.get('session_messages')) as
+        | { messageId: string }[]
+        | undefined;
+      return { first, retry, messages };
+    });
+
+    expect(result.first.success).toBe(true);
+    expect(result.retry.success).toBe(true);
+    if (!result.first.success || !result.retry.success) return;
+    expect(result.retry.messageId).toBe(result.first.messageId);
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it('replays an already-admitted initial message from the replay probe', async () => {
+    const sessionId = cloudId();
+    const stub = env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`);
+
+    const result = await runInDurableObject(stub, async instance => {
+      await instance.registerSession(preparedRegistration(sessionId));
+      const before = await instance.replayPreparedInitialMessage({ userId });
+      await instance.admitPreparedInitialMessage({ userId });
+      const after = await instance.replayPreparedInitialMessage({ userId });
+      return { before, after };
+    });
+
+    expect(result.before).toBeUndefined();
+    expect(result.after?.success).toBe(true);
+    if (!result.after || !result.after.success) return;
+    expect(result.after.messageId).toBe(INITIAL_MESSAGE_ID);
+  });
+
+  it('reports no prompt for a prepared session without a stored initial turn', async () => {
+    const sessionId = cloudId();
+    const stub = env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`);
+
+    const result = await runInDurableObject(stub, async instance => {
+      await instance.registerSession({
+        identity: { sessionId, userId },
+        auth: { kiloSessionId, kilocodeToken: 'test-session-token' },
+        agent: { mode: 'code', model: 'test-model' },
+        workspace: { sandboxId, sandboxProvider: 'cloudflare' as const },
+      });
+      return instance.admitPreparedInitialMessage({ userId });
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe('BAD_REQUEST');
+  });
+});

--- a/services/cloud-agent-next/test/integration/session/push-notifications.test.ts
+++ b/services/cloud-agent-next/test/integration/session/push-notifications.test.ts
@@ -1,6 +1,6 @@
 import { env, runInDurableObject, SELF } from 'cloudflare:test';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 
 import type { CloudAgentSession } from '../../../src/persistence/CloudAgentSession.js';
 import { createEventQueries } from '../../../src/session/queries/events.js';
@@ -23,8 +23,7 @@ const BATCH_REPRESENTATIVE_MESSAGE_ID = 'msg_018f1e2d3c4bBatchNewestMsg';
 
 async function createSession(userId: string) {
   const sessionId = `agent_${crypto.randomUUID()}`;
-  const id = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-  return { sessionId, stub: env.CLOUD_AGENT_SESSION.get(id) };
+  return { sessionId, stub: sessionStub(userId, sessionId) };
 }
 
 async function getNotificationJobs(): Promise<unknown> {
@@ -116,6 +115,40 @@ async function seedAssistantText(
     entityId: `part/${assistantMessageId}/part_push_response_0001`,
   });
 }
+
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
 
 describe('CloudAgentSession push notification producer', () => {
   beforeEach(async () => {

--- a/services/cloud-agent-next/test/integration/session/session-id-parsing.test.ts
+++ b/services/cloud-agent-next/test/integration/session/session-id-parsing.test.ts
@@ -6,15 +6,48 @@
  */
 
 import { env, runInDurableObject } from 'cloudflare:test';
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { groupedRegisterSessionInput } from '../../helpers/session-setup.js';
+
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
 
 describe('CloudAgentSession sessionId parsing from DO name', () => {
   it('extracts sessionId correctly when userId contains a colon (OAuth provider)', async () => {
     const userId = 'oauth/google:103883072551006019454';
     const sessionId = 'agent_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       return instance.registerSession(
@@ -35,8 +68,7 @@ describe('CloudAgentSession sessionId parsing from DO name', () => {
   it('extracts sessionId correctly when userId has no colon', async () => {
     const userId = 'user_simple';
     const sessionId = 'agent_11111111-2222-3333-4444-555555555555';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       return instance.registerSession(
@@ -57,8 +89,7 @@ describe('CloudAgentSession sessionId parsing from DO name', () => {
   it('stores the correct sessionId in metadata (not the userId fragment)', async () => {
     const userId = 'oauth/github:99999';
     const sessionId = 'agent_metadata-check';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const metadata = await runInDurableObject(stub, async instance => {
       await instance.registerSession(

--- a/services/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
+++ b/services/cloud-agent-next/test/integration/session/start-execution-v2.test.ts
@@ -4,7 +4,7 @@
 
 import { env, runInDurableObject } from 'cloudflare:test';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import {
   createPendingSessionMessage,
   listPendingSessionMessages,
@@ -21,13 +21,44 @@ import {
   registerReadySession,
 } from '../../helpers/session-setup.js';
 
+// Registered sessions leave dispatch and alarm work in the session DO. Interrupt
+// every session a test touched and clear its alarm, or that work wakes after
+// this file closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('CloudAgentSession message admission', () => {
   it('persists a readable default branch before preparation and retains it on registration retry', async () => {
     const userId = 'user_readable_branch';
     const sessionId = 'agent_readable_branch';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
     const input = groupedRegisterSessionInput({
       sessionId,
       userId,
@@ -56,9 +87,7 @@ describe('CloudAgentSession message admission', () => {
     async branch => {
       const userId = 'user_explicit_branch';
       const sessionId = `agent_explicit_branch_${branch.replaceAll('/', '_')}`;
-      const stub = env.CLOUD_AGENT_SESSION.get(
-        env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-      );
+      const stub = sessionStub(userId, sessionId);
 
       const result = await stub.registerSession(
         groupedRegisterSessionInput({
@@ -83,8 +112,7 @@ describe('CloudAgentSession message admission', () => {
     const userId = 'user_grouped_start' as const;
     const sessionId = 'agent_grouped_start' as const;
     const messageId = 'msg_018f1e2d3c4bInitMsgAbCdEfG';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const admitted = await instance.createSessionWithInitialAdmission({
@@ -130,9 +158,7 @@ describe('CloudAgentSession message admission', () => {
       path: '123e4567-e89b-12d3-a456-426614174000',
       files: ['123e4567-e89b-12d3-a456-426614174001.pdf'],
     };
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const admitted = await instance.createSessionWithInitialAdmission({
@@ -164,9 +190,7 @@ describe('CloudAgentSession message admission', () => {
   it('rejects registration metadata with an untyped repository', async () => {
     const userId = 'user_untyped_repository' as const;
     const sessionId = 'agent_untyped_repository' as const;
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const registration = await instance.registerSession({
@@ -199,8 +223,7 @@ describe('CloudAgentSession message admission', () => {
   it('persists Vercel provider selection without obsolete ownership control state', async () => {
     const userId = 'user_vercel_selection' as const;
     const sessionId = 'agent_vercel_selection' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const registration = await instance.registerSession({
@@ -231,9 +254,7 @@ describe('CloudAgentSession message admission', () => {
   it('finalizes inert Vercel deletion because disabled runtime integration could not create a resource', async () => {
     const userId = 'user_vercel_inert_delete' as const;
     const sessionId = 'agent_vercel_inert_delete' as const;
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await instance.registerSession({
@@ -258,9 +279,7 @@ describe('CloudAgentSession message admission', () => {
   });
 
   it('purges large Vercel payloads in bounded batches before exact-session stop', async () => {
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName('user_vercel_purge:agent_vercel_purge')
-    );
+    const stub = sessionStub('user_vercel_purge', 'agent_vercel_purge');
 
     const result = await runInDurableObject(stub, async instance => {
       await instance.registerSession({
@@ -380,9 +399,7 @@ describe('CloudAgentSession message admission', () => {
   });
 
   it('settles a lost exact-session stop response through terminal inspection', async () => {
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName('user_vercel_stop_loss:agent_vercel_stop_loss')
-    );
+    const stub = sessionStub('user_vercel_stop_loss', 'agent_vercel_stop_loss');
 
     const result = await runInDurableObject(stub, async instance => {
       await instance.registerSession({
@@ -429,9 +446,7 @@ describe('CloudAgentSession message admission', () => {
   });
 
   it('adopts a matching late create and stops only its exact session', async () => {
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName('user_vercel_late_create:agent_vercel_late_create')
-    );
+    const stub = sessionStub('user_vercel_late_create', 'agent_vercel_late_create');
 
     const result = await runInDurableObject(stub, async instance => {
       await instance.registerSession({
@@ -485,12 +500,8 @@ describe('CloudAgentSession message admission', () => {
   });
 
   it('routes explicit and retention Cloudflare deletion through the DO sandbox lifecycle owner', async () => {
-    const explicitStub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName('user_cf_explicit_delete:agent_cf_explicit_delete')
-    );
-    const retentionStub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName('user_cf_retention_delete:agent_cf_retention_delete')
-    );
+    const explicitStub = sessionStub('user_cf_explicit_delete', 'agent_cf_explicit_delete');
+    const retentionStub = sessionStub('user_cf_retention_delete', 'agent_cf_retention_delete');
 
     const reasons = await runInDurableObject(explicitStub, async instance => {
       await instance.registerSession(
@@ -539,9 +550,7 @@ describe('CloudAgentSession message admission', () => {
   });
 
   it('reconciles committed Cloudflare deletion intent and retains it until cleanup succeeds', async () => {
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName('user_cf_intent_recovery:agent_cf_intent_recovery')
-    );
+    const stub = sessionStub('user_cf_intent_recovery', 'agent_cf_intent_recovery');
 
     const result = await runInDurableObject(stub, async instance => {
       await instance.registerSession({
@@ -587,8 +596,7 @@ describe('CloudAgentSession message admission', () => {
   it('keeps Cloudflare registration free of Vercel runtime state', async () => {
     const userId = 'user_cloudflare_selection' as const;
     const sessionId = 'agent_cloudflare_selection' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const workspace = await runInDurableObject(stub, async instance => {
       await instance.registerSession({
@@ -614,8 +622,7 @@ describe('CloudAgentSession message admission', () => {
   it('surfaces initial admission failure after retaining registered DO metadata', async () => {
     const userId = 'user_grouped_start_failure' as const;
     const sessionId = 'agent_grouped_start_failure' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       for (let index = 0; index < 10; index++) {
@@ -662,8 +669,7 @@ describe('CloudAgentSession message admission', () => {
     const userId = 'user_grouped_start_retry' as const;
     const sessionId = 'agent_grouped_start_retry' as const;
     const messageId = 'msg_018f1e2d3c4bBoundMsgAbCdEf';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
     const input = {
       ...groupedRegisterSessionInput({
         sessionId,
@@ -708,8 +714,7 @@ describe('CloudAgentSession message admission', () => {
     const userId = 'user_provider_replay' as const;
     const sessionId = 'agent_provider_replay' as const;
     const messageId = 'msg_018f1e2d3c4bBoundMsgAbCdEf';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const initialInput = {
@@ -753,8 +758,7 @@ describe('CloudAgentSession message admission', () => {
   it('rejects metadata updates that attempt to change a registered sandbox provider', async () => {
     const userId = 'user_provider_update' as const;
     const sessionId = 'agent_provider_update' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await instance.registerSession({
@@ -792,9 +796,7 @@ describe('CloudAgentSession message admission', () => {
   });
 
   it('rejects metadata updates that replace sandbox name or persisted Vercel session ID', async () => {
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName('user_runtime_identity:agent_runtime_identity')
-    );
+    const stub = sessionStub('user_runtime_identity', 'agent_runtime_identity');
 
     const result = await runInDurableObject(stub, async instance => {
       await instance.registerSession({
@@ -847,8 +849,7 @@ describe('CloudAgentSession message admission', () => {
     const userId = 'user_grouped_start_mismatch' as const;
     const sessionId = 'agent_grouped_start_mismatch' as const;
     const messageId = 'msg_018f1e2d3c4bMismatAbCdEfGh';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const original = {
@@ -889,9 +890,7 @@ describe('CloudAgentSession message admission', () => {
     const messageId = 'msg_018f1e2d3c4bRouteMAbCdEfGh';
     const routeKey = 'usr-000000000000000000000000000000000000000000000000' as const;
     const sandboxId = 'usr-b4593afcaf2e9e1dfb1611150b786cfe8aeba3c77352a3df' as const;
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
     const base = groupedRegisterSessionInput({
       sessionId,
       userId,
@@ -943,9 +942,7 @@ describe('CloudAgentSession message admission', () => {
     const sessionId = 'agent_shared_route_ready_mismatch' as const;
     const routeKey = 'usr-000000000000000000000000000000000000000000000000' as const;
     const sandboxId = 'usr-b4593afcaf2e9e1dfb1611150b786cfe8aeba3c77352a3df' as const;
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       const registration = await instance.registerSession({
@@ -989,9 +986,7 @@ describe('CloudAgentSession message admission', () => {
     const userId = 'user_invalid_shared_route' as const;
     const sessionId = 'agent_invalid_shared_route' as const;
     const routeKey = 'usr-000000000000000000000000000000000000000000000000' as const;
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`)
-    );
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, instance =>
       instance.registerSession({
@@ -1024,8 +1019,7 @@ describe('CloudAgentSession message admission', () => {
   it('persists repaired DIND devcontainer workspace readiness metadata', async () => {
     const userId = 'user_devcontainer_ready' as const;
     const sessionId = 'agent_devcontainer_ready' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
     const devcontainer = {
       workspacePath: '/workspace/user/sessions/agent_devcontainer_ready',
       innerWorkspaceFolder: '/workspaces/repo',
@@ -1066,8 +1060,7 @@ describe('CloudAgentSession message admission', () => {
   it('drains prepared devcontainer sessions with their persisted DIND workspace plan', async () => {
     const userId = 'user_devcontainer_plan' as const;
     const sessionId = 'agent_devcontainer_plan' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let capturedPlan: any = null;
@@ -1120,8 +1113,7 @@ describe('CloudAgentSession message admission', () => {
   it('queues initiate when direct wrapper acceptance is unavailable', async () => {
     const userId = 'user_exec_plan' as const;
     const sessionId = 'agent_exec_plan' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let capturedPlan: any = null;
@@ -1168,8 +1160,7 @@ describe('CloudAgentSession message admission', () => {
   it('queues follow-up without calling orchestrator inline', async () => {
     const userId = 'user_exec_followup' as const;
     const sessionId = 'agent_exec_followup' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let capturedPlan: any = null;
@@ -1221,8 +1212,7 @@ describe('CloudAgentSession message admission', () => {
   it('flushes queued follow-up using the originally queued execution options', async () => {
     const userId = 'user_exec_followup_options' as const;
     const sessionId = 'agent_exec_followup_options' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let capturedPlan: any = null;
@@ -1313,8 +1303,7 @@ describe('CloudAgentSession message admission', () => {
   it('returns BAD_REQUEST for invalid direct messageId', async () => {
     const userId = 'user_exec_bad_message_id' as const;
     const sessionId = 'agent_exec_bad_message_id' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let capturedPlan: any = null;
@@ -1358,8 +1347,7 @@ describe('CloudAgentSession message admission', () => {
   it('uses the boundary-generated messageId for follow-up execution', async () => {
     const userId = 'user_exec_fallback' as const;
     const sessionId = 'agent_exec_fallback' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let capturedPlan: any = null;
@@ -1405,8 +1393,7 @@ describe('CloudAgentSession message admission', () => {
   it('enforces the pending queue limit without storing an eleventh message', async () => {
     const userId = 'user_exec_queue_full' as const;
     const sessionId = 'agent_exec_queue_full' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -1470,8 +1457,7 @@ describe('CloudAgentSession message admission', () => {
   it('queues a prepared-session message without tripping on stale runtime state', async () => {
     const userId = 'user_exec_prepared_stale_active' as const;
     const sessionId = 'agent_exec_prepared_stale_active' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let callCount = 0;
@@ -1519,8 +1505,7 @@ describe('CloudAgentSession message admission', () => {
     const userId = 'user_exec_prepared_initial_id' as const;
     const sessionId = 'agent_exec_prepared_initial_id' as const;
     const initialMessageId = 'msg_018f1e2d3c4bPrepInitAbCdEF';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -1561,8 +1546,7 @@ describe('CloudAgentSession message admission', () => {
     const userId = 'user_exec_prepared_id_wins' as const;
     const sessionId = 'agent_exec_prepared_id_wins' as const;
     const initialMessageId = 'msg_018f1e2d3c4bPrepWinsAbCdEF';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -1595,8 +1579,7 @@ describe('CloudAgentSession message admission', () => {
     const userId = 'user_exec_prepared_command' as const;
     const sessionId = 'agent_exec_prepared_command' as const;
     const initialMessageId = 'msg_018f1e2d3c4bPrepCmdXAbCdEF';
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -1644,8 +1627,7 @@ describe('CloudAgentSession message admission', () => {
   it('queues follow-up for later drain while current fenced wrapper work exists', async () => {
     const userId = 'user_exec_active_followup' as const;
     const sessionId = 'agent_exec_active_followup' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let callCount = 0;
@@ -1694,8 +1676,7 @@ describe('CloudAgentSession message admission', () => {
   it('returns durable admission idempotently when retrying an accepted messageId', async () => {
     const userId = 'user_exec_active_retry' as const;
     const sessionId = 'agent_exec_active_retry' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       let callCount = 0;
@@ -1746,8 +1727,7 @@ describe('CloudAgentSession message admission', () => {
   it('does not persist token overrides when model validation fails', async () => {
     const userId = 'user_exec_invalid_model' as const;
     const sessionId = 'agent_exec_invalid_model' as const;
-    const doId = env.CLOUD_AGENT_SESSION.idFromName(`${userId}:${sessionId}`);
-    const stub = env.CLOUD_AGENT_SESSION.get(doId);
+    const stub = sessionStub(userId, sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {

--- a/services/cloud-agent-next/test/integration/session/tool-loop-terminalization.test.ts
+++ b/services/cloud-agent-next/test/integration/session/tool-loop-terminalization.test.ts
@@ -1,6 +1,6 @@
 import { env, listDurableObjectIds, runInDurableObject } from 'cloudflare:test';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import type { CloudAgentSession } from '../../../src/persistence/CloudAgentSession.js';
 import { createEventQueries } from '../../../src/session/queries/events.js';
 import {
@@ -102,6 +102,40 @@ function completedEvents(state: DurableObjectState) {
   });
 }
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('tool-loop terminalization replay', () => {
   beforeEach(resetSessions);
 
@@ -115,9 +149,7 @@ describe('tool-loop terminalization replay', () => {
   for (const fixture of reconstructedToolLoopTurnFixtures) {
     it(`settles ${fixture.label} to the final assistant only after wrapper completion`, async () => {
       const sessionId = `agent_synthetic_${fixture.label}`;
-      const stub = env.CLOUD_AGENT_SESSION.get(
-        env.CLOUD_AGENT_SESSION.idFromName(`user_${fixture.label}:${sessionId}`)
-      );
+      const stub = sessionStub(`user_${fixture.label}`, sessionId);
 
       const result = await runInDurableObject(stub, async (instance, state) => {
         const wrapperState = await seedAcceptedTurn(instance, fixture, sessionId);
@@ -183,9 +215,7 @@ describe('tool-loop terminalization replay', () => {
     const fixture = reconstructedToolLoopTurnFixtures[0];
     if (!fixture) throw new Error('Expected a reconstructed tool-loop fixture');
     const sessionId = 'agent_synthetic_bare_complete';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`user_synthetic_bare_complete:${sessionId}`)
-    );
+    const stub = sessionStub('user_synthetic_bare_complete', sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       const wrapperState = await seedAcceptedTurn(instance, fixture, sessionId);
@@ -219,9 +249,7 @@ describe('tool-loop terminalization replay', () => {
     const fixture = reconstructedToolLoopTurnFixtures[0];
     if (!fixture) throw new Error('Expected a reconstructed tool-loop fixture');
     const sessionId = 'agent_synthetic_legacy_complete_race';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`user_synthetic_legacy_complete_race:${sessionId}`)
-    );
+    const stub = sessionStub('user_synthetic_legacy_complete_race', sessionId);
 
     const result = await runInDurableObject(stub, async instance => {
       await registerReadySession(instance, {
@@ -287,9 +315,7 @@ describe('tool-loop terminalization replay', () => {
     const fixture = reconstructedToolLoopTurnFixtures[1];
     if (!fixture) throw new Error('Expected a reconstructed tool-loop fixture');
     const sessionId = 'agent_synthetic_no_idle_fallback';
-    const stub = env.CLOUD_AGENT_SESSION.get(
-      env.CLOUD_AGENT_SESSION.idFromName(`user_synthetic_no_idle_fallback:${sessionId}`)
-    );
+    const stub = sessionStub('user_synthetic_no_idle_fallback', sessionId);
 
     const result = await runInDurableObject(stub, async (instance, state) => {
       const wrapperState = await seedAcceptedTurn(instance, fixture, sessionId);

--- a/services/cloud-agent-next/test/integration/worktree-deletion.test.ts
+++ b/services/cloud-agent-next/test/integration/worktree-deletion.test.ts
@@ -1,7 +1,7 @@
 import { env, runInDurableObject } from 'cloudflare:test';
 import type { CloudAgentWorktreeId } from '@kilocode/session-ingest-contracts';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { getWorktreeWorkspacePath } from '../../src/workspace';
 import { events } from '../../src/db/sqlite-schema';
 import {
@@ -310,6 +310,40 @@ function reply(socket: WebSocket, frame: RequestFrame, result: unknown, ok = tru
   );
 }
 
+// Registered sessions leave dispatch, alarm, and fire-and-forget publication
+// work in the session DO. Interrupt every session a test touched, clear its
+// alarm, and drain its publication tail, or that work wakes after this file
+// closes and its logs race the vitest worker shutdown as pending
+// onUserConsoleLog rejections (EnvironmentTeardownError).
+const touchedSessions = new Set<string>();
+
+function sessionStub(userId: string, sessionId: string) {
+  const sessionName = `${userId}:${sessionId}`;
+  touchedSessions.add(sessionName);
+  return env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName));
+}
+
+afterEach(async () => {
+  for (const sessionName of touchedSessions) {
+    await runInDurableObject(
+      env.CLOUD_AGENT_SESSION.get(env.CLOUD_AGENT_SESSION.idFromName(sessionName)),
+      async (instance, state) => {
+        try {
+          await instance.interruptExecution();
+        } catch {
+          // A session that never registered has no work to interrupt.
+        }
+        await state.storage.deleteAlarm();
+        const publicationTail = (instance as any).publicExtensionPublicationTail as
+          | Promise<unknown>
+          | undefined;
+        await publicationTail?.catch(() => undefined);
+      }
+    ).catch(() => undefined);
+  }
+  touchedSessions.clear();
+});
+
 describe('worktree deletion in Durable Objects', () => {
   it('retains never-run child lineage for cold deletion when scoped publication fails', async () => {
     const sessionId = cloudId();
@@ -395,7 +429,7 @@ describe('worktree deletion in Durable Objects', () => {
       const sandboxId = `usr-${crypto.randomUUID().replaceAll('-', '').padEnd(48, '0')}`;
       const otherSandboxId = `usr-${'d'.repeat(48)}`;
       const legacyId = `agent_${crypto.randomUUID()}`;
-      const legacy = env.CLOUD_AGENT_SESSION.getByName(`${userId}:${legacyId}`);
+      const legacy = sessionStub(userId, legacyId);
       await runInDurableObject(legacy, async (instance, state) => {
         await state.storage.put({
           metadata: {

--- a/services/cloud-agent-next/test/unit/wrapper/server.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/server.test.ts
@@ -831,7 +831,7 @@ describe('createPromptHandler', () => {
 
     expect(response.status).toBe(200);
     expect(commitMessage.stdout).toContain(BOT_CO_AUTHOR_TRAILER);
-  });
+  }, 15_000);
 
   it('chains existing hooks and suppresses co-authorship when the bot becomes primary author', async () => {
     const repoPath = await createRepo();
@@ -911,7 +911,7 @@ describe('createPromptHandler', () => {
     expect(fallbackMessage.stdout).not.toContain(BOT_CO_AUTHOR_TRAILER);
     expect(fallbackMessage.stdout).toContain('Existing-hook: applied');
     expect(configuredHooksPath.stdout.trim()).toContain('kilo-managed-hooks');
-  });
+  }, 15_000);
 
   it('keeps repository pre-commit hooks active while adding co-authorship', async () => {
     const repoPath = await createRepo();
@@ -948,7 +948,7 @@ describe('createPromptHandler', () => {
 
     expect(response.status).toBe(200);
     expect(commitExitCode).not.toBe(0);
-  });
+  }, 15_000);
 
   it('delegates repository hooks created after attribution is configured', async () => {
     const repoPath = await createRepo();
@@ -985,7 +985,7 @@ describe('createPromptHandler', () => {
 
     expect(response.status).toBe(200);
     expect(commitExitCode).not.toBe(0);
-  });
+  }, 15_000);
 
   it('fails closed when managed hook state is missing from an active private hook path', async () => {
     const repoPath = await createRepo();
@@ -1007,7 +1007,7 @@ describe('createPromptHandler', () => {
       timeoutMs: 5_000,
     });
     expect(configuredHooksPath.stdout.trim()).toBe(managedHooksPath);
-  });
+  }, 15_000);
 
   it('rejects the old flat prompt body', async () => {
     const state = new WrapperState();


### PR DESCRIPTION
## Changelog for users
- The live review transcript now streams and renders the assistant's text in real time on the mobile app while a review session runs.
- A manual review that cannot reach the code review service now ends in a retryable failure instead of staying on "Queued" with the transcript sheet stuck on "Waiting for the review transcript".
- A failed review's error dump is clamped to a bounded height so the "Retry review" action stays on screen.

## Changelog for maintainers
- `apps/mobile/src/components/code-reviewer/review-spectator-rows.ts`: assistant text parts from the cloud-agent stream no longer require a completed `state` field to render; canonical live text parts carry only `time`, and rows are replaced in place by part id as they grow.
- `services/cloud-agent-next/src/sandbox-session/SandboxSession.ts`: the control-plane DO now admits the stored prepared initial turn through the durable queue instead of returning "Prepared admission is legacy-only", and `replayPreparedInitialMessage` replays an already-admitted turn for retries.
- `apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts`: a worker `ECONNREFUSED` on both the dispatch and the status probe now fails a manual review with terminal reason `upstream_error`; webhook reviews stay `queued` for the stale-queued cron recovery.
- Added integration coverage for control-plane prepared admission, unit coverage for spectator text-part rendering, dispatch connection-refused coverage, and clamped error-dump coverage.
- `services/cloud-agent-next/test/unit/wrapper/server.test.ts`: raised several hook-handling test timeouts to 15s.

## Changes by area
- **Mobile code-reviewer (`apps/mobile/src/components/code-reviewer/`)**: the root transcript defect was in `review-spectator-rows.ts`, which gated text parts on a completed status that live stream parts never carry, dropping every assistant row while the review ran. The gate was removed so text streams and updates in place; the failure-dump block was also clamped to `numberOfLines={4}` so the retry action stays reachable. Mounted and unit tests cover streaming, in-place updates, terminal-state copy, and the clamped dump.
- **Web dispatch (`apps/web/src/lib/code-reviews/dispatch/`)**: manual reviews stranded on "Queued" when the worker refused both the dispatch and the status probe are now failed as retryable `upstream_error` failures; webhook reviews keep the stale-queued recovery. A helper detects the undici `fetch failed`/`ECONNREFUSED` cause chain.
- **Cloud agent session (`services/cloud-agent-next/src/sandbox-session/` + integration test)**: the control-plane SandboxSession now implements the retained legacy two-step prepared admission flow (register then initiate), admitting the stored initial turn via the same queue as submitted messages, so a manual review produces a transcript instead of failing with "Prepared admission is legacy-only". Integration tests cover admission, idempotent retries, the replay probe, and the missing-turn error.
- **Cloud agent wrapper tests (`services/cloud-agent-next/test/unit/wrapper/`)**: hook-handling tests got explicit 15s timeouts.

## E2E proof
4 checks passed: `backend`, `mobile-app` (mobile-device verifier passed; spot check clean), and `web`.

**Recording of the verified flow** (waits trimmed)

https://github.com/user-attachments/assets/14e9527e-6b1f-45c2-a3e3-5c252ae5b048

## Pre-existing UX defects observed (not changed here)
- 01-login-request-code.png — The blue “Refreshing…” bar overlaps and clips the KILO logo on the verify-code screen.
- e1-review-status.png — The failure tile dumps a raw stack trace that is clipped by the tab bar.
- review detail — raw TRPC stack dump fills the screen and pushes Retry review below the fold (e1-review-status.png).