### PR TITLE
fix(cloud-agent-next): retire native runtimes safely

### DIFF
--- a/services/cloud-agent-next/src/persistence/SandboxControl.ts
+++ b/services/cloud-agent-next/src/persistence/SandboxControl.ts
@@ -57,12 +57,18 @@ import {
   sessionOperationAckSchema,
   sessionOperationAuthorizationSchema,
   sessionOperationExpiresAt,
+  sessionOperationLookupResultSchema,
+  sessionAttachResultSchema,
+  sessionAttachPayloadSchema,
   sessionAbortPayloadSchema,
+  sessionAbortResultSchema,
+  sessionNativeRuntimeRetirementPayloadSchema,
   sessionRequestIdentitySchema,
   wrapperInstanceIdSchema,
   type ResponseFrame,
   type SessionAttachPayload,
   type SessionOperationAck,
+  type SessionOperationAuthorization,
   type SessionOperationDelivery,
   type SandboxHeartbeatPayload,
   type SessionEventIdentity,
@@ -140,7 +146,18 @@ import {
   saveTransitionLog,
   loadSessionCredentialGrants,
   saveSessionCredentialGrants,
+  loadNativeRuntimeRetirements,
+  saveNativeRuntimeRetirements,
+  type NativeRuntimeRetirementReceipt,
 } from '../sandbox-control/durable-state.js';
+import {
+  createNativeRuntimeRetirementWorkflow,
+  matchesNativeRuntimeRetirementAllocation,
+  releaseNativeRuntimeRetirement,
+  sameNativeRuntimeRetirement,
+  type NativeRuntimeRetirementConnection,
+  type NativeRuntimeRetirementWorkflow,
+} from '../sandbox-control/native-runtime-retirement.js';
 import {
   buildControlNetworkPolicy,
   prepareSessionCredentials as prepareCredentials,
@@ -321,6 +338,7 @@ export class SandboxControl extends DurableObject<Env> {
   private readonly lifecycleOperations = new Set<Promise<unknown>>();
   private worktreeDeletionChain: Promise<unknown> = Promise.resolve();
   private operationalInitialization: Promise<void> | null = null;
+  private readonly nativeRuntimeRetirement: NativeRuntimeRetirementWorkflow;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -340,8 +358,30 @@ export class SandboxControl extends DurableObject<Env> {
         this.onSessionPreparing(sessionIdentity, payload, identity),
       onOperationResult: (session, delivery, identity) =>
         this.onOperationResult(session, delivery, identity),
+      onNativeRuntimeRetired: (payload, identity) => this.onNativeRuntimeRetired(payload, identity),
       onSocketClosed: (handshakeComplete, identity) =>
         this.onSocketClosed(handshakeComplete, identity),
+    });
+    this.nativeRuntimeRetirement = createNativeRuntimeRetirementWorkflow({
+      storage: ctx.storage,
+      currentIncarnation: {
+        isCurrent: connection => this.isCurrentConnection(connection),
+        getConnection: () => {
+          const connection = this.socketHandler.getConnectionIdentity();
+          return connection ? (this.nativeRetirementConnection(connection) ?? null) : null;
+        },
+        sameConnection: (left, right) => this.sameConnection(left, right),
+      },
+      transport: {
+        supportsTargetedRetirement: () => this.supportsNativeRuntimeRetirement(),
+        abortNativeRuntime: input => this.abortNativeRuntime(input),
+        invalidateRecipients: receipt => this.invalidateNativeRetirementRecipients(receipt),
+        notifyRecipients: receipt => this.notifyNativeRetirementRecipients(receipt),
+      },
+      physicalEscalation: {
+        beginIfCurrent: receipt => this.beginNativeRetirementPhysicalFallback(receipt),
+      },
+      scheduleAlarm: deadlines => this.scheduleAlarm(deadlines),
     });
   }
 
@@ -369,6 +409,7 @@ export class SandboxControl extends DurableObject<Env> {
         );
       }
       await this.repairLifecycleScheduling(physical);
