### PR TITLE
fix(cloud-agent-next): recover and bound native event feeds

### DIFF
--- a/services/cloud-agent-next/test/unit/wrapper/worktree-credential-refresh.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/worktree-credential-refresh.test.ts
@@ -35,7 +35,12 @@ vi.mock('../../../wrapper/src/kilo-api.js', async importOriginal => ({
 }));
 vi.mock('../../../wrapper/src/control/sandbox-control-runtime.js', async importOriginal => ({
   ...(await importOriginal<typeof ControlRuntimeModule>()),
-  startSandboxControlEventFeed: vi.fn(async () => ({ isFresh: () => true })),
+  startSandboxControlEventFeed: vi.fn(async () => ({
+    isFresh: () => true,
+    usable: Promise.resolve(true),
+    close: () => {},
+    settled: Promise.resolve(),
+  })),
 }));
 vi.mock('../../../wrapper/src/restore-session.js', () => ({
   seedSessionIngestRegistration: vi.fn(async () => undefined),
@@ -337,7 +342,12 @@ describe('direct worktree credential refresh', () => {
     async condition => {
       const f = fixture();
       let fresh = true;
-      vi.mocked(startSandboxControlEventFeed).mockResolvedValueOnce({ isFresh: () => fresh });
+      vi.mocked(startSandboxControlEventFeed).mockResolvedValueOnce({
+        isFresh: () => fresh,
+        usable: Promise.resolve(true),
+        close: () => {},
+        settled: Promise.resolve(),
+      });
       await f.attach();
       await f.attach(auth, originalEnv, sibling);
       if (condition === 'stale') fresh = false;
@@ -548,7 +558,7 @@ describe('direct worktree credential refresh', () => {
   });
 
   it.each(['connection', 'http'] as const)(
-    'classifies real SDK SSE startup %s errors without retaining private data',
+    'recovers from real SDK SSE startup %s errors without retaining private data',
     async failure => {
       vi.mocked(fetch).mockImplementation(async request => {
         const url = request instanceof Request ? request.url : String(request);
@@ -582,17 +592,15 @@ describe('direct worktree credential refresh', () => {
       ).toHaveLength(1);
       expect(runtime.signal.aborted).toBe(false);
       feed.onUnexpectedClose(error);
-      await vi.waitFor(() => expect(f.onUnexpectedClose).toHaveBeenCalledTimes(1));
-      expect(f.onUnexpectedClose.mock.calls[0]?.[0]).toMatchObject({
-        directory: identity.directory,
-        reason: 'feed_failed',
-        cleanup: 'confirmed',
-      });
-      expect(runtime.signal.aborted).toBe(true);
+      await vi.waitFor(() =>
+        expect(vi.mocked(startSandboxControlEventFeed)).toHaveBeenCalledTimes(2)
+      );
+      expect(f.onUnexpectedClose).not.toHaveBeenCalled();
+      expect(runtime.signal.aborted).toBe(false);
     }
   );
 
-  it('ignores retired process feed failures but reports current feed errors without private data', async () => {
+  it('ignores retired process feed failures and recovers current feed errors', async () => {
     const f = fixture();
     const runtime = await f.attach();
     const oldFeed = vi.mocked(startSandboxControlEventFeed).mock.calls[0]?.[0];
@@ -606,23 +614,27 @@ describe('direct worktree credential refresh', () => {
     expect(currentFeed).toBeDefined();
     currentFeed?.onUnexpectedClose(new Error('private-current-feed-credential'));
     currentFeed?.onUnexpectedClose(new Error('private-duplicate-feed-credential'));
-    await vi.waitFor(() => expect(f.onUnexpectedClose).toHaveBeenCalledTimes(1));
-    expect(f.onUnexpectedClose.mock.calls[0]?.[0]).toMatchObject({
-      directory: identity.directory,
-      reason: 'feed_failed',
-      cleanup: 'confirmed',
-    });
-    expect(runtime.signal.aborted).toBe(true);
+    await vi.waitFor(() =>
+      expect(vi.mocked(startSandboxControlEventFeed)).toHaveBeenCalledTimes(3)
+    );
+    expect(f.onUnexpectedClose).not.toHaveBeenCalled();
+    expect(runtime.signal.aborted).toBe(false);
   });
 
-  it('does not expose a stale runtime before its watchdog fires', async () => {
+  it('keeps a stale runtime while its feed recovery begins', async () => {
     const f = fixture();
     let fresh = true;
-    vi.mocked(startSandboxControlEventFeed).mockResolvedValueOnce({ isFresh: () => fresh });
-    await f.attach();
+    vi.mocked(startSandboxControlEventFeed).mockResolvedValueOnce({
+      isFresh: () => fresh,
+      usable: Promise.resolve(true),
+      close: () => {},
+      settled: Promise.resolve(),
+    });
+    const runtime = await f.attach();
     fresh = false;
-    expect(f.registry.get(identity.directory)).toBeUndefined();
-    expect(f.registry.isHealthy()).toBe(false);
+    expect(f.registry.prepareForNewWork?.(identity.directory)).toBe(false);
+    expect(f.registry.get(identity.directory)).toBe(runtime);
+    expect(f.registry.isHealthy()).toBe(true);
   });
 
   it('discards heartbeat statuses from a replaced process with the same logical runtime', async () => {

--- a/services/cloud-agent-next/wrapper/src/control/operation-registry.ts
+++ b/services/cloud-agent-next/wrapper/src/control/operation-registry.ts
@@ -25,6 +25,7 @@ type OperationRegistryDependencies = {
     getRetained(
       directory: string
     ): WorktreeKiloRuntimes['get'] extends (directory: string) => infer Runtime ? Runtime : never;
+    prepareForNewWork?(directory: string): boolean;
     retireRuntime(
       directory: string,
       deadlineAt: number,
@@ -206,6 +207,7 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
       ...effects,
       isCurrent: () => active.get(identity.kiloSessionId) === operation,
       getRuntime: () => deps.native.get(identity.directory),
+      prepareForNewWork: () => deps.native.prepareForNewWork?.(identity.directory) ?? true,
       verifyQuiescence: (target, deadlineAt) =>
         deps.native.verifyQuiescence(identity.directory, target, deadlineAt),
       retireRuntime: (reason, deadlineAt, target) => {

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
@@ -665,6 +665,49 @@ describe('handleControlRequest', () => {
     expect(answered).toEqual([{ permissionId: 'perm_1', response: 'once' }]);
   });
 
+  it('fences new work during feed recovery while preserving pending input replies and Stop', async () => {
+    const kiloClient = fakeKilo({
+      getPermissions: async () => [
+        {
+          id: 'perm_1',
+          sessionID: session.kiloSessionId,
+          permission: 'bash',
+          patterns: [],
+          metadata: {},
+          always: [],
+        },
+      ],
+    });
+    const handlerDeps = deps({ kiloClient });
+    const runtimes = handlerDeps.kiloRuntimes;
+    if (!runtimes) throw new Error('Expected Kilo runtimes');
+    runtimes.prepareForNewWork = () => false;
+
+    expect(
+      await handleControlRequest('session.prompt', session, promptPayload, handlerDeps)
+    ).toEqual({
+      ok: false,
+      error: {
+        code: 'not_ready',
+        message: 'Native feed recovery is in progress',
+        retryable: true,
+        admission: 'not-admitted',
+      },
+    });
+    expect(
+      await handleControlRequest(
+        'session.permission.resolve',
+        session,
+        { permissionId: 'perm_1', response: 'once' },
+        handlerDeps
+      )
+    ).toEqual({ ok: true, result: { success: true } });
+    expect(await handleControlRequest('session.abort', session, {}, handlerDeps)).toEqual({
+      ok: true,
+      result: { status: 'already_idle' },
+    });
+  });
+
   it('does not send an unfenced abort when the wrapper owns no work', async () => {
     const aborted: string[] = [];
     const kiloClient = fakeKilo({

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
@@ -328,6 +328,7 @@ export function createControlHandlerDeps(input: Omit<HandlerDeps, 'operations'>)
       native: {
         get: directory => input.kiloRuntimes?.get(directory),
         getRetained: directory => input.kiloRuntimes?.getRetained?.(directory),
+        prepareForNewWork: directory => input.kiloRuntimes?.prepareForNewWork?.(directory) ?? true,
         retireRuntime: (directory, deadlineAt, target) =>
           input.kiloRuntimes?.retireRuntime?.(directory, deadlineAt, target) ??
           Promise.resolve('unconfirmed'),
@@ -492,6 +493,14 @@ export async function handleControlRequest(
   if (operation === 'session.operation.ack') return deps.operations.acknowledge(session, payload);
   const admission = deps.operations.admission(operation, session, payload, authorization);
   if (admission.kind === 'reply') return admission.result;
+  if (
+    (operation === 'session.attach' ||
+      operation === 'session.prompt' ||
+      operation === 'session.terminal.create') &&
+    deps.kiloRuntimes?.prepareForNewWork?.(session.directory) === false
+  ) {
+    return rejectBeforeAdmission('not_ready', 'Native feed recovery is in progress', true);
+  }
   if (
     (deps.signal?.aborted || (!deps.kiloReady && operation !== 'session.git.summary')) &&
     operation !== 'session.abort' &&

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.test.ts
@@ -3,6 +3,7 @@ import {
   KILO_FEED_FRESHNESS_TIMEOUT_MS,
   SANDBOX_CONTROL_REPORT_INTERVAL_MS,
   maybeStartSandboxControlClient,
+  observeKiloFeedResponse,
   startSandboxControlEventFeed,
 } from './sandbox-control-runtime';
 import type { SandboxControlClient, SandboxControlClientOptions } from './sandbox-control-client';
@@ -596,6 +597,31 @@ describe('maybeStartSandboxControlClient', () => {
 });
 
 describe('startSandboxControlEventFeed', () => {
+  it('counts raw SSE activity without requiring a parsed application event', async () => {
+    const abort = new AbortController();
+    const encoder = new TextEncoder();
+    let activity = 0;
+    const response = observeKiloFeedResponse(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode(': heartbeat\n\n'));
+            controller.close();
+          },
+        })
+      ),
+      abort.signal,
+      () => {
+        activity++;
+      }
+    );
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('Missing feed body');
+    let done = false;
+    while (!done) done = (await reader.read()).done;
+    expect(activity).toBe(1);
+  });
+
   it('waits for a real first event before startup and forwards that event', async () => {
     const abort = new AbortController();
     const firstEvent = Promise.withResolvers<void>();
@@ -671,6 +697,77 @@ describe('startSandboxControlEventFeed', () => {
     await new Promise<void>(resolve => setTimeout(resolve, 0));
     expect(closed).toBe(true);
     expect(failures).toEqual([]);
+  });
+
+  it('cancels a stalled iterator without waiting for failed disposal or late chunks', async () => {
+    const abort = new AbortController();
+    const next = Promise.withResolvers<IteratorResult<unknown>>();
+    const reading = Promise.withResolvers<void>();
+    const received: unknown[] = [];
+    const failures: unknown[] = [];
+    let first = true;
+    let returned = 0;
+    const stream = {
+      [Symbol.asyncIterator](): AsyncIterator<unknown> {
+        return {
+          next: () => {
+            if (first) {
+              first = false;
+              return Promise.resolve({ value: { payload: { type: 'server.connected' } } });
+            }
+            reading.resolve();
+            return next.promise;
+          },
+          return: () => {
+            returned += 1;
+            return Promise.reject(new Error('iterator disposal failed'));
+          },
+        };
+      },
+    };
+    const feed = await startSandboxControlEventFeed({
+      signal: abort.signal,
+      open: async () => ({ stream }),
+      consume: async events => {
+        for await (const event of events) received.push(event);
+      },
+      onUnexpectedClose: error => failures.push(error),
+    });
+    await reading.promise;
+    feed.close();
+    await feed.settled;
+    expect(abort.signal.aborted).toBe(false);
+    expect(returned).toBe(1);
+    next.resolve({ value: { payload: { type: 'session.updated' } } });
+    await flushAsyncWork();
+    expect(received).toEqual([{ payload: { type: 'server.connected' } }]);
+    expect(failures).toEqual([]);
+  });
+
+  it('aborts the transformed response reader when a subscription closes', async () => {
+    const abort = new AbortController();
+    const encoder = new TextEncoder();
+    let cancelled = false;
+    const response = observeKiloFeedResponse(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode(': heartbeat\n\n'));
+          },
+          cancel() {
+            cancelled = true;
+          },
+        })
+      ),
+      abort.signal,
+      () => {}
+    );
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('Missing feed body');
+    await reader.read();
+    abort.abort();
+    await reader.closed.catch(() => undefined);
+    expect(cancelled).toBe(true);
   });
 
   it('rejects when the global feed subscription fails', async () => {

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.ts
@@ -3,7 +3,10 @@ import {
   emitControlDiagnostic,
   type ControlDiagnosticReporter,
 } from '../../../src/shared/control-diagnostics.js';
-import type { SandboxHeartbeatPayload } from '../../../src/shared/sandbox-control-protocol.js';
+import {
+  MAX_SANDBOX_CONTROL_FRAME_BYTES,
+  type SandboxHeartbeatPayload,
+} from '../../../src/shared/sandbox-control-protocol.js';
 import {
   createSandboxControlClient,
   type SandboxControlClient,
@@ -32,8 +35,13 @@ type StartOptions = {
 
 type SandboxControlEventFeedOptions = {
   signal: AbortSignal;
-  open: (signal: AbortSignal) => Promise<{ stream?: AsyncIterable<unknown> }>;
+  open: (
+    signal: AbortSignal,
+    onActivity: () => void,
+    onFrame: (frame: string) => void
+  ) => Promise<{ stream?: AsyncIterable<unknown> }>;
   consume: (stream: AsyncIterable<unknown>) => Promise<void>;
+  deadlineAt?: number;
   onUnexpectedClose: (error: unknown) => void;
   onDiagnostic?: ControlDiagnosticReporter;
   now?: () => number;
@@ -73,6 +81,54 @@ export async function withKiloRequestDeadline<T>(
   }
 }
 
+export function observeKiloFeedResponse(
+  response: Response,
+  signal: AbortSignal,
+  onActivity: () => void,
+  onFrame?: (frame: string) => void
+): Response {
+  if (!response.body) return response;
+  let frameBytes = 0;
+  let lineBreaks = 0;
+  let previousCR = false;
+  let frame: number[] = [];
+  return new Response(
+    response.body.pipeThrough(
+      new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) {
+          signal.throwIfAborted();
+          if (chunk.byteLength > 0) onActivity();
+          for (const byte of chunk) {
+            frameBytes++;
+            frame.push(byte);
+            if (frameBytes > MAX_SANDBOX_CONTROL_FRAME_BYTES)
+              throw new KiloEventFeedError(
+                'feed_failed',
+                'Kilo event frame exceeds the transport budget'
+              );
+            if (byte === 13 || byte === 10) {
+              if (!(byte === 10 && previousCR)) lineBreaks++;
+              previousCR = byte === 13;
+              if (lineBreaks >= 2) {
+                onFrame?.(new TextDecoder().decode(Uint8Array.from(frame)));
+                frameBytes = 0;
+                lineBreaks = 0;
+                frame = [];
+              }
+            } else {
+              lineBreaks = 0;
+              previousCR = false;
+            }
+          }
+          controller.enqueue(chunk);
+        },
+      }),
+      { signal }
+    ),
+    { status: response.status, statusText: response.statusText, headers: response.headers }
+  );
+}
+
 function isFeedConnectedEvent(envelope: unknown): boolean {
   return (
     typeof envelope === 'object' &&
@@ -85,20 +141,87 @@ function isFeedConnectedEvent(envelope: unknown): boolean {
   );
 }
 
+function isFeedConnectedFrame(frame: string): boolean {
+  for (const line of frame.split(/\r?\n/)) {
+    if (!line.startsWith('data:')) continue;
+    try {
+      if (isFeedConnectedEvent(JSON.parse(line.slice('data:'.length).trimStart()))) return true;
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
 export async function startSandboxControlEventFeed(
   options: SandboxControlEventFeedOptions
-): Promise<{ isFresh: () => boolean }> {
+): Promise<{
+  isFresh: () => boolean;
+  usable: Promise<boolean>;
+  close: () => void;
+  settled: Promise<void>;
+}> {
   const controller = new AbortController();
   const signal = AbortSignal.any([options.signal, controller.signal]);
   const now = options.now ?? Date.now;
-  let feed: { stream?: AsyncIterable<unknown> };
-  let iterator: AsyncIterator<unknown>;
+  const deadlineAt = Math.min(
+    options.deadlineAt ?? Infinity,
+    now() + KILO_FEED_FRESHNESS_TIMEOUT_MS
+  );
+  let lastEventAt = now();
+  const onActivity = () => {
+    if (!signal.aborted) lastEventAt = now();
+  };
+  const usable = Promise.withResolvers<boolean>();
+  let usableSettled = false;
+  let initialFrameSeen = false;
+  let iterator: AsyncIterator<unknown> | undefined;
+  let disposed = false;
+  let closed = false;
+  const settleUsable = (value: boolean): void => {
+    if (usableSettled) return;
+    usableSettled = true;
+    usable.resolve(value);
+  };
+  const disposeIterator = (): void => {
+    if (disposed || !iterator) return;
+    disposed = true;
+    try {
+      const returned = iterator.return?.();
+      if (returned) void returned.catch(() => undefined);
+    } catch {
+      return;
+    }
+  };
+  const close = (): void => {
+    if (closed) return;
+    closed = true;
+    controller.abort();
+    settleUsable(false);
+    disposeIterator();
+  };
+  signal.addEventListener(
+    'abort',
+    () => {
+      settleUsable(false);
+      disposeIterator();
+    },
+    { once: true }
+  );
+  const onFrame = (frame: string): void => {
+    if (!initialFrameSeen) {
+      initialFrameSeen = true;
+      return;
+    }
+    if (!isFeedConnectedFrame(frame)) settleUsable(true);
+  };
   let first: IteratorResult<unknown>;
   emitControlDiagnostic(options.onDiagnostic, 'control.feed', { phase: 'opening' });
   try {
-    feed = await withTimeoutAndAbort(options.open(signal), {
+    if (now() >= deadlineAt) throw new Error('Kilo feed attempt expired');
+    const feed = await withTimeoutAndAbort(options.open(signal, onActivity, onFrame), {
       signal,
-      timeoutMs: KILO_FEED_FRESHNESS_TIMEOUT_MS,
+      timeoutMs: Math.max(1, deadlineAt - now()),
       timeoutMessage: 'Kilo global event feed startup timed out',
       abortMessage: 'Kilo global event feed cancelled',
     });
@@ -108,7 +231,7 @@ export async function startSandboxControlEventFeed(
     iterator = feed.stream[Symbol.asyncIterator]();
     first = await withTimeoutAndAbort(iterator.next(), {
       signal,
-      timeoutMs: KILO_FEED_FRESHNESS_TIMEOUT_MS,
+      timeoutMs: Math.max(1, deadlineAt - now()),
       timeoutMessage: 'Kilo global event feed startup timed out',
       abortMessage: 'Kilo global event feed cancelled',
     });
@@ -118,11 +241,11 @@ export async function startSandboxControlEventFeed(
     }
   } catch (error) {
     emitControlDiagnostic(options.onDiagnostic, 'control.feed', { phase: 'start_failed' });
-    controller.abort();
+    close();
     throw error;
   }
 
-  let lastEventAt = now();
+  onActivity();
   let eventsReceived = 1;
   const diagnostic = (phase: string): void =>
     emitControlDiagnostic(options.onDiagnostic, 'control.feed', {
@@ -136,7 +259,7 @@ export async function startSandboxControlEventFeed(
   const fail = (error: unknown, phase: 'stale' | 'ended' | 'failed'): void => {
     if (signal.aborted) return;
     diagnostic(phase);
-    controller.abort();
+    close();
     options.onUnexpectedClose(error);
   };
   const freshnessTimer = setInterval(() => {
@@ -150,13 +273,39 @@ export async function startSandboxControlEventFeed(
   freshnessTimer.unref();
   signal.addEventListener('abort', () => clearInterval(freshnessTimer), { once: true });
 
+  const next = (): Promise<IteratorResult<unknown>> => {
+    if (!iterator || signal.aborted) return Promise.resolve({ done: true, value: undefined });
+    let pending: Promise<IteratorResult<unknown>>;
+    try {
+      pending = Promise.resolve(iterator.next());
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const finish = (callback: () => void): void => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener('abort', onAbort);
+        callback();
+      };
+      const onAbort = () => finish(() => resolve({ done: true, value: undefined }));
+      signal.addEventListener('abort', onAbort, { once: true });
+      pending.then(
+        result => finish(() => resolve(result)),
+        error => finish(() => reject(error))
+      );
+      if (signal.aborted) onAbort();
+    });
+  };
+
   async function* establishedFeed(): AsyncGenerator<unknown> {
     try {
       yield first.value;
       while (!signal.aborted) {
-        const next = await iterator.next();
-        if (signal.aborted || next.done) return;
-        if (isFeedConnectedEvent(next.value)) {
+        const value = await next();
+        if (signal.aborted || value.done) return;
+        if (isFeedConnectedEvent(value.value)) {
           diagnostic('reconnected');
           throw new KiloEventFeedError(
             'feed_reconnected',
@@ -165,18 +314,19 @@ export async function startSandboxControlEventFeed(
         }
         lastEventAt = now();
         eventsReceived += 1;
-        yield next.value;
+        settleUsable(true);
+        yield value.value;
       }
     } finally {
-      await iterator.return?.();
+      disposeIterator();
     }
   }
 
-  void options.consume(establishedFeed()).then(
+  const settled = options.consume(establishedFeed()).then(
     () => fail(new KiloEventFeedError('feed_ended', 'Kilo global event feed ended'), 'ended'),
     error => fail(error, 'failed')
   );
-  return { isFresh };
+  return { isFresh, usable: usable.promise, close, settled };
 }
 
 export function maybeStartSandboxControlClient(

--- a/services/cloud-agent-next/wrapper/src/control/session-operation.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-operation.test.ts
@@ -711,4 +711,30 @@ describe('operation results and delivery', () => {
       })
     );
   });
+
+  it('does not fail an admitted prompt when feed recovery starts before submit', async () => {
+    const handlerDeps = deps({
+      sendOperationResult: (_session, delivery) => acknowledgeOperation(delivery),
+    });
+    const runtimes = handlerDeps.kiloRuntimes;
+    if (!runtimes) throw new Error('Expected Kilo runtimes');
+    let allow = true;
+    runtimes.prepareForNewWork = () => {
+      const current = allow;
+      allow = false;
+      return current;
+    };
+
+    await handleControlRequest(
+      'session.prompt',
+      session,
+      promptPayload,
+      handlerDeps,
+      operationAuthorization()
+    );
+    const record = onlyOperation(handlerDeps);
+    await record.done;
+    await record.waitForDelivery();
+    expect(record.snapshot().outcome?.status).toBe('completed');
+  });
 });

--- a/services/cloud-agent-next/wrapper/src/control/session-operation.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-operation.ts
@@ -102,6 +102,7 @@ export type SessionOperationDependencies = {
   signal?: AbortSignal;
   isCurrent: () => boolean;
   getRuntime: () => WorktreeKiloRuntime | undefined;
+  prepareForNewWork?: () => boolean;
   verifyQuiescence: (target: NativeOperationTarget, deadlineAt: number) => Promise<boolean>;
   retireRuntime: (reason: string, deadlineAt: number, target?: NativeOperationTarget) => void;
   emitSessionEvent: (payload: SessionEventPayload, options?: { retained?: true }) => void;
@@ -399,6 +400,8 @@ export class SessionOperation {
     work: Extract<SessionOperationWork, { operation: 'session.attach' }>
   ): Promise<ControlHandlerResult> {
     this.assertCurrent();
+    if (this.deps.prepareForNewWork?.() === false)
+      return fail('Native feed recovery is in progress', true);
     const result = await work.apply(this.session, work.payload, {
       signal: this.signal,
       assertCurrent: () => this.assertCurrent(),

--- a/services/cloud-agent-next/wrapper/src/control/worktree-feed.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-feed.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import { SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS } from '../../../src/shared/sandbox-control-protocol';
+import * as controlRuntime from './sandbox-control-runtime';
+import { createWorktreeFeed } from './worktree-feed';
+
+type FeedOptions = Parameters<typeof controlRuntime.startSandboxControlEventFeed>[0];
+
+function asFetch(
+  fn: (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>
+): typeof fetch {
+  return Object.assign(fn, { preconnect: fetch.preconnect });
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() >= deadline) break;
+    await Bun.sleep(10);
+  }
+  if (condition()) return;
+  throw new Error('Timed out waiting for native feed state');
+}
+
+function nativeFeed(options: FeedOptions) {
+  let fresh = true;
+  return {
+    emit: async (value: unknown) => {
+      await options.consume(
+        (async function* () {
+          yield value;
+        })()
+      );
+    },
+    fail: (reason: controlRuntime.KiloEventFeedError['reason']) => {
+      fresh = false;
+      options.onUnexpectedClose(
+        new controlRuntime.KiloEventFeedError(reason, 'Native feed failed')
+      );
+    },
+    result: {
+      isFresh: () => fresh && !options.signal.aborted,
+      usable: Promise.resolve(true),
+      close: () => {
+        fresh = false;
+      },
+      settled: Promise.resolve(),
+    },
+  };
+}
+
+function fixture(rejectReconnections = false) {
+  const source = {
+    scopeId: 'worktree_a',
+    runtimeId: crypto.randomUUID(),
+    directory: '/workspace',
+    kiloClient: { serverUrl: 'http://127.0.0.1:1' },
+    signal: new AbortController().signal,
+  };
+  const attempts: ReturnType<typeof nativeFeed>[] = [];
+  const failures: string[] = [];
+  const events: Array<{ type: string; properties: Record<string, unknown>; directory?: string }> =
+    [];
+  const start = spyOn(controlRuntime, 'startSandboxControlEventFeed').mockImplementation(
+    async options => {
+      if (rejectReconnections && attempts.length > 0) throw new Error('Feed unavailable');
+      const attempt = nativeFeed(options);
+      attempts.push(attempt);
+      return attempt.result;
+    }
+  );
+  const feed = createWorktreeFeed({
+    source,
+    isCurrent: (runtimeId, kiloClient) =>
+      runtimeId === source.runtimeId && kiloClient === source.kiloClient,
+    onEvent: event => events.push(event),
+    onFailure: reason => failures.push(reason),
+  });
+  return { attempts, events, failures, feed, source, start };
+}
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+
+describe('createWorktreeFeed', () => {
+  it.each(['feed_ended', 'feed_failed', 'feed_stale', 'feed_reconnected'] as const)(
+    'replaces a %s subscription without stopping the native process',
+    async reason => {
+      const h = fixture();
+      cleanups.push(() => {
+        h.feed.close();
+        h.start.mockRestore();
+      });
+      await h.feed.open();
+      const original = h.attempts[0];
+      if (!original) throw new Error('Missing original subscription');
+      original.fail(reason);
+      expect(h.feed.prepareForNewWork()).toBe(false);
+      await waitFor(() => h.attempts.length === 2 && h.feed.isFresh());
+      const replacement = h.attempts[1];
+      if (!replacement) throw new Error('Missing replacement subscription');
+      await original.emit({
+        directory: h.source.directory,
+        payload: { type: 'session.updated', properties: { sessionID: 'stale' } },
+      });
+      await replacement.emit({
+        directory: h.source.directory,
+        payload: { type: 'session.updated', properties: { sessionID: 'current' } },
+      });
+      expect(h.source.signal.aborted).toBe(false);
+      expect(h.feed.prepareForNewWork()).toBe(true);
+      expect(h.events).toEqual([
+        {
+          directory: h.source.directory,
+          type: 'session.updated',
+          properties: { sessionID: 'current' },
+        },
+      ]);
+      expect(h.failures).toEqual([]);
+    }
+  );
+
+  it('exhausts only the original recovery episode when replacement subscriptions cannot open', async () => {
+    const h = fixture(true);
+    cleanups.push(() => {
+      h.feed.close();
+      h.start.mockRestore();
+    });
+    await h.feed.open();
+    h.attempts[0]?.fail('feed_ended');
+    await waitFor(() => h.failures.length === 1);
+    expect(h.start).toHaveBeenCalledTimes(1 + SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS);
+    expect(h.failures).toEqual(['feed_ended']);
+    expect(h.source.signal.aborted).toBe(false);
+    expect(h.feed.prepareForNewWork()).toBe(false);
+  });
+
+  it('does not start a second recovery loop while an earlier attempt is uncertain', async () => {
+    const h = fixture();
+    cleanups.push(() => {
+      h.feed.close();
+      h.start.mockRestore();
+    });
+    await h.feed.open();
+    const original = h.attempts[0];
+    if (!original) throw new Error('Missing original subscription');
+    original.fail('feed_ended');
+    original.fail('feed_failed');
+    await waitFor(() => h.attempts.length === 2 && h.feed.isFresh());
+    expect(h.start).toHaveBeenCalledTimes(2);
+    expect(h.failures).toEqual([]);
+  });
+
+  it('keeps immediate real reconnects inside one bounded recovery episode', async () => {
+    const encoder = new TextEncoder();
+    const connected = encoder.encode(
+      'data: {"payload":{"type":"server.connected","properties":{}}}\n\n'
+    );
+    let closeInitial: (() => void) | undefined;
+    let connections = 0;
+    const failures: string[] = [];
+    const diagnostics: Array<{ event: string; fields: Record<string, unknown> }> = [];
+    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+      asFetch(async () => {
+        connections += 1;
+        const immediateReconnect = connections > 1;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(connected);
+              if (immediateReconnect) {
+                controller.enqueue(connected);
+                controller.close();
+              } else {
+                closeInitial = () => controller.close();
+              }
+            },
+          }),
+          { headers: { 'Content-Type': 'text/event-stream' } }
+        );
+      })
+    );
+    const source = {
+      scopeId: 'worktree_a',
+      runtimeId: crypto.randomUUID(),
+      directory: '/workspace',
+      kiloClient: { serverUrl: 'http://127.0.0.1:1' },
+      signal: new AbortController().signal,
+    };
+    const feed = createWorktreeFeed({
+      source,
+      isCurrent: (runtimeId, kiloClient) =>
+        runtimeId === source.runtimeId && kiloClient === source.kiloClient,
+      onFailure: reason => failures.push(reason),
+      onDiagnostic: (event, fields) => diagnostics.push({ event, fields }),
+    });
+    try {
+      await feed.open();
+      closeInitial?.();
+      await waitFor(() => connections >= 2);
+      expect(feed.prepareForNewWork()).toBe(false);
+      await waitFor(() => failures.length === 1);
+      expect(connections).toBe(1 + SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS);
+      expect(failures).toEqual(['feed_ended']);
+      expect(feed.prepareForNewWork()).toBe(false);
+      expect(diagnostics).toContainEqual(
+        expect.objectContaining({
+          event: 'control.feed',
+          fields: expect.objectContaining({ scopeId: source.scopeId }),
+        })
+      );
+    } finally {
+      feed.close();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it(
+    'expires raw incomplete reconnect activity within the original recovery deadline',
+    async () => {
+      const encoder = new TextEncoder();
+      const connected = encoder.encode(
+        'data: {"payload":{"type":"server.connected","properties":{}}}\n\n'
+      );
+      const rawActivity = encoder.encode(' ');
+      let closeInitial: (() => void) | undefined;
+      let connections = 0;
+      const failures: string[] = [];
+      const activities = new Set<ReturnType<typeof setInterval>>();
+      const source = {
+        scopeId: 'worktree_a',
+        runtimeId: crypto.randomUUID(),
+        directory: '/workspace',
+        kiloClient: { serverUrl: 'http://127.0.0.1:1' },
+        signal: new AbortController().signal,
+      };
+      const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+        asFetch(async () => {
+          connections += 1;
+          let activity: ReturnType<typeof setInterval> | undefined;
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(connected);
+                if (connections === 1) {
+                  closeInitial = () => controller.close();
+                } else {
+                  activity = setInterval(() => controller.enqueue(rawActivity), 1_000);
+                  activities.add(activity);
+                }
+              },
+              cancel() {
+                if (activity) {
+                  clearInterval(activity);
+                  activities.delete(activity);
+                }
+              },
+            }),
+            { headers: { 'Content-Type': 'text/event-stream' } }
+          );
+        })
+      );
+      const feed = createWorktreeFeed({
+        source,
+        isCurrent: (runtimeId, kiloClient) =>
+          runtimeId === source.runtimeId && kiloClient === source.kiloClient,
+        onFailure: reason => failures.push(reason),
+      });
+      try {
+        await feed.open();
+        const recoveryStartedAt = Date.now();
+        closeInitial?.();
+        await waitFor(() => connections === 2);
+        expect(connections).toBe(2);
+
+        await waitFor(
+          () => failures.length === 1,
+          controlRuntime.KILO_FEED_FRESHNESS_TIMEOUT_MS + 5_000
+        );
+
+        expect(Date.now() - recoveryStartedAt).toBeLessThanOrEqual(
+          controlRuntime.KILO_FEED_FRESHNESS_TIMEOUT_MS + 5_000
+        );
+        expect(connections).toBe(4);
+        expect(connections).toBeLessThanOrEqual(1 + SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS);
+        expect(failures).toEqual(['feed_ended']);
+        expect(source.signal.aborted).toBe(false);
+        expect(feed.prepareForNewWork()).toBe(false);
+      } finally {
+        feed.close();
+        for (const activity of activities) clearInterval(activity);
+        fetchSpy.mockRestore();
+      }
+    },
+    controlRuntime.KILO_FEED_FRESHNESS_TIMEOUT_MS + 10_000
+  );
+});

--- a/services/cloud-agent-next/wrapper/src/control/worktree-feed.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-feed.ts
@@ -1,0 +1,257 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import { createKiloClient as createKiloEventClient } from '@kilocode/sdk/v2/client';
+import {
+  emitControlDiagnostic,
+  type ControlDiagnosticReporter,
+} from '../../../src/shared/control-diagnostics.js';
+import { SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS } from '../../../src/shared/sandbox-control-protocol.js';
+import type { WrapperKiloClient } from '../kilo-api.js';
+import { withTimeoutAndAbort } from '../utils.js';
+import { unfilteredKiloEvents } from './feed.js';
+import {
+  KILO_CONTROL_REQUEST_TIMEOUT_MS,
+  KILO_FEED_FRESHNESS_TIMEOUT_MS,
+  KiloEventFeedError,
+  observeKiloFeedResponse,
+  startSandboxControlEventFeed,
+} from './sandbox-control-runtime.js';
+
+export type KiloFeedEvent = {
+  type: string;
+  properties: Record<string, unknown>;
+  directory?: string;
+};
+
+export type WorktreeFeedSource = Readonly<{
+  scopeId: string;
+  runtimeId: string;
+  directory: string;
+  kiloClient: Pick<WrapperKiloClient, 'serverUrl'>;
+  signal: AbortSignal;
+}>;
+
+export type WorktreeFeed = {
+  open(): Promise<void>;
+  isFresh(): boolean;
+  prepareForNewWork(): boolean;
+  close(): void;
+};
+
+type FeedAttempt = {
+  controller: AbortController;
+  failure: PromiseWithResolvers<unknown>;
+  failed: boolean;
+  feed?: Awaited<ReturnType<typeof startSandboxControlEventFeed>>;
+};
+
+type Recovery = {
+  controller: AbortController;
+  deadlineAt: number;
+  reason: KiloEventFeedError['reason'];
+};
+
+export function createWorktreeFeed(options: {
+  source: WorktreeFeedSource;
+  isCurrent: (runtimeId: string, client: WorktreeFeedSource['kiloClient']) => boolean;
+  onEvent?: (event: KiloFeedEvent) => void;
+  onFailure: (reason: KiloEventFeedError['reason']) => void;
+  onStateChange?: () => void;
+  onDiagnostic?: ControlDiagnosticReporter;
+}): WorktreeFeed {
+  const { scopeId, runtimeId, directory, kiloClient, signal: processSignal } = options.source;
+  const lifetime = new AbortController();
+  const signal = AbortSignal.any([lifetime.signal, processSignal]);
+  let active: FeedAttempt | undefined;
+  let recovery: Recovery | undefined;
+  let state: 'opening' | 'ready' | 'recovering' | 'unavailable' = 'opening';
+
+  function isCurrent(): boolean {
+    return !signal.aborted && options.isCurrent(runtimeId, kiloClient);
+  }
+
+  function isCurrentAttempt(attempt: FeedAttempt): boolean {
+    return isCurrent() && active === attempt && !attempt.controller.signal.aborted;
+  }
+
+  function closeActive(): void {
+    const attempt = active;
+    active = undefined;
+    attempt?.controller.abort();
+    const close = attempt?.feed?.close;
+    if (typeof close === 'function') close();
+  }
+
+  function failAttempt(attempt: FeedAttempt, error: unknown): void {
+    if (attempt.failed) return;
+    attempt.failed = true;
+    attempt.failure.resolve(error);
+    attempt.controller.abort();
+    const close = attempt.feed?.close;
+    if (typeof close === 'function') close();
+  }
+
+  async function connect(deadlineAt?: number, cancellation?: AbortSignal): Promise<void> {
+    if (!isCurrent()) throw new Error('Native feed source was superseded');
+    const attempt: FeedAttempt = {
+      controller: new AbortController(),
+      failure: Promise.withResolvers<unknown>(),
+      failed: false,
+    };
+    active = attempt;
+    const attemptSignal = cancellation
+      ? AbortSignal.any([signal, attempt.controller.signal, cancellation])
+      : AbortSignal.any([signal, attempt.controller.signal]);
+    const feed = await startSandboxControlEventFeed({
+      signal: attemptSignal,
+      deadlineAt,
+      open: (feedSignal, onActivity, onFrame) => {
+        const feedFetch: typeof fetch = Object.assign(async (...args: Parameters<typeof fetch>) => {
+          feedSignal.throwIfAborted();
+          const init: RequestInit & { duplex: 'half'; timeout: false } = {
+            ...args[1],
+            duplex: 'half',
+            timeout: false,
+          };
+          const response = await fetch(args[0], init);
+          feedSignal.throwIfAborted();
+          return observeKiloFeedResponse(response, feedSignal, onActivity, onFrame);
+        }, fetch);
+        const eventClient = createKiloEventClient({
+          baseUrl: kiloClient.serverUrl,
+          directory,
+          fetch: feedFetch,
+        });
+        return eventClient.global.event({
+          signal: feedSignal,
+          sseMaxRetryAttempts: 1,
+          onSseError: () => {
+            if (!feedSignal.aborted)
+              throw new KiloEventFeedError('feed_failed', 'Kilo global event feed failed');
+          },
+        });
+      },
+      consume: async stream => {
+        for await (const event of unfilteredKiloEvents(stream)) {
+          if (!isCurrentAttempt(attempt)) return;
+          options.onEvent?.(event);
+        }
+      },
+      onUnexpectedClose: error => {
+        if (!isCurrentAttempt(attempt)) return;
+        failAttempt(attempt, error);
+        if (state === 'ready')
+          recover(error instanceof KiloEventFeedError ? error.reason : 'feed_failed');
+      },
+      onDiagnostic: options.onDiagnostic
+        ? (event, fields) =>
+            emitControlDiagnostic(options.onDiagnostic, event, { ...fields, scopeId })
+        : undefined,
+    });
+    if (!isCurrentAttempt(attempt) || attempt.failed) {
+      feed.close();
+      throw new Error('Native feed attempt was superseded');
+    }
+    attempt.feed = feed;
+    if (deadlineAt !== undefined) {
+      try {
+        const usable = await withTimeoutAndAbort(
+          Promise.race([feed.usable, attempt.failure.promise.then(() => false)]),
+          {
+            signal: attemptSignal,
+            timeoutMs: Math.max(1, deadlineAt - Date.now()),
+            timeoutMessage: 'Kilo global event feed recovery timed out',
+            abortMessage: 'Kilo global event feed recovery cancelled',
+          }
+        );
+        if (!usable || !isCurrentAttempt(attempt) || attempt.failed)
+          throw new Error('Native feed attempt closed before becoming usable');
+      } catch (error) {
+        failAttempt(attempt, error);
+        throw error;
+      }
+    }
+  }
+
+  function unavailable(current: Recovery): void {
+    if (!isCurrent() || recovery !== current) return;
+    recovery = undefined;
+    state = 'unavailable';
+    options.onStateChange?.();
+    options.onFailure(current.reason);
+  }
+
+  async function retry(current: Recovery): Promise<void> {
+    for (let attempt = 1; attempt <= SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS; attempt++) {
+      if (!isCurrent() || recovery !== current || current.controller.signal.aborted) return;
+      const deadlineAt = Math.min(current.deadlineAt, Date.now() + KILO_CONTROL_REQUEST_TIMEOUT_MS);
+      if (Date.now() >= deadlineAt) break;
+      try {
+        await connect(deadlineAt, current.controller.signal);
+        if (!isCurrent() || recovery !== current || current.controller.signal.aborted) return;
+        recovery = undefined;
+        state = 'ready';
+        options.onStateChange?.();
+        return;
+      } catch {
+        if (!isCurrent() || recovery !== current || current.controller.signal.aborted) return;
+        closeActive();
+        if (attempt === SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS || Date.now() >= current.deadlineAt)
+          break;
+        await delay(
+          Math.min(1_000 * 2 ** (attempt - 1), Math.max(0, current.deadlineAt - Date.now())),
+          undefined,
+          { signal: current.controller.signal }
+        ).catch(() => undefined);
+      }
+    }
+    unavailable(current);
+  }
+
+  function recover(reason: KiloEventFeedError['reason']): void {
+    if (!isCurrent() || state === 'unavailable') return;
+    if (recovery) return;
+    const current: Recovery = {
+      controller: new AbortController(),
+      deadlineAt: Date.now() + KILO_FEED_FRESHNESS_TIMEOUT_MS,
+      reason,
+    };
+    recovery = current;
+    state = 'recovering';
+    closeActive();
+    options.onStateChange?.();
+    void retry(current);
+  }
+
+  function close(): void {
+    lifetime.abort();
+    recovery?.controller.abort();
+    recovery = undefined;
+    closeActive();
+  }
+
+  processSignal.addEventListener('abort', close, { once: true });
+  if (processSignal.aborted) close();
+
+  return {
+    async open() {
+      if (!isCurrent()) throw new Error('Native feed source was superseded');
+      if (state === 'unavailable') throw new Error('Native feed recovery is unavailable');
+      closeActive();
+      state = 'opening';
+      await connect();
+      if (!isCurrent()) throw new Error('Native feed source was superseded');
+      state = 'ready';
+      options.onStateChange?.();
+    },
+    isFresh() {
+      return state === 'ready' && active?.feed?.isFresh() === true;
+    },
+    prepareForNewWork() {
+      if (!isCurrent() || state === 'unavailable') return false;
+      if (state === 'ready' && active?.feed?.isFresh() === true) return true;
+      if (state === 'ready') recover('feed_stale');
+      return false;
+    },
+    close,
+  };
+}

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.test.ts
@@ -11,6 +11,8 @@ import {
 } from './worktree-runtime';
 import type { OwnedProcessScope } from './owned-processes';
 import {
+  SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS,
+  SANDBOX_CONTROL_EXECUTION_TIMEOUT_MS,
   sessionMessageOutcomeSchema,
   type SessionEventIdentity,
   type SessionRequestIdentity,
@@ -103,9 +105,11 @@ function asFetch(
 function createKiloStub(health: unknown = { healthy: true, version: '7.4.20' }) {
   const requests: Array<{ pathname: string; directory: string | null; body?: unknown }> = [];
   const permissions: Awaited<ReturnType<WrapperKiloClient['getPermissions']>> = [];
+  const sessionStatuses: Record<string, { type: string }> = {};
   const feeds = new Set<ReadableStreamDefaultController<Uint8Array>>();
   const encoder = new TextEncoder();
   let feedConnections = 0;
+  let heldPrompts: PromiseWithResolvers<void> | undefined;
   const server = Bun.serve({
     port: 0,
     hostname: '127.0.0.1',
@@ -144,7 +148,8 @@ function createKiloStub(health: unknown = { healthy: true, version: '7.4.20' }) 
       if (request.method === 'GET' && url.pathname === '/permission') {
         return Response.json(permissions);
       }
-      if (request.method === 'GET' && url.pathname === '/session/status') return Response.json({});
+      if (request.method === 'GET' && url.pathname === '/session/status')
+        return Response.json(sessionStatuses);
       if (request.method === 'GET' && url.pathname === '/pty') return Response.json([]);
       if (request.method === 'POST' && url.pathname.startsWith('/permission/')) {
         const id = decodeURIComponent(url.pathname.split('/')[2]);
@@ -154,6 +159,7 @@ function createKiloStub(health: unknown = { healthy: true, version: '7.4.20' }) 
         return Response.json(true);
       }
       if (request.method === 'POST' && url.pathname.endsWith('/abort')) {
+        heldPrompts?.resolve();
         return Response.json(true);
       }
       if (request.method === 'POST' && /\/session\/[^/]+\/(message|command)$/.test(url.pathname)) {
@@ -175,6 +181,7 @@ function createKiloStub(health: unknown = { healthy: true, version: '7.4.20' }) 
           },
           parts: [],
         };
+        await heldPrompts?.promise;
         return Response.json(completion);
       }
       if (request.method === 'GET' && url.pathname.startsWith('/session/')) {
@@ -198,11 +205,18 @@ function createKiloStub(health: unknown = { healthy: true, version: '7.4.20' }) 
     url: server.url.toString(),
     requests,
     permissions,
+    sessionStatuses,
     get feedConnections() {
       return feedConnections;
     },
     emit(event: unknown) {
       for (const feed of feeds) feed.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+    },
+    holdPrompts() {
+      heldPrompts ??= Promise.withResolvers<void>();
+    },
+    releasePrompts() {
+      heldPrompts?.resolve();
     },
     endFeeds() {
       for (const feed of feeds) feed.close();
@@ -594,7 +608,7 @@ describe('worktree Kilo runtime registry', () => {
   });
 
   it.each(['stream-error', 'feed-end', 'reconnect'] as const)(
-    'classifies real SDK SSE %s without exposing private errors or reconnecting',
+    'retires real SDK SSE %s only after bounded observer recovery fails',
     async failure => {
       const connected = 'data: {"payload":{"type":"server.connected","properties":{}}}\n\n';
       const encoder = new TextEncoder();
@@ -646,7 +660,7 @@ describe('worktree Kilo runtime registry', () => {
             ([request]) =>
               request instanceof Request && new URL(request.url).pathname === '/global/event'
           )
-        ).toHaveLength(1);
+        ).toHaveLength(1 + SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS);
       } finally {
         harness.registry.shutdown();
         fetchSpy.mockRestore();
@@ -708,9 +722,11 @@ describe('worktree Kilo runtime registry', () => {
     expect(harness.registry.get(identity.directory)).toBe(refreshed);
     expect(harness.unexpectedCloses).toBe(0);
     servers[1]?.endFeeds();
-    await waitUntil(() => harness.unexpectedCloses === 1);
-    expect(runtime.signal.aborted).toBe(true);
+    await waitUntil(() => (servers[1]?.feedConnections ?? 0) === 2);
+    expect(runtime.signal.aborted).toBe(false);
     expect(harness.registry.isHealthy()).toBe(true);
+    expect(harness.registry.get(identity.directory)).toBe(refreshed);
+    expect(harness.unexpectedCloses).toBe(0);
   });
 
   it('isolates different worktrees with separate servers, homes, auth files, and event clients', async () => {
@@ -1419,14 +1435,153 @@ describe('worktree Kilo runtime registry', () => {
     expect(stub.feedConnections).toBe(0);
   });
 
-  it('invalidates a runtime and reports an unexpected event-feed closure', async () => {
+  it('replaces an unexpected event-feed closure without invalidating its runtime', async () => {
     const harness = createRegistry();
     const runtime = await harness.registry.ensure(path.join(tmpDir, 'a'), auth);
     servers[0]?.endFeeds();
-    await waitUntil(() => harness.unexpectedCloses === 1);
+    await waitUntil(() => (servers[0]?.feedConnections ?? 0) === 2);
+    expect(runtime.signal.aborted).toBe(false);
+    expect(harness.registry.get(runtime.directory)).toBe(runtime);
+    expect(harness.closes).toBe(0);
+    expect(harness.unexpectedCloses).toBe(0);
+  });
+
+  it('retires a runtime on process exit independently of feed recovery', async () => {
+    const exited = Promise.withResolvers<void>();
+    const server = createKiloStub();
+    const failures: unknown[] = [];
+    servers.push(server);
+    const harness = createRegistry({
+      startServer: async options => {
+        options.onProcessScope?.({ stop: async () => true } as unknown as OwnedProcessScope);
+        return { url: server.url, close() {}, exited: exited.promise };
+      },
+      onUnexpectedClose: failure => failures.push(failure),
+    });
+    const runtime = await harness.registry.ensure(path.join(tmpDir, 'process-exit'), auth);
+    exited.resolve();
+    await waitUntil(() => failures.length === 1);
+    expect(failures).toEqual([
+      expect.objectContaining({
+        directory: runtime.directory,
+        reason: 'process_exited',
+        cleanup: 'confirmed',
+        runtimeId: runtime.runtimeId,
+      }),
+    ]);
     expect(runtime.signal.aborted).toBe(true);
     expect(harness.registry.get(runtime.directory)).toBeUndefined();
-    expect(harness.closes).toBe(1);
+  });
+
+  it('preserves an admitted operation and its runtime while a real feed recovers', async () => {
+    const timers = spyOn(globalThis, 'setTimeout');
+    const harness = createRegistry({
+      startServer: async options => {
+        const server = createKiloStub();
+        servers.push(server);
+        options.onProcessScope?.({
+          stop: async () => true,
+          verify: async () => true,
+        } as unknown as OwnedProcessScope);
+        return { url: server.url, close() {} };
+      },
+    });
+    const identity = rootIdentity(path.join(tmpDir, 'recovery'));
+    const runtime = await harness.registry.ensure(identity.directory, auth);
+    const server = servers.find(item => item.url === runtime.kiloClient.serverUrl);
+    if (!server) throw new Error('Missing Kilo test server');
+    const deps = createHandlerDeps(harness.registry);
+    const client = runtime.kiloClient;
+    const prompt = {
+      messageId: 'feed_recovery',
+      turn: { type: 'prompt' as const, prompt: 'continue the admitted work' },
+      agent: { mode: 'code', model: 'test' },
+    };
+    server.sessionStatuses[identity.kiloSessionId] = { type: 'idle' };
+    server.holdPrompts();
+    server.permissions.push({
+      id: 'permission_recovery',
+      sessionID: identity.kiloSessionId,
+      permission: 'bash',
+      patterns: [],
+      metadata: {},
+      always: [],
+    });
+    try {
+      expect(await handleControlRequest('session.prompt', identity, prompt, deps)).toEqual({
+        ok: true,
+        result: { messageId: prompt.messageId, status: 'accepted' },
+      });
+      await waitUntil(() =>
+        server.requests.some(
+          request => request.pathname === `/session/${identity.kiloSessionId}/message`
+        )
+      );
+      const executionDeadlineCount = timers.mock.calls.filter(
+        ([, ms]) => ms === SANDBOX_CONTROL_EXECUTION_TIMEOUT_MS
+      ).length;
+      expect(executionDeadlineCount).toBeGreaterThan(0);
+
+      server.endFeeds();
+      await waitUntil(() => server.feedConnections === 2);
+      expect(harness.registry.prepareForNewWork?.(identity.directory)).toBe(false);
+      expect(harness.registry.get(identity.directory)).toBe(runtime);
+      expect(runtime.kiloClient).toBe(client);
+      expect(runtime.kiloClient.serverUrl).toBe(client.serverUrl);
+      expect(
+        await handleControlRequest(
+          'session.prompt',
+          identity,
+          { ...prompt, messageId: 'feed_recovery_rejected' },
+          deps
+        )
+      ).toEqual({
+        ok: false,
+        error: {
+          code: 'not_ready',
+          message: 'Native feed recovery is in progress',
+          retryable: true,
+          admission: 'not-admitted',
+        },
+      });
+      expect(
+        await handleControlRequest(
+          'session.permission.resolve',
+          identity,
+          { permissionId: 'permission_recovery', response: 'once' },
+          deps
+        )
+      ).toEqual({ ok: true, result: { success: true } });
+      const stopping = handleControlRequest(
+        'session.abort',
+        identity,
+        { messageId: prompt.messageId },
+        deps
+      );
+      await waitUntil(() =>
+        server.requests.some(
+          request => request.pathname === `/session/${identity.kiloSessionId}/abort`
+        )
+      );
+      expect(await stopping).toEqual({ ok: true, result: { status: 'aborted' } });
+      expect(
+        server.requests.filter(
+          request => request.pathname === `/session/${identity.kiloSessionId}/message`
+        )
+      ).toHaveLength(1);
+      expect(
+        timers.mock.calls.filter(([, ms]) => ms === SANDBOX_CONTROL_EXECUTION_TIMEOUT_MS)
+      ).toHaveLength(executionDeadlineCount);
+
+      server.emit({ payload: { type: 'server.heartbeat', properties: {} } });
+      await waitUntil(() => harness.registry.prepareForNewWork?.(identity.directory) === true);
+      expect(harness.registry.get(identity.directory)).toBe(runtime);
+      expect(runtime.kiloClient).toBe(client);
+      expect(harness.unexpectedCloses).toBe(0);
+    } finally {
+      server.releasePrompts();
+      timers.mockRestore();
+    }
   });
 });
 

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
@@ -5,10 +5,7 @@ import path from 'node:path';
 import { createKiloClient } from '@kilocode/sdk';
 import { createKiloClient as createKiloEventClient } from '@kilocode/sdk/v2/client';
 import { CONTROL_PLANE_SANDBOX_PERMISSION } from '../../../src/shared/control-plane-permission.js';
-import {
-  emitControlDiagnostic,
-  type ControlDiagnosticReporter,
-} from '../../../src/shared/control-diagnostics.js';
+import type { ControlDiagnosticReporter } from '../../../src/shared/control-diagnostics.js';
 import { safeSandboxRuntimeVersion } from '../../../src/shared/sandbox-status.js';
 import {
   SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS,
@@ -24,16 +21,12 @@ import {
 } from '../kilo-api.js';
 import { withTimeoutAndAbort } from '../utils.js';
 import { isKiloServerProcess } from '../tool-cgroup.js';
-import { unfilteredKiloEvents } from './feed.js';
 import { createOwnedProcessScope, type OwnedProcessScope } from './owned-processes.js';
 import type { NativeOperationTarget, NativeRetirement } from './session-operation-cleanup.js';
 import { retireWorktreeRuntime } from './worktree-runtime-cleanup.js';
 import { forgetAttachedRoot, rememberAttachedRoot } from './session-directories.js';
-import {
-  KiloEventFeedError,
-  startSandboxControlEventFeed,
-  withKiloRequestDeadline,
-} from './sandbox-control-runtime.js';
+import { withKiloRequestDeadline, type KiloEventFeedError } from './sandbox-control-runtime.js';
+import { createWorktreeFeed, type WorktreeFeed } from './worktree-feed.js';
 
 export type WorktreeKiloAuth = NonNullable<SessionAttachPayload['kilo']>;
 
@@ -85,6 +78,7 @@ export type WorktreeKiloRuntimes = {
   ): Promise<boolean>;
   getRetained?(directory: string): WorktreeKiloRuntime | undefined;
   get(directory: string): WorktreeKiloRuntime | undefined;
+  prepareForNewWork?(directory: string): boolean;
   isHealthy(): boolean;
   shutdown(): void;
 };
@@ -124,7 +118,7 @@ type RuntimeEntry = {
   processIssued?: boolean;
   runtimeId: string;
   pendingPtys: number;
-  feed?: Awaited<ReturnType<typeof startSandboxControlEventFeed>>;
+  feed?: WorktreeFeed;
   starting?: Promise<WorktreeKiloRuntime>;
   stopped?: Promise<void>;
   retiring?: Promise<NativeRetirement>;
@@ -441,6 +435,8 @@ export function createWorktreeKiloRuntimes(options: {
     beforeMutation?: () => void
   ): Promise<WorktreeKiloRuntime> {
     const abort = new AbortController();
+    entry.feed?.close();
+    entry.feed = undefined;
     entry.processes = undefined;
     entry.processIssued = false;
     entry.stopped = undefined;
@@ -535,48 +531,36 @@ export function createWorktreeKiloRuntimes(options: {
         },
         signal: entry.abort.signal,
       };
+      const feed = createWorktreeFeed({
+        source: {
+          scopeId: entry.kilo.scopeId,
+          runtimeId: entry.runtimeId,
+          directory: entry.directory,
+          kiloClient: runtimeKiloClient,
+          signal: abort.signal,
+        },
+        isCurrent: (runtimeId, client) =>
+          entries.get(entry.directory) === entry &&
+          entry.runtimeId === runtimeId &&
+          entry.kiloClient === client &&
+          entry.processAbort === abort,
+        onEvent: event => options.onEvent?.(runtime, event),
+        onFailure: reason => failRuntime(entry, reason),
+        onDiagnostic: options.onDiagnostic,
+      });
+      entry.feed = feed;
+      await withTimeoutAndAbort(feed.open(), {
+        timeoutMs: KILO_STARTUP_TIMEOUT_MS,
+        timeoutMessage: 'Kilo event feed startup timed out',
+        signal: abort.signal,
+        abortMessage: 'Kilo worktree closed',
+      });
+      abort.signal.throwIfAborted();
+      entry.runtime = runtime;
       const eventClient = createKiloEventClient({
         baseUrl: server.url,
         directory: entry.directory,
       });
-      entry.feed = await withTimeoutAndAbort(
-        startSandboxControlEventFeed({
-          signal: abort.signal,
-          onDiagnostic: (event, fields) =>
-            emitControlDiagnostic(options.onDiagnostic, event, {
-              ...fields,
-              scopeId: entry.kilo.scopeId,
-            }),
-          open: signal =>
-            eventClient.global.event({
-              signal,
-              sseMaxRetryAttempts: 1,
-              onSseError: () => {
-                if (!signal.aborted) {
-                  throw new KiloEventFeedError('feed_failed', 'Kilo global event feed failed');
-                }
-              },
-            }),
-          consume: async stream => {
-            for await (const event of unfilteredKiloEvents(stream)) {
-              if (abort.signal.aborted) return;
-              options.onEvent?.(runtime, event);
-            }
-          },
-          onUnexpectedClose: error => {
-            if (abort.signal.aborted) return;
-            failRuntime(entry, error instanceof KiloEventFeedError ? error.reason : 'feed_failed');
-          },
-        }),
-        {
-          timeoutMs: KILO_STARTUP_TIMEOUT_MS,
-          timeoutMessage: 'Kilo event feed startup timed out',
-          signal: abort.signal,
-          abortMessage: 'Kilo worktree closed',
-        }
-      );
-      abort.signal.throwIfAborted();
-      entry.runtime = runtime;
       void withKiloRequestDeadline(
         signal => eventClient.global.health({ signal }),
         abort.signal
@@ -894,16 +878,22 @@ export function createWorktreeKiloRuntimes(options: {
     get(directory) {
       const entry = entries.get(directory);
       const runtime = entry?.starting ? undefined : entry?.runtime;
-      return !closed && runtime && !runtime.signal.aborted && entry?.feed?.isFresh()
-        ? runtime
-        : undefined;
+      return !closed && runtime && !runtime.signal.aborted ? runtime : undefined;
+    },
+    prepareForNewWork(directory) {
+      const entry = entries.get(directory);
+      return (
+        !entry ||
+        (!entry.abort.signal.aborted &&
+          (entry.runtime === undefined || entry.feed?.prepareForNewWork() === true))
+      );
     },
     isHealthy() {
       const healthy = [...entries.values()].some(
         entry =>
           entry.retiring === undefined &&
           !entry.abort.signal.aborted &&
-          (entry.starting !== undefined || !entry.runtime || entry.feed?.isFresh() === true)
+          (entry.starting !== undefined || !entry.runtime || !entry.runtime.signal.aborted)
       );
       return !closed && failedDirectories.size === 0 && (entries.size === 0 || healthy);
     },


### PR DESCRIPTION
## Summary
- Recover native event feeds after wrapper/runtime loss without treating the feed as lossless history.
- Bound feed recovery so reconnects cannot grow without a terminal limit.

## Stack
Control-plane recovery stack. Merge from the bottom. Each PR targets its parent, not `main` (except #5912).

1. #5912 `eshurakov/recovery-observation` → `main`
2. #5913 `eshurakov/recovery-results` → `eshurakov/recovery-observation`
3. #5914 `eshurakov/recovery-stop-scope` → `eshurakov/recovery-results`
4. #5915 `eshurakov/recovery-native-cleanup` → `eshurakov/recovery-stop-scope`
5. #5916 `eshurakov/recovery-session-delivery` → `eshurakov/recovery-native-cleanup`
6. #5917 `eshurakov/recovery-native-feed` → `eshurakov/recovery-session-delivery`
7. #5918 `eshurakov/recovery-control-connection` → `eshurakov/recovery-native-feed`
8. #5919 `eshurakov/recovery-stack` → `eshurakov/recovery-control-connection`
9. #5920 `eshurakov/recovery-not-ready-retry` → `eshurakov/recovery-stack`

Do not merge out of order.


## Reviewer Notes
Two commits. Unique vs parent.