### PR TITLE
fix(cloud-agent-next): isolate observation from liveness

### DIFF
--- a/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
+++ b/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
@@ -79,6 +79,12 @@ import { getSandboxControlStub } from '../sandbox-control/stub.js';
 import { DEADLINE_MS } from '../sandbox-control/deadlines.js';
 import { createMessageId } from '../session/message-id.js';
 import { validateControlSessionOptions } from './attach-payload.js';
+import { pendingInputProjection } from './session-input-projection.js';
+import {
+  createInteractionRefresh,
+  type InteractionRefresh,
+  type InteractionRefreshScope,
+} from './session-interaction-refresh.js';
 import {
   createWorktreeChanges,
   worktreeChangesContext,
@@ -206,6 +212,7 @@ export class SandboxSession extends DurableObject<Env> {
   private readonly activeOperations = new Set<Promise<unknown>>();
   private deletionCompletion: Promise<void> | undefined;
   private readonly worktreeChanges: ReturnType<typeof createWorktreeChanges>;
+  private readonly interactionRefresh: InteractionRefresh;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -290,6 +297,15 @@ export class SandboxSession extends DurableObject<Env> {
         ),
       waitUntil: promise => this.ctx.waitUntil(promise),
     });
+    this.interactionRefresh = createInteractionRefresh({
+      captureScope: () => this.captureInteractionScope(),
+      sync: (scope, trigger) => this.syncAcceptedMessage(scope, trigger),
+      onBackgroundError: () => {
+        logger
+          .withFields({ sessionId: this.sessionId })
+          .warn('Pending interaction sync unavailable');
+      },
+    });
     void ctx.blockConcurrencyWhile(async () => {
       await migrate(db, migrations);
       this.deletedWorktreeId = cloudAgentWorktreeIdSchema
@@ -314,7 +330,7 @@ export class SandboxSession extends DurableObject<Env> {
     const handler = createStreamHandler(this.ctx, this.eventQueries, sessionId, {
       deriveCloudStatus: () => this.deriveCloudStatus(),
       deriveQueuedMessages: () => this.deriveQueuedMessages(),
-      derivePendingInteractions: () => this.derivePendingInteractions(),
+      readPendingInteractions: () => this.derivePendingInteractions(),
       deriveSessionStatus: async () =>
         hasAcceptedMessage(this.loadMessages())
           ? { type: 'busy' as const }
@@ -1270,6 +1286,7 @@ export class SandboxSession extends DurableObject<Env> {
         now,
         accepted.lastActivityAt
       );
+      const scope = this.captureInteractionScope();
       await this.armQueueRetry(
         decision.action === 'rearm' ? decision.at : now + DEADLINE_MS.acceptedAlarmCap
       );
@@ -1292,8 +1309,12 @@ export class SandboxSession extends DurableObject<Env> {
           );
         logControlDiagnostic('accepted_reconciliation', { ...diagnostic, phase: 'started' });
         try {
-          const snapshot = await this.syncAcceptedMessage(accepted, epoch, 'accepted_alarm');
-          if (!snapshot || !this.isCurrentAcceptedMessage(accepted, epoch)) {
+          const snapshot = await this.interactionRefresh.refresh(scope, 'accepted_alarm');
+          if (
+            !snapshot ||
+            !scope ||
+            !this.interactionRefresh.isCurrent(scope, (scope.interactionRevision ?? 0) + 1)
+          ) {
             diagnostic.reason = snapshot ? 'accepted_message_changed' : 'sync_superseded';
             report('superseded');
             return;
@@ -2056,11 +2077,36 @@ export class SandboxSession extends DurableObject<Env> {
     return current?.state === 'accepted' && current.wrapperInstanceId === message.wrapperInstanceId;
   }
 
+  private captureInteractionScope(): InteractionRefreshScope | undefined {
+    const epoch = this.terminalLifecycle.captureEpoch();
+    const message = this.loadMessages().find(item => item.state === 'accepted');
+    if (epoch === null || !message) return undefined;
+    const metadata = this.terminalLifecycle.getStoredMetadata();
+    return {
+      message,
+      epoch,
+      interactionRevision: this.readPendingInteractions()?.revision,
+      sessionId: metadata?.identity.sessionId,
+      sandboxId: metadata?.workspace?.sandboxId,
+      kiloSessionId: metadata?.auth.kiloSessionId,
+      directory: metadata ? this.directory(metadata) : undefined,
+      worktreeId: metadata?.workspace?.worktreeId,
+    };
+  }
+
   private async syncAcceptedMessage(
-    message: MessageRecord,
-    epoch: number,
+    scope: InteractionRefreshScope,
     trigger: 'accepted_alarm' | 'pending_interactions'
   ): Promise<SessionSyncResult | undefined> {
+    const {
+      message,
+      epoch,
+      sessionId,
+      sandboxId,
+      kiloSessionId,
+      directory,
+      interactionRevision: revision,
+    } = scope;
     const startedAt = Date.now();
     const diagnostic: ControlDiagnosticFields = {
       sessionId: this.sessionId,
@@ -2075,28 +2121,27 @@ export class SandboxSession extends DurableObject<Env> {
     let outcome: 'synced' | 'superseded' | 'failed' = 'failed';
     logControlDiagnostic('session_sync', { ...diagnostic, phase: 'started' });
     try {
-      const metadata = this.terminalLifecycle.getStoredMetadata();
-      const sandboxId = metadata?.workspace?.sandboxId;
-      const kiloSessionId = metadata?.auth.kiloSessionId;
       diagnostic.sandboxId = sandboxId;
       diagnostic.kiloSessionId = kiloSessionId;
-      diagnostic.worktreeId = metadata?.workspace?.worktreeId;
+      diagnostic.worktreeId = scope.worktreeId;
       if (
-        !metadata ||
+        !sessionId ||
+        !directory ||
         !sandboxId ||
         !kiloSessionId ||
         !message.wrapperInstanceId ||
         this.pendingRuntimeCleanup()
       ) {
-        diagnostic.reason = !metadata
-          ? 'missing_metadata'
-          : !sandboxId
-            ? 'missing_sandbox'
-            : !kiloSessionId
-              ? 'missing_kilo_session'
-              : !message.wrapperInstanceId
-                ? 'missing_wrapper_identity'
-                : 'cleanup_pending';
+        diagnostic.reason =
+          !sessionId || !directory
+            ? 'missing_metadata'
+            : !sandboxId
+              ? 'missing_sandbox'
+              : !kiloSessionId
+                ? 'missing_kilo_session'
+                : !message.wrapperInstanceId
+                  ? 'missing_wrapper_identity'
+                  : 'cleanup_pending';
         throw new Error('Accepted runtime is unavailable');
       }
       const control = sandboxControlRpc(this.env, sandboxId);
@@ -2109,9 +2154,9 @@ export class SandboxSession extends DurableObject<Env> {
           diagnostic.timedOut = true;
         }
       );
-      if (!this.isCurrentAcceptedMessage(message, epoch)) {
+      if (!this.interactionRefresh.isCurrent(scope) || this.pendingRuntimeCleanup()) {
         outcome = 'superseded';
-        diagnostic.reason = 'accepted_message_changed';
+        diagnostic.reason = 'observation_scope_changed';
         return undefined;
       }
       diagnostic.stage = 'runtime_identity';
@@ -2151,19 +2196,13 @@ export class SandboxSession extends DurableObject<Env> {
               : 'wrapper_mismatch';
         throw new Error('Accepted runtime is not ready');
       }
-      diagnostic.stage = 'read_interactions';
-      const revision = this.readPendingInteractions()?.revision;
       diagnostic.interactionRevision = revision;
       diagnostic.stage = 'sync_request';
       const response = await withTimeout(
         control.request({
           operation: 'session.sync',
           expectedWrapperInstanceId: message.wrapperInstanceId,
-          session: {
-            sessionId: metadata.identity.sessionId,
-            kiloSessionId,
-            directory: this.directory(metadata),
-          },
+          session: { sessionId, kiloSessionId, directory },
           payload: {},
         }),
         SANDBOX_CONTROL_REQUEST_TIMEOUT_MS,
@@ -2172,9 +2211,9 @@ export class SandboxSession extends DurableObject<Env> {
           diagnostic.timedOut = true;
         }
       );
-      if (!this.isCurrentAcceptedMessage(message, epoch)) {
+      if (!this.interactionRefresh.isCurrent(scope) || this.pendingRuntimeCleanup()) {
         outcome = 'superseded';
-        diagnostic.reason = 'accepted_message_changed';
+        diagnostic.reason = 'observation_scope_changed';
         return undefined;
       }
       diagnostic.requestId = response?.requestId;
@@ -2211,7 +2250,7 @@ export class SandboxSession extends DurableObject<Env> {
         return root === undefined ? request.sessionID === kiloSessionId : root === kiloSessionId;
       };
       diagnostic.stage = 'scope_interactions';
-      const result = metadata.workspace?.worktreeId
+      const result = scope.worktreeId
         ? {
             ...parsed,
             questions: parsed.questions.filter(belongsToRoot),
@@ -2221,20 +2260,30 @@ export class SandboxSession extends DurableObject<Env> {
       diagnostic.questionCount = result.questions.length;
       diagnostic.permissionCount = result.permissions.length;
       diagnostic.stage = 'interaction_revision';
-      const applyInteractions = this.readPendingInteractions()?.revision === revision;
+      const previousInteractions = this.readPendingInteractions();
+      const currentRevision = previousInteractions?.revision;
+      const applySnapshot = currentRevision === revision;
       diagnostic.interactionSnapshotApplied = false;
-      if (applyInteractions) {
-        diagnostic.stage = 'persist_interactions';
-        this.ctx.storage.kv.put(PENDING_INTERACTIONS_KEY, {
-          revision: (revision ?? 0) + 1,
-          questions: result.questions,
-          permissions: result.permissions,
-        });
-        diagnostic.interactionSnapshotApplied = true;
+      if (!applySnapshot) {
+        diagnostic.reason = 'interaction_revision_changed';
+        outcome = 'superseded';
+        return undefined;
       }
+      if (!this.interactionRefresh.isCurrent(scope) || this.pendingRuntimeCleanup()) {
+        diagnostic.reason = 'observation_scope_changed';
+        outcome = 'superseded';
+        return undefined;
+      }
+      diagnostic.stage = 'persist_interactions';
+      this.ctx.storage.kv.put(PENDING_INTERACTIONS_KEY, {
+        revision: (currentRevision ?? 0) + 1,
+        questions: result.questions,
+        permissions: result.permissions,
+      });
+      diagnostic.interactionSnapshotApplied = true;
       diagnostic.stage = 'persist_status';
       persistSandboxControlSessionEvent({
-        sessionId: metadata.identity.sessionId,
+        sessionId,
         payload: {
           type: 'session.status',
           properties: { sessionID: kiloSessionId, status: result.status },
@@ -2242,9 +2291,27 @@ export class SandboxSession extends DurableObject<Env> {
         eventQueries: this.eventQueries,
         broadcast: event => this.broadcastStoredEvent(event),
       });
+      for (const event of pendingInputProjection(
+        sessionId,
+        previousInteractions,
+        result,
+        Date.now()
+      )) {
+        this.broadcastStoredEvent(event);
+      }
       outcome = 'synced';
       return result;
     } catch (error) {
+      if (
+        !this.interactionRefresh.isCurrent(
+          scope,
+          diagnostic.interactionSnapshotApplied ? (revision ?? 0) + 1 : revision
+        )
+      ) {
+        outcome = 'superseded';
+        diagnostic.reason = 'observation_scope_changed';
+        return undefined;
+      }
       diagnostic.reason ??= diagnostic.timedOut
         ? 'timeout'
         : error instanceof z.ZodError
@@ -2274,22 +2341,13 @@ export class SandboxSession extends DurableObject<Env> {
     }
   }
 
-  private async derivePendingInteractions(): Promise<
-    { questions: unknown[]; permissions: unknown[] } | undefined
-  > {
+  private derivePendingInteractions():
+    | { questions: unknown[]; permissions: unknown[] }
+    | undefined {
     const epoch = this.terminalLifecycle.captureEpoch();
     if (epoch === null) return undefined;
-    const accepted = this.loadMessages().find(message => message.state === 'accepted');
-    if (accepted) {
-      try {
-        await this.syncAcceptedMessage(accepted, epoch, 'pending_interactions');
-      } catch {
-        logger
-          .withFields({ sessionId: this.sessionId })
-          .warn('Pending interaction sync unavailable');
-      }
-    }
     if (!this.terminalLifecycle.isCurrent(epoch)) return undefined;
+    this.interactionRefresh.scheduleRefresh();
     const snapshot = this.readPendingInteractions();
     return snapshot
       ? { questions: snapshot.questions, permissions: snapshot.permissions }

--- a/services/cloud-agent-next/src/sandbox-session/session-input-projection.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-input-projection.ts
@@ -1,0 +1,45 @@
+import { isDeepStrictEqual } from 'node:util';
+import { z } from 'zod';
+import type { PendingInteractions } from './sandbox-control-event.js';
+import type { StoredEvent } from '../websocket/types.js';
+
+const requestsSchema = z.array(z.object({ id: z.string().min(1) }).passthrough());
+type Inputs = Pick<PendingInteractions, 'questions' | 'permissions'>;
+
+export function pendingInputProjection(
+  sessionId: string,
+  before: Inputs | undefined,
+  after: Inputs,
+  timestamp: number
+): StoredEvent[] {
+  const projected: StoredEvent[] = [];
+  const emit = (type: string, properties: Record<string, unknown>) => {
+    projected.push({
+      id: 0,
+      execution_id: '',
+      session_id: sessionId,
+      stream_event_type: 'kilocode',
+      payload: JSON.stringify({ type, event: type, properties }),
+      timestamp,
+    });
+  };
+  for (const [collection, kind] of [
+    ['questions', 'question'],
+    ['permissions', 'permission'],
+  ] as const) {
+    const next = requestsSchema.safeParse(after[collection]);
+    if (!next.success) continue;
+    const previous = requestsSchema.safeParse(before?.[collection] ?? []);
+    const old = new Map(
+      (previous.success ? previous.data : []).map(request => [request.id, request])
+    );
+    const current = new Map(next.data.map(request => [request.id, request]));
+    for (const requestID of old.keys()) {
+      if (!current.has(requestID)) emit(`${kind}.replied`, { requestID });
+    }
+    for (const [id, request] of current) {
+      if (!isDeepStrictEqual(old.get(id), request)) emit(`${kind}.asked`, request);
+    }
+  }
+  return projected;
+}

--- a/services/cloud-agent-next/src/sandbox-session/session-interaction-refresh.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-interaction-refresh.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createInteractionRefresh,
+  type InteractionRefreshScope,
+} from './session-interaction-refresh';
+import type { SessionSyncResult } from '../shared/sandbox-control-protocol';
+
+const result: SessionSyncResult = { status: { type: 'busy' }, questions: [], permissions: [] };
+
+function fixture() {
+  let scope: InteractionRefreshScope | undefined = {
+    message: { messageId: 'msg_1', state: 'accepted', wrapperInstanceId: 'wrapper_1' },
+    epoch: 1,
+    interactionRevision: 0,
+    sessionId: 'session_1',
+    sandboxId: 'sandbox_1',
+    kiloSessionId: 'root_1',
+    directory: '/workspace',
+    worktreeId: undefined,
+  };
+  const sync = vi.fn(async (): Promise<SessionSyncResult | undefined> => result);
+  const onBackgroundError = vi.fn();
+  const refresh = createInteractionRefresh({ captureScope: () => scope, sync, onBackgroundError });
+  return {
+    refresh,
+    sync,
+    onBackgroundError,
+    scope: () => scope,
+    setScope: (next: typeof scope) => {
+      scope = next;
+    },
+  };
+}
+
+describe('interaction refresh', () => {
+  it('does not read without a current accepted scope', async () => {
+    const f = fixture();
+    const captured = f.scope();
+    f.setScope(undefined);
+    expect(await f.refresh.refresh(captured, 'accepted_alarm')).toBeUndefined();
+    expect(f.sync).not.toHaveBeenCalled();
+  });
+
+  it('shares one actual read and its original promise across clients and watchdog', async () => {
+    const f = fixture();
+    const pending = Promise.withResolvers<SessionSyncResult>();
+    f.sync.mockReturnValue(pending.promise);
+    f.refresh.scheduleRefresh();
+    const first = f.refresh.refresh(f.scope(), 'pending_interactions');
+    const watchdog = f.refresh.refresh(f.scope(), 'accepted_alarm');
+    expect(watchdog).toBe(first);
+    await Promise.resolve();
+    expect(f.sync).toHaveBeenCalledTimes(1);
+    pending.resolve(result);
+    expect(await watchdog).toBe(result);
+  });
+
+  it.each([
+    'interactionRevision',
+    'epoch',
+    'sessionId',
+    'sandboxId',
+    'kiloSessionId',
+    'directory',
+    'worktreeId',
+    'messageId',
+    'wrapperInstanceId',
+  ] as const)(
+    'does not join old work after %s changes and old cleanup does not clear newer work',
+    async field => {
+      const f = fixture();
+      const old = Promise.withResolvers<SessionSyncResult>();
+      const next = Promise.withResolvers<SessionSyncResult>();
+      f.sync.mockReturnValueOnce(old.promise).mockReturnValueOnce(next.promise);
+      const first = f.refresh.refresh(f.scope(), 'pending_interactions');
+      await Promise.resolve();
+      const scope = f.scope();
+      if (!scope) throw new Error('Missing scope');
+      f.setScope(
+        field === 'messageId' || field === 'wrapperInstanceId'
+          ? { ...scope, message: { ...scope.message, [field]: 'new' } }
+          : { ...scope, [field]: typeof scope[field] === 'number' ? 2 : 'new' }
+      );
+      const second = f.refresh.refresh(f.scope(), 'pending_interactions');
+      await Promise.resolve();
+      old.resolve(result);
+      await first;
+      expect(f.refresh.refresh(f.scope(), 'accepted_alarm')).toBe(second);
+      expect(f.sync).toHaveBeenCalledTimes(2);
+      next.resolve(result);
+      await second;
+    }
+  );
+
+  it('preserves watchdog rejection while background scheduling handles it and can retry', async () => {
+    const f = fixture();
+    const pending = Promise.withResolvers<SessionSyncResult>();
+    f.sync.mockReturnValueOnce(pending.promise);
+    f.refresh.scheduleRefresh();
+    const watchdog = f.refresh.refresh(f.scope(), 'accepted_alarm');
+    const rejected = expect(watchdog).rejects.toThrow('sync failed');
+    pending.reject(new Error('sync failed'));
+    await rejected;
+    expect(f.onBackgroundError).toHaveBeenCalledTimes(1);
+    expect(await f.refresh.refresh(f.scope(), 'accepted_alarm')).toEqual(result);
+    expect(f.sync).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not convert a superseded result into failure', async () => {
+    const f = fixture();
+    f.sync.mockResolvedValue(undefined);
+    expect(await f.refresh.refresh(f.scope(), 'accepted_alarm')).toBeUndefined();
+    expect(f.onBackgroundError).not.toHaveBeenCalled();
+  });
+});

--- a/services/cloud-agent-next/src/sandbox-session/session-interaction-refresh.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-interaction-refresh.ts
@@ -1,0 +1,76 @@
+import type { SessionSyncResult } from '../shared/sandbox-control-protocol.js';
+import type { SessionMessageRecord } from './session-message-queue.js';
+
+export type InteractionRefreshScope = {
+  message: SessionMessageRecord;
+  epoch: number;
+  interactionRevision: number | undefined;
+  sessionId: string | undefined;
+  sandboxId: string | undefined;
+  kiloSessionId: string | undefined;
+  directory: string | undefined;
+  worktreeId: string | undefined;
+};
+
+type RefreshTrigger = 'accepted_alarm' | 'pending_interactions';
+type SyncResult = SessionSyncResult | undefined;
+
+type RefreshDeps = {
+  captureScope: () => InteractionRefreshScope | undefined;
+  sync: (scope: InteractionRefreshScope, trigger: RefreshTrigger) => Promise<SyncResult>;
+  onBackgroundError: () => void;
+};
+
+function scopeMatches(a: InteractionRefreshScope, b: InteractionRefreshScope): boolean {
+  return (
+    a.message.messageId === b.message.messageId &&
+    a.message.wrapperInstanceId === b.message.wrapperInstanceId &&
+    a.epoch === b.epoch &&
+    a.interactionRevision === b.interactionRevision &&
+    a.sessionId === b.sessionId &&
+    a.sandboxId === b.sandboxId &&
+    a.kiloSessionId === b.kiloSessionId &&
+    a.directory === b.directory &&
+    a.worktreeId === b.worktreeId
+  );
+}
+
+export function createInteractionRefresh(deps: RefreshDeps) {
+  let inflight: { scope: InteractionRefreshScope; promise: Promise<SyncResult> } | undefined;
+
+  function isCurrent(
+    scope: InteractionRefreshScope,
+    revision = scope.interactionRevision
+  ): boolean {
+    const current = deps.captureScope();
+    return (
+      current !== undefined && scopeMatches({ ...scope, interactionRevision: revision }, current)
+    );
+  }
+
+  function refresh(
+    scope: InteractionRefreshScope | undefined,
+    trigger: RefreshTrigger
+  ): Promise<SyncResult> {
+    if (!scope || !isCurrent(scope)) return Promise.resolve(undefined);
+    if (inflight && scopeMatches(inflight.scope, scope)) return inflight.promise;
+    const pending = Promise.resolve().then(() =>
+      isCurrent(scope) ? deps.sync(scope, trigger) : undefined
+    );
+    const entry = { scope, promise: pending };
+    inflight = entry;
+    const clear = () => {
+      if (inflight === entry) inflight = undefined;
+    };
+    void pending.then(clear, clear);
+    return pending;
+  }
+
+  function scheduleRefresh(): void {
+    void refresh(deps.captureScope(), 'pending_interactions').catch(deps.onBackgroundError);
+  }
+
+  return { refresh, scheduleRefresh, isCurrent };
+}
+
+export type InteractionRefresh = ReturnType<typeof createInteractionRefresh>;

--- a/services/cloud-agent-next/src/sandbox-session/session-message-queue.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-message-queue.test.ts
@@ -86,7 +86,7 @@ vi.mock('../websocket/stream.js', () => ({
     options?: {
       deriveCloudStatus?: () => Promise<unknown>;
       deriveQueuedMessages?: () => Promise<unknown>;
-      derivePendingInteractions?: () => Promise<unknown>;
+      readPendingInteractions?: () => unknown;
       deriveSessionStatus?: () => Promise<unknown>;
       getPreparationSnapshots?: () => Promise<unknown>;
     }
@@ -96,7 +96,7 @@ vi.mock('../websocket/stream.js', () => ({
       Response.json({
         cloudStatus: await options?.deriveCloudStatus?.(),
         queuedMessages: await options?.deriveQueuedMessages?.(),
-        pendingInteractions: await options?.derivePendingInteractions?.(),
+        pendingInteractions: options?.readPendingInteractions?.(),
         sessionStatus: await options?.deriveSessionStatus?.(),
         preparationSnapshots: await options?.getPreparationSnapshots?.(),
       }),
@@ -2770,6 +2770,38 @@ describe('SandboxSession orchestration', () => {
     expect(fixture.control.quarantineRuntime).toHaveBeenCalledOnce();
   });
 
+  it('keeps the original client-started sync deadline when the watchdog joins later', async () => {
+    const fixture = sessionFixture();
+    const sync = deferred<ResponseFrame>();
+    await fixture.admit('a');
+    await fixture.flush();
+    delegateRequest(fixture, 'session.sync', () => sync.promise);
+    vi.setSystemTime(Date.now() + DEADLINE_MS.acceptedOverdue);
+    await fixture.snapshot();
+    await fixture.flush();
+    await vi.advanceTimersByTimeAsync(SANDBOX_CONTROL_REQUEST_TIMEOUT_MS / 2);
+    const alarm = fixture.fireAlarm();
+    await fixture.flush();
+    expect(
+      fixture.control.request.mock.calls.filter(([input]) => input.operation === 'session.sync')
+    ).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(SANDBOX_CONTROL_REQUEST_TIMEOUT_MS / 2 - 1);
+    expect(fixture.record('a')?.state).toBe('accepted');
+    await vi.advanceTimersByTimeAsync(1);
+    await alarm;
+    expect(fixture.record('a')).toMatchObject({
+      state: 'failed',
+      failedReason: 'runtime_unhealthy',
+    });
+    const afterFailure = fixture.storage.kv.get('session_pending_interactions');
+    sync.resolve(
+      controlResponse({ status: { type: 'busy' }, questions: [{ id: 'late' }], permissions: [] })
+    );
+    await fixture.flush();
+    expect(fixture.storage.kv.get('session_pending_interactions')).toEqual(afterFailure);
+    expect(fixture.control.quarantineRuntime).toHaveBeenCalledOnce();
+  });
+
   it('does not apply a late unhealthy health result to the next accepted message', async () => {
     const fixture = sessionFixture();
     const sync = deferred<ResponseFrame>();
@@ -2867,6 +2899,7 @@ describe('SandboxSession orchestration', () => {
     expect(await fixture.snapshot()).toMatchObject({
       pendingInteractions: { questions: [childQuestion], permissions: [childPermission] },
     });
+    await fixture.flush();
     const rootQuestion = { id: 'root_q', sessionID: 'kilo_root' };
     delegateRequest(fixture, 'session.sync', async input => {
       expect(input.session).toEqual({
@@ -2881,10 +2914,12 @@ describe('SandboxSession orchestration', () => {
       });
     });
     expect(await fixture.snapshot()).toMatchObject({
-      pendingInteractions: {
-        questions: [rootQuestion, childQuestion],
-        permissions: [childPermission],
-      },
+      pendingInteractions: { questions: [childQuestion], permissions: [childPermission] },
+    });
+    await fixture.flush();
+    expect(fixture.storage.kv.get('session_pending_interactions')).toMatchObject({
+      questions: [rootQuestion, childQuestion],
+      permissions: [childPermission],
     });
     await fixture.rawEvent(
       'question.replied',
@@ -2946,6 +2981,8 @@ describe('SandboxSession orchestration', () => {
       error: { code: 'read_failed', message: 'Not available', retryable: true },
     }));
     expect(await fixture.snapshot()).not.toHaveProperty('pendingInteractions');
+    await fixture.flush();
+    expect(fixture.storage.kv.get('session_pending_interactions')).toBeUndefined();
     delegateRequest(fixture, 'session.sync', async input => {
       expect(input.session?.directory).toBe(DIRECTORY);
       return controlResponse({
@@ -2954,14 +2991,22 @@ describe('SandboxSession orchestration', () => {
         permissions: [{ id: 'p' }],
       });
     });
-    expect(await fixture.snapshot()).toMatchObject({
-      pendingInteractions: { questions: [{ id: 'q' }], permissions: [{ id: 'p' }] },
+    expect(await fixture.snapshot()).not.toHaveProperty('pendingInteractions');
+    await fixture.flush();
+    expect(fixture.storage.kv.get('session_pending_interactions')).toMatchObject({
+      questions: [{ id: 'q' }],
+      permissions: [{ id: 'p' }],
     });
     delegateRequest(fixture, 'session.sync', async () =>
       controlResponse({ status: { type: 'busy' }, questions: [], permissions: [] })
     );
     expect(await fixture.snapshot()).toMatchObject({
-      pendingInteractions: { questions: [], permissions: [] },
+      pendingInteractions: { questions: [{ id: 'q' }], permissions: [{ id: 'p' }] },
+    });
+    await fixture.flush();
+    expect(fixture.storage.kv.get('session_pending_interactions')).toMatchObject({
+      questions: [],
+      permissions: [],
     });
   });
 
@@ -2980,7 +3025,12 @@ describe('SandboxSession orchestration', () => {
       controlResponse({ status: { type: 'busy' }, questions: [question], permissions: [] })
     );
     expect(await snapshot).toMatchObject({
-      pendingInteractions: { questions: [], permissions: [] },
+      pendingInteractions: { questions: [question], permissions: [] },
+    });
+    await fixture.flush();
+    expect(fixture.storage.kv.get('session_pending_interactions')).toMatchObject({
+      questions: [],
+      permissions: [],
     });
   });
 

--- a/services/cloud-agent-next/src/websocket/stream.test.ts
+++ b/services/cloud-agent-next/src/websocket/stream.test.ts
@@ -900,6 +900,34 @@ describe('stream handler handleStreamRequest', () => {
     }
   });
 
+  it('awaits the legacy async input getter before deriving the remaining connection state', async () => {
+    const serverWs = makeFakeWebSocket();
+    mockWebSocketPair(serverWs);
+    const pending = Promise.withResolvers<{ questions: unknown[]; permissions: unknown[] }>();
+    const reading = Promise.withResolvers<void>();
+    const status = vi.fn(async () => ({ type: 'busy' as const }));
+    const handler = createStreamHandler(makeFakeState(), makeFakeEventQueries([]), SESSION_ID, {
+      derivePendingInteractions: () => {
+        reading.resolve();
+        return pending.promise;
+      },
+      deriveSessionStatus: status,
+    });
+    const connecting = handler.handleStreamRequest(
+      new Request('https://example.com/stream?replay=false', { headers: { Upgrade: 'websocket' } })
+    );
+    await reading.promise;
+    expect(status).not.toHaveBeenCalled();
+    expect(serverWs.sentMessages).toEqual([]);
+    pending.resolve({ questions: [{ id: 'legacy-question', questions: [] }], permissions: [] });
+    await connecting;
+    expect(status).toHaveBeenCalledOnce();
+    expect(parseSentMessages(serverWs).map(frame => frame.streamEventType)).toEqual([
+      'connected',
+      'kilocode',
+    ]);
+  });
+
   it.each([undefined, { questions: [], permissions: [] }])(
     'distinguishes unknown interactions from an authoritative empty snapshot: %j',
     async pendingInteractions => {

--- a/services/cloud-agent-next/src/websocket/stream.ts
+++ b/services/cloud-agent-next/src/websocket/stream.ts
@@ -104,6 +104,7 @@ export type StreamHandlerOptions = {
   deriveQueuedMessages?: () => Promise<QueuedMessageSnapshot[]>;
   deriveSessionStatus?: () => Promise<ConnectedEventData['sessionStatus']>;
   derivePendingInteractions?: () => Promise<ConnectedEventData['pendingInteractions']>;
+  readPendingInteractions?: () => ConnectedEventData['pendingInteractions'];
   getPreparationSnapshots?: () => Promise<StoredEvent[]>;
   reconcileMaterializedEvents?: boolean;
 };
@@ -207,12 +208,17 @@ export function createStreamHandler(
       };
       if (options?.reconcileMaterializedEvents) await sendPreparationSnapshots();
 
-      const pendingInteractions = await options?.derivePendingInteractions?.();
+      const derivedPendingInteractions = options?.readPendingInteractions
+        ? undefined
+        : await options?.derivePendingInteractions?.();
       const [cloudStatus, sessionStatus, queued] = await Promise.all([
         options?.deriveCloudStatus?.(),
         options?.deriveSessionStatus?.(),
         options?.deriveQueuedMessages?.() ?? [],
       ]);
+      const pendingInteractions = options?.readPendingInteractions
+        ? options.readPendingInteractions()
+        : derivedPendingInteractions;
       const sendSnapshot = (
         streamEventType:
           | 'kilocode'

--- a/services/cloud-agent-next/test/integration/sandbox-control.test.ts
+++ b/services/cloud-agent-next/test/integration/sandbox-control.test.ts
@@ -12761,7 +12761,7 @@ describe('SandboxSession running stream state', () => {
 });
 
 describe('SandboxSession root-scoped reconnect sync', () => {
-  it('reconciles an accepted root before connected and replays only its questions and permissions afterward', async () => {
+  it('connects from cached root inputs before sync and preserves scoped background reconciliation', async () => {
     const wrapperInstanceId = crypto.randomUUID();
     const ownerId = 'user_grouped_sync';
     const activeSessionId = GRANT_SESSION_ID;
@@ -12832,20 +12832,6 @@ describe('SandboxSession root-scoped reconnect sync', () => {
     };
     expect(emptyConnected.streamEventType).toBe('connected');
 
-    const pendingActiveResponse = SELF.fetch(
-      `http://worker.test/stream?sessionId=${activeSessionId}&userId=${ownerId}`,
-      { headers: { Upgrade: 'websocket' } }
-    );
-    const sync = JSON.parse(await incomingSync) as WrapperRequest;
-    expect(sync).toMatchObject({
-      operation: 'session.sync',
-      session: {
-        sessionId: activeSessionId,
-        kiloSessionId: ROOT_ID,
-        directory: '/workspace/shared',
-      },
-      payload: {},
-    });
     const questions = [
       { id: 'question_root', sessionID: ROOT_ID, questions: [{ question: 'Root?' }] },
       {
@@ -12859,6 +12845,67 @@ describe('SandboxSession root-scoped reconnect sync', () => {
       { id: 'permission_root', sessionID: ROOT_ID },
       { id: 'permission_child', sessionID: THIRD_ROOT_ID, rootKiloSessionId: ROOT_ID },
     ];
+    await runInDurableObject(active, async (_instance, state) => {
+      await state.storage.put('session_pending_interactions', {
+        revision: 1,
+        questions,
+        permissions,
+      });
+    });
+    const activeResponse = await SELF.fetch(
+      `http://worker.test/stream?sessionId=${activeSessionId}&userId=${ownerId}`,
+      { headers: { Upgrade: 'websocket' } }
+    );
+    const sync = JSON.parse(await incomingSync) as WrapperRequest;
+    expect(sync).toMatchObject({
+      operation: 'session.sync',
+      session: {
+        sessionId: activeSessionId,
+        kiloSessionId: ROOT_ID,
+        directory: '/workspace/shared',
+      },
+      payload: {},
+    });
+    if (activeResponse.status !== 101 || !activeResponse.webSocket) {
+      throw new Error(`Unexpected active-session stream status: ${activeResponse.status}`);
+    }
+    activeResponse.webSocket.accept();
+    const events = (await nextMessages(activeResponse.webSocket, 7)).map(
+      message => JSON.parse(message) as SessionStreamEvent
+    );
+    expect(events.map(event => event.streamEventType)).toEqual([
+      'connected',
+      'kilocode',
+      'kilocode',
+      'kilocode',
+      'kilocode',
+      'cloud.message.queued',
+      'cloud.message.sent',
+    ]);
+    expect(events[0]?.data).toMatchObject({
+      cloudStatus: { type: 'ready' },
+      activeMessageId: INITIAL_MESSAGE_ID,
+      pendingInteractions: { questions, permissions },
+    });
+    expect(events.slice(1, 3)).toEqual(
+      questions.map(question =>
+        expect.objectContaining({
+          eventId: 0,
+          sessionId: activeSessionId,
+          data: { type: 'question.asked', event: 'question.asked', properties: question },
+        })
+      )
+    );
+    expect(events.slice(3, 5)).toEqual(
+      permissions.map(permission =>
+        expect.objectContaining({
+          eventId: 0,
+          sessionId: activeSessionId,
+          data: { type: 'permission.asked', event: 'permission.asked', properties: permission },
+        })
+      )
+    );
+    const incomingStatus = nextMessage(activeResponse.webSocket);
     respondToWrapperRequest(wrapper, sync, {
       status: { type: 'busy' },
       questions: [
@@ -12872,49 +12919,13 @@ describe('SandboxSession root-scoped reconnect sync', () => {
         { id: 'permission_contradictory', sessionID: ROOT_ID, rootKiloSessionId: SECOND_ROOT_ID },
       ],
     });
-    const activeResponse = await pendingActiveResponse;
-    if (activeResponse.status !== 101 || !activeResponse.webSocket) {
-      throw new Error(`Unexpected active-session stream status: ${activeResponse.status}`);
-    }
-    activeResponse.webSocket.accept();
-    const events = (await nextMessages(activeResponse.webSocket, 8)).map(
-      message => JSON.parse(message) as SessionStreamEvent
-    );
-    expect(events.map(event => event.streamEventType)).toEqual([
-      'kilocode',
-      'connected',
-      'kilocode',
-      'kilocode',
-      'kilocode',
-      'kilocode',
-      'cloud.message.queued',
-      'cloud.message.sent',
-    ]);
-    expect(events[1]?.data).toMatchObject({
-      cloudStatus: { type: 'ready' },
-      activeMessageId: INITIAL_MESSAGE_ID,
-      pendingInteractions: { questions, permissions },
+    expect(JSON.parse(await incomingStatus)).toMatchObject({
+      streamEventType: 'kilocode',
+      data: { type: 'session.status' },
     });
-    expect(events.slice(2, 4)).toEqual(
-      questions.map(question =>
-        expect.objectContaining({
-          eventId: 0,
-          sessionId: activeSessionId,
-          data: { type: 'question.asked', event: 'question.asked', properties: question },
-        })
-      )
-    );
-    expect(events.slice(4, 6)).toEqual(
-      permissions.map(permission =>
-        expect.objectContaining({
-          eventId: 0,
-          sessionId: activeSessionId,
-          data: { type: 'permission.asked', event: 'permission.asked', properties: permission },
-        })
-      )
-    );
     await runInDurableObject(active, async (_instance, state) => {
       expect(await state.storage.get('session_pending_interactions')).toMatchObject({
+        revision: 2,
         questions,
         permissions,
       });

--- a/services/cloud-agent-next/test/integration/session-input-projection.test.ts
+++ b/services/cloud-agent-next/test/integration/session-input-projection.test.ts
@@ -1,0 +1,394 @@
+import { env, runInDurableObject } from 'cloudflare:test';
+import { drizzle } from 'drizzle-orm/durable-sqlite';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  cloudAgentEventSchema,
+  type CloudAgentEvent,
+} from '../../../../packages/cloud-agent-sdk/src/schemas';
+import { normalize, isChatEvent } from '../../../../packages/cloud-agent-sdk/src/normalizer';
+import { createServiceState } from '../../../../packages/cloud-agent-sdk/src/service-state';
+import type { SandboxSession } from '../../src/sandbox-session/SandboxSession';
+import type { ResponseFrame, SessionSyncResult } from '../../src/shared/sandbox-control-protocol';
+import { events } from '../../src/db/sqlite-schema';
+
+const root = 'ses_00000000000000000000000001';
+const question = {
+  id: 'question_repaired',
+  sessionID: root,
+  questions: [
+    {
+      question: 'Continue?',
+      header: 'Confirm',
+      options: [{ label: 'Yes', description: 'Continue' }],
+    },
+  ],
+};
+const permission = {
+  id: 'permission_repaired',
+  sessionID: root,
+  permission: 'bash',
+  patterns: ['ls'],
+  metadata: {},
+  always: [],
+};
+const empty: SessionSyncResult = { status: { type: 'busy' }, questions: [], permissions: [] };
+const asks: SessionSyncResult = { ...empty, questions: [question], permissions: [permission] };
+const response = (result: SessionSyncResult): ResponseFrame => ({
+  type: 'response',
+  requestId: 'projection',
+  ok: true,
+  result,
+});
+
+async function seed(instance: SandboxSession, state: DurableObjectState, initial = empty) {
+  await instance.registerSession({
+    identity: { sessionId: instance['requireSessionId'](), userId: 'user_projection' },
+    auth: { kiloSessionId: root, kilocodeToken: 'fixture-token' },
+    agent: { mode: 'code', model: 'test-model' },
+    workspace: { sandboxId: 'usr-abcdef123419', workspacePath: '/workspace/shared' },
+  });
+  const wrapperInstanceId = crypto.randomUUID();
+  const message = {
+    messageId: 'msg_projection',
+    state: 'accepted',
+    acceptedAt: Date.now(),
+    wrapperInstanceId,
+  };
+  state.storage.kv.put('session_messages', [message]);
+  state.storage.kv.put('session_pending_interactions', {
+    revision: 1,
+    questions: initial.questions,
+    permissions: initial.permissions,
+  });
+  const pending = Promise.withResolvers<ResponseFrame>();
+  const request = vi.fn(() => pending.promise);
+  const originalEnv = instance['env'];
+  Object.assign(instance, {
+    env: {
+      ...originalEnv,
+      SANDBOX_CONTROL: {
+        getByName: () => ({
+          getStatus: async () => ({ physical: 'running', connection: 'ready', wrapperInstanceId }),
+          request,
+        }),
+      },
+    },
+  });
+  const refresh = () =>
+    instance['interactionRefresh'].refresh(
+      instance['captureInteractionScope'](),
+      'pending_interactions'
+    );
+  return {
+    pending,
+    request,
+    refresh,
+    message,
+    storedEvents: () => drizzle(state.storage).select().from(events).all(),
+    cleanup: async () => {
+      pending.resolve(response(empty));
+      Object.assign(instance, { env: originalEnv });
+      await state.storage.deleteAlarm();
+    },
+  };
+}
+
+async function observe(result: Response) {
+  expect(result.status).toBe(101);
+  const socket = result.webSocket;
+  if (!socket) throw new Error('Missing client socket');
+  const view = createServiceState({ rootSessionId: root });
+  const frames: CloudAgentEvent[] = [];
+  socket.addEventListener('message', event => {
+    const frame = cloudAgentEventSchema.parse(JSON.parse(String(event.data)));
+    frames.push(frame);
+    const normalized = normalize(frame);
+    if (normalized && !isChatEvent(normalized)) view.process(normalized);
+  });
+  socket.accept();
+  await vi.waitFor(() =>
+    expect(frames.some(frame => frame.streamEventType === 'connected')).toBe(true)
+  );
+  return { socket, view, frames };
+}
+
+const connect = (instance: SandboxSession, query = '') =>
+  instance.fetch(
+    new Request(`http://worker.test/stream${query}`, { headers: { Upgrade: 'websocket' } })
+  );
+const inputFrames = (frames: CloudAgentEvent[]) =>
+  frames.filter(frame => {
+    const type = normalize(frame)?.type;
+    return type?.startsWith('question.') || type?.startsWith('permission.');
+  });
+const drainSocketMessages = () => new Promise<void>(resolve => setTimeout(resolve, 20));
+
+describe('Session pending-input projection', () => {
+  it('updates stable request IDs, skips unchanged snapshots, and removes absent inputs with membership-only hints', async () => {
+    const stub = env.SANDBOX_SESSION.getByName(`user_projection:workspace_${crypto.randomUUID()}`);
+    await runInDurableObject(stub, async (instance, state) => {
+      const f = await seed(instance, state, asks);
+      const client = await observe(await connect(instance));
+      const updatedQuestion = {
+        ...question,
+        questions: [{ ...question.questions[0], question: 'Continue deployment?' }],
+      };
+      const updatedPermission = {
+        ...permission,
+        patterns: ['pnpm test'],
+        metadata: { command: 'pnpm test' },
+      };
+      const updated = { ...empty, questions: [updatedQuestion], permissions: [updatedPermission] };
+      try {
+        await vi.waitFor(() => expect(client.view.getPermission()?.requestId).toBe(permission.id));
+        expect(client.view.getQuestion()?.questions).toEqual(question.questions);
+        f.pending.resolve(response(updated));
+        await f.refresh();
+        await vi.waitFor(() => {
+          expect(client.view.getQuestion()?.questions).toEqual(updatedQuestion.questions);
+          expect(client.view.getPermission()?.patterns).toEqual(updatedPermission.patterns);
+        });
+        expect(inputFrames(client.frames).map(frame => normalize(frame)?.type)).toEqual([
+          'question.asked',
+          'permission.asked',
+          'question.asked',
+          'permission.asked',
+        ]);
+        const beforeUnchanged = inputFrames(client.frames);
+        f.request.mockResolvedValue(
+          response({
+            ...updated,
+            questions: [{ questions: updatedQuestion.questions, sessionID: root, id: question.id }],
+          })
+        );
+        await f.refresh();
+        await drainSocketMessages();
+        expect(inputFrames(client.frames)).toEqual(beforeUnchanged);
+        f.request.mockResolvedValue(response(empty));
+        await f.refresh();
+        await vi.waitFor(() => {
+          expect(client.view.getQuestion()).toBeNull();
+          expect(client.view.getPermission()).toBeNull();
+        });
+        expect(
+          inputFrames(client.frames)
+            .slice(-2)
+            .map(frame => ({ eventId: frame.eventId, data: frame.data }))
+        ).toEqual([
+          {
+            eventId: 0,
+            data: {
+              type: 'question.replied',
+              event: 'question.replied',
+              properties: { requestID: question.id },
+            },
+          },
+          {
+            eventId: 0,
+            data: {
+              type: 'permission.replied',
+              event: 'permission.replied',
+              properties: { requestID: permission.id },
+            },
+          },
+        ]);
+        expect(f.storedEvents()).toHaveLength(3);
+        expect(
+          f.storedEvents().every(event => JSON.parse(event.payload).type === 'session.status')
+        ).toBe(true);
+        expect(state.storage.kv.get('session_pending_interactions')).toEqual({
+          revision: 4,
+          questions: [],
+          permissions: [],
+        });
+        expect(state.storage.kv.get('session_messages')).toEqual([f.message]);
+        expect(client.frames.filter(frame => frame.streamEventType === 'connected')).toHaveLength(
+          1
+        );
+      } finally {
+        client.socket.close();
+        await f.cleanup();
+      }
+    });
+  });
+
+  it.each([
+    { failure: 'unknown', initial: empty, next: asks },
+    { failure: 'unknown', initial: asks, next: empty },
+    { failure: 'failed', initial: empty, next: asks },
+    { failure: 'failed', initial: asks, next: empty },
+    { failure: 'stale', initial: empty, next: asks },
+    { failure: 'stale', initial: asks, next: empty },
+  ])(
+    'suppresses $failure refresh projection with cached questions=$initial.questions.length',
+    async ({ failure, initial, next }) => {
+      const stub = env.SANDBOX_SESSION.getByName(
+        `user_projection:workspace_${crypto.randomUUID()}`
+      );
+      await runInDurableObject(stub, async (instance, state) => {
+        const f = await seed(instance, state, initial);
+        const client = await observe(await connect(instance));
+        try {
+          await drainSocketMessages();
+          const before = [...client.frames];
+          const shared = f.refresh();
+          if (failure === 'stale') {
+            state.storage.kv.put('session_pending_interactions', {
+              revision: 2,
+              questions: initial.questions,
+              permissions: initial.permissions,
+            });
+            f.pending.resolve(response(next));
+            expect(await shared).toBeUndefined();
+          } else if (failure === 'failed') {
+            f.pending.reject(new Error('Native sync unavailable'));
+            await expect(shared).rejects.toThrow('Native sync unavailable');
+          } else {
+            f.pending.resolve({
+              type: 'response',
+              requestId: 'unknown',
+              ok: false,
+              error: { code: 'not_ready', message: 'Incomplete ancestry', retryable: false },
+            });
+            await expect(shared).rejects.toThrow('Session sync failed');
+          }
+          await drainSocketMessages();
+          expect(client.frames).toEqual(before);
+          expect(client.view.getQuestion()?.requestId ?? null).toBe(
+            initial.questions.length ? question.id : null
+          );
+          expect(client.view.getPermission()?.requestId ?? null).toBe(
+            initial.permissions.length ? permission.id : null
+          );
+          expect(f.storedEvents()).toEqual([]);
+          expect(state.storage.kv.get('session_messages')).toEqual([f.message]);
+        } finally {
+          client.socket.close();
+          await f.cleanup();
+        }
+      });
+    }
+  );
+
+  it.each([
+    empty,
+    {
+      ...empty,
+      questions: [
+        { ...question, questions: [{ ...question.questions[0], question: 'Latest content' }] },
+      ],
+      permissions: [permission],
+    },
+  ])(
+    'does not send stale cached asks after a repair completes during connection setup: %j',
+    async next => {
+      const stub = env.SANDBOX_SESSION.getByName(
+        `user_projection:workspace_${crypto.randomUUID()}`
+      );
+      await runInDurableObject(stub, async (instance, state) => {
+        const f = await seed(instance, state, asks);
+        const setupStarted = Promise.withResolvers<void>();
+        const setup = Promise.withResolvers<{ type: 'ready' }>();
+        const original = instance['deriveCloudStatus'];
+        Object.assign(instance, {
+          deriveCloudStatus: () => {
+            setupStarted.resolve();
+            return setup.promise;
+          },
+        });
+        const refresh = f.refresh();
+        const connecting = connect(instance);
+        let client: Awaited<ReturnType<typeof observe>> | undefined;
+        try {
+          await setupStarted.promise;
+          f.pending.resolve(response(next));
+          await refresh;
+          setup.resolve({ type: 'ready' });
+          client = await observe(await connecting);
+          await f.refresh();
+          await drainSocketMessages();
+          expect(client.view.getQuestion()).toEqual(
+            next.questions.length
+              ? {
+                  requestId: question.id,
+                  questions: [{ ...question.questions[0], question: 'Latest content' }],
+                }
+              : null
+          );
+          expect(client.view.getPermission()?.requestId ?? null).toBe(
+            next.permissions.length ? permission.id : null
+          );
+          const connectedIndex = client.frames.findIndex(
+            frame => frame.streamEventType === 'connected'
+          );
+          expect(
+            inputFrames(client.frames.slice(connectedIndex + 1)).map(frame => frame.data)
+          ).toEqual([
+            ...next.questions.map(properties => ({
+              type: 'question.asked',
+              event: 'question.asked',
+              properties,
+            })),
+            ...next.permissions.map(properties => ({
+              type: 'permission.asked',
+              event: 'permission.asked',
+              properties,
+            })),
+          ]);
+        } finally {
+          setup.resolve({ type: 'ready' });
+          Object.assign(instance, { deriveCloudStatus: original });
+          client?.socket.close();
+          await f.cleanup();
+        }
+      });
+    }
+  );
+
+  it('repairs inputs on an already-connected SDK consumer without reconnecting', async () => {
+    const stub = env.SANDBOX_SESSION.getByName(`user_projection:workspace_${crypto.randomUUID()}`);
+    await runInDurableObject(stub, async (instance, state) => {
+      const f = await seed(instance, state);
+      const client = await observe(await connect(instance));
+      const filtered = await observe(await connect(instance, '?eventTypes=output'));
+      try {
+        expect(client.view.getQuestion()).toBeNull();
+        expect(client.view.getPermission()).toBeNull();
+        f.pending.resolve(response(asks));
+        await f.refresh();
+        await vi.waitFor(() => {
+          expect(client.view.getQuestion()).toEqual({
+            requestId: question.id,
+            questions: question.questions,
+          });
+          expect(client.view.getPermission()).toMatchObject({
+            requestId: permission.id,
+            permission: permission.permission,
+          });
+        });
+        expect(f.request).toHaveBeenCalledTimes(1);
+        expect(inputFrames(client.frames).map(frame => frame.data)).toEqual([
+          { type: 'question.asked', event: 'question.asked', properties: question },
+          { type: 'permission.asked', event: 'permission.asked', properties: permission },
+        ]);
+        expect(inputFrames(client.frames).every(frame => frame.eventId === 0)).toBe(true);
+        expect(inputFrames(filtered.frames)).toEqual([]);
+        expect(client.frames.filter(frame => frame.streamEventType === 'connected')).toHaveLength(
+          1
+        );
+        expect(f.storedEvents()).toHaveLength(1);
+        expect(JSON.parse(f.storedEvents()[0].payload).type).toBe('session.status');
+        expect(state.storage.kv.get('session_pending_interactions')).toEqual({
+          revision: 2,
+          questions: [question],
+          permissions: [permission],
+        });
+        expect(state.storage.kv.get('session_messages')).toEqual([f.message]);
+      } finally {
+        filtered.socket.close();
+        client.socket.close();
+        await f.cleanup();
+      }
+    });
+  });
+});

--- a/services/cloud-agent-next/test/integration/session-observation.test.ts
+++ b/services/cloud-agent-next/test/integration/session-observation.test.ts
@@ -1,0 +1,372 @@
+import { env, runInDurableObject } from 'cloudflare:test';
+import { drizzle } from 'drizzle-orm/durable-sqlite';
+import { describe, expect, it, vi } from 'vitest';
+import type { SandboxSession } from '../../src/sandbox-session/SandboxSession';
+import type { SessionMessageRecord } from '../../src/sandbox-session/session-message-queue';
+import type { ResponseFrame, SessionSyncResult } from '../../src/shared/sandbox-control-protocol';
+import { DEADLINE_MS } from '../../src/sandbox-control/deadlines';
+import { events } from '../../src/db/sqlite-schema';
+
+const root = 'ses_00000000000000000000000001';
+const cached = {
+  revision: 3,
+  questions: [{ id: 'cached_question', sessionID: root }],
+  permissions: [],
+};
+const busy: SessionSyncResult = { status: { type: 'busy' }, questions: [], permissions: [] };
+const idle: SessionSyncResult = { status: { type: 'idle' }, questions: [], permissions: [] };
+
+function response(result: SessionSyncResult): ResponseFrame {
+  return { type: 'response', requestId: 'observation', ok: true, result };
+}
+
+async function fixture(instance: SandboxSession, state: DurableObjectState) {
+  const wrapperInstanceId = crypto.randomUUID();
+  const sessionId = instance['requireSessionId']();
+  await instance.registerSession({
+    identity: { sessionId, userId: 'user_observation' },
+    auth: { kiloSessionId: root, kilocodeToken: 'fixture-token' },
+    agent: { mode: 'code', model: 'test-model' },
+    repository: { type: 'github', repo: 'Kilo-Org/cloud' },
+    workspace: { sandboxId: 'usr-abcdef123419', workspacePath: '/workspace/shared' },
+  });
+  const message: SessionMessageRecord = {
+    messageId: 'msg_observed',
+    state: 'accepted',
+    wrapperInstanceId,
+    acceptedAt: Date.now() - DEADLINE_MS.acceptedOverdue - 100,
+    lastActivityAt: Date.now() - DEADLINE_MS.acceptedOverdue - 100,
+    deliveryDeadlineAt: Date.now() + 60_000,
+  };
+  state.storage.kv.put('session_messages', [message]);
+  state.storage.kv.put('session_pending_interactions', cached);
+  const pending = Promise.withResolvers<ResponseFrame>();
+  const control = {
+    getStatus: vi.fn(async () => ({ connection: 'ready', physical: 'running', wrapperInstanceId })),
+    request: vi.fn(() => pending.promise),
+    quarantineRuntime: vi.fn(async () => ({ quarantined: true })),
+  };
+  const originalEnv = instance['env'];
+  Object.assign(instance, {
+    env: { ...originalEnv, SANDBOX_CONTROL: { getByName: () => control } },
+  });
+  const storedEvents = () => drizzle(state.storage).select().from(events).all();
+  const cleanup = async () => {
+    pending.resolve(response(busy));
+    Object.assign(instance, { env: originalEnv });
+    await state.storage.deleteAlarm();
+  };
+  return { control, pending, message, storedEvents, cleanup };
+}
+
+async function connect(instance: SandboxSession) {
+  const result = await instance.fetch(
+    new Request('http://worker.test/stream', { headers: { Upgrade: 'websocket' } })
+  );
+  expect(result.status).toBe(101);
+  const socket = result.webSocket;
+  if (!socket) throw new Error('Missing stream socket');
+  const connected = new Promise<Record<string, unknown>>(resolve => {
+    socket.addEventListener('message', event => {
+      const frame = JSON.parse(String(event.data)) as {
+        streamEventType: string;
+        data: Record<string, unknown>;
+      };
+      if (frame.streamEventType === 'connected') resolve(frame.data);
+    });
+  });
+  socket.accept();
+  return { socket, connected: await connected };
+}
+
+describe('Session observation wiring', () => {
+  it('returns cached getters and connections while one read/application is shared with the watchdog', async () => {
+    const stub = env.SANDBOX_SESSION.getByName(`user_observation:workspace_${crypto.randomUUID()}`);
+    await runInDurableObject(stub, async (instance, state) => {
+      const f = await fixture(instance, state);
+      const streams: WebSocket[] = [];
+      try {
+        for (let index = 0; index < 3; index++) {
+          expect(instance['derivePendingInteractions']()).toEqual({
+            questions: cached.questions,
+            permissions: [],
+          });
+          const stream = await connect(instance);
+          streams.push(stream.socket);
+          expect(stream.connected).toMatchObject({
+            pendingInteractions: { questions: cached.questions, permissions: [] },
+          });
+        }
+        await vi.waitFor(() => expect(f.control.request).toHaveBeenCalledTimes(1));
+        expect(state.storage.kv.get('session_messages')).toEqual([f.message]);
+        const refresh = vi.spyOn(instance['interactionRefresh'], 'refresh');
+        const alarm = instance.alarm();
+        await vi.waitFor(() =>
+          expect(refresh).toHaveBeenCalledWith(expect.anything(), 'accepted_alarm')
+        );
+        expect(f.control.getStatus).toHaveBeenCalledTimes(1);
+        expect(f.control.request).toHaveBeenCalledTimes(1);
+        f.pending.resolve(response(busy));
+        await alarm;
+        expect(state.storage.kv.get('session_pending_interactions')).toEqual({
+          revision: 4,
+          questions: [],
+          permissions: [],
+        });
+        expect(
+          f.storedEvents().filter(event => event.stream_event_type === 'kilocode')
+        ).toHaveLength(1);
+        expect(state.storage.kv.get('session_messages')).toEqual([
+          expect.objectContaining({
+            messageId: f.message.messageId,
+            state: 'accepted',
+            acceptedAt: f.message.acceptedAt,
+            deliveryDeadlineAt: f.message.deliveryDeadlineAt,
+            lastActivityAt: expect.any(Number),
+          }),
+        ]);
+        refresh.mockRestore();
+      } finally {
+        for (const socket of streams) socket.close();
+        await f.cleanup();
+      }
+    });
+  });
+
+  it.each(['revision', 'message', 'wrapper', 'root', 'directory', 'lifecycle'] as const)(
+    'discards old idle/empty application after %s changes',
+    async change => {
+      const stub = env.SANDBOX_SESSION.getByName(
+        `user_observation:workspace_${crypto.randomUUID()}`
+      );
+      await runInDurableObject(stub, async (instance, state) => {
+        const f = await fixture(instance, state);
+        try {
+          instance['derivePendingInteractions']();
+          await vi.waitFor(() => expect(f.control.request).toHaveBeenCalledTimes(1));
+          const refresh = vi.spyOn(instance['interactionRefresh'], 'refresh');
+          const alarm = instance.alarm();
+          await vi.waitFor(() => expect(refresh).toHaveBeenCalled());
+          if (change === 'revision') {
+            instance['recordPendingInteraction']({
+              type: 'question.asked',
+              properties: { id: 'new_question', sessionID: root },
+            });
+          } else if (change === 'message' || change === 'wrapper') {
+            state.storage.kv.put('session_messages', [
+              {
+                ...f.message,
+                [change === 'message' ? 'messageId' : 'wrapperInstanceId']: crypto.randomUUID(),
+              },
+            ]);
+          } else if (change === 'lifecycle') {
+            const metadata = instance['terminalLifecycle'].getStoredMetadata();
+            if (!metadata) throw new Error('Missing metadata');
+            instance['terminalLifecycle'].beginDeletion(metadata);
+          } else {
+            const metadata = instance['terminalLifecycle'].getStoredMetadata();
+            if (!metadata?.workspace) throw new Error('Missing metadata');
+            state.storage.kv.put('session_metadata', {
+              ...metadata,
+              auth: {
+                ...metadata.auth,
+                ...(change === 'root' ? { kiloSessionId: 'ses_00000000000000000000000002' } : {}),
+              },
+              workspace: {
+                ...metadata.workspace,
+                ...(change === 'directory' ? { workspacePath: '/workspace/other' } : {}),
+              },
+            });
+          }
+          const before = {
+            interactions: state.storage.kv.get('session_pending_interactions'),
+            messages: state.storage.kv.get('session_messages'),
+            events: f.storedEvents(),
+          };
+          f.pending.resolve(response(idle));
+          await alarm;
+          expect(state.storage.kv.get('session_pending_interactions')).toEqual(before.interactions);
+          expect(state.storage.kv.get('session_messages')).toEqual(before.messages);
+          expect(f.storedEvents()).toEqual(before.events);
+          expect(f.control.quarantineRuntime).not.toHaveBeenCalled();
+          refresh.mockRestore();
+        } finally {
+          await f.cleanup();
+        }
+      });
+    }
+  );
+
+  it('preserves a shared sync failure for the watchdog runtime_unhealthy path', async () => {
+    const stub = env.SANDBOX_SESSION.getByName(`user_observation:workspace_${crypto.randomUUID()}`);
+    await runInDurableObject(stub, async (instance, state) => {
+      const f = await fixture(instance, state);
+      try {
+        instance['derivePendingInteractions']();
+        await vi.waitFor(() => expect(f.control.request).toHaveBeenCalledTimes(1));
+        const refresh = vi.spyOn(instance['interactionRefresh'], 'refresh');
+        const alarm = instance.alarm();
+        await vi.waitFor(() => expect(refresh).toHaveBeenCalled());
+        f.pending.reject(new Error('native read failed'));
+        await alarm;
+        expect(f.control.request).toHaveBeenCalledTimes(1);
+        expect(state.storage.kv.get('session_messages')).toEqual([
+          expect.objectContaining({ state: 'failed', failedReason: 'runtime_unhealthy' }),
+        ]);
+        expect(f.control.quarantineRuntime).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reason: 'runtime_unhealthy',
+            wrapperInstanceId: f.message.wrapperInstanceId,
+          })
+        );
+        expect(f.storedEvents().filter(event => event.stream_event_type === 'kilocode')).toEqual(
+          []
+        );
+        refresh.mockRestore();
+      } finally {
+        await f.cleanup();
+      }
+    });
+  });
+
+  it('preserves cached inputs on failed background sync and permits a later read', async () => {
+    const stub = env.SANDBOX_SESSION.getByName(`user_observation:workspace_${crypto.randomUUID()}`);
+    await runInDurableObject(stub, async (instance, state) => {
+      const f = await fixture(instance, state);
+      try {
+        instance['derivePendingInteractions']();
+        const shared = instance['interactionRefresh'].refresh(
+          instance['captureInteractionScope'](),
+          'pending_interactions'
+        );
+        f.pending.resolve({
+          type: 'response',
+          requestId: 'unknown',
+          ok: false,
+          error: { code: 'not_ready', message: 'Incomplete ancestry', retryable: false },
+        });
+        await expect(shared).rejects.toThrow('Session sync failed');
+        expect(state.storage.kv.get('session_pending_interactions')).toEqual(cached);
+        expect(state.storage.kv.get('session_messages')).toEqual([f.message]);
+        expect(f.storedEvents()).toEqual([]);
+        f.control.request.mockResolvedValue(response(busy));
+        instance['derivePendingInteractions']();
+        await instance['interactionRefresh'].refresh(
+          instance['captureInteractionScope'](),
+          'pending_interactions'
+        );
+        expect(f.control.request).toHaveBeenCalledTimes(2);
+        expect(state.storage.kv.get('session_messages')).toEqual([f.message]);
+      } finally {
+        await f.cleanup();
+      }
+    });
+  });
+
+  it('starts a new revision read while old work is pending without letting old cleanup clear it', async () => {
+    const stub = env.SANDBOX_SESSION.getByName(`user_observation:workspace_${crypto.randomUUID()}`);
+    await runInDurableObject(stub, async (instance, state) => {
+      const f = await fixture(instance, state);
+      const next = Promise.withResolvers<ResponseFrame>();
+      try {
+        instance['derivePendingInteractions']();
+        const first = instance['interactionRefresh'].refresh(
+          instance['captureInteractionScope'](),
+          'pending_interactions'
+        );
+        await vi.waitFor(() => expect(f.control.request).toHaveBeenCalledTimes(1));
+        instance['recordPendingInteraction']({
+          type: 'question.asked',
+          properties: { id: 'new_question', sessionID: root },
+        });
+        f.control.request.mockReturnValue(next.promise);
+        instance['derivePendingInteractions']();
+        const current = instance['interactionRefresh'].refresh(
+          instance['captureInteractionScope'](),
+          'pending_interactions'
+        );
+        await vi.waitFor(() => expect(f.control.request).toHaveBeenCalledTimes(2));
+        const interactions = state.storage.kv.get('session_pending_interactions');
+        f.pending.resolve(response(idle));
+        expect(await first).toBeUndefined();
+        expect(state.storage.kv.get('session_pending_interactions')).toEqual(interactions);
+        expect(f.storedEvents()).toEqual([]);
+        instance['derivePendingInteractions']();
+        expect(
+          instance['interactionRefresh'].refresh(
+            instance['captureInteractionScope'](),
+            'accepted_alarm'
+          )
+        ).toBe(current);
+        next.resolve(response(busy));
+        await current;
+        expect(f.control.request).toHaveBeenCalledTimes(2);
+        expect(f.storedEvents()).toHaveLength(1);
+        expect(state.storage.kv.get('session_messages')).toEqual([f.message]);
+      } finally {
+        next.resolve(response(busy));
+        await f.cleanup();
+      }
+    });
+  });
+
+  it('fences revision changes during runtime-status setup before issuing native sync', async () => {
+    const stub = env.SANDBOX_SESSION.getByName(`user_observation:workspace_${crypto.randomUUID()}`);
+    await runInDurableObject(stub, async (instance, state) => {
+      const f = await fixture(instance, state);
+      const status = Promise.withResolvers<Awaited<ReturnType<typeof f.control.getStatus>>>();
+      f.control.getStatus.mockReturnValue(status.promise);
+      try {
+        instance['derivePendingInteractions']();
+        const shared = instance['interactionRefresh'].refresh(
+          instance['captureInteractionScope'](),
+          'pending_interactions'
+        );
+        await vi.waitFor(() => expect(f.control.getStatus).toHaveBeenCalledTimes(1));
+        instance['recordPendingInteraction']({
+          type: 'question.asked',
+          properties: { id: 'new_question', sessionID: root },
+        });
+        status.resolve({
+          connection: 'ready',
+          physical: 'running',
+          wrapperInstanceId: f.message.wrapperInstanceId ?? '',
+        });
+        expect(await shared).toBeUndefined();
+        expect(f.control.request).not.toHaveBeenCalled();
+        expect(f.storedEvents()).toEqual([]);
+      } finally {
+        status.resolve({
+          connection: 'ready',
+          physical: 'running',
+          wrapperInstanceId: f.message.wrapperInstanceId ?? '',
+        });
+        await f.cleanup();
+      }
+    });
+  });
+
+  it('does not retarget a watchdog when the accepted message changes during alarm setup', async () => {
+    const stub = env.SANDBOX_SESSION.getByName(`user_observation:workspace_${crypto.randomUUID()}`);
+    await runInDurableObject(stub, async (instance, state) => {
+      const f = await fixture(instance, state);
+      const setup = Promise.withResolvers<void>();
+      const original = instance['armQueueRetry'];
+      Object.assign(instance, { armQueueRetry: () => setup.promise });
+      try {
+        const alarm = instance.alarm();
+        const nextMessage = { ...f.message, messageId: 'msg_new' };
+        state.storage.kv.put('session_messages', [nextMessage]);
+        setup.resolve();
+        await alarm;
+        expect(f.control.getStatus).not.toHaveBeenCalled();
+        expect(f.control.request).not.toHaveBeenCalled();
+        expect(state.storage.kv.get('session_messages')).toEqual([nextMessage]);
+      } finally {
+        setup.resolve();
+        Object.assign(instance, { armQueueRetry: original });
+        await f.cleanup();
+      }
+    });
+  });
+});

--- a/services/cloud-agent-next/test/unit/wrapper/worktree-credential-refresh.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/worktree-credential-refresh.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../wrapper/src/control/session-directories.js';
 import { resetDirectoryOperationState } from '../../../wrapper/src/control/worktree-operations.js';
 import {
+  createControlHandlerDeps,
   createSessionActivityRegistry,
   handleControlRequest,
   refreshHeartbeatPayload,
@@ -572,7 +573,7 @@ describe('direct worktree credential refresh', () => {
     f.statuses.mockReturnValueOnce(status.promise);
     const activity = createSessionActivityRegistry();
     activity.attach(identity.kiloSessionId);
-    const deps: HandlerDeps = {
+    const deps: HandlerDeps = createControlHandlerDeps({
       kiloRuntimes: f.registry,
       version: 'test',
       kiloReady: true,
@@ -581,7 +582,7 @@ describe('direct worktree credential refresh', () => {
       activity,
       emitSessionEvent: vi.fn(),
       retireRuntime: vi.fn(),
-    };
+    });
     const heartbeat = refreshHeartbeatPayload(deps);
     const oldClient = runtime.kiloClient;
     await f.attach(auth, { ...originalEnv, GH_TOKEN: 'github-renewed' });

--- a/services/cloud-agent-next/wrapper/src/control/main.ts
+++ b/services/cloud-agent-next/wrapper/src/control/main.ts
@@ -8,6 +8,7 @@ import {
 import {
   buildHeartbeatPayload,
   cancelControlTasks,
+  createControlHandlerDeps,
   createSessionActivityRegistry,
   refreshHeartbeatPayload,
   handleControlRequest,
@@ -92,7 +93,7 @@ function main(diagnostics: ControlDiagnostics, wrapperInstanceId: string): void 
         getKiloRuntime: directory => kiloRuntimes.get(directory),
       })
     : undefined;
-  const deps: HandlerDeps = {
+  const deps: HandlerDeps = createControlHandlerDeps({
     onDiagnostic: diagnostics.onDiagnostic,
     kiloRuntimes,
     version: WRAPPER_VERSION,
@@ -117,7 +118,7 @@ function main(diagnostics: ControlDiagnostics, wrapperInstanceId: string): void 
     },
     retireRuntime: reason => shutdown(1, reason),
     onShutdown: () => shutdown(0, 'Sandbox shutting down'),
-  };
+  });
 
   const mutationNotifications = createWorktreeMutationNotifications({
     sessions: deps.sessions,
@@ -215,7 +216,8 @@ function main(diagnostics: ControlDiagnostics, wrapperInstanceId: string): void 
           }
         },
       }),
-    getHeartbeatPayload: async () => withHeartbeatReason(await refreshHeartbeatPayload(deps)),
+    getHeartbeatPayload: () => withHeartbeatReason(buildHeartbeatPayload(deps)),
+    sampleHeartbeat: signal => refreshHeartbeatPayload(deps, signal).then(() => undefined),
   });
 
   diagnostics.onDiagnostic('wrapper.lifecycle', { phase: 'started', ok: Boolean(control) });

--- a/services/cloud-agent-next/wrapper/src/control/native-observations.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/native-observations.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { KILO_CONTROL_REQUEST_TIMEOUT_MS } from './sandbox-control-runtime';
+import { createNativeObservations } from './native-observations';
+import type { WrapperKiloClient } from '../kilo-api';
+import type { WorktreeKiloRuntime } from './worktree-runtime';
+
+type FakeRoot = {
+  kiloSessionId: string;
+  directory: string | undefined;
+  revision: symbol | undefined;
+};
+
+function fakeKilo(overrides: Partial<WrapperKiloClient> = {}): WrapperKiloClient {
+  return {
+    getSession: async id => ({ id }),
+    ensureSession: async () => undefined,
+    sendPrompt: async () => ({ info: {} as never, parts: [] }),
+    sendPromptAsync: async () => {},
+    sendCommand: async () => ({ info: {} as never, parts: [] }),
+    summarizeSession: async () => true,
+    generateCommitMessage: async () => ({ message: 'test' }),
+    abortSession: async () => true,
+    answerPermission: async () => true,
+    answerQuestion: async () => true,
+    rejectQuestion: async () => true,
+    getSessionStatuses: async () => ({}),
+    getQuestions: async () => [],
+    getPermissions: async () => [],
+    ...overrides,
+  } as WrapperKiloClient;
+}
+
+function fakeRuntime(
+  directory: string,
+  kiloClient: WrapperKiloClient,
+  signal?: AbortSignal
+): WorktreeKiloRuntime {
+  return {
+    scopeId: 'scope_1',
+    directory,
+    env: {},
+    kiloClient,
+    signal: signal ?? new AbortController().signal,
+  };
+}
+
+describe('createNativeObservations', () => {
+  let roots: FakeRoot[];
+  let runtimes: Map<string, WorktreeKiloRuntime>;
+  let reconciled: Array<{ statuses: unknown; roots: readonly string[] }>;
+
+  beforeEach(() => {
+    roots = [];
+    runtimes = new Map();
+    reconciled = [];
+  });
+
+  afterEach(() => {
+    roots = [];
+    runtimes.clear();
+    reconciled = [];
+  });
+
+  function createObservations(signal?: AbortSignal) {
+    return createNativeObservations({
+      signal,
+      roots: () => roots,
+      getRuntime: directory => runtimes.get(directory),
+      reconcileActivity: (statuses, r) => reconciled.push({ statuses, roots: r }),
+    });
+  }
+
+  it('coalesces concurrent refresh calls and shares the pending result', async () => {
+    let reads = 0;
+    const answer =
+      Promise.withResolvers<Awaited<ReturnType<WrapperKiloClient['getSessionStatuses']>>>();
+    const client = fakeKilo({
+      getSessionStatuses: async () => {
+        reads++;
+        return answer.promise;
+      },
+    });
+    const runtime = fakeRuntime('/workspace', client);
+    runtimes.set('/workspace', runtime);
+    const revision = Symbol();
+    roots = [{ kiloSessionId: 'kilo_1', directory: '/workspace', revision }];
+    const obs = createObservations();
+    const first = obs.refresh();
+    const second = obs.refresh();
+    answer.resolve({ kilo_1: { type: 'busy' } });
+    await Promise.all([first, second]);
+    expect(reads).toBe(1);
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]?.roots).toEqual(['kilo_1']);
+  });
+
+  it('reconciles activity from successful native status reads', async () => {
+    const client = fakeKilo({
+      getSessionStatuses: async () => ({ kilo_1: { type: 'idle' } }),
+    });
+    const runtime = fakeRuntime('/workspace', client);
+    runtimes.set('/workspace', runtime);
+    roots = [{ kiloSessionId: 'kilo_1', directory: '/workspace', revision: Symbol() }];
+    const obs = createObservations();
+    await obs.refresh();
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]?.statuses).toEqual({ kilo_1: { type: 'idle' } });
+  });
+
+  it('preserves cached activity on failed native reads', async () => {
+    const client = fakeKilo({
+      getSessionStatuses: async () => {
+        throw new Error('native read failed');
+      },
+    });
+    const runtime = fakeRuntime('/workspace', client);
+    runtimes.set('/workspace', runtime);
+    roots = [{ kiloSessionId: 'kilo_1', directory: '/workspace', revision: Symbol() }];
+    const obs = createObservations();
+    await obs.refresh();
+    expect(reconciled).toHaveLength(0);
+  });
+
+  it('excludes root from reconciliation when revision changes during read', async () => {
+    const originalRevision = Symbol();
+    const answer =
+      Promise.withResolvers<Awaited<ReturnType<WrapperKiloClient['getSessionStatuses']>>>();
+    const client = fakeKilo({ getSessionStatuses: () => answer.promise });
+    const runtime = fakeRuntime('/workspace', client);
+    runtimes.set('/workspace', runtime);
+    roots = [{ kiloSessionId: 'kilo_1', directory: '/workspace', revision: originalRevision }];
+    const obs = createObservations();
+    const pending = obs.refresh();
+    roots = [{ kiloSessionId: 'kilo_1', directory: '/workspace', revision: Symbol() }];
+    answer.resolve({ kilo_1: { type: 'idle' } });
+    await pending;
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]?.roots).toEqual([]);
+  });
+
+  it('discards result when runtime identity changes during read', async () => {
+    const answer =
+      Promise.withResolvers<Awaited<ReturnType<WrapperKiloClient['getSessionStatuses']>>>();
+    const client = fakeKilo({ getSessionStatuses: () => answer.promise });
+    const runtime = fakeRuntime('/workspace', client);
+    runtimes.set('/workspace', runtime);
+    roots = [{ kiloSessionId: 'kilo_1', directory: '/workspace', revision: Symbol() }];
+    const obs = createObservations();
+    const pending = obs.refresh();
+    runtimes.set('/workspace', fakeRuntime('/workspace', fakeKilo()));
+    answer.resolve({ kilo_1: { type: 'idle' } });
+    await pending;
+    expect(reconciled).toHaveLength(0);
+  });
+
+  it('forgets a directory when no roots reference it', async () => {
+    const client = fakeKilo({ getSessionStatuses: async () => ({ kilo_1: { type: 'idle' } }) });
+    const runtime = fakeRuntime('/workspace', client);
+    runtimes.set('/workspace', runtime);
+    roots = [{ kiloSessionId: 'kilo_1', directory: '/workspace', revision: Symbol() }];
+    const obs = createObservations();
+    await obs.refresh();
+    expect(reconciled).toHaveLength(1);
+    roots = [];
+    reconciled = [];
+    await obs.refresh();
+    expect(reconciled).toHaveLength(0);
+  });
+
+  it.each(['client', 'revision', 'root'] as const)(
+    'starts new scope after %s changes without applying old work or clearing new work',
+    async change => {
+      const first = Promise.withResolvers<Record<string, { type: string }>>();
+      const second = Promise.withResolvers<Record<string, { type: string }>>();
+      let reads = 0;
+      const read = () => (++reads === 1 ? first.promise : second.promise);
+      const runtime = fakeRuntime('/workspace', fakeKilo({ getSessionStatuses: read }));
+      runtimes.set('/workspace', runtime);
+      roots = [{ kiloSessionId: 'kilo_1', directory: '/workspace', revision: Symbol() }];
+      const obs = createObservations();
+      const old = obs.refresh();
+      if (change === 'client')
+        Object.assign(runtime, { kiloClient: fakeKilo({ getSessionStatuses: read }) });
+      else
+        roots = [
+          {
+            directory: '/workspace',
+            kiloSessionId: change === 'root' ? 'kilo_2' : 'kilo_1',
+            revision: Symbol(),
+          },
+        ];
+      const current = obs.refresh();
+      expect(reads).toBe(2);
+      first.resolve({ kilo_1: { type: 'idle' } });
+      await old;
+      expect(reconciled).toEqual([]);
+      const joined = obs.refresh();
+      expect(reads).toBe(2);
+      second.resolve({ kilo_1: { type: 'busy' } });
+      await Promise.all([current, joined]);
+      expect(reconciled).toHaveLength(1);
+    }
+  );
+
+  it('applies unrelated runtime observations without waiting for a stalled runtime', async () => {
+    const blocked = Promise.withResolvers<Record<string, { type: string }>>();
+    runtimes.set(
+      '/slow',
+      fakeRuntime('/slow', fakeKilo({ getSessionStatuses: () => blocked.promise }))
+    );
+    runtimes.set(
+      '/fast',
+      fakeRuntime(
+        '/fast',
+        fakeKilo({ getSessionStatuses: async () => ({ fast: { type: 'busy' } }) })
+      )
+    );
+    roots = [
+      { kiloSessionId: 'slow', directory: '/slow', revision: Symbol() },
+      { kiloSessionId: 'fast', directory: '/fast', revision: Symbol() },
+    ];
+    const pending = createObservations().refresh();
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(reconciled).toEqual([{ statuses: { fast: { type: 'busy' } }, roots: ['fast'] }]);
+    blocked.resolve({ slow: { type: 'idle' } });
+    await pending;
+  });
+
+  it.each(['deadline', 'cancel'] as const)(
+    'releases bounded sampling after %s even when the native read ignores abort',
+    async end => {
+      const timers = spyOn(globalThis, 'setTimeout');
+      const blocked = Promise.withResolvers<Record<string, { type: string }>>();
+      const abort = new AbortController();
+      let readSignal: AbortSignal | undefined;
+      let reads = 0;
+      runtimes.set(
+        '/workspace',
+        fakeRuntime(
+          '/workspace',
+          fakeKilo({
+            getSessionStatuses: (_directory, signal) => {
+              readSignal = signal;
+              reads++;
+              return blocked.promise;
+            },
+          })
+        )
+      );
+      roots = [{ kiloSessionId: 'kilo_1', directory: '/workspace', revision: Symbol() }];
+      const obs = createObservations();
+      try {
+        const first = obs.refresh(abort.signal);
+        const joined = obs.refresh(abort.signal);
+        expect(reads).toBe(1);
+        expect(
+          timers.mock.calls.filter(([, ms]) => ms === KILO_CONTROL_REQUEST_TIMEOUT_MS)
+        ).toHaveLength(1);
+        if (end === 'cancel') abort.abort();
+        else {
+          const deadline = timers.mock.calls.find(
+            ([, ms]) => ms === KILO_CONTROL_REQUEST_TIMEOUT_MS
+          )?.[0];
+          if (typeof deadline !== 'function') throw new Error('Missing native read deadline');
+          deadline();
+        }
+        await Promise.all([first, joined]);
+        expect(readSignal?.aborted).toBe(true);
+        expect(reconciled).toEqual([]);
+        blocked.resolve({ kilo_1: { type: 'idle' } });
+        await new Promise<void>(resolve => setImmediate(resolve));
+        expect(reconciled).toEqual([]);
+        await obs.refresh();
+        expect(reads).toBe(2);
+      } finally {
+        abort.abort();
+        blocked.resolve({});
+        timers.mockRestore();
+      }
+    }
+  );
+
+  it('skips refresh when aborted', async () => {
+    let reads = 0;
+    const client = fakeKilo({
+      getSessionStatuses: async () => {
+        reads++;
+        return {};
+      },
+    });
+    runtimes.set('/workspace', fakeRuntime('/workspace', client));
+    roots = [{ kiloSessionId: 'kilo_1', directory: '/workspace', revision: Symbol() }];
+    const abort = new AbortController();
+    abort.abort();
+    const obs = createObservations(abort.signal);
+    await obs.refresh();
+    expect(reads).toBe(0);
+  });
+});

--- a/services/cloud-agent-next/wrapper/src/control/native-observations.ts
+++ b/services/cloud-agent-next/wrapper/src/control/native-observations.ts
@@ -1,0 +1,122 @@
+import type { WrapperKiloClient } from '../kilo-api.js';
+import { withKiloRequestDeadline } from './sandbox-control-runtime';
+import type { WorktreeKiloRuntime } from './worktree-runtime.js';
+
+type RootSnapshot = {
+  kiloSessionId: string;
+  directory: string | undefined;
+  revision: symbol | undefined;
+};
+
+type DirectoryObservation = {
+  runtime: WorktreeKiloRuntime;
+  client: WrapperKiloClient;
+  roots: readonly RootSnapshot[];
+  pending: Promise<void> | undefined;
+};
+
+type NativeObservationDeps = {
+  signal?: AbortSignal;
+  roots: () => readonly RootSnapshot[];
+  getRuntime: (directory: string) => WorktreeKiloRuntime | undefined;
+  reconcileActivity: (
+    statuses: Awaited<ReturnType<WrapperKiloClient['getSessionStatuses']>>,
+    roots: readonly string[]
+  ) => void;
+};
+
+export function createNativeObservations(deps: NativeObservationDeps) {
+  const observations = new Map<string, DirectoryObservation>();
+
+  function forget(directory: string): void {
+    observations.delete(directory);
+  }
+
+  async function sampleDirectory(
+    directory: string,
+    roots: readonly RootSnapshot[],
+    signal?: AbortSignal
+  ): Promise<void> {
+    const runtime = deps.getRuntime(directory);
+    if (!runtime) {
+      forget(directory);
+      return;
+    }
+    const client = runtime.kiloClient;
+    let entry = observations.get(directory);
+    if (
+      entry &&
+      (entry.runtime !== runtime ||
+        entry.client !== client ||
+        entry.roots.length !== roots.length ||
+        !entry.roots.every(before =>
+          roots.some(
+            root => root.kiloSessionId === before.kiloSessionId && root.revision === before.revision
+          )
+        ))
+    ) {
+      entry = undefined;
+    }
+    if (!entry) {
+      entry = { runtime, client, roots: roots.map(root => ({ ...root })), pending: undefined };
+      observations.set(directory, entry);
+    }
+    if (entry.pending) return entry.pending;
+    const target = entry;
+    const capturedRoots = target.roots;
+    const signals = [runtime.signal];
+    if (deps.signal) signals.push(deps.signal);
+    if (signal) signals.push(signal);
+    const readSignal = AbortSignal.any(signals);
+    const isCurrent = () =>
+      !readSignal.aborted &&
+      observations.get(directory) === target &&
+      deps.getRuntime(directory) === runtime &&
+      runtime.kiloClient === client;
+
+    const pending = (async () => {
+      try {
+        const statuses = await withKiloRequestDeadline(
+          requestSignal => client.getSessionStatuses(directory, requestSignal),
+          readSignal
+        );
+        if (!isCurrent()) return;
+        const freshRoots = new Map(deps.roots().map(root => [root.kiloSessionId, root]));
+        const currentRoots = capturedRoots
+          .filter(before => {
+            const root = freshRoots.get(before.kiloSessionId);
+            return root?.directory === directory && root.revision === before.revision;
+          })
+          .map(root => root.kiloSessionId);
+        deps.reconcileActivity(statuses, currentRoots);
+      } catch {
+        return;
+      }
+    })();
+    target.pending = pending;
+    await pending.finally(() => {
+      if (target.pending === pending) target.pending = undefined;
+    });
+  }
+
+  async function refresh(signal?: AbortSignal): Promise<void> {
+    if (deps.signal?.aborted || signal?.aborted) return;
+    const rootsByDirectory = new Map<string, RootSnapshot[]>();
+    for (const root of deps.roots()) {
+      if (!root.directory) continue;
+      const roots = rootsByDirectory.get(root.directory) ?? [];
+      roots.push(root);
+      rootsByDirectory.set(root.directory, roots);
+    }
+    for (const directory of observations.keys()) {
+      if (!rootsByDirectory.has(directory)) forget(directory);
+    }
+    await Promise.all(
+      [...rootsByDirectory].map(([directory, roots]) => sampleDirectory(directory, roots, signal))
+    );
+  }
+
+  return { refresh };
+}
+
+export type NativeObservations = ReturnType<typeof createNativeObservations>;

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
@@ -28,6 +28,7 @@ import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../../../src/shared/runtime-e
 import {
   buildHeartbeatPayload,
   cancelControlTasks,
+  createControlHandlerDeps,
   createSessionActivityRegistry,
   handleControlRequest,
   refreshHeartbeatPayload,
@@ -133,7 +134,7 @@ function deps(
         signal: new AbortController().signal,
       }
     : undefined;
-  return {
+  return createControlHandlerDeps({
     kiloRuntimes: runtime
       ? ({
           attach: () => ({
@@ -158,7 +159,7 @@ function deps(
     applyAttach: (session, payload, deps) =>
       applySessionAttach(session, payload, { ...deps, sessionExists: async () => true }),
     ...rest,
-  };
+  });
 }
 
 function runtimeDeps(kiloClient: WrapperKiloClient) {
@@ -3605,6 +3606,98 @@ describe('control interactions and sync', () => {
     expect(resolved).toEqual([]);
   });
 
+  it.each(['question', 'permission'] as const)(
+    'keeps unresolved %s ancestry unknown regardless of claimed root and permits only proven replies',
+    async kind => {
+      rememberAttachedRoot('foreign', session.directory);
+      rememberChildSession({
+        childId: 'owned_child',
+        parentId: session.kiloSessionId,
+        directory: session.directory,
+      });
+      const replied: string[] = [];
+      for (const claimedRoot of [undefined, 'foreign', session.kiloSessionId]) {
+        const template = { ...question, ...permission };
+        const unknown = {
+          ...template,
+          id: 'unknown',
+          sessionID: 'unresolved_child',
+          rootKiloSessionId: claimedRoot,
+        };
+        const owned = {
+          ...template,
+          id: 'owned',
+          sessionID: 'owned_child',
+          rootKiloSessionId: 'foreign',
+        };
+        const foreign = {
+          ...template,
+          id: 'foreign',
+          sessionID: 'foreign',
+          rootKiloSessionId: session.kiloSessionId,
+        };
+        let requests = [unknown];
+        const handlerDeps = deps({
+          kiloClient: fakeKilo({
+            ...(kind === 'question'
+              ? { getQuestions: async () => requests }
+              : { getPermissions: async () => requests }),
+            answerQuestion: async id => {
+              replied.push(id);
+              return true;
+            },
+            answerPermission: async id => {
+              replied.push(id);
+              return true;
+            },
+          }),
+        });
+        expect(await handleControlRequest('session.sync', session, {}, handlerDeps)).toMatchObject({
+          ok: false,
+        });
+        requests = [unknown, owned, foreign];
+        for (const id of ['owned', 'unknown', 'foreign', 'missing']) {
+          const result = await handleControlRequest(
+            kind === 'question' ? 'session.question.resolve' : 'session.permission.resolve',
+            session,
+            kind === 'question'
+              ? { action: 'answer', questionId: id, answers: [['yes']] }
+              : { permissionId: id, response: 'once' },
+            handlerDeps
+          );
+          expect(result).toMatchObject(
+            id === 'owned' ? { ok: true } : { ok: false, error: { code: 'unauthorized' } }
+          );
+        }
+        expect(await handleControlRequest('session.sync', session, {}, handlerDeps)).toMatchObject({
+          ok: false,
+        });
+        requests = [foreign];
+        expect(await handleControlRequest('session.sync', session, {}, handlerDeps)).toEqual({
+          ok: true,
+          result: { status: { type: 'idle' }, questions: [], permissions: [] },
+        });
+      }
+      expect(replied).toEqual(['owned', 'owned', 'owned']);
+    }
+  );
+
+  it('replaces forged root metadata on positively owned root requests', async () => {
+    const handlerDeps = deps({
+      kiloClient: fakeKilo({
+        getQuestions: async () => [{ ...question, rootKiloSessionId: 'foreign' }],
+        getPermissions: async () => [{ ...permission, rootKiloSessionId: 'foreign' }],
+      }),
+    });
+    expect(await handleControlRequest('session.sync', session, {}, handlerDeps)).toMatchObject({
+      ok: true,
+      result: {
+        questions: [{ ...question, rootKiloSessionId: session.kiloSessionId }],
+        permissions: [{ ...permission, rootKiloSessionId: session.kiloSessionId }],
+      },
+    });
+  });
+
   it('stamps verified child-question snapshots for reconnect without trusting sibling root claims', async () => {
     const syncSession = {
       sessionId: 'workspace_sync_a',
@@ -3613,6 +3706,11 @@ describe('control interactions and sync', () => {
     };
     rememberAttachedRoot('kilo_sync_a', syncSession.directory);
     rememberAttachedRoot('kilo_sync_b', syncSession.directory);
+    rememberChildSession({
+      childId: 'unmapped_child',
+      parentId: 'kilo_sync_b',
+      directory: syncSession.directory,
+    });
     rememberChildSession({
       childId: 'kilo_sync_child',
       parentId: 'kilo_sync_a',
@@ -3682,6 +3780,11 @@ describe('control interactions and sync', () => {
     });
     rememberChildSession({ childId: 'grandchild', parentId: 'child', directory: childDirectory });
     rememberAttachedRoot('sibling', session.directory);
+    rememberChildSession({
+      childId: 'unmapped',
+      parentId: 'sibling',
+      directory: session.directory,
+    });
     const replies: unknown[] = [];
     const queried = new Set<string>();
     const handlerDeps = deps({
@@ -3805,6 +3908,7 @@ describe('control interactions and sync', () => {
   });
 
   it('uses fresh directory-scoped reads and preserves the complete pending interaction shape', async () => {
+    rememberAttachedRoot('other', session.directory);
     const directories: unknown[] = [];
     let calls = 0;
     const handlerDeps = deps({
@@ -3971,6 +4075,22 @@ describe('control interactions and sync', () => {
   });
 });
 
+describe('control handler dependency construction', () => {
+  it('preserves live readiness getters instead of freezing their initial value', () => {
+    let ready = true;
+    const input = {
+      ...deps(),
+      get kiloReady() {
+        return ready;
+      },
+    };
+    const handlers = createControlHandlerDeps(input);
+    expect(buildHeartbeatPayload(handlers).kilo.ready).toBe(true);
+    ready = false;
+    expect(buildHeartbeatPayload(handlers).kilo.ready).toBe(false);
+  });
+});
+
 describe('control wrapper heartbeat source policy', () => {
   const source = fs
     .readFileSync(new URL('./main.ts', import.meta.url), 'utf8')
@@ -3990,7 +4110,7 @@ describe('control wrapper heartbeat source policy', () => {
       'if (!payload.kilo.ready && heartbeatReason) payload.kilo.reason = heartbeatReason;'
     );
     expect(source).toContain(
-      'getHeartbeatPayload: async () => withHeartbeatReason(await refreshHeartbeatPayload(deps))'
+      'getHeartbeatPayload: () => withHeartbeatReason(buildHeartbeatPayload(deps))'
     );
   });
 

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
@@ -68,6 +68,7 @@ import {
   type WorktreeKiloCleanupClient,
 } from './delete-worktree';
 import { collectWorktreeChanges } from './worktree-changes';
+import { createNativeObservations, type NativeObservations } from './native-observations.js';
 
 export type HandlerSessionSnapshot = {
   kiloSessionId: string;
@@ -220,6 +221,7 @@ export type HandlerDeps = {
   tasks: Map<string, OwnedSessionTask>;
   signal?: AbortSignal;
   activity?: SessionActivityRegistry;
+  nativeObservations?: NativeObservations;
   emitSessionEvent: (session: SessionRequestIdentity, payload: SessionEventPayload) => void;
   retireRuntime: (reason: string) => void;
   onShutdown?: () => void;
@@ -303,50 +305,31 @@ export function buildHeartbeatPayload(deps: HandlerDeps): SandboxHeartbeatPayloa
   };
 }
 
-export async function refreshHeartbeatPayload(deps: HandlerDeps): Promise<SandboxHeartbeatPayload> {
-  const { activity, kiloRuntimes } = deps;
-  if (activity && kiloRuntimes) {
-    const rootsByDirectory = new Map<string, string[]>();
-    for (const { kiloSessionId } of activity.snapshots()) {
-      const directory = directoryForSession(kiloSessionId);
-      if (!directory) continue;
-      const roots = rootsByDirectory.get(directory) ?? [];
-      roots.push(kiloSessionId);
-      rootsByDirectory.set(directory, roots);
-    }
-    await Promise.all(
-      [...rootsByDirectory].map(async ([directory, roots]) => {
-        const runtime = kiloRuntimes.get(directory);
-        if (!runtime) return;
-        const revisions = new Map(roots.map(root => [root, activity.revision(root)]));
-        const kiloClient = runtime.kiloClient;
-        try {
-          const statuses = await withKiloRequestDeadline(
-            signal => kiloClient.getSessionStatuses(directory, signal),
-            deps.signal ? AbortSignal.any([deps.signal, runtime.signal]) : runtime.signal
-          );
-          if (
-            runtime.signal.aborted ||
-            deps.signal?.aborted ||
-            kiloRuntimes.get(directory) !== runtime ||
-            runtime.kiloClient !== kiloClient
-          )
-            return;
-          activity.reconcile(
-            statuses,
-            roots.filter(
-              root =>
-                directoryForSession(root) === directory &&
-                activity.revision(root) === revisions.get(root)
-            )
-          );
-        } catch {
-          return;
-        }
-      })
-    );
-  }
+export async function refreshHeartbeatPayload(
+  deps: HandlerDeps,
+  signal?: AbortSignal
+): Promise<SandboxHeartbeatPayload> {
+  await deps.nativeObservations?.refresh(signal);
   return buildHeartbeatPayload(deps);
+}
+
+export function createControlHandlerDeps(deps: HandlerDeps): HandlerDeps {
+  if (!deps.nativeObservations && deps.activity && deps.kiloRuntimes) {
+    deps.nativeObservations = createNativeObservations({
+      get signal() {
+        return deps.signal;
+      },
+      roots: () =>
+        (deps.activity?.snapshots() ?? []).map(({ kiloSessionId }) => ({
+          kiloSessionId,
+          directory: directoryForSession(kiloSessionId),
+          revision: deps.activity?.revision(kiloSessionId),
+        })),
+      getRuntime: directory => deps.kiloRuntimes?.get(directory),
+      reconcileActivity: (statuses, roots) => deps.activity?.reconcile(statuses, roots),
+    });
+  }
+  return deps;
 }
 
 function startSessionTask(
@@ -1149,22 +1132,30 @@ async function readRootRequests<Request extends { id: string; sessionID: string 
   session: SessionRequestIdentity,
   read: (directory: string, signal: AbortSignal) => Promise<Request[]>,
   signal: AbortSignal
-): Promise<Array<{ directory: string; request: Request }>> {
+): Promise<{ matches: Array<{ directory: string; request: Request }>; complete: boolean }> {
   const rootDirectory = directoryForSession(session.kiloSessionId) ?? session.directory;
   const scopes = await Promise.all(
     directoriesForRoot(session.kiloSessionId, rootDirectory).map(async directory => {
       const requests = await read(directory, signal);
-      return requests
-        .filter(
-          request =>
-            (request.sessionID === session.kiloSessionId ||
-              rootForSession(request.sessionID) === session.kiloSessionId) &&
-            (directoryForSession(request.sessionID) ?? rootDirectory) === directory
-        )
-        .map(request => ({ directory, request }));
+      const matches: Array<{ directory: string; request: Request }> = [];
+      let complete = true;
+      for (const request of requests) {
+        const root = rootForSession(request.sessionID);
+        if (request.sessionID === session.kiloSessionId || root === session.kiloSessionId) {
+          const requestDirectory = directoryForSession(request.sessionID);
+          if (requestDirectory === directory) matches.push({ directory, request });
+          else if (!requestDirectory) complete = false;
+        } else if (root === undefined) {
+          complete = false;
+        }
+      }
+      return { matches, complete };
     })
   );
-  return scopes.flat();
+  return {
+    matches: scopes.flatMap(scope => scope.matches),
+    complete: scopes.every(scope => scope.complete),
+  };
 }
 
 async function handlePermissionResolve(
@@ -1183,7 +1174,9 @@ async function handlePermissionResolve(
         (directory, signal) => kiloClient.getPermissions(directory, signal),
         signal
       );
-      const pending = permissions.find(item => item.request.id === parsed.data.permissionId);
+      const pending = permissions.matches.find(
+        item => item.request.id === parsed.data.permissionId
+      );
       if (!pending)
         return fail('unauthorized', 'Permission is not pending for this session', false);
       const success = await kiloClient.answerPermission(
@@ -1219,7 +1212,7 @@ async function handleQuestionResolve(
         (directory, signal) => kiloClient.getQuestions(directory, signal),
         signal
       );
-      const pending = questions.find(item => item.request.id === parsed.data.questionId);
+      const pending = questions.matches.find(item => item.request.id === parsed.data.questionId);
       if (!pending) return fail('unauthorized', 'Question is not pending for this session', false);
       const success =
         parsed.data.action === 'answer'
@@ -1337,7 +1330,7 @@ async function handleSync(
               signal
             ),
           questions => {
-            questionCount = questions.length;
+            questionCount = questions.matches.length;
           }
         ),
         query(
@@ -1349,24 +1342,27 @@ async function handleSync(
               signal
             ),
           permissions => {
-            permissionCount = permissions.length;
+            permissionCount = permissions.matches.length;
           }
         ),
       ]);
     }, deps.signal);
+    if (!questions.complete || !permissions.complete) {
+      throw new Error('Native requests contain unresolved ancestry');
+    }
     const ownedTask = deps.tasks.has(session.kiloSessionId);
     const status = ownedTask
       ? { type: 'busy' }
       : (statuses[session.kiloSessionId] ?? { type: 'idle' });
     const result = ok({
       status,
-      questions: questions.map(({ request }) =>
-        request.sessionID === session.kiloSessionId
+      questions: questions.matches.map(({ request }) =>
+        request.sessionID === session.kiloSessionId && !('rootKiloSessionId' in request)
           ? request
           : { ...request, rootKiloSessionId: session.kiloSessionId }
       ),
-      permissions: permissions.map(({ request }) =>
-        request.sessionID === session.kiloSessionId
+      permissions: permissions.matches.map(({ request }) =>
+        request.sessionID === session.kiloSessionId && !('rootKiloSessionId' in request)
           ? request
           : { ...request, rootKiloSessionId: session.kiloSessionId }
       ),

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, spyOn } from 'bun:test';
 import {
   KILO_FEED_FRESHNESS_TIMEOUT_MS,
+  SANDBOX_CONTROL_REPORT_INTERVAL_MS,
   maybeStartSandboxControlClient,
   startSandboxControlEventFeed,
 } from './sandbox-control-runtime';
 import type { SandboxControlClient, SandboxControlClientOptions } from './sandbox-control-client';
+import type { SandboxHeartbeatPayload } from '../../../src/shared/sandbox-control-protocol';
 
 function fakeClient(): SandboxControlClient {
   return {
@@ -16,6 +18,14 @@ function fakeClient(): SandboxControlClient {
 
 async function flushAsyncWork(): Promise<void> {
   await new Promise<void>(resolve => setImmediate(resolve));
+}
+
+function idlePayload(): SandboxHeartbeatPayload {
+  return {
+    state: 'idle',
+    kilo: { ready: true },
+    sessions: [],
+  };
 }
 
 describe('maybeStartSandboxControlClient', () => {
@@ -139,11 +149,7 @@ describe('maybeStartSandboxControlClient', () => {
 
   it('emits sandbox.ready then an immediate heartbeat when getHeartbeatPayload is set', async () => {
     const events: Array<{ event: string; payload: unknown }> = [];
-    const heartbeatPayload = {
-      state: 'idle',
-      kilo: { ready: true },
-      sessions: [],
-    };
+    const heartbeatPayload = idlePayload();
     const client: SandboxControlClient = {
       connect: async () => {},
       close: () => {},
@@ -177,7 +183,7 @@ describe('maybeStartSandboxControlClient', () => {
 
   it('emits readiness and heartbeats only while the Kilo event feed is live', async () => {
     const events: Array<{ event: string; payload: unknown }> = [];
-    const heartbeatPayload = { state: 'idle', kilo: { ready: true }, sessions: [] };
+    const heartbeatPayload = idlePayload();
     let ready = false;
     let received: SandboxControlClientOptions | undefined;
     const client: SandboxControlClient = {
@@ -219,7 +225,7 @@ describe('maybeStartSandboxControlClient', () => {
   it('does not re-advertise readiness after an established disconnect', async () => {
     const events: Array<{ event: string; payload: unknown }> = [];
     const connected: SandboxControlClient[] = [];
-    const heartbeatPayload = { state: 'idle' };
+    const heartbeatPayload = idlePayload();
     let received: SandboxControlClientOptions | undefined;
     const client: SandboxControlClient = {
       connect: async () => {},
@@ -258,77 +264,12 @@ describe('maybeStartSandboxControlClient', () => {
     client.close();
   });
 
-  it.each(['readiness', 'close', 'disconnect'] as const)(
-    'discards an asynchronous status poll after %s is lost',
-    async loss => {
-      const timers = spyOn(globalThis, 'setTimeout');
-      const events: Array<{ event: string; payload: unknown }> = [];
-      const pending = Promise.withResolvers<unknown>();
-      let ready = true;
-      let polls = 0;
-      let disconnected = 0;
-      let received: SandboxControlClientOptions | undefined;
-      const started = maybeStartSandboxControlClient(
-        {
-          SANDBOX_CONTROL_URL: 'wss://example.test/sandbox-control/sbx_1',
-          SANDBOX_CONTROL_CREDENTIAL: 'secret',
-          PROVIDER_INSTANCE_ID: 'inst_1',
-        },
-        () => {},
-        {
-          wrapperVersion: '2.4.0',
-          isReady: () => ready,
-          onDisconnected: () => {
-            disconnected++;
-          },
-          getHeartbeatPayload: async () => {
-            polls++;
-            return pending.promise;
-          },
-          createClient: options => {
-            received = options;
-            return {
-              connect: async () => {},
-              close: () => {},
-              sendEvent: (event, payload) => {
-                events.push({ event, payload });
-                return true;
-              },
-            };
-          },
-        }
-      );
-      try {
-        await flushAsyncWork();
-        expect(polls).toBe(1);
-        expect(events).toEqual([
-          { event: 'sandbox.ready', payload: { kiloReady: true, globalFeedAttached: true } },
-        ]);
-        if (loss === 'readiness') ready = false;
-        else if (loss === 'close') started?.close();
-        else received?.onDisconnected?.();
-        pending.resolve({ state: 'active' });
-        await flushAsyncWork();
-        expect(events).toEqual([
-          { event: 'sandbox.ready', payload: { kiloReady: true, globalFeedAttached: true } },
-        ]);
-        expect(polls).toBe(1);
-        expect(disconnected).toBe(loss === 'disconnect' ? 1 : 0);
-        expect(timers.mock.calls.filter(([, ms]) => ms === 30_000)).toHaveLength(0);
-      } finally {
-        started?.close();
-        pending.resolve({ state: 'idle' });
-        await flushAsyncWork();
-        timers.mockRestore();
-      }
-    }
-  );
-
-  it('awaits status results and permits at most one heartbeat poll at a time', async () => {
-    const timers = spyOn(globalThis, 'setTimeout');
+  it('sends heartbeats on a 15-second interval independent of sampling', async () => {
+    const timers = spyOn(globalThis, 'setInterval');
     const events: Array<{ event: string; payload: unknown }> = [];
-    const pending = Promise.withResolvers<unknown>();
-    let polls = 0;
+    let sampleCalls = 0;
+    const samplePending = Promise.withResolvers<void>();
+    const heartbeatPayload = idlePayload();
     const started = maybeStartSandboxControlClient(
       {
         SANDBOX_CONTROL_URL: 'wss://example.test/sandbox-control/sbx_1',
@@ -338,9 +279,10 @@ describe('maybeStartSandboxControlClient', () => {
       () => {},
       {
         wrapperVersion: '2.4.0',
-        getHeartbeatPayload: async () => {
-          polls++;
-          return polls === 1 ? { state: 'idle', poll: 1 } : pending.promise;
+        getHeartbeatPayload: () => heartbeatPayload,
+        sampleHeartbeat: async () => {
+          sampleCalls++;
+          await samplePending.promise;
         },
         createClient: () => ({
           connect: async () => {},
@@ -356,35 +298,32 @@ describe('maybeStartSandboxControlClient', () => {
       await flushAsyncWork();
       expect(events).toEqual([
         { event: 'sandbox.ready', payload: { kiloReady: true, globalFeedAttached: true } },
-        { event: 'sandbox.heartbeat', payload: { state: 'idle', poll: 1 } },
+        { event: 'sandbox.heartbeat', payload: heartbeatPayload },
       ]);
-      const tick = timers.mock.calls.find(([, ms]) => ms === 30_000)?.[0];
-      if (typeof tick !== 'function') throw new Error('Missing heartbeat timer');
-      tick();
-      tick();
-      await flushAsyncWork();
-      expect(polls).toBe(2);
-      expect(events).toHaveLength(2);
-      pending.resolve({ state: 'active', poll: 2 });
-      await flushAsyncWork();
-      expect(events.filter(item => item.event === 'sandbox.heartbeat')).toEqual([
-        { event: 'sandbox.heartbeat', payload: { state: 'idle', poll: 1 } },
-        { event: 'sandbox.heartbeat', payload: { state: 'active', poll: 2 } },
-      ]);
-      started?.close();
+      expect(sampleCalls).toBe(1);
+      const tick = timers.mock.calls.find(
+        ([, ms]) => ms === SANDBOX_CONTROL_REPORT_INTERVAL_MS
+      )?.[0];
+      if (typeof tick !== 'function') throw new Error('Missing heartbeat interval');
       tick();
       await flushAsyncWork();
-      expect(polls).toBe(2);
+      expect(sampleCalls).toBe(1);
+      expect(events.filter(e => e.event === 'sandbox.heartbeat')).toHaveLength(2);
+      samplePending.resolve();
+      await flushAsyncWork();
+      tick();
+      await flushAsyncWork();
+      expect(sampleCalls).toBe(2);
     } finally {
       started?.close();
-      pending.resolve({ state: 'idle' });
+      samplePending.resolve();
       await flushAsyncWork();
       timers.mockRestore();
     }
   });
 
-  it('retries failed status polling without emitting fabricated idle state or logging private errors', async () => {
-    const timers = spyOn(globalThis, 'setTimeout');
+  it('retries failed payload construction without emitting fabricated state', async () => {
+    const timers = spyOn(globalThis, 'setInterval');
     const events: Array<{ event: string; payload: unknown }> = [];
     const logs: string[] = [];
     let polls = 0;
@@ -402,15 +341,13 @@ describe('maybeStartSandboxControlClient', () => {
           disconnected++;
         },
         getHeartbeatPayload: () => {
-          if (++polls === 1) {
-            const failed = Promise.reject(new Error('private-status-credential'));
-            void failed.catch(() => {});
-            return failed;
-          }
-          return Promise.resolve({
-            state: 'active',
-            sessions: [{ kiloSessionId: 'kilo_1', state: 'finalizing' }],
-          });
+          polls++;
+          if (polls === 1) throw new Error('private-status-credential');
+          return {
+            state: 'active' as const,
+            kilo: { ready: true },
+            sessions: [{ kiloSessionId: 'kilo_1', state: 'finalizing' as const, idleForMs: 0 }],
+          };
         },
         createClient: () => ({
           connect: async () => {},
@@ -428,15 +365,14 @@ describe('maybeStartSandboxControlClient', () => {
         { event: 'sandbox.ready', payload: { kiloReady: true, globalFeedAttached: true } },
       ]);
       expect(disconnected).toBe(0);
-      const tick = timers.mock.calls.find(([, ms]) => ms === 30_000)?.[0];
-      if (typeof tick !== 'function') throw new Error('Missing heartbeat retry');
+      const tick = timers.mock.calls.find(
+        ([, ms]) => ms === SANDBOX_CONTROL_REPORT_INTERVAL_MS
+      )?.[0];
+      if (typeof tick !== 'function') throw new Error('Missing heartbeat interval');
       tick();
       await flushAsyncWork();
       expect(polls).toBe(2);
-      expect(events.at(-1)).toEqual({
-        event: 'sandbox.heartbeat',
-        payload: { state: 'active', sessions: [{ kiloSessionId: 'kilo_1', state: 'finalizing' }] },
-      });
+      expect(events.at(-1)?.event).toBe('sandbox.heartbeat');
       expect(disconnected).toBe(0);
       expect(logs.join('\n')).not.toContain('private-status-credential');
     } finally {
@@ -446,9 +382,9 @@ describe('maybeStartSandboxControlClient', () => {
   });
 
   it.each(['false', 'throw'] as const)(
-    'retires the connection when an awaited heartbeat delivery returns %s',
+    'retires the connection when heartbeat delivery returns %s',
     async failure => {
-      const timers = spyOn(globalThis, 'setTimeout');
+      const timers = spyOn(globalThis, 'setInterval');
       let disconnected = 0;
       const started = maybeStartSandboxControlClient(
         {
@@ -459,7 +395,7 @@ describe('maybeStartSandboxControlClient', () => {
         () => {},
         {
           wrapperVersion: '2.4.0',
-          getHeartbeatPayload: async () => ({ state: 'idle' }),
+          getHeartbeatPayload: () => idlePayload(),
           onDisconnected: () => {
             disconnected++;
           },
@@ -477,7 +413,9 @@ describe('maybeStartSandboxControlClient', () => {
       try {
         await flushAsyncWork();
         expect(disconnected).toBe(1);
-        expect(timers.mock.calls.filter(([, ms]) => ms === 30_000)).toHaveLength(0);
+        expect(
+          timers.mock.calls.filter(([, ms]) => ms === SANDBOX_CONTROL_REPORT_INTERVAL_MS)
+        ).toHaveLength(0);
       } finally {
         started?.close();
         timers.mockRestore();
@@ -526,6 +464,135 @@ describe('maybeStartSandboxControlClient', () => {
     expect(logs.join('\n')).not.toContain('Authorization');
     expect(logs.some(line => line.includes('sandbox control client failed'))).toBe(true);
   });
+
+  it.each(['readiness', 'close', 'disconnect'] as const)(
+    'cancels owned sampling and permanently stops reports after %s is lost',
+    async loss => {
+      const timers = spyOn(globalThis, 'setInterval');
+      const cleared = spyOn(globalThis, 'clearInterval');
+      const events: string[] = [];
+      const sampleBlocked = Promise.withResolvers<void>();
+      let ready = true;
+      let sampleCalls = 0;
+      let signal: AbortSignal | undefined;
+      let received: SandboxControlClientOptions | undefined;
+      let disconnected = 0;
+      const started = maybeStartSandboxControlClient(
+        {
+          SANDBOX_CONTROL_URL: 'wss://example.test/control',
+          SANDBOX_CONTROL_CREDENTIAL: 'secret',
+          PROVIDER_INSTANCE_ID: 'inst_1',
+        },
+        () => {},
+        {
+          wrapperVersion: '2.4.0',
+          isReady: () => ready,
+          getHeartbeatPayload: idlePayload,
+          onDisconnected: () => {
+            disconnected++;
+          },
+          sampleHeartbeat: async input => {
+            signal = input;
+            sampleCalls++;
+            await sampleBlocked.promise;
+          },
+          createClient: options => {
+            received = options;
+            return {
+              connect: async () => {},
+              close: () => {},
+              sendEvent: event => {
+                events.push(event);
+                return true;
+              },
+            };
+          },
+        }
+      );
+      try {
+        await flushAsyncWork();
+        const tick = timers.mock.calls.find(
+          ([, ms]) => ms === SANDBOX_CONTROL_REPORT_INTERVAL_MS
+        )?.[0];
+        if (typeof tick !== 'function') throw new Error('Missing heartbeat interval');
+        expect(events).toEqual(['sandbox.ready', 'sandbox.heartbeat']);
+        expect(signal?.aborted).toBe(false);
+        if (loss === 'readiness') ready = false;
+        else if (loss === 'close') started?.close();
+        else received?.onDisconnected?.();
+        tick();
+        expect(signal?.aborted).toBe(true);
+        expect(cleared).toHaveBeenCalledTimes(1);
+        sampleBlocked.resolve();
+        await flushAsyncWork();
+        ready = true;
+        tick();
+        await flushAsyncWork();
+        expect(events).toEqual(['sandbox.ready', 'sandbox.heartbeat']);
+        expect(sampleCalls).toBe(1);
+        expect(disconnected).toBe(loss === 'disconnect' ? 1 : 0);
+        expect(
+          timers.mock.calls.filter(([, ms]) => ms === SANDBOX_CONTROL_REPORT_INTERVAL_MS)
+        ).toHaveLength(1);
+      } finally {
+        started?.close();
+        sampleBlocked.resolve();
+        await flushAsyncWork();
+        timers.mockRestore();
+        cleared.mockRestore();
+      }
+    }
+  );
+
+  it.each(['throw', 'reject'] as const)(
+    'keeps reporting and retries when sampling callbacks %s',
+    async failure => {
+      const timers = spyOn(globalThis, 'setInterval');
+      const events: string[] = [];
+      const logs: string[] = [];
+      let samples = 0;
+      const started = maybeStartSandboxControlClient(
+        {
+          SANDBOX_CONTROL_URL: 'wss://example.test/control',
+          SANDBOX_CONTROL_CREDENTIAL: 'secret',
+          PROVIDER_INSTANCE_ID: 'inst_1',
+        },
+        message => logs.push(message),
+        {
+          wrapperVersion: '2.4.0',
+          getHeartbeatPayload: idlePayload,
+          sampleHeartbeat: () => {
+            samples++;
+            if (failure === 'throw') throw new Error('private-native-error');
+            return Promise.reject(new Error('private-native-error'));
+          },
+          createClient: () => ({
+            connect: async () => {},
+            close: () => {},
+            sendEvent: event => {
+              events.push(event);
+              return true;
+            },
+          }),
+        }
+      );
+      try {
+        await flushAsyncWork();
+        const tick = timers.mock.calls.find(
+          ([, ms]) => ms === SANDBOX_CONTROL_REPORT_INTERVAL_MS
+        )?.[0];
+        if (typeof tick !== 'function') throw new Error('Missing heartbeat interval');
+        tick();
+        await flushAsyncWork();
+        expect(events).toEqual(['sandbox.ready', 'sandbox.heartbeat', 'sandbox.heartbeat']);
+        expect(samples).toBe(2);
+        expect(logs.join(' ')).not.toContain('private-native-error');
+      } finally {
+        started?.close();
+        timers.mockRestore();
+      }
+    }
+  );
 });
 
 describe('startSandboxControlEventFeed', () => {

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.ts
@@ -3,6 +3,7 @@ import {
   emitControlDiagnostic,
   type ControlDiagnosticReporter,
 } from '../../../src/shared/control-diagnostics.js';
+import type { SandboxHeartbeatPayload } from '../../../src/shared/sandbox-control-protocol.js';
 import {
   createSandboxControlClient,
   type SandboxControlClient,
@@ -23,7 +24,8 @@ type StartOptions = {
   onRequest?: SandboxControlRequestHandler;
   onConnected?: (client: SandboxControlClient) => void;
   onDisconnected?: () => void;
-  getHeartbeatPayload?: () => unknown;
+  getHeartbeatPayload?: () => SandboxHeartbeatPayload;
+  sampleHeartbeat?: (signal: AbortSignal) => Promise<void>;
   isReady?: () => boolean;
   onDiagnostic?: ControlDiagnosticReporter;
 };
@@ -37,7 +39,7 @@ type SandboxControlEventFeedOptions = {
   now?: () => number;
 };
 
-const HEARTBEAT_INTERVAL_MS = 30_000;
+export const SANDBOX_CONTROL_REPORT_INTERVAL_MS = 15_000;
 export const KILO_FEED_FRESHNESS_TIMEOUT_MS = 30_000;
 export const KILO_CONTROL_REQUEST_TIMEOUT_MS = 10_000;
 
@@ -190,8 +192,9 @@ export function maybeStartSandboxControlClient(
   }
 
   const createClient = options.createClient ?? createSandboxControlClient;
-  let heartbeat: ReturnType<typeof setTimeout> | null = null;
-  let heartbeatInFlight = false;
+  let heartbeat: ReturnType<typeof setInterval> | null = null;
+  let sampling: Promise<void> | undefined;
+  const sampleAbort = new AbortController();
   let closed = false;
   let heartbeatSequence = 0;
   let lastSentAt: number | undefined;
@@ -204,8 +207,8 @@ export function maybeStartSandboxControlClient(
     });
 
   function stopHeartbeat(): void {
-    if (!heartbeat) return;
-    clearTimeout(heartbeat);
+    sampleAbort.abort();
+    if (heartbeat) clearInterval(heartbeat);
     heartbeat = null;
     diagnostic('stopped');
   }
@@ -217,46 +220,53 @@ export function maybeStartSandboxControlClient(
     options.onDisconnected?.();
   }
 
-  async function sendHeartbeat(active: SandboxControlClient): Promise<void> {
-    if (
-      closed ||
-      heartbeatInFlight ||
-      options.isReady?.() === false ||
-      !options.getHeartbeatPayload
-    )
+  function triggerSample(): void {
+    const sample = options.sampleHeartbeat;
+    if (closed || sampleAbort.signal.aborted || sampling || !sample) return;
+    const pending = Promise.resolve().then(() => {
+      if (!sampleAbort.signal.aborted) return sample(sampleAbort.signal);
+    });
+    sampling = pending;
+    void pending.then(
+      () => {
+        if (sampling === pending) sampling = undefined;
+      },
+      () => {
+        if (sampling === pending) sampling = undefined;
+        if (!sampleAbort.signal.aborted) log('sandbox control heartbeat sampling failed');
+      }
+    );
+  }
+
+  function sendHeartbeat(active: SandboxControlClient): void {
+    if (closed || sampleAbort.signal.aborted) return;
+    if (options.isReady?.() === false) {
+      stopHeartbeat();
       return;
-    heartbeatInFlight = true;
+    }
+    if (!options.getHeartbeatPayload) return;
     heartbeatSequence += 1;
     diagnostic('sending');
+    let payload: SandboxHeartbeatPayload;
     try {
-      const payload = await options.getHeartbeatPayload();
-      if (closed || options.isReady?.() === false) return;
-      try {
-        if (!active.sendEvent?.('sandbox.heartbeat', payload)) {
-          diagnostic('send_failed');
-          handleDisconnected();
-        } else {
-          lastSentAt = Date.now();
-          diagnostic('sent');
-        }
-      } catch {
-        diagnostic('send_threw');
+      payload = options.getHeartbeatPayload();
+    } catch {
+      diagnostic('send_threw');
+      log('sandbox control heartbeat failed');
+      return;
+    }
+    if (closed) return;
+    try {
+      if (!active.sendEvent?.('sandbox.heartbeat', payload)) {
+        diagnostic('send_failed');
         handleDisconnected();
+      } else {
+        lastSentAt = Date.now();
+        diagnostic('sent');
       }
     } catch {
-      if (!closed) {
-        diagnostic('send_threw');
-        log('sandbox control heartbeat failed');
-      }
-    } finally {
-      heartbeatInFlight = false;
-      if (!closed && options.isReady?.() !== false) {
-        heartbeat = setTimeout(() => {
-          heartbeat = null;
-          void sendHeartbeat(active);
-        }, HEARTBEAT_INTERVAL_MS);
-        heartbeat.unref();
-      }
+      diagnostic('send_threw');
+      handleDisconnected();
     }
   }
 
@@ -266,9 +276,15 @@ export function maybeStartSandboxControlClient(
       handleDisconnected();
       return;
     }
-    if (options.getHeartbeatPayload) {
-      stopHeartbeat();
-      void sendHeartbeat(active);
+    sendHeartbeat(active);
+    triggerSample();
+    if (!closed && !sampleAbort.signal.aborted && options.getHeartbeatPayload) {
+      if (heartbeat) clearInterval(heartbeat);
+      heartbeat = setInterval(() => {
+        sendHeartbeat(active);
+        triggerSample();
+      }, SANDBOX_CONTROL_REPORT_INTERVAL_MS);
+      heartbeat.unref();
     }
     options.onConnected?.(active);
   }


### PR DESCRIPTION
## Summary
- Keep wrapper observation independent of sandbox liveness so a dying or restarting runtime does not tear down in-flight event observation.
- Preserve native observation routing and handler behavior for control-plane recovery.

## Stack
Control-plane recovery stack. Merge from the bottom. Each PR targets its parent, not `main` (except #5912).

1. #5912 `eshurakov/recovery-observation` → `main`
2. #5913 `eshurakov/recovery-results` → `eshurakov/recovery-observation`
3. #5914 `eshurakov/recovery-stop-scope` → `eshurakov/recovery-results`
4. #5915 `eshurakov/recovery-native-cleanup` → `eshurakov/recovery-stop-scope`
5. #5916 `eshurakov/recovery-session-delivery` → `eshurakov/recovery-native-cleanup`
6. #5917 `eshurakov/recovery-native-feed` → `eshurakov/recovery-session-delivery`
7. #5918 `eshurakov/recovery-control-connection` → `eshurakov/recovery-native-feed`
8. #5919 `eshurakov/recovery-stack` → `eshurakov/recovery-control-connection`
9. #5920 `eshurakov/recovery-not-ready-retry` → `eshurakov/recovery-stack`

Do not merge out of order.


## Reviewer Notes
One commit. Unique vs `main`.