+      this.ctx.waitUntil(this.nativeRuntimeRetirement.resume());
       if (
         physical.stopTombstone ||
         (physical.state !== 'running' && physical.state !== 'creating')
@@ -623,19 +664,23 @@ export class SandboxControl extends DurableObject<Env> {
     ) {
       throw new Error('Sandbox runtime is not ready');
     }
+    const scopedSession = scopedStop
+      ? sessionRequestIdentitySchema.safeParse(input.session)
+      : undefined;
+    let scopedRoute: SessionRoute | undefined;
     if (scopedStop) {
-      const session = sessionRequestIdentitySchema.safeParse(input.session);
-      if (!session.success || expectedWrapperInstanceId === undefined)
+      if (!scopedSession?.success || expectedWrapperInstanceId === undefined)
         throw new Error('Scoped Stop identity is required');
-      const route = (await loadRouteTable(this.ctx.storage)).get(session.data.sessionId);
+      const route = (await loadRouteTable(this.ctx.storage)).get(scopedSession.data.sessionId);
       if (
         !route ||
-        route.kiloSessionId !== session.data.kiloSessionId ||
-        route.directory !== session.data.directory ||
+        route.kiloSessionId !== scopedSession.data.kiloSessionId ||
+        route.directory !== scopedSession.data.directory ||
         runtime.wrapperInstanceId !== expectedWrapperInstanceId
       )
         throw new Error('Scoped Stop target is stale');
       this.assertWorktreeAdmission(route.worktreeId);
+      scopedRoute = route;
     }
     if (input.operation === 'session.attach' || input.operation === 'session.prompt') {
       const payload = parseOperationPayload(input.operation, input.payload);
@@ -658,9 +703,10 @@ export class SandboxControl extends DurableObject<Env> {
         if (
           !route ||
           route.kiloSessionId !== identity.data.kiloSessionId ||
-          route.directory !== identity.data.directory
+          route.directory !== identity.data.directory ||
+          route.retiringNativeRuntimeId !== undefined
         ) {
-          throw new Error('Session is not attached to this sandbox runtime');
+          throw new Error('Session is not attached to a ready sandbox runtime');
         }
         this.assertWorktreeAdmission(route.worktreeId);
         const now = Date.now();
@@ -697,13 +743,128 @@ export class SandboxControl extends DurableObject<Env> {
     if (!isCurrent()) throw new Error('Sandbox wrapper runtime changed');
     if (scopedStop) {
       const payload = sessionAbortPayloadSchema.parse(input.payload);
-      return this.socketHandler.sendRequest({
-        ...input,
-        payload: stopAbortWirePayload(payload, this.socketHandler.supportsScopedStopAbort()),
-        deadlineAt: scopedStop.cleanupDeadlineAt,
-      });
+      const nativeRuntimeId = scopedRoute?.nativeRuntimeId;
+      const retirementConnection = this.nativeRetirementConnection(runtime);
+      const retirement =
+        nativeRuntimeId !== undefined && scopedRoute !== undefined && retirementConnection
+          ? await this.nativeRuntimeRetirement.begin({
+              connection: retirementConnection,
+              physical,
+              route: scopedRoute,
+              nativeRuntimeId,
+              reason: 'Scoped Stop cleanup',
+              operationId: scopedStop.operationId,
+              cleanupDeadlineAt: scopedStop.cleanupDeadlineAt,
+            })
+          : undefined;
+      if (retirement && retirement.operationId !== scopedStop.operationId)
+        return errorResponse(
+          crypto.randomUUID(),
+          'not_ready',
+          'Native runtime retirement is already in progress',
+          true
+        );
+      const retirementAttempt = retirement
+        ? await this.nativeRuntimeRetirement.claimTargetedAttempt(retirement)
+        : undefined;
+      if (retirement && !retirementAttempt)
+        return errorResponse(
+          crypto.randomUUID(),
+          'not_ready',
+          'Native runtime retirement is already in progress',
+          true
+        );
+      let response: ResponseFrame;
+      try {
+        const cleanupDeadlineAt = retirement?.cleanupDeadlineAt ?? scopedStop.cleanupDeadlineAt;
+        response = await this.socketHandler.sendRequest({
+          ...input,
+          payload: stopAbortWirePayload(
+            { ...payload, cleanupDeadlineAt },
+            this.socketHandler.supportsScopedStopAbort()
+          ),
+          deadlineAt: cleanupDeadlineAt,
+        });
+      } catch (error) {
+        if (retirementAttempt) await this.nativeRuntimeRetirement.defer(retirementAttempt);
+        throw error;
+      }
+      const result = response.ok ? sessionAbortResultSchema.safeParse(response.result) : undefined;
+      if (
+        result?.success &&
+        result.data.runtimeRetired === true &&
+        result.data.nativeRuntimeId !== undefined &&
+        nativeRuntimeId === result.data.nativeRuntimeId &&
+        retirementAttempt &&
+        this.supportsNativeRuntimeRetirement() &&
+        expectedWrapperInstanceId !== undefined
+      ) {
+        const invalidated = await this.nativeRuntimeRetirement.complete(retirementAttempt);
+        if (!invalidated)
+          return errorResponse(
+            response.requestId,
+            'not_ready',
+            'Native runtime retirement invalidation is pending',
+            true
+          );
+      } else if (retirementAttempt && result?.success && result.data.status !== 'unconfirmed') {
+        await this.nativeRuntimeRetirement.release(retirementAttempt);
+      } else if (retirementAttempt) {
+        await this.nativeRuntimeRetirement.defer(retirementAttempt);
+      }
+      return response;
     }
-    return this.socketHandler.sendRequest(input);
+    const outbound =
+      input.operation === 'session.attach' && this.supportsNativeRuntimeRetirement()
+        ? {
+            ...input,
+            payload: {
+              ...sessionAttachPayloadSchema.parse(input.payload),
+              captureNativeRuntimeId: true,
+            },
+          }
+        : input;
+    const response = await this.socketHandler.sendRequest(outbound);
+    if (input.operation === 'session.attach' && response.ok) {
+      const result = sessionAttachResultSchema.safeParse(response.result);
+      const session = sessionRequestIdentitySchema.safeParse(input.session);
+      if (result.success && session.success && result.data.nativeRuntimeId !== undefined) {
+        await this.recordNativeRuntime(
+          runtime,
+          physical,
+          session.data,
+          result.data.nativeRuntimeId,
+          authorization?.success ? authorization.data : undefined
+        );
+      }
+    }
+    if (
+      input.operation === 'session.operation.get' &&
+      response.ok &&
+      this.supportsNativeRuntimeRetirement()
+    ) {
+      const lookup = sessionOperationLookupResultSchema.safeParse(response.result);
+      const session = sessionRequestIdentitySchema.safeParse(input.session);
+      if (
+        lookup.success &&
+        lookup.data.state === 'completed' &&
+        lookup.data.delivery.authorization.operation === 'session.attach' &&
+        lookup.data.delivery.result.ok &&
+        session.success
+      ) {
+        const attached = sessionAttachResultSchema.safeParse(lookup.data.delivery.result.result);
+        if (attached.success && attached.data.nativeRuntimeId !== undefined) {
+          await this.recordNativeRuntime(
+            runtime,
+            physical,
+            session.data,
+            attached.data.nativeRuntimeId,
+            lookup.data.delivery.authorization
+          );
+        }
+      }
+    }
+    return response;
   }
 
   private async requestWorktreeChanges(
@@ -801,9 +962,27 @@ export class SandboxControl extends DurableObject<Env> {
     ]);
     if (ownerId !== input.ownerId) throw new Error('Sandbox owner mismatch');
     if (physical.state === 'stopped') return { quarantined: false };
+    const connection = this.activeConnection;
+    const retirementConnection = this.nativeRetirementConnection(connection);
     const wrapperInstanceId =
-      physical.stopTombstone?.wrapperInstanceId ?? this.activeConnection?.wrapperInstanceId;
+      physical.stopTombstone?.wrapperInstanceId ?? connection?.wrapperInstanceId;
     if (wrapperInstanceId !== input.wrapperInstanceId) return { quarantined: false };
+    const route = (await loadRouteTable(this.ctx.storage)).get(input.sessionId);
+    if (
+      route &&
+      route.ownerId === input.ownerId &&
+      retirementConnection &&
+      route.nativeRuntimeId !== undefined &&
+      !physical.stopTombstone
+    ) {
+      const retirement = await this.nativeRuntimeRetirement.retire({
+        connection: retirementConnection,
+        physical,
+        route,
+        reason: input.reason,
+      });
+      if (retirement !== 'unavailable') return { quarantined: true };
+    }
     if (!physical.stopTombstone) {
       const next = beginStop(physical, input.reason, Date.now(), wrapperInstanceId);
       await this.persistPhysical(physical, next, input.reason);
@@ -2599,6 +2778,10 @@ export class SandboxControl extends DurableObject<Env> {
       }
       return;
     }
+    if (id === 'nativeRetirement') {
+      await this.nativeRuntimeRetirement.resume();
+      return;
+    }
     if (id === 'reconciliation') {
       const physical = await loadPhysicalRecord(this.ctx.storage);
       if (this.shouldSlowReap(physical)) {
@@ -2986,6 +3169,20 @@ export class SandboxControl extends DurableObject<Env> {
             })
         )
     );
+  }
+
+  private async onNativeRuntimeRetired(
+    input: unknown,
+    connection: SandboxControlConnectionIdentity
+  ): Promise<{ retired: true } | undefined> {
+    const payload = sessionNativeRuntimeRetirementPayloadSchema.parse(input);
+    if (!this.supportsNativeRuntimeRetirement()) return undefined;
+    const retirementConnection = this.nativeRetirementConnection(connection);
+    if (!retirementConnection) return undefined;
+    return this.nativeRuntimeRetirement.receiveRetired({
+      connection: retirementConnection,
+      ...payload,
+    });
   }
 
   private async onOperationResult(
@@ -3526,6 +3723,51 @@ export class SandboxControl extends DurableObject<Env> {
     return current;
   }
 
+  private supportsNativeRuntimeRetirement(): boolean {
+    return (
+      this.socketHandler.supportsOperationResults() &&
+      this.socketHandler.supportsNativeRuntimeRetirement?.() === true
+    );
+  }
+
+  private nativeRetirementConnection(
+    connection: SandboxControlConnectionIdentity | null
+  ): NativeRuntimeRetirementConnection | undefined {
+    if (!connection?.wrapperInstanceId) return undefined;
+    return {
+      connectionId: connection.connectionId,
+      providerInstanceId: connection.providerInstanceId,
+      wrapperInstanceId: connection.wrapperInstanceId,
+    };
+  }
+
+  private async abortNativeRuntime(input: {
+    receipt: NativeRuntimeRetirementReceipt;
+    route: SessionRoute;
+  }): Promise<boolean> {
+    const response = await this.socketHandler.sendRequest({
+      operation: 'session.abort',
+      session: {
+        sessionId: input.route.sessionId,
+        kiloSessionId: input.route.kiloSessionId,
+        directory: input.route.directory,
+      },
+      payload: {
+        reason: input.receipt.reason,
+        nativeRuntimeId: input.receipt.nativeRuntimeId,
+        cleanupDeadlineAt: input.receipt.cleanupDeadlineAt,
+      },
+      deadlineAt: input.receipt.cleanupDeadlineAt,
+      timeoutMs: Math.max(1, input.receipt.cleanupDeadlineAt - Date.now()),
+    });
+    const result = response.ok ? sessionAbortResultSchema.safeParse(response.result) : undefined;
+    return (
+      result?.success === true &&
+      result.data.runtimeRetired === true &&
+      result.data.nativeRuntimeId === input.receipt.nativeRuntimeId
+    );
+  }
+
   private async readTerminalRuntime(
     input: SandboxTerminalAccessInput,
     allowExpiredCredentials = false
@@ -3683,11 +3925,20 @@ export class SandboxControl extends DurableObject<Env> {
     if (to.stopTombstone && wrapperInstanceId && !to.stopTombstone.wrapperInstanceId) {
       to = { ...to, stopTombstone: { ...to.stopTombstone, wrapperInstanceId } };
     }
+    await this.ctx.storage.transaction(() => this.persistPhysicalState(from, to, cause));
+    await this.afterPhysicalPersistence(from, to, cause, wrapperInstanceId);
+  }
+
+  private async afterPhysicalPersistence(
+    from: PhysicalRecord,
+    to: PhysicalRecord,
+    cause: string,
+    wrapperInstanceId: string | undefined
+  ): Promise<void> {
     const changed =
       from.state !== to.state || (from.stopTombstone === null && to.stopTombstone !== null);
     const unavailable =
       to.stopTombstone !== null || (to.state !== 'creating' && to.state !== 'running');
-    await this.ctx.storage.transaction(() => this.persistPhysicalState(from, to, cause));
     this.logDiagnostic('physical_committed', {
       allocationId: to.createIntent?.intentId ?? from.createIntent?.intentId,
       wrapperInstanceId,
@@ -3717,6 +3968,50 @@ export class SandboxControl extends DurableObject<Env> {
     }
   }
 
+  private async beginNativeRetirementPhysicalFallback(
+    receipt: NativeRuntimeRetirementReceipt
+  ): Promise<boolean> {
+    const committed = await this.ctx.storage.transaction(async () => {
+      const [physical, receipts] = await Promise.all([
+        loadPhysicalRecord(this.ctx.storage),
+        loadNativeRuntimeRetirements(this.ctx.storage),
+      ]);
+      const currentReceipt = receipts.find(
+        current =>
+          sameNativeRuntimeRetirement(current, {
+            directory: receipt.directory,
+            nativeRuntimeId: receipt.nativeRuntimeId,
+            connection: receipt.connection,
+          }) && current.operationId === receipt.operationId
+      );
+      if (
+        !currentReceipt ||
+        currentReceipt.state !== 'unconfirmed' ||
+        physical.stopTombstone ||
+        physical.state === 'stopped' ||
+        !matchesNativeRuntimeRetirementAllocation(currentReceipt, physical)
+      )
+        return undefined;
+      const next = beginStop(
+        physical,
+        currentReceipt.reason,
+        Date.now(),
+        currentReceipt.connection.wrapperInstanceId
+      );
+      await this.persistPhysicalState(physical, next, currentReceipt.reason);
+      return { physical, next, reason: currentReceipt.reason };
+    });
+    if (!committed) return false;
+    await this.afterPhysicalPersistence(
+      committed.physical,
+      committed.next,
+      committed.reason,
+      committed.next.stopTombstone?.wrapperInstanceId
+    );
+    this.ctx.waitUntil(this.recordStopAttempt());
+    return true;
+  }
+
   private async persistPhysicalState(
     from: PhysicalRecord,
     to: PhysicalRecord,
@@ -3733,6 +4028,21 @@ export class SandboxControl extends DurableObject<Env> {
     if (to.state === 'stopped') {
       await saveSessionCredentialGrants(this.ctx.storage, []);
       await this.ctx.storage.delete(CREDENTIAL_POLICY_DIRTY_KEY);
+      const [routes, receipts] = await Promise.all([
+        loadRouteTable(this.ctx.storage),
+        loadNativeRuntimeRetirements(this.ctx.storage),
+      ]);
+      const retired = receipts.filter(receipt =>
+        matchesNativeRuntimeRetirementAllocation(receipt, from)
+      );
+      for (const receipt of retired) releaseNativeRuntimeRetirement(routes, receipt, true);
+      if (retired.length > 0) {
+        await saveRouteTable(this.ctx.storage, routes);
+        await saveNativeRuntimeRetirements(
+          this.ctx.storage,
+          receipts.filter(receipt => !retired.includes(receipt))
+        );
+      }
     }
     if (changed) {
       await this.appendLog(
@@ -3793,46 +4103,173 @@ export class SandboxControl extends DurableObject<Env> {
     await this.scheduleAlarm(next);
   }
 
-  private async invalidateTerminalRuntime(
-    wrapperInstanceId: string,
-    confirmed: boolean
-  ): Promise<void> {
-    const routes = await loadRouteTable(this.ctx.storage);
-    await Promise.all(
-      [...routes.values()].map(route => {
-        return withTimeout(
+  private async recordNativeRuntime(
+    connection: SandboxControlConnectionIdentity,
+    physical: PhysicalRecord,
+    session: SessionRequestIdentity,
+    nativeRuntimeId: string,
+    authorization?: SessionOperationAuthorization
+  ): Promise<boolean> {
+    const wrapperInstanceId = connection.wrapperInstanceId;
+    if (!this.isCurrentConnection(connection) || !wrapperInstanceId) return false;
+    const recordedRoute = await this.ctx.storage.transaction(async () => {
+      const [currentPhysical, routes] = await Promise.all([
+        loadPhysicalRecord(this.ctx.storage),
+        loadRouteTable(this.ctx.storage),
+      ]);
+      const route = routes.get(session.sessionId);
+      if (
+        !route ||
+        route.kiloSessionId !== session.kiloSessionId ||
+        route.directory !== session.directory ||
+        (route.nativeRuntimeId !== undefined && route.nativeRuntimeId !== nativeRuntimeId) ||
+        route.retiringNativeRuntimeId !== undefined ||
+        !this.isCurrentConnection(connection) ||
+        currentPhysical.state !== 'running' ||
+        currentPhysical.stopTombstone ||
+        currentPhysical.providerRef !== connection.providerInstanceId ||
+        !sameAllocation(physical, currentPhysical)
+      )
+        return undefined;
+      routes.set(route.sessionId, { ...route, nativeRuntimeId });
+      await saveRouteTable(this.ctx.storage, routes);
+      return route;
+    });
+    if (!recordedRoute) return false;
+    try {
+      await withTimeout(
+        withDORetry(
+          () => getSandboxSessionStub(this.env, recordedRoute.ownerId, recordedRoute.sessionId),
+          stub =>
+            stub.recordNativeRuntime({
+              sandboxId: this.sandboxId,
+              wrapperInstanceId,
+              nativeRuntimeId,
+              ...(authorization ? { authorization } : {}),
+            }),
+          'recordNativeRuntime'
+        ),
+        DEADLINE_MS.stopAttempt,
+        'Native runtime route registration timed out'
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async invalidateNativeRetirementRecipients(
+    receipt: NativeRuntimeRetirementReceipt
+  ): Promise<boolean> {
+    const invalidated = await Promise.all(
+      receipt.recipients.map(recipient =>
+        withTimeout(
           withDORetry(
-            () => getSandboxSessionStub(this.env, route.ownerId, route.sessionId),
+            () => getSandboxSessionStub(this.env, recipient.ownerId, recipient.sessionId),
             stub =>
               stub.invalidateTerminalRuntime({
                 sandboxId: this.sandboxId,
-                wrapperInstanceId,
-                confirmed,
+                wrapperInstanceId: receipt.connection.wrapperInstanceId,
+                confirmed: true,
+                nativeRuntimeId: receipt.nativeRuntimeId,
               }),
             'invalidateTerminalRuntime'
           ),
-          DEADLINE_MS.stopAttempt,
-          'Sandbox terminal invalidation timed out'
-        ).catch(() => undefined);
-      })
-    );
-  }
-
-  private async notifyAttachedSessions(reason: string, wrapperInstanceId: string): Promise<void> {
-    const table = await loadRouteTable(this.ctx.storage);
-    await Promise.all(
-      [...table.values()].map(route =>
-        withTimeout(
-          withDORetry(
-            () => getSandboxSessionStub(this.env, route.ownerId, route.sessionId),
-            stub => stub.failWaitingMessages(reason, wrapperInstanceId),
-            'failWaitingMessages'
-          ),
-          DEADLINE_MS.stopAttempt,
-          'Sandbox failure notification timed out'
-        ).catch(() => undefined)
+          Math.max(1, receipt.replayUntil - Date.now()),
+          'Native runtime terminal invalidation timed out'
+        ).then(
+          () => true,
+          () => false
+        )
       )
     );
+    return invalidated.every(Boolean);
+  }
+
+  private async notifyNativeRetirementRecipients(
+    receipt: NativeRuntimeRetirementReceipt
+  ): Promise<boolean> {
+    const notified = await Promise.all(
+      receipt.recipients.map(recipient =>
+        withTimeout(
+          withDORetry(
+            () => getSandboxSessionStub(this.env, recipient.ownerId, recipient.sessionId),
+            stub =>
+              stub.failWaitingMessages(
+                receipt.reason,
+                receipt.connection.wrapperInstanceId,
+                receipt.nativeRuntimeId
+              ),
+            'failWaitingMessages'
+          ),
+          Math.max(1, receipt.replayUntil - Date.now()),
+          'Native runtime failure notification timed out'
+        ).then(
+          () => true,
+          () => false
+        )
+      )
+    );
+    return notified.every(Boolean);
+  }
+
+  private async invalidateTerminalRuntime(
+    wrapperInstanceId: string,
+    confirmed: boolean,
+    directory?: string
+  ): Promise<boolean> {
+    const routes = await loadRouteTable(this.ctx.storage);
+    const invalidated = await Promise.all(
+      [...routes.values()]
+        .filter(route => directory === undefined || route.directory === directory)
+        .map(route => {
+          return withTimeout(
+            withDORetry(
+              () => getSandboxSessionStub(this.env, route.ownerId, route.sessionId),
+              stub =>
+                stub.invalidateTerminalRuntime({
+                  sandboxId: this.sandboxId,
+                  wrapperInstanceId,
+                  confirmed,
+                }),
+              'invalidateTerminalRuntime'
+            ),
+            DEADLINE_MS.stopAttempt,
+            'Sandbox terminal invalidation timed out'
+          ).then(
+            () => true,
+            () => false
+          );
+        })
+    );
+    return invalidated.every(Boolean);
+  }
+
+  private async notifyAttachedSessions(
+    reason: string,
+    wrapperInstanceId: string,
+    directory?: string
+  ): Promise<boolean> {
+    const table = await loadRouteTable(this.ctx.storage);
+    const notified = await Promise.all(
+      [...table.values()]
+        .filter(route => directory === undefined || route.directory === directory)
+        .map(route =>
+          withTimeout(
+            withDORetry(
+              () => getSandboxSessionStub(this.env, route.ownerId, route.sessionId),
+              stub => stub.failWaitingMessages(reason, wrapperInstanceId),
+              'failWaitingMessages'
+            ),
+            DEADLINE_MS.stopAttempt,
+            'Sandbox failure notification timed out'
+          ).then(
+            () => true,
+            () => false
+          )
+        )
+    );
+    return notified.every(Boolean);
   }
 
   private mutateRoutes<T>(

--- a/services/cloud-agent-next/src/sandbox-control/deadlines.ts
+++ b/services/cloud-agent-next/src/sandbox-control/deadlines.ts
@@ -8,6 +8,7 @@ export const DEADLINE_IDS = [
   'stopAttempt',
   'reconciliation',
   'credentialExpiry',
+  'nativeRetirement',
 ] as const;
 export type DeadlineId = (typeof DEADLINE_IDS)[number];
 
@@ -27,6 +28,8 @@ export const DEADLINE_MS = {
   createSettle: 5 * 60_000,
   acceptedOverdue: 90_000,
   idleStopLeaseMargin: 60_000,
+  nativeRetirementRetry: 1_000,
+  nativeRetirementMaxAttempts: 5,
 } as const;
 
 export function leaseAtLeastMs(): number {

--- a/services/cloud-agent-next/src/sandbox-control/durable-state.ts
+++ b/services/cloud-agent-next/src/sandbox-control/durable-state.ts
@@ -20,6 +20,7 @@ const DEADLINES_KEY = 'deadlines';
 const LOG_KEY = 'transition_log';
 const CREDENTIAL_GRANTS_KEY = 'worktree_credential_grants';
 const RUNTIME_METADATA_KEY = 'runtime_metadata';
+const NATIVE_RUNTIME_RETIREMENTS_KEY = 'native_runtime_retirements';
 
 type ControlStorage = {
   get<T = unknown>(key: string): Promise<T | undefined>;
@@ -52,8 +53,45 @@ const sessionRouteSchema = z.object({
   lastStateAt: timestampSchema.nullable(),
   idleForMs: z.number().int().nonnegative().nullable(),
   waitingOn: z.enum(['model', 'tool', 'finalizing', 'preparation', 'input']).nullable(),
+  nativeRuntimeId: z.string().uuid().optional(),
+  retiringNativeRuntimeId: z.string().uuid().optional(),
 });
 const routeTableSchema = z.array(sessionRouteSchema);
+const nativeRuntimeRetirementRecipientSchema = sessionRouteSchema.pick({
+  sessionId: true,
+  kiloSessionId: true,
+  directory: true,
+  worktreeId: true,
+  ownerId: true,
+  nativeRuntimeId: true,
+});
+const nativeRuntimeRetirementSchema = z.object({
+  directory: z.string().min(1),
+  nativeRuntimeId: z.string().uuid(),
+  allocation: z.object({
+    providerRef: z.string().min(1),
+    createIntentId: z.string().min(1).optional(),
+  }),
+  connection: z.object({
+    connectionId: z.string().uuid(),
+    providerInstanceId: z.string().min(1),
+    wrapperInstanceId: z.string().uuid(),
+  }),
+  recipients: z.array(nativeRuntimeRetirementRecipientSchema).min(1),
+  reason: z.string().min(1).max(256),
+  operationId: z.string().uuid().optional(),
+  cleanupDeadlineAt: timestampSchema,
+  replayUntil: timestampSchema,
+  attempts: z.number().int().nonnegative(),
+  nextAttemptAt: timestampSchema.optional(),
+  notificationAttempts: z.number().int().nonnegative().default(0),
+  nextNotificationAttemptAt: timestampSchema.optional(),
+  notificationState: z.enum(['pending', 'delivered', 'exhausted']).default('pending'),
+  state: z.enum(['pending', 'completed', 'released', 'unconfirmed']),
+  disposition: z.enum(['pending', 'retired', 'operation_only', 'physical_fallback']),
+});
+
+export type NativeRuntimeRetirementReceipt = z.infer<typeof nativeRuntimeRetirementSchema>;
 
 export type StoredSandboxControlState = {
   physical: PhysicalRecord | null;
@@ -134,6 +172,25 @@ export async function saveRouteTable(
   await storage.put(ROUTES_KEY, [...table.values()]);
 }
 
+export async function loadNativeRuntimeRetirements(
+  storage: ControlStorage
+): Promise<NativeRuntimeRetirementReceipt[]> {
+  const stored = await storage.get(NATIVE_RUNTIME_RETIREMENTS_KEY);
+  const parsed = nativeRuntimeRetirementSchema.array().safeParse(stored ?? []);
+  if (!parsed.success) throw new Error('Invalid native runtime retirement receipts');
+  return parsed.data;
+}
+
+export async function saveNativeRuntimeRetirements(
+  storage: ControlStorage,
+  receipts: NativeRuntimeRetirementReceipt[]
+): Promise<void> {
+  await storage.put(
+    NATIVE_RUNTIME_RETIREMENTS_KEY,
+    nativeRuntimeRetirementSchema.array().parse(receipts)
+  );
+}
+
 export async function loadDeadlines(storage: ControlStorage): Promise<DeadlineTable> {
   return (await storage.get<DeadlineTable>(DEADLINES_KEY)) ?? emptyDeadlines();
 }
@@ -177,5 +234,6 @@ export async function eraseSandboxRecord(storage: ControlStorage): Promise<void>
     LOG_KEY,
     CREDENTIAL_GRANTS_KEY,
     RUNTIME_METADATA_KEY,
+    NATIVE_RUNTIME_RETIREMENTS_KEY,
   ]);
 }

--- a/services/cloud-agent-next/src/sandbox-control/frames.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/frames.test.ts
@@ -47,6 +47,7 @@ describe('sandbox control frames', () => {
         kiloVersionHeartbeat: true,
         sessionOperationResults: true,
         scopedStopAbort: true,
+        nativeRuntimeRetirement: true,
       },
     });
     const previous = { protocolVersion: 1, handshakeComplete: true };

--- a/services/cloud-agent-next/src/sandbox-control/frames.ts
+++ b/services/cloud-agent-next/src/sandbox-control/frames.ts
@@ -185,6 +185,7 @@ export function helloResult(): SandboxHelloResult {
       kiloVersionHeartbeat: true,
       sessionOperationResults: true,
       scopedStopAbort: true,
+      nativeRuntimeRetirement: true,
     },
   };
 }

--- a/services/cloud-agent-next/src/sandbox-control/lifecycle.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/lifecycle.test.ts
@@ -286,6 +286,7 @@ async function harness(
     receiveSandboxControlPreparing: vi.fn().mockResolvedValue({ applied: true }),
     failWaitingMessages: vi.fn().mockResolvedValue(undefined),
     invalidateTerminalRuntime: vi.fn().mockResolvedValue(undefined),
+    recordNativeRuntime: vi.fn().mockResolvedValue(undefined),
   };
   mocks.session.mockReturnValue(session);
   let hooks: SandboxControlSocketHooks = {};
@@ -303,6 +304,8 @@ async function harness(
       connection = null;
     }),
     closeProvisionalSockets: vi.fn(),
+    supportsOperationResults: () => true,
+    supportsNativeRuntimeRetirement: () => true,
     sendRequest,
   } as unknown as SandboxControlSocketHandler;
   mocks.socket.mockImplementation(
@@ -725,7 +728,10 @@ describe('SandboxControl lifecycle boundaries', () => {
           })
         ).resolves.toMatchObject({ ok: true });
         expect(h.sendRequest).toHaveBeenCalledWith(
-          expect.objectContaining({ operation: 'session.attach', payload })
+          expect.objectContaining({
+            operation: 'session.attach',
+            payload: { ...payload, captureNativeRuntimeId: true },
+          })
         );
         await expect(h.control.getStatus()).resolves.toMatchObject({ reported: 'ready' });
         if (!contained) {
@@ -1418,7 +1424,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       const requestFor = (expectedWrapperInstanceId?: string): SandboxControlOutboundRequest => ({
         operation,
         session: ROUTE,
-        payload: operation === 'session.prompt' ? PROMPT : {},
+        payload: operation === 'session.prompt' ? PROMPT : { captureNativeRuntimeId: true },
         expectedWrapperInstanceId,
       });
 
@@ -2303,6 +2309,668 @@ describe('SandboxControl lifecycle boundaries', () => {
       })
     ).rejects.toThrow('Invalid sandbox quarantine request');
     expect((await h.control.getPhysicalRecord()).stopTombstone).toBeNull();
+  });
+
+  it('records the exact native runtime returned by a successful attachment', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    h.sendRequest.mockResolvedValueOnce({
+      type: 'response',
+      requestId: 'attach_1',
+      ok: true,
+      result: { attached: true, nativeRuntimeId },
+    });
+
+    await expect(
+      h.control.request({
+        operation: 'session.attach',
+        session: {
+          sessionId: ROUTE.sessionId,
+          kiloSessionId: ROUTE.kiloSessionId,
+          directory: ROUTE.directory,
+        },
+        payload: {},
+        expectedWrapperInstanceId: identity.wrapperInstanceId,
+      })
+    ).resolves.toMatchObject({ ok: true });
+
+    await expect(h.control.listRoutes()).resolves.toEqual([
+      expect.objectContaining({ sessionId: ROUTE.sessionId, nativeRuntimeId }),
+    ]);
+  });
+
+  it('does not add native runtime capture to an older wrapper attachment', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    h.socket.supportsNativeRuntimeRetirement = () => false;
+
+    await expect(
+      h.control.request({
+        operation: 'session.attach',
+        session: ROUTE,
+        payload: {},
+        expectedWrapperInstanceId: identity.wrapperInstanceId,
+      })
+    ).resolves.toMatchObject({ ok: true });
+
+    expect(h.sendRequest).toHaveBeenLastCalledWith(
+      expect.objectContaining({ operation: 'session.attach', payload: {} })
+    );
+  });
+
+  it('records the original native runtime from a lost attachment response lookup', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const authorization = {
+      operation: 'session.attach' as const,
+      operationId: 'prepare_1',
+      messageId: 'message_1',
+      session: {
+        sessionId: ROUTE.sessionId,
+        kiloSessionId: ROUTE.kiloSessionId,
+        directory: ROUTE.directory,
+      },
+      wrapperInstanceId: identity.wrapperInstanceId ?? '',
+      dispatchDeadlineAt: Date.now() + 1_000,
+    };
+    h.sendRequest.mockResolvedValueOnce({
+      type: 'response',
+      requestId: 'lookup_1',
+      ok: true,
+      result: {
+        state: 'completed',
+        delivery: {
+          version: 2,
+          authorization,
+          completedAt: Date.now(),
+          result: { ok: true, result: { attached: true, nativeRuntimeId } },
+          events: [],
+          preparing: [],
+        },
+      },
+    });
+
+    await expect(
+      h.control.request({
+        operation: 'session.operation.get',
+        session: ROUTE,
+        payload: authorization,
+        expectedWrapperInstanceId: identity.wrapperInstanceId,
+      })
+    ).resolves.toMatchObject({ ok: true });
+
+    await expect(h.control.listRoutes()).resolves.toEqual([
+      expect.objectContaining({ nativeRuntimeId }),
+    ]);
+    expect(h.session.recordNativeRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({ nativeRuntimeId, wrapperInstanceId: identity.wrapperInstanceId })
+    );
+  });
+
+  it('invalidates only routes on the retired native incarnation', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    h.records.set('session_routes', [
+      { ...route, nativeRuntimeId },
+      {
+        ...route,
+        sessionId: 'workspace_22222222-2222-4222-8222-222222222222',
+        kiloSessionId: 'ses_22222222222222222222222222',
+        nativeRuntimeId,
+      },
+      {
+        ...route,
+        sessionId: 'workspace_33333333-3333-4333-8333-333333333333',
+        kiloSessionId: 'ses_33333333333333333333333333',
+        directory: '/workspace/m',
+        nativeRuntimeId: '33333333-3333-4333-8333-333333333333',
+      },
+      {
+        ...route,
+        sessionId: 'workspace_44444444-4444-4444-8444-444444444444',
+        kiloSessionId: 'ses_44444444444444444444444444',
+        directory: '/workspace/c',
+        nativeRuntimeId: '44444444-4444-4444-8444-444444444444',
+      },
+    ]);
+    h.socket.supportsNativeRuntimeRetirement = () => true;
+    h.socket.supportsScopedStopAbort = () => true;
+    const response = {
+      type: 'response' as const,
+      requestId: 'stop_1',
+      ok: true as const,
+      result: {
+        status: 'aborted' as const,
+        quiescent: true,
+        runtimeRetired: true,
+        nativeRuntimeId,
+      },
+    };
+    h.sendRequest.mockResolvedValueOnce(response);
+
+    await expect(
+      h.control.request({
+        operation: 'session.abort',
+        session: {
+          sessionId: ROUTE.sessionId,
+          kiloSessionId: ROUTE.kiloSessionId,
+          directory: ROUTE.directory,
+        },
+        payload: {
+          messageId: 'message_1',
+          operationId: '55555555-5555-4555-8555-555555555555',
+          cleanupDeadlineAt: Date.now() + 1_000,
+        },
+        expectedWrapperInstanceId: identity.wrapperInstanceId,
+      })
+    ).resolves.toEqual(response);
+
+    expect(h.session.invalidateTerminalRuntime).toHaveBeenCalledTimes(2);
+    expect(h.session.invalidateTerminalRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({ wrapperInstanceId: identity.wrapperInstanceId, confirmed: true })
+    );
+    await expect(h.control.listRoutes()).resolves.toEqual([
+      expect.not.objectContaining({ nativeRuntimeId }),
+      expect.not.objectContaining({ nativeRuntimeId }),
+      expect.objectContaining({ directory: '/workspace/m' }),
+      expect.objectContaining({ directory: '/workspace/c' }),
+    ]);
+  });
+
+  it('does not invalidate a replacement when an old scoped Stop reply arrives late', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const replacementRuntimeId = '22222222-2222-4222-8222-222222222222';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    h.records.set('session_routes', [{ ...route, nativeRuntimeId }]);
+    h.socket.supportsNativeRuntimeRetirement = () => true;
+    h.socket.supportsScopedStopAbort = () => true;
+    const reply = deferred<{
+      type: 'response';
+      requestId: string;
+      ok: true;
+      result: { status: 'aborted'; quiescent: true; runtimeRetired: true; nativeRuntimeId: string };
+    }>();
+    const sent = Promise.withResolvers<void>();
+    h.sendRequest.mockImplementationOnce(() => {
+      sent.resolve();
+      return reply.promise;
+    });
+    const stop = h.control.request({
+      operation: 'session.abort',
+      session: {
+        sessionId: ROUTE.sessionId,
+        kiloSessionId: ROUTE.kiloSessionId,
+        directory: ROUTE.directory,
+      },
+      payload: {
+        messageId: 'message_1',
+        operationId: '55555555-5555-4555-8555-555555555555',
+        cleanupDeadlineAt: Date.now() + 1_000,
+      },
+      expectedWrapperInstanceId: identity.wrapperInstanceId,
+    });
+    await sent.promise;
+    h.records.set('session_routes', [{ ...route, nativeRuntimeId: replacementRuntimeId }]);
+    reply.resolve({
+      type: 'response',
+      requestId: 'stop_1',
+      ok: true,
+      result: { status: 'aborted', quiescent: true, runtimeRetired: true, nativeRuntimeId },
+    });
+
+    await expect(stop).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'not_ready', retryable: true },
+    });
+    expect(h.session.invalidateTerminalRuntime).not.toHaveBeenCalled();
+    await expect(h.control.listRoutes()).resolves.toEqual([
+      expect.objectContaining({ nativeRuntimeId: replacementRuntimeId }),
+    ]);
+  });
+
+  it('retains a native retirement fence across a lost scoped Stop reply', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    h.records.set('session_routes', [{ ...route, nativeRuntimeId }]);
+    h.socket.supportsNativeRuntimeRetirement = () => true;
+    h.socket.supportsScopedStopAbort = () => true;
+    h.sendRequest.mockRejectedValueOnce(new Error('lost Stop reply'));
+
+    await expect(
+      h.control.request({
+        operation: 'session.abort',
+        session: {
+          sessionId: ROUTE.sessionId,
+          kiloSessionId: ROUTE.kiloSessionId,
+          directory: ROUTE.directory,
+        },
+        payload: {
+          messageId: 'message_1',
+          operationId: '55555555-5555-4555-8555-555555555555',
+          cleanupDeadlineAt: Date.now() + 1_000,
+        },
+        expectedWrapperInstanceId: identity.wrapperInstanceId,
+      })
+    ).rejects.toThrow('lost Stop reply');
+    await h.evict();
+
+    await expect(h.control.listRoutes()).resolves.toEqual([
+      expect.objectContaining({ nativeRuntimeId, retiringNativeRuntimeId: nativeRuntimeId }),
+    ]);
+    expect(h.session.invalidateTerminalRuntime).not.toHaveBeenCalled();
+  });
+
+  it('defers unconfirmed scoped Stop instead of releasing the retirement fence', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const operationId = '33333333-3333-4333-8333-333333333333';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    h.records.set('session_routes', [{ ...route, nativeRuntimeId }]);
+    h.socket.supportsNativeRuntimeRetirement = () => true;
+    h.socket.supportsScopedStopAbort = () => true;
+    const unconfirmed = {
+      type: 'response' as const,
+      requestId: 'stop_u',
+      ok: true as const,
+      result: { status: 'unconfirmed' as const, quiescent: false },
+    };
+    h.sendRequest.mockResolvedValueOnce(unconfirmed);
+    await expect(
+      h.control.request({
+        operation: 'session.abort',
+        session: {
+          sessionId: route.sessionId,
+          kiloSessionId: route.kiloSessionId,
+          directory: route.directory,
+        },
+        payload: {
+          messageId: 'message_a',
+          operationId,
+          cleanupDeadlineAt: Date.now() + 1_000,
+        },
+        expectedWrapperInstanceId: identity.wrapperInstanceId,
+      })
+    ).resolves.toEqual(unconfirmed);
+    expect(h.records.get('native_runtime_retirements')).toEqual([
+      expect.objectContaining({
+        operationId,
+        state: 'pending',
+      }),
+    ]);
+    await expect(h.control.listRoutes()).resolves.toEqual([
+      expect.objectContaining({ nativeRuntimeId, retiringNativeRuntimeId: nativeRuntimeId }),
+    ]);
+  });
+
+  it('keeps an operation-only Stop replay from blocking or changing a fresh native retirement', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const replacementRuntimeId = '22222222-2222-4222-8222-222222222222';
+    const operationA = '33333333-3333-4333-8333-333333333333';
+    const operationB = '44444444-4444-4444-8444-444444444444';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    h.records.set('session_routes', [{ ...route, nativeRuntimeId }]);
+    h.socket.supportsNativeRuntimeRetirement = () => true;
+    h.socket.supportsScopedStopAbort = () => true;
+    const stop = (messageId: string, operationId: string, cleanupDeadlineAt: number) =>
+      h.control.request({
+        operation: 'session.abort',
+        session: {
+          sessionId: route.sessionId,
+          kiloSessionId: route.kiloSessionId,
+          directory: route.directory,
+        },
+        payload: { messageId, operationId, cleanupDeadlineAt },
+        expectedWrapperInstanceId: identity.wrapperInstanceId,
+      });
+    const firstDeadline = Date.now() + 1_000;
+    const operationOnly = {
+      type: 'response' as const,
+      requestId: 'stop_a',
+      ok: true as const,
+      result: { status: 'aborted' as const, quiescent: true },
+    };
+    h.sendRequest.mockResolvedValueOnce(operationOnly);
+
+    await expect(stop('message_a', operationA, firstDeadline)).resolves.toEqual(operationOnly);
+    expect(h.records.get('native_runtime_retirements')).toEqual([
+      expect.objectContaining({
+        operationId: operationA,
+        cleanupDeadlineAt: firstDeadline,
+        state: 'released',
+        disposition: 'operation_only',
+      }),
+    ]);
+    await expect(h.control.listRoutes()).resolves.toEqual([
+      expect.objectContaining({ nativeRuntimeId }),
+    ]);
+
+    const reply = deferred<{
+      type: 'response';
+      requestId: string;
+      ok: true;
+      result: { status: 'aborted'; quiescent: true; runtimeRetired: true; nativeRuntimeId: string };
+    }>();
+    const sent = Promise.withResolvers<void>();
+    h.sendRequest.mockImplementationOnce(() => {
+      sent.resolve();
+      return reply.promise;
+    });
+    const stopB = stop('message_b', operationB, Date.now() + 2_000);
+    await sent.promise;
+
+    await expect(stop('message_a', operationA, Date.now() + 3_000)).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'not_ready', retryable: true },
+    });
+    expect(h.sendRequest).toHaveBeenCalledTimes(2);
+    expect(h.records.get('native_runtime_retirements')).toEqual([
+      expect.objectContaining({
+        operationId: operationA,
+        cleanupDeadlineAt: firstDeadline,
+        state: 'released',
+      }),
+      expect.objectContaining({ operationId: operationB, attempts: 1, state: 'pending' }),
+    ]);
+    await expect(h.control.listRoutes()).resolves.toEqual([
+      expect.objectContaining({ nativeRuntimeId, retiringNativeRuntimeId: nativeRuntimeId }),
+    ]);
+
+    const retired = {
+      type: 'response' as const,
+      requestId: 'stop_b',
+      ok: true as const,
+      result: {
+        status: 'aborted' as const,
+        quiescent: true as const,
+        runtimeRetired: true as const,
+        nativeRuntimeId,
+      },
+    };
+    reply.resolve(retired);
+    await expect(stopB).resolves.toEqual(retired);
+    expect(h.records.get('native_runtime_retirements')).toEqual([
+      expect.objectContaining({ operationId: operationA, state: 'released' }),
+      expect.objectContaining({
+        operationId: operationB,
+        state: 'completed',
+        notificationState: 'delivered',
+      }),
+    ]);
+
+    h.records.set('session_routes', [{ ...route, nativeRuntimeId: replacementRuntimeId }]);
+    h.session.invalidateTerminalRuntime.mockClear();
+    h.session.failWaitingMessages.mockClear();
+    await expect(
+      h.hooks.onNativeRuntimeRetired?.(
+        { directory: route.directory, nativeRuntimeId, reason: 'process_exited' },
+        identity
+      )
+    ).resolves.toEqual({ retired: true });
+    expect(h.session.invalidateTerminalRuntime).not.toHaveBeenCalled();
+    expect(h.session.failWaitingMessages).not.toHaveBeenCalled();
+    await expect(h.control.listRoutes()).resolves.toEqual([
+      expect.objectContaining({ nativeRuntimeId: replacementRuntimeId }),
+    ]);
+  });
+
+  it('does not physically stop when completed native proof wins a stale escalation', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    h.records.set('session_routes', [{ ...route, nativeRuntimeId }]);
+    const reply = deferred<never>();
+    const sent = Promise.withResolvers<void>();
+    h.sendRequest.mockImplementationOnce(() => {
+      sent.resolve();
+      return reply.promise;
+    });
+
+    const quarantine = h.control.quarantineRuntime({
+      ownerId: OWNER,
+      sessionId: route.sessionId,
+      wrapperInstanceId: identity.wrapperInstanceId ?? '',
+      reason: 'native_cleanup_unavailable',
+    });
+    await sent.promise;
+    await expect(
+      h.hooks.onNativeRuntimeRetired?.(
+        { directory: route.directory, nativeRuntimeId, reason: 'process_exited' },
+        identity
+      )
+    ).resolves.toEqual({ retired: true });
+    vi.setSystemTime(Date.now() + DEADLINE_MS.stopAttempt);
+    reply.reject(new Error('late lost reply'));
+
+    await expect(quarantine).resolves.toEqual({ quarantined: true });
+    await expect(h.control.getPhysicalRecord()).resolves.toMatchObject({
+      state: 'running',
+      stopTombstone: null,
+    });
+  });
+
+  it('coalesces concurrent native retirement commands for one runtime', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    h.records.set('session_routes', [{ ...route, nativeRuntimeId }]);
+    const reply = deferred<{
+      type: 'response';
+      requestId: string;
+      ok: true;
+      result: { status: 'aborted'; quiescent: true; runtimeRetired: true; nativeRuntimeId: string };
+    }>();
+    const sent = Promise.withResolvers<void>();
+    h.sendRequest.mockImplementationOnce(() => {
+      sent.resolve();
+      return reply.promise;
+    });
+    const first = h.control.quarantineRuntime({
+      ownerId: OWNER,
+      sessionId: route.sessionId,
+      wrapperInstanceId: identity.wrapperInstanceId ?? '',
+      reason: 'native_cleanup_unavailable',
+    });
+    await sent.promise;
+
+    await expect(
+      h.control.quarantineRuntime({
+        ownerId: OWNER,
+        sessionId: route.sessionId,
+        wrapperInstanceId: identity.wrapperInstanceId ?? '',
+        reason: 'native_cleanup_unavailable',
+      })
+    ).resolves.toEqual({ quarantined: true });
+    expect(h.sendRequest).toHaveBeenCalledOnce();
+    reply.resolve({
+      type: 'response',
+      requestId: 'abort_1',
+      ok: true,
+      result: { status: 'aborted', quiescent: true, runtimeRetired: true, nativeRuntimeId },
+    });
+    await expect(first).resolves.toEqual({ quarantined: true });
+  });
+
+  it('retains an exhausted notification fence without escalating a completed retirement', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    h.records.set('session_routes', [{ ...route, nativeRuntimeId }]);
+    h.session.failWaitingMessages.mockRejectedValue(new Error('session unavailable'));
+
+    await expect(
+      h.hooks.onNativeRuntimeRetired?.(
+        { directory: route.directory, nativeRuntimeId, reason: 'process_exited' },
+        identity
+      )
+    ).resolves.toBeUndefined();
+    for (let attempt = 1; attempt < DEADLINE_MS.nativeRetirementMaxAttempts; attempt++) {
+      await h.fireAlarm();
+    }
+
+    expect(h.session.failWaitingMessages).toHaveBeenCalledTimes(
+      DEADLINE_MS.nativeRetirementMaxAttempts
+    );
+    await expect(h.control.getPhysicalRecord()).resolves.toMatchObject({
+      state: 'running',
+      stopTombstone: null,
+    });
+    await expect(h.control.listRoutes()).resolves.toEqual([
+      expect.objectContaining({ nativeRuntimeId, retiringNativeRuntimeId: nativeRuntimeId }),
+    ]);
+    expect(h.records.get('native_runtime_retirements')).toEqual([
+      expect.objectContaining({ state: 'completed', notificationState: 'exhausted' }),
+    ]);
+  });
+
+  it('persists an automatic native retirement before failing only affected routes', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    h.records.set('session_routes', [
+      { ...route, nativeRuntimeId },
+      {
+        ...route,
+        sessionId: 'workspace_22222222-2222-4222-8222-222222222222',
+        kiloSessionId: 'ses_22222222222222222222222222',
+        nativeRuntimeId,
+      },
+      {
+        ...route,
+        sessionId: 'workspace_33333333-3333-4333-8333-333333333333',
+        kiloSessionId: 'ses_33333333333333333333333333',
+        directory: '/workspace/m',
+        nativeRuntimeId: '33333333-3333-4333-8333-333333333333',
+      },
+      {
+        ...route,
+        sessionId: 'workspace_44444444-4444-4444-8444-444444444444',
+        kiloSessionId: 'ses_44444444444444444444444444',
+        directory: '/workspace/c',
+        nativeRuntimeId: '44444444-4444-4444-8444-444444444444',
+      },
+    ]);
+
+    await expect(
+      h.hooks.onNativeRuntimeRetired?.(
+        { directory: ROUTE.directory, nativeRuntimeId, reason: 'process_exited' },
+        identity
+      )
+    ).resolves.toEqual({ retired: true });
+
+    expect(h.session.invalidateTerminalRuntime).toHaveBeenCalledTimes(2);
+    expect(h.session.failWaitingMessages).toHaveBeenCalledTimes(2);
+    expect(h.session.failWaitingMessages).toHaveBeenCalledWith(
+      'process_exited',
+      identity.wrapperInstanceId,
+      nativeRuntimeId
+    );
+    await expect(h.control.listRoutes()).resolves.toEqual([
+      expect.not.objectContaining({ nativeRuntimeId }),
+      expect.not.objectContaining({ nativeRuntimeId }),
+      expect.objectContaining({ directory: '/workspace/m' }),
+      expect.objectContaining({ directory: '/workspace/c' }),
+    ]);
+  });
+
+  it('replays a completed native retirement after reconstruction without touching N2', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const replacementRuntimeId = '22222222-2222-4222-8222-222222222222';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    h.records.set('session_routes', [{ ...route, nativeRuntimeId }]);
+
+    await expect(
+      h.hooks.onNativeRuntimeRetired?.(
+        { directory: ROUTE.directory, nativeRuntimeId, reason: 'process_exited' },
+        identity
+      )
+    ).resolves.toEqual({ retired: true });
+    h.session.invalidateTerminalRuntime.mockClear();
+    h.session.failWaitingMessages.mockClear();
+    await h.evict();
+    await h.flush();
+    expect(h.session.invalidateTerminalRuntime).not.toHaveBeenCalled();
+    expect(h.session.failWaitingMessages).not.toHaveBeenCalled();
+    h.records.set('session_routes', [{ ...route, nativeRuntimeId: replacementRuntimeId }]);
+    h.session.invalidateTerminalRuntime.mockClear();
+    h.session.failWaitingMessages.mockClear();
+
+    await expect(
+      h.hooks.onNativeRuntimeRetired?.(
+        { directory: ROUTE.directory, nativeRuntimeId, reason: 'process_exited' },
+        identity
+      )
+    ).resolves.toEqual({ retired: true });
+
+    expect(h.session.invalidateTerminalRuntime).not.toHaveBeenCalled();
+    expect(h.session.failWaitingMessages).not.toHaveBeenCalled();
+    await expect(h.control.listRoutes()).resolves.toEqual([
+      expect.objectContaining({ nativeRuntimeId: replacementRuntimeId }),
+    ]);
+  });
+
+  it('falls back to physical containment when targeted native cleanup is unavailable', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    h.records.set('session_routes', [{ ...route, nativeRuntimeId }]);
+    h.socket.supportsNativeRuntimeRetirement = () => false;
+
+    await expect(
+      h.control.quarantineRuntime({
+        ownerId: OWNER,
+        sessionId: ROUTE.sessionId,
+        wrapperInstanceId: identity.wrapperInstanceId ?? '',
+        reason: 'native_cleanup_unavailable',
+      })
+    ).resolves.toEqual({ quarantined: true });
+
+    await expect(h.control.getPhysicalRecord()).resolves.toMatchObject({
+      state: 'stopping',
+      stopTombstone: { reason: 'native_cleanup_unavailable' },
+    });
   });
 
   it('performs all five stop attempts, never reactivates the tombstone, and eventually releases by observation', async () => {

--- a/services/cloud-agent-next/src/sandbox-control/native-runtime-retirement.ts
+++ b/services/cloud-agent-next/src/sandbox-control/native-runtime-retirement.ts
@@ -1,0 +1,782 @@
+import type { NativeRuntimeRetirementReceipt } from './durable-state.js';
+import {
+  loadDeadlines,
+  loadNativeRuntimeRetirements,
+  loadPhysicalRecord,
+  loadRouteTable,
+  saveDeadlines,
+  saveNativeRuntimeRetirements,
+  saveRouteTable,
+} from './durable-state.js';
+import { armDeadline, cancelDeadline, DEADLINE_MS, type DeadlineTable } from './deadlines.js';
+import type { PhysicalRecord } from './physical-lifecycle.js';
+import type { SessionRoute } from './session-routes.js';
+
+export type NativeRuntimeRetirementConnection = {
+  connectionId: string;
+  providerInstanceId: string;
+  wrapperInstanceId: string;
+};
+
+export type NativeRuntimeRetirementStorage = Pick<
+  DurableObjectStorage,
+  'get' | 'put' | 'delete' | 'transaction'
+>;
+
+export type NativeRuntimeRetirementWorkflow = {
+  begin(input: {
+    connection: NativeRuntimeRetirementConnection;
+    physical: PhysicalRecord;
+    route: SessionRoute;
+    nativeRuntimeId: string;
+    reason: string;
+    operationId?: string;
+    cleanupDeadlineAt: number;
+  }): Promise<NativeRuntimeRetirementReceipt | undefined>;
+  complete(receipt: NativeRuntimeRetirementReceipt): Promise<boolean>;
+  release(receipt: NativeRuntimeRetirementReceipt): Promise<void>;
+  defer(receipt: NativeRuntimeRetirementReceipt): Promise<void>;
+  claimTargetedAttempt(
+    receipt: NativeRuntimeRetirementReceipt
+  ): Promise<NativeRuntimeRetirementReceipt | undefined>;
+  retire(input: {
+    connection: NativeRuntimeRetirementConnection;
+    physical: PhysicalRecord;
+    route: SessionRoute;
+    reason: string;
+    operationId?: string;
+  }): Promise<'retired' | 'pending' | 'unavailable'>;
+  receiveRetired(input: {
+    connection: NativeRuntimeRetirementConnection;
+    directory: string;
+    nativeRuntimeId: string;
+    reason: string;
+  }): Promise<{ retired: true } | undefined>;
+  resume(): Promise<void>;
+};
+
+export type NativeRuntimeRetirementWorkflowPorts = {
+  storage: NativeRuntimeRetirementStorage;
+  currentIncarnation: {
+    isCurrent(connection: NativeRuntimeRetirementConnection): boolean;
+    getConnection(): NativeRuntimeRetirementConnection | null;
+    sameConnection(
+      left: NativeRuntimeRetirementConnection,
+      right: NativeRuntimeRetirementConnection
+    ): boolean;
+  };
+  transport: {
+    supportsTargetedRetirement(): boolean;
+    abortNativeRuntime(input: {
+      receipt: NativeRuntimeRetirementReceipt;
+      route: SessionRoute;
+    }): Promise<boolean>;
+    invalidateRecipients(receipt: NativeRuntimeRetirementReceipt): Promise<boolean>;
+    notifyRecipients(receipt: NativeRuntimeRetirementReceipt): Promise<boolean>;
+  };
+  physicalEscalation: {
+    beginIfCurrent(receipt: NativeRuntimeRetirementReceipt): Promise<boolean>;
+  };
+  scheduleAlarm(deadlines: DeadlineTable): Promise<void>;
+  now?: () => number;
+};
+
+export function sameNativeRuntimeRetirement(
+  receipt: NativeRuntimeRetirementReceipt,
+  input: {
+    directory: string;
+    nativeRuntimeId: string;
+    connection: NativeRuntimeRetirementConnection;
+  }
+): boolean {
+  return (
+    receipt.directory === input.directory &&
+    receipt.nativeRuntimeId === input.nativeRuntimeId &&
+    receipt.connection.connectionId === input.connection.connectionId &&
+    receipt.connection.providerInstanceId === input.connection.providerInstanceId &&
+    receipt.connection.wrapperInstanceId === input.connection.wrapperInstanceId
+  );
+}
+
+export function createNativeRuntimeRetirement(
+  physical: PhysicalRecord,
+  connection: NativeRuntimeRetirementConnection,
+  routes: readonly SessionRoute[],
+  reason: string,
+  cleanupDeadlineAt: number,
+  replayUntil: number,
+  operationId?: string
+): NativeRuntimeRetirementReceipt | undefined {
+  if (!physical.providerRef || routes.length === 0) return undefined;
+  const [route] = routes;
+  if (!route?.nativeRuntimeId) return undefined;
+  if (
+    routes.some(
+      current =>
+        current.directory !== route.directory || current.nativeRuntimeId !== route.nativeRuntimeId
+    )
+  )
+    return undefined;
+  return {
+    directory: route.directory,
+    nativeRuntimeId: route.nativeRuntimeId,
+    allocation: {
+      providerRef: physical.providerRef,
+      ...(physical.createIntent ? { createIntentId: physical.createIntent.intentId } : {}),
+    },
+    connection,
+    recipients: routes.map(current => ({
+      sessionId: current.sessionId,
+      kiloSessionId: current.kiloSessionId,
+      directory: current.directory,
+      ...(current.worktreeId ? { worktreeId: current.worktreeId } : {}),
+      ownerId: current.ownerId,
+      nativeRuntimeId: current.nativeRuntimeId,
+    })),
+    reason,
+    ...(operationId ? { operationId } : {}),
+    cleanupDeadlineAt,
+    replayUntil,
+    attempts: 0,
+    notificationAttempts: 0,
+    notificationState: 'pending',
+    state: 'pending',
+    disposition: 'pending',
+  };
+}
+
+export function matchesNativeRuntimeRetirementAllocation(
+  receipt: NativeRuntimeRetirementReceipt,
+  physical: PhysicalRecord
+): boolean {
+  return (
+    physical.providerRef === receipt.allocation.providerRef &&
+    (receipt.allocation.createIntentId === undefined ||
+      physical.createIntent?.intentId === receipt.allocation.createIntentId)
+  );
+}
+
+export function routesMatchNativeRuntimeRetirement(
+  routes: Map<string, SessionRoute>,
+  receipt: NativeRuntimeRetirementReceipt
+): boolean {
+  return receipt.recipients.every(recipient => {
+    const route = routes.get(recipient.sessionId);
+    return (
+      route?.ownerId === recipient.ownerId &&
+      route.kiloSessionId === recipient.kiloSessionId &&
+      route.directory === recipient.directory &&
+      route.worktreeId === recipient.worktreeId &&
+      route.nativeRuntimeId === receipt.nativeRuntimeId &&
+      route.retiringNativeRuntimeId === receipt.nativeRuntimeId
+    );
+  });
+}
+
+export function fenceNativeRuntimeRetirement(
+  routes: Map<string, SessionRoute>,
+  receipt: NativeRuntimeRetirementReceipt
+): void {
+  for (const recipient of receipt.recipients) {
+    const route = routes.get(recipient.sessionId);
+    if (!route || route.nativeRuntimeId !== receipt.nativeRuntimeId) continue;
+    routes.set(route.sessionId, { ...route, retiringNativeRuntimeId: receipt.nativeRuntimeId });
+  }
+}
+
+export function releaseNativeRuntimeRetirement(
+  routes: Map<string, SessionRoute>,
+  receipt: NativeRuntimeRetirementReceipt,
+  clearNativeRuntime: boolean
+): void {
+  for (const recipient of receipt.recipients) {
+    const route = routes.get(recipient.sessionId);
+    if (
+      !route ||
+      route.nativeRuntimeId !== receipt.nativeRuntimeId ||
+      route.retiringNativeRuntimeId !== receipt.nativeRuntimeId
+    )
+      continue;
+    const next = { ...route };
+    delete next.retiringNativeRuntimeId;
+    if (clearNativeRuntime) delete next.nativeRuntimeId;
+    routes.set(route.sessionId, next);
+  }
+}
+
+function samePhysicalAllocation(left: PhysicalRecord, right: PhysicalRecord): boolean {
+  return (
+    left.providerRef === right.providerRef &&
+    left.createIntent?.intentId === right.createIntent?.intentId
+  );
+}
+
+function matchesReceipt(
+  current: NativeRuntimeRetirementReceipt,
+  receipt: NativeRuntimeRetirementReceipt
+): boolean {
+  return (
+    sameNativeRuntimeRetirement(current, receipt) && current.operationId === receipt.operationId
+  );
+}
+
+function holdsNativeRuntimeRetirementFence(receipt: NativeRuntimeRetirementReceipt): boolean {
+  return (
+    receipt.state === 'pending' ||
+    receipt.state === 'unconfirmed' ||
+    (receipt.state === 'completed' && receipt.notificationState !== 'delivered')
+  );
+}
+
+function hasOtherNativeRuntimeRetirementFence(
+  receipts: readonly NativeRuntimeRetirementReceipt[],
+  receipt: NativeRuntimeRetirementReceipt
+): boolean {
+  return receipts.some(
+    current =>
+      !matchesReceipt(current, receipt) &&
+      sameNativeRuntimeRetirement(current, receipt) &&
+      holdsNativeRuntimeRetirementFence(current)
+  );
+}
+
+function retainReceipt(receipt: NativeRuntimeRetirementReceipt, now: number): boolean {
+  if (receipt.state === 'pending' || receipt.state === 'unconfirmed') return true;
+  if (receipt.state === 'completed' && receipt.notificationState !== 'delivered') return true;
+  return receipt.replayUntil >= now;
+}
+
+export function createNativeRuntimeRetirementWorkflow(
+  ports: NativeRuntimeRetirementWorkflowPorts
+): NativeRuntimeRetirementWorkflow {
+  const now = ports.now ?? Date.now;
+
+  const reconcileSchedule = async (): Promise<void> => {
+    await ports.storage.transaction(async () => {
+      const currentTime = now();
+      const [routes, stored, deadlines] = await Promise.all([
+        loadRouteTable(ports.storage),
+        loadNativeRuntimeRetirements(ports.storage),
+        loadDeadlines(ports.storage),
+      ]);
+      const normalized = stored.map(receipt =>
+        receipt.state === 'completed' &&
+        receipt.notificationState === 'pending' &&
+        (currentTime >= receipt.replayUntil ||
+          receipt.notificationAttempts >= DEADLINE_MS.nativeRetirementMaxAttempts)
+          ? { ...receipt, notificationState: 'exhausted' as const }
+          : receipt
+      );
+      const expired = normalized.filter(receipt =>
+        (receipt.state === 'completed' && receipt.notificationState === 'delivered') ||
+        receipt.state === 'released'
+          ? receipt.replayUntil < currentTime
+          : false
+      );
+      for (const receipt of expired) {
+        if (!hasOtherNativeRuntimeRetirementFence(normalized, receipt))
+          releaseNativeRuntimeRetirement(routes, receipt, true);
+      }
+      const retained = normalized.filter(receipt => retainReceipt(receipt, currentTime));
+      if (expired.length > 0) await saveRouteTable(ports.storage, routes);
+      if (
+        retained.length !== stored.length ||
+        normalized.some((receipt, index) => receipt !== stored[index])
+      ) {
+        await saveNativeRuntimeRetirements(ports.storage, retained);
+      }
+
+      let nextAt: number | undefined;
+      const scheduleAt = (at: number) => {
+        nextAt = nextAt === undefined ? at : Math.min(nextAt, at);
+      };
+      for (const receipt of retained) {
+        if (receipt.state === 'pending') {
+          scheduleAt(
+            Math.min(
+              receipt.cleanupDeadlineAt,
+              Math.max(currentTime, receipt.nextAttemptAt ?? currentTime)
+            )
+          );
+          continue;
+        }
+        if (receipt.state === 'unconfirmed') {
+          scheduleAt(Math.max(currentTime, receipt.nextAttemptAt ?? currentTime));
+          continue;
+        }
+        if (receipt.state === 'completed' && receipt.notificationState === 'pending') {
+          scheduleAt(Math.max(currentTime, receipt.nextNotificationAttemptAt ?? currentTime));
+          continue;
+        }
+        if (
+          (receipt.state === 'completed' && receipt.notificationState === 'delivered') ||
+          receipt.state === 'released'
+        ) {
+          scheduleAt(receipt.replayUntil);
+        }
+      }
+      const next =
+        nextAt === undefined
+          ? cancelDeadline(deadlines, 'nativeRetirement')
+          : armDeadline(deadlines, 'nativeRetirement', nextAt);
+      await saveDeadlines(ports.storage, next);
+      await ports.scheduleAlarm(next);
+    });
+  };
+
+  const begin = async (
+    input: Parameters<NativeRuntimeRetirementWorkflow['begin']>[0]
+  ): Promise<NativeRuntimeRetirementReceipt | undefined> => {
+    const receipt = await ports.storage.transaction(async () => {
+      const [currentPhysical, routes, stored] = await Promise.all([
+        loadPhysicalRecord(ports.storage),
+        loadRouteTable(ports.storage),
+        loadNativeRuntimeRetirements(ports.storage),
+      ]);
+      const route = routes.get(input.route.sessionId);
+      if (
+        !route ||
+        !ports.currentIncarnation.isCurrent(input.connection) ||
+        currentPhysical.state !== 'running' ||
+        currentPhysical.stopTombstone ||
+        currentPhysical.providerRef !== input.connection.providerInstanceId ||
+        !samePhysicalAllocation(input.physical, currentPhysical) ||
+        route.ownerId !== input.route.ownerId ||
+        route.kiloSessionId !== input.route.kiloSessionId ||
+        route.directory !== input.route.directory ||
+        route.worktreeId !== input.route.worktreeId ||
+        route.nativeRuntimeId !== input.nativeRuntimeId ||
+        (route.retiringNativeRuntimeId !== undefined &&
+          route.retiringNativeRuntimeId !== input.nativeRuntimeId)
+      )
+        return undefined;
+      const related = [...routes.values()].filter(current => current.directory === route.directory);
+      if (
+        related.length === 0 ||
+        related.some(
+          current =>
+            current.nativeRuntimeId !== input.nativeRuntimeId ||
+            (current.retiringNativeRuntimeId !== undefined &&
+              current.retiringNativeRuntimeId !== input.nativeRuntimeId)
+        )
+      )
+        return undefined;
+      const existing = stored.find(
+        current =>
+          sameNativeRuntimeRetirement(current, {
+            directory: route.directory,
+            nativeRuntimeId: input.nativeRuntimeId,
+            connection: input.connection,
+          }) && current.operationId === input.operationId
+      );
+      if (existing) return existing;
+      const active = stored.find(
+        current =>
+          sameNativeRuntimeRetirement(current, {
+            directory: route.directory,
+            nativeRuntimeId: input.nativeRuntimeId,
+            connection: input.connection,
+          }) && holdsNativeRuntimeRetirementFence(current)
+      );
+      if (active) return active;
+      const created = createNativeRuntimeRetirement(
+        currentPhysical,
+        input.connection,
+        related,
+        input.reason,
+        input.cleanupDeadlineAt,
+        input.cleanupDeadlineAt + DEADLINE_MS.stopAttempt,
+        input.operationId
+      );
+      if (!created) return undefined;
+      fenceNativeRuntimeRetirement(routes, created);
+      await saveRouteTable(ports.storage, routes);
+      await saveNativeRuntimeRetirements(ports.storage, [
+        ...stored.filter(current => retainReceipt(current, now())),
+        created,
+      ]);
+      return created;
+    });
+    if (receipt) await reconcileSchedule();
+    return receipt;
+  };
+
+  const release = async (receipt: NativeRuntimeRetirementReceipt): Promise<void> => {
+    await ports.storage.transaction(async () => {
+      const [routes, stored] = await Promise.all([
+        loadRouteTable(ports.storage),
+        loadNativeRuntimeRetirements(ports.storage),
+      ]);
+      const current = stored.find(current => matchesReceipt(current, receipt));
+      if (!current || current.state !== 'pending') return;
+      if (!hasOtherNativeRuntimeRetirementFence(stored, current))
+        releaseNativeRuntimeRetirement(routes, current, false);
+      await saveRouteTable(ports.storage, routes);
+      await saveNativeRuntimeRetirements(
+        ports.storage,
+        stored.map(current =>
+          matchesReceipt(current, receipt)
+            ? { ...current, state: 'released' as const, disposition: 'operation_only' as const }
+            : current
+        )
+      );
+    });
+    await reconcileSchedule();
+  };
+
+  const deliverNotifications = async (
+    receipt: NativeRuntimeRetirementReceipt
+  ): Promise<boolean> => {
+    const claimed = await ports.storage.transaction(async () => {
+      const stored = await loadNativeRuntimeRetirements(ports.storage);
+      const current = stored.find(current => matchesReceipt(current, receipt));
+      if (!current || current.state !== 'completed') return { state: 'unavailable' as const };
+      if (current.notificationState === 'delivered') return { state: 'delivered' as const };
+      if (
+        current.notificationState === 'exhausted' ||
+        now() >= current.replayUntil ||
+        current.notificationAttempts >= DEADLINE_MS.nativeRetirementMaxAttempts
+      ) {
+        if (current.notificationState === 'pending') {
+          await saveNativeRuntimeRetirements(
+            ports.storage,
+            stored.map(item =>
+              matchesReceipt(item, receipt)
+                ? { ...item, notificationState: 'exhausted' as const }
+                : item
+            )
+          );
+        }
+        return { state: 'exhausted' as const };
+      }
+      if (
+        current.nextNotificationAttemptAt !== undefined &&
+        now() < current.nextNotificationAttemptAt
+      )
+        return { state: 'pending' as const };
+      const attempt = {
+        ...current,
+        notificationAttempts: current.notificationAttempts + 1,
+        nextNotificationAttemptAt: now() + DEADLINE_MS.stopAttempt,
+      };
+      await saveNativeRuntimeRetirements(
+        ports.storage,
+        stored.map(item => (matchesReceipt(item, receipt) ? attempt : item))
+      );
+      return { state: 'send' as const, receipt: attempt };
+    });
+    if (claimed.state !== 'send') {
+      await reconcileSchedule();
+      return claimed.state === 'delivered';
+    }
+    const [invalidated, notified] = await Promise.all([
+      ports.transport.invalidateRecipients(claimed.receipt),
+      ports.transport.notifyRecipients(claimed.receipt),
+    ]);
+    const delivered = invalidated && notified;
+    await ports.storage.transaction(async () => {
+      const [routes, stored] = await Promise.all([
+        loadRouteTable(ports.storage),
+        loadNativeRuntimeRetirements(ports.storage),
+      ]);
+      const current = stored.find(current => matchesReceipt(current, claimed.receipt));
+      if (!current || current.state !== 'completed' || current.notificationState !== 'pending')
+        return;
+      if (delivered) {
+        releaseNativeRuntimeRetirement(routes, current, true);
+        await saveRouteTable(ports.storage, routes);
+      }
+      const exhausted =
+        !delivered && current.notificationAttempts >= DEADLINE_MS.nativeRetirementMaxAttempts;
+      await saveNativeRuntimeRetirements(
+        ports.storage,
+        stored.map(item =>
+          matchesReceipt(item, claimed.receipt)
+            ? {
+                ...item,
+                ...(delivered
+                  ? {
+                      notificationState: 'delivered' as const,
+                      nextNotificationAttemptAt: undefined,
+                    }
+                  : exhausted
+                    ? {
+                        notificationState: 'exhausted' as const,
+                        nextNotificationAttemptAt: undefined,
+                      }
+                    : { nextNotificationAttemptAt: now() + DEADLINE_MS.nativeRetirementRetry }),
+              }
+            : item
+        )
+      );
+    });
+    await reconcileSchedule();
+    return delivered;
+  };
+
+  const complete = async (receipt: NativeRuntimeRetirementReceipt): Promise<boolean> => {
+    const committed = await ports.storage.transaction(async () => {
+      const [physical, routes, stored] = await Promise.all([
+        loadPhysicalRecord(ports.storage),
+        loadRouteTable(ports.storage),
+        loadNativeRuntimeRetirements(ports.storage),
+      ]);
+      const current = stored.find(current => matchesReceipt(current, receipt));
+      if (!current) return undefined;
+      if (current.state === 'completed') return current;
+      if (
+        current.state !== 'pending' ||
+        !ports.currentIncarnation.isCurrent(receipt.connection) ||
+        physical.state !== 'running' ||
+        physical.stopTombstone ||
+        !matchesNativeRuntimeRetirementAllocation(current, physical) ||
+        !routesMatchNativeRuntimeRetirement(routes, current)
+      )
+        return undefined;
+      const completed = {
+        ...current,
+        state: 'completed' as const,
+        disposition: 'retired' as const,
+      };
+      await saveNativeRuntimeRetirements(
+        ports.storage,
+        stored.map(item => (matchesReceipt(item, receipt) ? completed : item))
+      );
+      return completed;
+    });
+    if (!committed) return false;
+    return deliverNotifications(committed);
+  };
+
+  const escalate = async (receipt: NativeRuntimeRetirementReceipt): Promise<boolean> => {
+    const token = await ports.storage.transaction(async () => {
+      const stored = await loadNativeRuntimeRetirements(ports.storage);
+      const current = stored.find(current => matchesReceipt(current, receipt));
+      if (!current || current.state !== 'pending') return undefined;
+      const fallback = {
+        ...current,
+        state: 'unconfirmed' as const,
+        disposition: 'physical_fallback' as const,
+      };
+      await saveNativeRuntimeRetirements(
+        ports.storage,
+        stored.map(item => (matchesReceipt(item, receipt) ? fallback : item))
+      );
+      return fallback;
+    });
+    if (token) await ports.physicalEscalation.beginIfCurrent(token);
+    await reconcileSchedule();
+    return token !== undefined;
+  };
+
+  const claimRetirementAttempt = async (receipt: NativeRuntimeRetirementReceipt) => {
+    return ports.storage.transaction(async () => {
+      const stored = await loadNativeRuntimeRetirements(ports.storage);
+      const current = stored.find(current => matchesReceipt(current, receipt));
+      if (!current || current.state !== 'pending') return { state: 'unavailable' as const };
+      if (
+        now() >= current.cleanupDeadlineAt ||
+        current.attempts >= DEADLINE_MS.nativeRetirementMaxAttempts
+      )
+        return { state: 'escalate' as const, receipt: current };
+      if (current.nextAttemptAt !== undefined && now() < current.nextAttemptAt)
+        return { state: 'pending' as const };
+      const attempt = {
+        ...current,
+        attempts: current.attempts + 1,
+        nextAttemptAt: now() + DEADLINE_MS.stopAttempt,
+      };
+      await saveNativeRuntimeRetirements(
+        ports.storage,
+        stored.map(item => (matchesReceipt(item, receipt) ? attempt : item))
+      );
+      return { state: 'send' as const, receipt: attempt };
+    });
+  };
+
+  const settleRetirementAttempt = async (
+    receipt: NativeRuntimeRetirementReceipt
+  ): Promise<void> => {
+    await ports.storage.transaction(async () => {
+      const stored = await loadNativeRuntimeRetirements(ports.storage);
+      await saveNativeRuntimeRetirements(
+        ports.storage,
+        stored.map(current =>
+          matchesReceipt(current, receipt) &&
+          current.state === 'pending' &&
+          current.attempts === receipt.attempts
+            ? { ...current, nextAttemptAt: now() + DEADLINE_MS.nativeRetirementRetry }
+            : current
+        )
+      );
+    });
+  };
+
+  const defer = async (receipt: NativeRuntimeRetirementReceipt): Promise<void> => {
+    await settleRetirementAttempt(receipt);
+    await reconcileSchedule();
+  };
+
+  const claimTargetedAttempt = async (
+    receipt: NativeRuntimeRetirementReceipt
+  ): Promise<NativeRuntimeRetirementReceipt | undefined> => {
+    const claimed = await claimRetirementAttempt(receipt);
+    if (claimed.state === 'send') return claimed.receipt;
+    if (claimed.state === 'escalate') await escalate(claimed.receipt);
+    else await reconcileSchedule();
+    return undefined;
+  };
+
+  const retire = async (
+    input: Parameters<NativeRuntimeRetirementWorkflow['retire']>[0]
+  ): Promise<'retired' | 'pending' | 'unavailable'> => {
+    const nativeRuntimeId = input.route.nativeRuntimeId;
+    if (!nativeRuntimeId || !ports.transport.supportsTargetedRetirement()) return 'unavailable';
+    const receipt = await begin({
+      ...input,
+      nativeRuntimeId,
+      cleanupDeadlineAt: now() + DEADLINE_MS.stopAttempt,
+    });
+    if (!receipt) return 'unavailable';
+    if (receipt.operationId !== input.operationId)
+      return receipt.state === 'unconfirmed' ? 'unavailable' : 'pending';
+    if (receipt.state === 'completed') return (await complete(receipt)) ? 'retired' : 'pending';
+    if (receipt.state !== 'pending') return 'unavailable';
+    const claimed = await claimRetirementAttempt(receipt);
+    if (claimed.state === 'escalate') {
+      return (await escalate(claimed.receipt)) ? 'unavailable' : 'pending';
+    }
+    if (claimed.state !== 'send') {
+      await reconcileSchedule();
+      return claimed.state === 'pending' ? 'pending' : 'unavailable';
+    }
+    try {
+      if (
+        !(await ports.transport.abortNativeRuntime({
+          receipt: claimed.receipt,
+          route: input.route,
+        }))
+      ) {
+        await settleRetirementAttempt(claimed.receipt);
+        if (now() >= claimed.receipt.cleanupDeadlineAt) {
+          return (await escalate(claimed.receipt)) ? 'unavailable' : 'pending';
+        }
+        await reconcileSchedule();
+        return 'pending';
+      }
+    } catch {
+      await settleRetirementAttempt(claimed.receipt);
+      if (now() >= claimed.receipt.cleanupDeadlineAt) {
+        return (await escalate(claimed.receipt)) ? 'unavailable' : 'pending';
+      }
+      await reconcileSchedule();
+      return 'pending';
+    }
+    return (await complete(claimed.receipt)) ? 'retired' : 'pending';
+  };
+
+  const receiveRetired = async (
+    input: Parameters<NativeRuntimeRetirementWorkflow['receiveRetired']>[0]
+  ): Promise<{ retired: true } | undefined> => {
+    if (!ports.currentIncarnation.isCurrent(input.connection)) return undefined;
+    const [physical, routes, receipts] = await Promise.all([
+      loadPhysicalRecord(ports.storage),
+      loadRouteTable(ports.storage),
+      loadNativeRuntimeRetirements(ports.storage),
+    ]);
+    const matchesExisting = (receipt: NativeRuntimeRetirementReceipt) =>
+      sameNativeRuntimeRetirement(receipt, {
+        directory: input.directory,
+        nativeRuntimeId: input.nativeRuntimeId,
+        connection: input.connection,
+      });
+    const existing =
+      receipts.find(receipt => matchesExisting(receipt) && receipt.state === 'completed') ??
+      receipts.find(receipt => matchesExisting(receipt) && receipt.state === 'pending');
+    if (existing?.state === 'completed')
+      return (await complete(existing)) ? { retired: true } : undefined;
+    if (existing?.state === 'pending')
+      return (await complete(existing)) ? { retired: true } : undefined;
+    const matches = [...routes.values()].filter(route => route.directory === input.directory);
+    const route = matches[0];
+    if (
+      !route ||
+      matches.some(route => route.nativeRuntimeId !== input.nativeRuntimeId) ||
+      physical.state !== 'running' ||
+      physical.stopTombstone ||
+      physical.providerRef !== input.connection.providerInstanceId
+    )
+      return undefined;
+    const receipt = await begin({
+      connection: input.connection,
+      physical,
+      route,
+      nativeRuntimeId: input.nativeRuntimeId,
+      reason: input.reason,
+      cleanupDeadlineAt: now() + DEADLINE_MS.stopAttempt,
+    });
+    return receipt && (await complete(receipt)) ? { retired: true } : undefined;
+  };
+
+  const resume = async (): Promise<void> => {
+    const receipts = await loadNativeRuntimeRetirements(ports.storage);
+    if (receipts.length === 0) return;
+    for (const receipt of receipts) {
+      if (receipt.state === 'completed') {
+        await complete(receipt);
+        continue;
+      }
+      if (receipt.state === 'unconfirmed') {
+        await ports.physicalEscalation.beginIfCurrent(receipt);
+        continue;
+      }
+      if (receipt.state !== 'pending') continue;
+      if (now() >= receipt.cleanupDeadlineAt) {
+        await escalate(receipt);
+        continue;
+      }
+      const [physical, routes] = await Promise.all([
+        loadPhysicalRecord(ports.storage),
+        loadRouteTable(ports.storage),
+      ]);
+      const route = routes.get(receipt.recipients[0]?.sessionId ?? '');
+      const connection = ports.currentIncarnation.getConnection();
+      if (
+        !connection ||
+        !ports.currentIncarnation.sameConnection(connection, receipt.connection) ||
+        !ports.currentIncarnation.isCurrent(connection)
+      ) {
+        await defer(receipt);
+        continue;
+      }
+      if (
+        !route ||
+        !matchesNativeRuntimeRetirementAllocation(receipt, physical) ||
+        !routesMatchNativeRuntimeRetirement(routes, receipt) ||
+        !ports.transport.supportsTargetedRetirement()
+      ) {
+        await escalate(receipt);
+        continue;
+      }
+      await retire({
+        connection,
+        physical,
+        route,
+        reason: receipt.reason,
+        operationId: receipt.operationId,
+      });
+    }
+    await reconcileSchedule();
+  };
+
+  return {
+    begin,
+    complete,
+    release,
+    defer,
+    claimTargetedAttempt,
+    retire,
+    receiveRetired,
+    resume,
+  };
+}

--- a/services/cloud-agent-next/src/sandbox-control/session-routes.ts
+++ b/services/cloud-agent-next/src/sandbox-control/session-routes.ts
@@ -10,6 +10,8 @@ export type SessionRoute = {
   lastStateAt: number | null;
   idleForMs: number | null;
   waitingOn: 'model' | 'tool' | 'finalizing' | 'preparation' | 'input' | null;
+  nativeRuntimeId?: string;
+  retiringNativeRuntimeId?: string;
 };
 
 export type AttachRouteInput = {

--- a/services/cloud-agent-next/src/sandbox-control/socket.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/socket.test.ts
@@ -62,7 +62,8 @@ function asWs(ws: FakeWebSocket): WebSocket {
 function helloFrame(
   providerInstanceId: string,
   wrapperInstanceId?: string,
-  requestId = 'req_hello'
+  requestId = 'req_hello',
+  capabilities?: { nativeRuntimeRetirement?: boolean }
 ): string {
   return JSON.stringify({
     type: 'request',
@@ -72,6 +73,7 @@ function helloFrame(
       protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
       providerInstanceId,
       ...(wrapperInstanceId ? { wrapperInstanceId } : {}),
+      ...(capabilities ? { capabilities } : {}),
     },
   });
 }
@@ -326,6 +328,7 @@ describe('sandbox control socket handler', () => {
             kiloVersionHeartbeat: true,
             sessionOperationResults: true,
             scopedStopAbort: true,
+            nativeRuntimeRetirement: true,
           },
         },
       })
@@ -362,6 +365,20 @@ describe('sandbox control socket handler', () => {
     expect(onHandshakeComplete).toHaveBeenCalledWith(handler.getConnectionIdentity(), {
       wrapperVersion: null,
     });
+  });
+
+  it('reads the native runtime retirement capability from the wrapper handshake', async () => {
+    const incoming = createFakeWebSocket();
+    const handler = createSandboxControlSocketHandler(createFakeState([incoming]), 'sbx_test');
+
+    await handler.handleMessage(
+      asWs(incoming),
+      helloFrame('inst_1', WRAPPER_INSTANCE_ID, 'req_native_retirement', {
+        nativeRuntimeRetirement: true,
+      })
+    );
+
+    expect(handler.supportsNativeRuntimeRetirement()).toBe(true);
   });
 
   it('rejects duplicate hellos without replacing the current connection', async () => {

--- a/services/cloud-agent-next/src/sandbox-control/socket.ts
+++ b/services/cloud-agent-next/src/sandbox-control/socket.ts
@@ -14,6 +14,7 @@ import {
   SANDBOX_HELLO_DEADLINE_MS,
   sandboxControlSocketAttachmentSchema,
   sandboxControlObservationSchema,
+  sessionNativeRuntimeRetirementPayloadSchema,
   sessionOperationAuthorizationSchema,
   sessionOperationDeliverySchema,
   type SandboxControlObservation,
@@ -25,6 +26,7 @@ import {
   type SandboxHeartbeatPayload,
   type SessionEventIdentity,
   type SessionEventPayload,
+  type SessionNativeRuntimeRetirementPayload,
   type SessionOperationAck,
   type SessionOperationAuthorization,
   type SessionOperationDelivery,
@@ -94,6 +96,10 @@ export type SandboxControlSocketHooks = {
     delivery: SessionOperationDelivery,
     identity: SandboxControlConnectionIdentity
   ): Promise<SessionOperationAck | undefined> | SessionOperationAck | undefined;
+  onNativeRuntimeRetired?(
+    payload: SessionNativeRuntimeRetirementPayload,
+    identity: SandboxControlConnectionIdentity
+  ): Promise<{ retired: true } | undefined> | { retired: true } | undefined;
   onSocketClosed?(
     handshakeComplete: boolean,
     identity?: SandboxControlConnectionIdentity
@@ -110,6 +116,7 @@ export type SandboxControlSocketHandler = {
   hasHandshakenSocket(): boolean;
   supportsOperationResults(): boolean;
   supportsScopedStopAbort(): boolean;
+  supportsNativeRuntimeRetirement(): boolean;
   getConnectionIdentity(): SandboxControlConnectionIdentity | null;
   getReadySocket(): WebSocket | null;
   closeProvisionalSockets(): void;
@@ -342,6 +349,14 @@ export function createSandboxControlSocketHandler(
       const current = currentHandshakenSocket(state);
       return (
         current !== null && readAttachment(current.socket)?.capabilities?.scopedStopAbort === true
+      );
+    },
+
+    supportsNativeRuntimeRetirement(): boolean {
+      const current = currentHandshakenSocket(state);
+      return (
+        current !== null &&
+        readAttachment(current.socket)?.capabilities?.nativeRuntimeRetirement === true
       );
     },
 
@@ -641,6 +656,43 @@ export function createSandboxControlSocketHandler(
             frame.session,
             eventPayload.payload as SessionPreparingPayload,
             identity
+          );
+        }
+        return;
+      }
+
+      if (frame.operation === 'session.runtime.retired') {
+        const payload = sessionNativeRuntimeRetirementPayloadSchema.safeParse(frame.payload);
+        if (!payload.success) {
+          sendJson(
+            ws,
+            errorResponse(
+              frame.requestId,
+              'protocol_error',
+              'Invalid native runtime retirement payload'
+            )
+          );
+          return;
+        }
+        try {
+          const result = await hooks.onNativeRuntimeRetired?.(payload.data, identity);
+          if (!result)
+            throw new SandboxControlConnectionError(
+              'Native runtime retirement is not current',
+              true
+            );
+          if (!isCurrentConnection(state, ws, identity)) return;
+          sendJson(ws, okResponse(frame.requestId, result));
+        } catch (error) {
+          if (!isCurrentConnection(state, ws, identity)) return;
+          sendJson(
+            ws,
+            errorResponse(
+              frame.requestId,
+              'not_ready',
+              error instanceof Error ? error.message : 'Native runtime retirement failed',
+              true
+            )
           );
         }
         return;

--- a/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
+++ b/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
@@ -122,6 +122,7 @@ import {
   sessionPermissionResolveResultSchema,
   sessionQuestionResolveResultSchema,
   sessionAbortResultSchema,
+  sameSessionOperation,
   wrapperInstanceIdSchema,
   type SessionOperationAck,
   type SessionOperationAuthorization,
@@ -191,6 +192,14 @@ type SandboxControlEventInput = {
 const QUEUE_RETRY_MS = 5_000;
 const PENDING_RUNTIME_CLEANUP_KEY = 'pending_runtime_cleanup';
 const PENDING_INTERACTIONS_KEY = 'session_pending_interactions';
+const NATIVE_RUNTIME_FENCE_KEY = 'native_runtime_fence';
+const nativeRuntimeFenceSchema = z.object({
+  sandboxId: z.string().min(1),
+  wrapperInstanceId: wrapperInstanceIdSchema,
+  nativeRuntimeId: z.string().uuid(),
+  attachmentEpoch: z.number().int().positive(),
+  authorization: sessionOperationAuthorizationSchema,
+});
 const pendingRuntimeCleanupSchema = z.object({
   ownerId: z.string().min(1),
   sessionId: z.string().min(1),
@@ -1187,8 +1196,74 @@ export class SandboxSession extends DurableObject<Env> {
     sandboxId: string;
     wrapperInstanceId: string;
     confirmed: boolean;
+    nativeRuntimeId?: string;
   }): Promise<void> {
+    const current = nativeRuntimeFenceSchema.safeParse(
+      this.ctx.storage.kv.get<unknown>(NATIVE_RUNTIME_FENCE_KEY)
+    );
+    if (
+      input.nativeRuntimeId !== undefined &&
+      (!current.success ||
+        current.data.sandboxId !== input.sandboxId ||
+        current.data.wrapperInstanceId !== input.wrapperInstanceId ||
+        current.data.nativeRuntimeId !== input.nativeRuntimeId)
+    )
+      return;
     this.terminalLifecycle.invalidateRuntime(input);
+  }
+
+  async recordNativeRuntime(input: {
+    sandboxId: string;
+    wrapperInstanceId: string;
+    nativeRuntimeId: string;
+    authorization?: SessionOperationAuthorization;
+  }): Promise<void> {
+    const authorization = sessionOperationAuthorizationSchema.safeParse(input.authorization);
+    const epoch = this.terminalLifecycle.captureEpoch();
+    const metadata = this.terminalLifecycle.getStoredMetadata();
+    if (
+      !authorization.success ||
+      authorization.data.operation !== 'session.attach' ||
+      authorization.data.wrapperInstanceId !== input.wrapperInstanceId ||
+      authorization.data.session.sessionId !== this.sessionId ||
+      !metadata ||
+      metadata.workspace?.sandboxId !== input.sandboxId ||
+      authorization.data.session.kiloSessionId !== metadata.auth.kiloSessionId ||
+      authorization.data.session.directory !== this.directory(metadata) ||
+      epoch === null
+    )
+      return;
+    const message = this.loadMessages().find(
+      current => current.messageId === authorization.data.messageId
+    );
+    const proof = message?.operations?.attach;
+    if (
+      !proof?.completedAt ||
+      proof.attachmentEpoch === undefined ||
+      !sameSessionOperation(proof.authorization, authorization.data) ||
+      !this.terminalLifecycle.isCurrent(epoch)
+    )
+      return;
+    const newestAttachmentEpoch = Math.max(
+      0,
+      ...this.loadMessages().map(current => current.operations?.attach?.attachmentEpoch ?? 0)
+    );
+    const current = nativeRuntimeFenceSchema.safeParse(
+      this.ctx.storage.kv.get<unknown>(NATIVE_RUNTIME_FENCE_KEY)
+    );
+    if (
+      proof.attachmentEpoch !== newestAttachmentEpoch ||
+      (current.success && current.data.attachmentEpoch > proof.attachmentEpoch)
+    )
+      return;
+    this.ctx.storage.kv.put(
+      NATIVE_RUNTIME_FENCE_KEY,
+      nativeRuntimeFenceSchema.parse({
+        ...input,
+        attachmentEpoch: proof.attachmentEpoch,
+        authorization: authorization.data,
+      })
+    );
   }
 
   async isSandboxCleanupScheduled(): Promise<boolean> {
@@ -1987,6 +2062,21 @@ export class SandboxSession extends DurableObject<Env> {
           },
         }
       );
+      if (
+        dispatched.state === 'response' &&
+        authorization.operation === 'session.attach' &&
+        sandboxId
+      ) {
+        const attached = sessionAttachResultSchema.safeParse(dispatched.result);
+        if (attached.success && attached.data.nativeRuntimeId !== undefined) {
+          await this.recordNativeRuntime({
+            sandboxId,
+            wrapperInstanceId,
+            nativeRuntimeId: attached.data.nativeRuntimeId,
+            authorization,
+          });
+        }
+      }
       return dispatched;
     };
     await this.armQueueRetry(Math.min(deadlineAt, Date.now() + QUEUE_RETRY_MS));
@@ -2435,7 +2525,22 @@ export class SandboxSession extends DurableObject<Env> {
     if (this.pendingRuntimeCleanup()) await this.transferRuntimeCleanup();
   }
 
-  async failWaitingMessages(reason: string, wrapperInstanceId?: string): Promise<void> {
+  async failWaitingMessages(
+    reason: string,
+    wrapperInstanceId?: string,
+    nativeRuntimeId?: string
+  ): Promise<void> {
+    if (nativeRuntimeId !== undefined) {
+      const current = nativeRuntimeFenceSchema.safeParse(
+        this.ctx.storage.kv.get<unknown>(NATIVE_RUNTIME_FENCE_KEY)
+      );
+      if (
+        !current.success ||
+        current.data.nativeRuntimeId !== nativeRuntimeId ||
+        current.data.wrapperInstanceId !== wrapperInstanceId
+      )
+        return;
+    }
     const epoch = this.terminalLifecycle.captureEpoch();
     if (epoch === null) return;
     const before = this.loadMessages();

--- a/services/cloud-agent-next/src/sandbox-session/session-message-queue.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-message-queue.test.ts
@@ -2619,6 +2619,198 @@ describe('SandboxSession orchestration', () => {
     ).toEqual(['b']);
   });
 
+  it('persists a retained operation result without nested transactionSync', async () => {
+    const fixture = sessionFixture();
+    const kiloSessionId = fixture.metadata.auth.kiloSessionId;
+    if (!kiloSessionId) throw new Error('Missing Kilo session ID');
+    const authorization = {
+      operation: 'session.prompt',
+      operationId: 'a',
+      messageId: 'a',
+      session: { sessionId: SESSION_ID, kiloSessionId, directory: DIRECTORY },
+      wrapperInstanceId: RUNTIME_ID,
+      dispatchDeadlineAt: Date.now() + 60_000,
+    } satisfies SessionOperationAuthorization;
+    fixture.values.set('session_messages', [
+      {
+        messageId: 'a',
+        state: 'accepted',
+        wrapperInstanceId: RUNTIME_ID,
+        operations: { prompt: { authorization, dispatched: true } },
+      } as SessionMessageRecord,
+    ]);
+    let depth = 0;
+    const transactionSync = fixture.storage.transactionSync.bind(fixture.storage);
+    fixture.storage.transactionSync = <T>(callback: () => T): T => {
+      if (depth > 0) throw new Error('nested transactionSync');
+      depth += 1;
+      try {
+        return transactionSync(callback);
+      } finally {
+        depth -= 1;
+      }
+    };
+    await expect(
+      fixture.session.receiveSandboxOperationResult({
+        session: authorization.session,
+        wrapperInstanceId: authorization.wrapperInstanceId,
+        delivery: {
+          version: 2,
+          authorization,
+          completedAt: Date.now(),
+          result: { ok: true, result: { messageId: 'a', status: 'accepted' } },
+          outcome: { messageId: 'a', status: 'completed' },
+          events: [
+            {
+              type: 'autocommit_completed',
+              properties: { success: true, messageId: 'a' },
+              timestamp: new Date().toISOString(),
+            },
+          ],
+          preparing: [],
+        },
+      })
+    ).resolves.toMatchObject({ disposition: 'applied' });
+    expect(fixture.record('a')?.state).toBe('completed');
+  });
+
+  it('records the native runtime fence after attach completion is persisted', async () => {
+    const fixture = sessionFixture();
+    const kiloSessionId = fixture.metadata.auth.kiloSessionId;
+    if (!kiloSessionId) throw new Error('Missing Kilo session ID');
+    const nativeRuntimeId = '44444444-4444-4444-8444-444444444444';
+    const authorization = {
+      operation: 'session.attach',
+      operationId: '11111111-1111-4111-8111-111111111111',
+      messageId: 'a',
+      session: { sessionId: SESSION_ID, kiloSessionId, directory: DIRECTORY },
+      wrapperInstanceId: RUNTIME_ID,
+      dispatchDeadlineAt: Date.now() + 60_000,
+    } satisfies SessionOperationAuthorization;
+    fixture.values.set('session_messages', [
+      {
+        messageId: 'a',
+        state: 'accepted',
+        wrapperInstanceId: RUNTIME_ID,
+        operations: { attach: { authorization, dispatched: true } },
+      } as SessionMessageRecord,
+    ]);
+    await fixture.session.recordNativeRuntime({
+      sandboxId: SANDBOX_ID,
+      wrapperInstanceId: RUNTIME_ID,
+      nativeRuntimeId,
+      authorization,
+    });
+    expect(fixture.values.get('native_runtime_fence')).toBeUndefined();
+    fixture.values.set('session_messages', [
+      {
+        messageId: 'a',
+        state: 'accepted',
+        wrapperInstanceId: RUNTIME_ID,
+        operations: {
+          attach: {
+            authorization,
+            dispatched: true,
+            completedAt: Date.now(),
+            attachmentEpoch: 1,
+          },
+        },
+      } as SessionMessageRecord,
+    ]);
+    await fixture.session.recordNativeRuntime({
+      sandboxId: SANDBOX_ID,
+      wrapperInstanceId: RUNTIME_ID,
+      nativeRuntimeId,
+      authorization,
+    });
+    expect(fixture.values.get('native_runtime_fence')).toEqual(
+      expect.objectContaining({
+        sandboxId: SANDBOX_ID,
+        wrapperInstanceId: RUNTIME_ID,
+        nativeRuntimeId,
+      })
+    );
+  });
+
+  it('does not let a late N1 attachment record replace the current N2 fence', async () => {
+    const fixture = sessionFixture();
+    const kiloSessionId = fixture.metadata.auth.kiloSessionId;
+    if (!kiloSessionId) throw new Error('Missing Kilo session ID');
+    const authorization = (messageId: string, operationId: string, deadline: number) =>
+      ({
+        operation: 'session.attach',
+        operationId,
+        messageId,
+        session: {
+          sessionId: SESSION_ID,
+          kiloSessionId,
+          directory: DIRECTORY,
+        },
+        wrapperInstanceId: RUNTIME_ID,
+        dispatchDeadlineAt: deadline,
+      }) satisfies SessionOperationAuthorization;
+    const oldAuthorization = authorization(
+      'old',
+      '11111111-1111-4111-8111-111111111111',
+      Date.now() + 1_000
+    );
+    const nextAuthorization = authorization(
+      'next',
+      '22222222-2222-4222-8222-222222222222',
+      Date.now() + 2_000
+    );
+    fixture.values.set('session_messages', [
+      {
+        messageId: 'old',
+        state: 'accepted',
+        wrapperInstanceId: RUNTIME_ID,
+        operations: {
+          attach: {
+            authorization: oldAuthorization,
+            dispatched: true,
+            completedAt: Date.now(),
+            attachmentEpoch: 1,
+          },
+        },
+      } as SessionMessageRecord,
+      {
+        messageId: 'next',
+        state: 'accepted',
+        wrapperInstanceId: RUNTIME_ID,
+        operations: {
+          attach: {
+            authorization: nextAuthorization,
+            dispatched: true,
+            completedAt: Date.now(),
+            attachmentEpoch: 2,
+          },
+        },
+      } as SessionMessageRecord,
+    ]);
+
+    await fixture.session.recordNativeRuntime({
+      sandboxId: SANDBOX_ID,
+      wrapperInstanceId: RUNTIME_ID,
+      nativeRuntimeId: '22222222-2222-4222-8222-222222222222',
+      authorization: nextAuthorization,
+    });
+    await fixture.session.recordNativeRuntime({
+      sandboxId: SANDBOX_ID,
+      wrapperInstanceId: RUNTIME_ID,
+      nativeRuntimeId: '11111111-1111-4111-8111-111111111111',
+      authorization: oldAuthorization,
+    });
+
+    await fixture.session.failWaitingMessages(
+      'late_old_native_failure',
+      RUNTIME_ID,
+      '11111111-1111-4111-8111-111111111111'
+    );
+
+    expect(fixture.record('old')?.state).toBe('accepted');
+    expect(fixture.record('next')?.state).toBe('accepted');
+  });
+
   it('retains the original head deadline after awaited cancel cannot transfer quarantine', async () => {
     const fixture = sessionFixture();
     const attach = deferred<ResponseFrame>();

--- a/services/cloud-agent-next/src/sandbox-session/session-message-queue.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-message-queue.ts
@@ -43,6 +43,7 @@ export type SessionOperationProof = {
   result?: SessionOperationDelivery['result'];
   resultHash?: string;
   completedAt?: number;
+  attachmentEpoch?: number;
   decision?: SessionOperationAck['decision'];
 };
 
@@ -492,6 +493,11 @@ export function applySessionOperationResult(
     state: resultMessage.state,
     at: resultMessage.terminalAt ?? delivery.completedAt,
   };
+  const attachmentEpoch =
+    kind === 'attach'
+      ? (proof.attachmentEpoch ??
+        Math.max(0, ...messages.map(item => item.operations?.attach?.attachmentEpoch ?? 0)) + 1)
+      : undefined;
   return {
     messages: applied.map(item =>
       item.messageId === message.messageId
@@ -505,6 +511,7 @@ export function applySessionOperationResult(
                 resultHash,
                 completedAt: delivery.completedAt,
                 decision,
+                ...(attachmentEpoch !== undefined ? { attachmentEpoch } : {}),
               },
             },
           }
@@ -581,6 +588,9 @@ export function completeSessionOperationAttachment(
     nextQueuedMessageId(messages) !== message.messageId
   )
     return undefined;
+  const attachmentEpoch =
+    proof.attachmentEpoch ??
+    Math.max(0, ...messages.map(item => item.operations?.attach?.attachmentEpoch ?? 0)) + 1;
   return messages.map(item =>
     item.messageId === message.messageId
       ? {
@@ -588,7 +598,7 @@ export function completeSessionOperationAttachment(
           unresolvedDispatch: undefined,
           operations: {
             ...item.operations,
-            attach: { ...proof, completedAt: proof.completedAt ?? Date.now() },
+            attach: { ...proof, completedAt: proof.completedAt ?? Date.now(), attachmentEpoch },
           },
         }
       : item

--- a/services/cloud-agent-next/src/shared/sandbox-control-protocol.ts
+++ b/services/cloud-agent-next/src/shared/sandbox-control-protocol.ts
@@ -163,6 +163,7 @@ export const sandboxHelloPayloadSchema = z.object({
     .object({
       sessionOperationResults: z.boolean().optional(),
       scopedStopAbort: z.boolean().optional(),
+      nativeRuntimeRetirement: z.boolean().optional(),
     })
     .optional(),
 });
@@ -175,6 +176,7 @@ export const sandboxHelloResultSchema = z.object({
       kiloVersionHeartbeat: z.boolean().optional(),
       sessionOperationResults: z.boolean().optional(),
       scopedStopAbort: z.boolean().optional(),
+      nativeRuntimeRetirement: z.boolean().optional(),
     })
     .optional(),
 });
@@ -275,6 +277,7 @@ export type WorktreeDeleteResult = z.infer<typeof worktreeDeleteResultSchema>;
 
 export const sessionAttachPayloadSchema = z
   .object({
+    captureNativeRuntimeId: z.literal(true).optional(),
     snapshotIdentity: z.string().min(1).max(512).optional(),
     directory: z.string().min(1).max(1024).optional(),
     branch: z.string().min(1).max(256).optional(),
@@ -326,6 +329,7 @@ export const sessionAttachPayloadSchema = z
 export const sessionAttachResultSchema = z
   .object({
     attached: z.literal(true),
+    nativeRuntimeId: z.string().uuid().optional(),
   })
   .strict();
 
@@ -453,6 +457,7 @@ export const sessionAbortPayloadSchema = z
     reason: z.string().min(1).max(256).optional(),
     operationId: z.string().uuid().optional(),
     cleanupDeadlineAt: z.number().int().positive().optional(),
+    nativeRuntimeId: z.string().uuid().optional(),
   })
   .strict();
 
@@ -468,7 +473,23 @@ export const sessionAbortResultSchema = z
   .object({
     status: z.enum(['aborted', 'already_idle', 'unconfirmed']),
     quiescent: z.boolean().optional(),
+    runtimeRetired: z.boolean().optional(),
+    nativeRuntimeId: z.string().uuid().optional(),
     delivery: z.lazy(() => sessionOperationDeliverySchema).optional(),
+  })
+  .strict();
+
+export const sessionNativeRuntimeRetirementPayloadSchema = z
+  .object({
+    directory: z.string().min(1),
+    nativeRuntimeId: z.string().uuid(),
+    reason: z.string().min(1).max(256),
+  })
+  .strict();
+
+export const sessionNativeRuntimeRetirementResultSchema = z
+  .object({
+    retired: z.literal(true),
   })
   .strict();
 
@@ -602,6 +623,9 @@ export type SessionAttachPayload = z.infer<typeof sessionAttachPayloadSchema>;
 export type SessionAttachResult = z.infer<typeof sessionAttachResultSchema>;
 export type SessionPromptPayload = z.infer<typeof sessionPromptPayloadSchema>;
 export type SessionPromptResult = z.infer<typeof sessionPromptResultSchema>;
+export type SessionNativeRuntimeRetirementPayload = z.infer<
+  typeof sessionNativeRuntimeRetirementPayloadSchema
+>;
 export type SessionPermissionResolvePayload = z.infer<typeof sessionPermissionResolvePayloadSchema>;
 export type SessionPermissionResolveResult = z.infer<typeof sessionPermissionResolveResultSchema>;
 export type SessionQuestionResolvePayload = z.infer<typeof sessionQuestionResolvePayloadSchema>;
@@ -795,6 +819,7 @@ export const sandboxControlSocketAttachmentSchema = z.object({
     .object({
       sessionOperationResults: z.boolean().optional(),
       scopedStopAbort: z.boolean().optional(),
+      nativeRuntimeRetirement: z.boolean().optional(),
     })
     .optional(),
   providerInstanceId: z.string().min(1).max(256).optional(),

--- a/services/cloud-agent-next/test/integration/sandbox-control.test.ts
+++ b/services/cloud-agent-next/test/integration/sandbox-control.test.ts
@@ -395,6 +395,7 @@ async function completeHello(
           kiloVersionHeartbeat: true,
           sessionOperationResults: true,
           scopedStopAbort: true,
+          nativeRuntimeRetirement: true,
         },
       },
     })

--- a/services/cloud-agent-next/test/unit/wrapper/worktree-credential-refresh.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/worktree-credential-refresh.test.ts
@@ -86,8 +86,15 @@ function fixture() {
   const close = vi.fn();
   const startServer = vi.fn<
     NonNullable<Parameters<typeof createWorktreeKiloRuntimes>[0]['startServer']>
-  >(async () => {
+  >(async options => {
     const stopped = Promise.withResolvers<void>();
+    options.onProcessScope?.({
+      stop: async () => {
+        stopped.resolve();
+        return true;
+      },
+      verify: async () => true,
+    } as never);
     return {
       url: `http://127.0.0.1:${10000 + clients.length}`,
       stopped: stopped.promise,
@@ -421,11 +428,10 @@ describe('direct worktree credential refresh', () => {
   it('waits for confirmed old process exit before launching the refreshed process', async () => {
     const f = fixture();
     const stopped = Promise.withResolvers<void>();
-    f.startServer.mockImplementationOnce(async () => ({
-      url: 'http://127.0.0.1:10000',
-      close: f.close,
-      stopped: stopped.promise,
-    }));
+    f.startServer.mockImplementationOnce(async options => {
+      options.onProcessScope?.({ stop: async () => true, verify: async () => true } as never);
+      return { url: 'http://127.0.0.1:10000', close: f.close, stopped: stopped.promise };
+    });
     const runtime = await f.attach();
     const attachment = f.registry.attach(
       identity,
@@ -449,11 +455,10 @@ describe('direct worktree credential refresh', () => {
       const f = fixture();
       const stopped = Promise.withResolvers<void>();
       if (failure === 'process-stop-timeout') {
-        f.startServer.mockImplementationOnce(async () => ({
-          url: 'http://127.0.0.1:10000',
-          close: f.close,
-          stopped: stopped.promise,
-        }));
+        f.startServer.mockImplementationOnce(async options => {
+          options.onProcessScope?.({ stop: async () => false, verify: async () => false } as never);
+          return { url: 'http://127.0.0.1:10000', close: f.close, stopped: stopped.promise };
+        });
       }
       const runtime = await f.attach();
       await f.attach(auth, originalEnv, sibling);
@@ -474,10 +479,13 @@ describe('direct worktree credential refresh', () => {
       expect(await outcome).toMatchObject({ code: 'runtime_unhealthy', retryable: true });
       expect(runtime.signal.aborted).toBe(true);
       expect(f.registry.get(identity.directory)).toBeUndefined();
-      expect(f.registry.isHealthy()).toBe(false);
-      expect(f.onUnexpectedClose.mock.calls).toEqual([
-        [{ directory: identity.directory, reason: 'credential_refresh_failed' }],
-      ]);
+      await vi.waitFor(() => expect(f.onUnexpectedClose).toHaveBeenCalledTimes(1));
+      expect(f.registry.isHealthy()).toBe(failure !== 'process-stop-timeout');
+      expect(f.onUnexpectedClose.mock.calls[0]?.[0]).toMatchObject({
+        directory: identity.directory,
+        reason: 'credential_refresh_failed',
+        cleanup: failure === 'process-stop-timeout' ? 'unconfirmed' : 'confirmed',
+      });
       expect(f.startServer).toHaveBeenCalledTimes(failure === 'process-stop-timeout' ? 1 : 2);
       stopped.resolve();
       f.registry.shutdown();
@@ -492,11 +500,10 @@ describe('direct worktree credential refresh', () => {
   it('does not report intentional shutdown during a pending destructive refresh as unexpected', async () => {
     const f = fixture();
     const stopped = Promise.withResolvers<void>();
-    f.startServer.mockImplementationOnce(async () => ({
-      url: 'http://127.0.0.1:10000',
-      close: f.close,
-      stopped: stopped.promise,
-    }));
+    f.startServer.mockImplementationOnce(async options => {
+      options.onProcessScope?.({ stop: async () => true, verify: async () => true } as never);
+      return { url: 'http://127.0.0.1:10000', close: f.close, stopped: stopped.promise };
+    });
     await f.attach();
     const outcome = f
       .attach(auth, { ...originalEnv, GH_TOKEN: 'github-renewed' })
@@ -522,20 +529,22 @@ describe('direct worktree credential refresh', () => {
   it('reports confirmed process exit immediately even if the feed still appears fresh', async () => {
     const f = fixture();
     const stopped = Promise.withResolvers<void>();
-    f.startServer.mockImplementationOnce(async () => ({
-      url: 'http://127.0.0.1:10000',
-      close: f.close,
-      stopped: stopped.promise,
-    }));
+    f.startServer.mockImplementationOnce(async options => {
+      options.onProcessScope?.({ stop: async () => true, verify: async () => true } as never);
+      return { url: 'http://127.0.0.1:10000', close: f.close, stopped: stopped.promise };
+    });
     const runtime = await f.attach();
     stopped.resolve();
     await stopped.promise;
     expect(runtime.signal.aborted).toBe(true);
     expect(f.registry.get(identity.directory)).toBeUndefined();
-    expect(f.registry.isHealthy()).toBe(false);
-    expect(f.onUnexpectedClose.mock.calls).toEqual([
-      [{ directory: identity.directory, reason: 'process_exited' }],
-    ]);
+    await vi.waitFor(() => expect(f.onUnexpectedClose).toHaveBeenCalledTimes(1));
+    expect(f.registry.isHealthy()).toBe(true);
+    expect(f.onUnexpectedClose.mock.calls[0]?.[0]).toMatchObject({
+      directory: identity.directory,
+      reason: 'process_exited',
+      cleanup: 'confirmed',
+    });
   });
 
   it.each(['connection', 'http'] as const)(
@@ -573,9 +582,12 @@ describe('direct worktree credential refresh', () => {
       ).toHaveLength(1);
       expect(runtime.signal.aborted).toBe(false);
       feed.onUnexpectedClose(error);
-      expect(f.onUnexpectedClose.mock.calls).toEqual([
-        [{ directory: identity.directory, reason: 'feed_failed' }],
-      ]);
+      await vi.waitFor(() => expect(f.onUnexpectedClose).toHaveBeenCalledTimes(1));
+      expect(f.onUnexpectedClose.mock.calls[0]?.[0]).toMatchObject({
+        directory: identity.directory,
+        reason: 'feed_failed',
+        cleanup: 'confirmed',
+      });
       expect(runtime.signal.aborted).toBe(true);
     }
   );
@@ -594,9 +606,12 @@ describe('direct worktree credential refresh', () => {
     expect(currentFeed).toBeDefined();
     currentFeed?.onUnexpectedClose(new Error('private-current-feed-credential'));
     currentFeed?.onUnexpectedClose(new Error('private-duplicate-feed-credential'));
-    expect(f.onUnexpectedClose.mock.calls).toEqual([
-      [{ directory: identity.directory, reason: 'feed_failed' }],
-    ]);
+    await vi.waitFor(() => expect(f.onUnexpectedClose).toHaveBeenCalledTimes(1));
+    expect(f.onUnexpectedClose.mock.calls[0]?.[0]).toMatchObject({
+      directory: identity.directory,
+      reason: 'feed_failed',
+      cleanup: 'confirmed',
+    });
     expect(runtime.signal.aborted).toBe(true);
   });
 
@@ -806,6 +821,9 @@ describe('direct worktree credential refresh', () => {
       },
       signal: runtimeLifetime.signal,
     };
+    const getRuntime = f.registry.get.bind(f.registry);
+    f.registry.get = directory =>
+      directory === sibling.directory ? (fakeRuntime as typeof runtime) : getRuntime(directory);
     const siblingOp = deps.operations.start(
       sibling,
       undefined,
@@ -832,6 +850,7 @@ describe('direct worktree credential refresh', () => {
     siblingOp.cancel('test-cleanup', 'cancelled');
     held.resolve({ ok: true, result: {} });
     await siblingOp.done.catch(() => {});
+    f.registry.get = getRuntime;
     // Operation completion reconciles activity to idle; restore active state
     // to match the original test which only removed the task without touching activity
     activity.markActive(sibling.kiloSessionId);

--- a/services/cloud-agent-next/wrapper/src/control/apply-attach.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/apply-attach.test.ts
@@ -101,6 +101,7 @@ function fakeKiloRuntimes(overrides: Partial<WrapperKiloClient> = {}): WorktreeK
       let runtime = runtimes.get(directory);
       if (!runtime) {
         runtime = {
+          runtimeId: 'native_1',
           directory,
           scopeId: auth.scopeId,
           env: buildWorktreeKiloEnvironment(
@@ -118,6 +119,7 @@ function fakeKiloRuntimes(overrides: Partial<WrapperKiloClient> = {}): WorktreeK
       return {
         ready: Promise.resolve(runtime),
         signal: runtime.signal,
+        cleanup: async () => 'retired',
         commit: () => {},
         release: () => {},
       };
@@ -126,6 +128,21 @@ function fakeKiloRuntimes(overrides: Partial<WrapperKiloClient> = {}): WorktreeK
     deleteDirectory: async directory => {
       runtimes.delete(directory);
     },
+    retireRuntime: async (directory, _deadlineAt, target) => {
+      const runtime = runtimes.get(directory);
+      if (
+        !runtime ||
+        !target ||
+        target.runtimeId !== runtime.runtimeId ||
+        target.client !== runtime.kiloClient
+      )
+        return 'stale';
+      runtimes.delete(directory);
+      return 'retired';
+    },
+    verifyQuiescence: async (directory, target, deadlineAt) =>
+      runtimes.get(directory)?.kiloClient === target.client && Date.now() < deadlineAt,
+    getRetained: directory => runtimes.get(directory),
     get: directory => runtimes.get(directory),
     isHealthy: () => true,
     shutdown: () => {},

--- a/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
+++ b/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
@@ -21,6 +21,7 @@ import {
   type ExecResult,
   type ProcessOutputStream,
 } from '../utils.js';
+import type { WrapperKiloClient } from '../kilo-api.js';
 import {
   directoryForSession,
   forgetAttachedRoot,
@@ -31,17 +32,18 @@ import { authenticatedGitUrl } from './git-url';
 import { createOutputRedactor, createSecretRedactor } from '../redact-output';
 import { stripAnsi } from '../event-parser';
 import type { ControlHandlerResult } from './sandbox-control-handlers';
-import type { WrapperKiloClient } from '../kilo-api.js';
 import { restoreSession, seedSessionIngestRegistration } from '../restore-session.js';
 import { configureWorkspaceGitAuthor } from '../session-bootstrap.js';
 import { withKiloRequestDeadline } from './sandbox-control-runtime';
 import { ControlTerminalRuntimeError, type ControlTerminalRuntime } from './terminal-runtime.js';
 import {
   WorktreeKiloRuntimeError,
+  type WorktreeKiloRuntime,
   type WorktreeKiloAttachment,
   type WorktreeKiloRuntimes,
 } from './worktree-runtime.js';
 import { runDirectoryOperation } from './worktree-operations';
+import type { NativeRetirement } from './session-operation-cleanup.js';
 
 const BOOTSTRAP_MARKER = 'kilo-bootstrap-complete';
 const SETUP_COMMAND_INACTIVITY_TIMEOUT_MS = 4 * 60_000;
@@ -58,6 +60,11 @@ export type ApplyAttachDeps = {
   kiloRuntimes?: WorktreeKiloRuntimes;
   canRefreshCredentials?: () => boolean;
   signal?: AbortSignal;
+  assertCurrent?: () => void;
+  onMutation?: () => void;
+  onRuntime?: (runtime: WorktreeKiloRuntime) => void;
+  onError?: (error: unknown) => void;
+  onCleanupTarget?: (cleanup: (deadlineAt: number) => Promise<NativeRetirement>) => void;
   terminalRuntime?: Pick<ControlTerminalRuntime, 'rememberAttachedSession'>;
   mkdir?: (directory: string) => Promise<void>;
   hasGit?: (directory: string) => Promise<boolean>;
@@ -317,16 +324,20 @@ async function executeSessionAttach(
       session,
       attach.kilo,
       attach.env,
-      deps.canRefreshCredentials
+      deps.canRefreshCredentials,
+      deps.onMutation,
+      deps.onCleanupTarget
     );
     const signal = AbortSignal.any([taskSignal, attachment.signal]);
-    const { kiloClient, env } = await withTimeoutAndAbort(attachment.ready, {
+    const runtime = await withTimeoutAndAbort(attachment.ready, {
       signal,
       timeoutMs: SANDBOX_CONTROL_ATTACH_TIMEOUT_MS,
       timeoutMessage: 'Session attachment timed out',
       abortMessage: 'Session attachment cancelled',
     });
     signal.throwIfAborted();
+    const { kiloClient, env } = runtime;
+    deps.onRuntime?.(runtime);
     stage = 'workspace_prepare';
     const mkdir = deps.mkdir ?? (dir => fs.mkdir(dir, { recursive: true }).then(() => undefined));
     const hasGit = deps.hasGit ?? defaultHasGit;
@@ -551,6 +562,7 @@ async function executeSessionAttach(
     diagnostic('completed');
     return ok();
   } catch (error) {
+    deps.onError?.(error);
     diagnostic('failed');
     if (error instanceof WorktreeKiloRuntimeError || error instanceof ControlTerminalRuntimeError) {
       return fail(error.code, error.message, error.retryable);

--- a/services/cloud-agent-next/wrapper/src/control/control-test-fixtures.ts
+++ b/services/cloud-agent-next/wrapper/src/control/control-test-fixtures.ts
@@ -58,7 +58,7 @@ export function fakeKilo(overrides: Partial<WrapperKiloClient> = {}): WrapperKil
     answerQuestion: async () => true,
     rejectQuestion: async () => true,
     getSessionDetails: async (id: string, directory = session.directory) => ({ id, directory }),
-    getSessionStatuses: async () => ({}),
+    getSessionStatuses: async () => ({ [session.kiloSessionId]: { type: 'idle' } }),
     getQuestions: async () => [],
     getPermissions: async () => [],
     ...overrides,
@@ -92,6 +92,7 @@ export function createHandlerFixture(
   const runtime: WorktreeKiloRuntime | undefined = client
     ? {
         scopeId: kilo.scopeId,
+        runtimeId: 'native_1',
         directory: identity.directory,
         env: buildWorktreeKiloEnvironment(
           identity.directory,
@@ -112,12 +113,30 @@ export function createHandlerFixture(
             return {
               ready: Promise.resolve(runtime),
               signal: runtime.signal,
+              cleanup: async () => 'retired',
               commit: () => {},
               release: () => {},
             };
           },
           detach: () => true,
           deleteDirectory: async () => {},
+          getRetained: directory => (directory === runtime.directory ? runtime : undefined),
+          retireRuntime: async (directory, _deadlineAt, target) => {
+            if (
+              directory !== runtime.directory ||
+              !target ||
+              target.runtimeId !== runtime.runtimeId ||
+              target.client !== runtime.kiloClient
+            )
+              return 'stale';
+            nativeLifetime.abort();
+            return 'retired';
+          },
+          verifyQuiescence: async (directory, target, deadlineAt) =>
+            directory === runtime.directory &&
+            target.client === runtime.kiloClient &&
+            !nativeLifetime.signal.aborted &&
+            Date.now() < deadlineAt,
           get: directory =>
             directory === runtime.directory && !nativeLifetime.signal.aborted ? runtime : undefined,
           isHealthy: () => true,

--- a/services/cloud-agent-next/wrapper/src/control/delete-worktree.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/delete-worktree.test.ts
@@ -472,6 +472,7 @@ describe('scoped worktree runtime deletion', () => {
     } as WrapperKiloClient;
     const kiloRuntime: WorktreeKiloRuntime = {
       scopeId: 'test-scope',
+      runtimeId: 'native_1',
       directory,
       env: {},
       kiloClient,
@@ -479,6 +480,7 @@ describe('scoped worktree runtime deletion', () => {
     };
     const otherKiloRuntime: WorktreeKiloRuntime = {
       scopeId: 'test-scope-other',
+      runtimeId: 'native_2',
       directory: otherDirectory,
       env: {},
       kiloClient,

--- a/services/cloud-agent-next/wrapper/src/control/main.ts
+++ b/services/cloud-agent-next/wrapper/src/control/main.ts
@@ -33,6 +33,8 @@ const retirementCauses = new Map([
   ['Wrapper uncaught exception', 'uncaught_exception'],
   ['Wrapper unhandled rejection', 'unhandled_rejection'],
   ['Kilo cancellation failed', 'cancellation_failed'],
+  ['Kilo cancellation was not confirmed', 'cancellation_failed'],
+  ['Native cancellation did not settle', 'cancellation_failed'],
   ['Session outcome delivery failed', 'outcome_delivery_failed'],
   ['Execution exceeded the 60 minute limit', 'execution_deadline'],
   ['Session preparation timed out', 'preparation_deadline'],
@@ -79,12 +81,25 @@ function main(diagnostics: ControlDiagnostics, wrapperInstanceId: string): void 
         throw new Error('Sandbox control event delivery failed');
       }
     },
-    onUnexpectedClose: failure =>
-      shutdown(
-        1,
-        `Kilo worktree failed reason=${failure.reason} directory=${failure.directory}`,
-        failure.reason
-      ),
+    onUnexpectedClose: failure => {
+      logToFile(`Kilo worktree retired reason=${failure.reason} directory=${failure.directory}`);
+      if (failure.cleanup === 'unconfirmed' || !control?.reportNativeRuntimeRetirement) {
+        shutdown(1, failure.reason);
+        return;
+      }
+      void control
+        .reportNativeRuntimeRetirement({
+          directory: failure.directory,
+          nativeRuntimeId: failure.runtimeId,
+          reason: failure.reason,
+        })
+        .then(
+          retired => {
+            if (!retired) shutdown(1, failure.reason);
+          },
+          () => shutdown(1, failure.reason)
+        );
+    },
   });
   const terminalRuntime = controlConfig.SANDBOX_CONTROL_URL
     ? createControlTerminalRuntime({

--- a/services/cloud-agent-next/wrapper/src/control/native-observations.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/native-observations.test.ts
@@ -37,6 +37,7 @@ function fakeRuntime(
 ): WorktreeKiloRuntime {
   return {
     scopeId: 'scope_1',
+    runtimeId: 'native_1',
     directory,
     env: {},
     kiloClient,

--- a/services/cloud-agent-next/wrapper/src/control/operation-registry.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/operation-registry.test.ts
@@ -138,8 +138,8 @@ describe('operation admission and lookup', () => {
     ).toMatchObject({
       ok: true,
       result: {
-        status: 'unconfirmed',
-        quiescent: false,
+        status: 'aborted',
+        quiescent: true,
         delivery: { authorization },
       },
     });

--- a/services/cloud-agent-next/wrapper/src/control/operation-registry.ts
+++ b/services/cloud-agent-next/wrapper/src/control/operation-registry.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../src/shared/sandbox-control-protocol.js';
 import { rejectBeforeAdmission } from './control-handler-result.js';
 import type { WorktreeKiloRuntimes } from './worktree-runtime.js';
+import type { NativeOperationTarget, NativeRetirement } from './session-operation-cleanup.js';
 import {
   SessionOperation,
   type ControlHandlerResult,
@@ -17,7 +18,24 @@ import {
 } from './session-operation.js';
 
 type OperationRegistryDependencies = {
-  native: Pick<WorktreeKiloRuntimes, 'get'>;
+  native: {
+    get(
+      directory: string
+    ): WorktreeKiloRuntimes['get'] extends (directory: string) => infer Runtime ? Runtime : never;
+    getRetained(
+      directory: string
+    ): WorktreeKiloRuntimes['get'] extends (directory: string) => infer Runtime ? Runtime : never;
+    retireRuntime(
+      directory: string,
+      deadlineAt: number,
+      target?: NativeOperationTarget
+    ): Promise<NativeRetirement>;
+    verifyQuiescence(
+      directory: string,
+      target: NativeOperationTarget,
+      deadlineAt: number
+    ): Promise<boolean>;
+  };
   onStarted: (session: SessionRequestIdentity, preparation: boolean) => void;
   onCompleted: (session: SessionRequestIdentity) => void;
   retireRuntime: (reason: string) => void;
@@ -55,7 +73,13 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
   function prune(now = Date.now()): void {
     for (const [id, operation] of retained) {
       if (!operation.canPrune(now)) continue;
-      retained.delete(id);
+      if (operation.releaseProcessOwnership()) retained.delete(id);
+      else {
+        const deadlineAt = operation.captureCleanupDeadline();
+        void operation.cleanupOwnedWork(deadlineAt).then(confirmed => {
+          if (!confirmed) operation.requestRetirement('Owned process cleanup failed', deadlineAt);
+        });
+      }
     }
   }
 
@@ -147,6 +171,30 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
       : fail('unauthorized', 'Operation acknowledgement does not match the result', false);
   }
 
+  async function retireDirectory(
+    directory: string,
+    reason: string,
+    deadlineAt: number,
+    target?: NativeOperationTarget
+  ): Promise<NativeRetirement> {
+    const matching = [...active.values()].filter(operation => {
+      if (operation.session.directory !== directory) return false;
+      const operationTarget = operation.nativeTarget();
+      return target === undefined || operationTarget?.runtimeId === target.runtimeId;
+    });
+    for (const operation of matching) operation.cancel(reason, 'failed', deadlineAt);
+    if (
+      !(await Promise.all(matching.map(operation => operation.stopProcesses(deadlineAt)))).every(
+        Boolean
+      )
+    )
+      return 'unconfirmed';
+    const retirement = await deps.native.retireRuntime(directory, deadlineAt, target);
+    for (const operation of matching)
+      operation.confirmCleanup(retirement === 'retired' || retirement === 'stale', deadlineAt);
+    return retirement;
+  }
+
   function start(
     session: SessionRequestIdentity,
     authorization: SessionOperationAuthorization | undefined,
@@ -158,7 +206,17 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
       ...effects,
       isCurrent: () => active.get(identity.kiloSessionId) === operation,
       getRuntime: () => deps.native.get(identity.directory),
-      retireRuntime: reason => deps.retireRuntime(reason),
+      verifyQuiescence: (target, deadlineAt) =>
+        deps.native.verifyQuiescence(identity.directory, target, deadlineAt),
+      retireRuntime: (reason, deadlineAt, target) => {
+        if (!target) {
+          deps.retireRuntime(reason);
+          return;
+        }
+        void retireDirectory(identity.directory, reason, deadlineAt, target).then(retirement => {
+          if (retirement === 'unconfirmed') deps.retireRuntime(reason);
+        });
+      },
       onLocalCompletion: retain => {
         if (active.get(identity.kiloSessionId) === operation) {
           active.delete(identity.kiloSessionId);
@@ -167,6 +225,7 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
         if (authorization && !retain && retained.get(key(authorization)) === operation)
           retained.delete(key(authorization));
       },
+      onCleanupConfirmed: () => undefined,
     });
     if (authorization) retained.set(key(authorization), operation);
     active.set(identity.kiloSessionId, operation);
@@ -198,6 +257,7 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
     },
     hasActive: (rootKiloSessionId: string) => active.has(rootKiloSessionId),
     activeOperations: () => [...active.values()],
+    retireDirectory,
     retained: () => [...retained.values()],
     counts: () => ({ active: active.size, retained: retained.size }),
     async drainDelivery(deadlineAt: number): Promise<void> {

--- a/services/cloud-agent-next/wrapper/src/control/owned-processes.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/owned-processes.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { once } from 'node:events';
+import { createOwnedProcessScope } from './owned-processes.js';
+
+const spawned: ReturnType<typeof createOwnedProcessScope>[] = [];
+
+function killPid(pid: number): void {
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    return;
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(spawned.splice(0).map(scope => scope.stop(Date.now() + 1_000)));
+});
+
+describe('owned process scopes', () => {
+  it('coalesces cleanup and treats unavailable containment as unconfirmed', async () => {
+    const scope = createOwnedProcessScope();
+    spawned.push(scope);
+    const child = scope.spawn(process.execPath, ['-e', 'setInterval(() => {}, 1_000)'], {
+      cwd: process.cwd(),
+      env: process.env,
+    });
+    const exited = once(child, 'exit');
+    const first = scope.stop(Date.now() + 1_000);
+    const second = scope.stop(Date.now() + 500);
+
+    expect(second).toBe(first);
+    const stopped = await first;
+    expect(stopped).toBe(await scope.verify(false));
+    await exited;
+    if (process.platform !== 'linux') expect(await scope.verify(false)).toBe(false);
+  });
+
+  it('removes a delayed descendant that outlives its tracked parent when containment is available', async () => {
+    if (process.platform !== 'linux') return;
+    const scope = createOwnedProcessScope();
+    spawned.push(scope);
+    const parent = scope.spawn(
+      process.execPath,
+      [
+        '-e',
+        "const { spawn } = require('node:child_process'); setTimeout(() => { const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' }); process.stdout.write(String(child.pid)); setTimeout(() => process.exit(0), 20); }, 20);",
+      ],
+      { cwd: process.cwd(), env: process.env }
+    );
+    let output = '';
+    parent.stdout.on('data', data => {
+      output += data.toString();
+    });
+    await once(parent, 'exit');
+    const descendant = Number(output);
+    expect(Number.isSafeInteger(descendant)).toBe(true);
+
+    if (!(await scope.stop(Date.now() + 1_000))) {
+      killPid(descendant);
+      return;
+    }
+    expect(() => process.kill(descendant, 0)).toThrow();
+  });
+});

--- a/services/cloud-agent-next/wrapper/src/control/owned-processes.ts
+++ b/services/cloud-agent-next/wrapper/src/control/owned-processes.ts
@@ -1,0 +1,646 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import {
+  spawn,
+  type ChildProcessWithoutNullStreams,
+  type SpawnOptionsWithoutStdio,
+} from 'node:child_process';
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  rmdirSync,
+  statfsSync,
+  writeSync,
+} from 'node:fs';
+import { lstat, readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { Writable } from 'node:stream';
+import { setTimeout as delay } from 'node:timers/promises';
+
+export type OwnedProcessScope = {
+  spawn(
+    command: string,
+    args: string[],
+    options: SpawnOptionsWithoutStdio
+  ): ChildProcessWithoutNullStreams;
+  run<T>(operation: () => T): T;
+  seal(): void;
+  dispose(): boolean;
+  captureBaseline(allowed: (argv: string[]) => boolean, deadlineAt?: number): Promise<void>;
+  verify(baseline?: boolean, deadlineAt?: number): Promise<boolean>;
+  stop(deadlineAt: number): Promise<boolean>;
+};
+
+type ProcessIdentity = { pid: number; parent: number; group: number; identity: string };
+type OwnedChild = {
+  process: ChildProcessWithoutNullStreams;
+  identity?: string;
+  exited: boolean;
+};
+type Cgroup = {
+  directory: string;
+  reference: string;
+  dev: number;
+  ino: number;
+  descriptors: number[];
+  procs: number;
+  kill?: number;
+};
+
+const OBSERVATION_TIMEOUT_MS = 1_000;
+const current = new AsyncLocalStorage<OwnedProcessScope>();
+
+export function currentOwnedProcessScope(): OwnedProcessScope | undefined {
+  return current.getStore();
+}
+
+function assertBefore(deadlineAt: number): void {
+  if (!Number.isFinite(deadlineAt) || Date.now() >= deadlineAt) {
+    throw new Error('Owned process deadline expired');
+  }
+}
+
+function createDeadline(initialDeadlineAt: number) {
+  let deadlineAt = initialDeadlineAt;
+  const controller = new AbortController();
+  const expiration = Promise.withResolvers<never>();
+  void expiration.promise.catch(() => undefined);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expire = (): void => {
+    controller.abort();
+    expiration.reject(new Error('Owned process deadline expired'));
+  };
+  const arm = (): void => {
+    if (timer !== undefined) clearTimeout(timer);
+    if (!Number.isFinite(deadlineAt) || Date.now() >= deadlineAt) expire();
+    else timer = setTimeout(expire, deadlineAt - Date.now());
+  };
+  const check = (): void => {
+    assertBefore(deadlineAt);
+    controller.signal.throwIfAborted();
+  };
+  arm();
+  return {
+    check,
+    get deadlineAt() {
+      return deadlineAt;
+    },
+    shorten(next: number) {
+      deadlineAt = Math.min(deadlineAt, next);
+      if (!controller.signal.aborted) arm();
+    },
+    async wait<T>(operation: (signal: AbortSignal) => Promise<T>): Promise<T> {
+      check();
+      const value = await Promise.race([operation(controller.signal), expiration.promise]);
+      check();
+      return value;
+    },
+    close() {
+      if (timer !== undefined) clearTimeout(timer);
+      expire();
+    },
+  };
+}
+
+type Deadline = ReturnType<typeof createDeadline>;
+
+function parsePids(value: string): number[] {
+  return value
+    .split('\n')
+    .filter(Boolean)
+    .map(value => {
+      const pid = Number(value);
+      if (!/^\d+$/.test(value) || !Number.isSafeInteger(pid) || pid <= 0) {
+        throw new Error('Invalid process membership');
+      }
+      return pid;
+    });
+}
+
+function population(value: string): number {
+  const entries = value.split('\n').filter(line => line.startsWith('populated '));
+  if (entries.length !== 1 || !/^populated [01]$/.test(entries[0])) {
+    throw new Error('Process containment unavailable');
+  }
+  return Number(entries[0].slice('populated '.length));
+}
+
+function processIdentity(pid: number, value: string): ProcessIdentity {
+  if (!value.startsWith(`${pid} (`) || !value.includes(') ')) {
+    throw new Error('Process identity unavailable');
+  }
+  const fields = value
+    .slice(value.lastIndexOf(')') + 2)
+    .trim()
+    .split(/\s+/);
+  const startedAt = fields[19];
+  const parent = Number(fields[1]);
+  const group = Number(fields[2]);
+  if (
+    !startedAt ||
+    !/^\d+$/.test(startedAt) ||
+    !Number.isSafeInteger(parent) ||
+    parent < 0 ||
+    !Number.isSafeInteger(group) ||
+    group <= 0
+  ) {
+    throw new Error('Process identity unavailable');
+  }
+  return { pid, parent, group, identity: `${pid}:${startedAt}` };
+}
+
+function closeDescriptors(descriptors: number[]): void {
+  for (const descriptor of descriptors.splice(0)) {
+    try {
+      closeSync(descriptor);
+    } catch {
+      console.warn('Owned process descriptor close failed; continuing descriptor cleanup');
+    }
+  }
+}
+
+function createCgroup(): Cgroup | undefined {
+  const descriptors: number[] = [];
+  let created: { directory: string; dev: number; ino: number } | undefined;
+  try {
+    if (process.platform !== 'linux') return undefined;
+    const membership = readFileSync('/proc/self/cgroup', 'utf8')
+      .split('\n')
+      .find(line => line.startsWith('0::'))
+      ?.slice(3);
+    if (
+      !membership ||
+      !path.posix.isAbsolute(membership) ||
+      path.posix.normalize(membership) !== membership
+    ) {
+      return undefined;
+    }
+    const parent = path.join('/sys/fs/cgroup', membership);
+    const parentFd = openSync(
+      parent,
+      constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW
+    );
+    descriptors.push(parentFd);
+    const parentReference = `/proc/self/fd/${parentFd}`;
+    if (
+      statfsSync(parentReference).type !== 0x63677270 ||
+      !parsePids(readFileSync(path.join(parentReference, 'cgroup.procs'), 'utf8')).includes(
+        process.pid
+      )
+    ) {
+      throw new Error('Process containment root unavailable');
+    }
+    descriptors.push(
+      openSync(
+        path.join(parentReference, 'cgroup.procs'),
+        constants.O_WRONLY | constants.O_NOFOLLOW
+      )
+    );
+    const name = `kilo-control-${crypto.randomUUID()}`;
+    mkdirSync(path.join(parentReference, name));
+    const directory = path.join(parent, name);
+    const descriptor = openSync(
+      path.join(parentReference, name),
+      constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW
+    );
+    descriptors.push(descriptor);
+    const { dev, ino } = fstatSync(descriptor);
+    created = { directory, dev, ino };
+    const reference = `/proc/self/fd/${descriptor}`;
+    if (population(readFileSync(path.join(reference, 'cgroup.events'), 'utf8')) !== 0) {
+      throw new Error('Owned process containment is occupied');
+    }
+    const procs = openSync(
+      path.join(reference, 'cgroup.procs'),
+      constants.O_WRONLY | constants.O_NOFOLLOW
+    );
+    descriptors.push(procs);
+    let kill: number | undefined;
+    try {
+      kill = openSync(
+        path.join(reference, 'cgroup.kill'),
+        constants.O_WRONLY | constants.O_NOFOLLOW
+      );
+      descriptors.push(kill);
+    } catch {
+      console.warn('Owned process cgroup.kill unavailable; using verified child signals');
+    }
+    closeDescriptors(descriptors.splice(0, 2));
+    return { directory, reference, dev, ino, descriptors, procs, kill };
+  } catch {
+    if (created) {
+      try {
+        const fresh = lstatSync(created.directory);
+        if (fresh.dev === created.dev && fresh.ino === created.ino) rmdirSync(created.directory);
+      } catch {
+        console.warn('Owned process containment creation cleanup failed');
+      }
+    }
+    closeDescriptors(descriptors);
+    return undefined;
+  }
+}
+
+function sameDirectory(group: Cgroup, value: { dev: number; ino: number }): boolean {
+  return value.dev === group.dev && value.ino === group.ino;
+}
+
+async function assertDirectory(group: Cgroup, deadline: Deadline): Promise<void> {
+  if (group.descriptors.length === 0) throw new Error('Owned process containment is closed');
+  const value = await deadline.wait(() => lstat(group.directory));
+  if (group.descriptors.length === 0 || !value.isDirectory() || !sameDirectory(group, value)) {
+    throw new Error('Owned process containment changed');
+  }
+}
+
+function readText(file: string, deadline: Deadline): Promise<string> {
+  return deadline.wait(signal => readFile(file, { encoding: 'utf8', signal }));
+}
+
+async function snapshotCgroup(group: Cgroup, deadline: Deadline) {
+  await assertDirectory(group, deadline);
+  const pids = new Set<number>();
+  const directories: { path: string; dev: number; ino: number }[] = [];
+  const visit = async (directory: string): Promise<void> => {
+    const before = await deadline.wait(() => lstat(directory));
+    if (!before.isDirectory() || before.dev !== group.dev) {
+      throw new Error('Owned process containment changed');
+    }
+    for (const pid of parsePids(await readText(path.join(directory, 'cgroup.procs'), deadline))) {
+      pids.add(pid);
+    }
+    const entries = await deadline.wait(() => readdir(directory, { withFileTypes: true }));
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) throw new Error('Owned process containment changed');
+      if (entry.isDirectory()) await visit(path.join(directory, entry.name));
+    }
+    const after = await deadline.wait(() => lstat(directory));
+    if (before.dev !== after.dev || before.ino !== after.ino) {
+      throw new Error('Owned process containment changed');
+    }
+    directories.push({ path: directory, dev: after.dev, ino: after.ino });
+  };
+  await visit(`${group.reference}/.`);
+  await assertDirectory(group, deadline);
+  return { pids: [...pids], directories };
+}
+
+async function removeCgroupBeforeDeadline(group: Cgroup, deadline: Deadline): Promise<boolean> {
+  try {
+    const snapshot = await snapshotCgroup(group, deadline);
+    if (snapshot.pids.length > 0) return false;
+    for (const directory of snapshot.directories) {
+      await assertDirectory(group, deadline);
+      const fresh = await deadline.wait(() => lstat(directory.path));
+      if (fresh.dev !== directory.dev || fresh.ino !== directory.ino) return false;
+      deadline.check();
+      if (group.descriptors.length === 0) return true;
+      rmdirSync(directory.path === `${group.reference}/.` ? group.directory : directory.path);
+    }
+    closeDescriptors(group.descriptors);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function removeCgroup(group: Cgroup, deadlineAt: number): boolean {
+  try {
+    const check = (): void => {
+      assertBefore(deadlineAt);
+      if (!sameDirectory(group, lstatSync(group.directory))) {
+        throw new Error('Owned process containment changed');
+      }
+      assertBefore(deadlineAt);
+    };
+    check();
+    if (population(readFileSync(path.join(group.reference, 'cgroup.events'), 'utf8')) !== 0)
+      return false;
+    check();
+    const removeChildren = (directory: string): void => {
+      check();
+      const entries = readdirSync(directory, { withFileTypes: true });
+      for (const entry of entries) {
+        check();
+        if (entry.isSymbolicLink()) throw new Error('Owned process containment changed');
+        if (!entry.isDirectory()) continue;
+        const child = path.join(directory, entry.name);
+        const before = lstatSync(child);
+        removeChildren(child);
+        check();
+        const after = lstatSync(child);
+        if (before.dev !== after.dev || before.ino !== after.ino) {
+          throw new Error('Owned process containment changed');
+        }
+        check();
+        rmdirSync(child);
+      }
+    };
+    removeChildren(group.reference);
+    check();
+    rmdirSync(group.directory);
+    closeDescriptors(group.descriptors);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createOwnedProcessScope(): OwnedProcessScope {
+  let group: Cgroup | undefined;
+  let attempted = false;
+  let contained = true;
+  let sealed = false;
+  let removed = false;
+  let used = false;
+  let stopping: Promise<boolean> | undefined;
+  let stopDeadline: Deadline | undefined;
+  let stopped = false;
+  const children = new Set<OwnedChild>();
+  const baseline = new Set<string>();
+  const observations = new Set<Deadline>();
+  const live = (child: OwnedChild): boolean => !child.exited && child.process.pid !== undefined;
+
+  const verify = async (allowBaseline: boolean, deadline: Deadline): Promise<boolean> => {
+    try {
+      deadline.check();
+      if (!used || removed || stopped) return true;
+      if (!group || !contained) return false;
+      await assertDirectory(group, deadline);
+      const populated = population(
+        await readText(path.join(group.reference, 'cgroup.events'), deadline)
+      );
+      await assertDirectory(group, deadline);
+      if (populated === 0) return ![...children].some(live);
+      if (!allowBaseline || baseline.size === 0) return false;
+      const identities = new Set<string>();
+      for (const pid of (await snapshotCgroup(group, deadline)).pids) {
+        const { identity } = processIdentity(pid, await readText(`/proc/${pid}/stat`, deadline));
+        if (!baseline.has(identity)) return false;
+        identities.add(identity);
+      }
+      await assertDirectory(group, deadline);
+      return (
+        identities.size > 0 &&
+        [...children]
+          .filter(live)
+          .every(child => child.identity !== undefined && identities.has(child.identity))
+      );
+    } catch {
+      return false;
+    }
+  };
+
+  const signalChildren = async (signal: NodeJS.Signals, deadline: Deadline): Promise<void> => {
+    for (const child of children) {
+      deadline.check();
+      const pid = child.process.pid;
+      if (!live(child) || pid === undefined) continue;
+      try {
+        if (process.platform === 'linux') {
+          const fresh = processIdentity(pid, await readText(`/proc/${pid}/stat`, deadline));
+          if (!child.identity || fresh.identity !== child.identity || fresh.parent !== process.pid)
+            continue;
+          deadline.check();
+          if (!live(child)) continue;
+          if (fresh.group === pid) {
+            process.kill(-pid, signal);
+            continue;
+          }
+        }
+        deadline.check();
+        if (live(child)) child.process.kill(signal);
+      } catch {
+        console.warn('Owned process child signal failed; cleanup still requires verification');
+      }
+    }
+  };
+
+  const scope: OwnedProcessScope = {
+    spawn(command, args, options) {
+      if (sealed) throw new Error('Owned process admission is closed');
+      if (!attempted) {
+        attempted = true;
+        group = createCgroup();
+      }
+      const gated =
+        group !== undefined && options.shell !== true && typeof options.shell !== 'string';
+      const child = gated
+        ? spawn(
+            '/bin/sh',
+            [
+              '-c',
+              'IFS= read -r start <&3 && [ "$start" = start ] && exec 3<&- && exec "$@"',
+              'kilo-owned',
+              command,
+              ...args,
+            ],
+            { ...options, detached: true, stdio: ['pipe', 'pipe', 'pipe', 'pipe'] }
+          )
+        : spawn(command, args, { ...options, detached: true, stdio: 'pipe' });
+      const record: OwnedChild = { process: child, exited: false };
+      children.add(record);
+      child.once('exit', () => {
+        record.exited = true;
+      });
+      child.once('error', () => {
+        if (child.pid === undefined) record.exited = true;
+      });
+      if (child.pid !== undefined) {
+        used = true;
+        try {
+          const fresh = processIdentity(child.pid, readFileSync(`/proc/${child.pid}/stat`, 'utf8'));
+          if (fresh.parent === process.pid) record.identity = fresh.identity;
+        } catch {
+          console.warn('Owned process child identity unavailable; group signals remain disabled');
+        }
+        if (!gated) contained = false;
+      }
+      if (gated) {
+        const gate = child.stdio[3];
+        try {
+          if (
+            !(gate instanceof Writable) ||
+            !group ||
+            child.pid === undefined ||
+            !record.identity ||
+            !sameDirectory(group, lstatSync(group.directory))
+          ) {
+            throw new Error('Owned child identity unavailable');
+          }
+          const fresh = processIdentity(child.pid, readFileSync(`/proc/${child.pid}/stat`, 'utf8'));
+          if (fresh.identity !== record.identity || fresh.parent !== process.pid) {
+            throw new Error('Owned child changed');
+          }
+          writeSync(group.procs, String(child.pid), 0, 'utf8');
+          if (
+            !sameDirectory(group, lstatSync(group.directory)) ||
+            !parsePids(readFileSync(path.join(group.reference, 'cgroup.procs'), 'utf8')).includes(
+              child.pid
+            )
+          ) {
+            throw new Error('Owned child containment unavailable');
+          }
+          const activated = processIdentity(
+            child.pid,
+            readFileSync(`/proc/${child.pid}/stat`, 'utf8')
+          );
+          if (activated.identity !== record.identity || activated.parent !== process.pid) {
+            throw new Error('Owned child changed');
+          }
+          gate.on('error', () => {
+            contained = false;
+          });
+          gate.end('start\n');
+        } catch {
+          contained = false;
+          sealed = true;
+          if (gate instanceof Writable) {
+            gate.on('error', () => undefined);
+            gate.end();
+          }
+        }
+      }
+      return child;
+    },
+    run: operation => current.run(scope, operation),
+    seal() {
+      sealed = true;
+    },
+    dispose() {
+      sealed = true;
+      if (removed) return true;
+      if (used && (!group || !contained || [...children].some(live))) return false;
+      if (
+        group &&
+        !removeCgroup(group, stopDeadline?.deadlineAt ?? Date.now() + OBSERVATION_TIMEOUT_MS)
+      )
+        return false;
+      removed = true;
+      children.clear();
+      return true;
+    },
+    async captureBaseline(allowed, deadlineAt = Date.now() + OBSERVATION_TIMEOUT_MS) {
+      baseline.clear();
+      const deadline = createDeadline(Math.min(deadlineAt, stopDeadline?.deadlineAt ?? Infinity));
+      observations.add(deadline);
+      try {
+        if (!group || !contained || sealed) return;
+        const entries: (ProcessIdentity & { allowed: boolean })[] = [];
+        for (const pid of (await snapshotCgroup(group, deadline)).pids) {
+          const before = processIdentity(pid, await readText(`/proc/${pid}/stat`, deadline));
+          const argv = (await readText(`/proc/${pid}/cmdline`, deadline))
+            .split('\0')
+            .filter(Boolean);
+          const after = processIdentity(pid, await readText(`/proc/${pid}/stat`, deadline));
+          if (before.identity !== after.identity || before.parent !== after.parent) {
+            throw new Error('Native process identity changed');
+          }
+          entries.push({ ...after, allowed: allowed(argv) });
+        }
+        const roots = [...children].filter(live);
+        const root = roots[0];
+        if (roots.length !== 1 || !root) {
+          throw new Error('Native process ownership is ambiguous');
+        }
+        if (entries.find(entry => entry.pid === root.process.pid)?.identity !== root.identity) {
+          contained = false;
+          throw new Error('Native process containment changed');
+        }
+        let pid = root.process.pid;
+        const captured = new Set<string>();
+        while (pid !== undefined) {
+          const entry = entries.find(entry => entry.pid === pid);
+          if (!entry?.allowed || captured.has(entry.identity)) {
+            throw new Error('Native process identity unavailable');
+          }
+          captured.add(entry.identity);
+          const descendants = entries.filter(
+            candidate => candidate.parent === pid && candidate.allowed
+          );
+          if (descendants.length > 1) throw new Error('Native process ownership is ambiguous');
+          pid = descendants[0]?.pid;
+        }
+        deadline.check();
+        if (!sealed) {
+          for (const identity of captured) baseline.add(identity);
+        }
+      } catch {
+        baseline.clear();
+      } finally {
+        observations.delete(deadline);
+        deadline.close();
+      }
+    },
+    async verify(allowBaseline = false, deadlineAt = Date.now() + OBSERVATION_TIMEOUT_MS) {
+      if (stopped || removed || !used) return true;
+      if (stopping) return false;
+      const deadline = createDeadline(deadlineAt);
+      observations.add(deadline);
+      try {
+        return await verify(allowBaseline, deadline);
+      } catch {
+        return false;
+      } finally {
+        observations.delete(deadline);
+        deadline.close();
+      }
+    },
+    stop(deadlineAt) {
+      sealed = true;
+      for (const observation of observations) observation.shorten(deadlineAt);
+      if (stopping) {
+        if (!stopped) stopDeadline?.shorten(deadlineAt);
+        return stopping;
+      }
+      const deadline = createDeadline(deadlineAt);
+      stopDeadline = deadline;
+      const run = async (): Promise<boolean> => {
+        if (await verify(false, deadline)) return true;
+        await signalChildren('SIGTERM', deadline);
+        if ([...children].some(live)) {
+          const graceMs = Math.min(250, Math.max(0, (deadline.deadlineAt - Date.now()) / 2));
+          await deadline.wait(signal => delay(graceMs, undefined, { signal }));
+        }
+        if (group?.kill !== undefined) {
+          try {
+            await assertDirectory(group, deadline);
+            deadline.check();
+            if (!removed && group.descriptors.includes(group.kill)) {
+              writeSync(group.kill, '1', 0, 'utf8');
+            }
+          } catch {
+            console.warn('Owned process cgroup kill failed; using verified child signals');
+          }
+        }
+        await signalChildren('SIGKILL', deadline);
+        if (!group || !contained) return false;
+        while (true) {
+          if (await verify(false, deadline)) return true;
+          await deadline.wait(signal => delay(25, undefined, { signal }));
+        }
+      };
+      stopping = deadline
+        .wait(async () => {
+          if (!(await run())) return false;
+          deadline.check();
+          if (!group || removed || (await removeCgroupBeforeDeadline(group, deadline))) {
+            removed = true;
+            children.clear();
+          }
+          deadline.check();
+          stopped = true;
+          return true;
+        })
+        .catch(() => false)
+        .finally(() => deadline.close());
+      return stopping;
+    },
+  };
+  return scope;
+}

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.test.ts
@@ -304,7 +304,11 @@ describe('createSandboxControlClient', () => {
         protocolVersion: number;
         wrapperVersion: string;
         providerInstanceId: string;
-        capabilities?: { sessionOperationResults?: boolean; scopedStopAbort?: boolean };
+        capabilities?: {
+          sessionOperationResults?: boolean;
+          scopedStopAbort?: boolean;
+          nativeRuntimeRetirement?: boolean;
+        };
       };
     };
     expect(hello.operation).toBe('sandbox.hello');
@@ -312,7 +316,11 @@ describe('createSandboxControlClient', () => {
       protocolVersion: 1,
       wrapperVersion: '2.4.0',
       providerInstanceId: 'inst_1',
-      capabilities: { sessionOperationResults: true, scopedStopAbort: true },
+      capabilities: {
+        sessionOperationResults: true,
+        scopedStopAbort: true,
+        nativeRuntimeRetirement: true,
+      },
     });
     fake.respond(
       JSON.stringify({

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.ts
@@ -17,6 +17,8 @@ import {
   sandboxHelloResultSchema,
   sandboxHeartbeatPayloadSchema,
   sessionEventPayloadSchema,
+  sessionNativeRuntimeRetirementPayloadSchema,
+  sessionNativeRuntimeRetirementResultSchema,
   sessionOperationDeliverySchema,
   sessionOperationAckSchema,
   type ControlError,
@@ -88,6 +90,11 @@ export type SandboxControlClient = {
     signal: AbortSignal,
     deadlineAt: number
   ): Promise<SessionOperationAck>;
+  reportNativeRuntimeRetirement?(input: {
+    directory: string;
+    nativeRuntimeId: string;
+    reason: string;
+  }): Promise<boolean>;
 };
 
 type ClientState =
@@ -372,7 +379,11 @@ export function createSandboxControlClient(
           payload: {
             protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
             providerInstanceId: options.providerInstanceId,
-            capabilities: { sessionOperationResults: true, scopedStopAbort: true },
+            capabilities: {
+              sessionOperationResults: true,
+              scopedStopAbort: true,
+              nativeRuntimeRetirement: true,
+            },
             ...(wrapperInstanceId ? { wrapperInstanceId } : {}),
             ...(options.wrapperVersion ? { wrapperVersion: options.wrapperVersion } : {}),
           },
@@ -645,6 +656,60 @@ export function createSandboxControlClient(
       } finally {
         signal.removeEventListener('abort', onAbort);
       }
+    },
+
+    async reportNativeRuntimeRetirement(input): Promise<boolean> {
+      if (state.kind !== 'ready' || state.socket.readyState !== 1)
+        throw new ControlDeliveryError('Control transport unavailable', true);
+      const payload = sessionNativeRuntimeRetirementPayloadSchema.parse(input);
+      const { socket } = state;
+      const requestId = crypto.randomUUID();
+      const frame: RequestFrame = {
+        type: 'request',
+        requestId,
+        operation: 'session.runtime.retired',
+        payload,
+      };
+      const serialized = JSON.stringify(frame);
+      if (Buffer.byteLength(serialized) > MAX_SANDBOX_CONTROL_FRAME_BYTES)
+        throw new ControlDeliveryError('Native runtime retirement exceeds the frame budget', false);
+      const pending = new Promise<ResponseFrame>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          pendingRequests.delete(requestId);
+          reject(new ControlDeliveryError('Native runtime retirement timed out', true));
+        }, SANDBOX_CONTROL_REQUEST_TIMEOUT_MS);
+        timeout.unref();
+        pendingRequests.set(requestId, {
+          resolve: frame => {
+            clearTimeout(timeout);
+            resolve(frame);
+          },
+          reject: reason => {
+            clearTimeout(timeout);
+            reject(reason);
+          },
+        });
+      });
+      try {
+        socket.send(serialized);
+      } catch {
+        const waiter = pendingRequests.get(requestId);
+        if (waiter) {
+          pendingRequests.delete(requestId);
+          waiter.reject(
+            new ControlDeliveryError('Native runtime retirement publication failed', true)
+          );
+        }
+      }
+      const response = await pending;
+      if (
+        state.kind !== 'ready' ||
+        state.socket !== socket ||
+        socket.readyState !== 1 ||
+        !response.ok
+      )
+        return false;
+      return sessionNativeRuntimeRetirementResultSchema.safeParse(response.result).success;
     },
 
     sendEvent(

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
@@ -94,7 +94,7 @@ function fakeKilo(overrides: Partial<WrapperKiloClient> = {}): WrapperKiloClient
     answerPermission: async () => true,
     answerQuestion: async () => true,
     rejectQuestion: async () => true,
-    getSessionStatuses: async () => ({}),
+    getSessionStatuses: async () => ({ [session.kiloSessionId]: { type: 'idle' } }),
     getQuestions: async () => [],
     getPermissions: async () => [],
     ...overrides,
@@ -122,6 +122,7 @@ function deps(
   const runtime: WorktreeKiloRuntime | undefined = client
     ? {
         scopeId: kilo.scopeId,
+        runtimeId: 'native_1',
         directory: identity.directory,
         env: buildWorktreeKiloEnvironment(
           identity.directory,
@@ -140,11 +141,23 @@ function deps(
           attach: () => ({
             ready: Promise.resolve(runtime),
             signal: runtime.signal,
+            cleanup: async () => 'retired',
             commit: () => {},
             release: () => {},
           }),
           detach: () => true,
           deleteDirectory: async () => {},
+          getRetained: directory => (directory === runtime.directory ? runtime : undefined),
+          retireRuntime: async (directory, _deadlineAt, target) =>
+            directory === runtime.directory &&
+            target?.runtimeId === runtime.runtimeId &&
+            target?.client === runtime.kiloClient
+              ? 'unconfirmed'
+              : 'stale',
+          verifyQuiescence: async (directory, target) =>
+            directory === runtime.directory &&
+            target.runtimeId === runtime.runtimeId &&
+            target.client === runtime.kiloClient,
           get: directory => (directory === runtime.directory ? runtime : undefined),
           isHealthy: () => true,
           shutdown: () => {},
@@ -719,7 +732,11 @@ describe('handleControlRequest', () => {
         },
         getSessionStatuses: async () => {
           record('status', undefined);
-          return {};
+          return {
+            [session.kiloSessionId]: { type: 'idle' },
+            [sibling.kiloSessionId]: { type: 'idle' },
+            [other.kiloSessionId]: { type: 'idle' },
+          };
         },
         getPermissions: async () => {
           record('permissions', undefined);
@@ -744,6 +761,7 @@ describe('handleControlRequest', () => {
       runtimes.set(directory, {
         directory,
         scopeId: directory,
+        runtimeId: crypto.randomUUID(),
         env: buildWorktreeKiloEnvironment(
           directory,
           fs.mkdtempSync(path.join(homeRoot, 'worktree-')),
@@ -762,6 +780,24 @@ describe('handleControlRequest', () => {
         },
         detach: () => true,
         deleteDirectory: async () => {},
+        getRetained: directory => runtimes.get(directory),
+        retireRuntime: async (directory, _deadlineAt, target) => {
+          const runtime = runtimes.get(directory);
+          return runtime &&
+            target?.runtimeId === runtime.runtimeId &&
+            target?.client === runtime.kiloClient
+            ? 'unconfirmed'
+            : 'stale';
+        },
+        verifyQuiescence: async (directory, target) => {
+          const runtime = runtimes.get(directory);
+          return (
+            runtime !== undefined &&
+            target !== undefined &&
+            target.runtimeId === runtime.runtimeId &&
+            target.client === runtime.kiloClient
+          );
+        },
         get: directory => runtimes.get(directory),
         isHealthy: () => true,
         shutdown: () => {},
@@ -948,7 +984,7 @@ describe('handleControlRequest', () => {
           ok: true,
           result: { status: 'aborted' },
         });
-        expect(calls.at(-1)).toEqual({
+        expect(calls.at(-2)).toEqual({
           directory: identity.directory,
           operation: 'abort',
           value: {
@@ -956,6 +992,10 @@ describe('handleControlRequest', () => {
             directory: identity.directory,
             signal: expect.any(AbortSignal),
           },
+        });
+        expect(calls.at(-1)).toMatchObject({
+          directory: identity.directory,
+          operation: 'status',
         });
         expect(handlerDeps.operations.hasActive(identity.kiloSessionId)).toBe(false);
       } finally {
@@ -1920,6 +1960,7 @@ describe('production worktree deletion routes', () => {
     const detached: string[] = [];
     const forbidden: string[] = [];
     const siblingRuntime: WorktreeKiloRuntime = {
+      runtimeId: 'native_sibling',
       directory: siblingDirectory,
       scopeId: path.basename(siblingDirectory),
       env: {},
@@ -2346,9 +2387,9 @@ describe('owned control execution', () => {
         },
         handlerDeps
       );
-      expect(aborted).toEqual({ ok: true, result: { status: 'unconfirmed', quiescent: false } });
+      expect(aborted).toEqual({ ok: true, result: { status: 'aborted', quiescent: true } });
 
-      expect(retired).toEqual(['Native cancellation did not settle']);
+      expect(retired).toEqual([]);
     } finally {
       running.resolve(completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } }));
       await waitForTasks(handlerDeps);
@@ -2387,6 +2428,21 @@ describe('owned control execution', () => {
     expect(await attaching).toMatchObject({ ok: false });
   });
 
+  it('treats abort of a missing native runtime as already retired', async () => {
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    expect(
+      await handleControlRequest('session.abort', session, { nativeRuntimeId }, deps())
+    ).toEqual({
+      ok: true,
+      result: {
+        status: 'aborted',
+        quiescent: true,
+        runtimeRetired: true,
+        nativeRuntimeId,
+      },
+    });
+  });
+
   it.each(['false', 'malformed', 'HTTP failure'] as const)(
     'retires and rejects replacement work after an abort returns %s',
     async response => {
@@ -2413,7 +2469,7 @@ describe('owned control execution', () => {
         expect(
           await handleControlRequest('session.abort', session, { messageId: 'msg_1' }, handlerDeps)
         ).toMatchObject({ ok: false, error: { code: 'not_ready' } });
-        expect(retired).toEqual(['Kilo cancellation failed']);
+        expect(retired).toEqual(['Kilo cancellation was not confirmed']);
         expect(handlerDeps.signal?.aborted).toBe(true);
         expect(buildHeartbeatPayload(handlerDeps).kilo.ready).toBe(false);
         expect(handlerDeps.operations.counts().active).toBe(0);
@@ -2470,7 +2526,7 @@ describe('owned control execution', () => {
       expect(
         await handleControlRequest('session.abort', session, { messageId: 'msg_1' }, handlerDeps)
       ).toMatchObject({ ok: false, error: { code: 'not_ready' } });
-      expect(retired).toEqual(['Kilo cancellation failed']);
+      expect(retired).toEqual(['Kilo cancellation was not confirmed']);
       expect(handlerDeps.signal?.aborted).toBe(true);
       expect(handlerDeps.operations.counts().active).toBe(0);
       expect(
@@ -2538,7 +2594,7 @@ describe('owned control execution', () => {
       for (const deadline of deadlines) deadline();
       expect(await aborting).toMatchObject({ ok: false, error: { code: 'not_ready' } });
       expect(abortSignal.aborted).toBe(true);
-      expect(retired).toEqual(['Kilo cancellation failed']);
+      expect(retired).toEqual(['Kilo cancellation was not confirmed']);
       expect(handlerDeps.signal?.aborted).toBe(true);
       remoteStopped.resolve(true);
       running.resolve(completion());
@@ -2605,13 +2661,13 @@ describe('owned control execution', () => {
       if (typeof deadline !== 'function') throw new Error('Missing owned execution deadline');
       deadline();
       await waitForTasks(handlerDeps);
-      expect(retired).toEqual(['Execution exceeded the 60 minute limit']);
+      expect(retired).toEqual([]);
       expect(events[0]?.properties).toEqual({
         messageId: 'msg_1',
         status: 'cancelled',
         reason: 'Kilo execution ended with MessageAbortedError',
       });
-      expect(buildHeartbeatPayload(handlerDeps).kilo.ready).toBe(false);
+      expect(buildHeartbeatPayload(handlerDeps).kilo.ready).toBe(true);
       expect(
         await handleControlRequest(
           'session.prompt',
@@ -2619,7 +2675,7 @@ describe('owned control execution', () => {
           { ...promptPayload, messageId: 'next' },
           handlerDeps
         )
-      ).toMatchObject({ ok: false });
+      ).toMatchObject({ ok: true, result: { messageId: 'next', status: 'accepted' } });
     } finally {
       running.resolve(completion());
       timers.mockRestore();
@@ -2915,7 +2971,7 @@ describe('control finalization and compact', () => {
       expect(handlerDeps.operations.counts().active).toBe(1);
       stopped.resolve({ success: false });
       await waitForTasks(handlerDeps);
-      expect(retired).toEqual(['Execution exceeded the 60 minute limit']);
+      expect(retired).toEqual([]);
       expect(events.at(-1)?.properties).toEqual({
         messageId: 'msg_1',
         status: 'failed',
@@ -3339,12 +3395,13 @@ describe('control cancellation and attachments', () => {
       expect(await attaching).toMatchObject({ ok: false });
       expect(markerWritten).toBe(false);
       expect(handlerDeps.operations.counts().active).toBe(0);
-      expect(retired).toEqual(['Session preparation timed out']);
-      expect(buildHeartbeatPayload(handlerDeps).kilo.ready).toBe(false);
+      expect(retired).toEqual([]);
+      expect(buildHeartbeatPayload(handlerDeps).kilo.ready).toBe(true);
       expect(
         await handleControlRequest('session.attach', session, { kilo }, handlerDeps)
       ).toMatchObject({
-        ok: false,
+        ok: true,
+        result: { attached: true },
       });
     } finally {
       stopped.resolve({ exitCode: 0, stdout: '', stderr: '' });
@@ -4231,9 +4288,11 @@ describe('control wrapper heartbeat source policy', () => {
     expect(source).toContain(
       "diagnosticReason: NonNullable<SandboxHeartbeatPayload['kilo']['reason']> = 'shutdown'"
     );
+    expect(source).toMatch(/void control \.reportNativeRuntimeRetirement\(\{/);
     expect(source).toContain(
-      'onUnexpectedClose: failure => shutdown( 1, `Kilo worktree failed reason=${failure.reason} directory=${failure.directory}`, failure.reason )'
+      "if (failure.cleanup === 'unconfirmed' || !control?.reportNativeRuntimeRetirement) { shutdown(1, failure.reason); return; }"
     );
+    expect(source).toContain('nativeRuntimeId: failure.runtimeId,');
     expect(source).toContain(
       "onDisconnected: () => shutdown(1, 'Sandbox control connection lost', 'control_disconnected')"
     );

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
@@ -6,6 +6,7 @@ import {
   type ControlDiagnosticReporter,
 } from '../../../src/shared/control-diagnostics.js';
 import {
+  SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS,
   SESSION_OPERATIONS,
   sandboxShutdownPayloadSchema,
   sessionAbortPayloadSchema,
@@ -324,7 +325,16 @@ export async function refreshHeartbeatPayload(
 export function createControlHandlerDeps(input: Omit<HandlerDeps, 'operations'>): HandlerDeps {
   const deps: HandlerDeps = Object.assign(input, {
     operations: createOperationRegistry({
-      native: { get: directory => input.kiloRuntimes?.get(directory) },
+      native: {
+        get: directory => input.kiloRuntimes?.get(directory),
+        getRetained: directory => input.kiloRuntimes?.getRetained?.(directory),
+        retireRuntime: (directory, deadlineAt, target) =>
+          input.kiloRuntimes?.retireRuntime?.(directory, deadlineAt, target) ??
+          Promise.resolve('unconfirmed'),
+        verifyQuiescence: (directory, target, deadlineAt) =>
+          input.kiloRuntimes?.verifyQuiescence?.(directory, target, deadlineAt) ??
+          Promise.resolve(false),
+      },
       onStarted: (session, preparation) => {
         if (!preparation) deps.activity?.markActive(session.kiloSessionId);
         const snapshot = deps.sessions.find(item => item.kiloSessionId === session.kiloSessionId);
@@ -887,6 +897,32 @@ async function handleAbort(
 ): Promise<ControlHandlerResult> {
   const parsed = sessionAbortPayloadSchema.safeParse(payload ?? {});
   if (!parsed.success) return fail('protocol_error', 'Invalid payload', false);
+  if (parsed.data.nativeRuntimeId) {
+    const runtime = deps.kiloRuntimes?.getRetained?.(session.directory);
+    if (!runtime || runtime.runtimeId !== parsed.data.nativeRuntimeId) {
+      return ok({
+        status: 'aborted',
+        quiescent: true,
+        runtimeRetired: true,
+        nativeRuntimeId: parsed.data.nativeRuntimeId,
+      });
+    }
+    const deadlineAt =
+      parsed.data.cleanupDeadlineAt ?? Date.now() + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS;
+    const retirement = await deps.operations.retireDirectory(
+      session.directory,
+      'Native runtime retirement requested',
+      deadlineAt,
+      { runtimeId: parsed.data.nativeRuntimeId, client: runtime.kiloClient }
+    );
+    return ok({
+      status: retirement === 'unconfirmed' ? 'unconfirmed' : 'aborted',
+      quiescent: retirement !== 'unconfirmed',
+      ...(retirement === 'retired'
+        ? { runtimeRetired: true, nativeRuntimeId: parsed.data.nativeRuntimeId }
+        : {}),
+    });
+  }
   const task = deps.operations.abortTarget(session, parsed.data.messageId);
   if (task) {
     if (
@@ -899,13 +935,44 @@ async function handleAbort(
           : { status: 'already_idle' }
       );
     }
-    task.cancel('Session aborted', 'cancelled', parsed.data.cleanupDeadlineAt);
+    if (!parsed.data.operationId) {
+      task.cancel('Session aborted', 'cancelled', parsed.data.cleanupDeadlineAt);
+      const result = await task.done;
+      if (task.cleanup === 'unconfirmed')
+        return fail('not_ready', 'Kilo cancellation was not confirmed', false);
+      if (!result.ok && task.kind !== 'preparation') return result;
+      return ok({ status: 'aborted' });
+    }
+    const deadlineAt = task.captureCleanupDeadline(
+      parsed.data.cleanupDeadlineAt ?? Date.now() + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS
+    );
+    let quiescent = await task.cleanupOwnedWork(deadlineAt);
+    let runtimeRetired = false;
+    let nativeRuntimeId: string | undefined;
+    const target = task.nativeTarget();
+    if (!quiescent && target && Date.now() < deadlineAt) {
+      const retirementReason = 'Native cancellation did not settle';
+      const retirement = await deps.operations.retireDirectory(
+        session.directory,
+        retirementReason,
+        deadlineAt,
+        target
+      );
+      runtimeRetired = retirement === 'retired';
+      if (runtimeRetired) nativeRuntimeId = target.runtimeId;
+      quiescent = task.confirmCleanup(retirement !== 'unconfirmed', deadlineAt);
+      if (retirement === 'unconfirmed') deps.retireRuntime(retirementReason);
+    } else if (!quiescent) {
+      task.requestRetirement('Kilo cancellation failed', deadlineAt);
+    }
     const result = await task.done;
     if (parsed.data.operationId) {
       const delivery = task.deliveryResult();
       return ok({
-        status: 'unconfirmed',
-        quiescent: false,
+        status: quiescent ? 'aborted' : 'unconfirmed',
+        quiescent,
+        ...(runtimeRetired ? { runtimeRetired: true } : {}),
+        ...(nativeRuntimeId ? { nativeRuntimeId } : {}),
         ...(delivery ? { delivery } : {}),
       });
     }

--- a/services/cloud-agent-next/wrapper/src/control/session-operation-cleanup.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-operation-cleanup.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { SANDBOX_CONTROL_EXECUTION_TIMEOUT_MS } from '../../../src/shared/sandbox-control-protocol.js';
 import { handleControlRequest, type HandlerDeps } from './sandbox-control-handlers';
 import { KILO_CONTROL_REQUEST_TIMEOUT_MS } from './sandbox-control-runtime';
 import {
@@ -15,6 +16,8 @@ import {
 } from './control-test-fixtures';
 import { rememberAttachedRoot, resetSessionDirectoryState } from './session-directories';
 import { resetDirectoryOperationState } from './worktree-operations';
+import type { WorktreeKiloRuntime, WorktreeKiloRuntimes } from './worktree-runtime';
+import { SessionOperation } from './session-operation';
 
 let homeRoot: string;
 
@@ -35,6 +38,353 @@ function deps(overrides: Parameters<typeof createHandlerFixture>[1] = {}): Handl
 }
 
 describe('SessionOperation cleanup', () => {
+  it('expires by attempting targeted cleanup before runtime retirement', async () => {
+    jest.useFakeTimers();
+    const pending = Promise.withResolvers<ReturnType<typeof completion>>();
+    const order: string[] = [];
+    const client = fakeKilo({
+      sendPrompt: () => pending.promise,
+      abortSession: async () => {
+        order.push('abort');
+        return true;
+      },
+      getSessionStatuses: async () => ({ [session.kiloSessionId]: { type: 'idle' } }),
+    });
+    const runtime: WorktreeKiloRuntime = {
+      scopeId: 'worktree_1',
+      runtimeId: 'native_1',
+      directory: session.directory,
+      env: {},
+      kiloClient: client,
+      signal: new AbortController().signal,
+    };
+    const operation = new SessionOperation(
+      session,
+      undefined,
+      { operation: 'session.prompt', payload: promptPayload, runtime },
+      {
+        isCurrent: () => true,
+        getRuntime: () => runtime,
+        verifyQuiescence: async () => false,
+        retireRuntime: () => order.push('retire'),
+        emitSessionEvent: () => {},
+        onLocalCompletion: () => {},
+        onCleanupConfirmed: () => {},
+      }
+    );
+
+    await Promise.resolve();
+    jest.advanceTimersByTime(SANDBOX_CONTROL_EXECUTION_TIMEOUT_MS);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(order).toEqual(['abort', 'retire']);
+    pending.resolve(completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } }));
+    await operation.done;
+  });
+
+  it('does not accept an idle root while a scoped native child is active', async () => {
+    const pending = Promise.withResolvers<ReturnType<typeof completion>>();
+    let verified = 0;
+    const client = fakeKilo({
+      sendPrompt: () => pending.promise,
+      abortSession: async () => true,
+      getSessionStatuses: async () => ({
+        [session.kiloSessionId]: { type: 'idle' },
+        child: { type: 'busy' },
+      }),
+    });
+    const runtime: WorktreeKiloRuntime = {
+      scopeId: 'worktree_1',
+      runtimeId: 'native_1',
+      directory: session.directory,
+      env: {},
+      kiloClient: client,
+      signal: new AbortController().signal,
+    };
+    const operation = new SessionOperation(
+      session,
+      undefined,
+      { operation: 'session.prompt', payload: promptPayload, runtime },
+      {
+        isCurrent: () => true,
+        getRuntime: () => runtime,
+        verifyQuiescence: async () => {
+          verified += 1;
+          return true;
+        },
+        retireRuntime: () => {},
+        emitSessionEvent: () => {},
+        onLocalCompletion: () => {},
+        onCleanupConfirmed: () => {},
+      }
+    );
+
+    await Promise.resolve();
+    expect(await operation.cleanupOwnedWork(Date.now() + 1_000)).toBe(false);
+    expect(verified).toBe(0);
+    pending.resolve(completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } }));
+    await operation.done;
+  });
+
+  it('does not treat an abort acknowledgement or missing status as quiescence', async () => {
+    let aborts = 0;
+    const client = fakeKilo({
+      sendPrompt: async () => completion(),
+      abortSession: async () => {
+        aborts += 1;
+        return true;
+      },
+      getSessionStatuses: async () => ({}),
+    });
+    const runtime: WorktreeKiloRuntime = {
+      scopeId: 'worktree_1',
+      runtimeId: 'native_1',
+      directory: session.directory,
+      env: {},
+      kiloClient: client,
+      signal: new AbortController().signal,
+    };
+    const runtimes: WorktreeKiloRuntimes = {
+      attach: () => ({
+        ready: Promise.resolve(runtime),
+        signal: runtime.signal,
+        cleanup: async () => 'unconfirmed',
+        commit: () => {},
+        release: () => {},
+      }),
+      detach: () => true,
+      deleteDirectory: async () => {},
+      getRetained: () => runtime,
+      retireRuntime: async () => 'unconfirmed',
+      verifyQuiescence: async () => false,
+      get: () => runtime,
+      isHealthy: () => true,
+      shutdown: () => {},
+    };
+    const handlerDeps = deps({ kiloClient: client, kiloRuntimes: runtimes });
+    const authorization = operationAuthorization();
+    await handleControlRequest(
+      'session.prompt',
+      session,
+      promptPayload,
+      handlerDeps,
+      authorization
+    );
+    const stopped = await handleControlRequest(
+      'session.abort',
+      session,
+      {
+        messageId: authorization.messageId,
+        operationId: '11111111-1111-4111-8111-111111111111',
+        cleanupDeadlineAt: Date.now() + 1_000,
+      },
+      handlerDeps
+    );
+    expect(aborts).toBe(1);
+    expect(stopped).toMatchObject({
+      ok: true,
+      result: { status: 'unconfirmed', quiescent: false },
+    });
+  });
+
+  it('does not abort an active successor after a finished retained operation', async () => {
+    let successorActive = false;
+    const abort = jest.fn(async () => {
+      if (successorActive) throw new Error('successor aborted');
+      return true;
+    });
+    const client = fakeKilo({
+      abortSession: abort,
+      getSessionStatuses: async () =>
+        successorActive ? { [session.kiloSessionId]: { type: 'busy' } } : {},
+    });
+    const runtime: WorktreeKiloRuntime = {
+      scopeId: 'worktree_1',
+      runtimeId: 'native_1',
+      directory: session.directory,
+      env: {},
+      kiloClient: client,
+      signal: new AbortController().signal,
+    };
+    const operation = new SessionOperation(
+      session,
+      undefined,
+      { operation: 'session.prompt', payload: promptPayload, runtime },
+      {
+        isCurrent: () => true,
+        getRuntime: () => runtime,
+        verifyQuiescence: async () => false,
+        retireRuntime: () => {},
+        emitSessionEvent: () => {},
+        onLocalCompletion: () => {},
+        onCleanupConfirmed: () => {},
+      }
+    );
+
+    await operation.done;
+    successorActive = true;
+
+    expect(await operation.cleanupOwnedWork(Date.now() + 1_000)).toBe(true);
+    expect(abort).not.toHaveBeenCalled();
+  });
+
+  it('keeps an operation-only scoped Stop replay from retiring a successor native runtime', async () => {
+    const successor = Promise.withResolvers<ReturnType<typeof completion>>();
+    const successorStarted = Promise.withResolvers<void>();
+    const handlerDeps = deps({
+      kiloClient: fakeKilo({
+        sendPrompt: options => {
+          if (options.messageId === 'message_b') {
+            successorStarted.resolve();
+            return successor.promise;
+          }
+          return Promise.resolve(completion());
+        },
+        getSessionStatuses: async () => ({}),
+      }),
+    });
+    const authorizationA = operationAuthorization('session.prompt', 'message_a');
+    await handleControlRequest(
+      'session.prompt',
+      session,
+      { ...promptPayload, messageId: 'message_a' },
+      handlerDeps,
+      authorizationA
+    );
+    const operationA = handlerDeps.operations.retained()[0];
+    if (!operationA) throw new Error('Missing first operation');
+    await operationA.done;
+    const stopA = {
+      messageId: 'message_a',
+      operationId: '11111111-1111-4111-8111-111111111111',
+      cleanupDeadlineAt: Date.now() + 1_000,
+    };
+
+    expect(await handleControlRequest('session.abort', session, stopA, handlerDeps)).toMatchObject({
+      ok: true,
+      result: { status: 'aborted', quiescent: true },
+    });
+    expect(handlerDeps.kiloRuntimes?.get(session.directory)).toBeDefined();
+
+    const authorizationB = operationAuthorization('session.prompt', 'message_b');
+    await handleControlRequest(
+      'session.prompt',
+      session,
+      { ...promptPayload, messageId: 'message_b' },
+      handlerDeps,
+      authorizationB
+    );
+    await successorStarted.promise;
+    const operationB = handlerDeps.operations.active(session.kiloSessionId);
+
+    expect(await handleControlRequest('session.abort', session, stopA, handlerDeps)).toMatchObject({
+      ok: true,
+      result: { status: 'aborted', quiescent: true },
+    });
+    expect(handlerDeps.operations.active(session.kiloSessionId)).toBe(operationB);
+    expect(operationB?.signal.aborted).toBe(false);
+
+    const stopB = handleControlRequest(
+      'session.abort',
+      session,
+      {
+        messageId: 'message_b',
+        operationId: '22222222-2222-4222-8222-222222222222',
+        cleanupDeadlineAt: Date.now() + 1_000,
+      },
+      handlerDeps
+    );
+    successor.resolve(completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } }));
+
+    expect(await stopB).toMatchObject({
+      ok: true,
+      result: {
+        status: 'aborted',
+        quiescent: true,
+        runtimeRetired: true,
+        nativeRuntimeId: 'native_1',
+      },
+    });
+    expect(handlerDeps.kiloRuntimes?.get(session.directory)).toBeUndefined();
+  });
+
+  it('keeps a failed local attachment unconfirmed when its captured cleanup cannot prove retirement', async () => {
+    let cleanupCalls = 0;
+    const operation = new SessionOperation(
+      session,
+      undefined,
+      {
+        operation: 'session.attach',
+        payload: {} as never,
+        apply: async (_session, _payload, hooks) => {
+          hooks.onMutation?.();
+          hooks.onCleanupTarget?.(async () => {
+            cleanupCalls += 1;
+            return 'unconfirmed';
+          });
+          return {
+            ok: false,
+            error: { code: 'not_ready', message: 'attachment failed', retryable: true },
+          };
+        },
+        onAttached: () => {},
+      },
+      {
+        isCurrent: () => true,
+        getRuntime: () => undefined,
+        verifyQuiescence: async () => false,
+        retireRuntime: () => {},
+        emitSessionEvent: () => {},
+        onLocalCompletion: () => {},
+        onCleanupConfirmed: () => {},
+      }
+    );
+
+    await operation.done;
+
+    expect(await operation.cleanupOwnedWork(Date.now() + 1_000)).toBe(false);
+    expect(cleanupCalls).toBe(1);
+  });
+
+  it('uses captured pre-client retirement proof after a failed local attachment', async () => {
+    let cleanupCalls = 0;
+    const operation = new SessionOperation(
+      session,
+      undefined,
+      {
+        operation: 'session.attach',
+        payload: {} as never,
+        apply: async (_session, _payload, hooks) => {
+          hooks.onMutation?.();
+          hooks.onCleanupTarget?.(async () => {
+            cleanupCalls += 1;
+            return 'retired';
+          });
+          return {
+            ok: false,
+            error: { code: 'not_ready', message: 'attachment failed', retryable: true },
+          };
+        },
+        onAttached: () => {},
+      },
+      {
+        isCurrent: () => true,
+        getRuntime: () => undefined,
+        verifyQuiescence: async () => false,
+        retireRuntime: () => {},
+        emitSessionEvent: () => {},
+        onLocalCompletion: () => {},
+        onCleanupConfirmed: () => {},
+      }
+    );
+
+    await operation.done;
+
+    expect(await operation.cleanupOwnedWork(Date.now() + 1_000)).toBe(true);
+    expect(cleanupCalls).toBe(1);
+  });
+
   it('keeps an unconfirmed native receipt after its original cleanup allowance expires', async () => {
     jest.useFakeTimers();
     const started = Promise.withResolvers<void>();

--- a/services/cloud-agent-next/wrapper/src/control/session-operation-cleanup.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-operation-cleanup.ts
@@ -1,0 +1,138 @@
+import {
+  SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS,
+  type SessionRequestIdentity,
+} from '../../../src/shared/sandbox-control-protocol.js';
+import type { WrapperKiloClient } from '../kilo-api.js';
+import { withTimeoutAndAbort } from '../utils.js';
+import { withKiloRequestDeadline } from './sandbox-control-runtime.js';
+import type { OwnedProcessScope } from './owned-processes.js';
+
+export type NativeOperationTarget = Readonly<{
+  runtimeId: string;
+  client?: WrapperKiloClient;
+}>;
+
+export type NativeRetirement = 'retired' | 'stale' | 'unconfirmed';
+export type NativeCleanupEvidence = 'not_issued' | 'finished' | 'unconfirmed';
+
+type CleanupState = 'not_requested' | 'acknowledged' | 'confirmed' | 'unconfirmed';
+
+export class SessionOperationCleanup {
+  private deadlineAt?: number;
+  private state: CleanupState = 'not_requested';
+  private pending?: Promise<boolean>;
+  private processStop?: Promise<boolean>;
+  private nativeAbort?: Promise<boolean>;
+
+  constructor(
+    private readonly session: SessionRequestIdentity,
+    private readonly processes: OwnedProcessScope,
+    private readonly verifyQuiescence: (
+      target: NativeOperationTarget,
+      deadlineAt: number
+    ) => Promise<boolean>,
+    private readonly onConfirmed: () => void
+  ) {}
+
+  get cleanupDeadline(): number | undefined {
+    return this.deadlineAt;
+  }
+
+  get cleanupState(): CleanupState {
+    return this.state;
+  }
+
+  captureDeadline(deadlineAt = Date.now() + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS): number {
+    this.deadlineAt = Math.min(
+      this.deadlineAt ?? Infinity,
+      deadlineAt,
+      Date.now() + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS
+    );
+    return this.deadlineAt;
+  }
+
+  stopProcesses(deadlineAt: number): Promise<boolean> {
+    const captured = this.captureDeadline(deadlineAt);
+    this.processStop = this.processes.stop(captured);
+    return this.processStop;
+  }
+
+  async cleanup(input: {
+    deadlineAt: number;
+    target?: NativeOperationTarget;
+    preClientCleanup?: (deadlineAt: number) => Promise<NativeRetirement>;
+    completionEvidence: NativeCleanupEvidence;
+    cancel: () => void;
+  }): Promise<boolean> {
+    if (this.state === 'confirmed') return true;
+    const deadlineAt = this.captureDeadline(input.deadlineAt);
+    if (this.pending) return this.pending;
+    const processes = this.stopProcesses(deadlineAt);
+    if (input.completionEvidence === 'unconfirmed') input.cancel();
+    this.pending = (async () => {
+      if (!(await processes)) return false;
+      const target = input.target;
+      if (!target) {
+        const retired = await input.preClientCleanup?.(deadlineAt);
+        if (retired !== undefined) return retired === 'retired' || retired === 'stale';
+        return input.completionEvidence !== 'unconfirmed';
+      }
+      if (input.completionEvidence !== 'unconfirmed') return true;
+      const client = target.client;
+      if (!client) {
+        const retired = await input.preClientCleanup?.(deadlineAt);
+        return retired === 'retired' || retired === 'stale';
+      }
+      if (!(await this.abortNative(target, deadlineAt))) return false;
+      const statuses = await withTimeoutAndAbort(
+        withKiloRequestDeadline(signal =>
+          client.getSessionStatuses(this.session.directory, signal)
+        ),
+        {
+          timeoutMs: Math.max(1, deadlineAt - Date.now()),
+          timeoutMessage: 'Kilo cleanup status probe timed out',
+          abortMessage: 'Kilo cleanup status probe cancelled',
+        }
+      );
+      const observed = Object.values(statuses);
+      if (observed.length === 0 || !observed.every(value => value.type === 'idle')) return false;
+      return this.verifyQuiescence(target, deadlineAt);
+    })()
+      .catch(() => false)
+      .then(confirmed => this.confirm(confirmed, deadlineAt));
+    return this.pending;
+  }
+
+  confirm(confirmed: boolean, deadlineAt: number): boolean {
+    if (this.state === 'confirmed') return true;
+    const quiescent =
+      confirmed && Date.now() < Math.min(deadlineAt, this.deadlineAt ?? Number.POSITIVE_INFINITY);
+    this.state = quiescent ? 'confirmed' : 'unconfirmed';
+    if (quiescent) this.onConfirmed();
+    return quiescent;
+  }
+
+  private abortNative(target: NativeOperationTarget, deadlineAt: number): Promise<boolean> {
+    if (this.nativeAbort) return this.nativeAbort;
+    const client = target.client;
+    if (!client) return Promise.resolve(false);
+    this.nativeAbort = withTimeoutAndAbort(
+      withKiloRequestDeadline(async signal => {
+        const accepted = await client.abortSession({
+          sessionId: this.session.kiloSessionId,
+          directory: this.session.directory,
+          signal,
+        });
+        if (accepted !== true) return false;
+        if (this.state !== 'confirmed') this.state = 'acknowledged';
+        return true;
+      }),
+      {
+        timeoutMs: Math.max(1, deadlineAt - Date.now()),
+        timeoutMessage: 'Kilo cancellation timed out',
+        abortMessage: 'Kilo cancellation cancelled',
+      }
+    ).catch(() => false);
+    return this.nativeAbort;
+  }
+}

--- a/services/cloud-agent-next/wrapper/src/control/session-operation.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-operation.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../src/shared/control-diagnostics.js';
 import {
   SANDBOX_CONTROL_ATTACH_TIMEOUT_MS,
+  SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS,
   SANDBOX_CONTROL_EXECUTION_TIMEOUT_MS,
   SANDBOX_CONTROL_OUTCOME_TIMEOUT_MS,
   sessionOperationExpiresAt,
@@ -26,9 +27,15 @@ import { isKiloServerUnreachableError, type WrapperKiloClient } from '../kilo-ap
 import { materializeMessageAttachments } from '../session-bootstrap.js';
 import { runAutoCommit, type AutoCommitResult } from '../auto-commit.js';
 import { withTimeoutAndAbort } from '../utils.js';
-import type { AttachPreparingEmitter } from './apply-attach.js';
-import { KILO_CONTROL_REQUEST_TIMEOUT_MS } from './sandbox-control-runtime.js';
+import type { ApplyAttachDeps, AttachPreparingEmitter } from './apply-attach.js';
+import { createOwnedProcessScope, type OwnedProcessScope } from './owned-processes.js';
 import type { WorktreeKiloRuntime } from './worktree-runtime.js';
+import {
+  SessionOperationCleanup,
+  type NativeCleanupEvidence,
+  type NativeOperationTarget,
+  type NativeRetirement,
+} from './session-operation-cleanup.js';
 import { operationIntent } from './operation-intent.js';
 import {
   createOperationResultDelivery,
@@ -69,7 +76,16 @@ export type SessionOperationWork =
       apply: (
         session: SessionRequestIdentity,
         payload: SessionAttachPayload,
-        hooks: { signal: AbortSignal; emitPreparing?: AttachPreparingEmitter }
+        hooks: Pick<
+          ApplyAttachDeps,
+          | 'signal'
+          | 'assertCurrent'
+          | 'onMutation'
+          | 'onRuntime'
+          | 'onError'
+          | 'onCleanupTarget'
+          | 'emitPreparing'
+        >
       ) => Promise<ControlHandlerResult>;
       onAttached: () => void;
       emitPreparing?: AttachPreparingEmitter;
@@ -86,11 +102,14 @@ export type SessionOperationDependencies = {
   signal?: AbortSignal;
   isCurrent: () => boolean;
   getRuntime: () => WorktreeKiloRuntime | undefined;
-  retireRuntime: (reason: string) => void;
+  verifyQuiescence: (target: NativeOperationTarget, deadlineAt: number) => Promise<boolean>;
+  retireRuntime: (reason: string, deadlineAt: number, target?: NativeOperationTarget) => void;
   emitSessionEvent: (payload: SessionEventPayload, options?: { retained?: true }) => void;
   sendOperationResult?: OperationResultSender;
   onLocalCompletion: (retain: boolean) => void;
+  onCleanupConfirmed: () => void;
   onDiagnostic?: ControlDiagnosticReporter;
+  processes?: OwnedProcessScope;
 };
 
 class ControlTaskCancellation extends Error {
@@ -117,13 +136,15 @@ export class SessionOperation {
   readonly executionDeadlineAt: number;
   readonly signal: AbortSignal;
   readonly done: Promise<ControlHandlerResult>;
+  readonly processes: OwnedProcessScope;
   private readonly controller = new AbortController();
   private readonly completion = Promise.withResolvers<ControlHandlerResult>();
   private readonly intent: ReturnType<typeof operationIntent>;
   private readonly startedAt = Date.now();
   private readonly timeout: ReturnType<typeof setTimeout>;
   private phase: 'preparation' | 'execution' | 'finalizing';
-  private client?: WrapperKiloClient;
+  private target?: NativeOperationTarget;
+  private preClientCleanup?: (deadlineAt: number) => Promise<NativeRetirement>;
   private native: NativeResult = { state: 'not_started' };
   private nativePending?: Promise<unknown>;
   private finalization: Finalization = {};
@@ -131,7 +152,8 @@ export class SessionOperation {
   private outcome?: SessionMessageOutcome;
   private local?: { result: ControlHandlerResult; completedAt: number };
   private delivery?: OperationResultDelivery;
-  private cleanupDeadlineAt?: number;
+  private readonly cleanupOwner: SessionOperationCleanup;
+  private deadlineCleanup?: Promise<boolean>;
 
   constructor(
     session: SessionRequestIdentity,
@@ -165,6 +187,13 @@ export class SessionOperation {
     if (work.operation === 'session.prompt') signals.push(work.runtime.signal);
     this.signal = AbortSignal.any(signals);
     this.done = this.completion.promise;
+    this.processes = deps.processes ?? createOwnedProcessScope();
+    this.cleanupOwner = new SessionOperationCleanup(
+      this.session,
+      this.processes,
+      deps.verifyQuiescence,
+      () => deps.onCleanupConfirmed()
+    );
     this.diagnostic('started');
     this.timeout = setTimeout(
       () => this.expire(),
@@ -173,7 +202,11 @@ export class SessionOperation {
     this.timeout.unref();
     void Promise.resolve()
       .then(() =>
-        this.work.operation === 'session.attach' ? this.attach(this.work) : this.execute(this.work)
+        this.processes.run(() =>
+          this.work.operation === 'session.attach'
+            ? this.attach(this.work)
+            : this.execute(this.work)
+        )
       )
       .catch((error: unknown) => {
         this.recordUncertainty(error);
@@ -191,6 +224,38 @@ export class SessionOperation {
   get locallyComplete() {
     return this.local !== undefined;
   }
+  get cleanupDeadline() {
+    return this.cleanupOwner.cleanupDeadline;
+  }
+  get cleanup() {
+    return this.cleanupOwner.cleanupState;
+  }
+
+  nativeTarget(): NativeOperationTarget | undefined {
+    return this.target;
+  }
+
+  captureCleanupDeadline(deadlineAt = Date.now() + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS): number {
+    return this.cleanupOwner.captureDeadline(deadlineAt);
+  }
+
+  stopProcesses(deadlineAt: number): Promise<boolean> {
+    return this.cleanupOwner.stopProcesses(deadlineAt);
+  }
+
+  async cleanupOwnedWork(
+    deadlineAt: number,
+    reason = 'Session aborted',
+    status: 'failed' | 'cancelled' = 'cancelled'
+  ): Promise<boolean> {
+    return this.cleanupOwner.cleanup({
+      deadlineAt,
+      target: this.target,
+      preClientCleanup: this.preClientCleanup,
+      completionEvidence: this.cleanupEvidence(),
+      cancel: () => this.cancel(reason, status, deadlineAt),
+    });
+  }
 
   snapshot() {
     const retained = this.retainedNotifications.snapshot();
@@ -202,6 +267,8 @@ export class SessionOperation {
       preparing: retained.preparing,
       outcome: this.outcome ? structuredClone(this.outcome) : undefined,
       local: this.local ? structuredClone(this.local) : undefined,
+      cleanup: this.cleanupOwner.cleanupState,
+      cleanupDeadlineAt: this.cleanupOwner.cleanupDeadline,
       delivery: this.delivery?.snapshot(),
     };
   }
@@ -212,6 +279,10 @@ export class SessionOperation {
 
   waitForDelivery(): Promise<void> {
     return this.delivery?.drain() ?? Promise.resolve();
+  }
+
+  releaseProcessOwnership(): boolean {
+    return this.processes.dispose();
   }
 
   matchesAuthorization(authorization: SessionOperationAuthorization): boolean {
@@ -241,10 +312,17 @@ export class SessionOperation {
   }
 
   cancel(reason: string, status: 'failed' | 'cancelled', cleanupDeadlineAt?: number): void {
-    if (cleanupDeadlineAt !== undefined) {
-      this.cleanupDeadlineAt = Math.min(this.cleanupDeadlineAt ?? Infinity, cleanupDeadlineAt);
-    }
+    if (cleanupDeadlineAt !== undefined) this.captureCleanupDeadline(cleanupDeadlineAt);
     if (!this.local) this.controller.abort(new ControlTaskCancellation(status, reason));
+  }
+
+  requestRetirement(reason: string, deadlineAt: number): void {
+    if (this.cleanupOwner.cleanupState === 'confirmed') return;
+    this.deps.retireRuntime(reason, this.captureCleanupDeadline(deadlineAt), this.nativeTarget());
+  }
+
+  confirmCleanup(confirmed: boolean, deadlineAt: number): boolean {
+    return this.cleanupOwner.confirm(confirmed, deadlineAt);
   }
 
   private diagnostic(phase: string): void {
@@ -259,14 +337,21 @@ export class SessionOperation {
   }
 
   private expire(): void {
-    if (this.local) return;
+    if (this.local || this.deadlineCleanup) return;
     const reason =
       this.work.operation === 'session.attach'
         ? 'Session preparation timed out'
         : 'Execution exceeded the 60 minute limit';
     this.diagnostic('deadline_expired');
-    this.cancel(reason, 'failed');
-    this.deps.retireRuntime(reason);
+    const deadlineAt = this.captureCleanupDeadline(
+      Math.max(this.executionDeadlineAt, Date.now()) + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS
+    );
+    void this.stopProcesses(deadlineAt);
+    this.cancel(reason, 'failed', deadlineAt);
+    this.deadlineCleanup = this.cleanupOwnedWork(deadlineAt, reason, 'failed');
+    void this.deadlineCleanup.then(confirmed => {
+      if (!confirmed) this.requestRetirement(reason, deadlineAt);
+    });
   }
 
   private assertCurrent(): void {
@@ -283,9 +368,31 @@ export class SessionOperation {
       this.finalization.condensation = { state: 'unknown', error };
   }
 
-  private captureClient(client: WrapperKiloClient): void {
-    if (this.client) return;
-    this.client = client;
+  private captureRuntime(runtime: WorktreeKiloRuntime): void {
+    if (this.target) return;
+    this.target = Object.freeze({
+      runtimeId: runtime.runtimeId,
+      client: runtime.kiloClient,
+    });
+  }
+
+  private cleanupEvidence(): NativeCleanupEvidence {
+    if (this.native.state === 'not_started')
+      return this.local === undefined ? 'unconfirmed' : 'not_issued';
+    if (this.native.state !== 'completed') return 'unconfirmed';
+    if (
+      (this.native.completion === undefined && this.native.result === undefined) ||
+      this.native.completion?.error !== undefined ||
+      this.native.result === false ||
+      (this.finalization.autoCommit !== undefined &&
+        (this.finalization.autoCommit.state !== 'completed' ||
+          !this.finalization.autoCommit.result.success)) ||
+      (this.finalization.condensation !== undefined &&
+        (this.finalization.condensation.state !== 'completed' ||
+          this.finalization.condensation.result !== true))
+    )
+      return 'unconfirmed';
+    return 'finished';
   }
 
   private async attach(
@@ -294,6 +401,18 @@ export class SessionOperation {
     this.assertCurrent();
     const result = await work.apply(this.session, work.payload, {
       signal: this.signal,
+      assertCurrent: () => this.assertCurrent(),
+      onMutation: () => {
+        this.assertCurrent();
+        this.native.state = 'pending';
+      },
+      onRuntime: runtime => this.captureRuntime(runtime),
+      onCleanupTarget: cleanup => {
+        if (!this.preClientCleanup) this.preClientCleanup = cleanup;
+      },
+      onError: error => {
+        this.native.error = error;
+      },
       emitPreparing: event => {
         const retained =
           this.authorization && isRetainedOperationPreparing(event)
@@ -319,8 +438,18 @@ export class SessionOperation {
         true
       );
     }
-    if (result.ok) work.onAttached();
-    return result;
+    if (!result.ok) return result;
+    if (this.native.state === 'pending') this.native = { state: 'completed', result: true };
+    work.onAttached();
+    return {
+      ok: true,
+      result: {
+        attached: true,
+        ...(work.payload.captureNativeRuntimeId && this.target
+          ? { nativeRuntimeId: this.target.runtimeId }
+          : {}),
+      },
+    };
   }
 
   private emitFinalizationEvent(event: IngestEvent): void {
@@ -362,28 +491,6 @@ export class SessionOperation {
     );
     this.nativePending = observed;
     return observed;
-  }
-
-  private async waitForNativeAfterAbort(
-    pending: Promise<unknown>,
-    deadlineAt: number
-  ): Promise<void> {
-    try {
-      await withTimeoutAndAbort(
-        pending.then(
-          () => undefined,
-          () => undefined
-        ),
-        {
-          timeoutMs: Math.max(0, deadlineAt - Date.now()),
-          timeoutMessage: 'Native cancellation did not settle',
-          abortMessage: 'Native cancellation interrupted',
-        }
-      );
-    } catch (error) {
-      this.recordUncertainty(error);
-      this.deps.retireRuntime('Native cancellation did not settle');
-    }
   }
 
   private async summarize(
@@ -437,7 +544,7 @@ export class SessionOperation {
     const request = work.payload;
     const { runtime } = work;
     const { kiloClient, env } = runtime;
-    this.captureClient(kiloClient);
+    this.captureRuntime(runtime);
     const assertCurrent = (submitting = false) => {
       signal.throwIfAborted();
       if (
@@ -607,39 +714,26 @@ export class SessionOperation {
       };
       try {
         diagnostic('abort_started');
-        const cleanupDeadlineAt = Math.min(
-          this.cleanupDeadlineAt ?? Infinity,
-          Date.now() + KILO_CONTROL_REQUEST_TIMEOUT_MS
-        );
-        const abortController = new AbortController();
-        const abortTimer = setTimeout(
-          () => abortController.abort(new Error('Kilo cancellation timed out')),
-          Math.max(0, cleanupDeadlineAt - Date.now())
-        );
-        let aborted: boolean;
-        try {
-          aborted = await withTimeoutAndAbort(
-            kiloClient.abortSession({
-              sessionId: session.kiloSessionId,
-              directory: session.directory,
-              signal: abortController.signal,
-            }),
-            {
-              timeoutMs: Math.max(0, cleanupDeadlineAt - Date.now()),
-              timeoutMessage: 'Kilo cancellation timed out',
-              abortMessage: 'Kilo cancellation interrupted',
-            }
-          );
-        } finally {
-          clearTimeout(abortTimer);
+        const cleanupDeadlineAt = this.captureCleanupDeadline();
+        const cleanupConfirmed = await this.cleanupOwnedWork(cleanupDeadlineAt);
+        if (!cleanupConfirmed && !this.deadlineCleanup)
+          this.requestRetirement('Kilo cancellation was not confirmed', cleanupDeadlineAt);
+        const pending = this.nativePending;
+        if (cleanupConfirmed && pending) {
+          try {
+            await withTimeoutAndAbort(pending, {
+              timeoutMs: Math.max(1, cleanupDeadlineAt - Date.now()),
+              timeoutMessage: 'Native cancellation did not settle',
+              abortMessage: 'Native cancellation interrupted',
+            });
+          } catch (error) {
+            this.recordUncertainty(error);
+          }
         }
-        if (aborted !== true) throw new Error('Kilo cancellation was not confirmed');
-        const pendingNative = this.nativePending;
-        if (pendingNative) await this.waitForNativeAfterAbort(pendingNative, cleanupDeadlineAt);
         diagnostic('abort_completed');
       } catch (error) {
         diagnostic('abort_failed');
-        this.deps.retireRuntime('Kilo cancellation failed');
+        this.requestRetirement('Kilo cancellation failed', this.captureCleanupDeadline());
         result = kiloFailure(error);
       }
       const original = this.native.completion;
@@ -679,7 +773,7 @@ export class SessionOperation {
         diagnostic('outcome_sent', outcome.status);
       } catch {
         diagnostic('outcome_failed', outcome.status);
-        this.deps.retireRuntime('Session outcome delivery failed');
+        this.requestRetirement('Session outcome delivery failed', this.captureCleanupDeadline());
         return fail('Session outcome delivery failed', false);
       }
     }
@@ -688,6 +782,7 @@ export class SessionOperation {
 
   private complete(result: ControlHandlerResult): void {
     result = result.ok ? { ok: true, result: result.result } : { ok: false, error: result.error };
+    this.processes.seal();
     this.local = { result: structuredClone(result), completedAt: Date.now() };
     clearTimeout(this.timeout);
     const retain =

--- a/services/cloud-agent-next/wrapper/src/control/terminal-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/terminal-runtime.test.ts
@@ -70,6 +70,7 @@ function createRuntime(
       let worktree = worktrees.get(directory);
       if (!worktree) {
         worktree = {
+          runtimeId: `native_${worktrees.size + 1}`,
           scopeId: directory,
           directory,
           env: { WORKTREE_VALUE: directory },
@@ -551,6 +552,7 @@ describe('control terminal PTY ownership', () => {
     for (const identity of [firstSession, secondSession]) {
       const directory = identity.directory;
       worktrees.set(directory, {
+        runtimeId: `native_${identity.sessionId}`,
         directory,
         scopeId: directory,
         env: { HOME: `/home/${identity.sessionId}`, KILOCODE_TOKEN: `guest-${identity.sessionId}` },
@@ -763,6 +765,7 @@ describe('control terminal reverse WebSocket bridge', () => {
       [secondSession, secondServers, 'pty_second'],
     ] as const) {
       worktrees.set(identity.directory, {
+        runtimeId: `native_${identity.sessionId}`,
         scopeId: identity.directory,
         directory: identity.directory,
         env: {},

--- a/services/cloud-agent-next/wrapper/src/control/worktree-mutation-notifications.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-mutation-notifications.test.ts
@@ -257,6 +257,7 @@ function setup(deliver?: SendEvent, signal?: AbortSignal) {
     const controller = new AbortController();
     let client = {} as WrapperKiloClient;
     const runtime: WorktreeKiloRuntime = {
+      runtimeId: crypto.randomUUID(),
       directory,
       scopeId: directory,
       env: {},

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime-cleanup.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime-cleanup.ts
@@ -1,0 +1,67 @@
+import { withTimeoutAndAbort } from '../utils.js';
+import type { OwnedProcessScope } from './owned-processes.js';
+import type { NativeOperationTarget, NativeRetirement } from './session-operation-cleanup.js';
+
+export type RuntimeCleanupEntry<Root> = {
+  directory: string;
+  runtimeId: string;
+  abort: AbortController;
+  roots: Set<Root>;
+  kiloClient?: NativeOperationTarget['client'];
+  processes?: OwnedProcessScope;
+  processIssued?: boolean;
+  starting?: Promise<unknown>;
+  stopped?: Promise<void>;
+  retiring?: Promise<NativeRetirement>;
+  retirementResult?: NativeRetirement;
+};
+
+export function retireWorktreeRuntime<Entry extends RuntimeCleanupEntry<Root>, Root>(
+  entry: Entry,
+  requested: number | undefined,
+  target: NativeOperationTarget | undefined,
+  deps: {
+    cleanupDeadline: (entry: Entry, requested?: number) => number;
+    unregisterRoot: (root: Root) => void;
+    removeEntry: (entry: Entry) => void;
+  }
+): Promise<NativeRetirement> {
+  if (
+    target &&
+    (target.runtimeId !== entry.runtimeId ||
+      (target.client !== undefined && target.client !== entry.kiloClient))
+  )
+    return Promise.resolve('stale');
+  const deadlineAt = deps.cleanupDeadline(entry, requested);
+  if (entry.retiring) {
+    entry.processes?.stop(deadlineAt);
+    return entry.retiring;
+  }
+  const completion = Promise.withResolvers<NativeRetirement>();
+  entry.retiring = completion.promise;
+  const processes =
+    entry.processes?.stop(deadlineAt) ?? Promise.resolve(entry.processIssued !== true);
+  entry.abort.abort();
+  for (const root of [...entry.roots]) deps.unregisterRoot(root);
+  const cleanup = async (): Promise<NativeRetirement> => {
+    await Promise.resolve(entry.starting).catch(() => undefined);
+    if (!(await processes) || Date.now() >= deps.cleanupDeadline(entry)) return 'unconfirmed';
+    deps.removeEntry(entry);
+    return 'retired';
+  };
+  void withTimeoutAndAbort(cleanup(), {
+    timeoutMs: Math.max(1, deadlineAt - Date.now()),
+    timeoutMessage: 'Owned native runtime cleanup expired',
+    abortMessage: 'Owned native runtime cleanup cancelled',
+  }).then(
+    result => {
+      entry.retirementResult = result;
+      completion.resolve(result);
+    },
+    () => {
+      entry.retirementResult = 'unconfirmed';
+      completion.resolve('unconfirmed');
+    }
+  );
+  return completion.promise;
+}

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime-cleanup.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime-cleanup.ts
@@ -34,7 +34,7 @@ export function retireWorktreeRuntime<Entry extends RuntimeCleanupEntry<Root>, R
     return Promise.resolve('stale');
   const deadlineAt = deps.cleanupDeadline(entry, requested);
   if (entry.retiring) {
-    entry.processes?.stop(deadlineAt);
+    void entry.processes?.stop(deadlineAt);
     return entry.retiring;
   }
   const completion = Promise.withResolvers<NativeRetirement>();

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.test.ts
@@ -9,6 +9,7 @@ import {
   type WorktreeKiloAuth,
   type WorktreeKiloRuntimes,
 } from './worktree-runtime';
+import type { OwnedProcessScope } from './owned-processes';
 import {
   sessionMessageOutcomeSchema,
   type SessionEventIdentity,
@@ -215,6 +216,18 @@ function rootIdentity(directory: string, name = path.basename(directory)): Sessi
   return { sessionId: `workspace_${name}`, kiloSessionId: `root_${name}`, directory };
 }
 
+function proveOwnedProcesses(
+  options: Parameters<typeof startWorktreeKiloServer>[0],
+  stopped?: Promise<unknown>
+): void {
+  options.onProcessScope?.({
+    stop: async () => {
+      await stopped;
+      return true;
+    },
+  } as unknown as OwnedProcessScope);
+}
+
 function createRegistry(overrides: Partial<Parameters<typeof createWorktreeKiloRuntimes>[0]> = {}) {
   const launches: Array<Parameters<typeof startWorktreeKiloServer>[0]> = [];
   let closes = 0;
@@ -226,6 +239,7 @@ function createRegistry(overrides: Partial<Parameters<typeof createWorktreeKiloR
       launches.push(options);
       const server = createKiloStub();
       servers.push(server);
+      options.onProcessScope?.({ stop: async () => true } as unknown as OwnedProcessScope);
       return {
         url: server.url,
         close: () => {
@@ -359,7 +373,8 @@ describe('observed Kilo runtime version', () => {
     async secondHealth => {
       let count = 0;
       const { registry } = createRegistry({
-        startServer: async () => {
+        startServer: async options => {
+          proveOwnedProcesses(options);
           const server = createKiloStub(
             count++ === 0 ? { healthy: true, version: '7.4.20' } : secondHealth
           );
@@ -611,7 +626,7 @@ describe('worktree Kilo runtime registry', () => {
         else stream.enqueue(encoder.encode(connected));
         await waitUntil(() => failures.length > 0);
         expect(failures).toEqual([
-          {
+          expect.objectContaining({
             directory: runtime.directory,
             reason:
               failure === 'stream-error'
@@ -619,10 +634,12 @@ describe('worktree Kilo runtime registry', () => {
                 : failure === 'feed-end'
                   ? 'feed_ended'
                   : 'feed_reconnected',
-          },
+            cleanup: 'confirmed',
+            runtimeId: expect.any(String),
+          }),
         ]);
         expect(runtime.signal.aborted).toBe(true);
-        expect(harness.registry.isHealthy()).toBe(false);
+        expect(harness.registry.isHealthy()).toBe(true);
         expect(harness.registry.get(runtime.directory)).toBeUndefined();
         expect(
           fetchSpy.mock.calls.filter(
@@ -640,10 +657,11 @@ describe('worktree Kilo runtime registry', () => {
   it('keeps the refreshed SDK event feed healthy after intentional old-process shutdown', async () => {
     const received: string[] = [];
     const harness = createRegistry({
-      startServer: async () => {
+      startServer: async options => {
         const server = createKiloStub();
         servers.push(server);
         const stopped = Promise.withResolvers<void>();
+        proveOwnedProcesses(options, stopped.promise);
         return {
           url: server.url,
           stopped: stopped.promise,
@@ -659,16 +677,25 @@ describe('worktree Kilo runtime registry', () => {
     const identity = rootIdentity(path.join(tmpDir, 'shared'));
     const first = harness.registry.attach(identity, directAuth);
     const runtime = await first.ready;
+    const cleanupOriginal = first.cleanup
+      ? (deadlineAt: number) => first.cleanup?.(deadlineAt)
+      : undefined;
     first.commit();
     first.release();
     const originalClient = runtime.kiloClient;
+    const originalRuntimeId = runtime.runtimeId;
     const refresh = harness.registry.attach(
       identity,
       { ...directAuth, token: 'rotated-token' },
       undefined,
       () => true
     );
-    expect(await refresh.ready).toBe(runtime);
+    const refreshed = await refresh.ready;
+    expect(refreshed).toBe(runtime);
+    expect(refreshed.runtimeId).not.toBe(originalRuntimeId);
+    expect(runtime.signal.aborted).toBe(false);
+    expect(await cleanupOriginal?.(Date.now() + 1_000)).toBe('stale');
+    expect(harness.registry.get(identity.directory)).toBe(refreshed);
     refresh.commit();
     refresh.release();
     expect(runtime.kiloClient).not.toBe(originalClient);
@@ -678,12 +705,12 @@ describe('worktree Kilo runtime registry', () => {
     await waitUntil(() => received.includes('session.updated'));
     expect(runtime.signal.aborted).toBe(false);
     expect(harness.registry.isHealthy()).toBe(true);
-    expect(harness.registry.get(identity.directory)).toBe(runtime);
+    expect(harness.registry.get(identity.directory)).toBe(refreshed);
     expect(harness.unexpectedCloses).toBe(0);
     servers[1]?.endFeeds();
     await waitUntil(() => harness.unexpectedCloses === 1);
     expect(runtime.signal.aborted).toBe(true);
-    expect(harness.registry.isHealthy()).toBe(false);
+    expect(harness.registry.isHealthy()).toBe(true);
   });
 
   it('isolates different worktrees with separate servers, homes, auth files, and event clients', async () => {
@@ -1168,7 +1195,8 @@ describe('worktree Kilo runtime registry', () => {
     servers.push(server);
     let closes = 0;
     const { registry } = createRegistry({
-      startServer: async () => {
+      startServer: async options => {
+        proveOwnedProcesses(options);
         launched.resolve();
         await release.promise;
         return {
@@ -1215,6 +1243,7 @@ describe('worktree Kilo runtime registry', () => {
     const steps: string[] = [];
     const harness = createRegistry({
       startServer: async options => {
+        proveOwnedProcesses(options);
         const old = options.env.KILOCODE_TOKEN === auth.token;
         steps.push(old ? 'start-old' : 'start-new');
         if (old) {
@@ -1313,7 +1342,8 @@ describe('worktree Kilo runtime registry', () => {
     const stub = createKiloStub();
     servers.push(stub);
     const { registry } = createRegistry({
-      startServer: async () => {
+      startServer: async options => {
+        proveOwnedProcesses(options);
         attempts += 1;
         if (attempts === 1) throw new Error('actual-managed-token');
         return { url: stub.url, close: () => {} };
@@ -1364,7 +1394,8 @@ describe('worktree Kilo runtime registry', () => {
     servers.push(stub);
     let closes = 0;
     const { registry } = createRegistry({
-      startServer: async () => {
+      startServer: async options => {
+        proveOwnedProcesses(options);
         launched.resolve();
         await released.promise;
         return {
@@ -1406,6 +1437,7 @@ describe('worktree directory deletion', () => {
     const closed: string[] = [];
     const harness = createRegistry({
       startServer: async options => {
+        proveOwnedProcesses(options, stopped.promise);
         const stub = createKiloStub();
         servers.push(stub);
         return {
@@ -1454,13 +1486,16 @@ describe('worktree directory deletion', () => {
     servers.push(stub);
     let closes = 0;
     const harness = createRegistry({
-      startServer: async () => ({
-        url: stub.url,
-        close: () => {
-          closes++;
-        },
-        stopped: stopped.promise,
-      }),
+      startServer: async options => {
+        proveOwnedProcesses(options, stopped.promise);
+        return {
+          url: stub.url,
+          close: () => {
+            closes++;
+          },
+          stopped: stopped.promise,
+        };
+      },
     });
     const directory = path.join(tmpDir, 'stuck-exit');
     const runtime = await harness.registry.ensure(directory, auth);
@@ -1619,6 +1654,7 @@ describe('worktree directory deletion', () => {
       servers.push(stub);
       const harness = createRegistry({
         startServer: async options => {
+          proveOwnedProcesses(options);
           launches++;
           launched.resolve(options);
           await release.promise;
@@ -2094,5 +2130,119 @@ setInterval(() => {}, 1000);
     options.abort.abort();
     expect(await rejected(startWorktreeKiloServer(options))).toBeInstanceOf(Error);
     expect(fs.existsSync(options.env.PID_PATH)).toBe(false);
+  });
+
+  it('retires both roots that share a native process without stopping an isolated runtime', async () => {
+    const sharedProcesses = { stop: async () => true } as unknown as OwnedProcessScope;
+    const registry = createWorktreeKiloRuntimes({
+      homeRoot: path.join(tmpDir, 'homes'),
+      inheritedEnv: inherited,
+      startServer: async options => {
+        proveOwnedProcesses(options);
+        const server = createKiloStub();
+        servers.push(server);
+        options.onProcessScope?.(sharedProcesses);
+        return { url: server.url, close: () => {} };
+      },
+      onUnexpectedClose: () => {},
+    });
+    registries.push(registry);
+    const sharedDirectory = path.join(tmpDir, 'shared');
+    const isolatedDirectory = path.join(tmpDir, 'isolated');
+    const first = registry.attach(rootIdentity(sharedDirectory, 'first'), auth);
+    const runtime = await first.ready;
+    first.commit();
+    const sibling = registry.attach(rootIdentity(sharedDirectory, 'second'), auth);
+    await sibling.ready;
+    sibling.commit();
+    const isolated = registry.attach(rootIdentity(isolatedDirectory, 'isolated'), {
+      ...auth,
+      scopeId: 'worktree_isolated',
+    });
+    const isolatedRuntime = await isolated.ready;
+    isolated.commit();
+
+    expect(
+      await registry.retireRuntime?.(sharedDirectory, Date.now() + 1_000, {
+        runtimeId: runtime.runtimeId ?? '',
+        client: runtime.kiloClient,
+      })
+    ).toBe('retired');
+    expect(first.signal.aborted).toBe(true);
+    expect(sibling.signal.aborted).toBe(true);
+    expect(registry.get(sharedDirectory)).toBeUndefined();
+    expect(registry.get(isolatedDirectory)).toBe(isolatedRuntime);
+  });
+
+  it('retains failed native cleanup ownership without affecting another runtime', async () => {
+    const unresolvedProcesses = { stop: async () => false } as unknown as OwnedProcessScope;
+    const registry = createWorktreeKiloRuntimes({
+      homeRoot: path.join(tmpDir, 'homes'),
+      inheritedEnv: inherited,
+      startServer: async options => {
+        const server = createKiloStub();
+        servers.push(server);
+        options.onProcessScope?.(unresolvedProcesses);
+        return { url: server.url, close: () => {} };
+      },
+      onUnexpectedClose: () => {},
+    });
+    registries.push(registry);
+    const failedDirectory = path.join(tmpDir, 'failed');
+    const isolatedDirectory = path.join(tmpDir, 'isolated');
+    const first = registry.attach(rootIdentity(failedDirectory, 'first'), auth);
+    const runtime = await first.ready;
+    first.commit();
+    const sibling = registry.attach(rootIdentity(failedDirectory, 'second'), auth);
+    await sibling.ready;
+    sibling.commit();
+    const isolated = registry.attach(rootIdentity(isolatedDirectory, 'isolated'), {
+      ...auth,
+      scopeId: 'worktree_isolated',
+    });
+    const isolatedRuntime = await isolated.ready;
+    isolated.commit();
+
+    expect(
+      await registry.retireRuntime?.(failedDirectory, Date.now() + 1_000, {
+        runtimeId: runtime.runtimeId ?? '',
+        client: runtime.kiloClient,
+      })
+    ).toBe('unconfirmed');
+    expect(first.signal.aborted).toBe(true);
+    expect(sibling.signal.aborted).toBe(true);
+    expect(registry.getRetained?.(failedDirectory)).toBe(runtime);
+    expect(registry.get(isolatedDirectory)).toBe(isolatedRuntime);
+    expect(() => registry.attach(rootIdentity(failedDirectory, 'retry'), auth)).toThrow(
+      'Native runtime retirement is unconfirmed'
+    );
+  });
+
+  it('does not treat a stopped parent as native retirement proof without an owned scope', async () => {
+    const stopped = Promise.withResolvers<void>();
+    const registry = createWorktreeKiloRuntimes({
+      homeRoot: path.join(tmpDir, 'homes'),
+      inheritedEnv: inherited,
+      startServer: async () => {
+        const server = createKiloStub();
+        servers.push(server);
+        return { url: server.url, close: () => {}, stopped: stopped.promise };
+      },
+      onUnexpectedClose: () => {},
+    });
+    registries.push(registry);
+    const directory = path.join(tmpDir, 'unowned');
+    const attachment = registry.attach(rootIdentity(directory), auth);
+    const runtime = await attachment.ready;
+    attachment.commit();
+
+    expect(
+      await registry.retireRuntime?.(directory, Date.now() + 1_000, {
+        runtimeId: runtime.runtimeId ?? '',
+        client: runtime.kiloClient,
+      })
+    ).toBe('unconfirmed');
+    expect(attachment.signal.aborted).toBe(true);
+    stopped.resolve();
   });
 });

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
@@ -11,10 +10,11 @@ import {
   type ControlDiagnosticReporter,
 } from '../../../src/shared/control-diagnostics.js';
 import { safeSandboxRuntimeVersion } from '../../../src/shared/sandbox-status.js';
-import type {
-  ControlErrorCode,
-  SessionAttachPayload,
-  SessionRequestIdentity,
+import {
+  SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS,
+  type ControlErrorCode,
+  type SessionAttachPayload,
+  type SessionRequestIdentity,
 } from '../../../src/shared/sandbox-control-protocol.js';
 import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../../../src/shared/runtime-environment.js';
 import {
@@ -23,7 +23,11 @@ import {
   type WrapperKiloClient,
 } from '../kilo-api.js';
 import { withTimeoutAndAbort } from '../utils.js';
+import { isKiloServerProcess } from '../tool-cgroup.js';
 import { unfilteredKiloEvents } from './feed.js';
+import { createOwnedProcessScope, type OwnedProcessScope } from './owned-processes.js';
+import type { NativeOperationTarget, NativeRetirement } from './session-operation-cleanup.js';
+import { retireWorktreeRuntime } from './worktree-runtime-cleanup.js';
 import { forgetAttachedRoot, rememberAttachedRoot } from './session-directories.js';
 import {
   KiloEventFeedError,
@@ -36,10 +40,13 @@ export type WorktreeKiloAuth = NonNullable<SessionAttachPayload['kilo']>;
 type WorktreeKiloFailure = {
   directory: string;
   reason: KiloEventFeedError['reason'] | 'process_exited' | 'credential_refresh_failed';
+  runtimeId: string;
+  cleanup: 'confirmed' | 'unconfirmed';
 };
 
 export type WorktreeKiloRuntime = {
   readonly scopeId: string;
+  readonly runtimeId: string;
   readonly directory: string;
   readonly env: Record<string, string>;
   readonly kiloClient: WrapperKiloClient;
@@ -49,6 +56,7 @@ export type WorktreeKiloRuntime = {
 export type WorktreeKiloAttachment = {
   ready: Promise<WorktreeKiloRuntime>;
   signal: AbortSignal;
+  cleanup?(deadlineAt: number): Promise<NativeRetirement>;
   commit(): void;
   release(): void;
 };
@@ -59,10 +67,23 @@ export type WorktreeKiloRuntimes = {
     identity: SessionRequestIdentity,
     kilo: WorktreeKiloAuth,
     env?: Record<string, string>,
-    canRefreshCredentials?: () => boolean
+    canRefreshCredentials?: () => boolean,
+    beforeMutation?: () => void,
+    onCleanupTarget?: (cleanup: (deadlineAt: number) => Promise<NativeRetirement>) => void
   ): WorktreeKiloAttachment;
   detach(identity: SessionRequestIdentity): boolean;
   deleteDirectory(directory: string): Promise<void>;
+  retireRuntime?(
+    directory: string,
+    deadlineAt: number,
+    target?: NativeOperationTarget
+  ): Promise<NativeRetirement>;
+  verifyQuiescence?(
+    directory: string,
+    target: NativeOperationTarget,
+    deadlineAt: number
+  ): Promise<boolean>;
+  getRetained?(directory: string): WorktreeKiloRuntime | undefined;
   get(directory: string): WorktreeKiloRuntime | undefined;
   isHealthy(): boolean;
   shutdown(): void;
@@ -79,9 +100,16 @@ type ServerOptions = {
   env: Record<string, string>;
   signal: AbortSignal;
   timeoutMs?: number;
+  onProcessScope?: (scope: OwnedProcessScope) => void;
+  claimCleanupDeadline?: (deadlineAt?: number) => number;
 };
 
-type WorktreeKiloServerHandle = KiloServerHandle & { stopped?: Promise<void> };
+type WorktreeKiloServerHandle = Omit<KiloServerHandle, 'close'> & {
+  close(deadlineAt?: number): void;
+  stopped?: Promise<void>;
+  exited?: Promise<void>;
+  processes?: OwnedProcessScope;
+};
 
 type RuntimeEntry = {
   kilo: WorktreeKiloAuth;
@@ -92,11 +120,16 @@ type RuntimeEntry = {
   runtime?: WorktreeKiloRuntime;
   kiloClient?: WrapperKiloClient;
   processAbort?: AbortController;
+  processes?: OwnedProcessScope;
+  processIssued?: boolean;
+  runtimeId: string;
   pendingPtys: number;
   feed?: Awaited<ReturnType<typeof startSandboxControlEventFeed>>;
   starting?: Promise<WorktreeKiloRuntime>;
   stopped?: Promise<void>;
-  retiring?: Promise<void>;
+  retiring?: Promise<NativeRetirement>;
+  retirementResult?: NativeRetirement;
+  cleanupDeadlineAt?: number;
 };
 
 type RootAttachment = {
@@ -202,21 +235,41 @@ export async function startWorktreeKiloServer(
   options: ServerOptions
 ): Promise<WorktreeKiloServerHandle & { stopped: Promise<void> }> {
   options.signal.throwIfAborted();
-  const proc = spawn('kilo', ['serve', '--hostname=127.0.0.1', '--port=0'], {
+  const processes = createOwnedProcessScope();
+  options.onProcessScope?.(processes);
+  const proc = processes.spawn('kilo', ['serve', '--hostname=127.0.0.1', '--port=0'], {
     cwd: options.directory,
     env: options.env,
-    stdio: ['ignore', 'pipe', 'ignore'],
   });
+  proc.stderr.resume();
   const stopped = new Promise<void>(resolve => {
     proc.once('close', () => resolve());
   });
+  const exited = new Promise<void>(resolve => {
+    proc.once('exit', () => resolve());
+    proc.once('error', () => {
+      if (proc.pid === undefined) resolve();
+    });
+  });
+  let cleanupDeadlineAt: number | undefined;
+  const claimCleanupDeadline = (requested?: number): number => {
+    const owned = options.claimCleanupDeadline?.(requested) ?? requested;
+    cleanupDeadlineAt ??= owned ?? Date.now() + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS;
+    cleanupDeadlineAt = Math.min(cleanupDeadlineAt, owned ?? cleanupDeadlineAt);
+    return cleanupDeadlineAt;
+  };
   let closed = false;
-  const close = (): void => {
+  const closeAt = (deadlineAt?: number): void => {
     if (closed) return;
     closed = true;
     options.signal.removeEventListener('abort', close);
-    if (proc.exitCode === null && proc.signalCode === null) proc.kill();
+    if (deadlineAt === undefined) {
+      if (proc.exitCode === null && proc.signalCode === null) proc.kill('SIGTERM');
+      return;
+    }
+    void processes.stop(claimCleanupDeadline(deadlineAt));
   };
+  const close = (): void => closeAt();
   options.signal.addEventListener('abort', close, { once: true });
 
   try {
@@ -253,10 +306,18 @@ export async function startWorktreeKiloServer(
     });
     proc.stdout.resume();
     proc.once('exit', close);
-    return { url, close, stopped };
+    await processes.captureBaseline(isKiloServerProcess);
+    options.signal.throwIfAborted();
+    return { url, close: closeAt, stopped, exited, processes };
   } catch {
-    close();
-    await stopped;
+    const deadlineAt = claimCleanupDeadline();
+    const cleanup = processes.stop(deadlineAt);
+    closeAt(deadlineAt);
+    await withTimeoutAndAbort(cleanup, {
+      timeoutMs: Math.max(1, deadlineAt - Date.now()),
+      timeoutMessage: 'Kilo startup cleanup expired',
+      abortMessage: 'Kilo startup cleanup cancelled',
+    }).catch(() => false);
     throw new Error('Kilo server failed to start');
   }
 }
@@ -283,6 +344,7 @@ export function createWorktreeKiloRuntimes(options: {
 }): WorktreeKiloRuntimes {
   const entries = new Map<string, RuntimeEntry>();
   const directoriesByScope = new Map<string, string>();
+  const failedDirectories = new Set<string>();
   const roots = new Map<string, RootAttachment>();
   const homesByDirectory = new Map<string, Set<string>>();
   const deletedDirectories = new Set<string>();
@@ -314,47 +376,79 @@ export function createWorktreeKiloRuntimes(options: {
     return undefined;
   }
 
-  function retire(entry: RuntimeEntry): Promise<void> {
-    if (entry.retiring) return entry.retiring;
-    entry.retiring = Promise.resolve(entry.starting)
-      .catch(() => undefined)
-      .then(() => entry.stopped)
-      .then(() => {
-        if (entries.get(entry.directory) === entry) entries.delete(entry.directory);
-      });
-    void entry.retiring.catch(() => {});
-    if (
-      entries.get(entry.directory) === entry &&
-      directoriesByScope.get(entry.kilo.scopeId) === entry.directory
-    ) {
-      directoriesByScope.delete(entry.kilo.scopeId);
+  function cleanupDeadline(entry: RuntimeEntry, requested?: number): number {
+    entry.cleanupDeadlineAt ??= requested ?? Date.now() + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS;
+    entry.cleanupDeadlineAt = Math.min(
+      entry.cleanupDeadlineAt,
+      requested ?? entry.cleanupDeadlineAt
+    );
+    return entry.cleanupDeadlineAt;
+  }
+
+  function unregisterRoot(root: RootAttachment): void {
+    root.entry.roots.delete(root);
+    root.attached = false;
+    root.pending.clear();
+    if (roots.get(root.identity.kiloSessionId) === root) {
+      roots.delete(root.identity.kiloSessionId);
+      forgetAttachedRoot(root.identity.kiloSessionId, root.identity.directory);
     }
-    entry.abort.abort();
-    return entry.retiring;
+  }
+
+  function retire(
+    entry: RuntimeEntry,
+    requested?: number,
+    target?: NativeOperationTarget
+  ): Promise<NativeRetirement> {
+    return retireWorktreeRuntime(entry, requested, target, {
+      cleanupDeadline,
+      unregisterRoot,
+      removeEntry: retiring => {
+        if (entries.get(retiring.directory) === retiring) {
+          entries.delete(retiring.directory);
+          if (directoriesByScope.get(retiring.kilo.scopeId) === retiring.directory)
+            directoriesByScope.delete(retiring.kilo.scopeId);
+        }
+      },
+    });
   }
 
   function removeRoot(root: RootAttachment): void {
     if (roots.get(root.identity.kiloSessionId) !== root) return;
-    roots.delete(root.identity.kiloSessionId);
-    root.entry.roots.delete(root);
-    forgetAttachedRoot(root.identity.kiloSessionId, root.identity.directory);
+    unregisterRoot(root);
     root.abort.abort();
     if (root.entry.roots.size === 0) void retire(root.entry);
   }
 
   function failRuntime(entry: RuntimeEntry, reason: WorktreeKiloFailure['reason']): void {
     if (entry.abort.signal.aborted) return;
-    entry.abort.abort();
-    options.onUnexpectedClose({ directory: entry.directory, reason });
+    const deadlineAt = cleanupDeadline(entry);
+    const runtimeId = entry.runtimeId;
+    void retire(entry, deadlineAt).then(result => {
+      if (result === 'unconfirmed') failedDirectories.add(entry.directory);
+      options.onUnexpectedClose({
+        directory: entry.directory,
+        reason,
+        runtimeId,
+        cleanup: result === 'unconfirmed' ? 'unconfirmed' : 'confirmed',
+      });
+    });
   }
 
   async function start(
     entry: RuntimeEntry,
-    retiring: Promise<void> | undefined
+    retiring: Promise<NativeRetirement> | undefined,
+    beforeMutation?: () => void
   ): Promise<WorktreeKiloRuntime> {
     const abort = new AbortController();
+    entry.processes = undefined;
+    entry.processIssued = false;
+    entry.stopped = undefined;
     entry.processAbort = abort;
-    const stopProcess = () => abort.abort();
+    const stopProcess = () => {
+      void entry.processes?.stop(cleanupDeadline(entry));
+      abort.abort();
+    };
     entry.abort.signal.addEventListener('abort', stopProcess, { once: true });
     abort.signal.addEventListener(
       'abort',
@@ -367,12 +461,16 @@ export function createWorktreeKiloRuntimes(options: {
     const closeServer = (): void => {
       if (!server || serverClosed) return;
       serverClosed = true;
-      server.close();
+      const deadlineAt = cleanupDeadline(entry);
+      void server.processes?.stop(deadlineAt);
+      server.close(deadlineAt);
     };
     abort.signal.addEventListener('abort', closeServer, { once: true });
     try {
-      if (retiring) await retiring;
+      if (retiring && (await retiring) !== 'retired')
+        throw new Error('Predecessor native runtime is not contained');
       abort.signal.throwIfAborted();
+      beforeMutation?.();
       const authDirectory = path.join(entry.env.XDG_DATA_HOME, 'kilo');
       await fs.mkdir(authDirectory, { recursive: true, mode: 0o700 });
       await fs.mkdir(entry.env.XDG_RUNTIME_DIR, { recursive: true, mode: 0o700 });
@@ -385,15 +483,24 @@ export function createWorktreeKiloRuntimes(options: {
         directory: entry.directory,
         env: entry.env,
         signal: abort.signal,
+        onProcessScope: processes => {
+          entry.processes = processes;
+          entry.processIssued = true;
+          if (entry.cleanupDeadlineAt !== undefined) void processes.stop(entry.cleanupDeadlineAt);
+        },
+        claimCleanupDeadline: deadlineAt =>
+          entry.processAbort === abort ? cleanupDeadline(entry, deadlineAt) : (deadlineAt ?? 0),
       });
+      entry.processes = server.processes ?? entry.processes;
+      entry.processIssued = true;
       entry.stopped = server.stopped;
-      void server.stopped?.then(() => {
+      void (server.exited ?? server.stopped)?.then(() => {
         if (!abort.signal.aborted) failRuntime(entry, 'process_exited');
       });
       abort.signal.throwIfAborted();
       const client = createKiloClient({ baseUrl: server.url, directory: entry.directory });
       const kiloClient = createWrapperKiloClient(client, server.url, entry.directory);
-      entry.kiloClient = {
+      const runtimeKiloClient: WrapperKiloClient = {
         ...kiloClient,
         async createPty(options) {
           if (entry.starting) {
@@ -411,16 +518,19 @@ export function createWorktreeKiloRuntimes(options: {
           }
         },
       };
+      entry.kiloClient = runtimeKiloClient;
       const runtime: WorktreeKiloRuntime = entry.runtime ?? {
         scopeId: entry.kilo.scopeId,
+        get runtimeId() {
+          return entry.runtimeId;
+        },
         directory: entry.directory,
         get env() {
           return entry.env;
         },
         get kiloClient() {
-          if (!entry.kiloClient) {
+          if (!entry.kiloClient)
             throw new WorktreeKiloRuntimeError('not_ready', 'Kilo worktree is not ready', true);
-          }
           return entry.kiloClient;
         },
         signal: entry.abort.signal,
@@ -483,8 +593,9 @@ export function createWorktreeKiloRuntimes(options: {
       );
       return runtime;
     } catch {
+      if (!server) entry.processIssued = false;
       if (entry.runtime) failRuntime(entry, 'credential_refresh_failed');
-      else entry.abort.abort();
+      else void retire(entry);
       closeServer();
       throw new WorktreeKiloRuntimeError('not_ready', 'Kilo worktree failed to start', true);
     } finally {
@@ -496,7 +607,9 @@ export function createWorktreeKiloRuntimes(options: {
     entry: RuntimeEntry,
     kilo: WorktreeKiloAuth,
     env: Record<string, string>,
-    canRefreshCredentials: () => boolean
+    canRefreshCredentials: () => boolean,
+    beforeMutation?: () => void,
+    onDestructiveRefresh?: () => void
   ): Promise<WorktreeKiloRuntime> {
     const retry = () =>
       new WorktreeKiloRuntimeError(
@@ -526,17 +639,27 @@ export function createWorktreeKiloRuntimes(options: {
       if (error instanceof WorktreeKiloRuntimeError) throw error;
       throw new WorktreeKiloRuntimeError('not_ready', 'Worktree idle probe failed', true);
     }
+    const deadlineAt = cleanupDeadline(entry);
+    onDestructiveRefresh?.();
+    const stopped =
+      entry.processes?.stop(deadlineAt) ?? Promise.resolve(entry.processIssued !== true);
     entry.processAbort.abort();
     try {
       await withTimeoutAndAbort(entry.stopped, {
         signal: entry.abort.signal,
-        timeoutMs: KILO_STARTUP_TIMEOUT_MS,
+        timeoutMs: Math.max(1, deadlineAt - Date.now()),
         timeoutMessage: 'Kilo worktree credential refresh timed out',
         abortMessage: 'Kilo worktree credential refresh cancelled',
       });
+      if (!(await stopped) || Date.now() >= deadlineAt) {
+        throw new Error('Original native execution is not contained');
+      }
       entry.kilo = { ...kilo, targets: { ...kilo.targets } };
       entry.env = env;
-      return await start(entry, undefined);
+      entry.cleanupDeadlineAt = undefined;
+      entry.kiloClient = undefined;
+      entry.runtimeId = crypto.randomUUID();
+      return await start(entry, undefined, beforeMutation);
     } catch {
       failRuntime(entry, 'credential_refresh_failed');
       throw new WorktreeKiloRuntimeError(
@@ -551,7 +674,7 @@ export function createWorktreeKiloRuntimes(options: {
     get kiloCliVersion() {
       return observedVersion ?? null;
     },
-    attach(identity, kilo, environment, canRefreshCredentials) {
+    attach(identity, kilo, environment, canRefreshCredentials, beforeMutation, onCleanupTarget) {
       if (closed) {
         throw new WorktreeKiloRuntimeError('not_ready', 'Kilo worktrees are closed', false);
       }
@@ -565,7 +688,15 @@ export function createWorktreeKiloRuntimes(options: {
       let root = findRoot(identity);
       const scopeDirectory = directoriesByScope.get(kilo.scopeId);
       const previous = entries.get(directory);
+      if (previous?.retirementResult === 'unconfirmed') {
+        throw new WorktreeKiloRuntimeError(
+          'not_ready',
+          'Native runtime retirement is unconfirmed',
+          true
+        );
+      }
       let entry = previous?.retiring ? undefined : previous;
+      let cleanupRequired = false;
       if (
         (scopeDirectory && scopeDirectory !== directory) ||
         (entry && !sameAuth(entry.kilo, kilo))
@@ -614,7 +745,18 @@ export function createWorktreeKiloRuntimes(options: {
           }
           const refreshing = entry;
           entry.starting = Promise.resolve()
-            .then(() => refreshCredentials(refreshing, kilo, env, canRefreshCredentials))
+            .then(() =>
+              refreshCredentials(
+                refreshing,
+                kilo,
+                env,
+                canRefreshCredentials,
+                beforeMutation,
+                () => {
+                  cleanupRequired = true;
+                }
+              )
+            )
             .finally(() => {
               refreshing.starting = undefined;
             });
@@ -642,12 +784,15 @@ export function createWorktreeKiloRuntimes(options: {
           ),
           abort: new AbortController(),
           roots: new Set(),
+          runtimeId: crypto.randomUUID(),
           pendingPtys: 0,
         };
         const homes = homesByDirectory.get(directory) ?? new Set<string>();
         homes.add(home);
         homesByDirectory.set(directory, homes);
         entries.set(directory, entry);
+        cleanupRequired = true;
+        failedDirectories.delete(directory);
         directoriesByScope.set(kilo.scopeId, directory);
       }
       if (!root) {
@@ -663,6 +808,10 @@ export function createWorktreeKiloRuntimes(options: {
         rememberAttachedRoot(identity.kiloSessionId, directory);
       }
       const attachedRoot = root;
+      const cleanupTarget = Object.freeze({ runtimeId: entry.runtimeId });
+      onCleanupTarget?.(deadlineAt =>
+        cleanupRequired ? retire(entry, deadlineAt, cleanupTarget) : Promise.resolve('stale')
+      );
       const attempt = Symbol();
       attachedRoot.pending.add(attempt);
       const signal = AbortSignal.any([attachedRoot.abort.signal, entry.abort.signal]);
@@ -670,10 +819,15 @@ export function createWorktreeKiloRuntimes(options: {
         entry.starting ??
         (entry.runtime
           ? Promise.resolve(entry.runtime)
-          : (entry.starting = start(entry, previous?.retiring)));
+          : (entry.starting = start(entry, previous?.retiring, beforeMutation)));
       return {
         ready,
         signal,
+        cleanup(deadlineAt) {
+          return cleanupRequired
+            ? retire(entry, deadlineAt, cleanupTarget)
+            : Promise.resolve('stale');
+        },
         commit() {
           signal.throwIfAborted();
           if (!attachedRoot.pending.delete(attempt)) return;
@@ -698,16 +852,44 @@ export function createWorktreeKiloRuntimes(options: {
         if (root.identity.directory === directory) removeRoot(root);
       }
       if (entry) {
-        await withTimeoutAndAbort(retire(entry), {
+        const quiescent = await withTimeoutAndAbort(retire(entry), {
           timeoutMs: KILO_STARTUP_TIMEOUT_MS,
           timeoutMessage: 'Kilo worktree retirement timed out',
           abortMessage: 'Kilo worktree retirement cancelled',
         });
+        if (quiescent !== 'retired') throw new Error('Native worktree cleanup is unconfirmed');
       }
       for (const home of homesByDirectory.get(directory) ?? []) {
         await fs.rm(home, { recursive: true, force: true });
       }
       homesByDirectory.delete(directory);
+    },
+    async retireRuntime(directory, deadlineAt, target) {
+      const entry = entries.get(directory);
+      if (!entry) return 'stale';
+      return retire(entry, deadlineAt, target);
+    },
+    async verifyQuiescence(directory, target, deadlineAt) {
+      const entry = entries.get(directory);
+      if (
+        !entry ||
+        entry.runtimeId !== target.runtimeId ||
+        entry.kiloClient !== target.client ||
+        Date.now() >= deadlineAt
+      )
+        return false;
+      const verified = await (entry.processes?.verify(true, deadlineAt) ?? Promise.resolve(false));
+      return (
+        verified &&
+        Date.now() < deadlineAt &&
+        entries.get(directory) === entry &&
+        entry.runtimeId === target.runtimeId &&
+        entry.kiloClient === target.client &&
+        !entry.abort.signal.aborted
+      );
+    },
+    getRetained(directory) {
+      return entries.get(directory)?.runtime;
     },
     get(directory) {
       const entry = entries.get(directory);
@@ -717,15 +899,13 @@ export function createWorktreeKiloRuntimes(options: {
         : undefined;
     },
     isHealthy() {
-      return (
-        !closed &&
-        [...entries.values()].every(
-          entry =>
-            entry.retiring !== undefined ||
-            (!entry.abort.signal.aborted &&
-              (entry.starting !== undefined || !entry.runtime || entry.feed?.isFresh() === true))
-        )
+      const healthy = [...entries.values()].some(
+        entry =>
+          entry.retiring === undefined &&
+          !entry.abort.signal.aborted &&
+          (entry.starting !== undefined || !entry.runtime || entry.feed?.isFresh() === true)
       );
+      return !closed && failedDirectories.size === 0 && (entries.size === 0 || healthy);
     },
     shutdown() {
       if (closed) return;

--- a/services/cloud-agent-next/wrapper/src/utils.ts
+++ b/services/cloud-agent-next/wrapper/src/utils.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process';
 import { appendFileSync } from 'fs';
+import { currentOwnedProcessScope } from './control/owned-processes.js';
 
 export type ExecResult = {
   stdout: string;
@@ -119,16 +120,21 @@ export function runProcess(
   }
 
   return new Promise((resolve, reject) => {
-    const proc = spawn(command, args, {
+    const options = {
       cwd: opts?.cwd,
       ...(opts?.inheritEnv === false
         ? { env: opts.env ?? {} }
         : opts?.env
           ? { env: { ...process.env, ...opts.env } }
           : {}),
-      detached: true,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    };
+    const proc =
+      currentOwnedProcessScope()?.spawn(command, args, options) ??
+      spawn(command, args, {
+        ...options,
+        detached: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
     let stdout = '';
     let stderr = '';
     let stdoutTruncated = false;


### PR DESCRIPTION
## Summary
- Retire native runtimes with scoped receipts instead of collapsing cleanup onto the shared wrapper.
- Separate retirement receipts so a leftover process on one scope cannot retire an unrelated runtime.

## Stack
Control-plane recovery stack. Merge from the bottom. Each PR targets its parent, not `main` (except #5912).

1. #5912 `eshurakov/recovery-observation` → `main`
2. #5913 `eshurakov/recovery-results` → `eshurakov/recovery-observation`
3. #5914 `eshurakov/recovery-stop-scope` → `eshurakov/recovery-results`
4. #5915 `eshurakov/recovery-native-cleanup` → `eshurakov/recovery-stop-scope`
5. #5916 `eshurakov/recovery-session-delivery` → `eshurakov/recovery-native-cleanup`
6. #5917 `eshurakov/recovery-native-feed` → `eshurakov/recovery-session-delivery`
7. #5918 `eshurakov/recovery-control-connection` → `eshurakov/recovery-native-feed`
8. #5919 `eshurakov/recovery-stack` → `eshurakov/recovery-control-connection`
9. #5920 `eshurakov/recovery-not-ready-retry` → `eshurakov/recovery-stack`

Do not merge out of order.


## Reviewer Notes
Two commits. Unique vs parent.