### PR TITLE
feat(cloud-agent-next): recover control connections with event receipts

### DIFF
--- a/services/cloud-agent-next/src/persistence/SandboxControl.ts
+++ b/services/cloud-agent-next/src/persistence/SandboxControl.ts
@@ -30,6 +30,7 @@ import { getSandboxSessionStub } from '../sandbox-session/session-stub.js';
 import {
   createSandboxControlSocketHandler,
   type SandboxControlConnectionIdentity,
+  type SandboxControlEventResult,
   readSandboxControlConnection,
   type SandboxControlOutboundRequest,
   type SandboxControlSocketHandler,
@@ -149,7 +150,17 @@ import {
   loadNativeRuntimeRetirements,
   saveNativeRuntimeRetirements,
   type NativeRuntimeRetirementReceipt,
+  loadRecoveryDecisions,
+  saveRecoveryDecisions,
 } from '../sandbox-control/durable-state.js';
+import * as controlRecovery from '../sandbox-control/control-recovery.js';
+import { createRecoveryExecution } from '../sandbox-control/recovery-execution.js';
+import { createRecoveryAuthority } from '../sandbox-control/recovery-authority.js';
+import {
+  canRecoveryRetirementStopAllocation,
+  createRecoveryCleanup,
+  RECOVERY_CLEANUP_REASON,
+} from '../sandbox-control/recovery-cleanup.js';
 import {
   createNativeRuntimeRetirementWorkflow,
   matchesNativeRuntimeRetirementAllocation,
@@ -343,10 +354,43 @@ export class SandboxControl extends DurableObject<Env> {
   private worktreeDeletionChain: Promise<unknown> = Promise.resolve();
   private operationalInitialization: Promise<void> | null = null;
   private readonly nativeRuntimeRetirement: NativeRuntimeRetirementWorkflow;
+  private readonly recoveryAuthority: ReturnType<typeof createRecoveryAuthority>;
+  private readonly recoveryCleanup: ReturnType<typeof createRecoveryCleanup>;
+  private readonly recoveryExecution = createRecoveryExecution({
+    storage: this.ctx.storage,
+    sendRequest: request => this.socketHandler.sendRequest(request),
+    loadPhysical: () => loadPhysicalRecord(this.ctx.storage),
+    loadAuthority: recovery => this.recoveryAuthority.load(recovery),
+    onReady: (identity, recovery) => this.commitWrapperReady(identity, recovery),
+    reconcileStops: authority => this.recoveryAuthority.reconcileStops(authority),
+    reconcileOperations: authority => this.recoveryAuthority.reconcileOperations(authority),
+    onActivated: identity => this.activateWrapperReady(identity),
+    scheduleAlarm: deadlines => this.scheduleAlarm(deadlines),
+  });
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.sandboxId = ctx.id.name ?? ctx.id.toString();
+    this.recoveryAuthority = createRecoveryAuthority({
+      storage: ctx.storage,
+      env,
+      sandboxId: this.sandboxId,
+    });
+    this.recoveryCleanup = createRecoveryCleanup({
+      storage: ctx.storage,
+      retirement: { retire: input => this.nativeRuntimeRetirement.retire(input) },
+      getConnection: () =>
+        this.nativeRetirementConnection(
+          this.socketHandler.getConnectionIdentity() ?? this.activeConnection
+        ),
+      supportsTargetedRetirement: () => this.supportsNativeRuntimeRetirement(),
+      persistPhysical: (from, to, reason) => this.persistPhysicalState(from, to, reason),
+      onPhysicalStop: async (from, to, reason) => {
+        await this.afterPhysicalPersistence(from, to, reason, to.stopTombstone?.wrapperInstanceId);
+        this.ctx.waitUntil(this.recordStopAttempt());
+      },
+      scheduleAlarm: deadlines => this.scheduleAlarm(deadlines),
+    });
     this.provider = this.createProviderAdapter('cloudflare');
     this.ctx.setWebSocketAutoResponse(
       new WebSocketRequestResponsePair(SANDBOX_CONTROL_AUTO_PING, SANDBOX_CONTROL_AUTO_PONG)
@@ -356,10 +400,17 @@ export class SandboxControl extends DurableObject<Env> {
       onHandshakeComplete: (identity, runtime) => this.onHandshakeComplete(identity, runtime),
       onReady: identity => this.onWrapperReady(identity),
       onHeartbeat: (payload, identity) => this.onHeartbeat(payload, identity),
-      onSessionEvent: (sessionIdentity, payload, identity) =>
-        this.onSessionEvent(sessionIdentity, payload, identity),
-      onSessionPreparing: (sessionIdentity, payload, identity) =>
-        this.onSessionPreparing(sessionIdentity, payload, identity),
+      onSessionEvent: (sessionIdentity, payload, identity, receiptId, receiptHash, sequence) =>
+        this.onSessionEvent(sessionIdentity, payload, identity, receiptId, receiptHash, sequence),
+      onSessionPreparing: (sessionIdentity, payload, identity, receiptId, receiptHash, sequence) =>
+        this.onSessionPreparing(
+          sessionIdentity,
+          payload,
+          identity,
+          receiptId,
+          receiptHash,
+          sequence
+        ),
       onOperationResult: (session, delivery, identity) =>
         this.onOperationResult(session, delivery, identity),
       onNativeRuntimeRetired: (payload, identity) => this.onNativeRuntimeRetired(payload, identity),
@@ -374,7 +425,9 @@ export class SandboxControl extends DurableObject<Env> {
           const connection = this.socketHandler.getConnectionIdentity();
           return connection ? (this.nativeRetirementConnection(connection) ?? null) : null;
         },
-        sameConnection: (left, right) => this.sameConnection(left, right),
+        sameLifetime: (left, right) =>
+          left.providerInstanceId === right.providerInstanceId &&
+          left.wrapperInstanceId === right.wrapperInstanceId,
       },
       transport: {
         supportsTargetedRetirement: () => this.supportsNativeRuntimeRetirement(),
@@ -392,11 +445,12 @@ export class SandboxControl extends DurableObject<Env> {
   private ensureOperationalInitialized(): Promise<void> {
     return (this.operationalInitialization ??= this.ctx.blockConcurrencyWhile(async () => {
       const ctx = this.ctx;
-      const [readyAt, runtime, kind, physical] = await Promise.all([
+      const [readyAt, runtime, kind, physical, recovery] = await Promise.all([
         ctx.storage.get<number>(WRAPPER_READY_AT_KEY),
         ctx.storage.get<PersistedWrapperRuntime>(ACTIVE_WRAPPER_RUNTIME_KEY),
         ctx.storage.get<AgentSandboxProvider>(PROVIDER_KIND_KEY),
         loadPhysicalRecord(ctx.storage),
+        loadRecoveryDecisions(ctx.storage),
       ]);
       this.vercelLocator = vercelProviderLocatorSchema
         .optional()
@@ -430,10 +484,13 @@ export class SandboxControl extends DurableObject<Env> {
         runtime.readyConnectionId === current.connectionId &&
         readyAt !== undefined
       ) {
-        this.readyConnectionId = current.connectionId;
-        this.kiloReady = true;
+        if (recovery.every(item => item.activationAcknowledgedAt !== undefined)) {
+          this.readyConnectionId = current.connectionId;
+          this.kiloReady = true;
+        }
       } else {
-        this.kiloReady = !runtime && current !== null && readyAt !== undefined;
+        this.kiloReady =
+          !runtime && current !== null && readyAt !== undefined && recovery.length === 0;
       }
     }));
   }
@@ -637,7 +694,11 @@ export class SandboxControl extends DurableObject<Env> {
         Date.now() >= sessionOperationExpiresAt(maintenanceAuthorization.data))
     )
       throw new Error('Invalid session operation maintenance authorization');
-    const usesMaintenanceChannel = maintenance || scopedStop !== undefined;
+    const recoveryInteraction =
+      (input.operation === 'session.permission.resolve' ||
+        input.operation === 'session.question.resolve') &&
+      this.socketHandler.supportsConnectionRecovery();
+    const usesMaintenanceChannel = maintenance || scopedStop !== undefined || recoveryInteraction;
     const runtime = usesMaintenanceChannel
       ? this.socketHandler.getConnectionIdentity()
       : this.readyWrapperRuntime();
@@ -659,6 +720,21 @@ export class SandboxControl extends DurableObject<Env> {
         : this.readyWrapperRuntime();
       return current !== null && this.sameConnection(current, runtime);
     };
+    if (
+      maintenanceAuthorization?.success &&
+      maintenanceAuthorization.data.wrapperInstanceId !== runtime.wrapperInstanceId
+    )
+      throw new Error('Sandbox wrapper runtime changed');
+    if (
+      !usesMaintenanceChannel &&
+      input.session &&
+      !controlRecovery.admitsRecoveryRequest(
+        await loadRecoveryDecisions(this.ctx.storage),
+        runtime,
+        input.session
+      )
+    )
+      throw new Error('Session recovery is not ready');
     const physical = await loadPhysicalRecord(this.ctx.storage);
     if (
       ((!maintenance || scopedStop !== undefined) && physical.state !== 'running') ||
@@ -712,6 +788,14 @@ export class SandboxControl extends DurableObject<Env> {
         ) {
           throw new Error('Session is not attached to a ready sandbox runtime');
         }
+        if (
+          !controlRecovery.admitsRecoveryRequest(
+            await loadRecoveryDecisions(this.ctx.storage),
+            runtime,
+            identity.data
+          )
+        )
+          throw new Error('Session recovery is not ready');
         this.assertWorktreeAdmission(route.worktreeId);
         const now = Date.now();
         if (input.operation === 'session.prompt') {
@@ -744,6 +828,7 @@ export class SandboxControl extends DurableObject<Env> {
       });
     }
     if (!usesMaintenanceChannel) await this.assertRequestWorktreeAdmission(input);
+    if (recoveryInteraction) await this.assertRecoveryInteraction(input, runtime, physical);
     if (!isCurrent()) throw new Error('Sandbox wrapper runtime changed');
     if (scopedStop) {
       const payload = sessionAbortPayloadSchema.parse(input.payload);
@@ -869,6 +954,58 @@ export class SandboxControl extends DurableObject<Env> {
       }
     }
     return response;
+  }
+
+  private async assertRecoveryInteraction(
+    input: SandboxControlOutboundRequest,
+    runtime: SandboxControlConnectionIdentity,
+    physical: PhysicalRecord
+  ): Promise<void> {
+    const session = sessionRequestIdentitySchema.parse(input.session);
+    const payload = parseOperationPayload(input.operation, input.payload);
+    if (!payload.ok) throw new Error(payload.error.message);
+    await this.ctx.storage.transaction(async tx => {
+      const current = await loadPhysicalRecord(tx);
+      const route = (await loadRouteTable(tx)).get(session.sessionId);
+      const recovery = (await loadRecoveryDecisions(tx)).find(item =>
+        controlRecovery.sameRuntime(item, runtime)
+      );
+      const authority = recovery?.authority;
+      const root = authority?.roots?.find(item => item.sessionId === session.sessionId);
+      if (
+        this.runtimeDeleted ||
+        !runtime.recoveryCapable ||
+        !this.isCurrentConnection(runtime) ||
+        current.state !== 'running' ||
+        current.stopTombstone !== null ||
+        !sameAllocation(physical, current) ||
+        current.providerRef !== runtime.providerInstanceId ||
+        !route ||
+        route.kiloSessionId !== session.kiloSessionId ||
+        route.directory !== session.directory ||
+        route.retiringNativeRuntimeId !== undefined ||
+        (!recovery && !this.readyWrapperRuntime()) ||
+        (recovery &&
+          (!controlRecovery.sameConnection(recovery, runtime) ||
+            (root?.decision !== 'ready' &&
+              (recovery.exhaustedAt !== undefined ||
+                Date.now() >= (recovery.activationCommitDeadlineAt ?? recovery.deadlineAt))))) ||
+        (authority &&
+          (authority.allocation.providerRef !== current.providerRef ||
+            authority.allocation.createIntentId !== current.createIntent?.intentId ||
+            !root ||
+            root.ownerId !== route.ownerId ||
+            root.kiloSessionId !== route.kiloSessionId ||
+            root.directory !== route.directory ||
+            root.nativeRuntimeId !== route.nativeRuntimeId ||
+            root.observation === 'stale' ||
+            root.decision === 'stop_pending' ||
+            root.decision === 'execution_expired'))
+      )
+        throw new Error('Session interaction scope is stale');
+      this.assertWorktreeAdmission(route.worktreeId);
+      this.assertWorktreeAdmission(this.worktreeIdFromDirectory(session.directory));
+    });
   }
 
   private async requestWorktreeChanges(
@@ -1036,6 +1173,7 @@ export class SandboxControl extends DurableObject<Env> {
         physical,
         route: targetRoute,
         reason: input.reason,
+        cleanupDeadlineAt: Date.now() + DEADLINE_MS.stopAttempt,
       });
       if (retirement === 'retired') return { quarantined: true, disposition: 'native_retired' };
       if (retirement === 'pending') return { quarantined: true, disposition: 'native_pending' };
@@ -2805,7 +2943,26 @@ export class SandboxControl extends DurableObject<Env> {
       return;
     }
     if (id === 'wrapperReadiness' || id === 'startup') {
-      const physical = await loadPhysicalRecord(this.ctx.storage);
+      const [physical, runtime, recovery, readyAt] = await Promise.all([
+        loadPhysicalRecord(this.ctx.storage),
+        this.ctx.storage.get<PersistedWrapperRuntime>(ACTIVE_WRAPPER_RUNTIME_KEY),
+        loadRecoveryDecisions(this.ctx.storage),
+        this.ctx.storage.get<number>(WRAPPER_READY_AT_KEY),
+      ]);
+      if (
+        runtime?.recoveryCapable &&
+        runtime.providerInstanceId === physical.providerRef &&
+        (readyAt !== undefined ||
+          recovery.some(
+            item =>
+              controlRecovery.sameRuntime(item, runtime) &&
+              (item.cause !== 'activation_pending' || controlRecovery.activationCommitted(item))
+          ))
+      ) {
+        await this.exhaustExpiredRecovery(Date.now());
+        await this.reconcileExhaustedRecovery();
+        return;
+      }
       if (physical.state === 'creating' || physical.state === 'running') {
         await this.markFailed();
       }
@@ -2813,7 +2970,31 @@ export class SandboxControl extends DurableObject<Env> {
     }
     if (id === 'heartbeatExpiry') {
       const connection = this.activeConnection;
-      if (connection) await this.quarantineConnection(connection, 'heartbeat_expired');
+      if (connection?.recoveryCapable) {
+        await this.beginControlRecovery(connection, 'heartbeat_expired');
+        this.socketHandler.closeHandshakenSockets(4002, 'application_report_expired');
+      } else if (connection) await this.quarantineConnection(connection, 'heartbeat_expired');
+      return;
+    }
+    if (id === 'recoveryExpiry') {
+      await this.exhaustExpiredRecovery(Date.now());
+      await this.reconcileExhaustedRecovery();
+      return;
+    }
+    if (id === 'recoveryRetry') {
+      await this.reconcileExhaustedRecovery();
+      const connection = this.activeConnection;
+      if (connection?.recoveryCapable)
+        this.ctx.waitUntil(
+          this.recoveryExecution.reconcile({
+            identity: connection,
+            isCurrent: () => this.isCurrentConnection(connection),
+            acceptsPhysical: physical =>
+              physical.state === 'running' &&
+              physical.stopTombstone === null &&
+              physical.providerRef === connection.providerInstanceId,
+          })
+        );
       return;
     }
     if (id === 'idleStop') {
@@ -2878,7 +3059,11 @@ export class SandboxControl extends DurableObject<Env> {
       return;
     }
     const previous = this.activeConnection;
-    if (previous && !this.sameConnection(previous, identity)) {
+    const sameRuntime =
+      previous?.recoveryCapable === true &&
+      identity.recoveryCapable === true &&
+      controlRecovery.sameRuntime(previous, identity);
+    if (previous && !this.sameConnection(previous, identity) && !sameRuntime) {
       await this.quarantineConnection(previous, 'control_replaced');
       return;
     }
@@ -2903,6 +3088,25 @@ export class SandboxControl extends DurableObject<Env> {
         wrapperVersion: safeSandboxRuntimeVersion(runtime?.wrapperVersion),
         kiloCliVersion: null,
       });
+      const recovery = await loadRecoveryDecisions(this.ctx.storage);
+      const nextRecovery =
+        identity.recoveryCapable && identity.wrapperInstanceId
+          ? (() => {
+              const resumed = controlRecovery.beginRecovery(
+                recovery.find(item => item.wrapperInstanceId === identity.wrapperInstanceId),
+                { ...identity, wrapperInstanceId: identity.wrapperInstanceId },
+                sameRuntime ? 'control_disconnected' : 'activation_pending',
+                now
+              );
+              const next =
+                !controlRecovery.activationCommitted(resumed) &&
+                resumed.exhaustedAt === undefined &&
+                now >= resumed.deadlineAt
+                  ? controlRecovery.exhaustRecovery(resumed, now)
+                  : resumed;
+              return [...recovery.filter(item => item.episodeId !== next.episodeId), next];
+            })()
+          : recovery;
       await this.ctx.storage.put(ACTIVE_WRAPPER_RUNTIME_KEY, identity);
       await this.ctx.storage.delete(WRAPPER_READY_AT_KEY);
       if (current.state === 'creating') {
@@ -2918,11 +3122,21 @@ export class SandboxControl extends DurableObject<Env> {
       }
       let deadlines = await loadDeadlines(this.ctx.storage);
       deadlines = cancelDeadline(cancelDeadline(deadlines, 'heartbeatExpiry'), 'socketHandshake');
-      deadlines = armDeadline(
-        cancelDeadline(deadlines, 'startup'),
-        'wrapperReadiness',
-        now + DEADLINE_MS.wrapperReadiness
+      const establishedRecovery = nextRecovery.some(
+        item =>
+          identity.recoveryCapable &&
+          controlRecovery.sameRuntime(item, identity) &&
+          (item.cause !== 'activation_pending' || controlRecovery.activationCommitted(item))
       );
+      deadlines = establishedRecovery
+        ? cancelDeadline(cancelDeadline(deadlines, 'startup'), 'wrapperReadiness')
+        : armDeadline(
+            cancelDeadline(deadlines, 'startup'),
+            'wrapperReadiness',
+            Math.min(deadlines.wrapperReadiness ?? Infinity, now + DEADLINE_MS.wrapperReadiness)
+          );
+      deadlines = controlRecovery.recoveryDeadlines(deadlines, nextRecovery);
+      await saveRecoveryDecisions(this.ctx.storage, nextRecovery);
       await saveDeadlines(this.ctx.storage, deadlines);
       await this.scheduleAlarm(deadlines);
       await this.appendLog(connectionTransition(now, 'disconnected', 'connected', 'hello'));
@@ -2937,34 +3151,89 @@ export class SandboxControl extends DurableObject<Env> {
   }
 
   private async onWrapperReady(identity: SandboxControlConnectionIdentity): Promise<void> {
+    if (identity.recoveryCapable) {
+      this.ctx.waitUntil(
+        this.recoveryExecution.reconcile({
+          identity,
+          isCurrent: () => this.isCurrentConnection(identity),
+          acceptsPhysical: physical =>
+            physical.state === 'running' &&
+            physical.stopTombstone === null &&
+            physical.providerRef === identity.providerInstanceId,
+        })
+      );
+      return;
+    }
+    await this.commitWrapperReady(identity);
+  }
+
+  private async commitWrapperReady(
+    identity: SandboxControlConnectionIdentity,
+    recovery?: controlRecovery.SandboxRecoveryDecision
+  ): Promise<boolean> {
     const physical = await loadPhysicalRecord(this.ctx.storage);
     if (
       !this.isCurrentConnection(identity) ||
       physical.state === 'stopped' ||
       physical.providerRef !== identity.providerInstanceId
     )
-      return;
+      return false;
     const now = Date.now();
-    await this.ctx.storage.transaction(async () => {
-      await this.ctx.storage.put({
+    const committed = await this.ctx.storage.transaction(async tx => {
+      const current = await loadPhysicalRecord(tx);
+      if (
+        !this.isCurrentConnection(identity) ||
+        current.state === 'stopped' ||
+        current.stopTombstone !== null ||
+        current.providerRef !== identity.providerInstanceId
+      )
+        return false;
+      if (recovery) {
+        const records = await loadRecoveryDecisions(tx);
+        const currentRecovery = records.find(item => item.episodeId === recovery.episodeId);
+        if (
+          !currentRecovery ||
+          !controlRecovery.sameConnection(currentRecovery, identity) ||
+          currentRecovery.attempt !== recovery.attempt
+        )
+          return false;
+        await saveRecoveryDecisions(
+          tx,
+          records.map(item =>
+            item === currentRecovery ? controlRecovery.commitRecoveryActivation(item, now) : item
+          )
+        );
+      }
+      await tx.put({
         [ACTIVE_WRAPPER_RUNTIME_KEY]: {
           ...identity,
           readyConnectionId: identity.connectionId,
         } satisfies PersistedWrapperRuntime,
         [WRAPPER_READY_AT_KEY]: now,
       });
-      let deadlines = cancelDeadline(await loadDeadlines(this.ctx.storage), 'wrapperReadiness');
+      let deadlines = cancelDeadline(await loadDeadlines(tx), 'wrapperReadiness');
       deadlines = armDeadline(deadlines, 'heartbeatExpiry', now + DEADLINE_MS.heartbeatExpiry);
       deadlines = armDeadline(
         deadlines,
         'idleStop',
         deadlines.idleStop ?? now + DEADLINE_MS.idleStop
       );
-      await saveDeadlines(this.ctx.storage, deadlines);
-      await this.scheduleAlarm(deadlines);
+      deadlines = recovery
+        ? controlRecovery.recoveryDeadlines(deadlines, await loadRecoveryDecisions(tx))
+        : deadlines;
+      await saveDeadlines(tx, deadlines);
       await this.appendLog(connectionTransition(now, 'connected', 'ready', 'sandbox.ready'));
+      return true;
     });
+    if (committed) await this.scheduleAlarm(await loadDeadlines(this.ctx.storage));
+    if (!committed || recovery) return committed;
+    this.activateWrapperReady(identity);
+    return true;
+  }
+
+  private activateWrapperReady(identity: SandboxControlConnectionIdentity): void {
     if (!this.isCurrentConnection(identity)) return;
+    const now = Date.now();
     this.readyConnectionId = identity.connectionId;
     this.kiloReady = true;
     this.logDiagnostic('wrapper_ready', {
@@ -3003,7 +3272,7 @@ export class SandboxControl extends DurableObject<Env> {
       await this.quarantineConnection(identity, 'kilo_unhealthy');
       return;
     }
-    if (!this.readyWrapperRuntime()) {
+    if (!this.readyWrapperRuntime() && !identity.recoveryCapable) {
       this.logDiagnostic('heartbeat', { ...diagnostic, decision: 'runtime_not_ready' });
       return;
     }
@@ -3154,25 +3423,28 @@ export class SandboxControl extends DurableObject<Env> {
   private async onSessionEvent(
     identity: SessionEventIdentity | undefined,
     payload: SessionEventPayload,
-    connection: SandboxControlConnectionIdentity
-  ): Promise<void> {
+    connection: SandboxControlConnectionIdentity,
+    receiptId?: string,
+    receiptHash?: string,
+    sequence?: number
+  ): Promise<SandboxControlEventResult> {
     const diagnostic = {
       ...diagnosticConnection(connection),
       eventType: diagnosticEventType(payload.type),
     };
     if (!this.isCurrentConnection(connection)) {
       this.recordForwardDrop('stale_before_enqueue', diagnostic);
-      return;
+      return { applied: false };
     }
     if (!identity) {
       this.recordForwardDrop('missing_identity', diagnostic);
-      return;
+      return { applied: false };
     }
-    await this.forwardRoutedSessionFrame(
+    const forwarded = this.forwardRoutedSessionFrame(
       identity,
       payload.type,
       connection,
-      { identity, payload },
+      { identity, payload, ...(receiptId ? { receiptId, receiptHash, sequence } : {}) },
       (route, fields, physical) =>
         this.forwardSessionFrame(
           route,
@@ -3185,33 +3457,43 @@ export class SandboxControl extends DurableObject<Env> {
               identity,
               payload,
               wrapperInstanceId: connection.wrapperInstanceId,
-            })
+              ...(receiptId ? { receiptId, receiptHash, sequence } : {}),
+            }),
+          receiptId !== undefined
         )
     );
+    if (!receiptId) {
+      this.ctx.waitUntil(forwarded.then(() => undefined));
+      return { applied: true };
+    }
+    return forwarded;
   }
 
   private async onSessionPreparing(
     identity: SessionEventIdentity | undefined,
     payload: SessionPreparingPayload,
-    connection: SandboxControlConnectionIdentity
-  ): Promise<void> {
+    connection: SandboxControlConnectionIdentity,
+    receiptId?: string,
+    receiptHash?: string,
+    sequence?: number
+  ): Promise<SandboxControlEventResult> {
     const diagnostic = {
       ...diagnosticConnection(connection),
       eventType: 'session.preparing',
     };
     if (!this.isCurrentConnection(connection)) {
       this.recordForwardDrop('stale_before_enqueue', diagnostic);
-      return;
+      return { applied: false };
     }
     if (!identity) {
       this.recordForwardDrop('missing_identity', diagnostic);
-      return;
+      return { applied: false };
     }
-    await this.forwardRoutedSessionFrame(
+    const forwarded = this.forwardRoutedSessionFrame(
       identity,
       'session.preparing',
       connection,
-      { identity, payload },
+      { identity, payload, ...(receiptId ? { receiptId, receiptHash, sequence } : {}) },
       (route, fields, physical) =>
         this.forwardSessionFrame(
           route,
@@ -3224,9 +3506,16 @@ export class SandboxControl extends DurableObject<Env> {
               identity,
               payload,
               wrapperInstanceId: connection.wrapperInstanceId,
-            })
+              ...(receiptId ? { receiptId, receiptHash, sequence } : {}),
+            }),
+          receiptId !== undefined
         )
     );
+    if (!receiptId) {
+      this.ctx.waitUntil(forwarded.then(() => undefined));
+      return { applied: true };
+    }
+    return forwarded;
   }
 
   private async onNativeRuntimeRetired(
@@ -3443,8 +3732,8 @@ export class SandboxControl extends DurableObject<Env> {
       route: SessionRoute,
       diagnostic: ControlDiagnosticFields,
       physical: PhysicalRecord
-    ) => Promise<void>
-  ): Promise<void> {
+    ) => Promise<SandboxControlEventResult>
+  ): Promise<SandboxControlEventResult> {
     const diagnostic = {
       ...diagnosticConnection(connection),
       eventType: diagnosticEventType(eventType),
@@ -3452,12 +3741,12 @@ export class SandboxControl extends DurableObject<Env> {
     const table = await loadRouteTable(this.ctx.storage);
     if (!this.isCurrentConnection(connection)) {
       this.recordForwardDrop('stale_before_enqueue', diagnostic);
-      return;
+      return { applied: false };
     }
     const route = resolveSessionEventRoute(table, identity);
     if (!route) {
       this.recordForwardDrop('unroutable', { ...diagnostic, routeCount: table.size });
-      return;
+      return { applied: false };
     }
     const physical = await loadPhysicalRecord(this.ctx.storage);
     if (
@@ -3468,14 +3757,14 @@ export class SandboxControl extends DurableObject<Env> {
       !this.isCurrentConnection(connection)
     ) {
       this.recordForwardDrop('runtime_not_current', diagnostic);
-      return;
+      return { applied: false };
     }
     let frameBytes: number;
     try {
       frameBytes = sessionForwardFrameBytes(frame);
     } catch {
       this.recordForwardDrop('forwarding_frame_invalid', diagnostic);
-      return;
+      return { applied: false };
     }
     const queuedAt = Date.now();
     this.forwarding.enqueued++;
@@ -3500,8 +3789,9 @@ export class SandboxControl extends DurableObject<Env> {
           ...this.forwarding,
         });
         try {
-          if (this.isCurrentConnection(connection)) await forward(route, fields, physical);
-          else this.recordForwardDrop('stale_before_send', fields);
+          if (this.isCurrentConnection(connection)) return forward(route, fields, physical);
+          this.recordForwardDrop('stale_before_send', fields);
+          return { applied: false, retryable: true };
         } finally {
           this.forwarding.settled++;
           const totalForwardMs = Date.now() - queuedAt;
@@ -3527,6 +3817,7 @@ export class SandboxControl extends DurableObject<Env> {
         );
       })
     );
+    return next.catch(() => ({ applied: false, retryable: true }));
   }
 
   private recordForwardDrop(reason: string, fields: ControlDiagnosticFields): void {
@@ -3550,6 +3841,7 @@ export class SandboxControl extends DurableObject<Env> {
       current.kiloSessionId === route.kiloSessionId &&
       current.directory === route.directory &&
       current.worktreeId === route.worktreeId &&
+      current.nativeRuntimeId === route.nativeRuntimeId &&
       sameAllocation(physical, expectedPhysical) &&
       physical.state === 'running' &&
       !physical.stopTombstone &&
@@ -3568,11 +3860,14 @@ export class SandboxControl extends DurableObject<Env> {
     connection: SandboxControlConnectionIdentity,
     diagnostic: ControlDiagnosticFields,
     operation: 'receiveSandboxControlEvent' | 'receiveSandboxControlPreparing',
-    send: (stub: ReturnType<typeof getSandboxSessionStub>) => Promise<{ applied: boolean }>
-  ): Promise<void> {
+    send: (
+      stub: ReturnType<typeof getSandboxSessionStub>
+    ) => Promise<{ applied: boolean; retryable?: boolean }>,
+    requireApplied: boolean
+  ): Promise<SandboxControlEventResult> {
     if (!(await this.isCurrentSessionForward(route, connection, physical))) {
       this.recordForwardDrop('stale_before_send', diagnostic);
-      return;
+      return { applied: false, retryable: true };
     }
     const startedAt = Date.now();
     let timedOut = false;
@@ -3581,7 +3876,7 @@ export class SandboxControl extends DurableObject<Env> {
     const delivered = await withTimeout(
       withDORetry(
         () => getSandboxSessionStub(this.env, route.ownerId, route.sessionId),
-        async stub => {
+        async (stub): Promise<{ applied: boolean; retryable?: boolean }> => {
           skipped = !(await this.isCurrentSessionForward(route, connection, physical));
           if (skipped) {
             this.recordForwardDrop('stale_retry', diagnostic);
@@ -3590,6 +3885,7 @@ export class SandboxControl extends DurableObject<Env> {
           attempts++;
           const result = await send(stub);
           if (!(await this.isCurrentSessionForward(route, connection, physical))) {
+            skipped = true;
             this.recordForwardDrop('stale_after_send', diagnostic);
             return { applied: false };
           }
@@ -3618,9 +3914,14 @@ export class SandboxControl extends DurableObject<Env> {
           rpcWaitMs,
           ...this.forwarding,
         });
-        return true;
+        if (skipped) return { applied: false, retryable: true };
+        if (!requireApplied || result?.applied === true) return { applied: true };
+        return {
+          applied: false,
+          retryable: result?.retryable === true || operation === 'receiveSandboxControlPreparing',
+        };
       },
-      () => {
+      async () => {
         const rpcWaitMs = Date.now() - startedAt;
         this.forwarding.maxRpcWaitMs = Math.max(this.forwarding.maxRpcWaitMs, rpcWaitMs);
         this.forwarding.failed++;
@@ -3636,10 +3937,11 @@ export class SandboxControl extends DurableObject<Env> {
           },
           'warn'
         );
-        return false;
+        if (!requireApplied) await this.quarantineForwardingFailure(route, connection);
+        return { applied: false, retryable: true };
       }
     );
-    if (!delivered) await this.quarantineForwardingFailure(route, connection);
+    return delivered;
   }
 
   private async quarantineForwardingFailure(
@@ -3653,7 +3955,8 @@ export class SandboxControl extends DurableObject<Env> {
       !current ||
       current.ownerId !== route.ownerId ||
       current.directory !== route.directory ||
-      current.kiloSessionId !== route.kiloSessionId
+      current.kiloSessionId !== route.kiloSessionId ||
+      current.nativeRuntimeId !== route.nativeRuntimeId
     ) {
       this.logDiagnostic('forward_quarantine_skipped', {
         sessionId: route.sessionId,
@@ -3671,7 +3974,74 @@ export class SandboxControl extends DurableObject<Env> {
     if (!handshakeComplete || !identity || !this.isActiveConnection(identity)) return;
     const replacement = this.socketHandler.getConnectionIdentity();
     if (replacement && !this.sameConnection(replacement, identity)) return;
-    await this.quarantineConnection(identity, 'control_disconnected');
+    if (identity.recoveryCapable) await this.beginControlRecovery(identity, 'control_disconnected');
+    else await this.quarantineConnection(identity, 'control_disconnected');
+  }
+
+  private exhaustExpiredRecovery(now: number): Promise<void> {
+    return this.recoveryCleanup.exhaustExpired(now);
+  }
+
+  private reconcileExhaustedRecovery(): Promise<void> {
+    return this.recoveryCleanup.reconcile();
+  }
+
+  private async beginControlRecovery(
+    identity: SandboxControlConnectionIdentity,
+    cause: 'control_disconnected' | 'heartbeat_expired'
+  ): Promise<void> {
+    if (!identity.wrapperInstanceId || !this.isActiveConnection(identity)) return;
+    const wrapperInstanceId = identity.wrapperInstanceId;
+    const started = await this.ctx.storage.transaction(async tx => {
+      const physical = await loadPhysicalRecord(tx);
+      if (
+        physical.state !== 'running' ||
+        physical.stopTombstone !== null ||
+        physical.providerRef !== identity.providerInstanceId ||
+        !this.isActiveConnection(identity)
+      )
+        return undefined;
+      const recovery = await loadRecoveryDecisions(tx);
+      const resumed = controlRecovery.beginRecovery(
+        recovery.find(item => item.wrapperInstanceId === wrapperInstanceId),
+        { ...identity, wrapperInstanceId },
+        cause,
+        Date.now()
+      );
+      const next =
+        !controlRecovery.activationCommitted(resumed) &&
+        resumed.exhaustedAt === undefined &&
+        Date.now() >= resumed.deadlineAt
+          ? controlRecovery.exhaustRecovery(resumed, Date.now())
+          : resumed;
+      const nextRecovery = [...recovery.filter(item => item.episodeId !== next.episodeId), next];
+      await saveRecoveryDecisions(tx, nextRecovery);
+      await tx.put(ACTIVE_WRAPPER_RUNTIME_KEY, identity);
+      await tx.delete(WRAPPER_READY_AT_KEY);
+      const deadlines = controlRecovery.recoveryDeadlines(
+        cancelDeadline(await loadDeadlines(tx), 'heartbeatExpiry'),
+        nextRecovery
+      );
+      await saveDeadlines(tx, deadlines);
+      await this.scheduleAlarm(deadlines);
+      return next;
+    });
+    this.readyConnectionId = null;
+    this.kiloReady = false;
+    if (!started || started.authority || started.exhaustedAt !== undefined) return;
+    const authority = await this.recoveryAuthority.load(started);
+    if (!authority) return;
+    await this.ctx.storage.transaction(async tx => {
+      const recovery = await loadRecoveryDecisions(tx);
+      const current = recovery.find(item => item.episodeId === started.episodeId);
+      if (!current || current.authority || current.exhaustedAt !== undefined) return;
+      await saveRecoveryDecisions(
+        tx,
+        recovery.map(item =>
+          item === current ? controlRecovery.replaceRecoveryAuthority(item, authority) : item
+        )
+      );
+    });
   }
 
   private async quarantineConnection(
@@ -3824,6 +4194,7 @@ export class SandboxControl extends DurableObject<Env> {
         nativeRuntimeId: input.receipt.nativeRuntimeId,
         cleanupDeadlineAt: input.receipt.cleanupDeadlineAt,
       },
+      expectedWrapperInstanceId: input.receipt.connection.wrapperInstanceId,
       deadlineAt: input.receipt.cleanupDeadlineAt,
       timeoutMs: Math.max(1, input.receipt.cleanupDeadlineAt - Date.now()),
     });
@@ -4039,9 +4410,11 @@ export class SandboxControl extends DurableObject<Env> {
     receipt: NativeRuntimeRetirementReceipt
   ): Promise<boolean> {
     const committed = await this.ctx.storage.transaction(async () => {
-      const [physical, receipts] = await Promise.all([
+      const [physical, receipts, decisions, routes] = await Promise.all([
         loadPhysicalRecord(this.ctx.storage),
         loadNativeRuntimeRetirements(this.ctx.storage),
+        loadRecoveryDecisions(this.ctx.storage),
+        loadRouteTable(this.ctx.storage),
       ]);
       const currentReceipt = receipts.find(
         current =>
@@ -4056,7 +4429,20 @@ export class SandboxControl extends DurableObject<Env> {
         currentReceipt.state !== 'unconfirmed' ||
         physical.stopTombstone ||
         physical.state === 'stopped' ||
-        !matchesNativeRuntimeRetirementAllocation(currentReceipt, physical)
+        !matchesNativeRuntimeRetirementAllocation(currentReceipt, physical) ||
+        ((currentReceipt.reason === RECOVERY_CLEANUP_REASON ||
+          decisions.some(decision =>
+            controlRecovery.sameRuntime(decision, currentReceipt.connection)
+          )) &&
+          (!canRecoveryRetirementStopAllocation(
+            currentReceipt,
+            decisions,
+            physical,
+            routes,
+            Date.now()
+          ) ||
+            (this.activeConnection !== null &&
+              !controlRecovery.sameRuntime(this.activeConnection, currentReceipt.connection))))
       )
         return undefined;
       const next = beginStop(
@@ -4094,6 +4480,7 @@ export class SandboxControl extends DurableObject<Env> {
     }
     if (to.state === 'stopped') {
       await saveSessionCredentialGrants(this.ctx.storage, []);
+      await saveRecoveryDecisions(this.ctx.storage, []);
       await this.ctx.storage.delete(CREDENTIAL_POLICY_DIRTY_KEY);
       const [routes, receipts] = await Promise.all([
         loadRouteTable(this.ctx.storage),

--- a/services/cloud-agent-next/src/router/control-plane-session.ts
+++ b/services/cloud-agent-next/src/router/control-plane-session.ts
@@ -40,8 +40,12 @@ export async function interruptControlSession(
       withDORetry(stub, operation, operationName));
   const state = await retry(session => session.getControlState(), 'getControlState');
   if (!state) return undefined;
+  const controlState = controlSessionStateSchema.parse(state);
+  if (controlState.targets.length === 0) {
+    return controlState.stops?.[0];
+  }
   const request = createControlStopRequest(
-    controlSessionStateSchema.parse(state),
+    controlState,
     dependencies.now,
     dependencies.operationId
   );

--- a/services/cloud-agent-next/src/sandbox-control/backend-recovery-hooks.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/backend-recovery-hooks.test.ts
@@ -1,0 +1,963 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SandboxControl } from '../persistence/SandboxControl.js';
+import type { Env } from '../types.js';
+import type { ControlSessionState, ControlStopRequest } from '../shared/control-plane-session.js';
+import {
+  sameSessionOperation,
+  sandboxReconcilePayloadSchema,
+  sessionOperationAuthorizationSchema,
+  sessionOperationLookupResultSchema,
+  sessionOperationResultHash,
+  type ResponseFrame,
+  type SessionOperationAck,
+  type SessionOperationAuthorization,
+  type SessionOperationDelivery,
+} from '../shared/sandbox-control-protocol.js';
+import { encodeCloudflareProviderRef } from './cloudflare-provider.js';
+import type * as CloudflareProvider from './cloudflare-provider.js';
+import {
+  loadDeadlines,
+  loadNativeRuntimeRetirements,
+  loadRecoveryDecisions,
+  loadRouteTable,
+  saveDeadlines,
+  savePhysicalRecord,
+  saveRecoveryDecisions,
+  saveRouteTable,
+} from './durable-state.js';
+import { beginStop, type PhysicalRecord } from './physical-lifecycle.js';
+import type { SessionRoute } from './session-routes.js';
+import type { ProviderAdapter } from './provider.js';
+import type * as SocketModule from './socket.js';
+import type {
+  SandboxControlConnectionIdentity,
+  SandboxControlOutboundRequest,
+  SandboxControlSocketHandler,
+  SandboxControlSocketHooks,
+} from './socket.js';
+
+const mocks = vi.hoisted(() => ({ socket: vi.fn(), session: vi.fn(), provider: vi.fn() }));
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class {
+    constructor(
+      public ctx: DurableObjectState,
+      public env: Env
+    ) {}
+  },
+}));
+vi.mock('@cloudflare/sandbox', () => ({
+  getSandbox: vi.fn(() => {
+    throw new Error('Unexpected provider access');
+  }),
+}));
+vi.mock('./cloudflare-provider.js', async importOriginal => ({
+  ...(await importOriginal<typeof CloudflareProvider>()),
+  createCloudflareProviderAdapter: mocks.provider,
+}));
+vi.mock('./socket.js', async importOriginal => ({
+  ...(await importOriginal<typeof SocketModule>()),
+  createSandboxControlSocketHandler: mocks.socket,
+}));
+vi.mock('../sandbox-session/session-stub.js', () => ({ getSandboxSessionStub: mocks.session }));
+
+const NOW = 1_700_000_000_000;
+const SANDBOX_ID = 'ses-abcdef';
+const OWNER = 'owner_1';
+const WRAPPER = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const EXECUTION_DEADLINE = NOW + 600_000;
+const roots = [
+  {
+    sessionId: 'workspace_a',
+    kiloSessionId: 'kilo_a',
+    directory: '/workspace/a',
+    nativeRuntimeId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+  },
+  {
+    sessionId: 'workspace_b',
+    kiloSessionId: 'kilo_b',
+    directory: '/workspace/b',
+    nativeRuntimeId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  },
+] as const;
+const [rootA, rootB] = roots;
+const scenarios = ['pending Stop', 'getControlState timeout', 'operation.get timeout'] as const;
+type Scenario = (typeof scenarios)[number];
+
+function authorization(
+  root: (typeof roots)[number],
+  messageId = `original_${root.sessionId}`
+): SessionOperationAuthorization {
+  return {
+    operation: 'session.prompt',
+    operationId: messageId,
+    messageId,
+    session: {
+      sessionId: root.sessionId,
+      kiloSessionId: root.kiloSessionId,
+      directory: root.directory,
+    },
+    wrapperInstanceId: WRAPPER,
+    dispatchDeadlineAt: NOW + 5_000,
+  };
+}
+
+function response(result: unknown): ResponseFrame {
+  return { type: 'response', requestId: 'test_request', ok: true, result };
+}
+
+function maintenance(original: SessionOperationAuthorization): SandboxControlOutboundRequest {
+  return {
+    operation: 'session.operation.get',
+    session: original.session,
+    payload: original,
+    expectedWrapperInstanceId: original.wrapperInstanceId,
+    deadlineAt: Date.now() + 30_000,
+    timeoutMs: 30_000,
+  };
+}
+
+function prompt(original: SessionOperationAuthorization): SandboxControlOutboundRequest {
+  return {
+    operation: 'session.prompt',
+    session: original.session,
+    authorization: original,
+    expectedWrapperInstanceId: original.wrapperInstanceId,
+    payload: {
+      messageId: original.messageId,
+      turn: { type: 'prompt', prompt: 'Continue' },
+      agent: { mode: 'code', model: 'kilo/fake' },
+    },
+  };
+}
+
+function memoryState() {
+  const records = new Map<string, unknown>();
+  let alarmAt: number | null = null;
+  let tail: Promise<unknown> = Promise.resolve();
+  function remove(key: string): Promise<boolean>;
+  function remove(keys: string[]): Promise<number>;
+  async function remove(key: string | string[]): Promise<boolean | number> {
+    return typeof key === 'string'
+      ? records.delete(key)
+      : key.filter(item => records.delete(item)).length;
+  }
+  const storage = {
+    async get<T>(key: string): Promise<T | undefined> {
+      return structuredClone(records.get(key)) as T | undefined;
+    },
+    async list(options?: { prefix?: string }) {
+      return new Map(
+        structuredClone([...records].filter(([key]) => key.startsWith(options?.prefix ?? '')))
+      );
+    },
+    async put(key: string | Record<string, unknown>, value?: unknown) {
+      if (typeof key === 'string') records.set(key, structuredClone(value));
+      else
+        for (const [name, entry] of Object.entries(key)) records.set(name, structuredClone(entry));
+    },
+    delete: remove,
+    rollback() {
+      throw new Error('Transaction rolled back');
+    },
+    async getAlarm() {
+      return alarmAt;
+    },
+    async setAlarm(at: number) {
+      alarmAt = at;
+    },
+    async deleteAlarm() {
+      alarmAt = null;
+    },
+    transaction<T>(operation: (tx: DurableObjectTransaction) => Promise<T>): Promise<T> {
+      const pending = tail.then(async () => {
+        const snapshot = structuredClone(records);
+        const previousAlarm = alarmAt;
+        try {
+          return await operation(storage as unknown as DurableObjectTransaction);
+        } catch (error) {
+          records.clear();
+          for (const [key, value] of snapshot) records.set(key, value);
+          alarmAt = previousAlarm;
+          throw error;
+        }
+      });
+      tail = pending.catch(() => undefined);
+      return pending;
+    },
+  };
+  return storage;
+}
+
+async function harness() {
+  const storage = memoryState();
+  const pending: Promise<unknown>[] = [];
+  const ctx = {
+    id: { name: SANDBOX_ID },
+    storage,
+    getWebSockets: () => [],
+    setWebSocketAutoResponse: vi.fn(),
+    blockConcurrencyWhile: (operation: () => Promise<void>) => operation(),
+    waitUntil: (task: Promise<unknown>) => {
+      pending.push(task);
+    },
+  } as unknown as DurableObjectState;
+  const env = {} as Env;
+  const provider = {
+    resumable: false,
+    create: vi.fn<ProviderAdapter['create']>(),
+    launch: vi.fn<ProviderAdapter['launch']>(),
+    ensureBillingAdmission: vi.fn(async () => undefined),
+    observe: vi.fn<ProviderAdapter['observe']>(async () => ({ status: 'active' })),
+    stop: vi.fn<ProviderAdapter['stop']>(async () => 'terminal'),
+    ensureLeaseAtLeast: vi.fn(async () => undefined),
+    logs: vi.fn(async () => ''),
+  } satisfies ProviderAdapter;
+  mocks.provider.mockReturnValue(provider);
+  const containment = { kilocode: false, github: false, worktreeScoped: true } as const;
+  const providerRef = encodeCloudflareProviderRef({
+    sandboxId: SANDBOX_ID,
+    containment: false,
+    instanceId: 'allocation_1',
+  });
+  const physical = {
+    state: 'running',
+    providerRef,
+    resumable: false,
+    stopTombstone: null,
+    createIntent: { intentId: 'allocation_1', createdAt: NOW - 1_000, containment },
+    containment: { ...containment, providerRef },
+  } satisfies PhysicalRecord;
+  await savePhysicalRecord(storage, physical);
+  await saveRouteTable(
+    storage,
+    new Map(
+      roots.map(root => [
+        root.sessionId,
+        {
+          ...root,
+          ownerId: OWNER,
+          lastState: 'idle',
+          lastStateAt: NOW,
+          idleForMs: 0,
+          waitingOn: null,
+        } satisfies SessionRoute,
+      ])
+    )
+  );
+  let connection: SandboxControlConnectionIdentity = {
+    connectionId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+    providerInstanceId: providerRef,
+    wrapperInstanceId: WRAPPER,
+    recoveryCapable: true,
+  };
+  let hooks: SandboxControlSocketHooks = {};
+  let operationTimeout = false;
+  const sendRequest = vi.fn(
+    async (request: SandboxControlOutboundRequest): Promise<ResponseFrame> => {
+      if (request.operation === 'sandbox.reconcile') {
+        const { recovery, phase } = sandboxReconcilePayloadSchema.parse(request.payload);
+        return response({ episodeId: recovery.episodeId, attempt: recovery.attempt, phase });
+      }
+      if (request.operation === 'sandbox.status')
+        return response({ healthy: true, state: 'active', version: '2.4.0', kiloReady: true });
+      if (request.operation === 'session.operation.get') {
+        const original = sessionOperationAuthorizationSchema.parse(request.payload);
+        if (operationTimeout && original.session.sessionId === rootA.sessionId)
+          return new Promise(() => undefined);
+        return response({
+          state: 'running',
+          authorization: original,
+          executionDeadlineAt: EXECUTION_DEADLINE,
+        });
+      }
+      if (request.operation === 'session.prompt')
+        return response({
+          messageId: request.authorization?.messageId,
+          status: 'accepted',
+          executionDeadlineAt: EXECUTION_DEADLINE,
+        });
+      if (request.operation === 'session.abort')
+        return response({ status: 'unconfirmed', runtimeRetired: false });
+      if (request.operation === 'session.operation.ack') return response({ acknowledged: true });
+      if (
+        request.operation === 'session.permission.resolve' ||
+        request.operation === 'session.question.resolve'
+      )
+        return response({ success: true });
+      throw new Error(`Unexpected request ${request.operation}`);
+    }
+  );
+  const socket = {
+    getConnectionIdentity: () => connection,
+    hasHandshakenSocket: () => true,
+    supportsOperationResults: () => true,
+    supportsScopedStopAbort: () => true,
+    supportsNativeRuntimeRetirement: () => true,
+    supportsConnectionRecovery: (): boolean => true,
+    closeAll: vi.fn(),
+    closeHandshakenSockets: vi.fn(),
+    closeProvisionalSockets: vi.fn(),
+    sendRequest,
+  } satisfies Partial<SandboxControlSocketHandler>;
+  mocks.socket.mockImplementation((_ctx, _id, _waiters, callbacks: SandboxControlSocketHooks) => {
+    hooks = callbacks;
+    return socket;
+  });
+  let control = new SandboxControl(ctx, env);
+  const makeSession = () => ({
+    getControlState: vi.fn(
+      async (options?: { includeIdle?: boolean }): Promise<ControlSessionState | null> =>
+        options?.includeIdle
+          ? {
+              version: 1,
+              scope: { sandboxId: SANDBOX_ID, wrapperInstanceId: WRAPPER },
+              targets: [],
+            }
+          : null
+    ),
+    interruptExecution: vi.fn(async (request: ControlStopRequest) => ({
+      ...request,
+      state: 'accepted' as const,
+    })),
+    reconcileControlRecovery: vi.fn(async (authorizations: SessionOperationAuthorization[]) => {
+      for (const original of authorizations) {
+        const reply = await control.request(maintenance(original));
+        if (!reply.ok) return { state: 'unresolved' as const };
+        const lookup = sessionOperationLookupResultSchema.parse(reply.result);
+        if (lookup.state !== 'running' || !sameSessionOperation(lookup.authorization, original))
+          return { state: 'unresolved' as const };
+      }
+      return { state: 'reconciled' as const };
+    }),
+    receiveSandboxOperationResult: vi.fn(
+      async ({
+        delivery,
+      }: {
+        delivery: SessionOperationDelivery;
+      }): Promise<SessionOperationAck> => ({
+        version: 2,
+        authorization: delivery.authorization,
+        resultHash: await sessionOperationResultHash(delivery),
+        disposition: 'applied',
+        decision: { state: 'completed', at: delivery.completedAt },
+      })
+    ),
+    receiveSandboxControlEvent: vi.fn(async () => ({ applied: true })),
+    failWaitingMessages: vi.fn(async () => undefined),
+    invalidateTerminalRuntime: vi.fn(async () => undefined),
+    recordNativeRuntime: vi.fn(async () => undefined),
+  });
+  const sessionA = makeSession();
+  const sessionB = makeSession();
+  mocks.session.mockImplementation((_env, ownerId, sessionId) => {
+    if (ownerId !== OWNER) throw new Error('Unexpected Session owner');
+    if (sessionId === rootA.sessionId) return sessionA;
+    if (sessionId === rootB.sessionId) return sessionB;
+    throw new Error('Unexpected Session id');
+  });
+  const flush = async () => {
+    while (pending.length) await Promise.all(pending.splice(0));
+  };
+  await control.initializeOwner(OWNER);
+  await hooks.onHandshakeComplete?.(connection);
+  await hooks.onReady?.(connection);
+  await flush();
+  expect(await loadRecoveryDecisions(storage)).toEqual([]);
+  expect(sessionA.getControlState).toHaveBeenCalledWith({ includeIdle: true });
+  expect(sessionB.getControlState).toHaveBeenCalledWith({ includeIdle: true });
+  for (const [root, session] of [
+    [rootA, sessionA],
+    [rootB, sessionB],
+  ] as const) {
+    const original = authorization(root);
+    expect(await control.request(prompt(original))).toMatchObject({
+      ok: true,
+      result: {
+        status: 'accepted',
+        executionDeadlineAt: EXECUTION_DEADLINE,
+      },
+    });
+    session.getControlState.mockResolvedValue({
+      version: 1,
+      scope: { sandboxId: SANDBOX_ID, wrapperInstanceId: WRAPPER },
+      targets: [
+        {
+          messageId: original.messageId,
+          wrapperInstanceId: WRAPPER,
+          executionDeadlineAt: EXECUTION_DEADLINE,
+        },
+      ],
+      operations: [
+        {
+          messageId: original.messageId,
+          authorization: original,
+          executionDeadlineAt: EXECUTION_DEADLINE,
+        },
+      ],
+    });
+  }
+  return {
+    storage,
+    provider,
+    physical,
+    sessionA,
+    sessionB,
+    socket,
+    sendRequest,
+    get control() {
+      return control;
+    },
+    get hooks() {
+      return hooks;
+    },
+    get connection() {
+      return connection;
+    },
+    flush,
+    async reconstruct() {
+      control = new SandboxControl(ctx, env);
+      await control.getStatus();
+      await flush();
+    },
+    async reconnectForInteraction() {
+      await hooks.onSocketClosed?.(true, connection);
+      connection = { ...connection, connectionId: crypto.randomUUID() };
+      await hooks.onHandshakeComplete?.(connection);
+      await flush();
+      expect(await control.getStatus()).toMatchObject({ connection: 'connected' });
+      sendRequest.mockClear();
+    },
+    async recover(scenario: Scenario) {
+      if (scenario === 'pending Stop') {
+        const state = await sessionA.getControlState({ includeIdle: true });
+        if (!state) throw new Error('Expected accepted A state');
+        sessionA.getControlState.mockResolvedValue({
+          ...state,
+          stops: [
+            {
+              version: 1,
+              operationId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+              scope: state.scope,
+              targets: state.targets,
+              cleanupDeadlineAt: NOW + 20_000,
+              state: 'accepted',
+            },
+          ],
+        });
+      }
+      await hooks.onSocketClosed?.(true, connection);
+      if (scenario === 'getControlState timeout')
+        sessionA.getControlState.mockImplementation(() => new Promise(() => undefined));
+      operationTimeout = scenario === 'operation.get timeout';
+      vi.clearAllMocks();
+      vi.setSystemTime(NOW + 6_000);
+      connection = { ...connection, connectionId: 'ffffffff-ffff-4fff-8fff-ffffffffffff' };
+      await hooks.onHandshakeComplete?.(connection);
+      await hooks.onReady?.(connection);
+      if (scenario !== 'pending Stop') await vi.advanceTimersByTimeAsync(30_000);
+      await flush();
+    },
+    async retry(scenario: Scenario) {
+      const deadlines = await loadDeadlines(storage);
+      if (deadlines.recoveryRetry === undefined) throw new Error('Missing recovery retry deadline');
+      vi.setSystemTime(Math.max(Date.now(), deadlines.recoveryRetry));
+      await control.alarm();
+      if (scenario !== 'pending Stop') await vi.advanceTimersByTimeAsync(30_000);
+      await flush();
+    },
+  };
+}
+
+type Harness = Awaited<ReturnType<typeof harness>>;
+
+async function retained(h: Harness) {
+  const records = await loadRecoveryDecisions(h.storage);
+  expect(records).toHaveLength(1);
+  const record = records[0];
+  if (!record) throw new Error('Expected retained scoped recovery');
+  return record;
+}
+
+async function expectScopedAdmission(h: Harness) {
+  const admitted = {
+    ...authorization(rootB, 'followup_b'),
+    dispatchDeadlineAt: Date.now() + 5_000,
+  };
+  await expect
+    .soft(h.control.request(prompt(admitted)))
+    .resolves.toMatchObject({ ok: true, result: { status: 'accepted' } });
+  const blocked = { ...authorization(rootA, 'followup_a'), dispatchDeadlineAt: Date.now() + 5_000 };
+  await expect
+    .soft(h.control.request(prompt(blocked)))
+    .rejects.toThrow('Session recovery is not ready');
+  expect
+    .soft(
+      h.sendRequest.mock.calls.filter(
+        ([request]) =>
+          request.operation === 'session.prompt' && request.session?.sessionId === rootA.sessionId
+      )
+    )
+    .toEqual([]);
+  await expect.soft(h.control.request(maintenance(authorization(rootB)))).resolves.toEqual(
+    response({
+      state: 'running',
+      authorization: authorization(rootB),
+      executionDeadlineAt: EXECUTION_DEADLINE,
+    })
+  );
+}
+
+async function expectNoSiblingRetirement(h: Harness, scenario: Scenario) {
+  const retirements = await loadNativeRuntimeRetirements(h.storage);
+  expect
+    .soft(
+      retirements.some(
+        item =>
+          item.nativeRuntimeId === rootB.nativeRuntimeId ||
+          item.recipients.some(recipient => recipient.sessionId === rootB.sessionId)
+      )
+    )
+    .toBe(false);
+  expect
+    .soft(
+      h.sendRequest.mock.calls.filter(
+        ([request]) =>
+          request.operation === 'session.abort' &&
+          (scenario !== 'pending Stop' || request.session?.sessionId === rootB.sessionId)
+      )
+    )
+    .toEqual([]);
+  expect.soft(h.provider.stop).not.toHaveBeenCalled();
+  expect
+    .soft(h.sendRequest.mock.calls.filter(([request]) => request.operation === 'sandbox.shutdown'))
+    .toEqual([]);
+  expect.soft(h.socket.closeAll).not.toHaveBeenCalled();
+  expect.soft(h.socket.closeHandshakenSockets).not.toHaveBeenCalled();
+  expect.soft(await h.control.getPhysicalRecord()).toEqual(h.physical);
+  const routeB = (await loadRouteTable(h.storage)).get(rootB.sessionId);
+  expect.soft(routeB?.nativeRuntimeId).toBe(rootB.nativeRuntimeId);
+  expect.soft(routeB?.retiringNativeRuntimeId).toBeUndefined();
+  expect.soft(h.sessionB.failWaitingMessages).not.toHaveBeenCalled();
+  expect.soft(h.sessionB.invalidateTerminalRuntime).not.toHaveBeenCalled();
+  if (scenario !== 'pending Stop') {
+    expect.soft(retirements).toEqual([]);
+    expect.soft(h.sessionA.invalidateTerminalRuntime).not.toHaveBeenCalled();
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  vi.stubGlobal('WebSocketRequestResponsePair', class {});
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe.each([
+  {
+    operation: 'session.permission.resolve',
+    payload: { permissionId: 'permission_a', response: 'once' },
+  },
+  {
+    operation: 'session.question.resolve',
+    payload: { action: 'answer', questionId: 'question_a', answers: [['yes']] },
+  },
+  {
+    operation: 'session.question.resolve',
+    payload: { action: 'reject', questionId: 'question_a' },
+  },
+] satisfies Pick<SandboxControlOutboundRequest, 'operation' | 'payload'>[])(
+  'SandboxControl recovery interaction $operation $payload',
+  interaction => {
+    function request(): SandboxControlOutboundRequest {
+      return { ...interaction, session: authorization(rootA).session };
+    }
+
+    it('forwards the current reply before readiness and after reconstruction without admitting prompts', async () => {
+      const h = await harness();
+      await h.reconnectForInteraction();
+      const recovery = await retained(h);
+      expect(recovery.activationAcknowledgedAt).toBeUndefined();
+      expect(
+        recovery.authority?.roots?.find(root => root.sessionId === rootA.sessionId)
+      ).toMatchObject({
+        observation: 'known',
+        decision: 'operation_unknown',
+        nativeRuntimeId: rootA.nativeRuntimeId,
+      });
+      for (const reconstruct of [false, true]) {
+        if (reconstruct) await h.reconstruct();
+        expect(await h.control.getStatus()).toMatchObject({ connection: 'connected' });
+        await expect(h.control.request(request())).resolves.toEqual(response({ success: true }));
+        expect(h.sendRequest).toHaveBeenLastCalledWith(request());
+        await expect(h.control.request(prompt(authorization(rootA)))).rejects.toThrow(
+          'Sandbox runtime is not ready'
+        );
+      }
+      expect(h.sendRequest).toHaveBeenCalledTimes(2);
+      expect(await retained(h)).toEqual(recovery);
+      expect(h.provider.stop).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { session: undefined },
+      { session: { ...rootA, sessionId: 'workspace_missing' } },
+      { session: { ...rootA, kiloSessionId: rootB.kiloSessionId } },
+      { session: { ...rootA, directory: rootB.directory } },
+      { expectedWrapperInstanceId: rootB.nativeRuntimeId },
+      { payload: {} },
+    ])('rejects invalid or stale request scope %j without forwarding', async change => {
+      const h = await harness();
+      await h.reconnectForInteraction();
+      await expect(h.control.request({ ...request(), ...change })).rejects.toThrow();
+      expect(h.sendRequest).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      'missing route',
+      'native runtime replaced',
+      'native runtime retiring',
+      'owner changed',
+      'allocation changed',
+      'physical stopping',
+      'physical provider changed',
+      'runtime deleted',
+      'recovery connection changed',
+      'recovery wrapper changed',
+      'recovery exhausted',
+      'recovery expired',
+      'recovery root stale',
+      'recovery Stop pending',
+      'recovery missing',
+      'recovery not negotiated',
+    ])('rejects %s without forwarding', async change => {
+      const h = await harness();
+      await h.reconnectForInteraction();
+      const routes = await loadRouteTable(h.storage);
+      const route = routes.get(rootA.sessionId);
+      if (!route) throw new Error('Expected current route');
+      const recovery = await retained(h);
+      switch (change) {
+        case 'missing route':
+          routes.delete(rootA.sessionId);
+          break;
+        case 'native runtime replaced':
+          route.nativeRuntimeId = rootB.nativeRuntimeId;
+          break;
+        case 'native runtime retiring':
+          route.retiringNativeRuntimeId = rootA.nativeRuntimeId;
+          break;
+        case 'owner changed':
+          route.ownerId = 'owner_2';
+          break;
+        case 'allocation changed':
+          await savePhysicalRecord(h.storage, {
+            ...h.physical,
+            createIntent: { ...h.physical.createIntent, intentId: 'allocation_2' },
+          });
+          break;
+        case 'physical stopping':
+          await savePhysicalRecord(
+            h.storage,
+            beginStop(h.physical, 'test stop', Date.now(), WRAPPER)
+          );
+          break;
+        case 'physical provider changed':
+          await savePhysicalRecord(h.storage, { ...h.physical, providerRef: 'replacement' });
+          break;
+        case 'runtime deleted':
+          await h.storage.put('runtime_deleted', true);
+          await h.reconstruct();
+          break;
+        case 'recovery connection changed':
+          recovery.connectionId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+          break;
+        case 'recovery wrapper changed':
+          recovery.wrapperInstanceId = rootB.nativeRuntimeId;
+          break;
+        case 'recovery exhausted':
+          recovery.exhaustedAt = Date.now();
+          break;
+        case 'recovery expired':
+          recovery.deadlineAt = Date.now();
+          break;
+        case 'recovery root stale':
+        case 'recovery Stop pending': {
+          const root = recovery.authority?.roots?.find(item => item.sessionId === rootA.sessionId);
+          if (!root) throw new Error('Expected recovery root');
+          if (change === 'recovery root stale') root.observation = 'stale';
+          else root.decision = 'stop_pending';
+          break;
+        }
+        case 'recovery not negotiated':
+          vi.spyOn(h.socket, 'supportsConnectionRecovery').mockReturnValue(false);
+          break;
+      }
+      await saveRouteTable(h.storage, routes);
+      await saveRecoveryDecisions(h.storage, change === 'recovery missing' ? [] : [recovery]);
+      await expect(h.control.request(request())).rejects.toThrow();
+      expect(h.sendRequest).not.toHaveBeenCalled();
+    });
+  }
+);
+
+describe('SandboxControl production recovery hooks', () => {
+  it.each(['wrapperReadiness', 'startup'] as const)(
+    'does not fall back to %s while a replacement activation ACK is stalled',
+    async deadline => {
+      const h = await harness();
+      await h.recover('pending Stop');
+      const original = await retained(h);
+      await h.reconnectForInteraction();
+      await h.reconstruct();
+      const markFailed = vi.spyOn(h.control, 'markFailed');
+      expect(await h.storage.get('wrapper_ready_at')).toBeUndefined();
+      await saveDeadlines(h.storage, {
+        ...(await loadDeadlines(h.storage)),
+        recoveryRetry: undefined,
+        [deadline]: original.deadlineAt,
+      });
+      vi.setSystemTime(original.deadlineAt);
+      await h.control.alarm();
+      await h.flush();
+      expect(markFailed).not.toHaveBeenCalled();
+      expect((await retained(h)).exhaustedAt).toBeUndefined();
+      expect(await loadDeadlines(h.storage)).toMatchObject({
+        recoveryExpiry: original.activationCommitDeadlineAt,
+      });
+      if (original.activationCommitDeadlineAt === undefined)
+        throw new Error('Missing original activation ACK deadline');
+      vi.setSystemTime(original.activationCommitDeadlineAt);
+      await h.control.alarm();
+      await h.flush();
+      expect(await retained(h)).toMatchObject({
+        deadlineAt: original.deadlineAt,
+        exhaustedAt: original.activationCommitDeadlineAt,
+        authority: original.authority,
+      });
+      await expectNoSiblingRetirement(h, 'pending Stop');
+    }
+  );
+
+  it.each(
+    scenarios.flatMap(scenario =>
+      (['wrapperReadiness', 'startup'] as const).map(deadline => ({ scenario, deadline }))
+    )
+  )(
+    'keeps stale $deadline under scoped cleanup while A has $scenario',
+    async ({ scenario, deadline }) => {
+      const h = await harness();
+      await h.recover(scenario);
+      const original = await retained(h);
+      await h.reconnectForInteraction();
+      await h.hooks.onReady?.(h.connection);
+      await h.flush();
+      const resumed = await retained(h);
+      expect(resumed.deadlineAt).toBe(original.deadlineAt);
+      expect(resumed.attempt).toBe(original.attempt);
+      expect(await loadDeadlines(h.storage)).not.toHaveProperty('wrapperReadiness');
+      expect(await loadDeadlines(h.storage)).not.toHaveProperty('startup');
+      const markFailed = vi.spyOn(h.control, 'markFailed');
+      await saveDeadlines(h.storage, {
+        ...(await loadDeadlines(h.storage)),
+        recoveryRetry: undefined,
+        [deadline]: original.deadlineAt,
+      });
+      vi.setSystemTime(original.deadlineAt);
+      await h.control.alarm();
+      await h.flush();
+      expect(markFailed).not.toHaveBeenCalled();
+      expect(await retained(h)).toMatchObject({
+        episodeId: original.episodeId,
+        deadlineAt: original.deadlineAt,
+        exhaustedAt: original.deadlineAt,
+      });
+      await expectScopedAdmission(h);
+      await expectNoSiblingRetirement(h, scenario);
+    }
+  );
+
+  it.each(scenarios)(
+    'activates B without changing its original operation while A has %s',
+    async scenario => {
+      const h = await harness();
+      await h.recover(scenario);
+      const recovery = await retained(h);
+      expect.soft(recovery.activationAcknowledgedAt).toBe(Date.now());
+      expect.soft(recovery.authority?.roots).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sessionId: rootA.sessionId,
+            decision: scenario === 'pending Stop' ? 'stop_pending' : 'operation_unknown',
+          }),
+          expect.objectContaining({ sessionId: rootB.sessionId, decision: 'ready' }),
+        ])
+      );
+      expect
+        .soft(
+          h.sendRequest.mock.calls
+            .filter(([request]) => request.operation === 'sandbox.reconcile')
+            .map(([request]) => sandboxReconcilePayloadSchema.parse(request.payload).phase)
+        )
+        .toEqual(['drain', 'ready', 'commit']);
+      expect
+        .soft(h.sessionB.reconcileControlRecovery)
+        .toHaveBeenCalledExactlyOnceWith([authorization(rootB)]);
+      expect.soft(h.sendRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'session.operation.get',
+          session: authorization(rootB).session,
+          payload: authorization(rootB),
+          expectedWrapperInstanceId: WRAPPER,
+        })
+      );
+      expect
+        .soft(recovery.authority?.scopes.find(scope => scope.sessionId === rootB.sessionId))
+        .toMatchObject({
+          ...authorization(rootB).session,
+          messageId: authorization(rootB).messageId,
+          authorization: authorization(rootB),
+          executionDeadlineAt: EXECUTION_DEADLINE,
+          wrapperInstanceId: WRAPPER,
+          nativeRuntimeId: rootB.nativeRuntimeId,
+        });
+      expect
+        .soft(
+          h.sendRequest.mock.calls.filter(([request]) => request.operation === 'session.prompt')
+        )
+        .toEqual([]);
+      if (scenario === 'pending Stop')
+        expect.soft(h.sessionA.interruptExecution).toHaveBeenCalled();
+      await expectScopedAdmission(h);
+      await expectNoSiblingRetirement(h, scenario);
+      const bStateCalls = h.sessionB.getControlState.mock.calls.length;
+      const bReconcileCalls = h.sessionB.reconcileControlRecovery.mock.calls.length;
+      await h.reconstruct();
+      await expectScopedAdmission(h);
+      await h.retry(scenario);
+      expect.soft(h.sessionB.getControlState).toHaveBeenCalledTimes(bStateCalls);
+      expect.soft(h.sessionB.reconcileControlRecovery).toHaveBeenCalledTimes(bReconcileCalls);
+      const retried = await retained(h);
+      expect.soft(retried.episodeId).toBe(recovery.episodeId);
+      expect.soft(retried.activationAcknowledgedAt).toBe(recovery.activationAcknowledgedAt);
+      expect
+        .soft(retried.authority?.scopes.filter(scope => scope.sessionId === rootB.sessionId))
+        .toEqual(recovery.authority?.scopes.filter(scope => scope.sessionId === rootB.sessionId));
+    }
+  );
+
+  it.each(scenarios)(
+    'preserves B admission, input and result through exhausted recovery connection replacement when A has %s',
+    async scenario => {
+      const h = await harness();
+      await h.recover(scenario);
+      const initial = await retained(h);
+      await h.reconstruct();
+      await h.retry(scenario);
+      await h.reconstruct();
+      await h.retry(scenario);
+      const exhausted = await retained(h);
+      expect.soft(exhausted.exhaustedAt).toBeDefined();
+      expect.soft(exhausted.episodeId).toBe(initial.episodeId);
+      expect.soft(exhausted.activationAcknowledgedAt).toBe(initial.activationAcknowledgedAt);
+      expect
+        .soft(
+          exhausted.authority?.roots?.find(root => root.sessionId === rootB.sessionId)?.decision
+        )
+        .toBe('ready');
+      await h.reconstruct();
+      await h.reconnectForInteraction();
+      const pendingActivation = await retained(h);
+      expect(pendingActivation.connectionId).not.toBe(exhausted.connectionId);
+      expect(pendingActivation.activationAcknowledgedAt).toBeUndefined();
+      await expect(
+        h.control.request(
+          prompt({ ...authorization(rootB, 'before_ack'), dispatchDeadlineAt: Date.now() + 5_000 })
+        )
+      ).rejects.toThrow('Sandbox runtime is not ready');
+      await h.reconstruct();
+      await h.hooks.onReady?.(h.connection);
+      await h.flush();
+      expect(h.sendRequest).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          operation: 'sandbox.reconcile',
+          payload: {
+            phase: 'commit',
+            recovery: expect.objectContaining({
+              episodeId: initial.episodeId,
+              deadlineAt: initial.deadlineAt,
+              attempt: initial.attempt,
+            }),
+          },
+        })
+      );
+      const restored = await retained(h);
+      expect(restored).toMatchObject({
+        attempt: exhausted.attempt,
+        deadlineAt: exhausted.deadlineAt,
+        exhaustedAt: exhausted.exhaustedAt,
+        cleanupDeadlineAt: exhausted.cleanupDeadlineAt,
+        cleanupState: exhausted.cleanupState,
+        nextAttemptAt: exhausted.nextAttemptAt,
+        authority: exhausted.authority,
+        activationCommitDeadlineAt: exhausted.activationCommitDeadlineAt,
+        activationAcknowledgedAt: Date.now(),
+      });
+      await expectScopedAdmission(h);
+      await expect(
+        h.control.request({
+          operation: 'session.question.resolve',
+          session: authorization(rootB).session,
+          payload: { action: 'answer', questionId: 'question_b', answers: [['yes']] },
+        })
+      ).resolves.toEqual(response({ success: true }));
+      await h.control.alarm();
+      await h.flush();
+      await expectNoSiblingRetirement(h, scenario);
+      if (exhausted.cleanupDeadlineAt === undefined) throw new Error('Missing cleanup deadline');
+      vi.setSystemTime(exhausted.cleanupDeadlineAt);
+      await h.control.alarm();
+      await h.flush();
+      await h.reconstruct();
+      await expectNoSiblingRetirement(h, scenario);
+      await expectScopedAdmission(h);
+      const finalRecovery = await retained(h);
+      expect
+        .soft(finalRecovery.authority?.scopes.filter(scope => scope.sessionId === rootB.sessionId))
+        .toEqual(initial.authority?.scopes.filter(scope => scope.sessionId === rootB.sessionId));
+      const delivery: SessionOperationDelivery = {
+        version: 2,
+        authorization: authorization(rootB),
+        completedAt: Date.now(),
+        result: {
+          ok: true,
+          result: {
+            messageId: authorization(rootB).messageId,
+            status: 'accepted',
+            executionDeadlineAt: EXECUTION_DEADLINE,
+          },
+        },
+        outcome: { messageId: authorization(rootB).messageId, status: 'completed' },
+        events: [],
+        preparing: [],
+      };
+      await expect
+        .soft(h.hooks.onOperationResult?.(authorization(rootB).session, delivery, h.connection))
+        .resolves.toMatchObject({
+          authorization: authorization(rootB),
+          disposition: 'applied',
+          decision: { state: 'completed' },
+        });
+      expect.soft(h.sessionB.receiveSandboxOperationResult).toHaveBeenCalledExactlyOnceWith({
+        session: authorization(rootB).session,
+        wrapperInstanceId: WRAPPER,
+        delivery,
+      });
+      expect.soft(h.sessionA.receiveSandboxOperationResult).not.toHaveBeenCalled();
+      await h.flush();
+    }
+  );
+});

--- a/services/cloud-agent-next/src/sandbox-control/control-recovery.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/control-recovery.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+import {
+  beginRecovery,
+  canRepairActivation,
+  claimAttempt,
+  commitRecoveryActivation,
+  failAttempt,
+  recoveryDeadlines,
+  replaceRecoveryAuthority,
+  sameRuntime,
+  wireRecovery,
+  type RecoveryAuthority,
+  type SandboxRecoveryDecision,
+} from './control-recovery.js';
+
+const first = {
+  connectionId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  providerInstanceId: 'allocation_a',
+  wrapperInstanceId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+  recoveryCapable: true,
+};
+
+describe('exhausted scoped activation repair', () => {
+  const session = { sessionId: 'workspace_b', kiloSessionId: 'kilo_b', directory: '/workspace/b' };
+  const scope = {
+    ...session,
+    messageId: 'message_b',
+    wrapperInstanceId: first.wrapperInstanceId,
+    executionDeadlineAt: 60_000,
+    authorization: {
+      operation: 'session.prompt' as const,
+      operationId: 'message_b',
+      messageId: 'message_b',
+      session,
+      wrapperInstanceId: first.wrapperInstanceId,
+      dispatchDeadlineAt: 15_000,
+    },
+  };
+  const authority: RecoveryAuthority = {
+    source: 'session_control_state',
+    observedAt: 10_000,
+    allocation: { providerRef: first.providerInstanceId },
+    roots: [{ ...session, ownerId: 'owner_b', observation: 'known', decision: 'ready' }],
+    scopes: [scope],
+    stops: [],
+    wholeAllocation: false,
+  };
+  const original = commitRecoveryActivation(
+    { ...beginRecovery(undefined, first, 'control_disconnected', 10_000), attempt: 1, authority },
+    10_001
+  );
+  const exhausted: SandboxRecoveryDecision = {
+    ...original,
+    attempt: 3,
+    exhaustedAt: 13_000,
+    cleanupState: 'targeted',
+    cleanupDeadlineAt: 43_000,
+    nextAttemptAt: 20_000,
+    activationCommitAttempts: 1,
+    activationAcknowledgedAt: 10_002,
+  };
+
+  it('preserves the original receipt, ACK budget and independent cleanup schedule on reconnect', () => {
+    const connection = { ...first, connectionId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc' };
+    const rebound = beginRecovery(exhausted, connection, 'control_disconnected', 14_000);
+    expect(rebound).toEqual({
+      ...exhausted,
+      connectionId: connection.connectionId,
+      activationAcknowledgedAt: undefined,
+    });
+    expect(claimAttempt(rebound, first, 14_000)).toBeUndefined();
+    const claimed = claimAttempt(rebound, connection, 14_000);
+    if (!claimed) throw new Error('Expected exhausted activation repair');
+    expect(claimed.recovery).toMatchObject({
+      attempt: 3,
+      activationCommitAttempt: 1,
+      activationCommitAttempts: 2,
+      nextAttemptAt: 20_000,
+    });
+    expect(wireRecovery(claimed.recovery)).toEqual(wireRecovery(original));
+    const retry = failAttempt(claimed.recovery, 14_001);
+    expect(retry).toEqual({
+      ...claimed.recovery,
+      activationCommitNextAttemptAt: 15_001,
+    });
+    expect(recoveryDeadlines({}, [retry], 14_001)).toEqual({
+      recoveryExpiry: original.activationCommitDeadlineAt,
+      recoveryRetry: 15_001,
+    });
+    expect(claimAttempt(retry, connection, 15_000)).toBeUndefined();
+    const last = claimAttempt(retry, connection, 15_001);
+    if (!last) throw new Error('Expected final activation repair');
+    const failed = failAttempt(last.recovery, 15_002);
+    expect(failed).toEqual(last.recovery);
+    expect(failed.activationCommitAttempts).toBe(3);
+    expect(claimAttempt(failed, connection, 15_003)).toBeUndefined();
+    expect(recoveryDeadlines({}, [failed], 15_003)).toEqual({ recoveryRetry: 20_000 });
+  });
+
+  it.each<{ name: string; patch: Partial<SandboxRecoveryDecision>; eligible: boolean }>([
+    { name: 'ready scope with original authorization', patch: {}, eligible: true },
+    {
+      name: 'no original commit attempt',
+      patch: { activationCommitAttempt: undefined },
+      eligible: false,
+    },
+    { name: 'expired ACK window', patch: { activationCommitDeadlineAt: 20_000 }, eligible: false },
+    { name: 'spent ACK budget', patch: { activationCommitAttempts: 3 }, eligible: false },
+    { name: 'already acknowledged', patch: { activationAcknowledgedAt: 19_000 }, eligible: false },
+    {
+      name: 'no prior ready root',
+      patch: { authority: { ...authority, roots: [] } },
+      eligible: false,
+    },
+    {
+      name: 'no matching scope',
+      patch: { authority: { ...authority, scopes: [] } },
+      eligible: false,
+    },
+    {
+      name: 'expired original execution bound',
+      patch: { authority: { ...authority, scopes: [{ ...scope, executionDeadlineAt: 20_000 }] } },
+      eligible: false,
+    },
+    {
+      name: 'missing original authorization',
+      patch: { authority: { ...authority, scopes: [{ ...scope, authorization: undefined }] } },
+      eligible: false,
+    },
+    {
+      name: 'different wrapper scope',
+      patch: {
+        authority: { ...authority, scopes: [{ ...scope, wrapperInstanceId: crypto.randomUUID() }] },
+      },
+      eligible: false,
+    },
+    {
+      name: 'stale ready root',
+      patch: {
+        authority: {
+          ...authority,
+          roots: [{ ...session, ownerId: 'owner_b', observation: 'stale', decision: 'ready' }],
+        },
+      },
+      eligible: false,
+    },
+  ])('$name is eligible: $eligible', ({ patch, eligible }) => {
+    const decision = { ...exhausted, activationAcknowledgedAt: undefined, ...patch };
+    expect(canRepairActivation(decision, 20_000)).toBe(eligible);
+    expect(claimAttempt(decision, first, 20_000) !== undefined).toBe(eligible);
+  });
+});
+
+describe('control recovery', () => {
+  it('retains one deadline and moves its authority only to the same wrapper runtime', () => {
+    const started = beginRecovery(undefined, first, 'control_disconnected', 10_000);
+    const replacement = {
+      ...first,
+      connectionId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    };
+
+    const retained = beginRecovery(started, replacement, 'control_disconnected', 20_000);
+
+    expect(retained).toMatchObject({
+      episodeId: started.episodeId,
+      startedAt: 10_000,
+      deadlineAt: started.deadlineAt,
+      connectionId: replacement.connectionId,
+    });
+    expect(sameRuntime(first, replacement)).toBe(true);
+    expect(
+      sameRuntime(first, {
+        ...replacement,
+        wrapperInstanceId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      })
+    ).toBe(false);
+  });
+
+  it('fences old connections and exhausts bounded retries without extending the episode', () => {
+    const recovery = beginRecovery(undefined, first, 'heartbeat_expired', 10_000);
+    expect(
+      claimAttempt(recovery, { ...first, connectionId: crypto.randomUUID() }, 10_001)
+    ).toBeUndefined();
+
+    const claimed = claimAttempt(recovery, first, 10_001);
+    if (!claimed) throw new Error('Expected recovery attempt');
+    const retry = failAttempt(claimed.recovery, 10_002);
+    expect(retry.deadlineAt).toBe(recovery.deadlineAt);
+    expect(retry.nextAttemptAt).toBeDefined();
+
+    const exhausted = failAttempt({ ...retry, attempt: 3 }, 10_003);
+    expect(exhausted.exhaustedAt).toBe(10_003);
+    expect(recoveryDeadlines({}, [exhausted], 10_003)).toEqual({ recoveryRetry: 10_003 });
+  });
+
+  it('retains an activation receipt for the original attempt until its matching commit reply', () => {
+    const recovery = beginRecovery(undefined, first, 'control_disconnected', 10_000);
+    const claimed = claimAttempt(recovery, first, 10_001);
+    if (!claimed) throw new Error('Expected recovery attempt');
+
+    const committed = commitRecoveryActivation(claimed.recovery, 10_002);
+    const replay = claimAttempt(committed, first, 10_003);
+    if (!replay) throw new Error('Expected activation repair attempt');
+
+    expect(committed).toMatchObject({
+      episodeId: recovery.episodeId,
+      attempt: claimed.recovery.attempt,
+      activationCommittedAt: 10_002,
+    });
+    expect(replay).toMatchObject({
+      recovery: {
+        episodeId: recovery.episodeId,
+        attempt: claimed.recovery.attempt,
+        activationCommittedAt: 10_002,
+        activationCommitAttempts: 1,
+      },
+    });
+    expect(recoveryDeadlines({}, [committed], 10_002)).toEqual({
+      recoveryExpiry: 100_002,
+      recoveryRetry: 10_002,
+    });
+    expect(failAttempt({ ...replay.recovery, activationCommitAttempts: 3 }, 10_004)).toMatchObject({
+      exhaustedAt: 10_004,
+      activationCommittedAt: 10_002,
+    });
+  });
+
+  it('retains a Session execution bound independently from recovery observation timing', () => {
+    const recovery = beginRecovery(undefined, first, 'control_disconnected', 10_000);
+    const authority = {
+      source: 'session_control_state' as const,
+      observedAt: 10_100,
+      allocation: { providerRef: first.providerInstanceId },
+      scopes: [
+        {
+          sessionId: 'workspace_a',
+          kiloSessionId: 'kilo_a',
+          directory: '/workspace/a',
+          messageId: 'msg_a',
+          wrapperInstanceId: first.wrapperInstanceId,
+          executionDeadlineAt: recovery.deadlineAt,
+        },
+      ],
+      stops: [],
+      wholeAllocation: true,
+    };
+
+    const reconciled = replaceRecoveryAuthority(recovery, authority);
+    const replacement = beginRecovery(
+      reconciled,
+      { ...first, connectionId: crypto.randomUUID() },
+      'control_disconnected',
+      10_200
+    );
+
+    expect(replacement.deadlineAt).toBe(recovery.deadlineAt);
+    expect(replacement.authority?.scopes[0]).toMatchObject({
+      messageId: 'msg_a',
+      executionDeadlineAt: recovery.deadlineAt,
+    });
+  });
+});

--- a/services/cloud-agent-next/src/sandbox-control/control-recovery.ts
+++ b/services/cloud-agent-next/src/sandbox-control/control-recovery.ts
@@ -1,0 +1,471 @@
+import { z } from 'zod';
+import { controlStopRequestSchema } from '../shared/control-plane-session.js';
+import {
+  SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS,
+  SANDBOX_CONTROL_RECOVERY_ATTEMPT_TIMEOUT_MS,
+  SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS,
+  sessionOperationAuthorizationSchema,
+  type SandboxRecovery,
+} from '../shared/sandbox-control-protocol.js';
+import { armDeadline, cancelDeadline, DEADLINE_MS, type DeadlineTable } from './deadlines.js';
+import type { SandboxControlConnectionIdentity } from './socket.js';
+
+export const ACTIVE_WRAPPER_RUNTIME_KEY = 'active_wrapper_runtime';
+export const WRAPPER_READY_AT_KEY = 'wrapper_ready_at';
+export const RECOVERY_ACTIVATION_ACK_TIMEOUT_MS = 90_000;
+
+const recoveryAuthorityScopeSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    kiloSessionId: z.string().min(1),
+    directory: z.string().min(1),
+    messageId: z.string().min(1),
+    wrapperInstanceId: z.string().uuid().optional(),
+    nativeRuntimeId: z.string().uuid().optional(),
+    executionDeadlineAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER).optional(),
+    authorization: sessionOperationAuthorizationSchema.optional(),
+  })
+  .strict();
+
+const recoveryStopSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    ownerId: z.string().min(1),
+    request: controlStopRequestSchema,
+  })
+  .strict();
+
+const recoveryRootSchema = z.object({
+  sessionId: z.string().min(1),
+  ownerId: z.string().min(1),
+  kiloSessionId: z.string().min(1),
+  directory: z.string().min(1),
+  nativeRuntimeId: z.string().uuid().optional(),
+  observation: z.enum(['known', 'idle', 'stale', 'unknown']),
+  observedAt: z.number().int().nonnegative().optional(),
+  decision: z.enum(['ready', 'stop_pending', 'operation_unknown', 'execution_expired']).optional(),
+});
+
+export type RecoveryRoot = z.infer<typeof recoveryRootSchema>;
+export type RecoveryScopeResult = Pick<RecoveryRoot, 'sessionId' | 'decision'>;
+
+export const recoveryAuthoritySchema = z
+  .object({
+    source: z.literal('session_control_state'),
+    observedAt: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    allocation: z.object({
+      providerRef: z.string().min(1),
+      createIntentId: z.string().min(1).optional(),
+    }),
+    roots: z.array(recoveryRootSchema).optional(),
+    scopes: z.array(recoveryAuthorityScopeSchema),
+    stops: z.array(recoveryStopSchema),
+    wholeAllocation: z.boolean(),
+  })
+  .strict();
+
+export type RecoveryAuthority = z.infer<typeof recoveryAuthoritySchema>;
+
+export const sandboxRecoveryDecisionSchema = z
+  .object({
+    episodeId: z.string().uuid(),
+    cause: z.enum(['activation_pending', 'control_disconnected', 'heartbeat_expired']),
+    startedAt: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    deadlineAt: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    attempt: z.number().int().nonnegative().max(SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS),
+    connectionId: z.string().uuid(),
+    providerInstanceId: z.string().min(1),
+    wrapperInstanceId: z.string().uuid(),
+    nextAttemptAt: z.number().int().nonnegative().optional(),
+    exhaustedAt: z.number().int().nonnegative().optional(),
+    cleanupDeadlineAt: z.number().int().nonnegative().optional(),
+    cleanupState: z
+      .enum(['pending', 'targeted', 'physical_fallback', 'completed', 'unconfirmed'])
+      .optional(),
+    authority: recoveryAuthoritySchema.optional(),
+    activationCommittedAt: z.number().int().nonnegative().optional(),
+    activationCommitDeadlineAt: z.number().int().nonnegative().optional(),
+    activationCommitAttempts: z.number().int().nonnegative().optional(),
+    activationCommitAttempt: z.number().int().nonnegative().optional(),
+    activationCommitNextAttemptAt: z.number().int().nonnegative().optional(),
+    activationAcknowledgedAt: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
+export type SandboxRecoveryDecision = z.infer<typeof sandboxRecoveryDecisionSchema>;
+
+export type RecoveryAttempt = Readonly<{
+  recovery: SandboxRecoveryDecision;
+  deadlineAt: number;
+}>;
+
+export function activationCommitted(recovery: SandboxRecoveryDecision): boolean {
+  return recovery.activationCommittedAt !== undefined;
+}
+
+export function activationRepairPending(recovery: SandboxRecoveryDecision): boolean {
+  return activationCommitted(recovery) && recovery.activationAcknowledgedAt === undefined;
+}
+
+export function canRepairActivation(recovery: SandboxRecoveryDecision, now: number): boolean {
+  if (
+    !activationRepairPending(recovery) ||
+    (recovery.activationCommitDeadlineAt ?? 0) <= now ||
+    (recovery.activationCommitAttempts ?? 0) >= SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS
+  )
+    return false;
+  return recovery.exhaustedAt === undefined || hasReadyActivationScope(recovery, now);
+}
+
+export function hasReadyActivationScope(recovery: SandboxRecoveryDecision, now: number): boolean {
+  return (
+    recovery.activationCommitAttempt !== undefined &&
+    (recovery.authority?.roots?.some(
+      root =>
+        root.decision === 'ready' &&
+        (root.observation === 'known' || root.observation === 'idle') &&
+        recovery.authority?.scopes.some(
+          scope =>
+            scope.sessionId === root.sessionId &&
+            scope.kiloSessionId === root.kiloSessionId &&
+            scope.directory === root.directory &&
+            scope.nativeRuntimeId === root.nativeRuntimeId &&
+            scope.wrapperInstanceId === recovery.wrapperInstanceId &&
+            scope.authorization !== undefined &&
+            scope.executionDeadlineAt !== undefined &&
+            scope.executionDeadlineAt > now
+        )
+    ) ??
+      false)
+  );
+}
+
+export function commitRecoveryActivation(
+  recovery: SandboxRecoveryDecision,
+  now: number
+): SandboxRecoveryDecision {
+  return {
+    ...recovery,
+    activationCommittedAt: recovery.activationCommittedAt ?? now,
+    activationCommitDeadlineAt:
+      recovery.activationCommitDeadlineAt ?? now + RECOVERY_ACTIVATION_ACK_TIMEOUT_MS,
+    activationCommitAttempts: recovery.activationCommitAttempts ?? 0,
+    activationCommitAttempt: recovery.activationCommitAttempt ?? recovery.attempt,
+    activationCommitNextAttemptAt: now,
+  };
+}
+
+export function replaceRecoveryAuthority(
+  recovery: SandboxRecoveryDecision,
+  authority: RecoveryAuthority
+): SandboxRecoveryDecision {
+  const previous = recovery.authority;
+  if (!previous) return { ...recovery, authority };
+  if (
+    previous.allocation.providerRef !== authority.allocation.providerRef ||
+    previous.allocation.createIntentId !== authority.allocation.createIntentId
+  )
+    return recovery;
+  const roots = authority.roots?.map(root => {
+    const old = previous.roots?.find(item => item.sessionId === root.sessionId);
+    if (!old) return root;
+    if (root.observation === 'unknown' && old.observation !== 'unknown')
+      return { ...old, observation: 'stale' as const, decision: 'operation_unknown' as const };
+    if (
+      old.kiloSessionId !== root.kiloSessionId ||
+      old.directory !== root.directory ||
+      old.nativeRuntimeId !== root.nativeRuntimeId ||
+      old.ownerId !== root.ownerId
+    )
+      return { ...old, observation: 'stale' as const, decision: 'operation_unknown' as const };
+    return root;
+  });
+  for (const old of previous.roots ?? []) {
+    if (!roots?.some(root => root.sessionId === old.sessionId))
+      roots?.push({ ...old, observation: 'stale', decision: 'operation_unknown' });
+  }
+  const uncertain = (sessionId: string) => {
+    const root = roots?.find(item => item.sessionId === sessionId);
+    return (
+      root?.observation === 'stale' ||
+      root?.observation === 'unknown' ||
+      (!root && !authority.wholeAllocation)
+    );
+  };
+  const scopes = authority.scopes
+    .filter(scope => !uncertain(scope.sessionId))
+    .map(scope => {
+      const old = previous.scopes.find(
+        item =>
+          item.sessionId === scope.sessionId &&
+          item.messageId === scope.messageId &&
+          item.kiloSessionId === scope.kiloSessionId &&
+          item.directory === scope.directory &&
+          item.wrapperInstanceId === scope.wrapperInstanceId &&
+          item.nativeRuntimeId === scope.nativeRuntimeId
+      );
+      return old
+        ? {
+            ...scope,
+            authorization: old.authorization ?? scope.authorization,
+            executionDeadlineAt: old.executionDeadlineAt ?? scope.executionDeadlineAt,
+          }
+        : scope;
+    });
+  return {
+    ...recovery,
+    authority: {
+      ...authority,
+      allocation: previous.allocation,
+      ...(roots ? { roots } : {}),
+      scopes: [...scopes, ...previous.scopes.filter(scope => uncertain(scope.sessionId))],
+      stops: [
+        ...authority.stops.filter(stop => !uncertain(stop.sessionId)),
+        ...previous.stops.filter(stop => uncertain(stop.sessionId)),
+      ],
+      wholeAllocation:
+        authority.wholeAllocation && !(roots?.some(root => uncertain(root.sessionId)) ?? false),
+    },
+  };
+}
+
+export function hasUnresolvedRoots(authority: RecoveryAuthority | undefined): boolean {
+  return (
+    !authority ||
+    !authority.wholeAllocation ||
+    (authority.roots?.some(root => root.decision !== 'ready') ?? false)
+  );
+}
+
+export function admitsRecoveryRequest(
+  decisions: readonly SandboxRecoveryDecision[],
+  identity: SandboxControlConnectionIdentity,
+  session: { sessionId: string; kiloSessionId: string; directory: string }
+): boolean {
+  return decisions
+    .filter(item => sameRuntime(item, identity))
+    .every(item => {
+      const root = item.authority?.roots?.find(root => root.sessionId === session.sessionId);
+      return (
+        root?.decision === 'ready' &&
+        (root.observation === 'known' || root.observation === 'idle') &&
+        root.kiloSessionId === session.kiloSessionId &&
+        root.directory === session.directory
+      );
+    });
+}
+
+export function sameConnection(
+  left: SandboxControlConnectionIdentity,
+  right: SandboxControlConnectionIdentity
+): boolean {
+  return (
+    left.connectionId === right.connectionId &&
+    left.providerInstanceId === right.providerInstanceId &&
+    left.wrapperInstanceId === right.wrapperInstanceId
+  );
+}
+
+export function sameRuntime(
+  left: SandboxControlConnectionIdentity,
+  right: SandboxControlConnectionIdentity
+): boolean {
+  return (
+    left.providerInstanceId === right.providerInstanceId &&
+    left.wrapperInstanceId !== undefined &&
+    left.wrapperInstanceId === right.wrapperInstanceId
+  );
+}
+
+export function recoveryDeadlines(
+  deadlines: DeadlineTable,
+  recovery: readonly SandboxRecoveryDecision[],
+  now = Date.now()
+): DeadlineTable {
+  const active = recovery.filter(item =>
+    item.exhaustedAt === undefined
+      ? activationRepairPending(item)
+        ? (item.activationCommitDeadlineAt ?? 0) > now
+        : item.deadlineAt > now
+      : canRepairActivation(item, now)
+  );
+  let next = cancelDeadline(cancelDeadline(deadlines, 'recoveryExpiry'), 'recoveryRetry');
+  if (active.length > 0)
+    next = armDeadline(
+      next,
+      'recoveryExpiry',
+      Math.min(
+        ...active.map(item =>
+          activationRepairPending(item)
+            ? (item.activationCommitDeadlineAt ?? item.deadlineAt)
+            : item.deadlineAt
+        )
+      )
+    );
+  const retries = recovery.flatMap(item => {
+    const nextAttemptAt = activationRepairPending(item)
+      ? canRepairActivation(item, now)
+        ? (item.activationCommitNextAttemptAt ??
+          (item.activationCommitAttempt === undefined ? item.nextAttemptAt : undefined))
+        : undefined
+      : item.exhaustedAt === undefined
+        ? item.nextAttemptAt
+        : undefined;
+    return nextAttemptAt === undefined ? [] : [Math.max(now, nextAttemptAt)];
+  });
+  const cleanups = recovery
+    .filter(
+      item =>
+        item.exhaustedAt !== undefined &&
+        item.cleanupState !== 'completed' &&
+        item.cleanupState !== 'unconfirmed'
+    )
+    .map(item => Math.max(now, item.nextAttemptAt ?? item.cleanupDeadlineAt ?? now));
+  const scheduled = [...retries, ...cleanups];
+  return scheduled.length === 0 ? next : armDeadline(next, 'recoveryRetry', Math.min(...scheduled));
+}
+
+export function exhaustRecovery(
+  recovery: SandboxRecoveryDecision,
+  now: number
+): SandboxRecoveryDecision {
+  if (recovery.exhaustedAt !== undefined) return recovery;
+  return {
+    ...recovery,
+    exhaustedAt: now,
+    cleanupDeadlineAt: recovery.cleanupDeadlineAt ?? now + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS,
+    cleanupState: recovery.cleanupState ?? 'pending',
+    nextAttemptAt: now,
+  };
+}
+
+export function updateRecoveryCleanup(
+  recovery: SandboxRecoveryDecision,
+  state: NonNullable<SandboxRecoveryDecision['cleanupState']>,
+  nextAttemptAt?: number
+): SandboxRecoveryDecision {
+  if (recovery.exhaustedAt === undefined) return recovery;
+  return {
+    ...recovery,
+    cleanupState: state,
+    ...(nextAttemptAt === undefined ? { nextAttemptAt: undefined } : { nextAttemptAt }),
+  };
+}
+
+export function beginRecovery(
+  previous: SandboxRecoveryDecision | undefined,
+  identity: SandboxControlConnectionIdentity & { wrapperInstanceId: string },
+  cause: SandboxRecoveryDecision['cause'],
+  now: number
+): SandboxRecoveryDecision {
+  const deadlineAt = Math.min(previous?.deadlineAt ?? Infinity, now + DEADLINE_MS.heartbeatExpiry);
+  if (previous) {
+    return {
+      ...previous,
+      connectionId: identity.connectionId,
+      providerInstanceId: identity.providerInstanceId,
+      wrapperInstanceId: identity.wrapperInstanceId,
+      deadlineAt,
+      ...(previous.connectionId !== identity.connectionId
+        ? {
+            activationAcknowledgedAt: undefined,
+            activationCommitNextAttemptAt: previous.activationCommitNextAttemptAt ?? now,
+          }
+        : {}),
+    };
+  }
+  return {
+    episodeId: crypto.randomUUID(),
+    cause,
+    startedAt: now,
+    deadlineAt,
+    attempt: 0,
+    connectionId: identity.connectionId,
+    providerInstanceId: identity.providerInstanceId,
+    wrapperInstanceId: identity.wrapperInstanceId,
+  };
+}
+
+export function claimAttempt(
+  recovery: SandboxRecoveryDecision | undefined,
+  identity: SandboxControlConnectionIdentity,
+  now: number
+): RecoveryAttempt | undefined {
+  if (!recovery || !sameConnection(recovery, identity)) return undefined;
+  if (activationRepairPending(recovery)) {
+    const activationCommitDeadlineAt = recovery.activationCommitDeadlineAt;
+    const nextAttemptAt =
+      recovery.activationCommitNextAttemptAt ??
+      (recovery.activationCommitAttempt === undefined ? recovery.nextAttemptAt : undefined);
+    if (
+      activationCommitDeadlineAt === undefined ||
+      !canRepairActivation(recovery, now) ||
+      (nextAttemptAt !== undefined && now < nextAttemptAt)
+    )
+      return undefined;
+    return {
+      recovery: {
+        ...recovery,
+        activationCommitAttempts: (recovery.activationCommitAttempts ?? 0) + 1,
+        activationCommitNextAttemptAt: undefined,
+      },
+      deadlineAt: Math.min(
+        activationCommitDeadlineAt,
+        now + SANDBOX_CONTROL_RECOVERY_ATTEMPT_TIMEOUT_MS
+      ),
+    };
+  }
+  if (
+    recovery.exhaustedAt !== undefined ||
+    (recovery.nextAttemptAt !== undefined && now < recovery.nextAttemptAt) ||
+    recovery.attempt >= SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS ||
+    now >= recovery.deadlineAt
+  )
+    return undefined;
+  const claimed = { ...recovery, attempt: recovery.attempt + 1, nextAttemptAt: undefined };
+  return {
+    recovery: claimed,
+    deadlineAt: Math.min(claimed.deadlineAt, now + SANDBOX_CONTROL_RECOVERY_ATTEMPT_TIMEOUT_MS),
+  };
+}
+
+export function failAttempt(
+  recovery: SandboxRecoveryDecision,
+  now: number
+): SandboxRecoveryDecision {
+  if (activationRepairPending(recovery)) {
+    if (
+      recovery.activationCommitDeadlineAt === undefined ||
+      now >= recovery.activationCommitDeadlineAt ||
+      (recovery.activationCommitAttempts ?? SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS) >=
+        SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS
+    )
+      return exhaustRecovery(recovery, now);
+    return {
+      ...recovery,
+      activationCommitNextAttemptAt: Math.min(recovery.activationCommitDeadlineAt, now + 1_000),
+    };
+  }
+  if (
+    recovery.exhaustedAt !== undefined ||
+    now >= recovery.deadlineAt ||
+    recovery.attempt >= SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS
+  )
+    return exhaustRecovery(recovery, now);
+  return {
+    ...recovery,
+    nextAttemptAt: Math.min(recovery.deadlineAt, now + 1_000 * 2 ** (recovery.attempt - 1)),
+  };
+}
+
+export function wireRecovery(recovery: SandboxRecoveryDecision): SandboxRecovery {
+  return {
+    episodeId: recovery.episodeId,
+    cause: recovery.cause,
+    startedAt: recovery.startedAt,
+    deadlineAt: recovery.deadlineAt,
+    attempt: activationRepairPending(recovery)
+      ? (recovery.activationCommitAttempt ?? recovery.attempt)
+      : recovery.attempt,
+  };
+}

--- a/services/cloud-agent-next/src/sandbox-control/deadlines.ts
+++ b/services/cloud-agent-next/src/sandbox-control/deadlines.ts
@@ -3,6 +3,8 @@ export const DEADLINE_IDS = [
   'socketHandshake',
   'wrapperReadiness',
   'heartbeatExpiry',
+  'recoveryExpiry',
+  'recoveryRetry',
   'acceptedAlarmCap',
   'idleStop',
   'stopAttempt',

--- a/services/cloud-agent-next/src/sandbox-control/durable-state.ts
+++ b/services/cloud-agent-next/src/sandbox-control/durable-state.ts
@@ -13,6 +13,7 @@ import {
   type SessionCredentialGrant,
 } from './session-credentials.js';
 import { emptyTransitionLog, type TransitionRow } from './transition-log.js';
+import { sandboxRecoveryDecisionSchema, type SandboxRecoveryDecision } from './control-recovery.js';
 
 export const PHYSICAL_KEY = 'physical_record';
 const ROUTES_KEY = 'session_routes';
@@ -21,6 +22,7 @@ const LOG_KEY = 'transition_log';
 const CREDENTIAL_GRANTS_KEY = 'worktree_credential_grants';
 const RUNTIME_METADATA_KEY = 'runtime_metadata';
 const NATIVE_RUNTIME_RETIREMENTS_KEY = 'native_runtime_retirements';
+const RECOVERY_DECISIONS_KEY = 'recovery_decisions';
 
 type ControlStorage = {
   get<T = unknown>(key: string): Promise<T | undefined>;
@@ -191,6 +193,21 @@ export async function saveNativeRuntimeRetirements(
   );
 }
 
+export async function loadRecoveryDecisions(
+  storage: ControlStorage
+): Promise<SandboxRecoveryDecision[]> {
+  return sandboxRecoveryDecisionSchema
+    .array()
+    .parse((await storage.get(RECOVERY_DECISIONS_KEY)) ?? []);
+}
+
+export async function saveRecoveryDecisions(
+  storage: ControlStorage,
+  recovery: SandboxRecoveryDecision[]
+): Promise<void> {
+  await storage.put(RECOVERY_DECISIONS_KEY, sandboxRecoveryDecisionSchema.array().parse(recovery));
+}
+
 export async function loadDeadlines(storage: ControlStorage): Promise<DeadlineTable> {
   return (await storage.get<DeadlineTable>(DEADLINES_KEY)) ?? emptyDeadlines();
 }
@@ -235,5 +252,6 @@ export async function eraseSandboxRecord(storage: ControlStorage): Promise<void>
     CREDENTIAL_GRANTS_KEY,
     RUNTIME_METADATA_KEY,
     NATIVE_RUNTIME_RETIREMENTS_KEY,
+    RECOVERY_DECISIONS_KEY,
   ]);
 }

--- a/services/cloud-agent-next/src/sandbox-control/frames.ts
+++ b/services/cloud-agent-next/src/sandbox-control/frames.ts
@@ -6,7 +6,9 @@ import {
   SANDBOX_CONTROL_PROTOCOL_VERSION,
   controlFrameSchema,
   sandboxHeartbeatPayloadSchema,
+  sandboxEventPublicationPayloadSchema,
   sandboxHelloPayloadSchema,
+  sandboxReconcilePayloadSchema,
   sandboxReadyPayloadSchema,
   sandboxShutdownPayloadSchema,
   sandboxStatusPayloadSchema,
@@ -44,6 +46,8 @@ const CONTROL_EVENT_SET = new Set<string>(CONTROL_EVENTS);
 const REQUEST_PAYLOAD_SCHEMAS: Record<ControlOperation, z.ZodType> = {
   'sandbox.hello': sandboxHelloPayloadSchema,
   'sandbox.status': sandboxStatusPayloadSchema,
+  'sandbox.reconcile': sandboxReconcilePayloadSchema,
+  'sandbox.event.publish': sandboxEventPublicationPayloadSchema,
   'sandbox.shutdown': sandboxShutdownPayloadSchema,
   'worktree.prepareDeletion': worktreeDeletePayloadSchema,
   'worktree.delete': worktreeDeletePayloadSchema,
@@ -177,7 +181,10 @@ export function errorResponse(
   return { type: 'response', requestId, ok: false, error };
 }
 
-export function helloResult(): SandboxHelloResult {
+export function helloResult(capabilities?: {
+  connectionRecovery?: boolean;
+  eventReceipts?: boolean;
+}): SandboxHelloResult {
   return {
     protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
     handshakeComplete: true,
@@ -186,6 +193,8 @@ export function helloResult(): SandboxHelloResult {
       sessionOperationResults: true,
       scopedStopAbort: true,
       nativeRuntimeRetirement: true,
+      ...(capabilities?.connectionRecovery ? { connectionRecovery: true } : {}),
+      ...(capabilities?.eventReceipts ? { eventReceipts: true } : {}),
     },
   };
 }

--- a/services/cloud-agent-next/src/sandbox-control/lifecycle.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/lifecycle.test.ts
@@ -1,4 +1,8 @@
+import { createHash } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SandboxSession } from '../sandbox-session/SandboxSession.js';
+import { canonicalControlEventJson } from '../shared/control-event-canonical.js';
+import { createMemoryEventQueries } from '../session/preparation-test-helpers.js';
 import type { BillingContext } from '@kilocode/container-usage';
 import { SandboxControl, type SandboxAcquisition } from '../persistence/SandboxControl.js';
 import { SESSION_DELIVERY_TIMEOUT_MS } from '../sandbox-session/control-dispatch.js';
@@ -17,7 +21,12 @@ import type {
   SandboxControlSocketHooks,
 } from './socket.js';
 import { DEADLINE_MS } from './deadlines.js';
-import { loadDeadlines, loadRouteTable, loadSessionCredentialGrants } from './durable-state.js';
+import {
+  loadDeadlines,
+  loadRecoveryDecisions,
+  loadRouteTable,
+  loadSessionCredentialGrants,
+} from './durable-state.js';
 import type * as cloudflareProvider from './cloudflare-provider.js';
 import type * as SocketModule from './socket.js';
 import { decodeCloudflareProviderRef } from './cloudflare-provider.js';
@@ -32,6 +41,7 @@ const mocks = vi.hoisted(() => ({
   providerCreate: vi.fn(),
   socket: vi.fn(),
   session: vi.fn(),
+  eventQueries: vi.fn(),
 }));
 
 vi.mock('@cloudflare/sandbox', () => ({ getSandbox: mocks.getSandbox }));
@@ -66,6 +76,10 @@ vi.mock('./socket.js', async importOriginal => ({
   createSandboxControlSocketHandler: mocks.socket,
 }));
 vi.mock('../sandbox-session/session-stub.js', () => ({ getSandboxSessionStub: mocks.session }));
+vi.mock('drizzle-orm/durable-sqlite', () => ({ drizzle: vi.fn() }));
+vi.mock('drizzle-orm/durable-sqlite/migrator', () => ({ migrate: vi.fn(async () => undefined) }));
+vi.mock('../../drizzle/migrations', () => ({ default: {} }));
+vi.mock('../session/queries/index.js', () => ({ createEventQueries: mocks.eventQueries }));
 
 const SANDBOX_ID = 'ses-abcdef';
 const OWNER = 'owner_1';
@@ -80,6 +94,16 @@ const PROMPT = {
   turn: { type: 'prompt', prompt: 'Continue the task' },
   agent: { mode: 'code', model: 'kilo/fake' },
 };
+
+function nativeRetirementPayload(directory: string, nativeRuntimeId: string) {
+  return {
+    retirementId: '99999999-9999-4999-8999-999999999999',
+    directory,
+    nativeRuntimeId,
+    reason: 'process_exited',
+    cleanupDeadlineAt: Date.now() + DEADLINE_MS.stopAttempt,
+  };
+}
 const BILLING = parseSandboxBillingInput({
   sandboxId: SANDBOX_ID,
   subject: { type: 'user', id: OWNER },
@@ -282,6 +306,7 @@ async function harness(
         lifecycle: { version: 1, timestamp: Date.now() },
       })
     ),
+    getControlState: vi.fn().mockResolvedValue(null),
     receiveSandboxControlEvent: vi.fn().mockResolvedValue({ applied: true }),
     receiveSandboxControlPreparing: vi.fn().mockResolvedValue({ applied: true }),
     failWaitingMessages: vi.fn().mockResolvedValue(undefined),
@@ -362,13 +387,14 @@ async function harness(
         billing: BILLING,
       });
     },
-    async ready(runtime?: { wrapperVersion: string | null }) {
+    async ready(runtime?: { wrapperVersion: string | null; recoveryCapable?: boolean }) {
       const physical = await control.getPhysicalRecord();
       if (!physical.providerRef) throw new Error('No physical allocation');
       connection = {
         connectionId: crypto.randomUUID(),
         wrapperInstanceId: crypto.randomUUID(),
         providerInstanceId: physical.providerRef,
+        recoveryCapable: runtime?.recoveryCapable === true,
       };
       const identity = connection;
       await hooks.onHandshakeComplete?.(identity, runtime);
@@ -382,6 +408,9 @@ async function harness(
       alarmAt = null;
       await control.alarm();
       await flush();
+    },
+    replaceConnection(identity: SandboxControlConnectionIdentity) {
+      connection = identity;
     },
     async evict(passive = false) {
       control = new SandboxControl(ctx, env);
@@ -411,6 +440,66 @@ afterEach(() => {
 });
 
 describe('SandboxControl lifecycle boundaries', () => {
+  it('recovers one eligible wrapper runtime through the production socket hooks', async () => {
+    const h = await harness();
+    h.session.getControlState.mockResolvedValue({
+      version: 1,
+      scope: { sandboxId: SANDBOX_ID },
+      targets: [],
+    });
+    h.sendRequest.mockImplementation(async (request: SandboxControlOutboundRequest) => ({
+      type: 'response',
+      requestId: 'request_1',
+      ok: true,
+      result:
+        request.operation === 'sandbox.status'
+          ? { healthy: true, state: 'idle', version: '2.4.0', kiloReady: true }
+          : request.operation === 'sandbox.reconcile'
+            ? {
+                episodeId: (request.payload as { recovery: { episodeId: string } }).recovery
+                  .episodeId,
+                attempt: (request.payload as { recovery: { attempt: number } }).recovery.attempt,
+                phase: (request.payload as { phase: 'drain' | 'ready' | 'commit' }).phase,
+              }
+            : undefined,
+    }));
+    await h.create();
+    const first = await h.ready({ wrapperVersion: null, recoveryCapable: true });
+    await h.flush();
+
+    expect(h.sendRequest.mock.calls.map(([request]) => request.operation)).toEqual([
+      'sandbox.reconcile',
+      'sandbox.reconcile',
+      'sandbox.status',
+      'sandbox.reconcile',
+    ]);
+    expect(await loadRecoveryDecisions(h.storage)).toEqual([]);
+
+    await h.hooks.onSocketClosed?.(true, first);
+    const pending = await loadRecoveryDecisions(h.storage);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({ wrapperInstanceId: first.wrapperInstanceId });
+
+    const replacement = { ...first, connectionId: crypto.randomUUID() };
+    h.replaceConnection(replacement);
+    await h.hooks.onHandshakeComplete?.(replacement);
+    await h.hooks.onReady?.(replacement);
+    await h.flush();
+
+    expect(await loadRecoveryDecisions(h.storage)).toEqual([]);
+    expect((await h.control.getPhysicalRecord()).state).toBe('running');
+    expect(h.sendRequest.mock.calls.map(([request]) => request.operation)).toEqual([
+      'sandbox.reconcile',
+      'sandbox.reconcile',
+      'sandbox.status',
+      'sandbox.reconcile',
+      'sandbox.reconcile',
+      'sandbox.reconcile',
+      'sandbox.status',
+      'sandbox.reconcile',
+    ]);
+  });
+
   it('retains observed versions through readiness, eviction and stop, then clears them on a new allocation', async () => {
     const h = await harness();
     const status = () => h.control.getSandboxStatus({ ownerId: OWNER, provider: 'cloudflare' });
@@ -2741,7 +2830,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     h.session.failWaitingMessages.mockClear();
     await expect(
       h.hooks.onNativeRuntimeRetired?.(
-        { directory: route.directory, nativeRuntimeId, reason: 'process_exited' },
+        nativeRetirementPayload(route.directory, nativeRuntimeId),
         identity
       )
     ).resolves.toEqual({ retired: true });
@@ -2776,7 +2865,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     await sent.promise;
     await expect(
       h.hooks.onNativeRuntimeRetired?.(
-        { directory: route.directory, nativeRuntimeId, reason: 'process_exited' },
+        nativeRetirementPayload(route.directory, nativeRuntimeId),
         identity
       )
     ).resolves.toEqual({ retired: true });
@@ -2916,7 +3005,7 @@ describe('SandboxControl lifecycle boundaries', () => {
 
     await expect(
       h.hooks.onNativeRuntimeRetired?.(
-        { directory: route.directory, nativeRuntimeId, reason: 'process_exited' },
+        nativeRetirementPayload(route.directory, nativeRuntimeId),
         identity
       )
     ).resolves.toBeUndefined();
@@ -2972,7 +3061,7 @@ describe('SandboxControl lifecycle boundaries', () => {
 
     await expect(
       h.hooks.onNativeRuntimeRetired?.(
-        { directory: ROUTE.directory, nativeRuntimeId, reason: 'process_exited' },
+        nativeRetirementPayload(ROUTE.directory, nativeRuntimeId),
         identity
       )
     ).resolves.toEqual({ retired: true });
@@ -3004,7 +3093,7 @@ describe('SandboxControl lifecycle boundaries', () => {
 
     await expect(
       h.hooks.onNativeRuntimeRetired?.(
-        { directory: ROUTE.directory, nativeRuntimeId, reason: 'process_exited' },
+        nativeRetirementPayload(ROUTE.directory, nativeRuntimeId),
         identity
       )
     ).resolves.toEqual({ retired: true });
@@ -3020,7 +3109,7 @@ describe('SandboxControl lifecycle boundaries', () => {
 
     await expect(
       h.hooks.onNativeRuntimeRetired?.(
-        { directory: ROUTE.directory, nativeRuntimeId, reason: 'process_exited' },
+        nativeRetirementPayload(ROUTE.directory, nativeRuntimeId),
         identity
       )
     ).resolves.toEqual({ retired: true });
@@ -3519,6 +3608,567 @@ describe('SandboxControl lifecycle boundaries', () => {
     });
     expect(h.runtime(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
     expect(h.session.failWaitingMessages).not.toHaveBeenCalled();
+  });
+
+  describe('receipt-backed session forwarding', () => {
+    it('preserves pending native attach retryability through Control and the publication socket', async () => {
+      const h = await harness();
+      await h.create();
+      const connection = await h.ready();
+      const publication = {
+        event: 'session.event',
+        session: {
+          directory: ROUTE.directory,
+          kiloSessionId: ROUTE.kiloSessionId,
+          rootKiloSessionId: ROUTE.kiloSessionId,
+          nativeRuntimeId: '11111111-1111-4111-8111-111111111111',
+        },
+        payload: {
+          type: 'session.updated',
+          properties: { info: { id: ROUTE.kiloSessionId, title: 'Native startup' } },
+        },
+        sequence: 1,
+      };
+      const receiptId = '33333333-3333-4333-8333-333333333333';
+      const receiptHash = createHash('sha256')
+        .update(canonicalControlEventJson(publication))
+        .digest('hex');
+      const frame = {
+        type: 'request',
+        requestId: 'pending-native-attach',
+        operation: 'sandbox.event.publish',
+        payload: { ...publication, receiptId, receiptHash },
+      };
+      let attachment: unknown = {
+        ...connection,
+        handshakeComplete: true,
+        acceptedAt: Date.now(),
+        protocolVersion: 1,
+      };
+      const send = vi.fn();
+      const close = vi.fn();
+      const ws = {
+        readyState: 1,
+        deserializeAttachment: () => attachment,
+        serializeAttachment: (next: unknown) => {
+          attachment = next;
+        },
+        send,
+        close,
+      } as unknown as WebSocket;
+      const { createSandboxControlSocketHandler } =
+        await vi.importActual<typeof SocketModule>('./socket.js');
+      const handler = createSandboxControlSocketHandler(
+        { ...h.ctx, getWebSockets: () => [ws] } as DurableObjectState,
+        SANDBOX_ID,
+        undefined,
+        h.hooks
+      );
+      const pending = { applied: false, retryable: true };
+      h.session.receiveSandboxControlEvent.mockResolvedValueOnce(pending);
+      h.sendRequest.mockClear();
+      const before = structuredClone([...h.records]);
+      await handler.handleMessage(ws, JSON.stringify(frame));
+      await h.flush();
+      expect(h.session.receiveSandboxControlEvent).toHaveBeenCalledExactlyOnceWith({
+        identity: publication.session,
+        payload: publication.payload,
+        wrapperInstanceId: connection.wrapperInstanceId,
+        receiptId,
+        receiptHash,
+        sequence: 1,
+      });
+      expect(send).toHaveBeenLastCalledWith(
+        JSON.stringify({
+          type: 'response',
+          requestId: frame.requestId,
+          ok: false,
+          error: {
+            code: 'not_ready',
+            message: 'Sandbox event publication was not applied',
+            retryable: true,
+          },
+        })
+      );
+      h.session.receiveSandboxControlEvent.mockResolvedValueOnce({ applied: true });
+      await handler.handleMessage(ws, JSON.stringify(frame));
+      await h.flush();
+      expect(send).toHaveBeenLastCalledWith(
+        JSON.stringify({
+          type: 'response',
+          requestId: frame.requestId,
+          ok: true,
+          result: { receiptId, applied: true },
+        })
+      );
+      expect(h.session.receiveSandboxControlEvent).toHaveBeenCalledTimes(2);
+      expect([...h.records]).toEqual(before);
+      expect(h.socket.getConnectionIdentity()).toEqual(connection);
+      expect(close).not.toHaveBeenCalled();
+      expect(h.sendRequest).not.toHaveBeenCalled();
+      expect(h.session.failWaitingMessages).not.toHaveBeenCalled();
+      expect(h.session.invalidateTerminalRuntime).not.toHaveBeenCalled();
+      expect(h.runtime(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+    });
+
+    it('ACKs trailing native events and exact N1 replay through Session, Control, and the socket', async () => {
+      const h = await harness();
+      await h.create();
+      const connection = await h.ready();
+      const [route] = await h.control.listRoutes();
+      if (!route) throw new Error('Missing route');
+      const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+      const replacementRuntimeId = '22222222-2222-4222-8222-222222222222';
+      const authorization = {
+        operation: 'session.attach',
+        operationId: '55555555-5555-4555-8555-555555555555',
+        messageId: 'message_A',
+        session: {
+          sessionId: route.sessionId,
+          kiloSessionId: route.kiloSessionId,
+          directory: route.directory,
+        },
+        wrapperInstanceId: connection.wrapperInstanceId,
+        dispatchDeadlineAt: Date.now() + 1_000,
+      };
+      const nativeFence = {
+        sandboxId: SANDBOX_ID,
+        wrapperInstanceId: connection.wrapperInstanceId,
+        nativeRuntimeId,
+        attachmentEpoch: 1,
+        authorization,
+      };
+      const completed = {
+        messageId: 'message_A',
+        state: 'completed',
+        wrapperInstanceId: connection.wrapperInstanceId,
+      };
+      const values = new Map<string, unknown>([
+        ['session_metadata', await h.session.getCredentialMetadata()],
+        ['session_messages', [completed]],
+        ['native_runtime_fence', nativeFence],
+      ]);
+      const kv: SyncKvStorage = {
+        get: <T>(key: string): T | undefined => structuredClone(values.get(key)) as T | undefined,
+        put: <T>(key: string, value: T) => {
+          values.set(key, structuredClone(value));
+        },
+        delete: key => values.delete(key),
+        list: <T>(options?: SyncKvListOptions) =>
+          [...values.entries()]
+            .filter(([key]) => !options?.prefix || key.startsWith(options.prefix))
+            .map(([key, value]) => [key, structuredClone(value) as T] as [string, T]),
+      };
+      const sessionStorage = {
+        kv,
+        get: async <T>(key: string) => kv.get<T>(key),
+        sql: {},
+        transactionSync: <T>(callback: () => T) => callback(),
+      } as unknown as DurableObjectStorage;
+      const eventQueries = createMemoryEventQueries();
+      let eventSequence = 0;
+      eventQueries.insert = params =>
+        eventQueries.upsert({ ...params, entityId: `test-event/${++eventSequence}` });
+      mocks.eventQueries.mockReturnValue(eventQueries);
+      const initializing: Promise<unknown>[] = [];
+      const session = new SandboxSession(
+        {
+          ...h.ctx,
+          id: { name: `${OWNER}:${route.sessionId}` },
+          storage: sessionStorage,
+          blockConcurrencyWhile: (callback: () => Promise<void>) => {
+            const pending = callback();
+            initializing.push(pending);
+            return pending;
+          },
+        } as unknown as DurableObjectState,
+        {
+          ...h.env,
+          SANDBOX_CONTROL: { getByName: () => h.control },
+        } as unknown as Env
+      );
+      await Promise.all(initializing);
+      mocks.session.mockReturnValue(session);
+      const receive = vi.spyOn(session, 'receiveSandboxControlEvent');
+      const failWaitingMessages = vi.spyOn(session, 'failWaitingMessages');
+      const invalidateTerminalRuntime = vi.spyOn(session, 'invalidateTerminalRuntime');
+      const quarantine = vi.spyOn(h.control, 'quarantineRuntime');
+      h.records.set('session_routes', [{ ...route, nativeRuntimeId }]);
+      h.sendRequest.mockClear();
+
+      let attachment: unknown = {
+        ...connection,
+        handshakeComplete: true,
+        acceptedAt: Date.now(),
+        protocolVersion: 1,
+      };
+      const send = vi.fn();
+      const close = vi.fn();
+      const ws = {
+        readyState: 1,
+        deserializeAttachment: () => attachment,
+        serializeAttachment: (next: unknown) => {
+          attachment = next;
+        },
+        send,
+        close,
+      } as unknown as WebSocket;
+      const { createSandboxControlSocketHandler } =
+        await vi.importActual<typeof SocketModule>('./socket.js');
+      const handler = createSandboxControlSocketHandler(
+        {
+          ...h.ctx,
+          getWebSockets: () => [ws],
+        } as DurableObjectState,
+        SANDBOX_ID,
+        undefined,
+        h.hooks
+      );
+      const publication = {
+        event: 'session.event',
+        session: {
+          directory: route.directory,
+          kiloSessionId: route.kiloSessionId,
+          nativeRuntimeId,
+        },
+        payload: {
+          type: 'session.updated',
+          properties: { info: { id: route.kiloSessionId, title: 'Completed A' } },
+        },
+        sequence: 1,
+      };
+      const receiptId = '33333333-3333-4333-8333-333333333333';
+      const frame = {
+        type: 'request',
+        requestId: 'trailing-native-event',
+        operation: 'sandbox.event.publish',
+        payload: {
+          ...publication,
+          receiptId,
+          receiptHash: createHash('sha256')
+            .update(canonicalControlEventJson(publication))
+            .digest('hex'),
+        },
+      };
+      const beforeControl = structuredClone([...h.records]);
+      await handler.handleMessage(ws, JSON.stringify(frame));
+      await h.flush();
+      expect(await receive.mock.results[0]?.value).toEqual({ applied: true });
+      expect(send).toHaveBeenLastCalledWith(
+        JSON.stringify({
+          type: 'response',
+          requestId: frame.requestId,
+          ok: true,
+          result: { receiptId, applied: true },
+        })
+      );
+      const persisted = eventQueries.findByEntityPrefix('');
+      expect(persisted).toHaveLength(1);
+      expect(values.get('session_messages')).toEqual([completed]);
+      expect([...h.records]).toEqual(beforeControl);
+
+      h.records.set('session_routes', [{ ...route, nativeRuntimeId: replacementRuntimeId }]);
+      kv.put('native_runtime_fence', {
+        ...nativeFence,
+        nativeRuntimeId: replacementRuntimeId,
+        attachmentEpoch: 2,
+      });
+      kv.put('session_messages', [
+        completed,
+        {
+          messageId: 'message_B',
+          state: 'accepted',
+          wrapperInstanceId: connection.wrapperInstanceId,
+        },
+      ]);
+      const beforeReplacement = structuredClone([...h.records]);
+      const beforeSessionReplay = structuredClone([...values]);
+      await handler.handleMessage(ws, JSON.stringify(frame));
+      await h.flush();
+      expect(await receive.mock.results[1]?.value).toEqual({ applied: true });
+      expect(send.mock.calls[1]).toEqual(send.mock.calls[0]);
+
+      const stalePublication = { ...publication, sequence: 2 };
+      await handler.handleMessage(
+        ws,
+        JSON.stringify({
+          ...frame,
+          requestId: 'unseen-stale-native-event',
+          payload: {
+            ...stalePublication,
+            receiptId: '44444444-4444-4444-8444-444444444444',
+            receiptHash: createHash('sha256')
+              .update(canonicalControlEventJson(stalePublication))
+              .digest('hex'),
+          },
+        })
+      );
+      await h.flush();
+      expect(await receive.mock.results[2]?.value).toEqual({ applied: false });
+      expect(send).toHaveBeenLastCalledWith(
+        JSON.stringify({
+          type: 'response',
+          requestId: 'unseen-stale-native-event',
+          ok: false,
+          error: {
+            code: 'event_rejected',
+            message: 'Sandbox event publication was not applied',
+            retryable: false,
+          },
+        })
+      );
+      expect(receive).toHaveBeenCalledTimes(3);
+      expect([...h.records]).toEqual(beforeReplacement);
+      expect([...values]).toEqual(beforeSessionReplay);
+      expect(eventQueries.findByEntityPrefix('')).toEqual(persisted);
+
+      const replacementPublication = {
+        ...publication,
+        session: { ...publication.session, nativeRuntimeId: replacementRuntimeId },
+        sequence: 3,
+      };
+      const replacementReceiptId = '66666666-6666-4666-8666-666666666666';
+      await handler.handleMessage(
+        ws,
+        JSON.stringify({
+          ...frame,
+          requestId: 'replacement-native-event',
+          payload: {
+            ...replacementPublication,
+            receiptId: replacementReceiptId,
+            receiptHash: createHash('sha256')
+              .update(canonicalControlEventJson(replacementPublication))
+              .digest('hex'),
+          },
+        })
+      );
+      await h.flush();
+      expect(await receive.mock.results[3]?.value).toEqual({ applied: true });
+      expect(send).toHaveBeenLastCalledWith(
+        JSON.stringify({
+          type: 'response',
+          requestId: 'replacement-native-event',
+          ok: true,
+          result: { receiptId: replacementReceiptId, applied: true },
+        })
+      );
+      expect(eventQueries.findByEntityPrefix('')).toHaveLength(2);
+      expect(values.get('session_messages')).toEqual([
+        completed,
+        expect.objectContaining({ messageId: 'message_B', state: 'accepted' }),
+      ]);
+      expect([...h.records]).toEqual(beforeReplacement);
+      expect(h.socket.getConnectionIdentity()).toEqual(connection);
+      expect(close).not.toHaveBeenCalled();
+      expect(h.sendRequest).not.toHaveBeenCalled();
+      expect(failWaitingMessages).not.toHaveBeenCalled();
+      expect(invalidateTerminalRuntime).not.toHaveBeenCalled();
+      expect(quarantine).not.toHaveBeenCalled();
+      expect(h.runtime(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+    });
+
+    it.each([false, true])(
+      'leaves N2 healthy when Session returns applied=%s for an N1 receipt',
+      async applied => {
+        const h = await harness();
+        await h.create();
+        const connection = await h.ready();
+        const [route] = await h.control.listRoutes();
+        if (!route) throw new Error('Missing route');
+        const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+        const replacementRuntimeId = '22222222-2222-4222-8222-222222222222';
+        h.records.set('session_routes', [{ ...route, nativeRuntimeId: replacementRuntimeId }]);
+        const identity = {
+          directory: route.directory,
+          kiloSessionId: route.kiloSessionId,
+          nativeRuntimeId,
+        };
+        const payload = {
+          type: 'session.message.outcome',
+          properties: { messageId: 'message_A', status: 'completed' },
+        };
+        const receiptId = '33333333-3333-4333-8333-333333333333';
+        const receiptHash = 'a'.repeat(64);
+        h.session.receiveSandboxControlEvent.mockResolvedValueOnce({ applied });
+        const before = structuredClone([...h.records]);
+        h.sendRequest.mockClear();
+        const closeAll = vi.spyOn(h.socket, 'closeAll').mockClear();
+        const closeHandshakenSockets = vi.spyOn(h.socket, 'closeHandshakenSockets').mockClear();
+
+        await expect(
+          h.hooks.onSessionEvent?.(identity, payload, connection, receiptId, receiptHash, 1)
+        ).resolves.toEqual(applied ? { applied: true } : { applied: false, retryable: false });
+        await h.flush();
+
+        expect(h.session.receiveSandboxControlEvent).toHaveBeenCalledExactlyOnceWith({
+          identity,
+          payload,
+          wrapperInstanceId: connection.wrapperInstanceId,
+          receiptId,
+          receiptHash,
+          sequence: 1,
+        });
+        expect([...h.records]).toEqual(before);
+        expect(h.socket.getConnectionIdentity()).toEqual(connection);
+        expect(closeAll).not.toHaveBeenCalled();
+        expect(closeHandshakenSockets).not.toHaveBeenCalled();
+        expect(h.sendRequest).not.toHaveBeenCalled();
+        expect(h.session.failWaitingMessages).not.toHaveBeenCalled();
+        expect(h.session.invalidateTerminalRuntime).not.toHaveBeenCalled();
+        expect(h.runtime(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+      }
+    );
+
+    it('keeps preparation rejection retryable without tearing down healthy work', async () => {
+      const h = await harness();
+      await h.create();
+      const connection = await h.ready();
+      const [route] = await h.control.listRoutes();
+      if (!route) throw new Error('Missing route');
+      const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+      h.records.set('session_routes', [{ ...route, nativeRuntimeId }]);
+      h.session.receiveSandboxControlPreparing.mockResolvedValueOnce({ applied: false });
+      const before = structuredClone([...h.records]);
+      h.sendRequest.mockClear();
+
+      await expect(
+        h.hooks.onSessionPreparing?.(
+          { directory: route.directory, kiloSessionId: route.kiloSessionId, nativeRuntimeId },
+          {
+            version: 2,
+            attemptId: 'preparation_A',
+            triggerMessageId: 'message_A',
+            revision: 1,
+            timestamp: Date.now(),
+            step: 'cloning',
+            action: 'start',
+            message: 'Cloning repository',
+          },
+          connection,
+          '33333333-3333-4333-8333-333333333333',
+          'a'.repeat(64),
+          1
+        )
+      ).resolves.toEqual({ applied: false, retryable: true });
+      await h.flush();
+
+      expect(h.session.receiveSandboxControlPreparing).toHaveBeenCalledOnce();
+      expect([...h.records]).toEqual(before);
+      expect(h.socket.getConnectionIdentity()).toEqual(connection);
+      expect(h.sendRequest).not.toHaveBeenCalled();
+      expect(h.session.failWaitingMessages).not.toHaveBeenCalled();
+      expect(h.session.invalidateTerminalRuntime).not.toHaveBeenCalled();
+      expect(h.runtime(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+    });
+
+    it('leaves an exhausted transient delivery available for receipt replay', async () => {
+      const h = await harness();
+      await h.create();
+      const connection = await h.ready();
+      const identity = { directory: ROUTE.directory, kiloSessionId: ROUTE.kiloSessionId };
+      const payload = { type: 'message.updated', properties: { id: 'message_A' } };
+      const receiptId = '33333333-3333-4333-8333-333333333333';
+      const receiptHash = 'a'.repeat(64);
+      h.session.receiveSandboxControlEvent.mockRejectedValue(
+        Object.assign(new Error('Session temporarily unavailable'), { retryable: true })
+      );
+      const before = structuredClone([...h.records]);
+      h.sendRequest.mockClear();
+
+      const first = h.hooks.onSessionEvent?.(
+        identity,
+        payload,
+        connection,
+        receiptId,
+        receiptHash,
+        1
+      );
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(first).resolves.toEqual({ applied: false, retryable: true });
+      await h.flush();
+
+      expect(h.session.receiveSandboxControlEvent).toHaveBeenCalledTimes(3);
+      expect([...h.records]).toEqual(before);
+      expect(h.socket.getConnectionIdentity()).toEqual(connection);
+      expect(h.sendRequest).not.toHaveBeenCalled();
+      expect(h.session.failWaitingMessages).not.toHaveBeenCalled();
+      expect(h.session.invalidateTerminalRuntime).not.toHaveBeenCalled();
+      expect(h.runtime(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+
+      h.session.receiveSandboxControlEvent.mockResolvedValueOnce({ applied: true });
+      await expect(
+        h.hooks.onSessionEvent?.(identity, payload, connection, receiptId, receiptHash, 1)
+      ).resolves.toEqual({ applied: true });
+      await h.flush();
+      expect(h.session.receiveSandboxControlEvent).toHaveBeenCalledTimes(4);
+      expect(h.session.receiveSandboxControlEvent.mock.calls.at(-1)).toEqual(
+        h.session.receiveSandboxControlEvent.mock.calls[0]
+      );
+      expect([...h.records]).toEqual(before);
+    });
+
+    it.each(['applied', 'rejected', 'transport_failed', 'legacy_transport_failed'] as const)(
+      'fences an in-flight N1 %s and queued send after N2 replaces only the native runtime',
+      async result => {
+        const h = await harness();
+        await h.create();
+        const connection = await h.ready();
+        const [route] = await h.control.listRoutes();
+        if (!route) throw new Error('Missing route');
+        const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+        const replacementRuntimeId = '22222222-2222-4222-8222-222222222222';
+        h.records.set('session_routes', [{ ...route, nativeRuntimeId }]);
+        const identity = {
+          directory: route.directory,
+          kiloSessionId: route.kiloSessionId,
+          nativeRuntimeId,
+        };
+        const payload = { type: 'message.updated', properties: {} };
+        const forwarding = deferred<{ applied: boolean }>();
+        h.session.receiveSandboxControlEvent.mockReturnValueOnce(forwarding.promise);
+        const first = h.hooks.onSessionEvent?.(
+          identity,
+          payload,
+          connection,
+          result === 'legacy_transport_failed' ? undefined : '33333333-3333-4333-8333-333333333333',
+          'a'.repeat(64),
+          1
+        );
+        await vi.advanceTimersByTimeAsync(0);
+        expect(h.session.receiveSandboxControlEvent).toHaveBeenCalledOnce();
+        const queued = h.hooks.onSessionEvent?.(
+          identity,
+          payload,
+          connection,
+          '44444444-4444-4444-8444-444444444444',
+          'b'.repeat(64),
+          2
+        );
+        await vi.advanceTimersByTimeAsync(0);
+        h.records.set('session_routes', [{ ...route, nativeRuntimeId: replacementRuntimeId }]);
+        const before = structuredClone([...h.records]);
+        h.sendRequest.mockClear();
+        if (result === 'transport_failed' || result === 'legacy_transport_failed')
+          forwarding.reject(new Error('Session transport failed'));
+        else forwarding.resolve({ applied: result === 'applied' });
+
+        await expect(first).resolves.toEqual(
+          result === 'legacy_transport_failed'
+            ? { applied: true }
+            : { applied: false, retryable: true }
+        );
+        await expect(queued).resolves.toEqual({ applied: false, retryable: true });
+        await h.flush();
+
+        expect(h.session.receiveSandboxControlEvent).toHaveBeenCalledOnce();
+        expect([...h.records]).toEqual(before);
+        expect(h.socket.getConnectionIdentity()).toEqual(connection);
+        expect(h.sendRequest).not.toHaveBeenCalled();
+        expect(h.session.failWaitingMessages).not.toHaveBeenCalled();
+        expect(h.session.invalidateTerminalRuntime).not.toHaveBeenCalled();
+        expect(h.runtime(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+      }
+    );
   });
 
   it('forwards raw events and preparation with the runtime fence, then quarantines an exhausted delivery', async () => {

--- a/services/cloud-agent-next/src/sandbox-control/native-runtime-retirement.ts
+++ b/services/cloud-agent-next/src/sandbox-control/native-runtime-retirement.ts
@@ -45,12 +45,15 @@ export type NativeRuntimeRetirementWorkflow = {
     route: SessionRoute;
     reason: string;
     operationId?: string;
+    cleanupDeadlineAt: number;
   }): Promise<'retired' | 'pending' | 'unavailable'>;
   receiveRetired(input: {
     connection: NativeRuntimeRetirementConnection;
+    retirementId: string;
     directory: string;
     nativeRuntimeId: string;
     reason: string;
+    cleanupDeadlineAt: number;
   }): Promise<{ retired: true } | undefined>;
   resume(): Promise<void>;
 };
@@ -60,7 +63,7 @@ export type NativeRuntimeRetirementWorkflowPorts = {
   currentIncarnation: {
     isCurrent(connection: NativeRuntimeRetirementConnection): boolean;
     getConnection(): NativeRuntimeRetirementConnection | null;
-    sameConnection(
+    sameLifetime(
       left: NativeRuntimeRetirementConnection,
       right: NativeRuntimeRetirementConnection
     ): boolean;
@@ -93,6 +96,22 @@ export function sameNativeRuntimeRetirement(
     receipt.directory === input.directory &&
     receipt.nativeRuntimeId === input.nativeRuntimeId &&
     receipt.connection.connectionId === input.connection.connectionId &&
+    receipt.connection.providerInstanceId === input.connection.providerInstanceId &&
+    receipt.connection.wrapperInstanceId === input.connection.wrapperInstanceId
+  );
+}
+
+export function sameNativeRuntimeRetirementLifetime(
+  receipt: NativeRuntimeRetirementReceipt,
+  input: {
+    directory: string;
+    nativeRuntimeId: string;
+    connection: NativeRuntimeRetirementConnection;
+  }
+): boolean {
+  return (
+    receipt.directory === input.directory &&
+    receipt.nativeRuntimeId === input.nativeRuntimeId &&
     receipt.connection.providerInstanceId === input.connection.providerInstanceId &&
     receipt.connection.wrapperInstanceId === input.connection.wrapperInstanceId
   );
@@ -220,6 +239,20 @@ function matchesReceipt(
   );
 }
 
+function matchesRetirementLifetime(
+  current: NativeRuntimeRetirementReceipt,
+  input: {
+    directory: string;
+    nativeRuntimeId: string;
+    connection: NativeRuntimeRetirementConnection;
+    operationId?: string;
+  }
+): boolean {
+  return (
+    sameNativeRuntimeRetirementLifetime(current, input) && current.operationId === input.operationId
+  );
+}
+
 function holdsNativeRuntimeRetirementFence(receipt: NativeRuntimeRetirementReceipt): boolean {
   return (
     receipt.state === 'pending' ||
@@ -292,12 +325,7 @@ export function createNativeRuntimeRetirementWorkflow(
       };
       for (const receipt of retained) {
         if (receipt.state === 'pending') {
-          scheduleAt(
-            Math.min(
-              receipt.cleanupDeadlineAt,
-              Math.max(currentTime, receipt.nextAttemptAt ?? currentTime)
-            )
-          );
+          scheduleAt(Math.max(currentTime, receipt.nextAttemptAt ?? currentTime));
           continue;
         }
         if (receipt.state === 'unconfirmed') {
@@ -363,20 +391,23 @@ export function createNativeRuntimeRetirementWorkflow(
         return undefined;
       const existing = stored.find(
         current =>
-          sameNativeRuntimeRetirement(current, {
+          matchesRetirementLifetime(current, {
             directory: route.directory,
             nativeRuntimeId: input.nativeRuntimeId,
             connection: input.connection,
-          }) && current.operationId === input.operationId
+            operationId: input.operationId,
+          }) && matchesNativeRuntimeRetirementAllocation(current, currentPhysical)
       );
       if (existing) return existing;
       const active = stored.find(
         current =>
-          sameNativeRuntimeRetirement(current, {
+          sameNativeRuntimeRetirementLifetime(current, {
             directory: route.directory,
             nativeRuntimeId: input.nativeRuntimeId,
             connection: input.connection,
-          }) && holdsNativeRuntimeRetirementFence(current)
+          }) &&
+          matchesNativeRuntimeRetirementAllocation(current, currentPhysical) &&
+          holdsNativeRuntimeRetirementFence(current)
       );
       if (active) return active;
       const created = createNativeRuntimeRetirement(
@@ -524,9 +555,12 @@ export function createNativeRuntimeRetirementWorkflow(
       const current = stored.find(current => matchesReceipt(current, receipt));
       if (!current) return undefined;
       if (current.state === 'completed') return current;
+      const connection = ports.currentIncarnation.getConnection();
       if (
         current.state !== 'pending' ||
-        !ports.currentIncarnation.isCurrent(receipt.connection) ||
+        !connection ||
+        !ports.currentIncarnation.isCurrent(connection) ||
+        !ports.currentIncarnation.sameLifetime(connection, receipt.connection) ||
         physical.state !== 'running' ||
         physical.stopTombstone ||
         !matchesNativeRuntimeRetirementAllocation(current, physical) ||
@@ -556,7 +590,7 @@ export function createNativeRuntimeRetirementWorkflow(
       const fallback = {
         ...current,
         state: 'unconfirmed' as const,
-        disposition: 'physical_fallback' as const,
+        disposition: 'pending' as const,
       };
       await saveNativeRuntimeRetirements(
         ports.storage,
@@ -564,9 +598,28 @@ export function createNativeRuntimeRetirementWorkflow(
       );
       return fallback;
     });
-    if (token) await ports.physicalEscalation.beginIfCurrent(token);
+    const started = token && (await ports.physicalEscalation.beginIfCurrent(token));
+    if (token) {
+      await ports.storage.transaction(async () => {
+        const stored = await loadNativeRuntimeRetirements(ports.storage);
+        await saveNativeRuntimeRetirements(
+          ports.storage,
+          stored.map(current =>
+            matchesReceipt(current, token) && current.state === 'unconfirmed'
+              ? started
+                ? { ...current, disposition: 'physical_fallback' as const }
+                : {
+                    ...current,
+                    state: 'pending' as const,
+                    nextAttemptAt: now() + DEADLINE_MS.reconciliation,
+                  }
+              : current
+          )
+        );
+      });
+    }
     await reconcileSchedule();
-    return token !== undefined;
+    return started === true;
   };
 
   const claimRetirementAttempt = async (receipt: NativeRuntimeRetirementReceipt) => {
@@ -574,13 +627,13 @@ export function createNativeRuntimeRetirementWorkflow(
       const stored = await loadNativeRuntimeRetirements(ports.storage);
       const current = stored.find(current => matchesReceipt(current, receipt));
       if (!current || current.state !== 'pending') return { state: 'unavailable' as const };
+      if (current.nextAttemptAt !== undefined && now() < current.nextAttemptAt)
+        return { state: 'pending' as const };
       if (
         now() >= current.cleanupDeadlineAt ||
         current.attempts >= DEADLINE_MS.nativeRetirementMaxAttempts
       )
         return { state: 'escalate' as const, receipt: current };
-      if (current.nextAttemptAt !== undefined && now() < current.nextAttemptAt)
-        return { state: 'pending' as const };
       const attempt = {
         ...current,
         attempts: current.attempts + 1,
@@ -635,7 +688,7 @@ export function createNativeRuntimeRetirementWorkflow(
     const receipt = await begin({
       ...input,
       nativeRuntimeId,
-      cleanupDeadlineAt: now() + DEADLINE_MS.stopAttempt,
+      cleanupDeadlineAt: input.cleanupDeadlineAt,
     });
     if (!receipt) return 'unavailable';
     if (receipt.operationId !== input.operationId)
@@ -685,11 +738,11 @@ export function createNativeRuntimeRetirementWorkflow(
       loadNativeRuntimeRetirements(ports.storage),
     ]);
     const matchesExisting = (receipt: NativeRuntimeRetirementReceipt) =>
-      sameNativeRuntimeRetirement(receipt, {
+      sameNativeRuntimeRetirementLifetime(receipt, {
         directory: input.directory,
         nativeRuntimeId: input.nativeRuntimeId,
         connection: input.connection,
-      });
+      }) && matchesNativeRuntimeRetirementAllocation(receipt, physical);
     const existing =
       receipts.find(receipt => matchesExisting(receipt) && receipt.state === 'completed') ??
       receipts.find(receipt => matchesExisting(receipt) && receipt.state === 'pending');
@@ -713,7 +766,8 @@ export function createNativeRuntimeRetirementWorkflow(
       route,
       nativeRuntimeId: input.nativeRuntimeId,
       reason: input.reason,
-      cleanupDeadlineAt: now() + DEADLINE_MS.stopAttempt,
+      operationId: input.retirementId,
+      cleanupDeadlineAt: input.cleanupDeadlineAt,
     });
     return receipt && (await complete(receipt)) ? { retired: true } : undefined;
   };
@@ -743,7 +797,7 @@ export function createNativeRuntimeRetirementWorkflow(
       const connection = ports.currentIncarnation.getConnection();
       if (
         !connection ||
-        !ports.currentIncarnation.sameConnection(connection, receipt.connection) ||
+        !ports.currentIncarnation.sameLifetime(connection, receipt.connection) ||
         !ports.currentIncarnation.isCurrent(connection)
       ) {
         await defer(receipt);
@@ -764,6 +818,7 @@ export function createNativeRuntimeRetirementWorkflow(
         route,
         reason: receipt.reason,
         operationId: receipt.operationId,
+        cleanupDeadlineAt: receipt.cleanupDeadlineAt,
       });
     }
     await reconcileSchedule();

--- a/services/cloud-agent-next/src/sandbox-control/recovery-authority.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/recovery-authority.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../types.js';
+import type { SessionOperationAuthorization } from '../shared/sandbox-control-protocol.js';
+import {
+  beginRecovery,
+  replaceRecoveryAuthority,
+  type RecoveryAuthority,
+} from './control-recovery.js';
+import { createRecoveryAuthority } from './recovery-authority.js';
+import { savePhysicalRecord, saveRouteTable } from './durable-state.js';
+import { DEADLINE_MS } from './deadlines.js';
+
+const sessionStub = vi.hoisted(() => vi.fn());
+vi.mock('../sandbox-session/session-stub.js', () => ({ getSandboxSessionStub: sessionStub }));
+const identity = {
+  connectionId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  wrapperInstanceId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+  providerInstanceId: 'allocation_a',
+  recoveryCapable: true,
+};
+const routes = ['a', 'b'].map(name => ({
+  sessionId: `workspace_${name}`,
+  ownerId: 'owner',
+  kiloSessionId: `kilo_${name}`,
+  directory: `/workspace/${name}`,
+  nativeRuntimeId:
+    name === 'a' ? 'cccccccc-cccc-4ccc-8ccc-cccccccccccc' : 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+  lastState: 'active' as const,
+  lastStateAt: 10_000,
+  idleForMs: 0,
+  waitingOn: 'model' as const,
+}));
+function authorization(index: number): SessionOperationAuthorization {
+  const route = routes[index];
+  if (!route) throw new Error('Missing route');
+  return {
+    operation: 'session.prompt',
+    operationId: `message_${index}`,
+    messageId: `message_${index}`,
+    session: {
+      sessionId: route.sessionId,
+      kiloSessionId: route.kiloSessionId,
+      directory: route.directory,
+    },
+    wrapperInstanceId: identity.wrapperInstanceId,
+    dispatchDeadlineAt: 100_000,
+  };
+}
+async function harness() {
+  const records = new Map<string, unknown>();
+  const storage = {
+    get: async (key: string) => structuredClone(records.get(key)),
+    put: async (key: string, value: unknown) => {
+      records.set(key, structuredClone(value));
+    },
+    delete: async (keys: string[]) => keys.filter(key => records.delete(key)).length,
+  } as unknown as DurableObjectStorage;
+  await savePhysicalRecord(storage, {
+    state: 'running',
+    providerRef: identity.providerInstanceId,
+    createIntent: { intentId: 'create_a', createdAt: 1 },
+    stopTombstone: null,
+    resumable: true,
+  });
+  await saveRouteTable(storage, new Map(routes.map(route => [route.sessionId, route])));
+  const stubs = routes.map((route, index) => ({
+    getControlState: vi.fn().mockResolvedValue({
+      version: 1,
+      scope: { sandboxId: 'sandbox_a', wrapperInstanceId: identity.wrapperInstanceId },
+      targets: [
+        {
+          messageId: `message_${index}`,
+          wrapperInstanceId: identity.wrapperInstanceId,
+          executionDeadlineAt: 90_000 + index,
+        },
+      ],
+      operations: [
+        {
+          messageId: `message_${index}`,
+          authorization: authorization(index),
+          executionDeadlineAt: 90_000 + index,
+        },
+      ],
+    }),
+    interruptExecution: vi.fn(),
+    reconcileControlRecovery: vi.fn().mockResolvedValue({ state: 'reconciled' }),
+  }));
+  sessionStub.mockImplementation(
+    (_env, _owner, sessionId) => stubs[routes.findIndex(route => route.sessionId === sessionId)]
+  );
+  const owner = createRecoveryAuthority({ storage, env: {} as Env, sandboxId: 'sandbox_a' });
+  return {
+    storage,
+    owner,
+    stubs,
+    recovery: beginRecovery(undefined, identity, 'control_disconnected', Date.now()),
+  };
+}
+function required<T>(value: T | undefined): T {
+  if (value === undefined) throw new Error('Expected value');
+  return value;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(10_000);
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('recovery authority observations', () => {
+  it('retains immutable A bounds and Stop provenance when A times out, without changing B', async () => {
+    const h = await harness();
+    const a = required(h.stubs[0]);
+    const stop = {
+      version: 1,
+      operationId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+      scope: { sandboxId: 'sandbox_a', wrapperInstanceId: identity.wrapperInstanceId },
+      targets: [
+        {
+          messageId: 'message_0',
+          wrapperInstanceId: identity.wrapperInstanceId,
+          executionDeadlineAt: 90_000,
+        },
+      ],
+      cleanupDeadlineAt: 70_000,
+      state: 'accepted',
+    };
+    a.getControlState.mockResolvedValueOnce({
+      version: 1,
+      scope: stop.scope,
+      targets: stop.targets,
+      stops: [stop],
+      operations: [
+        { messageId: 'message_0', authorization: authorization(0), executionDeadlineAt: 90_000 },
+      ],
+    });
+    const first = required(await h.owner.load(h.recovery));
+    expect(first.stops).toHaveLength(1);
+    expect(first.scopes.filter(scope => scope.sessionId === 'workspace_a')).toHaveLength(2);
+    a.getControlState.mockImplementation(() => new Promise(() => undefined));
+    const loading = h.owner.load(replaceRecoveryAuthority(h.recovery, first));
+    await vi.advanceTimersByTimeAsync(DEADLINE_MS.stopAttempt);
+    const observed = required(await loading);
+    expect(observed.roots?.find(root => root.sessionId === 'workspace_a')).toMatchObject({
+      observation: 'stale',
+      decision: 'operation_unknown',
+      observedAt: 10_000,
+    });
+    expect(observed.scopes.filter(scope => scope.sessionId === 'workspace_a')).toEqual(
+      first.scopes.filter(scope => scope.sessionId === 'workspace_a')
+    );
+    expect(observed.stops).toEqual(first.stops);
+    expect(
+      observed.scopes.find(scope => scope.sessionId === 'workspace_b')?.executionDeadlineAt
+    ).toBe(90_001);
+    expect(observed.allocation).toEqual(first.allocation);
+    expect(observed.wholeAllocation).toBe(false);
+  });
+
+  it('distinguishes null ownership from an authoritative empty idle Session', async () => {
+    const h = await harness();
+    required(h.stubs[0]).getControlState.mockResolvedValue(null);
+    required(h.stubs[1]).getControlState.mockResolvedValue({
+      version: 1,
+      scope: { sandboxId: 'sandbox_a' },
+      targets: [],
+    });
+    const observed = required(await h.owner.load(h.recovery));
+    expect(observed.roots?.map(root => root.observation)).toEqual(['unknown', 'idle']);
+    expect(observed.wholeAllocation).toBe(false);
+  });
+
+  it('never retargets a captured native incarnation after the route changes', async () => {
+    const h = await harness();
+    const first = required(await h.owner.load(h.recovery));
+    const replacement = {
+      ...required(routes[0]),
+      nativeRuntimeId: crypto.randomUUID(),
+      directory: '/workspace/replacement',
+    };
+    await saveRouteTable(
+      h.storage,
+      new Map([replacement, required(routes[1])].map(route => [route.sessionId, route]))
+    );
+    const observed = required(await h.owner.load(replaceRecoveryAuthority(h.recovery, first)));
+    expect(observed.roots?.[0]).toMatchObject({
+      observation: 'stale',
+      nativeRuntimeId: routes[0]?.nativeRuntimeId,
+      directory: '/workspace/a',
+    });
+    expect(observed.scopes.filter(scope => scope.sessionId === 'workspace_a')).toEqual(
+      first.scopes.filter(scope => scope.sessionId === 'workspace_a')
+    );
+  });
+
+  it('returns independent Stop decisions while B operation maintenance succeeds', async () => {
+    const h = await harness();
+    const authority = required(await h.owner.load(h.recovery));
+    authority.stops = [
+      {
+        sessionId: 'workspace_a',
+        ownerId: 'owner',
+        request: {
+          version: 1,
+          operationId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+          scope: { sandboxId: 'sandbox_a' },
+          targets: [{ messageId: 'message_0' }],
+          cleanupDeadlineAt: 70_000,
+        },
+      },
+    ];
+    required(h.stubs[0]).interruptExecution.mockRejectedValue(new Error('Unavailable'));
+    expect(await h.owner.reconcileStops(authority)).toEqual([
+      { sessionId: 'workspace_a', decision: 'stop_pending' },
+      { sessionId: 'workspace_b', decision: 'ready' },
+    ]);
+    expect(await h.owner.reconcileOperations(authority)).toEqual([
+      { sessionId: 'workspace_a', decision: 'ready' },
+      { sessionId: 'workspace_b', decision: 'ready' },
+    ]);
+  });
+
+  it('does not reinterpret an RPC timeout as an equal-valued execution expiry', async () => {
+    const h = await harness();
+    const authority: RecoveryAuthority = required(await h.owner.load(h.recovery));
+    required(h.stubs[0]).reconcileControlRecovery.mockImplementation(
+      () => new Promise(() => undefined)
+    );
+    const timeout = h.owner.reconcileOperations(authority);
+    await vi.advanceTimersByTimeAsync(DEADLINE_MS.stopAttempt);
+    expect(await timeout).toEqual([
+      { sessionId: 'workspace_a', decision: 'operation_unknown' },
+      { sessionId: 'workspace_b', decision: 'ready' },
+    ]);
+    const executionExpired = {
+      ...authority,
+      scopes: authority.scopes.map(scope =>
+        scope.sessionId === 'workspace_a' ? { ...scope, executionDeadlineAt: Date.now() } : scope
+      ),
+    };
+    expect(await h.owner.reconcileOperations(executionExpired)).toEqual([
+      { sessionId: 'workspace_a', decision: 'execution_expired' },
+      { sessionId: 'workspace_b', decision: 'ready' },
+    ]);
+  });
+});

--- a/services/cloud-agent-next/src/sandbox-control/recovery-authority.ts
+++ b/services/cloud-agent-next/src/sandbox-control/recovery-authority.ts
@@ -1,0 +1,276 @@
+import { withTimeout } from '@kilocode/worker-utils';
+import { z } from 'zod';
+import type { Env } from '../types.js';
+import { getSandboxSessionStub } from '../sandbox-session/session-stub.js';
+import {
+  controlSessionStateSchema,
+  controlStopReceiptSchema,
+  controlStopRequestSchema,
+} from '../shared/control-plane-session.js';
+import { withControlDORetry as withDORetry } from './diagnostics.js';
+import { DEADLINE_MS } from './deadlines.js';
+import { loadPhysicalRecord, loadRouteTable } from './durable-state.js';
+import {
+  recoveryAuthoritySchema,
+  replaceRecoveryAuthority,
+  type SandboxRecoveryDecision,
+  type RecoveryAuthority,
+  type RecoveryRoot,
+  type RecoveryScopeResult,
+} from './control-recovery.js';
+
+function matchesControlStopRequest(
+  receipt: ReturnType<typeof controlStopReceiptSchema.parse>,
+  request: ReturnType<typeof controlStopRequestSchema.parse>
+): boolean {
+  return (
+    receipt.version === request.version &&
+    receipt.operationId === request.operationId &&
+    receipt.cleanupDeadlineAt === request.cleanupDeadlineAt &&
+    JSON.stringify(receipt.scope) === JSON.stringify(request.scope) &&
+    JSON.stringify(receipt.targets) === JSON.stringify(request.targets)
+  );
+}
+
+export function createRecoveryAuthority(input: {
+  storage: Pick<DurableObjectStorage, 'get' | 'put' | 'delete'>;
+  env: Env;
+  sandboxId: string;
+}) {
+  return {
+    async load(recovery: SandboxRecoveryDecision): Promise<RecoveryAuthority | undefined> {
+      const [physical, routes] = await Promise.all([
+        loadPhysicalRecord(input.storage),
+        loadRouteTable(input.storage),
+      ]);
+      if (
+        !physical.providerRef ||
+        physical.providerRef !== recovery.providerInstanceId ||
+        physical.state !== 'running' ||
+        physical.stopTombstone !== null ||
+        (recovery.authority &&
+          recovery.authority.allocation.createIntentId !== physical.createIntent?.intentId)
+      )
+        return undefined;
+      const scoped = await Promise.all(
+        [...routes.values()].map(async route => {
+          const recovered =
+            recovery.activationAcknowledgedAt === undefined
+              ? undefined
+              : recovery.authority?.roots?.find(
+                  root => root.sessionId === route.sessionId && root.decision === 'ready'
+                );
+          if (recovered)
+            return {
+              root: recovered,
+              scopes:
+                recovery.authority?.scopes.filter(scope => scope.sessionId === route.sessionId) ??
+                [],
+              stops: [],
+            };
+          const root: RecoveryRoot = {
+            sessionId: route.sessionId,
+            ownerId: route.ownerId,
+            kiloSessionId: route.kiloSessionId,
+            directory: route.directory,
+            ...(route.nativeRuntimeId ? { nativeRuntimeId: route.nativeRuntimeId } : {}),
+            observation: 'unknown',
+            decision: 'operation_unknown',
+          };
+          const unknown = { root, scopes: [], stops: [] };
+          try {
+            const state = z
+              .object(controlSessionStateSchema.shape)
+              .strict()
+              .nullable()
+              .parse(
+                await withTimeout(
+                  withDORetry(
+                    () => getSandboxSessionStub(input.env, route.ownerId, route.sessionId),
+                    stub => stub.getControlState({ includeIdle: true }),
+                    'getControlState'
+                  ),
+                  DEADLINE_MS.stopAttempt,
+                  'Recovery session authority timed out'
+                )
+              );
+            if (
+              state === null ||
+              state.scope.sandboxId !== input.sandboxId ||
+              (state.scope.wrapperInstanceId !== undefined &&
+                state.scope.wrapperInstanceId !== recovery.wrapperInstanceId)
+            )
+              return unknown;
+            const targets = [
+              ...state.targets,
+              ...(state.stops ?? []).flatMap(stop => stop.targets),
+            ];
+            if (
+              targets.some(
+                target =>
+                  target.wrapperInstanceId !== undefined &&
+                  target.wrapperInstanceId !== recovery.wrapperInstanceId
+              )
+            )
+              return unknown;
+            return {
+              root: {
+                ...root,
+                observation: targets.length === 0 ? ('idle' as const) : ('known' as const),
+                observedAt: Date.now(),
+                decision:
+                  (state.stops?.length ?? 0) > 0
+                    ? ('stop_pending' as const)
+                    : targets.length > 0
+                      ? ('operation_unknown' as const)
+                      : ('ready' as const),
+              },
+              scopes: targets.map(target => {
+                const operation = state.operations?.find(
+                  current => current.messageId === target.messageId
+                );
+                const executionDeadlineAt =
+                  operation?.executionDeadlineAt ?? target.executionDeadlineAt;
+                return {
+                  ...(operation &&
+                  operation.authorization.wrapperInstanceId === target.wrapperInstanceId
+                    ? { authorization: operation.authorization }
+                    : {}),
+                  sessionId: route.sessionId,
+                  kiloSessionId: route.kiloSessionId,
+                  directory: route.directory,
+                  messageId: target.messageId,
+                  ...(target.wrapperInstanceId
+                    ? { wrapperInstanceId: target.wrapperInstanceId }
+                    : {}),
+                  ...(route.nativeRuntimeId ? { nativeRuntimeId: route.nativeRuntimeId } : {}),
+                  ...(executionDeadlineAt ? { executionDeadlineAt } : {}),
+                };
+              }),
+              stops: (state.stops ?? []).map(stop => ({
+                sessionId: route.sessionId,
+                ownerId: route.ownerId,
+                request: controlStopRequestSchema.parse({
+                  version: stop.version,
+                  operationId: stop.operationId,
+                  scope: stop.scope,
+                  targets: stop.targets,
+                  cleanupDeadlineAt: stop.cleanupDeadlineAt,
+                }),
+              })),
+            };
+          } catch {
+            return unknown;
+          }
+        })
+      );
+      const authority = recoveryAuthoritySchema.parse({
+        source: 'session_control_state',
+        observedAt: Date.now(),
+        allocation: {
+          providerRef: physical.providerRef,
+          ...(physical.createIntent ? { createIntentId: physical.createIntent.intentId } : {}),
+        },
+        roots: scoped.map(item => item.root),
+        scopes: scoped.flatMap(item => item.scopes),
+        stops: scoped.flatMap(item => item.stops),
+        wholeAllocation: scoped.every(item => item.root.observation !== 'unknown'),
+      });
+      return replaceRecoveryAuthority(recovery, authority).authority;
+    },
+    async reconcileStops(authority: RecoveryAuthority): Promise<RecoveryScopeResult[]> {
+      return Promise.all(
+        (authority.roots ?? []).map(async root => {
+          const stops = authority.stops.filter(stop => stop.sessionId === root.sessionId);
+          const confirmed = await Promise.all(
+            stops.map(async stop => {
+              try {
+                const receipt = controlStopReceiptSchema.parse(
+                  await withTimeout(
+                    withDORetry(
+                      () => getSandboxSessionStub(input.env, stop.ownerId, stop.sessionId),
+                      stub => stub.interruptExecution(stop.request),
+                      'reconcileRecoveryStop'
+                    ),
+                    DEADLINE_MS.stopAttempt,
+                    'Recovery Stop reconciliation timed out'
+                  )
+                );
+                return (
+                  receipt.state === 'confirmed' && matchesControlStopRequest(receipt, stop.request)
+                );
+              } catch {
+                return false;
+              }
+            })
+          );
+          return {
+            sessionId: root.sessionId,
+            decision: confirmed.every(Boolean) ? 'ready' : 'stop_pending',
+          };
+        })
+      );
+    },
+    async reconcileOperations(authority: RecoveryAuthority): Promise<RecoveryScopeResult[]> {
+      const routes = await loadRouteTable(input.storage);
+      return Promise.all(
+        (authority.roots ?? []).map(async root => {
+          const unknown: RecoveryScopeResult = {
+            sessionId: root.sessionId,
+            decision: 'operation_unknown',
+          };
+          if (root.decision === 'ready') return { sessionId: root.sessionId, decision: 'ready' };
+          const route = routes.get(root.sessionId);
+          if (
+            !route ||
+            route.ownerId !== root.ownerId ||
+            route.kiloSessionId !== root.kiloSessionId ||
+            route.directory !== root.directory ||
+            route.nativeRuntimeId !== root.nativeRuntimeId ||
+            root.observation === 'unknown' ||
+            root.observation === 'stale'
+          )
+            return unknown;
+          const scopes = authority.scopes.filter(scope => scope.sessionId === root.sessionId);
+          if (
+            scopes.some(
+              scope =>
+                scope.executionDeadlineAt !== undefined && scope.executionDeadlineAt <= Date.now()
+            )
+          )
+            return { sessionId: root.sessionId, decision: 'execution_expired' };
+          const authorizations = scopes.flatMap(scope =>
+            scope.authorization ? [scope.authorization] : []
+          );
+          if (
+            authorizations.some(
+              auth =>
+                auth.session.sessionId !== root.sessionId ||
+                auth.session.kiloSessionId !== root.kiloSessionId ||
+                auth.session.directory !== root.directory
+            )
+          )
+            return unknown;
+          if (scopes.length > 0 && authorizations.length === 0) return unknown;
+          if (authorizations.length === 0) return { sessionId: root.sessionId, decision: 'ready' };
+          try {
+            const result = await withTimeout(
+              withDORetry(
+                () => getSandboxSessionStub(input.env, root.ownerId, root.sessionId),
+                stub => stub.reconcileControlRecovery(authorizations),
+                'reconcileRecoveryOperations'
+              ),
+              DEADLINE_MS.stopAttempt,
+              'Recovery operation reconciliation timed out'
+            );
+            return result.state === 'reconciled'
+              ? { sessionId: root.sessionId, decision: 'ready' }
+              : unknown;
+          } catch {
+            return unknown;
+          }
+        })
+      );
+    },
+  };
+}

--- a/services/cloud-agent-next/src/sandbox-control/recovery-cleanup.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/recovery-cleanup.test.ts
@@ -1,0 +1,531 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  RecoveryAuthority,
+  RecoveryRoot,
+  SandboxRecoveryDecision,
+} from './control-recovery.js';
+import {
+  loadDeadlines,
+  loadNativeRuntimeRetirements,
+  loadPhysicalRecord,
+  loadRecoveryDecisions,
+  loadRouteTable,
+  saveNativeRuntimeRetirements,
+  savePhysicalRecord,
+  saveRecoveryDecisions,
+  saveRouteTable,
+  type NativeRuntimeRetirementReceipt,
+} from './durable-state.js';
+import { createNativeRuntimeRetirement } from './native-runtime-retirement.js';
+import type { PhysicalRecord } from './physical-lifecycle.js';
+import type { SessionRoute } from './session-routes.js';
+import {
+  canRecoveryRetirementStopAllocation,
+  createRecoveryCleanup,
+  ownsRecoveryCleanupAllocation,
+  RECOVERY_CLEANUP_REASON,
+  selectRecoveryCleanupRoots,
+} from './recovery-cleanup.js';
+
+const connection = {
+  connectionId: '11111111-1111-4111-8111-111111111111',
+  providerInstanceId: 'provider-1',
+  wrapperInstanceId: '22222222-2222-4222-8222-222222222222',
+};
+const nativeRuntimeId = '33333333-3333-4333-8333-333333333333';
+const route: SessionRoute = {
+  sessionId: 'session-1',
+  ownerId: 'owner-1',
+  kiloSessionId: 'kilo-1',
+  directory: '/workspace/a',
+  nativeRuntimeId,
+  retiringNativeRuntimeId: nativeRuntimeId,
+  lastState: 'active',
+  lastStateAt: 1,
+  idleForMs: 0,
+  waitingOn: 'model',
+};
+const root: RecoveryRoot = {
+  sessionId: route.sessionId,
+  ownerId: route.ownerId,
+  kiloSessionId: route.kiloSessionId,
+  directory: route.directory,
+  nativeRuntimeId,
+  observation: 'known',
+  decision: 'execution_expired',
+};
+const physical: PhysicalRecord = {
+  state: 'running',
+  providerRef: connection.providerInstanceId,
+  createIntent: { intentId: 'allocation-1', createdAt: 1 },
+  stopTombstone: null,
+  resumable: false,
+};
+const authority: RecoveryAuthority = {
+  source: 'session_control_state',
+  observedAt: 100,
+  allocation: { providerRef: connection.providerInstanceId, createIntentId: 'allocation-1' },
+  roots: [root],
+  scopes: [
+    {
+      sessionId: root.sessionId,
+      kiloSessionId: root.kiloSessionId,
+      directory: root.directory,
+      nativeRuntimeId,
+      messageId: 'message-1',
+      executionDeadlineAt: 200,
+    },
+  ],
+  stops: [],
+  wholeAllocation: true,
+};
+const decision: SandboxRecoveryDecision = {
+  ...connection,
+  episodeId: '44444444-4444-4444-8444-444444444444',
+  cause: 'control_disconnected',
+  startedAt: 100,
+  deadlineAt: 200,
+  attempt: 1,
+  exhaustedAt: 200,
+  cleanupDeadlineAt: 300,
+  cleanupState: 'pending',
+  authority,
+};
+
+function retirement(overrides: Partial<NativeRuntimeRetirementReceipt> = {}) {
+  const receipt = createNativeRuntimeRetirement(
+    physical,
+    connection,
+    [route],
+    RECOVERY_CLEANUP_REASON,
+    300,
+    1_000
+  );
+  if (!receipt) throw new Error('Missing fixture receipt');
+  return { ...receipt, ...overrides };
+}
+
+async function fixture(record: SandboxRecoveryDecision = decision) {
+  const values = new Map<string, unknown>();
+  const store = {
+    async get<T>(key: string): Promise<T | undefined> {
+      return structuredClone(values.get(key)) as T | undefined;
+    },
+    async put(key: string, value: unknown) {
+      values.set(key, structuredClone(value));
+    },
+    async delete(keys: string[]) {
+      return keys.filter(key => values.delete(key)).length;
+    },
+    async transaction<T>(run: (tx: DurableObjectTransaction) => Promise<T>): Promise<T> {
+      return run(store as unknown as DurableObjectTransaction);
+    },
+  };
+  const storage = store as unknown as Parameters<typeof createRecoveryCleanup>[0]['storage'];
+  let time = 250;
+  let currentConnection: typeof connection | undefined = connection;
+  const retire = vi
+    .fn<Parameters<typeof createRecoveryCleanup>[0]['retirement']['retire']>()
+    .mockResolvedValue('pending');
+  const onPhysicalStop = vi
+    .fn<Parameters<typeof createRecoveryCleanup>[0]['onPhysicalStop']>()
+    .mockResolvedValue(undefined);
+  const scheduleAlarm = vi.fn().mockResolvedValue(undefined);
+  const cleanup = createRecoveryCleanup({
+    storage,
+    retirement: { retire },
+    getConnection: () => currentConnection,
+    supportsTargetedRetirement: () => true,
+    persistPhysical: (_from, to) => savePhysicalRecord(storage, to),
+    onPhysicalStop,
+    scheduleAlarm,
+    now: () => time,
+  });
+  await savePhysicalRecord(storage, physical);
+  await saveRouteTable(storage, new Map([[route.sessionId, route]]));
+  await saveRecoveryDecisions(storage, [record]);
+  return {
+    cleanup,
+    storage,
+    retire,
+    onPhysicalStop,
+    scheduleAlarm,
+    setTime: (value: number) => {
+      time = value;
+    },
+    setConnection: (value: typeof connection | undefined) => {
+      currentConnection = value;
+    },
+  };
+}
+
+describe('recovery cleanup selection', () => {
+  it.each(['stop_pending', 'execution_expired'] as const)(
+    'selects known %s roots without requiring an operation scope',
+    state => {
+      const selected = { ...root, decision: state };
+      expect(
+        selectRecoveryCleanupRoots({ ...authority, scopes: [], roots: [selected] }, 250)
+      ).toEqual([selected]);
+    }
+  );
+
+  it.each([
+    { observation: 'known', decision: 'ready' },
+    { observation: 'known', decision: 'operation_unknown' },
+    { observation: 'unknown', decision: 'execution_expired' },
+    { observation: 'stale', decision: 'stop_pending' },
+    { observation: 'idle', decision: 'ready' },
+    { observation: 'known' },
+  ] satisfies Partial<RecoveryRoot>[])(
+    'does not treat transport expiry as authority for $observation/$decision',
+    state => {
+      expect(
+        selectRecoveryCleanupRoots(
+          { ...authority, scopes: [], roots: [{ ...root, decision: undefined, ...state }] },
+          999
+        )
+      ).toEqual([]);
+    }
+  );
+
+  it('uses an original execution bound, not the failed RPC deadline, for stale ownership', () => {
+    const stale = {
+      ...root,
+      observation: 'stale' as const,
+      decision: 'operation_unknown' as const,
+    };
+    const uncertain = { ...authority, roots: [stale], wholeAllocation: false };
+    expect(selectRecoveryCleanupRoots(uncertain, 199)).toEqual([]);
+    expect(selectRecoveryCleanupRoots(uncertain, 200)).toEqual([stale]);
+    expect(
+      selectRecoveryCleanupRoots({ ...uncertain, roots: [{ ...stale, decision: 'ready' }] }, 200)
+    ).toEqual([]);
+  });
+
+  it('retains cleanup responsibility for an idle root with a pending Stop', () => {
+    const stopped = { ...root, observation: 'idle' as const, decision: 'stop_pending' as const };
+    expect(selectRecoveryCleanupRoots({ ...authority, scopes: [], roots: [stopped] }, 250)).toEqual(
+      [stopped]
+    );
+  });
+
+  it('only selects legacy operation scopes with an expired execution deadline or Stop', () => {
+    const legacy = { ...authority, roots: undefined };
+    expect(selectRecoveryCleanupRoots(legacy, 199)).toEqual([]);
+    expect(selectRecoveryCleanupRoots(legacy, 200)).toEqual(legacy.scopes);
+  });
+});
+
+describe('targeted recovery cleanup', () => {
+  it('releases stale observation gates on exact native proof without new cleanup authority', async () => {
+    const f = await fixture({
+      ...decision,
+      authority: {
+        ...authority,
+        wholeAllocation: false,
+        roots: [{ ...root, observation: 'stale', decision: 'operation_unknown' }],
+      },
+    });
+    const proof = retirement({
+      state: 'completed',
+      disposition: 'retired',
+      notificationState: 'pending',
+    });
+    await saveNativeRuntimeRetirements(f.storage, [proof]);
+    await f.cleanup.reconcile();
+    expect(await loadRecoveryDecisions(f.storage)).toEqual([]);
+    expect(await loadNativeRuntimeRetirements(f.storage)).toEqual([proof]);
+    expect(f.retire).not.toHaveBeenCalled();
+    expect(f.onPhysicalStop).not.toHaveBeenCalled();
+  });
+
+  it.each(['pending', 'exhausted', 'delivered'] as const)(
+    'releases gates and the episode on exact proof with %s notifications, retaining replay',
+    async notificationState => {
+      const f = await fixture();
+      const receipt = retirement({ state: 'completed', disposition: 'retired', notificationState });
+      await saveNativeRuntimeRetirements(f.storage, [receipt]);
+      await f.cleanup.reconcile();
+      expect(await loadRecoveryDecisions(f.storage)).toEqual([]);
+      const released = (await loadRouteTable(f.storage)).get(route.sessionId);
+      expect(released?.nativeRuntimeId).toBeUndefined();
+      expect(released?.retiringNativeRuntimeId).toBeUndefined();
+      expect(await loadNativeRuntimeRetirements(f.storage)).toEqual([receipt]);
+      expect((await loadDeadlines(f.storage)).recoveryRetry).toBeUndefined();
+      expect(f.retire).not.toHaveBeenCalled();
+      expect(f.onPhysicalStop).not.toHaveBeenCalled();
+    }
+  );
+
+  it('preserves the original cleanup deadline through retries and notification failure', async () => {
+    const f = await fixture();
+    await f.cleanup.reconcile();
+    expect(f.retire.mock.calls[0]?.[0].cleanupDeadlineAt).toBe(300);
+    f.setTime(275);
+    f.retire.mockImplementationOnce(async () => {
+      await saveNativeRuntimeRetirements(f.storage, [
+        retirement({ state: 'completed', disposition: 'retired' }),
+      ]);
+      throw new Error('Session notification failed');
+    });
+    await f.cleanup.reconcile();
+    expect(f.retire.mock.calls[1]?.[0].cleanupDeadlineAt).toBe(300);
+    expect(await loadRecoveryDecisions(f.storage)).toEqual([]);
+    expect(f.onPhysicalStop).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { allocation: { providerRef: 'provider-1', createIntentId: 'older-allocation' } },
+    { connection: { ...connection, wrapperInstanceId: '55555555-5555-4555-8555-555555555555' } },
+    { nativeRuntimeId: '66666666-6666-4666-8666-666666666666' },
+    { disposition: 'operation_only' as const },
+    { recipients: [{ ...root, ownerId: 'other-owner' }] },
+  ])('rejects non-exact retirement proof %#', async mismatch => {
+    const f = await fixture();
+    await saveNativeRuntimeRetirements(f.storage, [
+      retirement({ state: 'completed', disposition: 'retired', ...mismatch }),
+    ]);
+    await f.cleanup.reconcile();
+    expect((await loadRecoveryDecisions(f.storage))[0]?.cleanupState).toBe('targeted');
+    expect((await loadRouteTable(f.storage)).get(route.sessionId)?.nativeRuntimeId).toBe(
+      nativeRuntimeId
+    );
+  });
+
+  it('uses old exact proof after reconnect without retargeting a replacement route', async () => {
+    const f = await fixture();
+    const replacement = { ...route, nativeRuntimeId: '77777777-7777-4777-8777-777777777777' };
+    await saveRouteTable(f.storage, new Map([[route.sessionId, replacement]]));
+    f.setConnection({ ...connection, connectionId: '88888888-8888-4888-8888-888888888888' });
+    await saveNativeRuntimeRetirements(f.storage, [
+      retirement({ state: 'completed', disposition: 'retired' }),
+    ]);
+    await f.cleanup.reconcile();
+    expect(await loadRecoveryDecisions(f.storage)).toEqual([]);
+    expect((await loadRouteTable(f.storage)).get(route.sessionId)).toEqual(replacement);
+    expect(f.retire).not.toHaveBeenCalled();
+  });
+
+  it('releases proven roots but retains uncertain sibling authority', async () => {
+    const unknown = {
+      ...root,
+      sessionId: 'session-2',
+      directory: '/workspace/b',
+      observation: 'unknown' as const,
+      decision: undefined,
+    };
+    const f = await fixture({
+      ...decision,
+      authority: { ...authority, roots: [root, unknown], wholeAllocation: false },
+    });
+    await saveNativeRuntimeRetirements(f.storage, [
+      retirement({ state: 'completed', disposition: 'retired' }),
+    ]);
+    await f.cleanup.reconcile();
+    const current = (await loadRecoveryDecisions(f.storage))[0];
+    expect(current?.cleanupState).toBe('unconfirmed');
+    expect(current?.authority?.roots).toEqual([
+      { ...root, observation: 'idle', decision: 'ready' },
+      unknown,
+    ]);
+    expect(
+      (await loadRouteTable(f.storage)).get(route.sessionId)?.retiringNativeRuntimeId
+    ).toBeUndefined();
+    expect(f.onPhysicalStop).not.toHaveBeenCalled();
+  });
+
+  it('rechecks root authority after retiring another native runtime', async () => {
+    const sibling = {
+      ...root,
+      sessionId: 'session-2',
+      kiloSessionId: 'kilo-2',
+      directory: '/workspace/b',
+      nativeRuntimeId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    };
+    const f = await fixture({ ...decision, authority: { ...authority, roots: [root, sibling] } });
+    await saveRouteTable(
+      f.storage,
+      new Map([
+        [route.sessionId, route],
+        [sibling.sessionId, { ...route, ...sibling }],
+      ])
+    );
+    f.retire.mockImplementationOnce(async () => {
+      await saveRecoveryDecisions(f.storage, [
+        {
+          ...decision,
+          authority: { ...authority, roots: [root, { ...sibling, decision: 'ready' }] },
+        },
+      ]);
+      return 'pending';
+    });
+    await f.cleanup.reconcile();
+    expect(f.retire).toHaveBeenCalledOnce();
+    expect(f.retire.mock.calls[0]?.[0].route.sessionId).toBe(root.sessionId);
+    expect(f.onPhysicalStop).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    'protects a ready sibling with its route still attached: %s',
+    async attached => {
+      const sibling = {
+        ...root,
+        sessionId: 'session-2',
+        kiloSessionId: 'kilo-2',
+        decision: 'ready' as const,
+      };
+      const f = await fixture({ ...decision, authority: { ...authority, roots: [root, sibling] } });
+      await saveRouteTable(
+        f.storage,
+        new Map([
+          [route.sessionId, route],
+          [sibling.sessionId, { ...route, ...sibling }],
+        ])
+      );
+      if (!attached) await saveRouteTable(f.storage, new Map([[route.sessionId, route]]));
+      await f.cleanup.reconcile();
+      f.setTime(300);
+      await f.cleanup.reconcile();
+      expect(f.retire).not.toHaveBeenCalled();
+      expect(f.onPhysicalStop).not.toHaveBeenCalled();
+      expect((await loadRecoveryDecisions(f.storage))[0]?.cleanupState).toBe('unconfirmed');
+    }
+  );
+});
+
+describe('recovery physical fallback', () => {
+  it('commits a stop before entering physical fallback even with pending native cleanup', async () => {
+    const f = await fixture();
+    await saveNativeRuntimeRetirements(f.storage, [retirement()]);
+    f.setTime(300);
+    await f.cleanup.reconcile();
+    expect((await loadPhysicalRecord(f.storage)).stopTombstone).toMatchObject({
+      reason: RECOVERY_CLEANUP_REASON,
+      attempts: 0,
+    });
+    expect((await loadRecoveryDecisions(f.storage))[0]?.cleanupState).toBe('physical_fallback');
+    expect(f.onPhysicalStop).toHaveBeenCalledOnce();
+    expect(f.retire).not.toHaveBeenCalled();
+    await f.cleanup.reconcile();
+    expect(f.onPhysicalStop).toHaveBeenCalledOnce();
+  });
+
+  it('ends denied fallback without a perpetual cleanup alarm or an invented stop', async () => {
+    const f = await fixture({
+      ...decision,
+      authority: { ...authority, wholeAllocation: false },
+      cleanupState: 'physical_fallback',
+    });
+    await saveNativeRuntimeRetirements(f.storage, [retirement()]);
+    f.setTime(300);
+    await f.cleanup.reconcile();
+    expect((await loadRecoveryDecisions(f.storage))[0]?.cleanupState).toBe('unconfirmed');
+    expect((await loadNativeRuntimeRetirements(f.storage))[0]?.state).toBe('unconfirmed');
+    expect((await loadDeadlines(f.storage)).recoveryRetry).toBeUndefined();
+    expect((await loadPhysicalRecord(f.storage)).stopTombstone).toBeNull();
+    expect(f.onPhysicalStop).not.toHaveBeenCalled();
+  });
+
+  it.each(['allocation', 'route', 'owner', 'wrapper', 'authority'] as const)(
+    'revalidates %s changes after a targeted await',
+    async change => {
+      const f = await fixture();
+      f.retire.mockImplementationOnce(async () => {
+        f.setTime(300);
+        if (change === 'allocation')
+          await savePhysicalRecord(f.storage, {
+            ...physical,
+            createIntent: { intentId: 'replacement', createdAt: 275 },
+          });
+        if (change === 'route')
+          await saveRouteTable(
+            f.storage,
+            new Map([
+              [route.sessionId, route],
+              ['new-session', { ...route, sessionId: 'new-session', directory: '/workspace/new' }],
+            ])
+          );
+        if (change === 'owner')
+          await saveRouteTable(
+            f.storage,
+            new Map([[route.sessionId, { ...route, ownerId: 'other-owner' }]])
+          );
+        if (change === 'wrapper')
+          f.setConnection({
+            ...connection,
+            wrapperInstanceId: '99999999-9999-4999-8999-999999999999',
+          });
+        if (change === 'authority')
+          await saveRecoveryDecisions(f.storage, [
+            { ...decision, authority: { ...authority, roots: [{ ...root, decision: 'ready' }] } },
+          ]);
+        return 'pending';
+      });
+      await f.cleanup.reconcile();
+      expect((await loadPhysicalRecord(f.storage)).stopTombstone).toBeNull();
+      expect((await loadRecoveryDecisions(f.storage))[0]?.cleanupState).toBe('unconfirmed');
+      expect(f.onPhysicalStop).not.toHaveBeenCalled();
+    }
+  );
+
+  it('requires exact allocation and whole-allocation ownership in PR4 escalation', () => {
+    const routes = new Map([[route.sessionId, route]]);
+    expect(
+      canRecoveryRetirementStopAllocation(retirement(), [decision], physical, routes, 300)
+    ).toBe(true);
+    expect(
+      canRecoveryRetirementStopAllocation(
+        retirement({ cleanupDeadlineAt: 301 }),
+        [decision],
+        physical,
+        routes,
+        300
+      )
+    ).toBe(false);
+    expect(
+      ownsRecoveryCleanupAllocation(
+        decision,
+        { ...physical, createIntent: { intentId: 'replacement', createdAt: 250 } },
+        routes,
+        300
+      )
+    ).toBe(false);
+    expect(
+      ownsRecoveryCleanupAllocation(
+        { ...decision, authority: { ...authority, roots: [{ ...root, observation: 'unknown' }] } },
+        physical,
+        routes,
+        300
+      )
+    ).toBe(false);
+  });
+});
+
+describe('recovery exhaustion persistence', () => {
+  it('keeps the original cleanup deadline and exhausts only due episodes', async () => {
+    const f = await fixture({ ...decision, exhaustedAt: undefined, cleanupState: undefined });
+    await f.cleanup.exhaustExpired(199);
+    expect((await loadRecoveryDecisions(f.storage))[0]?.exhaustedAt).toBeUndefined();
+    await f.cleanup.exhaustExpired(200);
+    await f.cleanup.exhaustExpired(275);
+    expect((await loadRecoveryDecisions(f.storage))[0]).toMatchObject({
+      exhaustedAt: 200,
+      cleanupDeadlineAt: 300,
+    });
+  });
+
+  it('uses activation repair expiry rather than the expired transport deadline', async () => {
+    const f = await fixture({
+      ...decision,
+      exhaustedAt: undefined,
+      cleanupState: undefined,
+      activationCommittedAt: 190,
+      activationCommitDeadlineAt: 290,
+    });
+    await f.cleanup.exhaustExpired(250);
+    expect((await loadRecoveryDecisions(f.storage))[0]?.exhaustedAt).toBeUndefined();
+    await f.cleanup.exhaustExpired(290);
+    expect((await loadRecoveryDecisions(f.storage))[0]?.exhaustedAt).toBe(290);
+  });
+});

--- a/services/cloud-agent-next/src/sandbox-control/recovery-cleanup.ts
+++ b/services/cloud-agent-next/src/sandbox-control/recovery-cleanup.ts
@@ -1,0 +1,468 @@
+import * as recovery from './control-recovery.js';
+import {
+  loadDeadlines,
+  loadNativeRuntimeRetirements,
+  loadPhysicalRecord,
+  loadRecoveryDecisions,
+  loadRouteTable,
+  saveDeadlines,
+  saveNativeRuntimeRetirements,
+  saveRecoveryDecisions,
+  saveRouteTable,
+  type NativeRuntimeRetirementReceipt,
+} from './durable-state.js';
+import { DEADLINE_MS, type DeadlineTable } from './deadlines.js';
+import {
+  sameNativeRuntimeRetirementLifetime,
+  type NativeRuntimeRetirementConnection,
+  type NativeRuntimeRetirementWorkflow,
+} from './native-runtime-retirement.js';
+import { beginStop, type PhysicalRecord } from './physical-lifecycle.js';
+import type { SessionRoute } from './session-routes.js';
+
+export const RECOVERY_CLEANUP_REASON = 'Control recovery exhausted';
+
+type CleanupRoot = {
+  sessionId: string;
+  ownerId?: string;
+  kiloSessionId: string;
+  directory: string;
+  nativeRuntimeId?: string;
+};
+
+type CleanupStorage = Pick<DurableObjectStorage, 'get' | 'put' | 'delete' | 'transaction'>;
+type CleanupState = NonNullable<recovery.SandboxRecoveryDecision['cleanupState']>;
+
+export function selectRecoveryCleanupRoots(
+  authority: recovery.RecoveryAuthority,
+  now: number
+): CleanupRoot[] {
+  if (authority.roots !== undefined) {
+    return authority.roots.filter(root => {
+      if (root.decision === 'ready') return false;
+      const expiredOperation = authority.scopes.some(
+        scope =>
+          scope.sessionId === root.sessionId &&
+          scope.kiloSessionId === root.kiloSessionId &&
+          scope.directory === root.directory &&
+          scope.nativeRuntimeId === root.nativeRuntimeId &&
+          scope.executionDeadlineAt !== undefined &&
+          scope.executionDeadlineAt <= now
+      );
+      return (
+        expiredOperation ||
+        ((root.observation === 'known' || root.observation === 'idle') &&
+          (root.decision === 'stop_pending' || root.decision === 'execution_expired'))
+      );
+    });
+  }
+  return authority.scopes.filter(
+    scope =>
+      (scope.executionDeadlineAt !== undefined && scope.executionDeadlineAt <= now) ||
+      authority.stops.some(stop => stop.sessionId === scope.sessionId)
+  );
+}
+
+function matchesRoot(route: CleanupRoot, root: CleanupRoot): boolean {
+  return (
+    route.sessionId === root.sessionId &&
+    (root.ownerId === undefined || route.ownerId === root.ownerId) &&
+    route.kiloSessionId === root.kiloSessionId &&
+    route.directory === root.directory &&
+    route.nativeRuntimeId === root.nativeRuntimeId
+  );
+}
+
+function matchesAllocation(
+  decision: recovery.SandboxRecoveryDecision,
+  physical: PhysicalRecord
+): boolean {
+  return (
+    decision.authority !== undefined &&
+    decision.authority.allocation.providerRef === decision.providerInstanceId &&
+    physical.providerRef === decision.providerInstanceId &&
+    physical.createIntent?.intentId === decision.authority.allocation.createIntentId
+  );
+}
+
+function provesRetirement(
+  receipt: NativeRuntimeRetirementReceipt,
+  decision: recovery.SandboxRecoveryDecision,
+  root: CleanupRoot
+): boolean {
+  return (
+    root.nativeRuntimeId !== undefined &&
+    receipt.state === 'completed' &&
+    receipt.disposition === 'retired' &&
+    receipt.allocation.providerRef === decision.authority?.allocation.providerRef &&
+    receipt.allocation.createIntentId === decision.authority?.allocation.createIntentId &&
+    sameNativeRuntimeRetirementLifetime(receipt, {
+      directory: root.directory,
+      nativeRuntimeId: root.nativeRuntimeId,
+      connection: decision,
+    }) &&
+    receipt.recipients.some(recipient => matchesRoot(recipient, root))
+  );
+}
+
+export function ownsRecoveryCleanupAllocation(
+  decision: recovery.SandboxRecoveryDecision,
+  physical: PhysicalRecord,
+  routes: Map<string, SessionRoute>,
+  now: number
+): boolean {
+  const authority: recovery.RecoveryAuthority | undefined = decision.authority;
+  if (!authority?.wholeAllocation || !matchesAllocation(decision, physical)) return false;
+  const roots = selectRecoveryCleanupRoots(authority, now);
+  return (
+    roots.length > 0 &&
+    authority.roots?.length === roots.length &&
+    authority.roots.every(root => root.observation === 'known' || root.observation === 'idle') &&
+    routes.size > 0 &&
+    roots.every(root => {
+      const route = routes.get(root.sessionId);
+      return route !== undefined && matchesRoot(route, root);
+    }) &&
+    [...routes.values()].every(route =>
+      roots.some(root => root.ownerId === route.ownerId && matchesRoot(route, root))
+    )
+  );
+}
+
+export function canRecoveryRetirementStopAllocation(
+  receipt: NativeRuntimeRetirementReceipt,
+  decisions: recovery.SandboxRecoveryDecision[],
+  physical: PhysicalRecord,
+  routes: Map<string, SessionRoute>,
+  now: number
+): boolean {
+  return decisions.some(
+    decision =>
+      decision.exhaustedAt !== undefined &&
+      decision.cleanupState !== 'completed' &&
+      decision.cleanupState !== 'unconfirmed' &&
+      decision.cleanupDeadlineAt !== undefined &&
+      decision.cleanupDeadlineAt <= now &&
+      receipt.cleanupDeadlineAt === decision.cleanupDeadlineAt &&
+      receipt.allocation.createIntentId === decision.authority?.allocation.createIntentId &&
+      receipt.allocation.providerRef === decision.providerInstanceId &&
+      receipt.connection.wrapperInstanceId === decision.wrapperInstanceId &&
+      ownsRecoveryCleanupAllocation(decision, physical, routes, now)
+  );
+}
+
+export function createRecoveryCleanup(input: {
+  storage: CleanupStorage;
+  retirement: Pick<NativeRuntimeRetirementWorkflow, 'retire'>;
+  getConnection: () => NativeRuntimeRetirementConnection | undefined;
+  supportsTargetedRetirement: () => boolean;
+  persistPhysical: (from: PhysicalRecord, to: PhysicalRecord, reason: string) => Promise<void>;
+  onPhysicalStop: (from: PhysicalRecord, to: PhysicalRecord, reason: string) => Promise<void>;
+  scheduleAlarm: (deadlines: DeadlineTable) => Promise<void>;
+  now?: () => number;
+}) {
+  const now = input.now ?? Date.now;
+
+  const save = async (
+    tx: DurableObjectTransaction,
+    decisions: recovery.SandboxRecoveryDecision[]
+  ): Promise<void> => {
+    const deadlines = recovery.recoveryDeadlines(await loadDeadlines(tx), decisions, now());
+    await saveRecoveryDecisions(tx, decisions);
+    await saveDeadlines(tx, deadlines);
+    await input.scheduleAlarm(deadlines);
+  };
+
+  const update = async (
+    episodeId: string,
+    state: CleanupState,
+    nextAttemptAt?: number
+  ): Promise<void> => {
+    await input.storage.transaction(async tx => {
+      const decisions = await loadRecoveryDecisions(tx);
+      const current = decisions.find(item => item.episodeId === episodeId);
+      if (!current || current.exhaustedAt === undefined) return;
+      await save(
+        tx,
+        decisions.map(item =>
+          item === current ? recovery.updateRecoveryCleanup(item, state, nextAttemptAt) : item
+        )
+      );
+    });
+  };
+
+  const complete = async (episodeId: string): Promise<boolean> => {
+    return input.storage.transaction(async tx => {
+      const [decisions, physical, receipts, routes] = await Promise.all([
+        loadRecoveryDecisions(tx),
+        loadPhysicalRecord(tx),
+        loadNativeRuntimeRetirements(tx),
+        loadRouteTable(tx),
+      ]);
+      const current = decisions.find(item => item.episodeId === episodeId);
+      if (!current || current.exhaustedAt === undefined) return false;
+      if (!matchesAllocation(current, physical)) return false;
+      if (physical.state === 'stopped') {
+        await save(
+          tx,
+          decisions.filter(item => item !== current)
+        );
+        return true;
+      }
+      const authority = current.authority;
+      if (!authority) return false;
+      const roots = authority.roots?.filter(root => root.decision !== 'ready') ?? authority.scopes;
+      const proven = roots.filter(root =>
+        receipts.some(receipt => provesRetirement(receipt, current, root))
+      );
+      if (proven.length === 0) return false;
+      for (const root of proven) {
+        const route = routes.get(root.sessionId);
+        if (
+          !route ||
+          !matchesRoot(route, root) ||
+          (route.retiringNativeRuntimeId !== undefined &&
+            route.retiringNativeRuntimeId !== root.nativeRuntimeId)
+        )
+          continue;
+        const proof = receipts.find(receipt => provesRetirement(receipt, current, root));
+        if (
+          !proof?.recipients.some(
+            recipient => matchesRoot(recipient, route) && recipient.worktreeId === route.worktreeId
+          )
+        )
+          continue;
+        const next = { ...route };
+        delete next.retiringNativeRuntimeId;
+        delete next.nativeRuntimeId;
+        routes.set(route.sessionId, next);
+      }
+      await saveRouteTable(tx, routes);
+      const nextAuthority: recovery.RecoveryAuthority = {
+        ...authority,
+        ...(authority.roots
+          ? {
+              roots: authority.roots.map(root =>
+                proven.some(target => matchesRoot(root, target))
+                  ? { ...root, observation: 'idle' as const, decision: 'ready' as const }
+                  : root
+              ),
+            }
+          : {}),
+      };
+      const finished = nextAuthority.roots
+        ? nextAuthority.roots.every(
+            root =>
+              root.decision === 'ready' &&
+              (root.observation === 'known' || root.observation === 'idle')
+          ) &&
+          [...routes.values()].every(route =>
+            nextAuthority.roots?.some(
+              root =>
+                root.sessionId === route.sessionId &&
+                root.ownerId === route.ownerId &&
+                root.kiloSessionId === route.kiloSessionId &&
+                root.directory === route.directory
+            )
+          )
+        : authority.wholeAllocation && authority.scopes.length === proven.length;
+      const settled = selectRecoveryCleanupRoots(nextAuthority, now()).length === 0;
+      await save(
+        tx,
+        finished
+          ? decisions.filter(item => item !== current)
+          : decisions.map(item =>
+              item === current
+                ? {
+                    ...recovery.updateRecoveryCleanup(
+                      current,
+                      settled ? 'unconfirmed' : 'targeted',
+                      settled ? undefined : current.cleanupDeadlineAt
+                    ),
+                    authority: nextAuthority,
+                  }
+                : item
+            )
+      );
+      return finished || settled;
+    });
+  };
+
+  const beginPhysicalFallback = async (episodeId: string): Promise<void> => {
+    const committed = await input.storage.transaction(async tx => {
+      const [physical, decisions, routes, receipts] = await Promise.all([
+        loadPhysicalRecord(tx),
+        loadRecoveryDecisions(tx),
+        loadRouteTable(tx),
+        loadNativeRuntimeRetirements(tx),
+      ]);
+      const current = decisions.find(item => item.episodeId === episodeId);
+      if (!current || current.exhaustedAt === undefined) return undefined;
+      const connection = input.getConnection();
+      const canStop =
+        (!connection || recovery.sameRuntime(connection, current)) &&
+        current.cleanupState !== 'unconfirmed' &&
+        current.cleanupState !== 'completed' &&
+        current.cleanupDeadlineAt !== undefined &&
+        now() >= current.cleanupDeadlineAt &&
+        ownsRecoveryCleanupAllocation(current, physical, routes, now());
+      const stopping = matchesAllocation(current, physical) && physical.stopTombstone !== null;
+      const next =
+        canStop && physical.state === 'running' && !physical.stopTombstone
+          ? beginStop(physical, RECOVERY_CLEANUP_REASON, now(), current.wrapperInstanceId)
+          : undefined;
+      if (next) await input.persistPhysical(physical, next, RECOVERY_CLEANUP_REASON);
+      const state = next || stopping ? 'physical_fallback' : 'unconfirmed';
+      if (state === 'unconfirmed') {
+        await saveNativeRuntimeRetirements(
+          tx,
+          receipts.map(receipt =>
+            receipt.reason === RECOVERY_CLEANUP_REASON &&
+            receipt.state === 'pending' &&
+            receipt.connection.wrapperInstanceId === current.wrapperInstanceId &&
+            receipt.allocation.providerRef === current.providerInstanceId &&
+            receipt.allocation.createIntentId === current.authority?.allocation.createIntentId
+              ? { ...receipt, state: 'unconfirmed', nextAttemptAt: undefined }
+              : receipt
+          )
+        );
+      }
+      await save(
+        tx,
+        decisions.map(item =>
+          item === current
+            ? recovery.updateRecoveryCleanup(
+                item,
+                state,
+                state === 'physical_fallback' ? now() + DEADLINE_MS.reconciliation : undefined
+              )
+            : item
+        )
+      );
+      return next ? { physical, next } : undefined;
+    });
+    if (committed)
+      await input.onPhysicalStop(committed.physical, committed.next, RECOVERY_CLEANUP_REASON);
+  };
+
+  const retireRoot = async (episodeId: string, root: CleanupRoot): Promise<void> => {
+    const target = await input.storage.transaction(async tx => {
+      const [decisions, physical, routes] = await Promise.all([
+        loadRecoveryDecisions(tx),
+        loadPhysicalRecord(tx),
+        loadRouteTable(tx),
+      ]);
+      const current = decisions.find(item => item.episodeId === episodeId);
+      const connection = input.getConnection();
+      const route = routes.get(root.sessionId);
+      if (
+        !current?.authority ||
+        current.exhaustedAt === undefined ||
+        current.cleanupState === 'completed' ||
+        current.cleanupState === 'unconfirmed' ||
+        current.cleanupDeadlineAt === undefined ||
+        now() >= current.cleanupDeadlineAt ||
+        !connection ||
+        !recovery.sameRuntime(connection, current) ||
+        !matchesAllocation(current, physical) ||
+        physical.state !== 'running' ||
+        physical.stopTombstone ||
+        !root.nativeRuntimeId ||
+        !route ||
+        !matchesRoot(route, root)
+      )
+        return undefined;
+      const roots = selectRecoveryCleanupRoots(current.authority, now());
+      if (
+        !roots.some(target => matchesRoot(target, root)) ||
+        current.authority.roots?.some(
+          sibling =>
+            sibling.directory === root.directory &&
+            !roots.some(target => matchesRoot(sibling, target))
+        ) ||
+        [...routes.values()].some(
+          sibling =>
+            sibling.directory === root.directory &&
+            !roots.some(target => matchesRoot(sibling, target))
+        )
+      )
+        return undefined;
+      return {
+        connection,
+        physical,
+        route,
+        reason: RECOVERY_CLEANUP_REASON,
+        cleanupDeadlineAt: current.cleanupDeadlineAt,
+      };
+    });
+    if (target) await input.retirement.retire(target);
+  };
+
+  const reconcile = async (): Promise<void> => {
+    const decisions = await loadRecoveryDecisions(input.storage);
+    for (const decision of decisions) {
+      if (decision.exhaustedAt === undefined || decision.cleanupState === 'completed') continue;
+      if (await complete(decision.episodeId)) continue;
+      if (decision.cleanupState === 'unconfirmed') continue;
+      const physical = await loadPhysicalRecord(input.storage);
+      const authority = decision.authority;
+      if (!authority || !matchesAllocation(decision, physical)) {
+        await update(decision.episodeId, 'unconfirmed');
+        continue;
+      }
+      if (physical.stopTombstone) {
+        await update(decision.episodeId, 'physical_fallback', now() + DEADLINE_MS.reconciliation);
+        continue;
+      }
+      const roots = selectRecoveryCleanupRoots(authority, now());
+      const connection = input.getConnection();
+      const cleanupDeadlineAt = decision.cleanupDeadlineAt;
+      if (cleanupDeadlineAt === undefined || roots.length === 0) {
+        await update(decision.episodeId, 'unconfirmed');
+        continue;
+      }
+      if (
+        connection &&
+        recovery.sameRuntime(connection, decision) &&
+        input.supportsTargetedRetirement() &&
+        now() < cleanupDeadlineAt
+      ) {
+        const attempted = new Set<string>();
+        for (const root of roots) {
+          const key = JSON.stringify([root.directory, root.nativeRuntimeId]);
+          if (attempted.has(key)) continue;
+          attempted.add(key);
+          try {
+            await retireRoot(decision.episodeId, root);
+          } catch {
+            continue;
+          }
+        }
+      }
+      if (await complete(decision.episodeId)) continue;
+      if (now() < cleanupDeadlineAt) {
+        await update(decision.episodeId, 'targeted', cleanupDeadlineAt);
+      } else {
+        await beginPhysicalFallback(decision.episodeId);
+      }
+    }
+  };
+
+  return {
+    async exhaustExpired(at: number): Promise<void> {
+      await input.storage.transaction(async tx => {
+        const decisions = await loadRecoveryDecisions(tx);
+        const next = decisions.map(item =>
+          item.exhaustedAt === undefined &&
+          (recovery.activationRepairPending(item)
+            ? (item.activationCommitDeadlineAt ?? 0) <= at
+            : item.deadlineAt <= at)
+            ? recovery.exhaustRecovery(item, at)
+            : item
+        );
+        if (next.some((item, index) => item !== decisions[index])) await save(tx, next);
+      });
+    },
+    reconcile,
+  };
+}

--- a/services/cloud-agent-next/src/sandbox-control/recovery-execution.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/recovery-execution.test.ts
@@ -1,0 +1,847 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  sandboxReconcilePayloadSchema,
+  type ResponseFrame,
+} from '../shared/sandbox-control-protocol.js';
+import {
+  ACTIVE_WRAPPER_RUNTIME_KEY,
+  WRAPPER_READY_AT_KEY,
+  admitsRecoveryRequest,
+  beginRecovery,
+  commitRecoveryActivation,
+  recoveryDeadlines,
+  sameConnection,
+  type RecoveryAuthority,
+  type RecoveryScopeResult,
+  type SandboxRecoveryDecision,
+} from './control-recovery.js';
+import {
+  loadDeadlines,
+  loadPhysicalRecord,
+  loadRecoveryDecisions,
+  loadRouteTable,
+  saveDeadlines,
+  savePhysicalRecord,
+  saveRecoveryDecisions,
+  saveRouteTable,
+} from './durable-state.js';
+import type { PhysicalRecord } from './physical-lifecycle.js';
+import { createRecoveryExecution, type RecoveryExecutionRuntime } from './recovery-execution.js';
+import type { SandboxControlOutboundRequest } from './socket.js';
+
+const NOW = 1_000_000;
+const identity = {
+  connectionId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  providerInstanceId: 'allocation_a',
+  wrapperInstanceId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+  recoveryCapable: true,
+};
+const rootA = {
+  sessionId: 'workspace_a',
+  ownerId: 'owner_a',
+  kiloSessionId: 'kilo_a',
+  directory: '/workspace/a',
+  nativeRuntimeId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  observation: 'known',
+  decision: 'ready',
+} satisfies NonNullable<RecoveryAuthority['roots']>[number];
+const rootB = {
+  sessionId: 'workspace_b',
+  ownerId: 'owner_b',
+  kiloSessionId: 'kilo_b',
+  directory: '/workspace/b',
+  nativeRuntimeId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+  observation: 'known',
+  decision: 'ready',
+} satisfies NonNullable<RecoveryAuthority['roots']>[number];
+
+function memoryStorage() {
+  const values = new Map<string, unknown>();
+  let failCommit = false;
+  const view = (rows: Map<string, unknown>) => ({
+    async get<T = unknown>(key: string): Promise<T | undefined> {
+      return structuredClone(rows.get(key)) as T | undefined;
+    },
+    async put<T>(key: string, value: T): Promise<void> {
+      rows.set(key, structuredClone(value));
+    },
+    async delete(keys: string[]): Promise<number> {
+      return keys.filter(key => rows.delete(key)).length;
+    },
+  });
+  return {
+    ...view(values),
+    failNextTransaction() {
+      failCommit = true;
+    },
+    async transaction<T>(callback: (tx: DurableObjectTransaction) => Promise<T>): Promise<T> {
+      const draft = structuredClone(values);
+      const result = await callback(view(draft) as DurableObjectTransaction);
+      if (failCommit) {
+        failCommit = false;
+        throw new Error('Ready transaction persistence failed');
+      }
+      values.clear();
+      for (const [key, value] of draft) values.set(key, value);
+      return result;
+    },
+  };
+}
+
+function authority(): RecoveryAuthority {
+  return {
+    source: 'session_control_state',
+    observedAt: NOW - 1_000,
+    allocation: { providerRef: identity.providerInstanceId, createIntentId: 'create_a' },
+    roots: [rootA, rootB],
+    scopes: [rootA, rootB].map(root => {
+      const messageId = `message_${root.sessionId}`;
+      return {
+        sessionId: root.sessionId,
+        kiloSessionId: root.kiloSessionId,
+        directory: root.directory,
+        messageId,
+        wrapperInstanceId: identity.wrapperInstanceId,
+        nativeRuntimeId: root.nativeRuntimeId,
+        executionDeadlineAt: NOW + 60_000,
+        authorization: {
+          operation: 'session.prompt',
+          operationId: messageId,
+          messageId,
+          session: {
+            sessionId: root.sessionId,
+            kiloSessionId: root.kiloSessionId,
+            directory: root.directory,
+          },
+          wrapperInstanceId: identity.wrapperInstanceId,
+          dispatchDeadlineAt: NOW + 5_000,
+        },
+      };
+    }),
+    stops: [
+      {
+        sessionId: rootA.sessionId,
+        ownerId: rootA.ownerId,
+        request: {
+          version: 1,
+          operationId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+          scope: { sandboxId: 'sandbox_a', wrapperInstanceId: identity.wrapperInstanceId },
+          targets: [
+            {
+              messageId: `message_${rootA.sessionId}`,
+              wrapperInstanceId: identity.wrapperInstanceId,
+              executionDeadlineAt: NOW + 60_000,
+            },
+          ],
+          cleanupDeadlineAt: NOW + 10_000,
+        },
+      },
+    ],
+    wholeAllocation: true,
+  };
+}
+
+function recoveryDecision(): SandboxRecoveryDecision {
+  return {
+    ...beginRecovery(undefined, identity, 'control_disconnected', NOW),
+    authority: authority(),
+  };
+}
+
+function committedDecision(): SandboxRecoveryDecision {
+  return commitRecoveryActivation(
+    {
+      ...recoveryDecision(),
+      startedAt: NOW - 100_000,
+      deadlineAt: NOW - 10_000,
+      attempt: 2,
+    },
+    NOW
+  );
+}
+
+function acknowledge(request: SandboxControlOutboundRequest): ResponseFrame {
+  if (request.operation === 'sandbox.status') {
+    return {
+      type: 'response',
+      requestId: 'status',
+      ok: true,
+      result: { healthy: true, state: 'idle', version: 'test', kiloReady: true },
+    };
+  }
+  if (request.operation !== 'sandbox.reconcile')
+    throw new Error(`Unexpected operation: ${request.operation}`);
+  const { recovery, phase } = sandboxReconcilePayloadSchema.parse(request.payload);
+  return {
+    type: 'response',
+    requestId: phase,
+    ok: true,
+    result: { episodeId: recovery.episodeId, attempt: recovery.attempt, phase },
+  };
+}
+
+async function harness(decision = recoveryDecision()) {
+  const storage = memoryStorage();
+  await saveRecoveryDecisions(storage, [decision]);
+  await saveDeadlines(storage, recoveryDeadlines({ idleStop: NOW + 300_000 }, [decision]));
+  const physical = {
+    state: 'running' as const,
+    providerRef: identity.providerInstanceId,
+    createIntent: { intentId: 'create_a', createdAt: NOW - 100_000 },
+    stopTombstone: null,
+    resumable: true,
+  };
+  await savePhysicalRecord(storage, physical);
+  await saveRouteTable(
+    storage,
+    new Map(
+      [rootA, rootB].map(root => [
+        root.sessionId,
+        { ...root, lastState: 'active', lastStateAt: NOW, idleForMs: null, waitingOn: null },
+      ])
+    )
+  );
+  const runtime = {
+    identity,
+    isCurrent: vi.fn(() => true),
+    acceptsPhysical: vi.fn(
+      (current: PhysicalRecord) =>
+        current.state === 'running' &&
+        current.stopTombstone === null &&
+        current.providerRef === identity.providerInstanceId
+    ),
+  } satisfies RecoveryExecutionRuntime;
+  const dependencies = {
+    storage,
+    sendRequest: vi.fn(async (request: SandboxControlOutboundRequest) => acknowledge(request)),
+    loadPhysical: vi.fn(() => loadPhysicalRecord(storage)),
+    loadAuthority: vi.fn(async () => authority()),
+    reconcileStops: vi.fn(
+      async (): Promise<RecoveryScopeResult[]> => [
+        { sessionId: rootB.sessionId, decision: 'ready' },
+        { sessionId: rootA.sessionId, decision: 'ready' },
+      ]
+    ),
+    reconcileOperations: vi.fn(
+      async (): Promise<RecoveryScopeResult[]> => [
+        { sessionId: rootB.sessionId, decision: 'ready' },
+        { sessionId: rootA.sessionId, decision: 'ready' },
+      ]
+    ),
+    onReady: vi.fn<Parameters<typeof createRecoveryExecution>[0]['onReady']>(
+      async (connection, claimed) =>
+        storage.transaction(async tx => {
+          const records = await loadRecoveryDecisions(tx);
+          const current = records.find(item => item.episodeId === claimed.episodeId);
+          if (
+            !current ||
+            !sameConnection(current, connection) ||
+            current.attempt !== claimed.attempt
+          )
+            return false;
+          const committed = records.map(item =>
+            item === current ? commitRecoveryActivation(item, Date.now()) : item
+          );
+          await saveRecoveryDecisions(tx, committed);
+          await saveDeadlines(tx, recoveryDeadlines(await loadDeadlines(tx), committed));
+          await tx.put(ACTIVE_WRAPPER_RUNTIME_KEY, {
+            ...connection,
+            readyConnectionId: connection.connectionId,
+          });
+          await tx.put(WRAPPER_READY_AT_KEY, Date.now());
+          return true;
+        })
+    ),
+    onActivated: vi.fn(),
+    scheduleAlarm: vi.fn<Parameters<typeof createRecoveryExecution>[0]['scheduleAlarm']>(
+      async () => undefined
+    ),
+  } satisfies Parameters<typeof createRecoveryExecution>[0];
+  return {
+    storage,
+    runtime,
+    dependencies,
+    physical,
+    reconstruct: () => createRecoveryExecution(dependencies),
+    async retained() {
+      const records = await loadRecoveryDecisions(storage);
+      expect(records).toHaveLength(1);
+      const record = records[0];
+      if (!record) throw new Error('Expected a durable recovery record');
+      return record;
+    },
+    requests() {
+      return dependencies.sendRequest.mock.calls.map(([request]) =>
+        request.operation === 'sandbox.reconcile'
+          ? sandboxReconcilePayloadSchema.parse(request.payload).phase
+          : request.operation
+      );
+    },
+  };
+}
+
+function expectActivationOnly(dependencies: Awaited<ReturnType<typeof harness>>['dependencies']) {
+  expect(dependencies.loadAuthority).not.toHaveBeenCalled();
+  expect(dependencies.reconcileStops).not.toHaveBeenCalled();
+  expect(dependencies.reconcileOperations).not.toHaveBeenCalled();
+  expect(dependencies.loadPhysical).not.toHaveBeenCalled();
+  expect(dependencies.onReady).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => vi.useRealTimers());
+
+describe('createRecoveryExecution activation replay', () => {
+  it('replays only commit after the original recovery deadline with the original episode and attempt', async () => {
+    const committed = committedDecision();
+    const h = await harness(committed);
+    h.dependencies.loadPhysical.mockRejectedValue(new Error('Physical observation unavailable'));
+    h.dependencies.loadAuthority.mockRejectedValue(new Error('Session authority unavailable'));
+
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(true);
+
+    expectActivationOnly(h.dependencies);
+    expect(h.runtime.acceptsPhysical).not.toHaveBeenCalled();
+    expect(h.dependencies.sendRequest).toHaveBeenCalledExactlyOnceWith({
+      operation: 'sandbox.reconcile',
+      expectedWrapperInstanceId: identity.wrapperInstanceId,
+      payload: {
+        phase: 'commit',
+        recovery: {
+          episodeId: committed.episodeId,
+          cause: committed.cause,
+          startedAt: committed.startedAt,
+          deadlineAt: committed.deadlineAt,
+          attempt: 2,
+        },
+      },
+      deadlineAt: NOW + 30_000,
+      timeoutMs: 30_000,
+    });
+    expect(h.dependencies.onActivated).toHaveBeenCalledExactlyOnceWith(identity);
+    expect(await loadRecoveryDecisions(h.storage)).toEqual([]);
+    expect(await h.storage.get(ACTIVE_WRAPPER_RUNTIME_KEY)).toEqual({
+      ...identity,
+      readyConnectionId: identity.connectionId,
+    });
+    expect(await h.storage.get(WRAPPER_READY_AT_KEY)).toBe(NOW);
+    expect(await loadDeadlines(h.storage)).toEqual({
+      idleStop: NOW + 300_000,
+      heartbeatExpiry: NOW + 90_000,
+    });
+    expect(h.dependencies.scheduleAlarm).toHaveBeenLastCalledWith({
+      idleStop: NOW + 300_000,
+      heartbeatExpiry: NOW + 90_000,
+    });
+  });
+
+  it('retains lost commit response scheduling and repairs it after reconstruction without reconciling authority again', async () => {
+    const h = await harness();
+    h.dependencies.sendRequest.mockImplementation(async request => {
+      const response = acknowledge(request);
+      if (
+        request.operation === 'sandbox.reconcile' &&
+        sandboxReconcilePayloadSchema.parse(request.payload).phase === 'commit'
+      ) {
+        throw new Error('Commit response lost');
+      }
+      return response;
+    });
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+    const retained = await h.retained();
+    expect(retained).toMatchObject({
+      attempt: 1,
+      activationCommittedAt: NOW,
+      activationCommitDeadlineAt: NOW + 90_000,
+      activationCommitAttempts: 1,
+      activationCommitNextAttemptAt: NOW + 1_000,
+    });
+    expect(retained.activationAcknowledgedAt).toBeUndefined();
+    expect(retained.exhaustedAt).toBeUndefined();
+    expect(h.requests()).toEqual(['drain', 'ready', 'sandbox.status', 'commit']);
+    expect(h.dependencies.onActivated).not.toHaveBeenCalled();
+    const deadlines = {
+      idleStop: NOW + 300_000,
+      recoveryExpiry: NOW + 90_000,
+      recoveryRetry: NOW + 1_000,
+    };
+    expect(await loadDeadlines(h.storage)).toEqual(deadlines);
+    expect(h.dependencies.scheduleAlarm).toHaveBeenLastCalledWith(deadlines);
+
+    vi.clearAllMocks();
+    h.dependencies.sendRequest.mockImplementation(async request => acknowledge(request));
+    vi.setSystemTime(NOW + 999);
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+    expect(await h.retained()).toEqual(retained);
+    expect(await loadDeadlines(h.storage)).toEqual(deadlines);
+    expect(h.dependencies.sendRequest).not.toHaveBeenCalled();
+    vi.setSystemTime(NOW + 1_000);
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(true);
+    expectActivationOnly(h.dependencies);
+    expect(h.requests()).toEqual(['commit']);
+    expect(h.dependencies.sendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          phase: 'commit',
+          recovery: {
+            episodeId: retained.episodeId,
+            cause: retained.cause,
+            startedAt: retained.startedAt,
+            deadlineAt: retained.deadlineAt,
+            attempt: 1,
+          },
+        },
+      })
+    );
+    expect(await loadRecoveryDecisions(h.storage)).toEqual([]);
+    expect(await loadDeadlines(h.storage)).toEqual({
+      idleStop: NOW + 300_000,
+      heartbeatExpiry: NOW + 91_000,
+    });
+    expect(h.dependencies.onActivated).toHaveBeenCalledExactlyOnceWith(identity);
+  });
+
+  it('retains the committed receipt when readiness repair or completion alarm persistence fails', async () => {
+    const h = await harness(committedDecision());
+    h.dependencies.scheduleAlarm.mockImplementation(async deadlines => {
+      if (deadlines.heartbeatExpiry !== undefined) throw new Error('Readiness alarm unavailable');
+    });
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+    const retained = await h.retained();
+    expect(retained).toMatchObject({
+      activationCommittedAt: NOW,
+      activationCommitDeadlineAt: NOW + 90_000,
+      activationCommitAttempts: 1,
+      activationCommitNextAttemptAt: NOW + 1_000,
+    });
+    expect(retained.activationAcknowledgedAt).toBeUndefined();
+    expect(h.dependencies.onActivated).not.toHaveBeenCalled();
+    expectActivationOnly(h.dependencies);
+    h.dependencies.scheduleAlarm.mockResolvedValue(undefined);
+    vi.setSystemTime(NOW + 1_000);
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(true);
+    expect(await h.storage.get(WRAPPER_READY_AT_KEY)).toBe(NOW);
+    expect(await loadRecoveryDecisions(h.storage)).toEqual([]);
+  });
+
+  it('allows at most three commit ACK attempts across reconstruction without renewing the episode or budget', async () => {
+    const committed = committedDecision();
+    const h = await harness(committed);
+    h.dependencies.sendRequest.mockRejectedValue(new Error('Commit response lost'));
+    for (const attempt of [1, 2, 3]) {
+      vi.setSystemTime(NOW + (attempt - 1) * 1_000);
+      expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+      expect(await h.retained()).toMatchObject({
+        episodeId: committed.episodeId,
+        attempt: committed.attempt,
+        startedAt: committed.startedAt,
+        deadlineAt: committed.deadlineAt,
+        activationCommittedAt: NOW,
+        activationCommitDeadlineAt: NOW + 90_000,
+        activationCommitAttempts: attempt,
+      });
+      expect(h.dependencies.sendRequest).toHaveBeenCalledTimes(attempt);
+    }
+    const exhausted = await h.retained();
+    expect(exhausted).toMatchObject({ exhaustedAt: NOW + 2_000, cleanupState: 'pending' });
+    const deadlines = await loadDeadlines(h.storage);
+    expect(deadlines).toEqual({ idleStop: NOW + 300_000, recoveryRetry: NOW + 2_000 });
+    expect(h.dependencies.scheduleAlarm).toHaveBeenLastCalledWith(deadlines);
+    vi.setSystemTime(NOW + 3_000);
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+    expect(await h.retained()).toEqual(exhausted);
+    expect(h.requests()).toEqual(['commit', 'commit', 'commit']);
+    expectActivationOnly(h.dependencies);
+    expect(h.dependencies.onActivated).not.toHaveBeenCalled();
+  });
+
+  it('bounds commit ACKs to the original 90-second window across reconstruction', async () => {
+    const h = await harness(committedDecision());
+    h.dependencies.sendRequest.mockRejectedValueOnce(new Error('Commit response lost'));
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+    vi.setSystemTime(NOW + 89_000);
+    h.dependencies.sendRequest.mockImplementationOnce(async request => {
+      vi.setSystemTime(NOW + 90_000);
+      return acknowledge(request);
+    });
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+    expect(h.dependencies.sendRequest).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        deadlineAt: NOW + 90_000,
+        timeoutMs: 1_000,
+      })
+    );
+    const expired = await h.retained();
+    expect(expired).toMatchObject({
+      activationCommitDeadlineAt: NOW + 90_000,
+      activationCommitAttempts: 2,
+      exhaustedAt: NOW + 90_000,
+    });
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+    expect(await h.retained()).toEqual(expired);
+    expect(h.requests()).toEqual(['commit', 'commit']);
+    expectActivationOnly(h.dependencies);
+    expect(h.dependencies.onActivated).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { episodeId: 'ffffffff-ffff-4fff-8fff-ffffffffffff' },
+    { attempt: 1 },
+    { phase: 'ready' },
+  ])(
+    'retains the activation receipt when the commit ACK has a mismatched fence: %j',
+    async mismatch => {
+      const committed = committedDecision();
+      const h = await harness(committed);
+      h.dependencies.sendRequest.mockResolvedValue({
+        type: 'response',
+        requestId: 'commit',
+        ok: true,
+        result: {
+          episodeId: committed.episodeId,
+          attempt: committed.attempt,
+          phase: 'commit',
+          ...mismatch,
+        },
+      });
+      expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+      expect(await h.retained()).toMatchObject({
+        episodeId: committed.episodeId,
+        attempt: committed.attempt,
+        activationCommittedAt: NOW,
+        activationCommitAttempts: 1,
+        activationCommitNextAttemptAt: NOW + 1_000,
+      });
+      expect(h.dependencies.onActivated).not.toHaveBeenCalled();
+      expectActivationOnly(h.dependencies);
+      expect(h.dependencies.scheduleAlarm).toHaveBeenLastCalledWith(await loadDeadlines(h.storage));
+    }
+  );
+});
+
+describe('createRecoveryExecution exhausted activation fences', () => {
+  const committed = committedDecision();
+  const decision: SandboxRecoveryDecision = {
+    ...committed,
+    attempt: 3,
+    exhaustedAt: NOW - 1_000,
+    cleanupState: 'targeted',
+    cleanupDeadlineAt: NOW + 10_000,
+    nextAttemptAt: NOW + 5_000,
+    activationCommitAttempts: 1,
+    authority: { ...authority(), roots: [{ ...rootA, decision: 'stop_pending' }, rootB] },
+  };
+
+  it.each([
+    'stopped physical',
+    'different allocation',
+    'different create intent',
+    'missing route',
+    'different owner',
+    'different native runtime',
+    'retiring runtime',
+    'expired scope',
+    'missing authorization',
+    'no ready root',
+    'expired ACK window',
+  ])('does not claim or restore readiness with %s', async failure => {
+    const h = await harness(decision);
+    const routes = await loadRouteTable(h.storage);
+    const route = routes.get(rootB.sessionId);
+    if (!route) throw new Error('Expected B route');
+    if (failure === 'stopped physical')
+      await savePhysicalRecord(h.storage, { ...h.physical, state: 'stopped' });
+    if (failure === 'different allocation')
+      await savePhysicalRecord(h.storage, { ...h.physical, providerRef: 'allocation_replaced' });
+    if (failure === 'different create intent')
+      await savePhysicalRecord(h.storage, {
+        ...h.physical,
+        createIntent: { ...h.physical.createIntent, intentId: 'create_replaced' },
+      });
+    if (failure === 'missing route') routes.delete(rootB.sessionId);
+    if (failure === 'different owner') route.ownerId = 'owner_replaced';
+    if (failure === 'different native runtime') route.nativeRuntimeId = rootA.nativeRuntimeId;
+    if (failure === 'retiring runtime') route.retiringNativeRuntimeId = rootB.nativeRuntimeId;
+    await saveRouteTable(h.storage, routes);
+    const retained = await h.retained();
+    if (failure === 'expired ACK window') retained.activationCommitDeadlineAt = NOW;
+    if (!retained.authority) throw new Error('Expected retained authority');
+    if (failure === 'no ready root')
+      retained.authority.roots = [{ ...rootA, decision: 'stop_pending' }];
+    retained.authority.scopes = retained.authority.scopes.map(scope => ({
+      ...scope,
+      ...(failure === 'expired scope' ? { executionDeadlineAt: NOW } : {}),
+      ...(failure === 'missing authorization' ? { authorization: undefined } : {}),
+    }));
+    await saveRecoveryDecisions(h.storage, [retained]);
+    const before = await h.retained();
+    const deadlines = await loadDeadlines(h.storage);
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+    expect(await h.retained()).toEqual(before);
+    expect(await loadDeadlines(h.storage)).toEqual(deadlines);
+    expect(h.dependencies.sendRequest).not.toHaveBeenCalled();
+    expect(h.dependencies.onActivated).not.toHaveBeenCalled();
+    expect(await h.storage.get(ACTIVE_WRAPPER_RUNTIME_KEY)).toBeUndefined();
+    expect(await h.storage.get(WRAPPER_READY_AT_KEY)).toBeUndefined();
+  });
+
+  it.each(['route retirement', 'physical replacement'])(
+    'rechecks %s after the ACK before restoring readiness',
+    async change => {
+      const h = await harness(decision);
+      h.dependencies.sendRequest.mockImplementationOnce(async request => {
+        if (change === 'route retirement') {
+          const routes = await loadRouteTable(h.storage);
+          const route = routes.get(rootB.sessionId);
+          if (!route) throw new Error('Expected B route');
+          route.retiringNativeRuntimeId = rootB.nativeRuntimeId;
+          await saveRouteTable(h.storage, routes);
+        } else {
+          await savePhysicalRecord(h.storage, {
+            ...h.physical,
+            createIntent: { ...h.physical.createIntent, intentId: 'create_replaced' },
+          });
+        }
+        return acknowledge(request);
+      });
+      expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+      const retained = await h.retained();
+      expect(retained).toEqual({
+        ...decision,
+        activationCommitAttempts: 2,
+        activationCommitNextAttemptAt: NOW + 1_000,
+      });
+      expect(h.requests()).toEqual(['commit']);
+      expect(h.dependencies.onActivated).not.toHaveBeenCalled();
+      expect(await h.storage.get(ACTIVE_WRAPPER_RUNTIME_KEY)).toBeUndefined();
+      expect(await h.storage.get(WRAPPER_READY_AT_KEY)).toBeUndefined();
+      vi.setSystemTime(NOW + 1_000);
+      expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+      expect(await h.retained()).toEqual(retained);
+      expect(h.requests()).toEqual(['commit']);
+    }
+  );
+});
+
+describe('createRecoveryExecution ready persistence', () => {
+  it('rolls back a failed ready transaction and retains the prior recovery attempt and retry schedule', async () => {
+    const decision = { ...recoveryDecision(), attempt: 1, nextAttemptAt: NOW };
+    const h = await harness(decision);
+    h.dependencies.sendRequest.mockImplementation(async request => {
+      if (request.operation === 'sandbox.status') h.storage.failNextTransaction();
+      return acknowledge(request);
+    });
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+    const retained = await h.retained();
+    expect(retained).toMatchObject({
+      episodeId: decision.episodeId,
+      startedAt: decision.startedAt,
+      deadlineAt: decision.deadlineAt,
+      attempt: 2,
+      nextAttemptAt: NOW + 2_000,
+    });
+    expect(retained.activationCommittedAt).toBeUndefined();
+    expect(retained.activationCommitDeadlineAt).toBeUndefined();
+    expect(retained.activationCommitAttempts).toBeUndefined();
+    expect(retained.exhaustedAt).toBeUndefined();
+    expect(await h.storage.get(WRAPPER_READY_AT_KEY)).toBeUndefined();
+    expect(await h.storage.get(ACTIVE_WRAPPER_RUNTIME_KEY)).toBeUndefined();
+    expect(h.requests()).toEqual(['drain', 'ready', 'sandbox.status']);
+    expect(h.dependencies.onReady).toHaveBeenCalledOnce();
+    expect(h.dependencies.onActivated).not.toHaveBeenCalled();
+    expect(await loadDeadlines(h.storage)).toEqual({
+      idleStop: NOW + 300_000,
+      recoveryExpiry: decision.deadlineAt,
+      recoveryRetry: NOW + 2_000,
+    });
+    expect(h.dependencies.scheduleAlarm).toHaveBeenLastCalledWith(await loadDeadlines(h.storage));
+
+    h.dependencies.sendRequest.mockImplementation(async request => acknowledge(request));
+    vi.setSystemTime(NOW + 1_999);
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+    expect(await h.retained()).toEqual(retained);
+    vi.setSystemTime(NOW + 2_000);
+    expect(await h.reconstruct().reconcile(h.runtime)).toBe(true);
+    expect(h.dependencies.onReady).toHaveBeenLastCalledWith(
+      identity,
+      expect.objectContaining({
+        episodeId: decision.episodeId,
+        attempt: 3,
+        deadlineAt: decision.deadlineAt,
+      })
+    );
+    expect(await loadRecoveryDecisions(h.storage)).toEqual([]);
+    expect(await loadPhysicalRecord(h.storage)).toEqual(h.physical);
+  });
+});
+
+describe('createRecoveryExecution scoped recovery', () => {
+  it.each(['operation_unknown', 'stop_pending'] as const)(
+    'commits ready B while A remains %s and preserves authority fences across reconstruction',
+    async decision => {
+      const initial = recoveryDecision();
+      const h = await harness(initial);
+      const refreshed = authority();
+      refreshed.observedAt = NOW;
+      refreshed.scopes = refreshed.scopes.map(scope => ({
+        ...scope,
+        executionDeadlineAt: NOW + 120_000,
+        authorization: scope.authorization && {
+          ...scope.authorization,
+          dispatchDeadlineAt: NOW + 65_000,
+        },
+      }));
+      h.dependencies.loadAuthority.mockResolvedValue(refreshed);
+      h.dependencies.reconcileStops.mockResolvedValue([
+        { sessionId: rootB.sessionId, decision: 'ready' },
+        {
+          sessionId: rootA.sessionId,
+          decision: decision === 'stop_pending' ? 'stop_pending' : 'ready',
+        },
+      ]);
+      h.dependencies.reconcileOperations.mockResolvedValue([
+        { sessionId: rootB.sessionId, decision: 'ready' },
+        {
+          sessionId: rootA.sessionId,
+          decision: decision === 'operation_unknown' ? 'operation_unknown' : 'ready',
+        },
+      ]);
+      expect(await h.reconstruct().reconcile(h.runtime)).toBe(true);
+      expect(h.requests()).toEqual(['drain', 'ready', 'sandbox.status', 'commit']);
+      expect(h.dependencies.onActivated).toHaveBeenCalledExactlyOnceWith(identity);
+      const retained = await h.retained();
+      expect(retained).toMatchObject({
+        episodeId: initial.episodeId,
+        attempt: 1,
+        activationCommittedAt: NOW,
+        activationAcknowledgedAt: NOW,
+        nextAttemptAt: NOW + 1_000,
+      });
+      expect(retained.exhaustedAt).toBeUndefined();
+      expect(retained.cleanupState).toBeUndefined();
+      expect(retained.authority).toEqual({
+        ...authority(),
+        observedAt: NOW,
+        roots: [{ ...rootA, decision }, rootB],
+      });
+      expect(admitsRecoveryRequest([retained], identity, rootA)).toBe(false);
+      expect(admitsRecoveryRequest([retained], identity, rootB)).toBe(true);
+      expect(
+        admitsRecoveryRequest([retained], identity, { ...rootB, kiloSessionId: 'replacement' })
+      ).toBe(false);
+      expect(
+        admitsRecoveryRequest([retained], identity, { ...rootB, directory: '/replacement' })
+      ).toBe(false);
+      expect(await loadPhysicalRecord(h.storage)).toEqual(h.physical);
+      expect(h.dependencies.scheduleAlarm).toHaveBeenLastCalledWith({
+        idleStop: NOW + 300_000,
+        heartbeatExpiry: NOW + 90_000,
+        recoveryExpiry: initial.deadlineAt,
+        recoveryRetry: NOW + 1_000,
+      });
+
+      vi.clearAllMocks();
+      vi.setSystemTime(NOW + 1_000);
+      expect(await h.reconstruct().reconcile(h.runtime)).toBe(true);
+      const retried = await h.retained();
+      expect(retried.authority).toEqual(retained.authority);
+      expect(retried).toMatchObject({
+        episodeId: initial.episodeId,
+        attempt: 2,
+        activationAcknowledgedAt: NOW,
+        nextAttemptAt: NOW + 3_000,
+      });
+      expect(retried.exhaustedAt).toBeUndefined();
+      expect(retried.cleanupState).toBeUndefined();
+      expect(h.dependencies.onReady).not.toHaveBeenCalled();
+      expect(h.dependencies.sendRequest).not.toHaveBeenCalled();
+      expect(admitsRecoveryRequest([retried], identity, rootA)).toBe(false);
+      expect(admitsRecoveryRequest([retried], identity, rootB)).toBe(true);
+      expect(await loadPhysicalRecord(h.storage)).toEqual(h.physical);
+
+      vi.setSystemTime(NOW + 3_000);
+      expect(await h.reconstruct().reconcile(h.runtime)).toBe(true);
+      const exhausted = await h.retained();
+      expect(exhausted).toMatchObject({
+        attempt: 3,
+        activationCommitAttempt: 1,
+        activationCommitAttempts: 1,
+        exhaustedAt: NOW + 3_000,
+        cleanupState: 'pending',
+      });
+      const connection = { ...identity, connectionId: 'ffffffff-ffff-4fff-8fff-ffffffffffff' };
+      const rebound = {
+        ...beginRecovery(exhausted, connection, 'control_disconnected', NOW + 4_000),
+        cleanupState: 'targeted' as const,
+        nextAttemptAt: NOW + 20_000,
+      };
+      await saveRecoveryDecisions(h.storage, [rebound]);
+      const runtime = { ...h.runtime, identity: connection };
+      vi.clearAllMocks();
+      vi.setSystemTime(NOW + 6_000);
+      h.dependencies.sendRequest.mockRejectedValueOnce(
+        new Error('Maintenance commit response lost')
+      );
+      expect(await h.reconstruct().reconcile(runtime)).toBe(false);
+      const retry = await h.retained();
+      expect(retry).toEqual({
+        ...rebound,
+        activationCommitAttempts: 2,
+        activationCommitNextAttemptAt: NOW + 7_000,
+      });
+      expect(await loadDeadlines(h.storage)).toMatchObject({
+        recoveryExpiry: exhausted.activationCommitDeadlineAt,
+        recoveryRetry: NOW + 7_000,
+      });
+      vi.setSystemTime(NOW + 6_999);
+      expect(await h.reconstruct().reconcile(runtime)).toBe(false);
+      expect(await h.retained()).toEqual(retry);
+      expect(h.requests()).toEqual(['commit']);
+      vi.setSystemTime(NOW + 7_000);
+      expect(await h.reconstruct().reconcile(runtime)).toBe(true);
+      const repaired = await h.retained();
+      expect(repaired).toEqual({
+        ...rebound,
+        activationCommitAttempts: 3,
+        activationCommitNextAttemptAt: undefined,
+        activationAcknowledgedAt: NOW + 7_000,
+      });
+      expectActivationOnly(h.dependencies);
+      expect(h.requests()).toEqual(['commit', 'commit']);
+      for (const [request] of h.dependencies.sendRequest.mock.calls) {
+        expect(request.payload).toEqual({
+          phase: 'commit',
+          recovery: {
+            episodeId: exhausted.episodeId,
+            cause: exhausted.cause,
+            startedAt: exhausted.startedAt,
+            deadlineAt: exhausted.deadlineAt,
+            attempt: 1,
+          },
+        });
+      }
+      expect(await h.storage.get(ACTIVE_WRAPPER_RUNTIME_KEY)).toEqual({
+        ...connection,
+        readyConnectionId: connection.connectionId,
+      });
+      expect(await h.storage.get(WRAPPER_READY_AT_KEY)).toBe(NOW);
+      expect(await loadDeadlines(h.storage)).toEqual({
+        idleStop: NOW + 300_000,
+        heartbeatExpiry: NOW + 97_000,
+        recoveryRetry: NOW + 20_000,
+      });
+      expect(admitsRecoveryRequest([repaired], connection, rootA)).toBe(false);
+      expect(admitsRecoveryRequest([repaired], connection, rootB)).toBe(true);
+      const spent = beginRecovery(repaired, identity, 'control_disconnected', NOW + 8_000);
+      await saveRecoveryDecisions(h.storage, [spent]);
+      vi.setSystemTime(NOW + 8_000);
+      expect(await h.reconstruct().reconcile(h.runtime)).toBe(false);
+      expect(await h.retained()).toEqual(spent);
+      expect(h.requests()).toEqual(['commit', 'commit']);
+    }
+  );
+});

--- a/services/cloud-agent-next/src/sandbox-control/recovery-execution.ts
+++ b/services/cloud-agent-next/src/sandbox-control/recovery-execution.ts
@@ -1,0 +1,296 @@
+import {
+  SANDBOX_CONTROL_RECOVERY_ATTEMPT_TIMEOUT_MS,
+  sandboxReconcileResultSchema,
+  sandboxStatusResultSchema,
+} from '../shared/sandbox-control-protocol.js';
+import * as recovery from './control-recovery.js';
+import {
+  loadDeadlines,
+  loadPhysicalRecord,
+  loadRecoveryDecisions,
+  loadRouteTable,
+  saveDeadlines,
+  saveRecoveryDecisions,
+} from './durable-state.js';
+import { armDeadline, cancelDeadline, DEADLINE_MS, type DeadlineTable } from './deadlines.js';
+import type { PhysicalRecord } from './physical-lifecycle.js';
+import type { SandboxControlConnectionIdentity, SandboxControlSocketHandler } from './socket.js';
+import { SandboxControlConnectionError } from './waiters.js';
+
+export type RecoveryExecutionRuntime = Readonly<{
+  identity: SandboxControlConnectionIdentity;
+  isCurrent: () => boolean;
+  acceptsPhysical: (physical: PhysicalRecord) => boolean;
+}>;
+
+type Dependencies = {
+  storage: Pick<DurableObjectStorage, 'transaction'>;
+  sendRequest: SandboxControlSocketHandler['sendRequest'];
+  loadPhysical: () => Promise<PhysicalRecord>;
+  loadAuthority: (
+    decision: recovery.SandboxRecoveryDecision
+  ) => Promise<recovery.RecoveryAuthority | undefined>;
+  onReady: (
+    identity: SandboxControlConnectionIdentity,
+    decision: recovery.SandboxRecoveryDecision
+  ) => Promise<boolean>;
+  reconcileStops: (
+    authority: recovery.RecoveryAuthority
+  ) => Promise<recovery.RecoveryScopeResult[]>;
+  reconcileOperations: (
+    authority: recovery.RecoveryAuthority
+  ) => Promise<recovery.RecoveryScopeResult[]>;
+  onActivated: (identity: SandboxControlConnectionIdentity) => void;
+  scheduleAlarm: (deadlines: DeadlineTable) => Promise<void>;
+};
+
+export function createRecoveryExecution(dependencies: Dependencies) {
+  const pending = new Map<string, Promise<boolean>>();
+
+  async function retainsReadyScope(
+    tx: DurableObjectTransaction,
+    decision: recovery.SandboxRecoveryDecision,
+    runtime: RecoveryExecutionRuntime
+  ): Promise<boolean> {
+    const [physical, routes] = await Promise.all([loadPhysicalRecord(tx), loadRouteTable(tx)]);
+    const authority = decision.authority;
+    if (
+      !authority ||
+      !runtime.acceptsPhysical(physical) ||
+      physical.providerRef !== authority.allocation.providerRef ||
+      physical.createIntent?.intentId !== authority.allocation.createIntentId
+    )
+      return false;
+    return recovery.hasReadyActivationScope(
+      {
+        ...decision,
+        authority: {
+          ...authority,
+          roots: authority.roots?.filter(root => {
+            const route = routes.get(root.sessionId);
+            return (
+              route?.ownerId === root.ownerId &&
+              route.kiloSessionId === root.kiloSessionId &&
+              route.directory === root.directory &&
+              route.nativeRuntimeId === root.nativeRuntimeId &&
+              route.retiringNativeRuntimeId === undefined
+            );
+          }),
+        },
+      },
+      Date.now()
+    );
+  }
+
+  async function reconcile(runtime: RecoveryExecutionRuntime): Promise<boolean> {
+    if (!runtime.identity.recoveryCapable || !runtime.isCurrent()) return false;
+    const initialClaimed = await dependencies.storage.transaction(async tx => {
+      const records = await loadRecoveryDecisions(tx);
+      const current = records.find(
+        item => item.wrapperInstanceId === runtime.identity.wrapperInstanceId
+      );
+      const attempt = recovery.claimAttempt(current, runtime.identity, Date.now());
+      if (
+        !attempt ||
+        (attempt.recovery.exhaustedAt !== undefined &&
+          !(await retainsReadyScope(tx, attempt.recovery, runtime)))
+      )
+        return;
+      await saveRecoveryDecisions(
+        tx,
+        records.map(item => (item === current ? attempt.recovery : item))
+      );
+      const deadlines = recovery.recoveryDeadlines(
+        await loadDeadlines(tx),
+        records.map(item => (item === current ? attempt.recovery : item))
+      );
+      await saveDeadlines(tx, deadlines);
+      await dependencies.scheduleAlarm(deadlines);
+      return attempt;
+    });
+    if (!initialClaimed) return false;
+    let claimed = initialClaimed;
+    const persist = async (
+      update: (
+        current: recovery.SandboxRecoveryDecision
+      ) => recovery.SandboxRecoveryDecision | undefined,
+      finishActivation = false
+    ) => {
+      const saved = await dependencies.storage.transaction(async tx => {
+        const records = await loadRecoveryDecisions(tx);
+        const current = records.find(item => item.episodeId === claimed.recovery.episodeId);
+        if (!current || !recovery.sameConnection(current, runtime.identity) || !runtime.isCurrent())
+          throw new SandboxControlConnectionError('Recovery authority changed', false);
+        if (
+          finishActivation &&
+          current.exhaustedAt !== undefined &&
+          !(await retainsReadyScope(tx, current, runtime))
+        )
+          throw new SandboxControlConnectionError('Recovered scope is no longer ready', false);
+        const next = update(current);
+        const remaining = next
+          ? records.map(item => (item === current ? next : item))
+          : records.filter(item => item !== current);
+        let deadlines = recovery.recoveryDeadlines(await loadDeadlines(tx), remaining);
+        if (
+          current.activationCommittedAt !== undefined &&
+          current.activationAcknowledgedAt === undefined &&
+          (next === undefined || next.activationAcknowledgedAt !== undefined)
+        ) {
+          await tx.put(recovery.ACTIVE_WRAPPER_RUNTIME_KEY, {
+            ...runtime.identity,
+            readyConnectionId: runtime.identity.connectionId,
+          });
+          await tx.put(recovery.WRAPPER_READY_AT_KEY, current.activationCommittedAt);
+          deadlines = armDeadline(
+            cancelDeadline(deadlines, 'wrapperReadiness'),
+            'heartbeatExpiry',
+            Date.now() + DEADLINE_MS.heartbeatExpiry
+          );
+        }
+        await saveRecoveryDecisions(tx, remaining);
+        await saveDeadlines(tx, deadlines);
+        if (finishActivation) await dependencies.scheduleAlarm(deadlines);
+        return { next, deadlines };
+      });
+      if (saved.next) claimed = { ...claimed, recovery: saved.next };
+      if (!finishActivation) await dependencies.scheduleAlarm(saved.deadlines);
+    };
+    try {
+      const repairingActivation = recovery.activationRepairPending(claimed.recovery);
+      const episodeDeadlineAt = () =>
+        recovery.activationRepairPending(claimed.recovery)
+          ? (claimed.recovery.activationCommitDeadlineAt ?? claimed.recovery.deadlineAt)
+          : claimed.recovery.deadlineAt;
+      const requestDeadlineAt = () =>
+        Math.min(episodeDeadlineAt(), Date.now() + SANDBOX_CONTROL_RECOVERY_ATTEMPT_TIMEOUT_MS);
+      const assertCurrent = async () => {
+        if (
+          !runtime.isCurrent() ||
+          Date.now() >= episodeDeadlineAt() ||
+          (!recovery.activationRepairPending(claimed.recovery) &&
+            !runtime.acceptsPhysical(await dependencies.loadPhysical()))
+        )
+          throw new SandboxControlConnectionError('Recovery attempt expired', false);
+      };
+      const phase = async (phase: 'drain' | 'ready' | 'commit') => {
+        const deadlineAt = requestDeadlineAt();
+        const wireRecovery = recovery.wireRecovery(claimed.recovery);
+        const response = await dependencies.sendRequest({
+          operation: 'sandbox.reconcile',
+          expectedWrapperInstanceId: runtime.identity.wrapperInstanceId,
+          payload: { recovery: wireRecovery, phase },
+          deadlineAt,
+          timeoutMs: Math.max(1, deadlineAt - Date.now()),
+        });
+        await assertCurrent();
+        if (!response.ok)
+          throw new SandboxControlConnectionError('Recovery was not acknowledged', true);
+        const acknowledgement = sandboxReconcileResultSchema.parse(response.result);
+        if (
+          acknowledgement.episodeId !== claimed.recovery.episodeId ||
+          acknowledgement.attempt !== wireRecovery.attempt ||
+          acknowledgement.phase !== phase
+        )
+          throw new SandboxControlConnectionError('Recovery acknowledgement changed', false);
+      };
+      const finish = async () => {
+        await persist(current => {
+          if (!recovery.activationCommitted(current))
+            throw new SandboxControlConnectionError('Recovery activation was not committed', true);
+          if (current.exhaustedAt === undefined && !recovery.hasUnresolvedRoots(current.authority))
+            return undefined;
+          return recovery.failAttempt(
+            {
+              ...current,
+              activationAcknowledgedAt: current.activationAcknowledgedAt ?? Date.now(),
+            },
+            Date.now()
+          );
+        }, true);
+        dependencies.onActivated(runtime.identity);
+        return true;
+      };
+      await assertCurrent();
+      if (repairingActivation) {
+        await phase('commit');
+        return await finish();
+      }
+      const authority = await dependencies.loadAuthority(claimed.recovery);
+      if (!authority)
+        throw new SandboxControlConnectionError('Recovery authority is unavailable', true);
+      await persist(current => recovery.replaceRecoveryAuthority(current, authority));
+      if (claimed.recovery.activationAcknowledgedAt === undefined) await phase('drain');
+      const effectiveAuthority = claimed.recovery.authority;
+      if (!effectiveAuthority)
+        throw new SandboxControlConnectionError('Recovery authority is unavailable', true);
+      const [stops, operations] = await Promise.all([
+        dependencies.reconcileStops(effectiveAuthority),
+        dependencies.reconcileOperations(effectiveAuthority),
+      ]);
+      await persist(current => ({
+        ...current,
+        authority: {
+          ...effectiveAuthority,
+          roots: effectiveAuthority.roots?.map(root => {
+            const stop = stops.find(item => item.sessionId === root.sessionId)?.decision;
+            const operation = operations.find(item => item.sessionId === root.sessionId)?.decision;
+            const decision = stop === 'stop_pending' ? stop : (operation ?? 'operation_unknown');
+            return {
+              ...root,
+              decision:
+                root.observation === 'stale' || root.observation === 'unknown'
+                  ? 'operation_unknown'
+                  : decision,
+            };
+          }),
+        },
+      }));
+      if (claimed.recovery.activationAcknowledgedAt !== undefined) return await finish();
+      await phase('ready');
+      const statusDeadlineAt = requestDeadlineAt();
+      const status = await dependencies.sendRequest({
+        operation: 'sandbox.status',
+        payload: {},
+        expectedWrapperInstanceId: runtime.identity.wrapperInstanceId,
+        deadlineAt: statusDeadlineAt,
+        timeoutMs: Math.max(1, statusDeadlineAt - Date.now()),
+      });
+      await assertCurrent();
+      if (!status.ok || !sandboxStatusResultSchema.parse(status.result).kiloReady)
+        throw new SandboxControlConnectionError('Recovered wrapper is not ready', true);
+      if (!(await dependencies.onReady(runtime.identity, claimed.recovery)))
+        throw new SandboxControlConnectionError('Recovery activation was not committed', true);
+      await persist(current => {
+        const acknowledgement = recovery.claimAttempt(current, runtime.identity, Date.now());
+        if (!acknowledgement)
+          throw new SandboxControlConnectionError('Activation acknowledgement expired', false);
+        claimed = acknowledgement;
+        return acknowledgement.recovery;
+      });
+      await assertCurrent();
+      await phase('commit');
+      return await finish();
+    } catch {
+      await persist(current => recovery.failAttempt(current, Date.now())).catch(() => undefined);
+      return false;
+    }
+  }
+
+  return {
+    reconcile(runtime: RecoveryExecutionRuntime): Promise<boolean> {
+      const key = [
+        runtime.identity.providerInstanceId,
+        runtime.identity.wrapperInstanceId,
+        runtime.identity.connectionId,
+      ].join(':');
+      const existing = pending.get(key);
+      if (existing) return existing;
+      const running = reconcile(runtime).finally(() => {
+        if (pending.get(key) === running) pending.delete(key);
+      });
+      pending.set(key, running);
+      return running;
+    },
+  };
+}

--- a/services/cloud-agent-next/src/sandbox-control/socket.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/socket.test.ts
@@ -1007,6 +1007,144 @@ describe('sandbox control socket handler', () => {
     );
   });
 
+  it('returns an exact receipt only after a session event is applied', async () => {
+    const ws = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    });
+    const receiptId = '123e4567-e89b-42d3-a456-426614174099';
+    const receiptHash = 'a'.repeat(64);
+    const onSessionEvent = vi.fn().mockResolvedValue({ applied: true });
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([ws]),
+      'sbx_test',
+      undefined,
+      { onSessionEvent }
+    );
+
+    await handler.handleMessage(
+      asWs(ws),
+      JSON.stringify({
+        type: 'request',
+        requestId: 'event-receipt',
+        operation: 'sandbox.event.publish',
+        payload: {
+          event: 'session.event',
+          receiptId,
+          receiptHash,
+          sequence: 1,
+          session: { directory: '/workspace/a', kiloSessionId: 'kilo_1' },
+          payload: { type: 'message.updated', properties: { id: 'msg_1' } },
+        },
+      })
+    );
+
+    expect(onSessionEvent).toHaveBeenCalledWith(
+      { directory: '/workspace/a', kiloSessionId: 'kilo_1' },
+      { type: 'message.updated', properties: { id: 'msg_1' } },
+      handler.getConnectionIdentity(),
+      receiptId,
+      receiptHash,
+      1
+    );
+    expect(JSON.parse(ws.send.mock.calls.at(-1)?.[0] as string)).toEqual({
+      type: 'response',
+      requestId: 'event-receipt',
+      ok: true,
+      result: { receiptId, applied: true },
+    });
+  });
+
+  it.each([false, true, undefined, 'transport_error'] as const)(
+    'returns rejection retryability %s without ACKing, then accepts the next receipt',
+    async retryable => {
+      const ws = createFakeWebSocket({
+        handshakeComplete: true,
+        acceptedAt: Date.now(),
+        protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+        providerInstanceId: 'inst_1',
+        wrapperInstanceId: WRAPPER_INSTANCE_ID,
+      });
+      const onSessionEvent = vi.fn().mockResolvedValue({ applied: true });
+      if (retryable === 'transport_error')
+        onSessionEvent.mockRejectedValueOnce(new Error('Session transport unavailable'));
+      else onSessionEvent.mockResolvedValueOnce({ applied: false, retryable });
+      const handler = createSandboxControlSocketHandler(
+        createFakeState([ws]),
+        'sbx_test',
+        undefined,
+        { onSessionEvent }
+      );
+      const publication = {
+        type: 'request',
+        requestId: 'rejected-event',
+        operation: 'sandbox.event.publish',
+        payload: {
+          event: 'session.event',
+          receiptId: '123e4567-e89b-42d3-a456-426614174099',
+          receiptHash: 'a'.repeat(64),
+          sequence: 1,
+          session: {
+            directory: '/workspace/a',
+            kiloSessionId: 'kilo_1',
+            nativeRuntimeId: '11111111-1111-4111-8111-111111111111',
+          },
+          payload: { type: 'session.updated', properties: { info: { id: 'kilo_1' } } },
+        },
+      };
+
+      await handler.handleMessage(asWs(ws), JSON.stringify(publication));
+      expect(ws.send).toHaveBeenCalledExactlyOnceWith(
+        JSON.stringify({
+          type: 'response',
+          requestId: publication.requestId,
+          ok: false,
+          error: {
+            code: retryable === false ? 'event_rejected' : 'not_ready',
+            message:
+              retryable === 'transport_error'
+                ? 'Sandbox event publication failed'
+                : 'Sandbox event publication was not applied',
+            retryable: retryable !== false,
+          },
+        })
+      );
+      expect(ws.close).not.toHaveBeenCalled();
+
+      const receiptId = '123e4567-e89b-42d3-a456-426614174100';
+      await handler.handleMessage(
+        asWs(ws),
+        JSON.stringify({
+          ...publication,
+          requestId: 'next-event',
+          payload: {
+            ...publication.payload,
+            receiptId,
+            sequence: 2,
+            session: {
+              ...publication.payload.session,
+              nativeRuntimeId: '22222222-2222-4222-8222-222222222222',
+            },
+          },
+        })
+      );
+      expect(onSessionEvent).toHaveBeenCalledTimes(2);
+      expect(ws.send).toHaveBeenCalledTimes(2);
+      expect(ws.send).toHaveBeenLastCalledWith(
+        JSON.stringify({
+          type: 'response',
+          requestId: 'next-event',
+          ok: true,
+          result: { receiptId, applied: true },
+        })
+      );
+      expect(ws.close).not.toHaveBeenCalled();
+    }
+  );
+
   it('does not dispatch a session.event with an invalid payload', async () => {
     const ws = createFakeWebSocket({
       handshakeComplete: true,

--- a/services/cloud-agent-next/src/sandbox-control/socket.ts
+++ b/services/cloud-agent-next/src/sandbox-control/socket.ts
@@ -14,6 +14,7 @@ import {
   SANDBOX_HELLO_DEADLINE_MS,
   sandboxControlSocketAttachmentSchema,
   sandboxControlObservationSchema,
+  sandboxEventPublicationPayloadSchema,
   sessionNativeRuntimeRetirementPayloadSchema,
   sessionOperationAuthorizationSchema,
   sessionOperationDeliverySchema,
@@ -68,7 +69,10 @@ export type SandboxControlConnectionIdentity = {
   connectionId: string;
   providerInstanceId: string;
   wrapperInstanceId?: string;
+  recoveryCapable?: boolean;
 };
+
+export type SandboxControlEventResult = { applied: boolean; retryable?: boolean };
 
 export type SandboxControlSocketHooks = {
   validateHandshake?(providerInstanceId: string): boolean | Promise<boolean>;
@@ -84,13 +88,19 @@ export type SandboxControlSocketHooks = {
   onSessionEvent?(
     sessionIdentity: SessionEventIdentity | undefined,
     payload: SessionEventPayload,
-    identity: SandboxControlConnectionIdentity
-  ): void | Promise<void>;
+    identity: SandboxControlConnectionIdentity,
+    receiptId?: string,
+    receiptHash?: string,
+    sequence?: number
+  ): void | SandboxControlEventResult | Promise<void | SandboxControlEventResult | undefined>;
   onSessionPreparing?(
     sessionIdentity: SessionEventIdentity | undefined,
     payload: SessionPreparingPayload,
-    identity: SandboxControlConnectionIdentity
-  ): void | Promise<void>;
+    identity: SandboxControlConnectionIdentity,
+    receiptId?: string,
+    receiptHash?: string,
+    sequence?: number
+  ): void | SandboxControlEventResult | Promise<void | SandboxControlEventResult | undefined>;
   onOperationResult?(
     session: SessionRequestIdentity,
     delivery: SessionOperationDelivery,
@@ -117,6 +127,7 @@ export type SandboxControlSocketHandler = {
   supportsOperationResults(): boolean;
   supportsScopedStopAbort(): boolean;
   supportsNativeRuntimeRetirement(): boolean;
+  supportsConnectionRecovery(): boolean;
   getConnectionIdentity(): SandboxControlConnectionIdentity | null;
   getReadySocket(): WebSocket | null;
   closeProvisionalSockets(): void;
@@ -214,6 +225,7 @@ function readConnectionIdentity(
   return {
     connectionId: attachment.connectionId,
     providerInstanceId: attachment.providerInstanceId,
+    ...(attachment.recoveryCapable ? { recoveryCapable: true } : {}),
     ...(attachment.wrapperInstanceId ? { wrapperInstanceId: attachment.wrapperInstanceId } : {}),
   };
 }
@@ -357,6 +369,14 @@ export function createSandboxControlSocketHandler(
       return (
         current !== null &&
         readAttachment(current.socket)?.capabilities?.nativeRuntimeRetirement === true
+      );
+    },
+
+    supportsConnectionRecovery(): boolean {
+      const current = currentHandshakenSocket(state);
+      return (
+        current !== null &&
+        readAttachment(current.socket)?.capabilities?.connectionRecovery === true
       );
     },
 
@@ -514,6 +534,7 @@ export function createSandboxControlSocketHandler(
           connectionId: attachment.connectionId,
           providerInstanceId: payload.providerInstanceId,
           ...(payload.wrapperInstanceId ? { wrapperInstanceId: payload.wrapperInstanceId } : {}),
+          ...(payload.capabilities?.connectionRecovery === true ? { recoveryCapable: true } : {}),
         };
         const completed: SandboxControlSocketAttachment = {
           handshakeComplete: true,
@@ -521,6 +542,7 @@ export function createSandboxControlSocketHandler(
           acceptedAt: attachment.acceptedAt,
           connectionId: identity.connectionId,
           protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+          ...(identity.recoveryCapable ? { recoveryCapable: true } : {}),
           providerInstanceId: identity.providerInstanceId,
           ...(payload.capabilities ? { capabilities: payload.capabilities } : {}),
           ...(identity.wrapperInstanceId ? { wrapperInstanceId: identity.wrapperInstanceId } : {}),
@@ -567,7 +589,16 @@ export function createSandboxControlSocketHandler(
         }
 
         if (!isCurrentConnection(state, ws, identity)) return;
-        sendJson(ws, okResponse(frame.requestId, helloResult()));
+        sendJson(
+          ws,
+          okResponse(
+            frame.requestId,
+            helloResult({
+              connectionRecovery: payload.capabilities?.connectionRecovery === true,
+              eventReceipts: payload.capabilities?.eventReceipts === true,
+            })
+          )
+        );
         sendJson(ws, {
           type: 'request',
           requestId: crypto.randomUUID(),
@@ -657,6 +688,67 @@ export function createSandboxControlSocketHandler(
             eventPayload.payload as SessionPreparingPayload,
             identity
           );
+        }
+        return;
+      }
+
+      if (frame.operation === 'sandbox.event.publish') {
+        const publication = sandboxEventPublicationPayloadSchema.safeParse(frame.payload);
+        if (!publication.success) {
+          sendJson(
+            ws,
+            errorResponse(
+              frame.requestId,
+              'protocol_error',
+              'Invalid sandbox event publication',
+              false
+            )
+          );
+          return;
+        }
+        try {
+          const result =
+            publication.data.event === 'session.event'
+              ? await hooks.onSessionEvent?.(
+                  publication.data.session,
+                  publication.data.payload,
+                  identity,
+                  publication.data.receiptId,
+                  publication.data.receiptHash,
+                  publication.data.sequence
+                )
+              : await hooks.onSessionPreparing?.(
+                  publication.data.session,
+                  publication.data.payload,
+                  identity,
+                  publication.data.receiptId,
+                  publication.data.receiptHash,
+                  publication.data.sequence
+                );
+          if (!isCurrentConnection(state, ws, identity)) return;
+          if (!result?.applied) {
+            sendJson(ws, {
+              type: 'response',
+              requestId: frame.requestId,
+              ok: false,
+              error: {
+                code: result?.retryable === false ? 'event_rejected' : 'not_ready',
+                message: 'Sandbox event publication was not applied',
+                retryable: result?.retryable !== false,
+              },
+            } satisfies ResponseFrame);
+            return;
+          }
+          sendJson(
+            ws,
+            okResponse(frame.requestId, { receiptId: publication.data.receiptId, applied: true })
+          );
+        } catch {
+          if (isCurrentConnection(state, ws, identity))
+            sendJson(
+              ws,
+              errorResponse(frame.requestId, 'not_ready', 'Sandbox event publication failed', true)
+            );
         }
         return;
       }

--- a/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
+++ b/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
@@ -108,6 +108,7 @@ import {
 } from '../session/preparation-history.js';
 import {
   SANDBOX_CONTROL_ATTACH_TIMEOUT_MS,
+  SANDBOX_CONTROL_OPERATION_LIMIT,
   SANDBOX_CONTROL_OUTCOME_TIMEOUT_MS,
   SANDBOX_CONTROL_REQUEST_TIMEOUT_MS,
   controlErrorCodes,
@@ -150,6 +151,7 @@ import {
 } from './control-dispatch.js';
 import { acceptedAlarmDecision } from './accepted-overdue.js';
 import { createSessionStopLifecycle } from './session-stop-lifecycle.js';
+import { sessionStopReceipt } from './session-stop.js';
 import { progressSessionStop } from './session-stop-progress.js';
 import { bootPreparingStep, provisionPreparingStep } from './preparing-steps.js';
 import { createSandboxTerminalBridge, type SandboxTerminalRecord } from './terminal-bridge.js';
@@ -183,6 +185,14 @@ import {
   dispatchSessionOperation,
   operationDispatchError,
 } from './session-operation.js';
+import {
+  controlEventReceiptDisposition,
+  hasValidControlEventReceipt,
+  recordControlEventReceipt,
+  bindControlEventReceiptIdentity,
+  retireControlEventReceiptIdentity,
+  type ControlEventReceiptDisposition,
+} from './control-event-receipts.js';
 
 const METADATA_KEY = SANDBOX_SESSION_METADATA_KEY;
 const MESSAGES_KEY = 'session_messages';
@@ -190,8 +200,11 @@ const DELETED_WORKTREE_KEY = SANDBOX_SESSION_DELETED_WORKTREE_KEY;
 const DELETION_COMPLETED_KEY = 'deletion_completed';
 
 type SandboxControlEventInput = {
-  identity: { directory: string; kiloSessionId?: string; rootKiloSessionId?: string };
+  identity: SessionEventIdentity;
   payload: { type: string; properties: Record<string, unknown>; timestamp?: string };
+  receiptId?: string;
+  receiptHash?: string;
+  sequence?: number;
 };
 const QUEUE_RETRY_MS = 5_000;
 const PENDING_RUNTIME_CLEANUP_KEY = 'pending_runtime_cleanup';
@@ -406,13 +419,13 @@ export class SandboxSession extends DurableObject<Env> {
 
   receiveSandboxControlEvent(
     input: SandboxControlEventInput & { wrapperInstanceId?: string }
-  ): Promise<{ applied: boolean }> {
+  ): Promise<{ applied: boolean; retryable?: boolean }> {
     return this.trackOperation(this.applySandboxControlEvent(input));
   }
 
   private async applySandboxControlEvent(
     input: SandboxControlEventInput & { wrapperInstanceId?: string }
-  ): Promise<{ applied: boolean }> {
+  ): Promise<{ applied: boolean; retryable?: boolean }> {
     const startedAt = Date.now();
     const metadata = await this.getMetadata();
     const epoch = this.terminalLifecycle.captureEpoch();
@@ -434,6 +447,8 @@ export class SandboxSession extends DurableObject<Env> {
       return { applied };
     };
     if (!metadata || epoch === null) return result(false, 'session_unavailable');
+    if (!(await this.hasValidControlEventReceipt('session.event', input)))
+      return result(false, 'receipt_conflict');
     const root = metadata.auth.kiloSessionId;
     if (input.identity.directory !== this.directory(metadata))
       return result(false, 'directory_mismatch');
@@ -471,6 +486,31 @@ export class SandboxSession extends DurableObject<Env> {
         }
       }
     }
+    if (
+      eventKiloSessionId !== undefined &&
+      eventKiloSessionId !== root &&
+      (root === undefined || input.identity.rootKiloSessionId !== root)
+    )
+      return result(false, 'root_mismatch');
+    if (!this.terminalLifecycle.isCurrent(epoch)) return result(false, 'epoch_changed');
+    if (input.receiptId !== undefined) {
+      if (!this.isCurrentEventRuntime(input.wrapperInstanceId))
+        return result(false, 'runtime_mismatch');
+      const receipt = this.controlEventReceipt(input);
+      if (receipt === 'duplicate') return result(true, 'duplicate');
+      if (receipt !== 'apply') return result(false, 'receipt_conflict');
+    }
+    if (input.receiptId !== undefined) {
+      const attachment = this.nativeAttachmentEventDisposition(
+        input.identity,
+        input.wrapperInstanceId
+      );
+      if (attachment === 'pending')
+        return { ...result(false, 'native_runtime_pending'), retryable: true };
+      if (attachment === 'rejected') return result(false, 'native_runtime_mismatch');
+    }
+    if (!this.isCurrentNativeEventRuntime(input.identity, input.wrapperInstanceId))
+      return result(false, 'native_runtime_mismatch');
     const sessionId = this.requireSessionId();
     if (input.payload.type === 'session.message.outcome') {
       const outcome = sessionMessageOutcomeSchema.safeParse(input.payload.properties);
@@ -496,8 +536,15 @@ export class SandboxSession extends DurableObject<Env> {
       if (
         existing?.wrapperInstanceId === input.wrapperInstanceId &&
         existing.state === outcome.data.status
-      )
-        return result(true, 'duplicate', diagnostic);
+      ) {
+        const receipt = this.commitControlEventReceipt(
+          input,
+          () => this.terminalLifecycle.isCurrent(epoch) && this.isCurrentReceiptRuntime(input)
+        );
+        return result(receipt === 'apply' || receipt === 'duplicate', 'duplicate', diagnostic);
+      }
+      if (!this.isCurrentReceiptRuntime(input))
+        return result(false, 'runtime_mismatch', diagnostic);
       const settled = applyMessageOutcome(
         messages,
         outcome.data,
@@ -517,8 +564,28 @@ export class SandboxSession extends DurableObject<Env> {
           diagnostic
         );
       }
-      if (!this.saveMessages(settled, epoch, 'wrapper_outcome'))
-        return result(false, 'epoch_changed', diagnostic);
+      let receipt: ControlEventReceiptDisposition | undefined;
+      const saved = this.saveMessages(
+        settled,
+        epoch,
+        'wrapper_outcome',
+        undefined,
+        () => this.recordControlEventReceipt(input),
+        () => {
+          if (!this.terminalLifecycle.isCurrent(epoch) || !this.isCurrentReceiptRuntime(input))
+            return false;
+          receipt = this.controlEventReceipt(input);
+          return receipt === 'apply';
+        }
+      );
+      if (!saved) {
+        if (receipt === 'duplicate') return result(true, 'duplicate', diagnostic);
+        return result(
+          false,
+          receipt === undefined || receipt === 'apply' ? 'epoch_changed' : 'receipt_conflict',
+          diagnostic
+        );
+      }
       if (this.isCurrentEventRuntime(input.wrapperInstanceId)) {
         this.worktreeChanges.onEvent(
           this.worktreeContext(metadata),
@@ -536,15 +603,15 @@ export class SandboxSession extends DurableObject<Env> {
     }
     if (!this.isCurrentEventRuntime(input.wrapperInstanceId))
       return result(false, 'runtime_mismatch');
-    if (
-      eventKiloSessionId !== undefined &&
-      eventKiloSessionId !== root &&
-      (root === undefined || input.identity.rootKiloSessionId !== root)
-    )
-      return result(false, 'root_mismatch');
     if (input.payload.type === WORKTREE_CHANGED_EVENT) {
       if (!root || eventKiloSessionId !== root) return result(false, 'root_mismatch');
       if (!input.wrapperInstanceId) return result(false, 'missing_wrapper_identity');
+      const receipt = this.commitControlEventReceipt(
+        input,
+        () => this.terminalLifecycle.isCurrent(epoch) && this.isCurrentReceiptRuntime(input)
+      );
+      if (receipt === 'duplicate') return result(true, 'duplicate');
+      if (receipt !== 'apply') return result(false, 'receipt_conflict');
       this.worktreeChanges.onEvent(
         this.worktreeContext(metadata),
         eventKiloSessionId,
@@ -558,17 +625,40 @@ export class SandboxSession extends DurableObject<Env> {
       !this.loadMessages().some(
         message => message.state === 'accepted' || message.state === 'queued'
       )
-    )
-      return result(false, 'no_pending_work');
-    this.recordPendingInteraction(input.payload);
-    persistSandboxControlSessionEvent({
-      sessionId,
-      payload: input.payload,
-      eventQueries: this.eventQueries,
-      broadcast: event => this.broadcastStoredEvent(event),
+    ) {
+      if (input.receiptId === undefined) return result(false, 'no_pending_work');
+      const receipt = this.commitControlEventReceipt(
+        input,
+        () => this.terminalLifecycle.isCurrent(epoch) && this.isCurrentReceiptRuntime(input)
+      );
+      return result(receipt === 'apply' || receipt === 'duplicate', 'no_pending_work');
+    }
+    const notifications: StoredEvent[] = [];
+    const receipt = this.ctx.storage.transactionSync(() => {
+      if (
+        !this.terminalLifecycle.isCurrent(epoch) ||
+        !this.isCurrentEventRuntime(input.wrapperInstanceId) ||
+        !this.isCurrentNativeEventRuntime(input.identity, input.wrapperInstanceId)
+      )
+        return 'stale';
+      const current = this.controlEventReceipt(input);
+      if (current !== 'apply') return current;
+      this.recordPendingInteraction(input.payload);
+      persistSandboxControlSessionEvent({
+        sessionId,
+        payload: input.payload,
+        eventQueries: this.eventQueries,
+        broadcast: event => notifications.push(event),
+      });
+      const activeMessages = recordAcceptedMessageActivity(this.loadMessages(), Date.now());
+      if (activeMessages && this.terminalLifecycle.isCurrent(epoch))
+        this.ctx.storage.kv.put(MESSAGES_KEY, activeMessages);
+      this.recordControlEventReceipt(input);
+      return 'apply' as const;
     });
-    const activeMessages = recordAcceptedMessageActivity(this.loadMessages(), Date.now());
-    if (activeMessages) this.saveMessages(activeMessages, epoch);
+    if (receipt === 'duplicate') return result(true, 'duplicate');
+    if (receipt !== 'apply') return result(false, 'receipt_conflict');
+    for (const notification of notifications) this.broadcastStoredEvent(notification);
     this.worktreeChanges.onEvent(
       this.worktreeContext(metadata),
       eventKiloSessionId,
@@ -629,6 +719,9 @@ export class SandboxSession extends DurableObject<Env> {
     identity: SessionEventIdentity;
     payload: SessionPreparingPayload;
     wrapperInstanceId?: string;
+    receiptId?: string;
+    receiptHash?: string;
+    sequence?: number;
   }): Promise<{ applied: boolean }> {
     const metadata = await this.getMetadata();
     const epoch = this.terminalLifecycle.captureEpoch();
@@ -643,6 +736,8 @@ export class SandboxSession extends DurableObject<Env> {
       return { applied };
     };
     if (!metadata || epoch === null) return result(false, 'session_unavailable');
+    if (!(await this.hasValidControlEventReceipt('session.preparing', input)))
+      return result(false, 'receipt_conflict');
     const root = metadata.auth.kiloSessionId;
     if (input.identity.directory !== this.directory(metadata))
       return result(false, 'directory_mismatch');
@@ -674,14 +769,36 @@ export class SandboxSession extends DurableObject<Env> {
               : 'runtime_mismatch'
       );
     }
-    if (message.state !== 'queued') return result(true, 'already_settled');
+    if (message.state !== 'queued') {
+      const receipt = this.commitControlEventReceipt(
+        input,
+        () => this.terminalLifecycle.isCurrent(epoch) && this.isCurrentReceiptRuntime(input)
+      );
+      return result(receipt === 'apply' || receipt === 'duplicate', 'already_settled');
+    }
     const sessionId = this.requireSessionId();
-    applyControlPlanePreparingEvent({
-      sessionId,
-      data: input.payload,
-      eventQueries: this.eventQueries,
-      broadcast: event => this.broadcastStoredEvent(event),
+    const notifications: StoredEvent[] = [];
+    const receipt = this.ctx.storage.transactionSync(() => {
+      if (
+        !this.terminalLifecycle.isCurrent(epoch) ||
+        !this.isCurrentEventRuntime(input.wrapperInstanceId) ||
+        !this.isCurrentNativeEventRuntime(input.identity, input.wrapperInstanceId)
+      )
+        return 'stale';
+      const current = this.controlEventReceipt(input);
+      if (current !== 'apply') return current;
+      applyControlPlanePreparingEvent({
+        sessionId,
+        data: input.payload,
+        eventQueries: this.eventQueries,
+        broadcast: event => notifications.push(event),
+      });
+      this.recordControlEventReceipt(input);
+      return 'apply' as const;
     });
+    if (receipt === 'duplicate') return result(true, 'duplicate');
+    if (receipt !== 'apply') return result(false, 'receipt_conflict');
+    for (const notification of notifications) this.broadcastStoredEvent(notification);
     return result(true, 'processed');
   }
 
@@ -751,6 +868,21 @@ export class SandboxSession extends DurableObject<Env> {
       notifications,
     });
     if (!ack) return undefined;
+    if (
+      authorization.operation === 'session.attach' &&
+      delivery.result.ok &&
+      (ack.disposition === 'applied' || ack.disposition === 'identical') &&
+      metadata.workspace?.sandboxId
+    ) {
+      const attached = sessionAttachResultSchema.safeParse(delivery.result.result);
+      if (attached.success && attached.data.nativeRuntimeId !== undefined)
+        await this.recordNativeRuntime({
+          sandboxId: metadata.workspace.sandboxId,
+          wrapperInstanceId: input.wrapperInstanceId,
+          nativeRuntimeId: attached.data.nativeRuntimeId,
+          authorization,
+        });
+    }
     for (const notification of notifications) this.broadcastStoredEvent(notification);
     if (ack.disposition === 'applied' && delivery.outcome) {
       if (this.isCurrentEventRuntime(input.wrapperInstanceId))
@@ -893,11 +1025,11 @@ export class SandboxSession extends DurableObject<Env> {
     return;
   }
 
-  async getControlState(): Promise<ControlSessionState | null> {
-    return this.controlSessionState();
+  async getControlState(options?: { includeIdle: true }): Promise<ControlSessionState | null> {
+    return this.controlSessionState(options?.includeIdle === true);
   }
 
-  private controlSessionState(): ControlSessionState | null {
+  private controlSessionState(includeIdle: boolean): ControlSessionState | null {
     const metadata = this.terminalLifecycle.getStoredMetadata();
     const sandboxId = metadata?.workspace?.sandboxId;
     if (!metadata || !sandboxId || this.terminalLifecycle.captureEpoch() === null) return null;
@@ -905,7 +1037,8 @@ export class SandboxSession extends DurableObject<Env> {
       .filter(
         message =>
           (message.state === 'queued' || message.state === 'accepted') &&
-          message.cancellation === undefined
+          message.cancellation === undefined &&
+          (!includeIdle || message.state === 'accepted' || message.wrapperInstanceId !== undefined)
       )
       .map(message => ({
         messageId: message.messageId,
@@ -914,17 +1047,67 @@ export class SandboxSession extends DurableObject<Env> {
           ? { executionDeadlineAt: message.executionDeadlineAt }
           : {}),
       }));
-    if (targets.length === 0) return null;
-    return controlSessionStateSchema.parse({
-      version: 1,
-      scope: {
-        sandboxId,
-        ...(this.terminalLifecycle.getAttachedWrapperInstanceId()
-          ? { wrapperInstanceId: this.terminalLifecycle.getAttachedWrapperInstanceId() }
-          : {}),
-      },
-      targets,
+    const operations = this.loadMessages().flatMap(message => {
+      const authorization = sessionOperationAuthorizationSchema.safeParse(
+        message.operations?.prompt?.authorization
+      );
+      if (!authorization.success || !message.operations?.prompt?.dispatched) return [];
+      return [
+        {
+          messageId: message.messageId,
+          authorization: authorization.data,
+          ...(message.executionDeadlineAt
+            ? { executionDeadlineAt: message.executionDeadlineAt }
+            : {}),
+        },
+      ];
     });
+    const stops = this.stopLifecycle.pending().map(stop => sessionStopReceipt(stop));
+    if (!includeIdle && targets.length === 0 && stops.length === 0) return null;
+    return z
+      .object(controlSessionStateSchema.shape)
+      .strict()
+      .parse({
+        version: 1,
+        scope: {
+          sandboxId,
+          ...(this.terminalLifecycle.getAttachedWrapperInstanceId()
+            ? { wrapperInstanceId: this.terminalLifecycle.getAttachedWrapperInstanceId() }
+            : {}),
+        },
+        targets,
+        ...(stops.length > 0 ? { stops } : {}),
+        ...(operations.length > 0 ? { operations } : {}),
+      });
+  }
+
+  async reconcileControlRecovery(
+    input: unknown
+  ): Promise<{ state: 'reconciled' | 'unresolved' | 'stale' }> {
+    const requested = z
+      .array(sessionOperationAuthorizationSchema)
+      .max(SANDBOX_CONTROL_OPERATION_LIMIT)
+      .parse(input);
+    const epoch = this.terminalLifecycle.captureEpoch();
+    if (epoch === null) return { state: 'stale' };
+    for (const authorization of requested) {
+      const message = this.loadMessages().find(item => item.messageId === authorization.messageId);
+      const stored = sessionOperationAuthorizationSchema.safeParse(
+        message?.operations?.prompt?.authorization
+      );
+      if (
+        !message ||
+        !stored.success ||
+        !message.operations?.prompt?.dispatched ||
+        !sameSessionOperation(stored.data, authorization) ||
+        !this.terminalLifecycle.isCurrent(epoch)
+      )
+        return { state: 'stale' };
+      const observed = await this.observeAcceptedOperation(message, epoch);
+      if (!this.terminalLifecycle.isCurrent(epoch)) return { state: 'stale' };
+      if (observed !== 'running' && observed !== 'completed') return { state: 'unresolved' };
+    }
+    return { state: 'reconciled' };
   }
 
   async interruptExecution(): Promise<{ success: boolean; message?: string }>;
@@ -1244,12 +1427,18 @@ export class SandboxSession extends DurableObject<Env> {
     );
     const proof = message?.operations?.attach;
     if (
-      !proof?.completedAt ||
+      !proof?.dispatched ||
+      !proof.completedAt ||
       proof.attachmentEpoch === undefined ||
       !sameSessionOperation(proof.authorization, authorization.data) ||
       !this.terminalLifecycle.isCurrent(epoch)
     )
       return;
+    if (proof.result !== undefined) {
+      if (!proof.result.ok) return;
+      const attached = sessionAttachResultSchema.safeParse(proof.result.result);
+      if (!attached.success || attached.data.nativeRuntimeId !== input.nativeRuntimeId) return;
+    }
     const newestAttachmentEpoch = Math.max(
       0,
       ...this.loadMessages().map(current => current.operations?.attach?.attachmentEpoch ?? 0)
@@ -1259,7 +1448,10 @@ export class SandboxSession extends DurableObject<Env> {
     );
     if (
       proof.attachmentEpoch !== newestAttachmentEpoch ||
-      (current.success && current.data.attachmentEpoch > proof.attachmentEpoch)
+      (current.success &&
+        (current.data.attachmentEpoch > proof.attachmentEpoch ||
+          (current.data.attachmentEpoch === proof.attachmentEpoch &&
+            current.data.nativeRuntimeId !== input.nativeRuntimeId)))
     )
       return;
     this.ctx.storage.kv.put(
@@ -1994,22 +2186,26 @@ export class SandboxSession extends DurableObject<Env> {
         (current.operations?.attach?.dispatched || current.operations?.prompt?.dispatched)
       )
         return;
-      wrapperInstanceId = runtime.data;
-      this.saveMessages(
+      const saved = this.saveMessages(
         this.loadMessages().map(message =>
           message.messageId === messageId
             ? {
                 ...message,
-                wrapperInstanceId,
+                wrapperInstanceId: runtime.data,
                 unresolvedDispatch:
-                  message.wrapperInstanceId === wrapperInstanceId
+                  message.wrapperInstanceId === runtime.data
                     ? message.unresolvedDispatch
                     : undefined,
               }
             : message
         ),
-        epoch
+        epoch,
+        'coordinator',
+        undefined,
+        () => bindControlEventReceiptIdentity(this.ctx.storage.kv, runtime.data),
+        isCurrent
       );
+      if (saved) wrapperInstanceId = runtime.data;
     };
     const dispatch = async <T>(
       kind: 'attach' | 'prompt',
@@ -2112,6 +2308,16 @@ export class SandboxSession extends DurableObject<Env> {
       if (dispatched.state !== 'response' && dispatched.state !== 'completed') {
         if (dispatched.state === 'running' && operation === 'session.prompt') return dispatched;
         throw operationDispatchError(dispatched);
+      }
+      if (operation === 'session.attach') {
+        const attached = sessionAttachResultSchema.parse(dispatched.result);
+        if (attached.nativeRuntimeId !== undefined)
+          await this.recordNativeRuntime({
+            sandboxId,
+            wrapperInstanceId,
+            nativeRuntimeId: attached.nativeRuntimeId,
+            authorization,
+          });
       }
       return dispatched;
     };
@@ -2484,7 +2690,6 @@ export class SandboxSession extends DurableObject<Env> {
     const sandboxId = metadata.workspace?.sandboxId;
     if (!sandboxId) return;
     const pending = this.pendingRuntimeCleanup();
-    // The first retained fence names the runtime that caused this cleanup. Never retarget it.
     if (pending) return;
     const nativeRuntime = nativeRuntimeFenceSchema.safeParse(
       this.ctx.storage.kv.get<unknown>(NATIVE_RUNTIME_FENCE_KEY)
@@ -2547,8 +2752,26 @@ export class SandboxSession extends DurableObject<Env> {
         response.disposition === 'physical_stopped' ||
         response.disposition === 'wrapper_replaced'
       ) {
-        if (this.pendingRuntimeCleanup()?.wrapperInstanceId === pending.wrapperInstanceId)
+        this.ctx.storage.transactionSync(() => {
+          const current = this.pendingRuntimeCleanup();
+          if (
+            !current ||
+            current.ownerId !== pending.ownerId ||
+            current.sessionId !== pending.sessionId ||
+            current.sandboxId !== pending.sandboxId ||
+            current.wrapperInstanceId !== pending.wrapperInstanceId ||
+            current.nativeRuntimeId !== pending.nativeRuntimeId ||
+            current.reason !== pending.reason ||
+            (pending.authorization
+              ? !current.authorization ||
+                !sameSessionOperation(current.authorization, pending.authorization)
+              : current.authorization !== undefined)
+          )
+            return;
+          if (response.disposition !== 'native_retired')
+            retireControlEventReceiptIdentity(this.ctx.storage.kv, pending.wrapperInstanceId);
           this.ctx.storage.kv.delete(PENDING_RUNTIME_CLEANUP_KEY);
+        });
         return this.pendingRuntimeCleanup() === undefined;
       }
       if (
@@ -2651,6 +2874,121 @@ export class SandboxSession extends DurableObject<Env> {
       this.ctx.storage.kv.get<unknown>(PENDING_INTERACTIONS_KEY)
     );
     return parsed.success ? parsed.data : undefined;
+  }
+
+  private controlEventReceipt(input: {
+    receiptId?: string;
+    receiptHash?: string;
+    sequence?: number;
+    wrapperInstanceId?: string;
+  }): ControlEventReceiptDisposition {
+    return controlEventReceiptDisposition(this.ctx.storage.kv, input);
+  }
+
+  private nativeAttachmentEventDisposition(
+    identity: SessionEventIdentity,
+    wrapperInstanceId?: string
+  ): 'pending' | 'rejected' | undefined {
+    if (identity.nativeRuntimeId === undefined) return undefined;
+    const messages = this.loadMessages();
+    const headId = nextQueuedMessageId(messages);
+    const message = messages.find(item => item.messageId === headId);
+    const proof = message?.operations?.attach;
+    if (
+      !proof?.dispatched ||
+      message?.cancellation !== undefined ||
+      message?.wrapperInstanceId !== wrapperInstanceId ||
+      proof.authorization.wrapperInstanceId !== wrapperInstanceId ||
+      proof.authorization.session.sessionId !== this.sessionId ||
+      proof.authorization.session.directory !== identity.directory ||
+      proof.authorization.session.kiloSessionId !==
+        (identity.rootKiloSessionId ?? identity.kiloSessionId)
+    )
+      return undefined;
+    const current = nativeRuntimeFenceSchema.safeParse(
+      this.ctx.storage.kv.get<unknown>(NATIVE_RUNTIME_FENCE_KEY)
+    );
+    if (current.success && sameSessionOperation(current.data.authorization, proof.authorization))
+      return undefined;
+    if (proof.result) {
+      if (!proof.result.ok) return 'rejected';
+      const attached = sessionAttachResultSchema.safeParse(proof.result.result);
+      if (!attached.success || attached.data.nativeRuntimeId !== identity.nativeRuntimeId)
+        return 'rejected';
+    }
+    return Date.now() < sessionOperationExpiresAt(proof.authorization) ? 'pending' : 'rejected';
+  }
+
+  private isCurrentNativeEventRuntime(
+    identity: SessionEventIdentity,
+    wrapperInstanceId?: string
+  ): boolean {
+    if (identity.nativeRuntimeId === undefined) return true;
+    const current = nativeRuntimeFenceSchema.safeParse(
+      this.ctx.storage.kv.get<unknown>(NATIVE_RUNTIME_FENCE_KEY)
+    );
+    return (
+      current.success &&
+      current.data.wrapperInstanceId === wrapperInstanceId &&
+      current.data.nativeRuntimeId === identity.nativeRuntimeId
+    );
+  }
+
+  private isCurrentReceiptRuntime(input: {
+    identity: SessionEventIdentity;
+    receiptId?: string;
+    receiptHash?: string;
+    sequence?: number;
+    wrapperInstanceId?: string;
+  }): boolean {
+    return (
+      (input.receiptId === undefined &&
+        input.receiptHash === undefined &&
+        input.sequence === undefined) ||
+      (this.isCurrentEventRuntime(input.wrapperInstanceId) &&
+        this.isCurrentNativeEventRuntime(input.identity, input.wrapperInstanceId))
+    );
+  }
+
+  private async hasValidControlEventReceipt(
+    event: 'session.event' | 'session.preparing',
+    input: {
+      identity: SessionEventIdentity;
+      payload: unknown;
+      receiptId?: string;
+      receiptHash?: string;
+      sequence?: number;
+      wrapperInstanceId?: string;
+    }
+  ): Promise<boolean> {
+    return hasValidControlEventReceipt(event, input);
+  }
+
+  private commitControlEventReceipt(
+    input: {
+      receiptId?: string;
+      receiptHash?: string;
+      sequence?: number;
+      wrapperInstanceId?: string;
+    },
+    isCurrent: () => boolean = () => true
+  ): ControlEventReceiptDisposition {
+    return this.ctx.storage.transactionSync(() => {
+      if (!isCurrent()) return 'stale';
+      const receipt = this.controlEventReceipt(input);
+      if (receipt !== 'apply') return receipt;
+      this.recordControlEventReceipt(input);
+      return 'apply';
+    });
+  }
+
+  private recordControlEventReceipt(input: {
+    receiptId?: string;
+    receiptHash?: string;
+    sequence?: number;
+    wrapperInstanceId?: string;
+  }): void {
+    recordControlEventReceipt(this.ctx.storage.kv, input);
   }
 
   private recordPendingInteraction(payload: {
@@ -3102,7 +3440,8 @@ export class SandboxSession extends DurableObject<Env> {
     epoch?: number,
     source: 'coordinator' | 'wrapper_outcome' | 'operation_result' = 'coordinator',
     deferredNotifications?: StoredEvent[],
-    onPersist?: () => void
+    onPersist?: () => void,
+    beforePersist?: () => boolean
   ): boolean {
     return this.commitSavedMessages(
       messages,
@@ -3110,6 +3449,7 @@ export class SandboxSession extends DurableObject<Env> {
       source,
       deferredNotifications,
       onPersist,
+      beforePersist,
       write => this.ctx.storage.transactionSync(write)
     );
   }
@@ -3126,6 +3466,7 @@ export class SandboxSession extends DurableObject<Env> {
       source,
       deferredNotifications,
       undefined,
+      undefined,
       write => write()
     );
   }
@@ -3136,6 +3477,7 @@ export class SandboxSession extends DurableObject<Env> {
     source: 'coordinator' | 'wrapper_outcome' | 'operation_result',
     deferredNotifications: StoredEvent[] | undefined,
     onPersist: (() => void) | undefined,
+    beforePersist: (() => boolean) | undefined,
     enclose: (write: () => void) => void
   ): boolean {
     const currentEpoch = epoch ?? this.terminalLifecycle.captureEpoch();
@@ -3147,7 +3489,10 @@ export class SandboxSession extends DurableObject<Env> {
       return false;
     const events: StoredEvent[] = [];
     const committed: ControlDiagnosticFields[] = [];
+    let persisted = false;
     const write = () => {
+      if (!this.terminalLifecycle.isCurrent(currentEpoch)) return;
+      if (beforePersist?.() === false) return;
       const before = this.loadMessages();
       const previousById = new Map(before.map(message => [message.messageId, message]));
       const queuedHeadId = nextQueuedMessageId(before);
@@ -3217,8 +3562,10 @@ export class SandboxSession extends DurableObject<Env> {
       });
       this.ctx.storage.kv.put(MESSAGES_KEY, next);
       onPersist?.();
+      persisted = true;
     };
     enclose(write);
+    if (!persisted) return false;
     for (const fields of committed) {
       logControlDiagnostic('session_message_committed', {
         sessionId: this.sessionId,

--- a/services/cloud-agent-next/src/sandbox-session/control-event-receipts.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/control-event-receipts.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bindControlEventReceiptIdentity,
+  controlEventReceiptDisposition,
+  readControlEventReceipts,
+  recordControlEventReceipt,
+  retireControlEventReceiptIdentity,
+} from './control-event-receipts.js';
+
+const runtimeA = '11111111-1111-4111-8111-111111111111';
+const runtimeB = '22222222-2222-4222-8222-222222222222';
+
+function receipt(wrapperInstanceId: string, sequence: number) {
+  return {
+    receiptId: `${String(sequence).padStart(8, '0')}-1111-4111-8111-111111111111`,
+    receiptHash: 'a'.repeat(64),
+    wrapperInstanceId,
+    sequence,
+  };
+}
+
+function storage() {
+  const values = new Map<string, unknown>();
+  return {
+    get<T>(key: string): T | undefined {
+      return values.get(key) as T | undefined;
+    },
+    put<T>(key: string, value: T): void {
+      values.set(key, value);
+    },
+  };
+}
+
+describe('control event receipts', () => {
+  it('preserves the stream on the same wrapper and retires it only when the admitted wrapper changes', () => {
+    const state = storage();
+    bindControlEventReceiptIdentity(state, runtimeA);
+    recordControlEventReceipt(state, receipt(runtimeA, 2));
+    bindControlEventReceiptIdentity(state, runtimeA);
+    expect(controlEventReceiptDisposition(state, receipt(runtimeA, 1))).toBe('stale');
+    expect(controlEventReceiptDisposition(state, receipt(runtimeA, 2))).toBe('duplicate');
+    expect(controlEventReceiptDisposition(state, receipt(runtimeB, 1))).toBe('stale');
+
+    bindControlEventReceiptIdentity(state, runtimeB);
+    expect(controlEventReceiptDisposition(state, receipt(runtimeA, 3))).toBe('stale');
+    expect(controlEventReceiptDisposition(state, receipt(runtimeB, 1))).toBe('apply');
+    expect(() => bindControlEventReceiptIdentity(state, runtimeA)).toThrow('retired');
+    expect(readControlEventReceipts(state).activeWrapperInstanceId).toBe(runtimeB);
+  });
+
+  it('does not derive the admitted wrapper identity from an event', () => {
+    const state = storage();
+    recordControlEventReceipt(state, receipt(runtimeA, 1));
+    expect(readControlEventReceipts(state).activeWrapperInstanceId).toBeUndefined();
+  });
+
+  it('rejects a retired wrapper identity after pruning its receipt state', () => {
+    const state = storage();
+    const first = receipt(runtimeA, 1);
+    recordControlEventReceipt(state, first);
+    expect(controlEventReceiptDisposition(state, first)).toBe('duplicate');
+
+    retireControlEventReceiptIdentity(state, runtimeA);
+    expect(controlEventReceiptDisposition(state, first)).toBe('stale');
+
+    const second = receipt(runtimeB, 1);
+    recordControlEventReceipt(state, second);
+    expect(controlEventReceiptDisposition(state, second)).toBe('duplicate');
+    expect(controlEventReceiptDisposition(state, { ...first, sequence: 2 })).toBe('stale');
+  });
+});

--- a/services/cloud-agent-next/src/sandbox-session/control-event-receipts.ts
+++ b/services/cloud-agent-next/src/sandbox-session/control-event-receipts.ts
@@ -1,0 +1,181 @@
+import { z } from 'zod';
+import { canonicalControlEventJson } from '../shared/control-event-canonical.js';
+import { wrapperInstanceIdSchema } from '../shared/sandbox-control-protocol.js';
+
+export const CONTROL_EVENT_RECEIPTS_KEY = 'control_event_receipts';
+const CONTROL_EVENT_RECEIPT_LIMIT = 64;
+
+const controlEventReceiptSchema = z
+  .object({
+    receiptId: z.string().uuid(),
+    receiptHash: z.string().regex(/^[a-f0-9]{64}$/),
+    wrapperInstanceId: wrapperInstanceIdSchema,
+    sequence: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  })
+  .strict();
+
+const controlEventReceiptStoreSchema = z
+  .object({
+    activeWrapperInstanceId: wrapperInstanceIdSchema.optional(),
+    highWater: z.record(wrapperInstanceIdSchema, z.number().int().nonnegative()),
+    retiredWrapperInstanceIds: z
+      .array(wrapperInstanceIdSchema)
+      .max(CONTROL_EVENT_RECEIPT_LIMIT)
+      .default([]),
+    receipts: z.array(controlEventReceiptSchema).max(CONTROL_EVENT_RECEIPT_LIMIT),
+  })
+  .strict();
+
+export type ControlEventReceiptInput = {
+  receiptId?: string;
+  receiptHash?: string;
+  sequence?: number;
+  wrapperInstanceId?: string;
+};
+
+export type ControlEventReceiptDisposition = 'apply' | 'duplicate' | 'conflict' | 'stale';
+
+type ControlEventReceiptStorage = {
+  get<T>(key: string): T | undefined;
+  put<T>(key: string, value: T): void;
+};
+
+type ControlEventReceiptState = z.infer<typeof controlEventReceiptStoreSchema>;
+
+export function parseControlEventReceipt(input: ControlEventReceiptInput) {
+  return controlEventReceiptSchema.safeParse({
+    receiptId: input.receiptId,
+    receiptHash: input.receiptHash,
+    sequence: input.sequence,
+    wrapperInstanceId: input.wrapperInstanceId,
+  });
+}
+
+export function readControlEventReceipts(
+  storage: ControlEventReceiptStorage
+): ControlEventReceiptState {
+  const stored = storage.get<unknown>(CONTROL_EVENT_RECEIPTS_KEY);
+  if (stored === undefined) {
+    return { highWater: {}, retiredWrapperInstanceIds: [], receipts: [] };
+  }
+  const parsed = controlEventReceiptStoreSchema.safeParse(stored);
+  if (!parsed.success) throw new Error('Invalid control event receipt storage');
+  return parsed.data;
+}
+
+export function controlEventReceiptDisposition(
+  storage: ControlEventReceiptStorage,
+  input: ControlEventReceiptInput
+): ControlEventReceiptDisposition {
+  if (
+    input.receiptId === undefined &&
+    input.receiptHash === undefined &&
+    input.sequence === undefined
+  )
+    return 'apply';
+  const receipt = parseControlEventReceipt(input);
+  if (!receipt.success) return 'conflict';
+  const state = readControlEventReceipts(storage);
+  if (
+    state.retiredWrapperInstanceIds.includes(receipt.data.wrapperInstanceId) ||
+    (state.activeWrapperInstanceId !== undefined &&
+      state.activeWrapperInstanceId !== receipt.data.wrapperInstanceId)
+  )
+    return 'stale';
+  const stored = state.receipts.find(
+    item =>
+      item.receiptId === receipt.data.receiptId &&
+      item.wrapperInstanceId === receipt.data.wrapperInstanceId
+  );
+  if (stored)
+    return stored.receiptHash === receipt.data.receiptHash &&
+      stored.sequence === receipt.data.sequence
+      ? 'duplicate'
+      : 'conflict';
+  return receipt.data.sequence <= (state.highWater[receipt.data.wrapperInstanceId] ?? 0)
+    ? 'stale'
+    : 'apply';
+}
+
+export function recordControlEventReceipt(
+  storage: ControlEventReceiptStorage,
+  input: ControlEventReceiptInput
+): void {
+  const receipt = parseControlEventReceipt(input);
+  if (!receipt.success) return;
+  const current = readControlEventReceipts(storage);
+  storage.put(CONTROL_EVENT_RECEIPTS_KEY, {
+    ...current,
+    highWater: {
+      ...current.highWater,
+      [receipt.data.wrapperInstanceId]: receipt.data.sequence,
+    },
+    receipts: [...current.receipts, receipt.data].slice(-CONTROL_EVENT_RECEIPT_LIMIT),
+  });
+}
+
+export function bindControlEventReceiptIdentity(
+  storage: ControlEventReceiptStorage,
+  wrapperInstanceId: string
+): void {
+  const current = readControlEventReceipts(storage);
+  if (current.activeWrapperInstanceId === wrapperInstanceId) return;
+  if (current.retiredWrapperInstanceIds.includes(wrapperInstanceId))
+    throw new Error('Cannot bind a retired control event wrapper');
+  if (current.activeWrapperInstanceId)
+    retireControlEventReceiptIdentity(storage, current.activeWrapperInstanceId);
+  storage.put(CONTROL_EVENT_RECEIPTS_KEY, {
+    ...readControlEventReceipts(storage),
+    activeWrapperInstanceId: wrapperInstanceId,
+  });
+}
+
+export function retireControlEventReceiptIdentity(
+  storage: ControlEventReceiptStorage,
+  wrapperInstanceId: string
+): void {
+  const current = readControlEventReceipts(storage);
+  const { [wrapperInstanceId]: _, ...highWater } = current.highWater;
+  storage.put(CONTROL_EVENT_RECEIPTS_KEY, {
+    ...current,
+    ...(current.activeWrapperInstanceId === wrapperInstanceId
+      ? { activeWrapperInstanceId: undefined }
+      : {}),
+    highWater,
+    retiredWrapperInstanceIds: [
+      ...current.retiredWrapperInstanceIds.filter(item => item !== wrapperInstanceId),
+      wrapperInstanceId,
+    ].slice(-CONTROL_EVENT_RECEIPT_LIMIT),
+    receipts: current.receipts.filter(item => item.wrapperInstanceId !== wrapperInstanceId),
+  });
+}
+
+export async function hasValidControlEventReceipt(
+  event: 'session.event' | 'session.preparing',
+  input: {
+    identity: unknown;
+    payload: unknown;
+  } & ControlEventReceiptInput
+): Promise<boolean> {
+  if (
+    input.receiptId === undefined &&
+    input.receiptHash === undefined &&
+    input.sequence === undefined
+  )
+    return true;
+  const receipt = parseControlEventReceipt(input);
+  if (!receipt.success) return false;
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(
+      canonicalControlEventJson({
+        event,
+        session: input.identity,
+        payload: input.payload,
+        sequence: receipt.data.sequence,
+      })
+    )
+  );
+  const hash = [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
+  return hash === receipt.data.receiptHash;
+}

--- a/services/cloud-agent-next/src/sandbox-session/session-message-queue.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-message-queue.test.ts
@@ -1,4 +1,6 @@
+import { createHash } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { canonicalControlEventJson } from '../shared/control-event-canonical.js';
 import { normalizeCliEvent } from '../../../../packages/cloud-agent-sdk/src/normalizer';
 import { createServiceState } from '../../../../packages/cloud-agent-sdk/src/service-state';
 import { SandboxSession } from './SandboxSession.js';
@@ -941,6 +943,32 @@ function controlResponse(result: unknown): ResponseFrame {
   return { type: 'response', requestId: 'request', ok: true, result };
 }
 
+function receiptedEvent(
+  sequence: number,
+  payload: Parameters<SandboxSession['receiveSandboxControlEvent']>[0]['payload'],
+  wrapperInstanceId = RUNTIME_ID,
+  nativeRuntimeId?: string
+) {
+  const identity = {
+    directory: DIRECTORY,
+    kiloSessionId: 'kilo_root',
+    rootKiloSessionId: 'kilo_root',
+    ...(nativeRuntimeId ? { nativeRuntimeId } : {}),
+  };
+  return {
+    identity,
+    wrapperInstanceId,
+    payload,
+    sequence,
+    receiptId: crypto.randomUUID(),
+    receiptHash: createHash('sha256')
+      .update(
+        canonicalControlEventJson({ event: 'session.event', session: identity, payload, sequence })
+      )
+      .digest('hex'),
+  };
+}
+
 function controlFailure(retryable: boolean, code = 'not_ready'): ResponseFrame {
   return {
     type: 'response',
@@ -1199,6 +1227,171 @@ describe('SandboxSession orchestration', () => {
     expect(fixture.record('b')?.deliveryDeadlineAt).toBe(Date.now() + SESSION_DELIVERY_TIMEOUT_MS);
   });
 
+  it('commits one canonical outcome with its receipt and replays it after a lost response', async () => {
+    const fixture = sessionFixture();
+    await fixture.admit('receipt');
+    await fixture.flush();
+    const event = {
+      identity: {
+        directory: DIRECTORY,
+        kiloSessionId: 'kilo_root',
+        rootKiloSessionId: 'kilo_root',
+      },
+      wrapperInstanceId: RUNTIME_ID,
+      receiptId: '11111111-1111-4111-8111-111111111111',
+      receiptHash: 'fe56f74e2e533bffb077a4b73ded75450cdbb4752e421e6bb77d44093fd762f8',
+      sequence: 1,
+      payload: {
+        type: 'session.message.outcome',
+        properties: { messageId: 'receipt', status: 'completed' },
+      },
+    };
+
+    await expect(
+      Promise.all([
+        fixture.session.receiveSandboxControlEvent(event),
+        fixture.session.receiveSandboxControlEvent(event),
+      ])
+    ).resolves.toEqual([{ applied: true }, { applied: true }]);
+    expect(fixture.record('receipt')?.state).toBe('completed');
+    expect(fixture.terminalEvents()).toHaveLength(1);
+    expect(fixture.values.get('control_event_receipts')).toMatchObject({
+      highWater: { [RUNTIME_ID]: 1 },
+    });
+
+    fixture.reload();
+    await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+      applied: true,
+    });
+    await expect(
+      fixture.session.receiveSandboxControlEvent({
+        ...event,
+        receiptHash: 'f'.repeat(64),
+      })
+    ).resolves.toEqual({ applied: false });
+    expect(fixture.terminalEvents()).toHaveLength(1);
+  });
+
+  it.each([
+    { type: 'session.status', properties: { sessionID: 'kilo_root', status: { type: 'busy' } } },
+    {
+      type: 'question.asked',
+      properties: { id: 'question-a', sessionID: 'kilo_root', questions: [] },
+    },
+  ])(
+    'replays $type after the operation result completes A without another event',
+    async payload => {
+      const fixture = sessionFixture();
+      fixture.setStatus({
+        physical: 'running',
+        connection: 'ready',
+        wrapperInstanceId: RUNTIME_ID,
+        operationResults: true,
+      });
+      await fixture.admit('a');
+      await fixture.flush();
+      const event = receiptedEvent(1, payload);
+      await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+        applied: true,
+      });
+      const authorization = fixture.record('a')?.operations?.prompt?.authorization;
+      if (!authorization) throw new Error('Missing prompt operation authorization');
+      await expect(
+        fixture.session.receiveSandboxOperationResult({
+          session: authorization.session,
+          wrapperInstanceId: RUNTIME_ID,
+          delivery: {
+            version: 2,
+            authorization,
+            completedAt: Date.now(),
+            result: { ok: true, result: { messageId: 'a', status: 'accepted' } },
+            outcome: { messageId: 'a', status: 'completed' },
+            events: [],
+            preparing: [],
+          },
+        })
+      ).resolves.toMatchObject({ disposition: 'applied' });
+      expect(fixture.record('a')?.state).toBe('completed');
+      const events = fixture.eventQueries.findByEntityPrefix('');
+      fixture.reload();
+      await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+        applied: true,
+      });
+      expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(events);
+      expect(fixture.terminalEvents()).toHaveLength(1);
+      expect(fixture.control.quarantineRuntime).not.toHaveBeenCalled();
+
+      const invalid = { ...event, identity: { ...event.identity, directory: '/foreign' } };
+      invalid.receiptHash = createHash('sha256')
+        .update(
+          canonicalControlEventJson({
+            event: 'session.event',
+            session: invalid.identity,
+            payload,
+            sequence: invalid.sequence,
+          })
+        )
+        .digest('hex');
+      await expect(fixture.session.receiveSandboxControlEvent(invalid)).resolves.toEqual({
+        applied: false,
+      });
+      expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(events);
+    }
+  );
+
+  it('receipts ignored trailing interactions without reviving them for the next message', async () => {
+    const fixture = sessionFixture();
+    await fixture.admit('a');
+    await fixture.flush();
+    await fixture.outcome('a', 'completed');
+    const event = receiptedEvent(1, {
+      type: 'question.asked',
+      properties: { id: 'late-question', sessionID: 'kilo_root', questions: [] },
+    });
+    const events = fixture.eventQueries.findByEntityPrefix('');
+    await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+      applied: true,
+    });
+    expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(events);
+    expect(fixture.values.get('control_event_receipts')).toMatchObject({
+      highWater: { [RUNTIME_ID]: 1 },
+    });
+    await fixture.admit('b');
+    await fixture.flush();
+    fixture.reload();
+    const beforeReplay = fixture.eventQueries.findByEntityPrefix('');
+    await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+      applied: true,
+    });
+    expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(beforeReplay);
+    expect(fixture.values.get('session_pending_interactions')).not.toMatchObject({
+      questions: [expect.objectContaining({ id: 'late-question' })],
+    });
+    expect(fixture.record('b')?.state).toBe('accepted');
+    expect(fixture.control.quarantineRuntime).not.toHaveBeenCalled();
+  });
+
+  it('accepts valid trailing native status after A completes without runtime cleanup', async () => {
+    const fixture = sessionFixture();
+    await fixture.admit('a');
+    await fixture.flush();
+    await fixture.outcome('a', 'completed');
+    const event = receiptedEvent(1, {
+      type: 'session.updated',
+      properties: { info: { id: 'kilo_root', title: 'Completed turn' } },
+    });
+    await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+      applied: true,
+    });
+    const events = fixture.eventQueries.findByEntityPrefix('');
+    await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+      applied: true,
+    });
+    expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(events);
+    expect(fixture.record('a')?.state).toBe('completed');
+    expect(fixture.control.quarantineRuntime).not.toHaveBeenCalled();
+  });
+
   it('dispatches the first normal attach and prompt once with operation receipts enabled', async () => {
     const fixture = sessionFixture();
     fixture.setStatus({
@@ -1297,6 +1490,461 @@ describe('SandboxSession orchestration', () => {
     }
   );
 
+  describe('native startup attach authority', () => {
+    it('retries a startup event until the authorized attach response registers its native fence', async () => {
+      const fixture = sessionFixture();
+      const nativeRuntimeId = NEXT_RUNTIME_ID;
+      const attach = deferred<ResponseFrame>();
+      fixture.setStatus({
+        physical: 'running',
+        connection: 'ready',
+        wrapperInstanceId: RUNTIME_ID,
+        operationResults: true,
+      });
+      delegateRequest(fixture, 'session.attach', () => attach.promise);
+      await fixture.admit('a');
+      await fixture.flush();
+      const authorization = fixture.record('a')?.operations?.attach?.authorization;
+      if (!authorization) throw new Error('Missing attach authorization');
+      const event = receiptedEvent(
+        1,
+        {
+          type: 'session.updated',
+          properties: { info: { id: 'kilo_root', title: 'Native startup' } },
+        },
+        RUNTIME_ID,
+        nativeRuntimeId
+      );
+      const before = fixture.eventQueries.findByEntityPrefix('');
+      const receipts = structuredClone(fixture.values.get('control_event_receipts'));
+      await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+        applied: false,
+        retryable: true,
+      });
+      expect(fixture.values.has('native_runtime_fence')).toBe(false);
+      expect(fixture.values.get('control_event_receipts')).toEqual(receipts);
+      expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(before);
+      expect(fixture.record('a')).toMatchObject({
+        state: 'queued',
+        operations: { attach: { dispatched: true, authorization } },
+      });
+      expect(fixture.record('a')?.operations?.attach?.completedAt).toBeUndefined();
+      expect(
+        fixture.control.request.mock.calls.filter(([input]) => input.operation === 'session.prompt')
+      ).toHaveLength(0);
+
+      attach.resolve(controlResponse({ attached: true, nativeRuntimeId }));
+      await fixture.flush();
+      expect(fixture.values.get('native_runtime_fence')).toMatchObject({
+        sandboxId: SANDBOX_ID,
+        wrapperInstanceId: RUNTIME_ID,
+        nativeRuntimeId,
+        authorization,
+        attachmentEpoch: fixture.record('a')?.operations?.attach?.attachmentEpoch,
+      });
+      expect(fixture.record('a')?.operations?.attach?.completedAt).toBeDefined();
+      expect(fixture.record('a')?.state).toBe('accepted');
+      const beforeApply = fixture.eventQueries.findByEntityPrefix('');
+      await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+        applied: true,
+      });
+      const applied = fixture.eventQueries.findByEntityPrefix('');
+      expect(applied).toHaveLength(beforeApply.length + 1);
+      const broadcasts = orchestrationMocks.broadcast.mock.calls.length;
+      await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+        applied: true,
+      });
+      expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(applied);
+      expect(orchestrationMocks.broadcast).toHaveBeenCalledTimes(broadcasts);
+      const promptAuthorization = fixture.record('a')?.operations?.prompt?.authorization;
+      if (!promptAuthorization) throw new Error('Missing prompt authorization');
+      await expect(
+        fixture.session.receiveSandboxOperationResult({
+          session: promptAuthorization.session,
+          wrapperInstanceId: RUNTIME_ID,
+          delivery: {
+            version: 2,
+            authorization: promptAuthorization,
+            completedAt: Date.now(),
+            result: { ok: true, result: { messageId: 'a', status: 'accepted' } },
+            outcome: { messageId: 'a', status: 'completed' },
+            events: [],
+            preparing: [],
+          },
+        })
+      ).resolves.toMatchObject({ disposition: 'applied' });
+      await fixture.flush();
+      fixture.reload();
+      await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+        applied: true,
+      });
+      expect(fixture.record('a')?.state).toBe('completed');
+      expect(fixture.terminalEvents()).toHaveLength(1);
+      expect(
+        fixture.control.request.mock.calls
+          .map(([input]) => input.operation)
+          .filter(operation => operation === 'session.attach' || operation === 'session.prompt')
+      ).toEqual(['session.attach', 'session.prompt']);
+      expect(fixture.control.quarantineRuntime).not.toHaveBeenCalled();
+    });
+
+    it.each(['publication', 'lookup'] as const)(
+      'registers the native fence from an exact retained attach %s after response loss',
+      async source => {
+        const fixture = sessionFixture();
+        const attach = deferred<ResponseFrame>();
+        fixture.setStatus({
+          physical: 'running',
+          connection: 'ready',
+          wrapperInstanceId: RUNTIME_ID,
+          operationResults: true,
+        });
+        delegateRequest(fixture, 'session.attach', () => attach.promise);
+        await fixture.admit('a');
+        await fixture.flush();
+        const authorization = fixture.record('a')?.operations?.attach?.authorization;
+        if (!authorization) throw new Error('Missing attach authorization');
+        const event = receiptedEvent(
+          1,
+          {
+            type: 'session.updated',
+            properties: { info: { id: 'kilo_root', title: 'Buffered native startup' } },
+          },
+          RUNTIME_ID,
+          NEXT_RUNTIME_ID
+        );
+        await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+          applied: false,
+          retryable: true,
+        });
+        const delivery: SessionOperationDelivery = {
+          version: 2,
+          authorization,
+          completedAt: Date.now(),
+          result: { ok: true, result: { attached: true, nativeRuntimeId: NEXT_RUNTIME_ID } },
+          events: [],
+          preparing: [],
+        };
+        const expectedFence = {
+          sandboxId: SANDBOX_ID,
+          wrapperInstanceId: RUNTIME_ID,
+          nativeRuntimeId: NEXT_RUNTIME_ID,
+          authorization,
+        };
+        fixture.reload();
+        if (source === 'publication') {
+          await expect(
+            fixture.session.receiveSandboxOperationResult({
+              session: authorization.session,
+              wrapperInstanceId: RUNTIME_ID,
+              delivery,
+            })
+          ).resolves.toMatchObject({ disposition: 'applied' });
+          expect(fixture.values.get('native_runtime_fence')).toMatchObject(expectedFence);
+        }
+        delegateRequest(fixture, 'session.operation.get', async input => {
+          expect(input.payload).toEqual(authorization);
+          return controlResponse({ state: 'completed', delivery });
+        });
+        let fenceAtAcknowledgement: unknown;
+        delegateRequest(fixture, 'session.operation.ack', async () => {
+          fenceAtAcknowledgement = structuredClone(fixture.values.get('native_runtime_fence'));
+          return controlResponse({ acknowledged: true });
+        });
+        await fixture.fireAlarm();
+        await fixture.flush();
+        expect(fenceAtAcknowledgement).toMatchObject(expectedFence);
+        expect(fixture.record('a')).toMatchObject({
+          state: 'accepted',
+          operations: { attach: { resultHash: await sessionOperationResultHash(delivery) } },
+        });
+        fixture.values.delete('native_runtime_fence');
+        fixture.reload();
+        const beforeRegistration = structuredClone([...fixture.values]);
+        await fixture.session.recordNativeRuntime({
+          ...expectedFence,
+          nativeRuntimeId: '11111111-1111-4111-8111-111111111111',
+        });
+        expect([...fixture.values]).toEqual(beforeRegistration);
+        expect(fixture.values.has('native_runtime_fence')).toBe(false);
+        await expect(
+          fixture.session.receiveSandboxOperationResult({
+            session: authorization.session,
+            wrapperInstanceId: RUNTIME_ID,
+            delivery,
+          })
+        ).resolves.toMatchObject({ disposition: 'identical' });
+        expect(fixture.values.get('native_runtime_fence')).toMatchObject(expectedFence);
+        const before = fixture.eventQueries.findByEntityPrefix('');
+        await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+          applied: true,
+        });
+        const applied = fixture.eventQueries.findByEntityPrefix('');
+        expect(applied).toHaveLength(before.length + 1);
+        await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+          applied: true,
+        });
+        expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(applied);
+        expect(
+          fixture.control.request.mock.calls
+            .map(([input]) => input.operation)
+            .filter(operation => operation === 'session.attach' || operation === 'session.prompt')
+        ).toEqual(['session.attach', 'session.prompt']);
+        expect(fixture.control.quarantineRuntime).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each([false, true])(
+      'never adopts stale N1 during pending N2 attach or replaces N2 within the same attach epoch with prior fence=%s',
+      async priorFence => {
+        const fixture = sessionFixture();
+        const attach = deferred<ResponseFrame>();
+        const prompt = deferred<ResponseFrame>();
+        const staleNativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+        if (priorFence) {
+          const previousAuthorization: SessionOperationAuthorization = {
+            operation: 'session.attach',
+            operationId: 'attach-previous',
+            messageId: 'previous',
+            session: { sessionId: SESSION_ID, kiloSessionId: 'kilo_root', directory: DIRECTORY },
+            wrapperInstanceId: RUNTIME_ID,
+            dispatchDeadlineAt: Date.now() + SESSION_DELIVERY_TIMEOUT_MS,
+          };
+          fixture.storage.kv.put('session_messages', [
+            {
+              messageId: 'previous',
+              state: 'completed',
+              wrapperInstanceId: RUNTIME_ID,
+              operations: {
+                attach: {
+                  authorization: previousAuthorization,
+                  dispatched: true,
+                  completedAt: Date.now() - 1,
+                  attachmentEpoch: 1,
+                },
+              },
+            } satisfies SessionMessageRecord,
+          ]);
+          await fixture.session.recordNativeRuntime({
+            sandboxId: SANDBOX_ID,
+            wrapperInstanceId: RUNTIME_ID,
+            nativeRuntimeId: staleNativeRuntimeId,
+            authorization: previousAuthorization,
+          });
+          expect(fixture.values.get('native_runtime_fence')).toMatchObject({
+            nativeRuntimeId: staleNativeRuntimeId,
+            attachmentEpoch: 1,
+          });
+        }
+        fixture.setStatus({
+          physical: 'running',
+          connection: 'ready',
+          wrapperInstanceId: RUNTIME_ID,
+          operationResults: true,
+        });
+        delegateRequest(fixture, 'session.attach', () => attach.promise);
+        await fixture.admit('a');
+        await fixture.flush();
+        const authorization = fixture.record('a')?.operations?.attach?.authorization;
+        if (!authorization) throw new Error('Missing attach authorization');
+        delegateRequest(fixture, 'session.prompt', () => prompt.promise);
+        const payload = {
+          type: 'session.updated',
+          properties: { info: { id: 'kilo_root', title: 'Native startup' } },
+        };
+        const stale = receiptedEvent(1, payload, RUNTIME_ID, staleNativeRuntimeId);
+        const pendingState = structuredClone([...fixture.values]);
+        const pendingEvents = fixture.eventQueries.findByEntityPrefix('');
+        await expect(fixture.session.receiveSandboxControlEvent(stale)).resolves.toEqual({
+          applied: false,
+          retryable: true,
+        });
+        expect([...fixture.values]).toEqual(pendingState);
+        expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(pendingEvents);
+        expect(fixture.values.has('native_runtime_fence')).toBe(priorFence);
+        attach.resolve(controlResponse({ attached: true, nativeRuntimeId: NEXT_RUNTIME_ID }));
+        await fixture.flush();
+        const fence = structuredClone(fixture.values.get('native_runtime_fence'));
+        expect(fence).toMatchObject({
+          nativeRuntimeId: NEXT_RUNTIME_ID,
+          authorization,
+          attachmentEpoch: priorFence ? 2 : 1,
+        });
+        await fixture.session.recordNativeRuntime({
+          sandboxId: SANDBOX_ID,
+          wrapperInstanceId: RUNTIME_ID,
+          nativeRuntimeId: staleNativeRuntimeId,
+          authorization,
+        });
+        expect(fixture.values.get('native_runtime_fence')).toEqual(fence);
+        expect(fixture.record('a')?.state).toBe('queued');
+        const before = fixture.eventQueries.findByEntityPrefix('');
+        await expect(fixture.session.receiveSandboxControlEvent(stale)).resolves.toEqual({
+          applied: false,
+        });
+        expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(before);
+        await expect(
+          fixture.session.receiveSandboxControlEvent(
+            receiptedEvent(1, payload, RUNTIME_ID, NEXT_RUNTIME_ID)
+          )
+        ).resolves.toEqual({ applied: true });
+        prompt.resolve(controlResponse({ messageId: 'a', status: 'accepted' }));
+        await fixture.flush();
+        fixture.reload();
+        await expect(fixture.session.receiveSandboxControlEvent(stale)).resolves.toEqual({
+          applied: false,
+        });
+        expect(fixture.record('a')?.state).toBe('accepted');
+        expect(fixture.values.get('native_runtime_fence')).toEqual(fence);
+        expect(fixture.control.quarantineRuntime).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each([false, true])(
+      'never falls back to the previous N1 fence across pending B expiry with retained N2 result=%s',
+      async retainedResult => {
+        const fixture = sessionFixture();
+        const attach = deferred<ResponseFrame>();
+        fixture.setStatus({
+          physical: 'running',
+          connection: 'ready',
+          wrapperInstanceId: RUNTIME_ID,
+          operationResults: true,
+        });
+        delegateRequest(fixture, 'session.attach', () => attach.promise);
+        await fixture.admit('b');
+        await fixture.flush();
+        const current = fixture.record('b');
+        const proof = current?.operations?.attach;
+        if (!current || !proof) throw new Error('Missing B attach proof');
+        const previousAuthorization = {
+          ...proof.authorization,
+          operationId: 'attach-a',
+          messageId: 'a',
+        };
+        fixture.storage.kv.put('session_messages', [
+          {
+            messageId: 'a',
+            state: 'completed',
+            wrapperInstanceId: RUNTIME_ID,
+            operations: {
+              attach: {
+                authorization: previousAuthorization,
+                dispatched: true,
+                completedAt: Date.now() - 1,
+                attachmentEpoch: 1,
+              },
+            },
+          } satisfies SessionMessageRecord,
+          current,
+        ]);
+        const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+        await fixture.session.recordNativeRuntime({
+          sandboxId: SANDBOX_ID,
+          wrapperInstanceId: RUNTIME_ID,
+          nativeRuntimeId,
+          authorization: previousAuthorization,
+        });
+        expect(fixture.values.get('native_runtime_fence')).toMatchObject({
+          nativeRuntimeId,
+          attachmentEpoch: 1,
+        });
+        if (retainedResult) {
+          const registration = vi.spyOn(fixture.session, 'recordNativeRuntime');
+          registration.mockResolvedValueOnce(undefined);
+          await expect(
+            fixture.session.receiveSandboxOperationResult({
+              session: proof.authorization.session,
+              wrapperInstanceId: RUNTIME_ID,
+              delivery: {
+                version: 2,
+                authorization: proof.authorization,
+                completedAt: Date.now(),
+                result: { ok: true, result: { attached: true, nativeRuntimeId: NEXT_RUNTIME_ID } },
+                events: [],
+                preparing: [],
+              },
+            })
+          ).resolves.toMatchObject({ disposition: 'applied' });
+          registration.mockRestore();
+          expect(fixture.record('b')?.operations?.attach).toMatchObject({
+            attachmentEpoch: 2,
+            result: { ok: true, result: { attached: true, nativeRuntimeId: NEXT_RUNTIME_ID } },
+          });
+        }
+        const event = receiptedEvent(
+          1,
+          {
+            type: 'session.updated',
+            properties: { info: { id: 'kilo_root', title: 'Stale N1 startup' } },
+          },
+          RUNTIME_ID,
+          nativeRuntimeId
+        );
+        const before = structuredClone([...fixture.values]);
+        const events = fixture.eventQueries.findByEntityPrefix('');
+        vi.setSystemTime(sessionOperationExpiresAt(proof.authorization) - 1);
+        await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual(
+          retainedResult ? { applied: false } : { applied: false, retryable: true }
+        );
+        expect([...fixture.values]).toEqual(before);
+        vi.setSystemTime(sessionOperationExpiresAt(proof.authorization));
+        await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+          applied: false,
+        });
+        expect([...fixture.values]).toEqual(before);
+        expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(events);
+        expect(fixture.values.get('native_runtime_fence')).toMatchObject({
+          nativeRuntimeId,
+          attachmentEpoch: 1,
+        });
+        expect(await fixture.session.isSandboxCleanupScheduled()).toBe(false);
+        expect(fixture.control.quarantineRuntime).not.toHaveBeenCalled();
+      }
+    );
+
+    it('rejects an unknown native event when the pending attach proof expires without cleanup', async () => {
+      const fixture = sessionFixture();
+      const attach = deferred<ResponseFrame>();
+      fixture.setStatus({
+        physical: 'running',
+        connection: 'ready',
+        wrapperInstanceId: RUNTIME_ID,
+        operationResults: true,
+      });
+      delegateRequest(fixture, 'session.attach', () => attach.promise);
+      await fixture.admit('a');
+      await fixture.flush();
+      const authorization = fixture.record('a')?.operations?.attach?.authorization;
+      if (!authorization) throw new Error('Missing attach authorization');
+      const event = receiptedEvent(
+        1,
+        {
+          type: 'session.updated',
+          properties: { info: { id: 'kilo_root', title: 'Expired native startup' } },
+        },
+        RUNTIME_ID,
+        NEXT_RUNTIME_ID
+      );
+      vi.setSystemTime(sessionOperationExpiresAt(authorization) - 1);
+      await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+        applied: false,
+        retryable: true,
+      });
+      const before = structuredClone([...fixture.values]);
+      const events = fixture.eventQueries.findByEntityPrefix('');
+      vi.setSystemTime(sessionOperationExpiresAt(authorization));
+      await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+        applied: false,
+      });
+      expect([...fixture.values]).toEqual(before);
+      expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(events);
+      expect(fixture.values.has('native_runtime_fence')).toBe(false);
+      expect(await fixture.session.isSandboxCleanupScheduled()).toBe(false);
+      expect(fixture.control.quarantineRuntime).not.toHaveBeenCalled();
+    });
+  });
+
   it('allows B to reattach on the same wrapper only after native retirement is confirmed', async () => {
     const fixture = sessionFixture();
     const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
@@ -1315,6 +1963,32 @@ describe('SandboxSession orchestration', () => {
       wrapperInstanceId: RUNTIME_ID,
       nativeRuntimeId,
       authorization,
+    });
+    const originalEvent = receiptedEvent(
+      1,
+      {
+        type: 'session.status',
+        properties: { sessionID: 'kilo_root', status: { type: 'busy' } },
+      },
+      RUNTIME_ID,
+      nativeRuntimeId
+    );
+    const bufferedEvent = receiptedEvent(
+      2,
+      {
+        type: 'permission.asked',
+        properties: {
+          id: 'permission-a',
+          sessionID: 'kilo_root',
+          permission: 'bash',
+          patterns: ['*'],
+        },
+      },
+      RUNTIME_ID,
+      nativeRuntimeId
+    );
+    await expect(fixture.session.receiveSandboxControlEvent(originalEvent)).resolves.toEqual({
+      applied: true,
     });
     fixture.control.quarantineRuntime.mockImplementation(async input => {
       expect(input).toMatchObject({
@@ -1354,7 +2028,194 @@ describe('SandboxSession orchestration', () => {
       fixture.control.request.mock.calls.filter(([input]) => input.operation === 'session.prompt')
     ).toHaveLength(2);
     expect(await fixture.session.isSandboxCleanupScheduled()).toBe(false);
+    const nextAuthorization = fixture.record('b')?.operations?.attach?.authorization;
+    if (!nextAuthorization) throw new Error('Missing B attach authorization');
+    await fixture.session.recordNativeRuntime({
+      sandboxId: SANDBOX_ID,
+      wrapperInstanceId: RUNTIME_ID,
+      nativeRuntimeId: NEXT_RUNTIME_ID,
+      authorization: nextAuthorization,
+    });
+    fixture.reload();
+    const beforeReplay = fixture.eventQueries.findByEntityPrefix('');
+    const beforeMessage = fixture.record('b');
+    await expect(fixture.session.receiveSandboxControlEvent(bufferedEvent)).resolves.toEqual({
+      applied: false,
+    });
+    await expect(
+      fixture.session.receiveSandboxControlEvent(
+        receiptedEvent(
+          2,
+          { type: 'session.message.outcome', properties: { messageId: 'b', status: 'failed' } },
+          RUNTIME_ID,
+          nativeRuntimeId
+        )
+      )
+    ).resolves.toEqual({ applied: false });
+    expect(fixture.record('b')).toEqual(beforeMessage);
+    expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(beforeReplay);
+    expect(fixture.control.quarantineRuntime).toHaveBeenCalledTimes(1);
+    expect(fixture.values.get('control_event_receipts')).toMatchObject({
+      highWater: { [RUNTIME_ID]: 1 },
+    });
+    const nextEvent = receiptedEvent(
+      3,
+      {
+        type: 'permission.asked',
+        properties: {
+          id: 'permission-b',
+          sessionID: 'kilo_root',
+          permission: 'bash',
+          patterns: ['*'],
+        },
+      },
+      RUNTIME_ID,
+      NEXT_RUNTIME_ID
+    );
+    await expect(fixture.session.receiveSandboxControlEvent(nextEvent)).resolves.toEqual({
+      applied: true,
+    });
+    const events = fixture.eventQueries.findByEntityPrefix('');
+    await expect(fixture.session.receiveSandboxControlEvent(originalEvent)).resolves.toEqual({
+      applied: true,
+    });
+    await expect(
+      fixture.session.receiveSandboxControlEvent({
+        ...originalEvent,
+        identity: { ...originalEvent.identity, nativeRuntimeId: NEXT_RUNTIME_ID },
+      })
+    ).resolves.toEqual({ applied: false });
+    await fixture.session.failWaitingMessages('late-native-failure', RUNTIME_ID, nativeRuntimeId);
+    await fixture.session.invalidateTerminalRuntime({
+      sandboxId: SANDBOX_ID,
+      wrapperInstanceId: RUNTIME_ID,
+      nativeRuntimeId,
+      confirmed: true,
+    });
+    expect(fixture.record('b')?.state).toBe('accepted');
+    expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(events);
+    expect(fixture.values.get('control_event_receipts')).toMatchObject({
+      activeWrapperInstanceId: RUNTIME_ID,
+      highWater: { [RUNTIME_ID]: 3 },
+      retiredWrapperInstanceIds: [],
+    });
   });
+
+  it('binds a new wrapper receipt lifetime when B starts unbound after idle recycle', async () => {
+    const fixture = sessionFixture();
+    await fixture.admit('a');
+    await fixture.flush();
+    const originalEvent = receiptedEvent(1, {
+      type: 'session.message.outcome',
+      properties: { messageId: 'a', status: 'completed' },
+    });
+    await expect(fixture.session.receiveSandboxControlEvent(originalEvent)).resolves.toEqual({
+      applied: true,
+    });
+    const ready = deferred<ControlStatus>();
+    fixture.control.ensureReady.mockImplementationOnce(() => ready.promise);
+    await fixture.admit('b');
+    await fixture.flush();
+    expect(fixture.record('b')).toMatchObject({ state: 'queued' });
+    expect(fixture.record('b')?.wrapperInstanceId).toBeUndefined();
+    fixture.setStatus({
+      physical: 'running',
+      connection: 'ready',
+      wrapperInstanceId: NEXT_RUNTIME_ID,
+    });
+    ready.resolve({
+      physical: 'running',
+      connection: 'ready',
+      wrapperInstanceId: NEXT_RUNTIME_ID,
+      attachment: ATTACHMENT,
+    });
+    await fixture.flush();
+    expect(fixture.record('b')).toMatchObject({
+      state: 'accepted',
+      wrapperInstanceId: NEXT_RUNTIME_ID,
+    });
+    expect(fixture.values.get('control_event_receipts')).toMatchObject({
+      activeWrapperInstanceId: NEXT_RUNTIME_ID,
+      highWater: {},
+      retiredWrapperInstanceIds: [RUNTIME_ID],
+    });
+    fixture.reload();
+    const nextEvent = receiptedEvent(
+      1,
+      {
+        type: 'permission.asked',
+        properties: {
+          id: 'permission-b',
+          sessionID: 'kilo_root',
+          permission: 'bash',
+          patterns: ['*'],
+        },
+      },
+      NEXT_RUNTIME_ID
+    );
+    await expect(fixture.session.receiveSandboxControlEvent(nextEvent)).resolves.toEqual({
+      applied: true,
+    });
+    const events = fixture.eventQueries.findByEntityPrefix('');
+    await expect(fixture.session.receiveSandboxControlEvent(originalEvent)).resolves.toEqual({
+      applied: false,
+    });
+    await expect(
+      fixture.session.receiveSandboxControlEvent(
+        receiptedEvent(2, {
+          type: 'session.message.outcome',
+          properties: { messageId: 'b', status: 'failed' },
+        })
+      )
+    ).resolves.toEqual({ applied: false });
+    expect(fixture.record('b')?.state).toBe('accepted');
+    expect(fixture.eventQueries.findByEntityPrefix('')).toEqual(events);
+    expect(fixture.values.get('control_event_receipts')).toMatchObject({
+      activeWrapperInstanceId: NEXT_RUNTIME_ID,
+      highWater: { [NEXT_RUNTIME_ID]: 1 },
+    });
+  });
+
+  it.each(['native runtime', 'authorization'] as const)(
+    'does not release a newer same-wrapper cleanup when the %s changes during transfer',
+    async changed => {
+      const fixture = sessionFixture();
+      const authorization: SessionOperationAuthorization = {
+        operation: 'session.attach',
+        operationId: 'attach-a',
+        messageId: 'a',
+        session: { sessionId: SESSION_ID, kiloSessionId: 'kilo_root', directory: DIRECTORY },
+        wrapperInstanceId: RUNTIME_ID,
+        dispatchDeadlineAt: Date.now() + 30_000,
+      };
+      const pending = {
+        ownerId: 'user_1',
+        sessionId: SESSION_ID,
+        sandboxId: SANDBOX_ID,
+        wrapperInstanceId: RUNTIME_ID,
+        nativeRuntimeId: '11111111-1111-4111-8111-111111111111',
+        reason: 'runtime_unhealthy',
+        authorization,
+      };
+      fixture.values.set('pending_runtime_cleanup', pending);
+      const oldReply = deferred<RuntimeQuarantineResult>();
+      fixture.control.quarantineRuntime.mockImplementationOnce(() => oldReply.promise);
+      const oldTransfer = fixture.fireAlarm();
+      await fixture.flush();
+      expect(fixture.control.quarantineRuntime).toHaveBeenCalledTimes(1);
+      const newer = {
+        ...pending,
+        ...(changed === 'native runtime'
+          ? { nativeRuntimeId: NEXT_RUNTIME_ID }
+          : { authorization: { ...authorization, operationId: 'attach-b', messageId: 'b' } }),
+      };
+      fixture.values.set('pending_runtime_cleanup', newer);
+      oldReply.resolve({ quarantined: true, disposition: 'native_retired' });
+      await oldTransfer;
+      expect(fixture.values.get('pending_runtime_cleanup')).toEqual(newer);
+      expect(await fixture.session.isSandboxCleanupScheduled()).toBe(true);
+    }
+  );
 
   it('keeps cleanup pending when a target-scoped quarantine is unconfirmed without a successor', async () => {
     const fixture = sessionFixture();
@@ -4190,6 +5051,16 @@ describe('SandboxSession durable Stop wiring', () => {
     return createControlStopRequest(state, Date.now(), operationId);
   }
 
+  it('exposes explicit idle ownership to recovery without manufacturing a Stop target', async () => {
+    const fixture = sessionFixture();
+    expect(await fixture.session.getControlState()).toBeNull();
+    expect(await fixture.session.getControlState({ includeIdle: true })).toMatchObject({
+      version: 1,
+      scope: { sandboxId: expect.any(String) },
+      targets: [],
+    });
+  });
+
   it('keeps the Stop receipt absent when the paired message transaction fails', async () => {
     const fixture = sessionFixture();
     await fixture.admit('a');
@@ -4236,6 +5107,37 @@ describe('SandboxSession durable Stop wiring', () => {
         operationId: request.operationId,
         cleanupDeadlineAt: request.cleanupDeadlineAt,
       },
+    });
+  });
+
+  it('retains the immutable pending Stop receipt after A leaves active recovery targets', async () => {
+    const fixture = sessionFixture();
+    await fixture.admit('a');
+    await fixture.flush();
+    const request = await stopRequest(fixture, '33333333-3333-4333-8333-333333333336');
+
+    await expect(fixture.session.interruptExecution(request)).resolves.toMatchObject({
+      state: 'accepted',
+      cleanupDeadlineAt: request.cleanupDeadlineAt,
+    });
+    const recovered = await fixture.session.getControlState();
+
+    expect(recovered).toMatchObject({
+      targets: [],
+      stops: [
+        {
+          operationId: request.operationId,
+          scope: request.scope,
+          targets: request.targets,
+          cleanupDeadlineAt: request.cleanupDeadlineAt,
+          state: 'accepted',
+        },
+      ],
+    });
+    await expect(fixture.session.interruptExecution(request)).resolves.toMatchObject({
+      operationId: request.operationId,
+      cleanupDeadlineAt: request.cleanupDeadlineAt,
+      state: 'accepted',
     });
   });
 

--- a/services/cloud-agent-next/src/sandbox-session/session-message-queue.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-message-queue.ts
@@ -40,6 +40,7 @@ export type SessionOperationProof = {
   authorization: SessionOperationAuthorization;
   dispatched: boolean;
   executionDeadlineAt?: number;
+  executionDeadlineSource?: 'dispatch' | 'wrapper';
   result?: SessionOperationDelivery['result'];
   resultHash?: string;
   completedAt?: number;
@@ -559,6 +560,7 @@ export function recordSessionOperationDispatch(
                     executionDeadlineAt:
                       item.executionDeadlineAt ??
                       authorization.dispatchDeadlineAt + SANDBOX_CONTROL_EXECUTION_TIMEOUT_MS,
+                    executionDeadlineSource: proof?.executionDeadlineSource ?? 'dispatch',
                   }
                 : {}),
             },
@@ -570,6 +572,43 @@ export function recordSessionOperationDispatch(
                   authorization.dispatchDeadlineAt + SANDBOX_CONTROL_EXECUTION_TIMEOUT_MS,
               }
             : {}),
+        }
+      : item
+  );
+}
+
+export function recordSessionOperationExecutionDeadline(
+  messages: readonly SessionMessageRecord[],
+  authorization: SessionOperationAuthorization,
+  executionDeadlineAt: number
+): SessionMessageRecord[] | undefined {
+  const message = messages.find(item => item.messageId === authorization.messageId);
+  const prompt = message?.operations?.prompt;
+  const storedAuthorization = sessionOperationAuthorizationSchema.safeParse(prompt?.authorization);
+  if (
+    authorization.operation !== 'session.prompt' ||
+    !Number.isSafeInteger(executionDeadlineAt) ||
+    executionDeadlineAt <= 0 ||
+    !message ||
+    !prompt?.dispatched ||
+    !storedAuthorization.success ||
+    !sameSessionOperation(storedAuthorization.data, authorization)
+  )
+    return undefined;
+  if (prompt.executionDeadlineSource === 'wrapper') return [...messages];
+  return messages.map(item =>
+    item.messageId === message.messageId
+      ? {
+          ...item,
+          executionDeadlineAt,
+          operations: {
+            ...item.operations,
+            prompt: {
+              ...prompt,
+              executionDeadlineAt,
+              executionDeadlineSource: 'wrapper',
+            },
+          },
         }
       : item
   );

--- a/services/cloud-agent-next/src/sandbox-session/session-operation.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-operation.ts
@@ -24,6 +24,7 @@ import {
   applySessionOperationResult,
   completeSessionOperationAttachment,
   recordSessionOperationDispatch,
+  recordSessionOperationExecutionDeadline,
   type SessionMessageRecord,
 } from './session-message-queue.js';
 import { applyControlPlanePreparingEvent } from './control-plane-preparing.js';
@@ -46,6 +47,10 @@ export type SessionOperationEffects = {
   assertAdmission: () => void;
   assertScope: () => void;
   defer: (pending: Promise<void>) => void;
+  recordExecutionDeadline?: (
+    authorization: SessionOperationAuthorization,
+    executionDeadlineAt: number
+  ) => boolean;
 };
 
 type RunningOperation = Extract<
@@ -123,6 +128,12 @@ export async function reconcileSessionOperation(
       lookup.state === 'completed' ? lookup.delivery.authorization : lookup.authorization;
     if (!sameSessionOperation(observed, authorization))
       throw new Error('Operation observation identity changed');
+    if (
+      lookup.state === 'running' &&
+      lookup.executionDeadlineAt !== undefined &&
+      effects.recordExecutionDeadline?.(authorization, lookup.executionDeadlineAt) === false
+    )
+      return { state: 'uncertain', reason: 'unverified' };
     if (lookup.state === 'completed') {
       if (
         (await persistSessionOperationDelivery(lookup.delivery, operationDeadlineAt, effects)) ===
@@ -168,7 +179,17 @@ export async function dispatchSessionOperation(
       const lookup = await reconcileSessionOperation(
         authorization,
         sessionOperationExpiresAt(authorization),
-        effects
+        {
+          ...effects,
+          recordExecutionDeadline: (original, executionDeadlineAt) => {
+            const updated = recordSessionOperationExecutionDeadline(
+              messages.read(),
+              original,
+              executionDeadlineAt
+            );
+            return updated !== undefined && messages.commit(updated);
+          },
+        }
       );
       if (lookup.state !== 'completed') return lookup;
       if (!lookup.delivery.result.ok)
@@ -220,6 +241,15 @@ export async function dispatchSessionOperation(
       const prompt = sessionPromptResultSchema.parse(result);
       if (prompt.messageId !== authorization.messageId)
         throw new Error('Prompt response message identity mismatch');
+      if (prompt.executionDeadlineAt !== undefined) {
+        const updated = recordSessionOperationExecutionDeadline(
+          messages.read(),
+          authorization,
+          prompt.executionDeadlineAt
+        );
+        if (!updated || !messages.commit(updated))
+          return { state: 'uncertain', reason: 'unverified' };
+      }
       return { state: 'response', result: prompt };
     } catch (error) {
       if (rejectedBeforeAdmission(error)) record(false);

--- a/services/cloud-agent-next/src/sandbox-session/session-stop.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-stop.test.ts
@@ -3,6 +3,7 @@ import type { ControlStopRequest } from '../shared/control-plane-session.js';
 import type { SessionOperationAuthorization } from '../shared/sandbox-control-protocol.js';
 import {
   recordSessionOperationDispatch,
+  recordSessionOperationExecutionDeadline,
   type SessionMessageRecord,
 } from './session-message-queue.js';
 import { admitSessionStop, type PersistedSessionStop } from './session-stop.js';
@@ -181,5 +182,37 @@ describe('execution deadline persistence', () => {
 
     expect(admission.receipt).toMatchObject({ cleanupDeadlineAt: 11_000 });
     expect(admission.messages).toMatchObject([{ executionDeadlineAt: 3_611_000 }]);
+  });
+
+  it('replaces the dispatch ceiling once with the original wrapper execution boundary', () => {
+    const authorization: SessionOperationAuthorization = {
+      operation: 'session.prompt',
+      operationId: 'message-a',
+      messageId: 'message-a',
+      session: { sessionId: 'workspace-a', kiloSessionId: 'kilo-a', directory: '/workspace/a' },
+      wrapperInstanceId: RUNTIME_A,
+      dispatchDeadlineAt: 31_000,
+    };
+    const dispatched = recordSessionOperationDispatch(
+      [message('message-a', 'queued', RUNTIME_A)],
+      authorization
+    );
+    if (!dispatched) throw new Error('Initial dispatch proof was not recorded');
+
+    const started = recordSessionOperationExecutionDeadline(dispatched, authorization, 3_600_500);
+    if (!started) throw new Error('Wrapper execution boundary was not recorded');
+    const replayedBoundary = recordSessionOperationExecutionDeadline(
+      started,
+      authorization,
+      3_700_000
+    );
+    if (!replayedBoundary) throw new Error('Stored execution boundary was not preserved');
+    const recovered = recordSessionOperationDispatch(
+      structuredClone(replayedBoundary),
+      authorization
+    );
+
+    expect(recovered).toMatchObject([{ executionDeadlineAt: 3_600_500 }]);
+    expect(recovered?.[0]?.operations?.prompt).toMatchObject({ executionDeadlineAt: 3_600_500 });
   });
 });

--- a/services/cloud-agent-next/src/shared/control-event-canonical.ts
+++ b/services/cloud-agent-next/src/shared/control-event-canonical.ts
@@ -1,0 +1,35 @@
+export function canonicalizeControlEvent(value: unknown): unknown {
+  const ancestors = new Set<object>();
+
+  const normalize = (current: unknown, arrayItem = false): unknown => {
+    if (current === undefined) return arrayItem ? null : undefined;
+    if (current === null || typeof current === 'string' || typeof current === 'boolean')
+      return current;
+    if (typeof current === 'number') {
+      if (!Number.isFinite(current)) throw new Error('Control event contains an invalid number');
+      return current;
+    }
+    if (Array.isArray(current)) return current.map(item => normalize(item, true));
+    if (typeof current !== 'object') throw new Error('Control event contains an unsupported value');
+    if (ancestors.has(current)) throw new Error('Control event contains a cycle');
+    ancestors.add(current);
+    try {
+      const normalized: Record<string, unknown> = {};
+      for (const key of Object.keys(current).sort()) {
+        const item = normalize((current as Record<string, unknown>)[key]);
+        if (item !== undefined) normalized[key] = item;
+      }
+      return normalized;
+    } finally {
+      ancestors.delete(current);
+    }
+  };
+
+  const normalized = normalize(value);
+  if (normalized === undefined) throw new Error('Control event contains an unsupported value');
+  return normalized;
+}
+
+export function canonicalControlEventJson(value: unknown): string {
+  return JSON.stringify(canonicalizeControlEvent(value));
+}

--- a/services/cloud-agent-next/src/shared/control-plane-session.ts
+++ b/services/cloud-agent-next/src/shared/control-plane-session.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS,
+  sessionOperationAuthorizationSchema,
   wrapperInstanceIdSchema,
 } from './sandbox-control-protocol.js';
 
@@ -31,14 +32,6 @@ export const controlStopRequestSchema = z
   })
   .strict();
 
-export const controlSessionStateSchema = z
-  .object({
-    version: z.literal(1),
-    scope: controlStopScopeSchema,
-    targets: z.array(controlStopTargetSchema).min(1),
-  })
-  .strict();
-
 export const controlStopReceiptSchema = z
   .object({
     version: z.literal(1),
@@ -50,6 +43,27 @@ export const controlStopReceiptSchema = z
     message: z.string().optional(),
   })
   .strict();
+
+export const controlSessionStateSchema = z
+  .object({
+    version: z.literal(1),
+    scope: controlStopScopeSchema,
+    targets: z.array(controlStopTargetSchema),
+    stops: z.array(controlStopReceiptSchema).optional(),
+    operations: z
+      .array(
+        z
+          .object({
+            messageId: z.string().min(1),
+            authorization: sessionOperationAuthorizationSchema,
+            executionDeadlineAt: timestampSchema.optional(),
+          })
+          .strict()
+      )
+      .optional(),
+  })
+  .strict()
+  .refine(value => value.targets.length > 0 || (value.stops?.length ?? 0) > 0);
 
 export type ControlStopRequest = z.infer<typeof controlStopRequestSchema>;
 export type ControlSessionState = z.infer<typeof controlSessionStateSchema>;

--- a/services/cloud-agent-next/src/shared/sandbox-control-protocol.ts
+++ b/services/cloud-agent-next/src/shared/sandbox-control-protocol.ts
@@ -34,10 +34,13 @@ export const SANDBOX_CONTROL_OPERATION_LIMIT = 32;
 export const SANDBOX_CONTROL_OUTCOME_TIMEOUT_MS = 90_000;
 export const SANDBOX_CONTROL_OUTCOME_RETRY_MS = 1_000;
 export const SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS = 3;
+export const SANDBOX_CONTROL_RECOVERY_ATTEMPT_TIMEOUT_MS = 30_000;
 
 export const SANDBOX_OPERATIONS = [
   'sandbox.hello',
   'sandbox.status',
+  'sandbox.reconcile',
+  'sandbox.event.publish',
   'sandbox.shutdown',
   'worktree.prepareDeletion',
   'worktree.delete',
@@ -84,6 +87,7 @@ export const controlErrorCodes = [
   'session_busy',
   'runtime_unhealthy',
   'idempotency_conflict',
+  'event_rejected',
 ] as const;
 
 export type ControlErrorCode = (typeof controlErrorCodes)[number];
@@ -106,6 +110,7 @@ export const sessionRequestIdentitySchema = z.object({
 
 export const sessionEventIdentitySchema = z.object({
   directory: z.string().min(1),
+  nativeRuntimeId: z.string().uuid().optional(),
   kiloSessionId: z.string().min(1).optional(),
   rootKiloSessionId: z.string().min(1).optional(),
 });
@@ -165,6 +170,8 @@ export const sandboxHelloPayloadSchema = z.object({
       sessionOperationResults: z.boolean().optional(),
       scopedStopAbort: z.boolean().optional(),
       nativeRuntimeRetirement: z.boolean().optional(),
+      connectionRecovery: z.boolean().optional(),
+      eventReceipts: z.boolean().optional(),
     })
     .optional(),
 });
@@ -178,12 +185,42 @@ export const sandboxHelloResultSchema = z.object({
       sessionOperationResults: z.boolean().optional(),
       scopedStopAbort: z.boolean().optional(),
       nativeRuntimeRetirement: z.boolean().optional(),
+      connectionRecovery: z.boolean().optional(),
+      eventReceipts: z.boolean().optional(),
     })
     .optional(),
 });
 
 export type SandboxHelloPayload = z.infer<typeof sandboxHelloPayloadSchema>;
 export type SandboxHelloResult = z.infer<typeof sandboxHelloResultSchema>;
+
+export const sandboxRecoverySchema = z
+  .object({
+    episodeId: z.string().uuid(),
+    cause: z.enum(['activation_pending', 'control_disconnected', 'heartbeat_expired']),
+    startedAt: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    deadlineAt: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    attempt: z.number().int().nonnegative().max(SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS),
+  })
+  .strict()
+  .refine(value => value.deadlineAt >= value.startedAt);
+
+export type SandboxRecovery = z.infer<typeof sandboxRecoverySchema>;
+
+export const sandboxReconcilePayloadSchema = z
+  .object({
+    recovery: sandboxRecoverySchema,
+    phase: z.enum(['drain', 'ready', 'commit']),
+  })
+  .strict();
+
+export const sandboxReconcileResultSchema = z
+  .object({
+    episodeId: z.string().uuid(),
+    attempt: z.number().int().nonnegative().max(SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS),
+    phase: z.enum(['drain', 'ready', 'commit']),
+  })
+  .strict();
 
 export const sandboxReadyPayloadSchema = z
   .object({
@@ -413,6 +450,7 @@ export const sessionPromptResultSchema = z
   .object({
     messageId: z.string().min(1).max(128),
     status: z.enum(['accepted', 'existing']),
+    executionDeadlineAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER).optional(),
   })
   .strict();
 
@@ -482,9 +520,11 @@ export const sessionAbortResultSchema = z
 
 export const sessionNativeRuntimeRetirementPayloadSchema = z
   .object({
+    retirementId: z.string().uuid(),
     directory: z.string().min(1),
     nativeRuntimeId: z.string().uuid(),
     reason: z.string().min(1).max(256),
+    cleanupDeadlineAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
   })
   .strict();
 
@@ -614,6 +654,33 @@ export const sessionPreparingPayloadSchema = z
   })
   .passthrough();
 
+export const sandboxEventPublicationPayloadSchema = z.discriminatedUnion('event', [
+  z
+    .object({
+      event: z.literal('session.event'),
+      receiptId: z.string().uuid(),
+      receiptHash: z.string().regex(/^[a-f0-9]{64}$/),
+      sequence: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+      session: sessionEventIdentitySchema,
+      payload: sessionEventPayloadSchema,
+    })
+    .strict(),
+  z
+    .object({
+      event: z.literal('session.preparing'),
+      receiptId: z.string().uuid(),
+      receiptHash: z.string().regex(/^[a-f0-9]{64}$/),
+      sequence: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+      session: sessionEventIdentitySchema,
+      payload: sessionPreparingPayloadSchema,
+    })
+    .strict(),
+]);
+
+export const sandboxEventPublicationResultSchema = z
+  .object({ receiptId: z.string().uuid(), applied: z.literal(true) })
+  .strict();
+
 export type SandboxReadyPayload = z.infer<typeof sandboxReadyPayloadSchema>;
 export type SandboxHeartbeatPayload = z.infer<typeof sandboxHeartbeatPayloadSchema>;
 export type SandboxStatusPayload = z.infer<typeof sandboxStatusPayloadSchema>;
@@ -647,6 +714,8 @@ export type SessionTerminalConnectPayload = z.infer<typeof sessionTerminalConnec
 export type SessionTerminalConnectResult = z.infer<typeof sessionTerminalConnectResultSchema>;
 export type SessionEventPayload = z.infer<typeof sessionEventPayloadSchema>;
 export type SessionPreparingPayload = z.infer<typeof sessionPreparingPayloadSchema>;
+export type SandboxEventPublicationPayload = z.infer<typeof sandboxEventPublicationPayloadSchema>;
+export type SandboxEventPublicationResult = z.infer<typeof sandboxEventPublicationResultSchema>;
 
 export const sessionOperationAuthorizationSchema = z
   .object({
@@ -746,6 +815,7 @@ export const sessionOperationLookupResultSchema = z.discriminatedUnion('state', 
     .object({
       state: z.literal('running'),
       authorization: sessionOperationAuthorizationSchema,
+      executionDeadlineAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER).optional(),
     })
     .strict(),
   z
@@ -816,11 +886,13 @@ export const sandboxControlSocketAttachmentSchema = z.object({
   acceptedAt: z.number().int().nonnegative(),
   connectionId: z.string().uuid().optional(),
   protocolVersion: z.literal(SANDBOX_CONTROL_PROTOCOL_VERSION).optional(),
+  recoveryCapable: z.boolean().optional(),
   capabilities: z
     .object({
       sessionOperationResults: z.boolean().optional(),
       scopedStopAbort: z.boolean().optional(),
       nativeRuntimeRetirement: z.boolean().optional(),
+      connectionRecovery: z.boolean().optional(),
     })
     .optional(),
   providerInstanceId: z.string().min(1).max(256).optional(),

--- a/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
+++ b/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
@@ -52,7 +52,7 @@ const workspacePreparations = new Map<string, Promise<ControlHandlerResult | und
 
 export type AttachPreparingEmitter = (
   event: PreparingEventDataV2,
-  options?: { retained?: true }
+  options?: { retained?: true; nativeRuntimeId?: string }
 ) => void;
 
 export type ApplyAttachDeps = {

--- a/services/cloud-agent-next/wrapper/src/control/control-event-ordering.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/control-event-ordering.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, mock, spyOn } from 'bun:test';
+import { MAX_SANDBOX_CONTROL_FRAME_BYTES } from '../../../src/shared/sandbox-control-protocol';
+import {
+  controlEventReceiptDisposition,
+  recordControlEventReceipt,
+} from '../../../src/sandbox-session/control-event-receipts';
+import { createControlEventTransport } from './control-event-transport';
+import { createControlEventOutbox, type ControlEventPublication } from './control-event-outbox';
+
+const session = {
+  directory: '/workspace',
+  kiloSessionId: 'ses_root',
+  rootKiloSessionId: 'ses_root',
+};
+const medium = {
+  type: 'message.updated',
+  properties: { text: 'm'.repeat(Math.floor(MAX_SANDBOX_CONTROL_FRAME_BYTES * 0.45)) },
+};
+const large = {
+  type: 'message.updated',
+  properties: { text: 'l'.repeat(Math.floor(MAX_SANDBOX_CONTROL_FRAME_BYTES * 0.7)) },
+};
+const small = { type: 'session.idle', properties: {} };
+
+function receiptStorage() {
+  const values = new Map<string, unknown>();
+  return {
+    get: <T>(key: string) => values.get(key) as T | undefined,
+    put: <T>(key: string, value: T) => {
+      values.set(key, value);
+    },
+  };
+}
+
+describe('control event publication ordering', () => {
+  it.each(['session.event', 'session.preparing'] as const)(
+    'backpressures a later synchronous %s behind a larger native event for the same Session',
+    async event => {
+      const storage = receiptStorage();
+      const wrapperInstanceId = crypto.randomUUID();
+      const applied: ControlEventPublication[] = [];
+      const rejected: ControlEventPublication[] = [];
+      const failure = mock();
+      const transport = createControlEventTransport({
+        supportsReceipts: () => true,
+        prepare: input => input,
+        publish: async publication => {
+          const receipt = { ...publication, wrapperInstanceId };
+          if (controlEventReceiptDisposition(storage, receipt) !== 'apply') {
+            rejected.push(publication);
+            return;
+          }
+          recordControlEventReceipt(storage, receipt);
+          applied.push(publication);
+        },
+        sendLegacy: () => false,
+        onFailure: failure,
+      });
+      try {
+        for (let index = 0; index < 8; index += 1)
+          expect(transport.enqueue('session.event', medium, session)).toBe(true);
+        const native = transport.publishSessionEvent(large, session);
+        const overtook = transport.enqueue(event, small, session);
+        await transport.resume();
+        expect(await native).toBe(true);
+        if (!overtook) expect(transport.enqueue(event, small, session)).toBe(true);
+        expect(await transport.resume()).toBe(true);
+        expect(rejected.map(publication => publication.sequence)).toEqual([]);
+        expect(overtook).toBe(false);
+        expect(applied.map(publication => publication.sequence)).toEqual([
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 11,
+        ]);
+        expect(applied[8]?.payload).toEqual(large);
+        expect(applied[9]?.payload).toEqual(small);
+        expect(failure).not.toHaveBeenCalled();
+      } finally {
+        transport.close();
+      }
+    }
+  );
+
+  it('keeps the older reservation through wakeup and preserves its original receipt', async () => {
+    const published: ControlEventPublication[] = [];
+    const outbox = createControlEventOutbox({
+      publish: async publication => {
+        published.push(publication);
+      },
+      onFailure: mock(),
+    });
+    try {
+      for (let index = 0; index < 8; index += 1)
+        expect(
+          outbox.enqueue(outbox.prepare({ event: 'session.event', session, payload: medium }))
+        ).toBe(true);
+      const older = outbox.prepare({ event: 'session.event', session, payload: large });
+      const original = structuredClone(older);
+      expect(outbox.enqueue(older)).toBe(false);
+      const waiting = outbox.waitForSpace(older);
+      const later = outbox.prepare({
+        event: 'session.preparing',
+        session: { ...session, kiloSessionId: 'ses_child' },
+        payload: small,
+      });
+      expect(outbox.enqueue(later)).toBe(false);
+      const draining = outbox.resume();
+      expect(await waiting).toBe(true);
+      expect(outbox.enqueue(later)).toBe(false);
+      expect(outbox.enqueue(older)).toBe(true);
+      expect(outbox.enqueue(later)).toBe(true);
+      await draining;
+      expect(await outbox.resume()).toBe(true);
+      expect(published.map(publication => publication.sequence)).toEqual([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+      ]);
+      expect(older).toEqual(original);
+      expect(published[8]).toMatchObject({
+        receiptId: original.receiptId,
+        receiptHash: original.receiptHash,
+        sequence: original.sequence,
+        session: original.session,
+        payload: original.payload,
+      });
+    } finally {
+      outbox.close();
+    }
+  });
+
+  it.each(['count', 'bytes'] as const)(
+    'bounds waiting reservations by %s and coalesces repeated waits',
+    async budget => {
+      const outbox = createControlEventOutbox({ publish: async () => {}, onFailure: mock() });
+      try {
+        for (let index = 0; index < (budget === 'count' ? 256 : 8); index += 1)
+          expect(
+            outbox.enqueue(
+              outbox.prepare({
+                event: 'session.event',
+                session,
+                payload: budget === 'count' ? small : medium,
+              })
+            )
+          ).toBe(true);
+        const prepare = () =>
+          outbox.prepare({
+            event: 'session.event',
+            session,
+            payload: budget === 'count' ? small : large,
+          });
+        const first = prepare();
+        const limit =
+          budget === 'count'
+            ? 256
+            : Math.floor((4 * MAX_SANDBOX_CONTROL_FRAME_BYTES) / first.bytes);
+        const waiting = [outbox.waitForSpace(first)];
+        for (let index = 1; index < limit; index += 1) waiting.push(outbox.waitForSpace(prepare()));
+        expect(outbox.waitForSpace(first)).toBe(waiting[0]);
+        expect(await outbox.waitForSpace(prepare())).toBe(false);
+        outbox.close();
+        expect(await Promise.all(waiting)).toEqual(Array.from({ length: limit }, () => false));
+      } finally {
+        outbox.close();
+      }
+    }
+  );
+
+  it('re-arms a woken reservation if another Session consumes the available bytes', async () => {
+    const outbox = createControlEventOutbox({ publish: async () => {}, onFailure: mock() });
+    try {
+      for (let index = 0; index < 8; index += 1)
+        expect(
+          outbox.enqueue(outbox.prepare({ event: 'session.event', session, payload: medium }))
+        ).toBe(true);
+      const older = outbox.prepare({ event: 'session.event', session, payload: large });
+      expect(outbox.enqueue(older)).toBe(false);
+      const waiting = outbox.waitForSpace(older);
+      expect(await outbox.resume()).toBe(true);
+      expect(await waiting).toBe(true);
+      outbox.pause();
+      const other = { ...session, kiloSessionId: 'ses_other', rootKiloSessionId: 'ses_other' };
+      for (let index = 0; index < 8; index += 1)
+        expect(
+          outbox.enqueue(
+            outbox.prepare({ event: 'session.event', session: other, payload: medium })
+          )
+        ).toBe(true);
+      expect(outbox.enqueue(older)).toBe(false);
+      const waitingAgain = outbox.waitForSpace(older);
+      expect(waitingAgain).not.toBe(waiting);
+      expect(outbox.waitForSpace(older)).toBe(waitingAgain);
+      let settled = false;
+      void waitingAgain.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      outbox.close();
+      expect(await waitingAgain).toBe(false);
+    } finally {
+      outbox.close();
+    }
+  });
+
+  it('releases an expired ordering reservation and wakes its same-root successor', async () => {
+    const clock = spyOn(Date, 'now').mockReturnValue(1_000);
+    const timers = spyOn(globalThis, 'setTimeout');
+    const failure = mock();
+    const outbox = createControlEventOutbox({ publish: async () => {}, onFailure: failure });
+    try {
+      for (let index = 0; index < 8; index += 1)
+        expect(
+          outbox.enqueue(outbox.prepare({ event: 'session.event', session, payload: medium }))
+        ).toBe(true);
+      const older = outbox.prepare({ event: 'session.event', session, payload: large });
+      expect(outbox.enqueue(older)).toBe(false);
+      const waiting = outbox.waitForSpace(older);
+      const expire = timers.mock.calls.at(-1)?.[0];
+      if (typeof expire !== 'function') throw new Error('Missing reservation deadline');
+      clock.mockReturnValue(2_000);
+      const later = outbox.prepare({ event: 'session.preparing', session, payload: small });
+      expect(outbox.enqueue(later)).toBe(false);
+      const laterWaiting = outbox.waitForSpace(later);
+      clock.mockReturnValue(older.deadlineAt);
+      expire();
+      expect(await waiting).toBe(true);
+      expect(await laterWaiting).toBe(true);
+      expect(outbox.enqueue(older)).toBe(true);
+      expect(failure).toHaveBeenCalledWith({ reason: 'expired', publication: older });
+      expect(outbox.enqueue(later)).toBe(true);
+    } finally {
+      outbox.close();
+      timers.mockRestore();
+      clock.mockRestore();
+    }
+  });
+});

--- a/services/cloud-agent-next/wrapper/src/control/control-event-outbox.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/control-event-outbox.test.ts
@@ -1,0 +1,484 @@
+import { describe, expect, it, mock, spyOn } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { canonicalControlEventJson } from '../../../src/shared/control-event-canonical';
+import { ControlDeliveryError } from './sandbox-control-client';
+import { createControlEventOutbox, type ControlEventPublication } from './control-event-outbox';
+import {
+  MAX_SANDBOX_CONTROL_FRAME_BYTES,
+  sandboxEventPublicationPayloadSchema,
+} from '../../../src/shared/sandbox-control-protocol';
+
+const session = {
+  directory: '/workspace',
+  kiloSessionId: 'ses_root',
+  rootKiloSessionId: 'ses_root',
+};
+
+describe('control event outbox', () => {
+  it('snapshots native lifetime before replacement and binds it into the receipt hash', async () => {
+    const published: ControlEventPublication[] = [];
+    const outbox = createControlEventOutbox({
+      publish: async publication => {
+        published.push(publication);
+      },
+      onFailure: mock(),
+    });
+    const nativeRuntimeId = crypto.randomUUID();
+    const identity = { ...session, nativeRuntimeId };
+    const payload = { type: 'session.status', properties: { status: { type: 'idle' } } };
+    const first = outbox.prepare({ event: 'session.event', session: identity, payload });
+    expect(outbox.enqueue(first)).toBe(true);
+    identity.nativeRuntimeId = crypto.randomUUID();
+    expect(
+      outbox.enqueue(outbox.prepare({ event: 'session.event', session: identity, payload }))
+    ).toBe(true);
+    expect(await outbox.resume()).toBe(true);
+    expect(published.map(item => item.session.nativeRuntimeId)).toEqual([
+      nativeRuntimeId,
+      identity.nativeRuntimeId,
+    ]);
+    const { bytes, deadlineAt, ...wire } = first;
+    expect(bytes).toBeGreaterThan(0);
+    expect(deadlineAt).toBeGreaterThan(Date.now());
+    const parsed = sandboxEventPublicationPayloadSchema.parse(wire);
+    expect(wire).toEqual(parsed);
+    const hash = (value: unknown) =>
+      createHash('sha256').update(canonicalControlEventJson(value)).digest('hex');
+    const content = {
+      event: parsed.event,
+      session: parsed.session,
+      payload: parsed.payload,
+      sequence: parsed.sequence,
+    };
+    expect(hash(content)).toBe(first.receiptHash);
+    expect(hash({ ...content, session: identity })).not.toBe(first.receiptHash);
+    expect(hash({ ...content, session })).not.toBe(first.receiptHash);
+    expect(
+      sandboxEventPublicationPayloadSchema.safeParse({
+        ...wire,
+        session: { ...session, nativeRuntimeId: 'invalid' },
+      }).success
+    ).toBe(false);
+    expect(() =>
+      outbox.prepare({
+        event: 'session.event',
+        session: { ...session, nativeRuntimeId: 'invalid' },
+        payload,
+      })
+    ).toThrow();
+  });
+
+  it('keeps receipt publications without native identity wire-compatible', () => {
+    const outbox = createControlEventOutbox({ publish: async () => {}, onFailure: mock() });
+    const publication = outbox.prepare({
+      event: 'session.event',
+      session,
+      payload: { type: 'session.idle', properties: {} },
+    });
+    const { bytes, deadlineAt, ...wire } = publication;
+    expect(bytes).toBeGreaterThan(0);
+    expect(deadlineAt).toBeGreaterThan(Date.now());
+    expect(wire).toEqual(sandboxEventPublicationPayloadSchema.parse(wire));
+    expect(wire.session).toEqual(session);
+    expect(wire.receiptHash).toBe(
+      createHash('sha256')
+        .update(
+          canonicalControlEventJson({
+            event: wire.event,
+            session,
+            payload: wire.payload,
+            sequence: wire.sequence,
+          })
+        )
+        .digest('hex')
+    );
+  });
+
+  it('autonomously retries one stable receipt without future events or resume calls', async () => {
+    const published: Array<{ publication: ControlEventPublication; deadlineAt: number }> = [];
+    const retried = Promise.withResolvers<void>();
+    const failure = mock();
+    const outbox = createControlEventOutbox({
+      publish: async (publication, deadlineAt) => {
+        published.push({ publication, deadlineAt });
+        if (published.length === 1) throw new ControlDeliveryError('offline', true);
+        retried.resolve();
+      },
+      onFailure: failure,
+    });
+    try {
+      const publication = outbox.prepare({
+        event: 'session.event',
+        session,
+        payload: { type: 'message.updated', properties: { id: 'msg_1' } },
+      });
+      expect(outbox.enqueue(publication)).toBe(true);
+      expect(await outbox.resume()).toBe(false);
+      await retried.promise;
+      expect(await outbox.resume()).toBe(true);
+      expect(published).toHaveLength(2);
+      expect(published[1]).toEqual(published[0]);
+      expect(published[1]?.deadlineAt).toBe(publication.deadlineAt);
+      expect(failure).not.toHaveBeenCalled();
+    } finally {
+      outbox.close();
+    }
+  });
+
+  it('coalesces retry triggers and never overlaps publication attempts', async () => {
+    const retried = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const published: number[] = [];
+    const outbox = createControlEventOutbox({
+      publish: async publication => {
+        published.push(publication.sequence);
+        if (published.length === 1) throw new ControlDeliveryError('not attached', true);
+        if (published.length === 2) {
+          retried.resolve();
+          await release.promise;
+        }
+      },
+      onFailure: mock(),
+    });
+    const publication = () =>
+      outbox.prepare({ event: 'session.event', session, payload: { type: 'session.idle' } });
+    try {
+      outbox.enqueue(publication());
+      expect(await outbox.resume()).toBe(false);
+      for (let index = 0; index < 20; index += 1) {
+        outbox.enqueue(publication());
+        expect(await outbox.resume()).toBe(false);
+      }
+      expect(published).toEqual([1]);
+      await retried.promise;
+      const draining = outbox.resume();
+      for (let index = 0; index < 20; index += 1) expect(outbox.resume()).toBe(draining);
+      expect(published).toEqual([1, 1]);
+      release.resolve();
+      expect(await draining).toBe(true);
+      expect(published).toEqual([1, ...Array.from({ length: 21 }, (_, index) => index + 1)]);
+    } finally {
+      release.resolve();
+      outbox.close();
+    }
+  });
+
+  it('coalesces publication callbacks that synchronously enqueue and resume', async () => {
+    const published: number[] = [];
+    const outbox = createControlEventOutbox({
+      publish: async publication => {
+        published.push(publication.sequence);
+        if (published.length !== 1) return;
+        expect(
+          outbox.enqueue(
+            outbox.prepare({
+              event: 'session.event',
+              session,
+              payload: { type: 'session.idle' },
+            })
+          )
+        ).toBe(true);
+        void outbox.resume();
+      },
+      onFailure: mock(),
+    });
+    try {
+      outbox.enqueue(
+        outbox.prepare({
+          event: 'session.event',
+          session,
+          payload: { type: 'session.idle' },
+        })
+      );
+      expect(await outbox.resume()).toBe(true);
+      expect(published).toEqual([1, 2]);
+    } finally {
+      outbox.close();
+    }
+  });
+
+  it('settles an in-flight pump on close without reporting expiry or publishing queued events', async () => {
+    const started = Promise.withResolvers<void>();
+    const held = Promise.withResolvers<void>();
+    const failure = mock();
+    const published = mock(() => {
+      started.resolve();
+      return held.promise;
+    });
+    const outbox = createControlEventOutbox({ publish: published, onFailure: failure });
+    for (let index = 0; index < 2; index += 1)
+      outbox.enqueue(
+        outbox.prepare({
+          event: 'session.event',
+          session,
+          payload: { type: 'session.idle' },
+        })
+      );
+    const pumping = outbox.resume();
+    await started.promise;
+    outbox.close();
+    expect(await pumping).toBe(false);
+    held.reject(new ControlDeliveryError('late connection close', true));
+    await Promise.resolve();
+    expect(published).toHaveBeenCalledTimes(1);
+    expect(failure).not.toHaveBeenCalled();
+    expect(await outbox.resume()).toBe(false);
+  });
+
+  it.each(['retry', 'paused', 'pending'] as const)(
+    'expires an old native publication at its original deadline while %s and admits its replacement',
+    async phase => {
+      const clock = spyOn(Date, 'now').mockReturnValue(1_000);
+      const timers = spyOn(globalThis, 'setTimeout');
+      const failure = mock();
+      const held = Promise.withResolvers<void>();
+      const published: Array<{ publication: ControlEventPublication; deadlineAt: number }> = [];
+      const nativeRuntimeId = crypto.randomUUID();
+      const replacementId = crypto.randomUUID();
+      const outbox = createControlEventOutbox({
+        publish: async (publication, deadlineAt) => {
+          published.push({ publication, deadlineAt });
+          if (publication.session.nativeRuntimeId !== nativeRuntimeId) return;
+          if (phase === 'pending') return held.promise;
+          throw new ControlDeliveryError('not attached', true);
+        },
+        onFailure: failure,
+      });
+      try {
+        const original = outbox.prepare({
+          event: 'session.event',
+          session: { ...session, nativeRuntimeId },
+          payload: { type: 'session.idle' },
+        });
+        expect(original.deadlineAt).toBe(31_000);
+        outbox.enqueue(original);
+        clock.mockReturnValue(30_900);
+        outbox.enqueue(
+          outbox.prepare({
+            event: 'session.event',
+            session: { ...session, nativeRuntimeId: replacementId },
+            payload: { type: 'session.idle' },
+          })
+        );
+        const pumping = phase === 'paused' ? undefined : outbox.resume();
+        if (phase === 'retry') expect(await pumping).toBe(false);
+        else await Promise.resolve();
+        expect(timers.mock.calls.at(-1)?.[1]).toBe(100);
+        const expire = timers.mock.calls.at(-1)?.[0];
+        if (typeof expire !== 'function') throw new Error('Missing publication deadline');
+        clock.mockReturnValue(original.deadlineAt);
+        clearTimeout(
+          timers.mock.results.at(-1)?.value as ReturnType<typeof setTimeout> | undefined
+        );
+        expire();
+        await pumping;
+        expect(await outbox.resume()).toBe(true);
+        expect(failure).toHaveBeenCalledTimes(1);
+        expect(failure).toHaveBeenCalledWith({ reason: 'expired', publication: original });
+        expect(published.at(-1)?.publication.session.nativeRuntimeId).toBe(replacementId);
+        expect(
+          published.filter(item => item.publication.session.nativeRuntimeId === nativeRuntimeId)
+        ).toHaveLength(phase === 'paused' ? 0 : 1);
+        if (phase === 'pending') {
+          const unhandled: unknown[] = [];
+          const onUnhandled = (reason: unknown) => {
+            unhandled.push(reason);
+          };
+          process.on('unhandledRejection', onUnhandled);
+          try {
+            held.reject(new ControlDeliveryError('late old publication failure', false));
+            await Promise.resolve();
+            expect(unhandled).toEqual([]);
+          } finally {
+            process.off('unhandledRejection', onUnhandled);
+          }
+        }
+        await Promise.resolve();
+        expect(failure).toHaveBeenCalledTimes(1);
+      } finally {
+        held.resolve();
+        outbox.close();
+        timers.mockRestore();
+        clock.mockRestore();
+      }
+    }
+  );
+
+  it.each(['pause', 'close', 'permanent'] as const)(
+    'does not retry after %s and reports permanent failure only once',
+    async stop => {
+      const published = mock(async () => {
+        throw new ControlDeliveryError('unavailable', stop !== 'permanent');
+      });
+      const failure = mock();
+      const outbox = createControlEventOutbox({ publish: published, onFailure: failure });
+      try {
+        outbox.enqueue(
+          outbox.prepare({ event: 'session.event', session, payload: { type: 'session.idle' } })
+        );
+        expect(await outbox.resume()).toBe(stop === 'permanent');
+        if (stop === 'pause') outbox.pause();
+        else if (stop === 'close') outbox.close();
+        else {
+          expect(await outbox.resume()).toBe(true);
+          expect(await outbox.resume()).toBe(true);
+        }
+        await new Promise(resolve => setTimeout(resolve, 300));
+        expect(published).toHaveBeenCalledTimes(1);
+        expect(failure).toHaveBeenCalledTimes(stop === 'permanent' ? 1 : 0);
+      } finally {
+        outbox.close();
+      }
+    }
+  );
+
+  it('settles an expired backpressured publication without failing the replacement outbox', async () => {
+    const clock = spyOn(Date, 'now').mockReturnValue(1_000);
+    const timers = spyOn(globalThis, 'setTimeout');
+    const failure = mock();
+    const published = mock(async () => {});
+    const outbox = createControlEventOutbox({ publish: published, onFailure: failure });
+    const prepare = () =>
+      outbox.prepare({ event: 'session.event', session, payload: { type: 'session.idle' } });
+    try {
+      const expired = prepare();
+      clock.mockReturnValue(2_000);
+      for (let index = 0; index < 256; index += 1) expect(outbox.enqueue(prepare())).toBe(true);
+      expect(outbox.enqueue(expired)).toBe(false);
+      const waiting = outbox.waitForSpace(expired);
+      const expire = timers.mock.calls.at(-1)?.[0];
+      if (typeof expire !== 'function') throw new Error('Missing backpressure deadline');
+      clock.mockReturnValue(expired.deadlineAt);
+      clearTimeout(timers.mock.results.at(-1)?.value as ReturnType<typeof setTimeout> | undefined);
+      expire();
+      expect(await waiting).toBe(true);
+      expect(outbox.enqueue(expired)).toBe(true);
+      expect(failure).toHaveBeenCalledWith({ reason: 'expired', publication: expired });
+      expect(await outbox.resume()).toBe(true);
+      expect(published).toHaveBeenCalledTimes(256);
+    } finally {
+      outbox.close();
+      timers.mockRestore();
+      clock.mockRestore();
+    }
+  });
+
+  it('applies producer backpressure only after the bounded offline burst', () => {
+    const published = mock(async () => {});
+    const failed = mock();
+    const outbox = createControlEventOutbox({ publish: published, onFailure: failed });
+
+    for (let index = 0; index < 256; index += 1)
+      expect(
+        outbox.enqueue(
+          outbox.prepare({
+            event: 'session.event',
+            session,
+            payload: { type: 'message.updated', properties: { id: `msg_${index}` } },
+          })
+        )
+      ).toBe(true);
+    expect(
+      outbox.enqueue(
+        outbox.prepare({
+          event: 'session.event',
+          session,
+          payload: { type: 'message.updated', properties: { id: 'overflow' } },
+        })
+      )
+    ).toBe(false);
+    expect(failed).not.toHaveBeenCalled();
+    expect(published).not.toHaveBeenCalled();
+    outbox.close();
+  });
+
+  it('retains an immutable event snapshot across a sustained offline burst', async () => {
+    const published: Array<{ payload: { properties: { nested: { state: string } } } }> = [];
+    const outbox = createControlEventOutbox({
+      publish: async publication => {
+        published.push(publication as (typeof published)[number]);
+      },
+      onFailure: mock(),
+    });
+    const payload = { type: 'message.updated', properties: { nested: { state: 'queued' } } };
+    expect(outbox.enqueue(outbox.prepare({ event: 'session.event', session, payload }))).toBe(true);
+    payload.properties.nested.state = 'mutated';
+    for (let index = 0; index < 96; index += 1)
+      expect(
+        outbox.enqueue(
+          outbox.prepare({
+            event: 'session.event',
+            session,
+            payload: { type: 'message.updated', properties: { id: `burst_${index}` } },
+          })
+        )
+      ).toBe(true);
+
+    expect(await outbox.resume()).toBe(true);
+    expect(published).toHaveLength(97);
+    expect(published[0]?.payload.properties.nested.state).toBe('queued');
+  });
+
+  it('waits for the exact byte footprint of one prepared publication', async () => {
+    const firstPublication = Promise.withResolvers<void>();
+    let calls = 0;
+    const outbox = createControlEventOutbox({
+      publish: async () => {
+        calls += 1;
+        if (calls === 1) await firstPublication.promise;
+      },
+      onFailure: mock(),
+    });
+    const medium = () =>
+      outbox.prepare({
+        event: 'session.event',
+        session,
+        payload: {
+          type: 'message.updated',
+          properties: { text: 'm'.repeat(Math.floor(MAX_SANDBOX_CONTROL_FRAME_BYTES * 0.45)) },
+        },
+      });
+    for (let index = 0; index < 8; index += 1) expect(outbox.enqueue(medium())).toBe(true);
+    const blocked = outbox.prepare({
+      event: 'session.event',
+      session,
+      payload: {
+        type: 'message.updated',
+        properties: { text: 'l'.repeat(Math.floor(MAX_SANDBOX_CONTROL_FRAME_BYTES * 0.7)) },
+      },
+    });
+    expect(outbox.enqueue(blocked)).toBe(false);
+    const waiting = outbox.waitForSpace(blocked);
+    let settled = false;
+    void waiting.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    const pumping = outbox.resume();
+    firstPublication.resolve();
+    expect(await waiting).toBe(true);
+    expect(outbox.enqueue(blocked)).toBe(true);
+    await pumping;
+  });
+
+  it('wakes a blocked producer when the outbox closes', async () => {
+    const outbox = createControlEventOutbox({ publish: async () => {}, onFailure: mock() });
+    for (let index = 0; index < 256; index += 1)
+      outbox.enqueue(
+        outbox.prepare({
+          event: 'session.event',
+          session,
+          payload: { type: 'message.updated', properties: { id: `msg_${index}` } },
+        })
+      );
+    const blocked = outbox.prepare({
+      event: 'session.event',
+      session,
+      payload: { type: 'message.updated', properties: { id: 'blocked' } },
+    });
+    const waiting = outbox.waitForSpace(blocked);
+    outbox.close();
+    expect(await waiting).toBe(false);
+  });
+});

--- a/services/cloud-agent-next/wrapper/src/control/control-event-outbox.ts
+++ b/services/cloud-agent-next/wrapper/src/control/control-event-outbox.ts
@@ -1,0 +1,300 @@
+import { createHash } from 'node:crypto';
+import { canonicalControlEventJson } from '../../../src/shared/control-event-canonical.js';
+import {
+  MAX_SANDBOX_CONTROL_FRAME_BYTES,
+  sessionEventIdentitySchema,
+} from '../../../src/shared/sandbox-control-protocol.js';
+import type { SessionEventIdentity } from '../../../src/shared/sandbox-control-protocol.js';
+
+const MAX_EVENTS = 256;
+const MAX_BYTES = 4 * MAX_SANDBOX_CONTROL_FRAME_BYTES;
+const RETRY_DELAY_MS = 250;
+
+export type ControlEventPublication = {
+  event: 'session.event' | 'session.preparing';
+  receiptId: string;
+  receiptHash: string;
+  sequence: number;
+  session: SessionEventIdentity;
+  payload: unknown;
+};
+
+export type PreparedControlEventPublication = ControlEventPublication & {
+  bytes: number;
+  readonly deadlineAt: number;
+};
+
+export type ControlEventOutboxFailure = {
+  reason: 'expired' | 'rejected';
+  publication: ControlEventPublication;
+};
+
+export type ControlEventOutbox = {
+  prepare(
+    input: Omit<ControlEventPublication, 'receiptId' | 'receiptHash' | 'sequence'>
+  ): PreparedControlEventPublication;
+  enqueue(publication: PreparedControlEventPublication): boolean;
+  waitForSpace(publication: PreparedControlEventPublication): Promise<boolean>;
+  pause(): void;
+  resume(): Promise<boolean>;
+  close(): void;
+};
+
+export function createControlEventOutbox(options: {
+  publish: (publication: ControlEventPublication, deadlineAt: number) => Promise<void>;
+  onFailure: (failure: ControlEventOutboxFailure) => void;
+}): ControlEventOutbox {
+  const entries: PreparedControlEventPublication[] = [];
+  const spaceWaiters = new Map<
+    PreparedControlEventPublication,
+    {
+      promise: Promise<boolean>;
+      ready: boolean;
+      resolve: (available: boolean) => void;
+      timeout: ReturnType<typeof setTimeout>;
+    }
+  >();
+  let waitingBytes = 0;
+  let bytes = 0;
+  let paused = true;
+  let closed = false;
+  let pending: Promise<boolean> | undefined;
+  let nextSequence = 0;
+  let retryAt: number | undefined;
+  let wakeup: ReturnType<typeof setTimeout> | undefined;
+  let expirePending: (() => void) | undefined;
+
+  const clearWakeup = () => {
+    clearTimeout(wakeup);
+    wakeup = undefined;
+  };
+
+  const hasSpaceFor = (publication: PreparedControlEventPublication): boolean => {
+    if (entries.length >= MAX_EVENTS || bytes + publication.bytes > MAX_BYTES) return false;
+    const root = publication.session.rootKiloSessionId ?? publication.session.kiloSessionId;
+    for (const reserved of spaceWaiters.keys()) {
+      if (
+        reserved.sequence < publication.sequence &&
+        Date.now() < reserved.deadlineAt &&
+        reserved.session.directory === publication.session.directory &&
+        (reserved.session.rootKiloSessionId ?? reserved.session.kiloSessionId) === root
+      )
+        return false;
+    }
+    return true;
+  };
+
+  const releaseSpaceWaiter = (publication: PreparedControlEventPublication) => {
+    const waiter = spaceWaiters.get(publication);
+    if (!waiter) return;
+    clearTimeout(waiter.timeout);
+    spaceWaiters.delete(publication);
+    waitingBytes -= publication.bytes;
+    return waiter;
+  };
+
+  const notifySpace = (available: boolean) => {
+    const now = Date.now();
+    for (const [publication, waiter] of spaceWaiters) {
+      if (!available || now >= publication.deadlineAt) releaseSpaceWaiter(publication);
+      else if (!hasSpaceFor(publication)) continue;
+      waiter.ready = true;
+      waiter.resolve(available);
+    }
+  };
+
+  const prepare = (
+    input: Omit<ControlEventPublication, 'receiptId' | 'receiptHash' | 'sequence'>
+  ): PreparedControlEventPublication => {
+    const snapshot = JSON.parse(
+      canonicalControlEventJson({
+        ...input,
+        session: sessionEventIdentitySchema.parse(input.session),
+      })
+    ) as Omit<ControlEventPublication, 'receiptId' | 'receiptHash' | 'sequence'>;
+    const sequence = nextSequence + 1;
+    const receiptId = crypto.randomUUID();
+    const receiptHash = createHash('sha256')
+      .update(canonicalControlEventJson({ ...snapshot, sequence }))
+      .digest('hex');
+    nextSequence = sequence;
+    const publication = { ...snapshot, sequence, receiptId, receiptHash };
+    const bytes = Buffer.byteLength(
+      JSON.stringify({
+        type: 'request',
+        requestId: '00000000-0000-4000-8000-000000000000',
+        operation: 'sandbox.event.publish',
+        payload: publication,
+      })
+    );
+    if (bytes > MAX_SANDBOX_CONTROL_FRAME_BYTES)
+      throw new Error('Control event exceeds the frame budget');
+    return { ...publication, bytes, deadlineAt: Date.now() + 30_000 };
+  };
+
+  const removeHead = (entry: PreparedControlEventPublication) => {
+    entries.shift();
+    bytes -= entry.bytes;
+    retryAt = undefined;
+    notifySpace(true);
+  };
+
+  const expireHead = () => {
+    while (entries[0] && Date.now() >= entries[0].deadlineAt) {
+      const entry = entries[0];
+      removeHead(entry);
+      options.onFailure({ reason: 'expired', publication: entry });
+    }
+  };
+
+  const scheduleWakeup = () => {
+    clearWakeup();
+    const entry = entries[0];
+    if (closed || pending || !entry) return;
+    const nextAt = paused ? entry.deadlineAt : Math.min(retryAt ?? Date.now(), entry.deadlineAt);
+    wakeup = setTimeout(
+      () => {
+        wakeup = undefined;
+        expireHead();
+        if (!paused) void pump();
+        else scheduleWakeup();
+      },
+      Math.max(1, nextAt - Date.now())
+    );
+    wakeup.unref();
+  };
+
+  const pump = (): Promise<boolean> => {
+    if (pending) return pending;
+    if (closed) return Promise.resolve(false);
+    expireHead();
+    if (paused || (retryAt !== undefined && Date.now() < retryAt)) {
+      scheduleWakeup();
+      return Promise.resolve(entries.length === 0);
+    }
+    clearWakeup();
+    pending = Promise.resolve()
+      .then(async () => {
+        while (!paused && !closed) {
+          expireHead();
+          const entry = entries[0];
+          if (!entry) return true;
+          let timeout: ReturnType<typeof setTimeout> | undefined;
+          const published = options.publish(
+            {
+              event: entry.event,
+              receiptId: entry.receiptId,
+              receiptHash: entry.receiptHash,
+              sequence: entry.sequence,
+              session: entry.session,
+              payload: entry.payload,
+            },
+            entry.deadlineAt
+          );
+          try {
+            const expired = new Promise<void>(resolve => {
+              expirePending = resolve;
+              timeout = setTimeout(resolve, Math.max(1, entry.deadlineAt - Date.now()));
+              timeout.unref();
+            });
+            await Promise.race([published, expired]);
+          } catch (error) {
+            if (closed || Date.now() >= entry.deadlineAt) {
+              void published.catch(() => undefined);
+              if (closed) return false;
+              continue;
+            }
+            if (!(error instanceof Error) || !('retryable' in error) || error.retryable !== true) {
+              removeHead(entry);
+              options.onFailure({ reason: 'rejected', publication: entry });
+              continue;
+            }
+            retryAt = Date.now() + RETRY_DELAY_MS;
+            return false;
+          } finally {
+            clearTimeout(timeout);
+            expirePending = undefined;
+          }
+          if (closed || Date.now() >= entry.deadlineAt) {
+            void published.catch(() => undefined);
+            if (closed) return false;
+            continue;
+          }
+          removeHead(entry);
+        }
+        return entries.length === 0;
+      })
+      .finally(() => {
+        pending = undefined;
+        scheduleWakeup();
+      });
+    return pending;
+  };
+
+  return {
+    prepare,
+    enqueue(publication) {
+      if (closed) return false;
+      if (Date.now() >= publication.deadlineAt) {
+        releaseSpaceWaiter(publication)?.resolve(true);
+        notifySpace(true);
+        options.onFailure({ reason: 'expired', publication });
+        return true;
+      }
+      if (!hasSpaceFor(publication)) return false;
+      entries.push({ ...publication });
+      bytes += publication.bytes;
+      releaseSpaceWaiter(publication)?.resolve(true);
+      notifySpace(true);
+      if (!paused) void pump();
+      else scheduleWakeup();
+      return true;
+    },
+    waitForSpace(publication) {
+      if (closed) return Promise.resolve(false);
+      if (Date.now() >= publication.deadlineAt) return Promise.resolve(true);
+      const existing = spaceWaiters.get(publication);
+      if (existing) {
+        if (existing.ready && !hasSpaceFor(publication)) {
+          const { promise, resolve } = Promise.withResolvers<boolean>();
+          existing.promise = promise;
+          existing.resolve = resolve;
+          existing.ready = false;
+        }
+        return existing.promise;
+      }
+      if (spaceWaiters.size >= MAX_EVENTS || waitingBytes + publication.bytes > MAX_BYTES)
+        return Promise.resolve(false);
+      const { promise, resolve } = Promise.withResolvers<boolean>();
+      const timeout = setTimeout(
+        () => {
+          releaseSpaceWaiter(publication)?.resolve(true);
+          notifySpace(true);
+        },
+        Math.max(1, publication.deadlineAt - Date.now())
+      );
+      timeout.unref();
+      const ready = hasSpaceFor(publication);
+      spaceWaiters.set(publication, { promise, resolve, timeout, ready });
+      waitingBytes += publication.bytes;
+      if (ready) resolve(true);
+      return promise;
+    },
+    pause() {
+      paused = true;
+      scheduleWakeup();
+    },
+    resume() {
+      paused = false;
+      return pump();
+    },
+    close() {
+      closed = true;
+      clearWakeup();
+      expirePending?.();
+      entries.length = 0;
+      bytes = 0;
+      notifySpace(false);
+    },
+  };
+}

--- a/services/cloud-agent-next/wrapper/src/control/control-event-transport.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/control-event-transport.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, mock, spyOn } from 'bun:test';
+import {
+  createControlEventFailureHandler,
+  createControlEventTransport,
+} from './control-event-transport';
+import type { ControlEventOutboxFailure, ControlEventPublication } from './control-event-outbox';
+import { ControlDeliveryError } from './sandbox-control-client';
+import { createOperationRegistry } from './operation-registry';
+import { acknowledgeOperation, fakeKilo, operationAuthorization } from './control-test-fixtures';
+import type {
+  SessionOperationAck,
+  SessionOperationDelivery,
+} from '../../../src/shared/sandbox-control-protocol';
+import type { NativeRetirement } from './session-operation-cleanup';
+
+const session = {
+  directory: '/workspace',
+  kiloSessionId: 'ses_root',
+  rootKiloSessionId: 'ses_root',
+};
+const payload = { type: 'session.idle', properties: {} };
+
+describe('native-scoped control event failures', () => {
+  it.each(['expired', 'rejected'] as const)(
+    'reports an immutable N1 %s publication without retiring or blocking N2',
+    async reason => {
+      const clock = spyOn(Date, 'now').mockReturnValue(1_000);
+      const originalNativeId = crypto.randomUUID();
+      const identity = { ...session, nativeRuntimeId: originalNativeId };
+      const replacement = { runtimeId: crypto.randomUUID() };
+      const retired = mock();
+      const handleFailure = createControlEventFailureHandler({
+        getRuntime: directory => (directory === session.directory ? replacement : undefined),
+        onFailure: retired,
+      });
+      const failures: ControlEventOutboxFailure[] = [];
+      const published: ControlEventPublication[] = [];
+      const transport = createControlEventTransport({
+        supportsReceipts: () => true,
+        prepare: input => input,
+        publish: async publication => {
+          published.push(publication);
+          if (publication.sequence === 1) throw new ControlDeliveryError('rejected', false);
+        },
+        sendLegacy: () => false,
+        onFailure: failure => {
+          failures.push(failure);
+          handleFailure(failure);
+        },
+      });
+      try {
+        expect(transport.enqueue('session.event', payload, identity)).toBe(true);
+        identity.nativeRuntimeId = replacement.runtimeId;
+        clock.mockReturnValue(2_000);
+        expect(transport.enqueue('session.event', payload, identity)).toBe(true);
+        if (reason === 'expired') clock.mockReturnValue(31_000);
+        expect(await transport.resume()).toBe(true);
+        expect(failures).toHaveLength(1);
+        expect(failures[0]).toMatchObject({
+          reason,
+          publication: { sequence: 1, session: { ...session, nativeRuntimeId: originalNativeId } },
+        });
+        expect(retired).not.toHaveBeenCalled();
+        expect(published.at(-1)?.session.nativeRuntimeId).toBe(replacement.runtimeId);
+        expect(await transport.publishSessionEvent(payload, identity)).toBe(true);
+        expect(await transport.resume()).toBe(true);
+        expect(published.map(publication => publication.sequence)).toEqual(
+          reason === 'expired' ? [2, 3] : [1, 2, 3]
+        );
+        expect(failures).toHaveLength(1);
+        expect(retired).not.toHaveBeenCalled();
+      } finally {
+        transport.close();
+        clock.mockRestore();
+      }
+    }
+  );
+
+  it('coalesces retirement of the failed native lifetime without poisoning its replacement', async () => {
+    const original = { runtimeId: crypto.randomUUID() };
+    let current = original;
+    const retired = mock();
+    const handleFailure = createControlEventFailureHandler({
+      getRuntime: () => current,
+      onFailure: retired,
+    });
+    const failures: ControlEventOutboxFailure[] = [];
+    const published: ControlEventPublication[] = [];
+    const transport = createControlEventTransport({
+      supportsReceipts: () => true,
+      prepare: input => input,
+      publish: async publication => {
+        published.push(publication);
+        if (publication.session.nativeRuntimeId === original.runtimeId)
+          throw new ControlDeliveryError('rejected', false);
+      },
+      sendLegacy: () => false,
+      onFailure: failure => {
+        failures.push(failure);
+        handleFailure(failure);
+      },
+    });
+    try {
+      for (let index = 0; index < 2; index += 1)
+        expect(
+          transport.enqueue('session.event', payload, {
+            ...session,
+            nativeRuntimeId: original.runtimeId,
+          })
+        ).toBe(true);
+      expect(await transport.resume()).toBe(true);
+      expect(failures).toHaveLength(2);
+      expect(retired).toHaveBeenCalledTimes(1);
+      expect(retired).toHaveBeenCalledWith(failures[0], original);
+      current = { runtimeId: crypto.randomUUID() };
+      expect(
+        await transport.publishSessionEvent(payload, {
+          ...session,
+          nativeRuntimeId: current.runtimeId,
+        })
+      ).toBe(true);
+      expect(await transport.resume()).toBe(true);
+      expect(published.at(-1)?.session.nativeRuntimeId).toBe(current.runtimeId);
+      expect(retired).toHaveBeenCalledTimes(1);
+      const failure = failures[0];
+      if (!failure) throw new Error('Missing native failure');
+      handleFailure(failure);
+      handleFailure({
+        ...failure,
+        publication: {
+          ...failure.publication,
+          session: { ...session, nativeRuntimeId: current.runtimeId },
+        },
+      });
+      expect(retired).toHaveBeenCalledTimes(2);
+      expect(retired.mock.calls[1]?.[1]).toBe(current);
+    } finally {
+      transport.close();
+    }
+  });
+
+  it('preserves a sealed result and its acknowledgement when failure retires the matching native runtime', async () => {
+    const nativeLifetime = new AbortController();
+    const runtime = {
+      runtimeId: crypto.randomUUID(),
+      scopeId: 'scope_1',
+      directory: session.directory,
+      env: {},
+      kiloClient: fakeKilo(),
+      signal: nativeLifetime.signal,
+    };
+    const target = { runtimeId: runtime.runtimeId, client: runtime.kiloClient };
+    const nativeRetire = mock(async (): Promise<NativeRetirement> => {
+      nativeLifetime.abort();
+      return 'retired';
+    });
+    const registry = createOperationRegistry({
+      native: {
+        get: () => runtime,
+        getRetained: () => runtime,
+        retireRuntime: nativeRetire,
+        verifyQuiescence: async () => true,
+      },
+      onStarted: mock(),
+      onCompleted: mock(),
+      retireRuntime: mock(),
+    });
+    const sending = Promise.withResolvers<SessionOperationDelivery>();
+    const acknowledgement = Promise.withResolvers<SessionOperationAck>();
+    const authorization = operationAuthorization('session.attach');
+    const operation = registry.start(
+      authorization.session,
+      authorization,
+      {
+        operation: 'session.attach',
+        payload: {},
+        apply: async (_session, _payload, deps) => {
+          deps.onRuntime?.(runtime);
+          return { ok: true, result: { attached: true } };
+        },
+        onAttached: mock(),
+      },
+      {
+        emitSessionEvent: mock(),
+        sendOperationResult: delivery => {
+          sending.resolve(delivery);
+          return acknowledgement.promise;
+        },
+      }
+    );
+    await operation.done;
+    const sealed = await sending.promise;
+    let retirement: Promise<NativeRetirement> | undefined;
+    const transport = createControlEventTransport({
+      supportsReceipts: () => true,
+      prepare: input => input,
+      publish: async () => {
+        throw new ControlDeliveryError('rejected', false);
+      },
+      sendLegacy: () => false,
+      onFailure: createControlEventFailureHandler({
+        getRuntime: () => runtime,
+        onFailure: failure => {
+          retirement = registry.retireDirectory(
+            failure.publication.session.directory,
+            'Session event delivery rejected',
+            Date.now() + 30_000,
+            target
+          );
+        },
+      }),
+    });
+    try {
+      expect(operation.nativeTarget()).toEqual(target);
+      expect(operation.snapshot().delivery?.state).toBe('pending');
+      expect(
+        transport.enqueue('session.event', payload, {
+          ...session,
+          nativeRuntimeId: runtime.runtimeId,
+        })
+      ).toBe(true);
+      expect(await transport.resume()).toBe(true);
+      expect(await retirement).toBe('retired');
+      expect(nativeRetire).toHaveBeenCalledTimes(1);
+      expect(nativeRetire).toHaveBeenCalledWith(session.directory, expect.any(Number), target);
+      expect(runtime.signal.aborted).toBe(true);
+      expect(registry.retained()).toEqual([operation]);
+      expect(operation.deliveryResult()).toEqual(sealed);
+      expect(operation.snapshot().delivery?.state).toBe('pending');
+      acknowledgement.resolve(await acknowledgeOperation(sealed));
+      await operation.waitForDelivery();
+      expect(operation.snapshot().delivery?.state).toBe('acknowledged');
+      expect(operation.deliveryResult()).toEqual(sealed);
+    } finally {
+      transport.close();
+      acknowledgement.resolve(await acknowledgeOperation(sealed));
+      await operation.waitForDelivery();
+    }
+  });
+
+  it('reports failures without native identity without guessing the current runtime', async () => {
+    const retired = mock();
+    const getRuntime = mock(() => ({ runtimeId: crypto.randomUUID() }));
+    const handleFailure = createControlEventFailureHandler({ getRuntime, onFailure: retired });
+    const reported = mock((failure: ControlEventOutboxFailure) => handleFailure(failure));
+    const transport = createControlEventTransport({
+      supportsReceipts: () => true,
+      prepare: input => input,
+      publish: async () => {
+        throw new ControlDeliveryError('rejected', false);
+      },
+      sendLegacy: () => false,
+      onFailure: reported,
+    });
+    try {
+      expect(transport.enqueue('session.event', payload, session)).toBe(true);
+      expect(await transport.resume()).toBe(true);
+      handleFailure();
+      expect(reported).toHaveBeenCalledTimes(1);
+      expect(getRuntime).not.toHaveBeenCalled();
+      expect(retired).not.toHaveBeenCalled();
+    } finally {
+      transport.close();
+    }
+  });
+});

--- a/services/cloud-agent-next/wrapper/src/control/control-event-transport.ts
+++ b/services/cloud-agent-next/wrapper/src/control/control-event-transport.ts
@@ -1,0 +1,72 @@
+import type { SessionEventIdentity } from '../../../src/shared/sandbox-control-protocol.js';
+import {
+  createControlEventOutbox,
+  type ControlEventOutboxFailure,
+  type ControlEventPublication,
+} from './control-event-outbox.js';
+
+type EventKind = 'session.event' | 'session.preparing';
+
+export function createControlEventFailureHandler<Runtime extends { runtimeId: string }>(options: {
+  getRuntime: (directory: string) => Runtime | undefined;
+  onFailure: (failure: ControlEventOutboxFailure, runtime: Runtime) => void;
+}) {
+  const failedRuntimes = new WeakSet<Runtime>();
+  return (failure?: ControlEventOutboxFailure): void => {
+    if (!failure) return;
+    const { directory, nativeRuntimeId } = failure.publication.session;
+    if (!nativeRuntimeId) return;
+    const runtime = options.getRuntime(directory);
+    if (runtime?.runtimeId !== nativeRuntimeId || failedRuntimes.has(runtime)) return;
+    failedRuntimes.add(runtime);
+    options.onFailure(failure, runtime);
+  };
+}
+
+export function createControlEventTransport(options: {
+  supportsReceipts: () => boolean;
+  publish: (publication: ControlEventPublication, deadlineAt: number) => Promise<void>;
+  prepare: (input: {
+    event: EventKind;
+    session: SessionEventIdentity;
+    payload: unknown;
+  }) => Omit<ControlEventPublication, 'receiptId' | 'receiptHash' | 'sequence'>;
+  sendLegacy: (payload: unknown, session: SessionEventIdentity) => boolean;
+  onFailure: (failure: ControlEventOutboxFailure) => void;
+}) {
+  const outbox = createControlEventOutbox({
+    publish: options.publish,
+    onFailure: options.onFailure,
+  });
+
+  function enqueue(event: EventKind, payload: unknown, session: SessionEventIdentity): boolean {
+    if (!options.supportsReceipts()) return options.sendLegacy(payload, session);
+    try {
+      return outbox.enqueue(outbox.prepare(options.prepare({ event, session, payload })));
+    } catch {
+      return false;
+    }
+  }
+
+  return {
+    async publishSessionEvent(payload: unknown, session: SessionEventIdentity): Promise<boolean> {
+      if (!options.supportsReceipts()) return options.sendLegacy(payload, session);
+      try {
+        const publication = outbox.prepare(
+          options.prepare({ event: 'session.event', session, payload })
+        );
+        while (!outbox.enqueue(publication)) {
+          if (!(await outbox.waitForSpace(publication))) return false;
+        }
+        void outbox.resume();
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    enqueue,
+    pause: () => outbox.pause(),
+    resume: () => outbox.resume(),
+    close: () => outbox.close(),
+  };
+}

--- a/services/cloud-agent-next/wrapper/src/control/feed.ts
+++ b/services/cloud-agent-next/wrapper/src/control/feed.ts
@@ -1,3 +1,4 @@
+import type { SessionEventIdentity } from '../../../src/shared/sandbox-control-protocol.js';
 import type { HandlerSessionSnapshot } from './sandbox-control-handlers';
 import { directoryForSession, rememberChildSession, rootForSession } from './session-directories';
 
@@ -40,9 +41,10 @@ export function sessionEventIdentity(input: {
   sessionId?: string;
   directory?: string;
   runtimeDirectory?: string;
+  nativeRuntimeId?: string;
   type?: string;
   properties?: Record<string, unknown>;
-}): { directory: string; kiloSessionId?: string; rootKiloSessionId?: string } | undefined {
+}): SessionEventIdentity | undefined {
   let directory = input.directory;
   if ((input.type === 'session.created' || input.type === 'session.updated') && input.properties) {
     const info = input.properties.info;
@@ -73,6 +75,7 @@ export function sessionEventIdentity(input: {
     directory,
     ...(input.sessionId ? { kiloSessionId: input.sessionId } : {}),
     rootKiloSessionId: root,
+    ...(input.nativeRuntimeId !== undefined ? { nativeRuntimeId: input.nativeRuntimeId } : {}),
   };
 }
 

--- a/services/cloud-agent-next/wrapper/src/control/main.ts
+++ b/services/cloud-agent-next/wrapper/src/control/main.ts
@@ -12,7 +12,6 @@ import {
   createSessionActivityRegistry,
   refreshHeartbeatPayload,
   handleControlRequest,
-  type HandlerDeps,
 } from './sandbox-control-handlers';
 import { eventKiloSessionId, sessionEventIdentity, updateSessionSnapshots } from './feed';
 import { createControlTerminalRuntime } from './terminal-runtime';
@@ -20,6 +19,7 @@ import { createWorktreeKiloRuntimes } from './worktree-runtime';
 import { createControlDiagnostics, type ControlDiagnostics } from './diagnostics';
 import { controlLogWrapperIdSchema } from '../../../src/shared/control-diagnostics.js';
 import { createWorktreeMutationNotifications } from './worktree-mutation-notifications';
+import { createControlEventFailureHandler } from './control-event-transport';
 
 const retirementCauses = new Map([
   ['Kilo event feed is no longer healthy', 'event_feed_unhealthy'],
@@ -56,7 +56,7 @@ function main(diagnostics: ControlDiagnostics, wrapperInstanceId: string): void 
   let heartbeatReason: SandboxHeartbeatPayload['kilo']['reason'];
   const kiloRuntimes = createWorktreeKiloRuntimes({
     onDiagnostic: diagnostics.onDiagnostic,
-    onEvent: (runtime, event) => {
+    onEvent: async (runtime, event) => {
       mutationNotifications.observe(runtime, event);
       const identity = sessionEventIdentity({
         ...event,
@@ -72,32 +72,50 @@ function main(diagnostics: ControlDiagnostics, wrapperInstanceId: string): void 
         event.properties
       );
       if (
-        !control?.sendEvent?.(
-          'session.event',
+        !control?.publishSessionEvent ||
+        !(await control.publishSessionEvent(
           { type: event.type, properties: event.properties },
           identity
-        )
+        ))
       ) {
-        throw new Error('Sandbox control event delivery failed');
+        try {
+          await deps.operations.retireDirectory(
+            runtime.directory,
+            'Session event delivery failed',
+            Date.now() + KILO_CONTROL_REQUEST_TIMEOUT_MS,
+            { runtimeId: runtime.runtimeId, client: runtime.kiloClient }
+          );
+        } catch {
+          diagnostics.onDiagnostic('wrapper.lifecycle', { phase: 'failed' });
+        }
+        return;
       }
     },
     onUnexpectedClose: failure => {
       logToFile(`Kilo worktree retired reason=${failure.reason} directory=${failure.directory}`);
+      const stillCurrent = () => {
+        const current = kiloRuntimes.get(failure.directory);
+        return current === undefined || current.runtimeId === failure.runtimeId;
+      };
       if (failure.cleanup === 'unconfirmed' || !control?.reportNativeRuntimeRetirement) {
-        shutdown(1, failure.reason);
+        if (stillCurrent()) shutdown(1, failure.reason);
         return;
       }
       void control
         .reportNativeRuntimeRetirement({
+          retirementId: failure.retirementId,
           directory: failure.directory,
           nativeRuntimeId: failure.runtimeId,
           reason: failure.reason,
+          cleanupDeadlineAt: failure.cleanupDeadlineAt,
         })
         .then(
           retired => {
-            if (!retired) shutdown(1, failure.reason);
+            if (!retired && stillCurrent()) shutdown(1, failure.reason);
           },
-          () => shutdown(1, failure.reason)
+          () => {
+            if (stillCurrent()) shutdown(1, failure.reason);
+          }
         );
     },
   });
@@ -108,7 +126,7 @@ function main(diagnostics: ControlDiagnostics, wrapperInstanceId: string): void 
         getKiloRuntime: directory => kiloRuntimes.get(directory),
       })
     : undefined;
-  const deps: HandlerDeps = createControlHandlerDeps({
+  const deps = createControlHandlerDeps({
     onDiagnostic: diagnostics.onDiagnostic,
     kiloRuntimes,
     version: WRAPPER_VERSION,
@@ -124,21 +142,18 @@ function main(diagnostics: ControlDiagnostics, wrapperInstanceId: string): void 
         throw new Error('Sandbox control operation result delivery unavailable');
       return control.sendOperationResult(session, delivery, signal, deadlineAt);
     },
-    emitSessionEvent: (session, payload, options) => {
-      if (
-        !control?.sendEvent?.(
-          'session.event',
-          payload,
-          {
-            directory: session.directory,
-            kiloSessionId: session.kiloSessionId,
-            rootKiloSessionId: session.kiloSessionId,
-          },
-          options?.retained ? { preserveConnectionOnFailure: true } : undefined
-        )
-      )
-        throw new Error('Sandbox control event delivery failed');
-    },
+    emitSessionEvent: (session, payload, options) =>
+      control?.sendEvent?.(
+        'session.event',
+        payload,
+        {
+          directory: session.directory,
+          kiloSessionId: session.kiloSessionId,
+          rootKiloSessionId: session.kiloSessionId,
+          ...(options?.nativeRuntimeId ? { nativeRuntimeId: options.nativeRuntimeId } : {}),
+        },
+        options?.retained ? { preserveConnectionOnFailure: true } : undefined
+      ) === true,
     retireRuntime: reason => shutdown(1, reason),
     onShutdown: () => shutdown(0, 'Sandbox shutting down'),
   });
@@ -223,9 +238,28 @@ function main(diagnostics: ControlDiagnostics, wrapperInstanceId: string): void 
     wrapperVersion: WRAPPER_VERSION,
     isReady: () => deps.kiloReady,
     onConnected: () => diagnostics.onDiagnostic('wrapper.lifecycle', { phase: 'ready', ok: true }),
+    onEventReceiptFailure: createControlEventFailureHandler({
+      getRuntime: directory => kiloRuntimes.get(directory),
+      onFailure: (failure, runtime) => {
+        void deps.operations
+          .retireDirectory(
+            failure.publication.session.directory,
+            `Session event delivery ${failure.reason}`,
+            Date.now() + KILO_CONTROL_REQUEST_TIMEOUT_MS,
+            { runtimeId: runtime.runtimeId, client: runtime.kiloClient }
+          )
+          .catch(() => {
+            diagnostics.onDiagnostic('wrapper.lifecycle', { phase: 'failed' });
+          });
+      },
+    }),
     onDisconnected: () => shutdown(1, 'Sandbox control connection lost', 'control_disconnected'),
-    onRequest: (operation, session, payload, authorization) =>
-      handleControlRequest(
+    onReconcile: async (_phase, deadlineAt) => {
+      if (Date.now() >= deadlineAt) throw new Error('Control recovery deadline expired');
+      await deps.operations.drainDelivery(deadlineAt);
+    },
+    onRequest: (operation, session, payload, authorization) => {
+      return handleControlRequest(
         operation,
         session,
         payload,
@@ -241,6 +275,7 @@ function main(diagnostics: ControlDiagnostics, wrapperInstanceId: string): void 
                   directory: session.directory,
                   kiloSessionId: session.kiloSessionId,
                   rootKiloSessionId: session.kiloSessionId,
+                  ...(options?.nativeRuntimeId ? { nativeRuntimeId: options.nativeRuntimeId } : {}),
                 },
                 options?.retained ? { preserveConnectionOnFailure: true } : undefined
               )
@@ -249,7 +284,8 @@ function main(diagnostics: ControlDiagnostics, wrapperInstanceId: string): void 
           },
         },
         authorization
-      ),
+      );
+    },
     getHeartbeatPayload: () => withHeartbeatReason(buildHeartbeatPayload(deps)),
     sampleHeartbeat: signal => refreshHeartbeatPayload(deps, signal).then(() => undefined),
   });

--- a/services/cloud-agent-next/wrapper/src/control/operation-registry.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/operation-registry.test.ts
@@ -90,6 +90,7 @@ describe('operation admission and lookup', () => {
     expect(sessionOperationLookupResultSchema.parse(lookup.result)).toEqual({
       state: 'running',
       authorization,
+      executionDeadlineAt: record.executionDeadlineAt,
     });
     expect(
       await handleControlRequest(

--- a/services/cloud-agent-next/wrapper/src/control/operation-registry.ts
+++ b/services/cloud-agent-next/wrapper/src/control/operation-registry.ts
@@ -127,6 +127,9 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
               : {
                   state: 'running',
                   authorization: target,
+                  ...(existing.executionDeadlineAt
+                    ? { executionDeadlineAt: existing.executionDeadlineAt }
+                    : {}),
                 }
           )
         );
@@ -142,7 +145,11 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
       return reply(
         operation === 'session.attach'
           ? existing.done
-          : ok({ messageId: target.messageId, status: 'existing' })
+          : ok({
+              messageId: target.messageId,
+              status: 'existing',
+              executionDeadlineAt: existing.executionDeadlineAt,
+            })
       );
     }
     if (operation === 'session.operation.get') return reply(ok({ state: 'missing' }));

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.test.ts
@@ -6,9 +6,14 @@ import {
   MAX_SANDBOX_CONTROL_FRAME_BYTES,
   SANDBOX_CONTROL_REQUEST_TIMEOUT_MS,
   sandboxHeartbeatPayloadSchema,
+  sandboxEventPublicationPayloadSchema,
   sessionEventPayloadSchema,
+  type SandboxEventPublicationPayload,
+  type SessionOperationDelivery,
 } from '../../../src/shared/sandbox-control-protocol';
 import { unfilteredKiloEvents } from './feed';
+import { acknowledgeOperation, operationAuthorization } from './control-test-fixtures';
+import { createControlEventFailureHandler } from './control-event-transport';
 import {
   createSandboxControlClient,
   type SandboxControlClientOptions,
@@ -211,7 +216,7 @@ describe('heartbeat version rollout compatibility', () => {
           type: 'response',
           requestId: hello.requestId,
           ok: true,
-          result: helloResult(),
+          result: helloResult({ connectionRecovery: true }),
         })
       );
       first.close();
@@ -278,6 +283,54 @@ describe('heartbeat version rollout compatibility', () => {
 });
 
 describe('createSandboxControlClient', () => {
+  it('replays one native retirement receipt after a lost acknowledgement on reconnect', async () => {
+    const { client, sockets } = createClientFixture();
+    const payload = {
+      retirementId: '11111111-1111-4111-8111-111111111111',
+      directory: '/workspace/a',
+      nativeRuntimeId: '22222222-2222-4222-8222-222222222222',
+      reason: 'process_exited',
+      cleanupDeadlineAt: Date.now() + 5_000,
+    };
+    try {
+      const connecting = client.connect();
+      await Promise.resolve();
+      await handshake(sockets[0], helloResult({ connectionRecovery: true }));
+      await connecting;
+      const report = client.reportNativeRuntimeRetirement?.(payload);
+      const first = sockets[0];
+      if (!report || !first) throw new Error('Native retirement report did not start');
+      await Promise.resolve();
+      const initial = JSON.parse(first.sent.at(-1) ?? '{}');
+      expect(initial).toMatchObject({ operation: 'session.runtime.retired', payload });
+      first.close();
+
+      await waitForReconnect();
+      const replacement = sockets[1];
+      await handshake(replacement);
+      await new Promise(resolve => setTimeout(resolve, 300));
+      const replay = JSON.parse(replacement?.sent.at(-1) ?? '{}');
+      expect(replay).toMatchObject({ operation: 'session.runtime.retired', payload });
+      replacement?.respond(
+        JSON.stringify({
+          type: 'response',
+          requestId: replay.requestId,
+          ok: true,
+          result: { retired: true },
+        })
+      );
+      expect(await report).toBe(true);
+      const replayedReport = client.reportNativeRuntimeRetirement?.(payload);
+      if (!replayedReport) throw new Error('Native retirement receipt was not retained');
+      expect(await replayedReport).toBe(true);
+      expect(
+        replacement?.sent.filter(frame => frame.includes('session.runtime.retired'))
+      ).toHaveLength(1);
+    } finally {
+      client.close();
+    }
+  });
+
   it('opens with an Authorization header and completes sandbox.hello plus status probe', async () => {
     const fake = new FakeWebSocket();
     const client = createSandboxControlClient({
@@ -308,6 +361,8 @@ describe('createSandboxControlClient', () => {
           sessionOperationResults?: boolean;
           scopedStopAbort?: boolean;
           nativeRuntimeRetirement?: boolean;
+          connectionRecovery?: boolean;
+          eventReceipts?: boolean;
         };
       };
     };
@@ -320,6 +375,8 @@ describe('createSandboxControlClient', () => {
         sessionOperationResults: true,
         scopedStopAbort: true,
         nativeRuntimeRetirement: true,
+        connectionRecovery: true,
+        eventReceipts: true,
       },
     });
     fake.respond(
@@ -430,6 +487,390 @@ describe('createSandboxControlClient', () => {
       result: { healthy: true, state: 'idle', version: '2.4.0', kiloReady: true },
     });
     client.close();
+  });
+
+  it('gates new session work until the exact recovery episode is marked ready', async () => {
+    const fake = new FakeWebSocket();
+    const onRequest = mock(async () => ({ ok: true as const, result: { accepted: true } }));
+    const onReconcile = mock(async () => {});
+    const client = createSandboxControlClient({
+      url: 'wss://example.test/sandbox-control/sbx_1',
+      credential: 'secret',
+      providerInstanceId: 'inst_1',
+      openWebSocket: () => fake as unknown as WebSocket,
+      onRequest,
+      onReconcile,
+    });
+    const recovery = {
+      episodeId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      cause: 'control_disconnected' as const,
+      startedAt: 1,
+      deadlineAt: Date.now() + 10_000,
+      attempt: 1,
+    };
+
+    const connecting = client.connect();
+    await handshake(fake);
+    await connecting;
+    fake.respond(
+      JSON.stringify({
+        type: 'request',
+        requestId: 'drain',
+        operation: 'sandbox.reconcile',
+        payload: { recovery, phase: 'drain' },
+      })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    fake.respond(
+      JSON.stringify({
+        type: 'request',
+        requestId: 'blocked',
+        operation: 'session.prompt',
+        payload: {},
+      })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onReconcile).toHaveBeenCalledWith('drain', recovery.deadlineAt);
+    expect(onRequest).not.toHaveBeenCalled();
+    expect(JSON.parse(fake.sent.at(-1) ?? '{}')).toMatchObject({
+      requestId: 'blocked',
+      ok: false,
+      error: { code: 'not_ready' },
+    });
+
+    fake.respond(
+      JSON.stringify({
+        type: 'request',
+        requestId: 'ready',
+        operation: 'sandbox.reconcile',
+        payload: { recovery, phase: 'ready' },
+      })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    fake.respond(
+      JSON.stringify({
+        type: 'request',
+        requestId: 'commit',
+        operation: 'sandbox.reconcile',
+        payload: { recovery, phase: 'commit' },
+      })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    fake.respond(
+      JSON.stringify({
+        type: 'request',
+        requestId: 'commit-replay',
+        operation: 'sandbox.reconcile',
+        payload: { recovery, phase: 'commit' },
+      })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(JSON.parse(fake.sent.at(-1) ?? '{}')).toMatchObject({
+      requestId: 'commit-replay',
+      ok: true,
+      result: { episodeId: recovery.episodeId, attempt: recovery.attempt, phase: 'commit' },
+    });
+
+    fake.respond(
+      JSON.stringify({
+        type: 'request',
+        requestId: 'admitted',
+        operation: 'session.prompt',
+        payload: {},
+      })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onReconcile).toHaveBeenLastCalledWith('commit', recovery.deadlineAt);
+    expect(onReconcile).toHaveBeenCalledTimes(3);
+    expect(onRequest).toHaveBeenCalledTimes(1);
+    client.close();
+  });
+
+  it('ACKs an exact committed recovery after a lost reply and the original deadline expires', async () => {
+    const startedAt = Date.now();
+    const clock = spyOn(Date, 'now').mockReturnValue(startedAt);
+    const onReconcile = mock(async () => {});
+    const onRequest = mock(async () => ({ ok: true, result: { accepted: true } }));
+    const { client, sockets } = createClientFixture({ onReconcile, onRequest });
+    const recovery = {
+      episodeId: crypto.randomUUID(),
+      cause: 'control_disconnected',
+      startedAt,
+      deadlineAt: startedAt + 1_000,
+      attempt: 1,
+    };
+    try {
+      const connecting = client.connect();
+      await Promise.resolve();
+      const first = sockets[0];
+      if (!first) throw new Error('Missing first socket');
+      await handshake(first, helloResult({ connectionRecovery: true }));
+      await connecting;
+      for (const phase of ['drain', 'ready', 'commit']) {
+        if (phase === 'commit') {
+          first.send = () => {
+            throw new Error('Lost commit reply');
+          };
+        }
+        first.respond(
+          JSON.stringify({
+            type: 'request',
+            requestId: phase,
+            operation: 'sandbox.reconcile',
+            payload: { recovery, phase },
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      }
+      expect(onReconcile).toHaveBeenNthCalledWith(1, 'drain', recovery.deadlineAt);
+      expect(onReconcile).toHaveBeenNthCalledWith(2, 'ready', recovery.deadlineAt);
+      expect(onReconcile).toHaveBeenNthCalledWith(3, 'commit', recovery.deadlineAt);
+      expect(first.sent.map(data => JSON.parse(data).requestId)).not.toContain('commit');
+      expect(first.readyState).toBe(3);
+      await waitForReconnect();
+      clock.mockReturnValue(recovery.deadlineAt + 1);
+      const replacement = sockets[1];
+      if (!replacement) throw new Error('Missing replacement socket');
+      await handshake(replacement, helloResult({ connectionRecovery: true }));
+      await client.connect();
+      for (const payload of [
+        { recovery, phase: 'commit' },
+        { recovery: { ...recovery, episodeId: crypto.randomUUID() }, phase: 'commit' },
+        { recovery: { ...recovery, attempt: 2 }, phase: 'commit' },
+        { recovery: { ...recovery, deadlineAt: recovery.deadlineAt - 1 }, phase: 'commit' },
+        { recovery, phase: 'ready' },
+        { recovery, phase: 'drain' },
+        { recovery, phase: 'commit' },
+      ]) {
+        const exactCommit = payload.recovery === recovery && payload.phase === 'commit';
+        const requestId = crypto.randomUUID();
+        replacement.respond(
+          JSON.stringify({ type: 'request', requestId, operation: 'sandbox.reconcile', payload })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(JSON.parse(replacement.sent.at(-1) ?? '{}')).toEqual({
+          type: 'response',
+          requestId,
+          ...(exactCommit
+            ? {
+                ok: true,
+                result: {
+                  episodeId: recovery.episodeId,
+                  attempt: recovery.attempt,
+                  phase: 'commit',
+                },
+              }
+            : {
+                ok: false,
+                error: {
+                  code: 'not_ready',
+                  message: 'Recovery authority changed',
+                  retryable: false,
+                },
+              }),
+        });
+      }
+      expect(onReconcile).toHaveBeenCalledTimes(3);
+      expect(onRequest).not.toHaveBeenCalled();
+      expect(replacement.readyState).toBe(1);
+    } finally {
+      client.close();
+      clock.mockRestore();
+    }
+  });
+
+  it('ACKs an exact committed recovery after socket loss during commit reconcile', async () => {
+    const startedAt = Date.now();
+    const clock = spyOn(Date, 'now').mockReturnValue(startedAt);
+    const held = Promise.withResolvers<void>();
+    let commitStarted = (): void => {};
+    const started = new Promise<void>(resolve => {
+      commitStarted = resolve;
+    });
+    const onReconcile = mock(async (phase: string) => {
+      if (phase !== 'commit') return;
+      commitStarted();
+      await held.promise;
+    });
+    const onRequest = mock(async () => ({ ok: true, result: { accepted: true } }));
+    const { client, sockets } = createClientFixture({ onReconcile, onRequest });
+    const recovery = {
+      episodeId: crypto.randomUUID(),
+      cause: 'control_disconnected',
+      startedAt,
+      deadlineAt: startedAt + 1_000,
+      attempt: 1,
+    };
+    try {
+      const connecting = client.connect();
+      await Promise.resolve();
+      const first = sockets[0];
+      if (!first) throw new Error('Missing first socket');
+      await handshake(first, helloResult({ connectionRecovery: true }));
+      await connecting;
+      for (const phase of ['drain', 'ready', 'commit']) {
+        first.respond(
+          JSON.stringify({
+            type: 'request',
+            requestId: phase,
+            operation: 'sandbox.reconcile',
+            payload: { recovery, phase },
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      }
+      await started;
+      first.close();
+      held.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await waitForReconnect();
+      clock.mockReturnValue(recovery.deadlineAt + 1);
+      const replacement = sockets[1];
+      if (!replacement) throw new Error('Missing replacement socket');
+      await handshake(replacement, helloResult({ connectionRecovery: true }));
+      await client.connect();
+      const requestId = crypto.randomUUID();
+      replacement.respond(
+        JSON.stringify({
+          type: 'request',
+          requestId,
+          operation: 'sandbox.reconcile',
+          payload: { recovery, phase: 'commit' },
+        })
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(JSON.parse(replacement.sent.at(-1) ?? '{}')).toEqual({
+        type: 'response',
+        requestId,
+        ok: true,
+        result: {
+          episodeId: recovery.episodeId,
+          attempt: recovery.attempt,
+          phase: 'commit',
+        },
+      });
+      expect(onReconcile).toHaveBeenCalledTimes(3);
+      expect(onRequest).not.toHaveBeenCalled();
+    } finally {
+      client.close();
+      clock.mockRestore();
+    }
+  });
+
+  it('rejects a stale committed replay without clearing a newer recovery gate', async () => {
+    const startedAt = Date.now();
+    const clock = spyOn(Date, 'now').mockReturnValue(startedAt);
+    const fake = new FakeWebSocket();
+    const onReconcile = mock(async () => {});
+    const onRequest = mock(async () => ({ ok: true, result: { accepted: true } }));
+    const { client } = createClientFixture({
+      openWebSocket: () => fake as unknown as WebSocket,
+      onReconcile,
+      onRequest,
+    });
+    const previous = {
+      episodeId: crypto.randomUUID(),
+      cause: 'control_disconnected',
+      startedAt,
+      deadlineAt: startedAt + 1_000,
+      attempt: 1,
+    };
+    const current = {
+      ...previous,
+      episodeId: crypto.randomUUID(),
+      deadlineAt: startedAt + 10_000,
+    };
+    try {
+      const connecting = client.connect();
+      await handshake(fake);
+      await connecting;
+      for (const payload of [
+        { recovery: previous, phase: 'drain' },
+        { recovery: previous, phase: 'ready' },
+        { recovery: previous, phase: 'commit' },
+        { recovery: current, phase: 'drain' },
+      ]) {
+        fake.respond(
+          JSON.stringify({
+            type: 'request',
+            requestId: crypto.randomUUID(),
+            operation: 'sandbox.reconcile',
+            payload,
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(JSON.parse(fake.sent.at(-1) ?? '{}').ok).toBe(true);
+      }
+      for (const now of [startedAt, previous.deadlineAt + 1]) {
+        clock.mockReturnValue(now);
+        fake.respond(
+          JSON.stringify({
+            type: 'request',
+            requestId: 'stale-commit',
+            operation: 'sandbox.reconcile',
+            payload: { recovery: previous, phase: 'commit' },
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(JSON.parse(fake.sent.at(-1) ?? '{}')).toMatchObject({
+          requestId: 'stale-commit',
+          ok: false,
+          error: { code: 'not_ready', retryable: false },
+        });
+        for (const operation of ['session.attach', 'session.prompt']) {
+          fake.respond(
+            JSON.stringify({ type: 'request', requestId: operation, operation, payload: {} })
+          );
+          await Promise.resolve();
+          await Promise.resolve();
+          expect(JSON.parse(fake.sent.at(-1) ?? '{}')).toMatchObject({
+            requestId: operation,
+            ok: false,
+            error: { code: 'not_ready', retryable: true },
+          });
+        }
+      }
+      expect(onReconcile).toHaveBeenCalledTimes(4);
+      expect(onRequest).not.toHaveBeenCalled();
+      for (const phase of ['ready', 'commit']) {
+        fake.respond(
+          JSON.stringify({
+            type: 'request',
+            requestId: phase,
+            operation: 'sandbox.reconcile',
+            payload: { recovery: current, phase },
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(JSON.parse(fake.sent.at(-1) ?? '{}')).toMatchObject({
+          requestId: phase,
+          ok: true,
+          result: { episodeId: current.episodeId, attempt: current.attempt, phase },
+        });
+      }
+      expect(onReconcile).toHaveBeenCalledTimes(6);
+      expect(onReconcile).toHaveBeenLastCalledWith('commit', current.deadlineAt);
+    } finally {
+      client.close();
+      clock.mockRestore();
+    }
   });
 
   it.each([
@@ -607,6 +1048,7 @@ describe('createSandboxControlClient', () => {
         directory: '/workspace',
         kiloSessionId: 'ses_1',
         rootKiloSessionId: 'ses_1',
+        nativeRuntimeId: crypto.randomUUID(),
       }
     );
 
@@ -626,6 +1068,331 @@ describe('createSandboxControlClient', () => {
       payload: { type: 'session.status', properties: { sessionID: 'ses_1' } },
     });
     client.close();
+  });
+
+  it.each([
+    'event-rejected',
+    'retryable-rejection',
+    'transport-error',
+    'other-error',
+    'false-ack',
+    'wrong-receipt',
+  ] as const)(
+    'preserves N1 before N2 ordering through publication disposition: %s',
+    async disposition => {
+      const failure = mock(() => {});
+      const logs: string[] = [];
+      const { client, sockets, onDisconnected } = createClientFixture({
+        onEventReceiptFailure: failure,
+        log: message => logs.push(message),
+      });
+      const hello = {
+        protocolVersion: 1,
+        handshakeComplete: true,
+        capabilities: { connectionRecovery: true, eventReceipts: true },
+      };
+      const nativeIds = [crypto.randomUUID(), crypto.randomUUID()];
+      const published: SandboxEventPublicationPayload[] = [];
+      const firstPublished = Promise.withResolvers<void>();
+      const replacementPublished = Promise.withResolvers<void>();
+      try {
+        const connecting = client.connect();
+        await Promise.resolve();
+        await handshake(sockets[0], hello);
+        await connecting;
+        sockets[0]?.close();
+        for (const nativeRuntimeId of nativeIds)
+          expect(
+            client.sendEvent?.(
+              'session.event',
+              { type: 'session.status', properties: { status: { type: 'idle' } } },
+              {
+                directory: '/workspace',
+                kiloSessionId: 'ses_1',
+                rootKiloSessionId: 'ses_1',
+                nativeRuntimeId,
+              }
+            )
+          ).toBe(true);
+        await waitForReconnect();
+        const socket = sockets[1];
+        if (!socket) throw new Error('Missing replacement socket');
+        socket.send = data => {
+          socket.sent.push(data);
+          const frame = JSON.parse(data) as {
+            operation?: string;
+            requestId: string;
+            payload: unknown;
+          };
+          if (frame.operation !== 'sandbox.event.publish') return;
+          const publication = sandboxEventPublicationPayloadSchema.parse(frame.payload);
+          published.push(publication);
+          firstPublished.resolve();
+          if (publication.sequence === 2) replacementPublished.resolve();
+          const acknowledgement = { receiptId: publication.receiptId, applied: true };
+          const response =
+            published.length > 1
+              ? { ok: true, result: acknowledgement }
+              : disposition === 'false-ack'
+                ? { ok: true, result: { ...acknowledgement, applied: false } }
+                : disposition === 'wrong-receipt'
+                  ? { ok: true, result: { ...acknowledgement, receiptId: crypto.randomUUID() } }
+                  : {
+                      ok: false,
+                      error: {
+                        code:
+                          disposition === 'transport-error'
+                            ? 'not_ready'
+                            : disposition === 'other-error'
+                              ? 'unauthorized'
+                              : 'event_rejected',
+                        retryable:
+                          disposition === 'retryable-rejection' ||
+                          disposition === 'transport-error',
+                        message: 'private rejected input',
+                      },
+                    };
+          socket.respond(
+            JSON.stringify({ type: 'response', requestId: frame.requestId, ...response })
+          );
+        };
+        await handshake(socket, hello);
+        await firstPublished.promise;
+        await waitForReconnect();
+        if (disposition === 'retryable-rejection' || disposition === 'transport-error') {
+          expect(published.map(item => item.session.nativeRuntimeId)).toEqual(
+            nativeIds.slice(0, 1)
+          );
+          await replacementPublished.promise;
+          await waitForReconnect();
+          expect(published.map(item => item.session.nativeRuntimeId)).toEqual([
+            nativeIds[0],
+            ...nativeIds,
+          ]);
+          expect(published.map(item => item.sequence)).toEqual([1, 1, 2]);
+          expect(published[1]).toEqual(published[0]);
+          expect(failure).not.toHaveBeenCalled();
+          expect(logs).not.toContain('sandbox control event publication rejected');
+        } else {
+          expect(published.map(item => item.session.nativeRuntimeId)).toEqual(nativeIds);
+          expect(published.map(item => item.sequence)).toEqual([1, 2]);
+          expect(failure).toHaveBeenCalledTimes(1);
+          expect(failure).toHaveBeenCalledWith({
+            reason: 'rejected',
+            publication: expect.objectContaining(published[0]),
+          });
+          expect(logs).toContain('sandbox control event publication rejected');
+        }
+        expect(socket.readyState).toBe(1);
+        expect(sockets).toHaveLength(2);
+        socket.close();
+        await waitForReconnect();
+        await handshake(sockets[2], hello);
+        await waitForReconnect();
+        expect(sockets[2]?.sent.some(data => data.includes('sandbox.event.publish'))).toBe(false);
+        expect(onDisconnected).not.toHaveBeenCalled();
+        expect(logs.join('\n')).not.toContain('private rejected input');
+      } finally {
+        client.close();
+      }
+    }
+  );
+
+  it('keeps reconnect readiness, attach, maintenance and sealed results independent of expiring N1 events', async () => {
+    const startedAt = Date.now();
+    const clock = spyOn(Date, 'now').mockReturnValue(startedAt);
+    const timers = spyOn(globalThis, 'setTimeout');
+    const failure = mock();
+    const retire = mock();
+    let currentRuntime = { runtimeId: crypto.randomUUID() };
+    const handleFailure = createControlEventFailureHandler({
+      getRuntime: () => currentRuntime,
+      onFailure: retire,
+    });
+    const connected = mock();
+    const request = mock(async () => ({ ok: true, result: { attached: true } }));
+    const logs: string[] = [];
+    const { client, sockets, onDisconnected } = createClientFixture({
+      onConnected: connected,
+      onEventReceiptFailure: eventFailure => {
+        failure(eventFailure);
+        handleFailure(eventFailure);
+      },
+      onRequest: request,
+      log: message => logs.push(message),
+    });
+    const hello = {
+      protocolVersion: 1,
+      handshakeComplete: true,
+      capabilities: { connectionRecovery: true, eventReceipts: true },
+    };
+    const identity = {
+      directory: '/workspace',
+      kiloSessionId: 'kilo_1',
+      rootKiloSessionId: 'kilo_1',
+      nativeRuntimeId: currentRuntime.runtimeId,
+    };
+    const delivery: SessionOperationDelivery = {
+      version: 2,
+      authorization: operationAuthorization(),
+      completedAt: startedAt,
+      result: { ok: true, result: {} },
+      outcome: { messageId: 'msg_1', status: 'completed' },
+      events: [],
+      preparing: [],
+    };
+    const acknowledgement = await acknowledgeOperation(delivery);
+    try {
+      const connecting = client.connect();
+      await Promise.resolve();
+      await handshake(sockets[0], hello);
+      await connecting;
+      sockets[0]?.close();
+      expect(
+        client.sendEvent?.('session.event', { type: 'session.idle', properties: {} }, identity)
+      ).toBe(true);
+      const result = client
+        .sendOperationResult?.(
+          delivery.authorization.session,
+          delivery,
+          new AbortController().signal,
+          startedAt + 60_000
+        )
+        .catch((error: unknown) => error);
+      const retirement = client.reportNativeRuntimeRetirement?.({
+        retirementId: crypto.randomUUID(),
+        directory: identity.directory,
+        nativeRuntimeId: identity.nativeRuntimeId,
+        reason: 'process_exited',
+        cleanupDeadlineAt: startedAt + 60_000,
+      });
+      await waitForReconnect();
+      clock.mockReturnValue(startedAt + 250);
+      const socket = sockets[1];
+      if (!socket) throw new Error('Missing replacement socket');
+      const reconnectTimers = timers.mock.calls.length;
+      await handshake(socket, hello);
+      await waitForReconnect();
+      const frames = socket.sent.map(data => JSON.parse(data));
+      const eventFrame = frames.find(frame => frame.operation === 'sandbox.event.publish');
+      const resultFrame = frames.find(frame => frame.operation === 'session.operation.result');
+      const retirementFrame = frames.find(frame => frame.operation === 'session.runtime.retired');
+      expect(connected).toHaveBeenCalledTimes(2);
+      expect(eventFrame?.payload.session.nativeRuntimeId).toBe(identity.nativeRuntimeId);
+      expect(resultFrame?.payload).toEqual(delivery);
+      expect(retirementFrame).toBeDefined();
+      socket.respond(
+        JSON.stringify({
+          type: 'request',
+          requestId: 'attach-n2',
+          operation: 'session.attach',
+          session: delivery.authorization.session,
+          payload: {},
+        })
+      );
+      expect(client.sendEvent?.('sandbox.heartbeat', versionHeartbeat(null))).toBe(true);
+      await waitForReconnect();
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(socket.sent.map(data => JSON.parse(data))).toContainEqual({
+        type: 'response',
+        requestId: 'attach-n2',
+        ok: true,
+        result: { attached: true },
+      });
+      socket.respond(
+        JSON.stringify({
+          type: 'response',
+          requestId: retirementFrame.requestId,
+          ok: true,
+          result: { retired: true },
+        })
+      );
+      expect(await retirement).toBe(true);
+      clock.mockReturnValue(startedAt + 29_000);
+      const replacement = { ...identity, nativeRuntimeId: crypto.randomUUID() };
+      currentRuntime = { runtimeId: replacement.nativeRuntimeId };
+      expect(
+        client.sendEvent?.('session.event', { type: 'session.idle', properties: {} }, replacement)
+      ).toBe(true);
+      clock.mockReturnValue(startedAt + 30_000);
+      for (let index = reconnectTimers; index < timers.mock.calls.length; index += 1) {
+        const [expire, ms] = timers.mock.calls[index] ?? [];
+        if (ms !== 29_750 || typeof expire !== 'function') continue;
+        clearTimeout(
+          timers.mock.results[index]?.value as ReturnType<typeof setTimeout> | undefined
+        );
+        expire();
+      }
+      await waitForReconnect();
+      expect(logs).toContain('sandbox control event publication expired');
+      expect(failure).toHaveBeenCalledTimes(1);
+      expect(failure).toHaveBeenCalledWith({
+        reason: 'expired',
+        publication: expect.objectContaining(eventFrame.payload),
+      });
+      expect(retire).not.toHaveBeenCalled();
+      expect(onDisconnected).not.toHaveBeenCalled();
+      expect(socket.readyState).toBe(1);
+      const replacementFrame = socket.sent
+        .map(data => JSON.parse(data))
+        .find(
+          frame =>
+            frame.operation === 'sandbox.event.publish' &&
+            frame.payload.session.nativeRuntimeId === replacement.nativeRuntimeId
+        );
+      expect(replacementFrame).toBeDefined();
+      socket.respond(
+        JSON.stringify({
+          type: 'response',
+          requestId: resultFrame.requestId,
+          ok: true,
+          result: acknowledgement,
+        })
+      );
+      expect(await result).toEqual(acknowledgement);
+      socket.respond(
+        JSON.stringify({
+          type: 'response',
+          requestId: replacementFrame.requestId,
+          ok: true,
+          result: { receiptId: replacementFrame.payload.receiptId, applied: true },
+        })
+      );
+      await waitForReconnect();
+      expect(failure).toHaveBeenCalledTimes(1);
+      expect(retire).not.toHaveBeenCalled();
+      expect(sockets).toHaveLength(2);
+    } finally {
+      client.close();
+      timers.mockRestore();
+      clock.mockRestore();
+    }
+  });
+
+  it('uses the legacy session.event frame when event receipts are not negotiated', async () => {
+    const fake = new FakeWebSocket();
+    const { client } = createClientFixture({ openWebSocket: () => fake as unknown as WebSocket });
+    try {
+      const connecting = client.connect();
+      await handshake(fake);
+      await connecting;
+      if (!client.publishSessionEvent) throw new Error('Missing session event publisher');
+      expect(
+        await client.publishSessionEvent(
+          {
+            type: 'session.message.outcome',
+            properties: { messageId: 'msg_1', status: 'completed' },
+          },
+          { directory: '/workspace', kiloSessionId: 'ses_1', rootKiloSessionId: 'ses_1' }
+        )
+      ).toBe(true);
+      expect(JSON.parse(fake.sent.at(-1) ?? '{}')).toMatchObject({
+        type: 'event',
+        event: 'session.event',
+      });
+    } finally {
+      client.close();
+    }
   });
 
   it('bounds a producer-shaped 2 MiB PDF event and preserves the following owned outcome', async () => {
@@ -769,7 +1536,7 @@ describe('createSandboxControlClient', () => {
     }
   });
 
-  it('retires the wrapper connection instead of reconnecting across an established gap', async () => {
+  it('reconnects the wrapper connection across an established gap', async () => {
     const sockets: FakeWebSocket[] = [];
     const wrapperInstanceId = crypto.randomUUID();
     let disconnects = 0;
@@ -792,22 +1559,23 @@ describe('createSandboxControlClient', () => {
 
     const connecting = client.connect();
     await Promise.resolve();
-    await handshake(sockets[0]);
+    await handshake(sockets[0], helloResult({ connectionRecovery: true }));
     await connecting;
     expect(JSON.parse(sockets[0]?.sent[0] ?? '{}')).toMatchObject({
       payload: { wrapperInstanceId },
     });
     sockets[0]?.close();
     await waitForReconnect();
-    expect(sockets).toHaveLength(1);
-    expect(disconnects).toBe(1);
+    expect(sockets).toHaveLength(2);
+    expect(disconnects).toBe(0);
+    await handshake(sockets[1], helloResult({ connectionRecovery: true }));
+    await client.connect();
     expect(
       client.sendEvent?.('session.event', {
         type: 'session.message.outcome',
         properties: { messageId: 'msg_1', status: 'completed' },
       })
-    ).toBe(false);
-    expect(client.connect()).rejects.toThrow('sandbox control client closed');
+    ).toBe(true);
     client.close();
   });
 
@@ -900,13 +1668,13 @@ describe('createSandboxControlClient', () => {
 
     const connecting = client.connect();
     await Promise.resolve();
-    await handshake(sockets[0]);
+    await handshake(sockets[0], helloResult({ connectionRecovery: true }));
     await connecting;
     sockets[0]?.error();
     sockets[0]?.close();
     await waitForReconnect();
-    expect(sockets).toHaveLength(1);
-    expect(disconnects).toBe(1);
+    expect(sockets).toHaveLength(2);
+    expect(disconnects).toBe(0);
     client.close();
   });
 
@@ -926,7 +1694,7 @@ describe('createSandboxControlClient', () => {
 
     const connecting = client.connect();
     await Promise.resolve();
-    await handshake(sockets[0]);
+    await handshake(sockets[0], helloResult({ connectionRecovery: true }));
     await connecting;
     client.close();
     await waitForReconnect();
@@ -951,13 +1719,13 @@ describe('createSandboxControlClient', () => {
 
     const connecting = client.connect();
     await Promise.resolve();
-    await handshake(sockets[0]);
+    await handshake(sockets[0], helloResult({ connectionRecovery: true }));
     await connecting;
     const first = sockets[0];
     if (!first) throw new Error('missing first socket');
     first.close();
     await waitForReconnect();
-    expect(sockets).toHaveLength(1);
+    expect(sockets).toHaveLength(2);
 
     first.readyState = 1;
     const sentBefore = first.sent.length;
@@ -1166,7 +1934,7 @@ describe('createSandboxControlClient', () => {
     try {
       const connecting = client.connect();
       await Promise.resolve();
-      await handshake(sockets[0]);
+      await handshake(sockets[0], helloResult({ connectionRecovery: true }));
       await connecting;
       const socket = sockets[0];
       if (!socket) throw new Error('missing socket');
@@ -1213,10 +1981,9 @@ describe('createSandboxControlClient', () => {
       await waitForReconnect();
       socket.error();
       socket.close();
-      expect(onDisconnected).toHaveBeenCalledTimes(1);
-      expect(openWebSocket).toHaveBeenCalledTimes(1);
+      expect(onDisconnected).toHaveBeenCalledTimes(0);
+      expect(openWebSocket).toHaveBeenCalledTimes(2);
       expect(client.sendEvent?.('sandbox.ready', { kiloReady: true })).toBe(false);
-      expect(client.connect()).rejects.toThrow('sandbox control client closed');
     } finally {
       client.close();
       timers.mockRestore();
@@ -1230,7 +1997,7 @@ describe('createSandboxControlClient', () => {
     try {
       const connecting = client.connect();
       await Promise.resolve();
-      await handshake(sockets[0]);
+      await handshake(sockets[0], helloResult({ connectionRecovery: true }));
       await connecting;
       const socket = sockets[0];
       if (!socket) throw new Error('missing socket');
@@ -1248,7 +2015,7 @@ describe('createSandboxControlClient', () => {
       await waitForReconnect();
       expect(onRequest).toHaveBeenCalledTimes(1);
       expect(socket.sent).toHaveLength(2);
-      expect(onDisconnected).toHaveBeenCalledTimes(1);
+      expect(onDisconnected).toHaveBeenCalledTimes(0);
     } finally {
       outcome.resolve({ ok: true });
       client.close();

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.ts
@@ -6,17 +6,24 @@ import {
 import { z } from 'zod';
 import { prepareIngestFrame } from '../../../src/shared/ingest-frame.js';
 import type { IngestEvent } from '../../../src/shared/protocol.js';
+import { withTimeoutAndAbort } from '../utils.js';
+import { createControlEventTransport } from './control-event-transport.js';
+import type { ControlEventOutboxFailure } from './control-event-outbox.js';
 import {
   CONTROL_OPERATIONS,
   MAX_SANDBOX_CONTROL_FRAME_BYTES,
   SANDBOX_CONTROL_AUTO_PING,
   SANDBOX_CONTROL_PROTOCOL_VERSION,
+  SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS,
   SANDBOX_CONTROL_REQUEST_TIMEOUT_MS,
   controlFrameSchema,
   controlErrorCodes,
   sandboxHelloResultSchema,
   sandboxHeartbeatPayloadSchema,
+  sandboxEventPublicationResultSchema,
+  sandboxReconcilePayloadSchema,
   sessionEventPayloadSchema,
+  sessionPreparingPayloadSchema,
   sessionNativeRuntimeRetirementPayloadSchema,
   sessionNativeRuntimeRetirementResultSchema,
   sessionOperationDeliverySchema,
@@ -54,6 +61,11 @@ export type SandboxControlClientOptions = {
   openWebSocket?: (url: string, credential: string) => WebSocket;
   onRequest?: SandboxControlRequestHandler;
   onDisconnected?: () => void;
+  onConnectionLost?: () => void;
+  onReconnectExhausted?: () => void;
+  onConnected?: () => void;
+  onEventReceiptFailure?: (failure: ControlEventOutboxFailure) => void;
+  onReconcile?: (phase: 'drain' | 'ready' | 'commit', deadlineAt: number) => Promise<void> | void;
   log?: (message: string) => void;
   onDiagnostic?: ControlDiagnosticReporter;
   reconnectDelayMs?: (attempt: number) => number;
@@ -81,9 +93,10 @@ export type SandboxControlClient = {
   sendEvent?(
     event: string,
     payload: unknown,
-    session?: { directory: string; kiloSessionId?: string; rootKiloSessionId?: string },
+    session?: SessionEventIdentity,
     options?: { preserveConnectionOnFailure?: boolean }
   ): boolean;
+  publishSessionEvent?(payload: unknown, session: SessionEventIdentity): Promise<boolean>;
   sendOperationResult?(
     session: SessionRequestIdentity,
     delivery: SessionOperationDelivery,
@@ -91,16 +104,25 @@ export type SandboxControlClient = {
     deadlineAt: number
   ): Promise<SessionOperationAck>;
   reportNativeRuntimeRetirement?(input: {
+    retirementId: string;
     directory: string;
     nativeRuntimeId: string;
     reason: string;
+    cleanupDeadlineAt: number;
   }): Promise<boolean>;
 };
 
 type ClientState =
   | { kind: 'idle' }
   | { kind: 'starting'; promise: Promise<void>; abort: AbortController }
-  | { kind: 'ready'; socket: WebSocket; dispose: () => void; kiloVersionHeartbeat: boolean }
+  | {
+      kind: 'ready';
+      socket: WebSocket;
+      dispose: () => void;
+      kiloVersionHeartbeat: boolean;
+      connectionRecovery: boolean;
+      eventReceipts: boolean;
+    }
   | { kind: 'closed' };
 
 const CONNECT_TIMEOUT_MS = 10_000;
@@ -140,7 +162,19 @@ function serializeEvent(event: string, payload: unknown, session?: SessionEventI
   const frame: EventFrame = {
     type: 'event',
     event,
-    ...(session ? { session } : {}),
+    ...(session
+      ? {
+          session: {
+            directory: session.directory,
+            ...(session.kiloSessionId !== undefined
+              ? { kiloSessionId: session.kiloSessionId }
+              : {}),
+            ...(session.rootKiloSessionId !== undefined
+              ? { rootKiloSessionId: session.rootKiloSessionId }
+              : {}),
+          },
+        }
+      : {}),
     payload: sessionPayload ? prepareSessionEvent(sessionPayload) : payload,
   };
   let serialized = JSON.stringify(frame);
@@ -182,7 +216,13 @@ export function createSandboxControlClient(
 ): SandboxControlClient {
   const wrapperInstanceId = options.wrapperInstanceId;
   let state: ClientState = { kind: 'idle' };
+  let recovery: { episodeId: string; attempt: number; deadlineAt: number } | undefined;
+  let committedRecovery: { episodeId: string; attempt: number; deadlineAt: number } | undefined;
+  let readiness = Promise.withResolvers<void>();
+  let reconnecting = false;
   let eventSequence = 0;
+  let eventReceipts = false;
+  const nativeRetirementReports = new Map<string, Promise<boolean>>();
   const pendingRequests = new Map<
     string,
     { resolve: (frame: ResponseFrame) => void; reject: (reason: unknown) => void }
@@ -213,13 +253,22 @@ export function createSandboxControlClient(
     const current = state;
     diagnostic('retired', ws);
     rejectPendingRequests('Sandbox control connection closed');
-    state = { kind: 'closed' };
+    state = { kind: 'idle' };
+    readiness = Promise.withResolvers<void>();
     current.dispose();
-    options.onDisconnected?.();
+    eventTransport.pause();
+    options.onConnectionLost?.();
+    if (!current.connectionRecovery) {
+      state = { kind: 'closed' };
+      readiness.resolve();
+      options.onDisconnected?.();
+      return;
+    }
+    reconnect();
   }
 
   async function dispatchRequest(ws: WebSocket, request: RequestFrame): Promise<void> {
-    if (state.kind !== 'ready' || state.socket !== ws || !options.onRequest) return;
+    if (state.kind !== 'ready' || state.socket !== ws) return;
     const startedAt = Date.now();
     let errorCode: string | undefined;
     let retryable: boolean | undefined;
@@ -238,12 +287,97 @@ export function createSandboxControlClient(
     requestDiagnostic('received');
     let outcome: Awaited<ReturnType<SandboxControlRequestHandler>>;
     try {
-      outcome = await options.onRequest(
-        request.operation,
-        request.session,
-        request.payload,
-        request.authorization
-      );
+      const reconciliation =
+        request.operation === 'sandbox.reconcile'
+          ? sandboxReconcilePayloadSchema.safeParse(request.payload)
+          : undefined;
+      if (reconciliation) {
+        if (!reconciliation.success) {
+          outcome = {
+            ok: false,
+            error: {
+              code: 'protocol_error',
+              message: 'Invalid recovery request',
+              retryable: false,
+            },
+          };
+        } else {
+          const matchesCommittedRecovery =
+            reconciliation.data.phase === 'commit' &&
+            committedRecovery?.episodeId === reconciliation.data.recovery.episodeId &&
+            committedRecovery.attempt === reconciliation.data.recovery.attempt &&
+            committedRecovery.deadlineAt === reconciliation.data.recovery.deadlineAt;
+          const matchesActiveRecovery =
+            recovery?.episodeId === reconciliation.data.recovery.episodeId &&
+            recovery.attempt === reconciliation.data.recovery.attempt &&
+            recovery.deadlineAt === reconciliation.data.recovery.deadlineAt;
+          if (
+            !matchesCommittedRecovery &&
+            (Date.now() >= reconciliation.data.recovery.deadlineAt ||
+              (reconciliation.data.phase !== 'drain' && !matchesActiveRecovery))
+          ) {
+            outcome = {
+              ok: false,
+              error: { code: 'not_ready', message: 'Recovery authority changed', retryable: false },
+            };
+          } else {
+            if (!matchesCommittedRecovery) {
+              if (reconciliation.data.phase === 'drain') {
+                recovery = {
+                  episodeId: reconciliation.data.recovery.episodeId,
+                  attempt: reconciliation.data.recovery.attempt,
+                  deadlineAt: reconciliation.data.recovery.deadlineAt,
+                };
+                committedRecovery = undefined;
+              }
+              await options.onReconcile?.(
+                reconciliation.data.phase,
+                reconciliation.data.recovery.deadlineAt
+              );
+              if (
+                recovery?.episodeId !== reconciliation.data.recovery.episodeId ||
+                recovery.attempt !== reconciliation.data.recovery.attempt ||
+                recovery.deadlineAt !== reconciliation.data.recovery.deadlineAt ||
+                (state.kind === 'ready' && state.socket !== ws)
+              )
+                return;
+              if (reconciliation.data.phase === 'commit') {
+                committedRecovery = {
+                  episodeId: reconciliation.data.recovery.episodeId,
+                  attempt: reconciliation.data.recovery.attempt,
+                  deadlineAt: reconciliation.data.recovery.deadlineAt,
+                };
+                recovery = undefined;
+              }
+            }
+            outcome = {
+              ok: true,
+              result: {
+                episodeId: reconciliation.data.recovery.episodeId,
+                attempt: reconciliation.data.recovery.attempt,
+                phase: reconciliation.data.phase,
+              },
+            };
+          }
+        }
+      } else if (recovery && ['session.attach', 'session.prompt'].includes(request.operation)) {
+        outcome = {
+          ok: false,
+          error: { code: 'not_ready', message: 'Recovery is still in progress', retryable: true },
+        };
+      } else if (options.onRequest) {
+        outcome = await options.onRequest(
+          request.operation,
+          request.session,
+          request.payload,
+          request.authorization
+        );
+      } else {
+        outcome = {
+          ok: false,
+          error: { code: 'not_ready', message: 'No request handler', retryable: true },
+        };
+      }
     } catch {
       outcome = {
         ok: false,
@@ -325,6 +459,8 @@ export function createSandboxControlClient(
       const requestId = crypto.randomUUID();
       let phase: 'opening' | 'hello' | 'status' | 'finished' = 'opening';
       let kiloVersionHeartbeat = false;
+      let connectionRecovery = false;
+      let negotiatedEventReceipts = false;
       let timeout = setTimeout(fail, Math.min(CONNECT_TIMEOUT_MS, deadlineAt - Date.now()));
 
       function dispose(): void {
@@ -383,6 +519,8 @@ export function createSandboxControlClient(
               sessionOperationResults: true,
               scopedStopAbort: true,
               nativeRuntimeRetirement: true,
+              connectionRecovery: true,
+              eventReceipts: true,
             },
             ...(wrapperInstanceId ? { wrapperInstanceId } : {}),
             ...(options.wrapperVersion ? { wrapperVersion: options.wrapperVersion } : {}),
@@ -427,6 +565,8 @@ export function createSandboxControlClient(
             return;
           }
           kiloVersionHeartbeat = hello.data.capabilities?.kiloVersionHeartbeat === true;
+          connectionRecovery = hello.data.capabilities?.connectionRecovery === true;
+          negotiatedEventReceipts = hello.data.capabilities?.eventReceipts === true;
           phase = 'status';
           diagnostic('hello_accepted', ws);
           return;
@@ -469,13 +609,19 @@ export function createSandboxControlClient(
           kind: 'ready',
           socket: ws,
           kiloVersionHeartbeat,
+          connectionRecovery,
+          eventReceipts: negotiatedEventReceipts,
           dispose: () => {
             clearInterval(keepalive);
             dispose();
           },
         };
         diagnostic('ready', ws);
+        eventReceipts = negotiatedEventReceipts;
         resolve();
+        readiness.resolve();
+        options.onConnected?.();
+        void eventTransport.resume();
       }
 
       signal.addEventListener('abort', fail, { once: true });
@@ -498,7 +644,7 @@ export function createSandboxControlClient(
       deadlineAt - Date.now()
     );
     try {
-      for (let attempt = 1; ; attempt += 1) {
+      for (let attempt = 1; attempt <= SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS; attempt += 1) {
         signal.throwIfAborted();
         if (Date.now() >= deadlineAt) throw new Error('sandbox control startup timeout');
         try {
@@ -511,7 +657,8 @@ export function createSandboxControlClient(
         } catch {
           signal.throwIfAborted();
           const remaining = deadlineAt - Date.now();
-          if (remaining <= 0) throw new Error('sandbox control startup timeout');
+          if (remaining <= 0 || attempt === SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS)
+            throw new Error('sandbox control startup timeout');
           options.log?.('sandbox control connect failed');
           const delayMs = Math.min(
             remaining,
@@ -535,27 +682,250 @@ export function createSandboxControlClient(
     }
   }
 
+  function startConnection(): Promise<void> {
+    if (state.kind === 'closed') return Promise.reject(new Error('sandbox control client closed'));
+    if (state.kind === 'ready') return Promise.resolve();
+    if (state.kind === 'starting') return state.promise;
+    const deadlineAt = Date.now() + SANDBOX_CONTROL_REQUEST_TIMEOUT_MS;
+    const starting: Extract<ClientState, { kind: 'starting' }> = {
+      kind: 'starting',
+      abort: new AbortController(),
+      promise: Promise.resolve().then(() => connectUntilReady(starting, deadlineAt)),
+    };
+    state = starting;
+    return starting.promise;
+  }
+
+  function reconnect(): void {
+    if (reconnecting || state.kind !== 'idle') return;
+    reconnecting = true;
+    void startConnection().then(
+      () => {
+        reconnecting = false;
+      },
+      () => {
+        reconnecting = false;
+        if (state.kind !== 'closed') state = { kind: 'closed' };
+        readiness.resolve();
+        options.onReconnectExhausted?.();
+        options.onDisconnected?.();
+      }
+    );
+  }
+
+  async function waitForReady(signal: AbortSignal, deadlineAt: number): Promise<WebSocket> {
+    while (state.kind !== 'ready') {
+      signal.throwIfAborted();
+      if (state.kind === 'closed' || Date.now() >= deadlineAt)
+        throw new ControlDeliveryError('Control transport unavailable', true);
+      try {
+        await withTimeoutAndAbort(readiness.promise, {
+          signal,
+          timeoutMs: Math.max(1, deadlineAt - Date.now()),
+          timeoutMessage: 'Control transport unavailable',
+          abortMessage: 'Control transport wait cancelled',
+        });
+      } catch {
+        signal.throwIfAborted();
+        throw new ControlDeliveryError('Control transport unavailable', true);
+      }
+    }
+    return state.socket;
+  }
+
+  async function publishEvent(
+    publication: {
+      event: 'session.event' | 'session.preparing';
+      receiptId: string;
+      receiptHash: string;
+      session: SessionEventIdentity;
+      payload: unknown;
+    },
+    deadlineAt: number
+  ): Promise<void> {
+    if (
+      state.kind !== 'ready' ||
+      !state.eventReceipts ||
+      state.socket.readyState !== 1 ||
+      Date.now() >= deadlineAt
+    )
+      throw new ControlDeliveryError('Control event transport is unavailable', true);
+    const socket = state.socket;
+    const requestId = crypto.randomUUID();
+    const frame: RequestFrame = {
+      type: 'request',
+      requestId,
+      operation: 'sandbox.event.publish',
+      payload: publication,
+    };
+    const serialized = JSON.stringify(frame);
+    if (Buffer.byteLength(serialized) > MAX_SANDBOX_CONTROL_FRAME_BYTES)
+      throw new ControlDeliveryError('Control event exceeds the frame budget', false);
+    const response = await new Promise<ResponseFrame>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => {
+          pendingRequests.delete(requestId);
+          reject(new ControlDeliveryError('Control event receipt timed out', true));
+        },
+        Math.max(1, Math.min(SANDBOX_CONTROL_REQUEST_TIMEOUT_MS, deadlineAt - Date.now()))
+      );
+      timeout.unref();
+      pendingRequests.set(requestId, {
+        resolve: frame => {
+          clearTimeout(timeout);
+          resolve(frame);
+        },
+        reject: reason => {
+          clearTimeout(timeout);
+          reject(reason);
+        },
+      });
+      try {
+        socket.send(serialized);
+      } catch {
+        pendingRequests.delete(requestId);
+        clearTimeout(timeout);
+        reject(new ControlDeliveryError('Control event publication failed', true));
+      }
+    });
+    if (
+      state.kind !== 'ready' ||
+      state.socket !== socket ||
+      socket.readyState !== 1 ||
+      Date.now() >= deadlineAt
+    )
+      throw new ControlDeliveryError('Control event acknowledgement is stale', true);
+    if (!response.ok)
+      throw new ControlDeliveryError(
+        'Control event was not acknowledged',
+        response.error?.retryable === true && !PERMANENT_CONTROL_ERRORS.has(response.error.code)
+      );
+    const acknowledgement = sandboxEventPublicationResultSchema.safeParse(response.result);
+    if (!acknowledgement.success || acknowledgement.data.receiptId !== publication.receiptId)
+      throw new ControlDeliveryError('Control event acknowledgement is invalid', false);
+  }
+
+  function sendLegacySessionEvent(payload: unknown, session: SessionEventIdentity): boolean {
+    if (state.kind !== 'ready') return false;
+    const { socket } = state;
+    if (socket.readyState !== 1) {
+      retireConnection(socket);
+      return false;
+    }
+    try {
+      socket.send(serializeEvent('session.event', payload, session));
+      return true;
+    } catch {
+      retireConnection(socket);
+      return false;
+    }
+  }
+
+  const eventTransport = createControlEventTransport({
+    supportsReceipts: () => eventReceipts,
+    publish: publishEvent,
+    prepare: ({ event, payload, session }) =>
+      event === 'session.event'
+        ? {
+            event,
+            session,
+            payload: prepareSessionEvent(sessionEventPayloadSchema.parse(payload)),
+          }
+        : { event, session, payload: sessionPreparingPayloadSchema.parse(payload) },
+    sendLegacy: (payload, session) => sendLegacySessionEvent(payload, session),
+    onFailure: failure => {
+      options.log?.(`sandbox control event publication ${failure.reason}`);
+      options.onEventReceiptFailure?.(failure);
+    },
+  });
+
+  async function sendNativeRuntimeRetirement(
+    payload: ReturnType<typeof sessionNativeRuntimeRetirementPayloadSchema.parse>,
+    deadlineAt: number
+  ): Promise<boolean> {
+    const signal = new AbortController().signal;
+    while (Date.now() < deadlineAt) {
+      try {
+        const socket = await waitForReady(signal, deadlineAt);
+        if (socket.readyState !== 1)
+          throw new ControlDeliveryError('Control transport unavailable', true);
+        const requestId = crypto.randomUUID();
+        const frame: RequestFrame = {
+          type: 'request',
+          requestId,
+          operation: 'session.runtime.retired',
+          payload,
+        };
+        const serialized = JSON.stringify(frame);
+        if (Buffer.byteLength(serialized) > MAX_SANDBOX_CONTROL_FRAME_BYTES)
+          throw new ControlDeliveryError(
+            'Native runtime retirement exceeds the frame budget',
+            false
+          );
+        const response = await new Promise<ResponseFrame>((resolve, reject) => {
+          const timeout = setTimeout(
+            () => {
+              pendingRequests.delete(requestId);
+              reject(new ControlDeliveryError('Native runtime retirement timed out', true));
+            },
+            Math.max(1, Math.min(SANDBOX_CONTROL_REQUEST_TIMEOUT_MS, deadlineAt - Date.now()))
+          );
+          timeout.unref();
+          pendingRequests.set(requestId, {
+            resolve: frame => {
+              clearTimeout(timeout);
+              resolve(frame);
+            },
+            reject: reason => {
+              clearTimeout(timeout);
+              reject(reason);
+            },
+          });
+          try {
+            socket.send(serialized);
+          } catch {
+            pendingRequests.delete(requestId);
+            clearTimeout(timeout);
+            reject(new ControlDeliveryError('Native runtime retirement publication failed', true));
+          }
+        });
+        if (
+          state.kind !== 'ready' ||
+          state.socket !== socket ||
+          socket.readyState !== 1 ||
+          Date.now() >= deadlineAt
+        )
+          throw new ControlDeliveryError(
+            'Native runtime retirement acknowledgement is stale',
+            true
+          );
+        if (!response.ok)
+          throw new ControlDeliveryError(
+            'Native runtime retirement was not acknowledged',
+            response.error?.retryable === true && !PERMANENT_CONTROL_ERRORS.has(response.error.code)
+          );
+        return sessionNativeRuntimeRetirementResultSchema.safeParse(response.result).success;
+      } catch (error) {
+        if (!(error instanceof ControlDeliveryError) || !error.retryable) return false;
+        if (Date.now() >= deadlineAt) return false;
+        await delay(Math.min(250, Math.max(1, deadlineAt - Date.now())));
+      }
+    }
+    return false;
+  }
+
   return {
     connect(): Promise<void> {
-      if (state.kind === 'closed')
-        return Promise.reject(new Error('sandbox control client closed'));
-      if (state.kind === 'ready') return Promise.resolve();
-      if (state.kind === 'starting') return state.promise;
-      const deadlineAt = Date.now() + SANDBOX_CONTROL_REQUEST_TIMEOUT_MS;
-      const starting: Extract<ClientState, { kind: 'starting' }> = {
-        kind: 'starting',
-        abort: new AbortController(),
-        promise: Promise.resolve().then(() => connectUntilReady(starting, deadlineAt)),
-      };
-      state = starting;
-      return starting.promise;
+      return startConnection();
     },
 
     close(): void {
       const current = state;
       diagnostic('closed', current.kind === 'ready' ? current.socket : undefined);
       rejectPendingRequests('Sandbox control client closed');
+      eventTransport.close();
       state = { kind: 'closed' };
+      readiness.resolve();
       if (current.kind === 'starting')
         current.abort.abort(new Error('sandbox control client closed'));
       else if (current.kind === 'ready') current.dispose();
@@ -570,9 +940,9 @@ export function createSandboxControlClient(
       signal.throwIfAborted();
       if (Date.now() >= deadlineAt)
         throw new ControlDeliveryError('Control delivery expired', false);
-      if (state.kind !== 'ready' || state.socket.readyState !== 1)
+      const socket = await waitForReady(signal, deadlineAt);
+      if (socket.readyState !== 1)
         throw new ControlDeliveryError('Control transport unavailable', true);
-      const { socket } = state;
       const requestId = crypto.randomUUID();
       let payload: SessionOperationDelivery;
       try {
@@ -659,57 +1029,17 @@ export function createSandboxControlClient(
     },
 
     async reportNativeRuntimeRetirement(input): Promise<boolean> {
-      if (state.kind !== 'ready' || state.socket.readyState !== 1)
-        throw new ControlDeliveryError('Control transport unavailable', true);
       const payload = sessionNativeRuntimeRetirementPayloadSchema.parse(input);
-      const { socket } = state;
-      const requestId = crypto.randomUUID();
-      const frame: RequestFrame = {
-        type: 'request',
-        requestId,
-        operation: 'session.runtime.retired',
-        payload,
-      };
-      const serialized = JSON.stringify(frame);
-      if (Buffer.byteLength(serialized) > MAX_SANDBOX_CONTROL_FRAME_BYTES)
-        throw new ControlDeliveryError('Native runtime retirement exceeds the frame budget', false);
-      const pending = new Promise<ResponseFrame>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          pendingRequests.delete(requestId);
-          reject(new ControlDeliveryError('Native runtime retirement timed out', true));
-        }, SANDBOX_CONTROL_REQUEST_TIMEOUT_MS);
-        timeout.unref();
-        pendingRequests.set(requestId, {
-          resolve: frame => {
-            clearTimeout(timeout);
-            resolve(frame);
-          },
-          reject: reason => {
-            clearTimeout(timeout);
-            reject(reason);
-          },
-        });
-      });
-      try {
-        socket.send(serialized);
-      } catch {
-        const waiter = pendingRequests.get(requestId);
-        if (waiter) {
-          pendingRequests.delete(requestId);
-          waiter.reject(
-            new ControlDeliveryError('Native runtime retirement publication failed', true)
-          );
-        }
-      }
-      const response = await pending;
-      if (
-        state.kind !== 'ready' ||
-        state.socket !== socket ||
-        socket.readyState !== 1 ||
-        !response.ok
-      )
-        return false;
-      return sessionNativeRuntimeRetirementResultSchema.safeParse(response.result).success;
+      const key = JSON.stringify(payload);
+      const existing = nativeRetirementReports.get(key);
+      if (existing) return existing;
+      const report = sendNativeRuntimeRetirement(payload, payload.cleanupDeadlineAt);
+      nativeRetirementReports.set(key, report);
+      return report;
+    },
+
+    async publishSessionEvent(payload, session): Promise<boolean> {
+      return eventTransport.publishSessionEvent(payload, session);
     },
 
     sendEvent(
@@ -743,6 +1073,24 @@ export function createSandboxControlClient(
           bytes,
           bufferedBytes: state.kind === 'ready' ? state.socket.bufferedAmount : undefined,
         });
+      if (
+        eventReceipts &&
+        session &&
+        (event === 'session.event' || event === 'session.preparing')
+      ) {
+        try {
+          const accepted = eventTransport.enqueue(event, payload, session);
+          if (!accepted) eventDiagnostic('outbox_rejected');
+          else {
+            void eventTransport.resume();
+            eventDiagnostic('outbox_enqueued');
+          }
+          return accepted;
+        } catch {
+          eventDiagnostic('outbox_rejected');
+          return false;
+        }
+      }
       if (state.kind !== 'ready') {
         eventDiagnostic('skipped');
         return false;

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
@@ -4333,7 +4333,7 @@ describe('control wrapper heartbeat source policy', () => {
     );
     expect(source).toMatch(/void control \.reportNativeRuntimeRetirement\(\{/);
     expect(source).toContain(
-      "if (failure.cleanup === 'unconfirmed' || !control?.reportNativeRuntimeRetirement) { shutdown(1, failure.reason); return; }"
+      "if (failure.cleanup === 'unconfirmed' || !control?.reportNativeRuntimeRetirement)"
     );
     expect(source).toContain('nativeRuntimeId: failure.runtimeId,');
     expect(source).toContain(

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
@@ -225,8 +225,8 @@ export type HandlerDeps = {
   emitSessionEvent: (
     session: SessionRequestIdentity,
     payload: SessionEventPayload,
-    options?: { retained?: true }
-  ) => void;
+    options?: { retained?: true; nativeRuntimeId?: string }
+  ) => unknown;
   retireRuntime: (reason: string) => void;
   onShutdown?: () => void;
   onDiagnostic?: ControlDiagnosticReporter;
@@ -257,8 +257,10 @@ function operationEffects(session: SessionRequestIdentity, deps: HandlerDeps) {
   return {
     signal: deps.signal,
     onDiagnostic: deps.onDiagnostic,
-    emitSessionEvent: (event: SessionEventPayload, options?: { retained?: true }) =>
-      deps.emitSessionEvent(session, event, options),
+    emitSessionEvent: (
+      event: SessionEventPayload,
+      options?: { retained?: true; nativeRuntimeId?: string }
+    ) => deps.emitSessionEvent(session, event, options),
     sendOperationResult: send
       ? (delivery: SessionOperationDelivery, signal: AbortSignal, deadlineAt: number) =>
           send(session, delivery, signal, deadlineAt)
@@ -866,11 +868,15 @@ function handlePrompt(
       existing.messageId === request.messageId &&
       !existing.signal.aborted
     ) {
-      return ok({ messageId: request.messageId, status: 'existing' });
+      return ok({
+        messageId: request.messageId,
+        status: 'existing',
+        ...(authorization ? { executionDeadlineAt: existing.executionDeadlineAt } : {}),
+      });
     }
     return rejectBeforeAdmission('session_busy', 'Session has work in progress', true);
   }
-  deps.operations.start(
+  const operation = deps.operations.start(
     session,
     authorization,
     {
@@ -882,7 +888,11 @@ function handlePrompt(
     },
     operationEffects(session, deps)
   );
-  return ok({ messageId: request.messageId, status: 'accepted' });
+  return ok({
+    messageId: request.messageId,
+    status: 'accepted',
+    ...(authorization ? { executionDeadlineAt: operation.executionDeadlineAt } : {}),
+  });
 }
 
 async function abortKiloSession(

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.test.ts
@@ -103,7 +103,8 @@ describe('maybeStartSandboxControlClient', () => {
       wrapperVersion: '2.4.0',
     });
     expect(received?.log).toBeTypeOf('function');
-    expect(received?.onDisconnected).toBeTypeOf('function');
+    expect(received?.onConnectionLost).toBeTypeOf('function');
+    expect(received?.onReconnectExhausted).toBeTypeOf('function');
     await Promise.resolve();
     expect(connectCalls).toBe(1);
     expect(logs.join('\n')).not.toContain(credential);
@@ -520,7 +521,7 @@ describe('maybeStartSandboxControlClient', () => {
         expect(signal?.aborted).toBe(false);
         if (loss === 'readiness') ready = false;
         else if (loss === 'close') started?.close();
-        else received?.onDisconnected?.();
+        else received?.onReconnectExhausted?.();
         tick();
         expect(signal?.aborted).toBe(true);
         expect(cleared).toHaveBeenCalledTimes(1);

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.ts
@@ -27,6 +27,8 @@ type StartOptions = {
   onRequest?: SandboxControlRequestHandler;
   onConnected?: (client: SandboxControlClient) => void;
   onDisconnected?: () => void;
+  onEventReceiptFailure?: () => void;
+  onReconcile?: (phase: 'drain' | 'ready' | 'commit', deadlineAt: number) => Promise<void> | void;
   getHeartbeatPayload?: () => SandboxHeartbeatPayload;
   sampleHeartbeat?: (signal: AbortSignal) => Promise<void>;
   isReady?: () => boolean;
@@ -344,8 +346,9 @@ export function maybeStartSandboxControlClient(
   const createClient = options.createClient ?? createSandboxControlClient;
   let heartbeat: ReturnType<typeof setInterval> | null = null;
   let sampling: Promise<void> | undefined;
-  const sampleAbort = new AbortController();
+  let sampleAbort = new AbortController();
   let closed = false;
+  let connectedThroughCallback = false;
   let heartbeatSequence = 0;
   let lastSentAt: number | undefined;
   const diagnostic = (phase: string): void =>
@@ -361,6 +364,11 @@ export function maybeStartSandboxControlClient(
     if (heartbeat) clearInterval(heartbeat);
     heartbeat = null;
     diagnostic('stopped');
+  }
+
+  function handleConnectionLost(): void {
+    if (closed) return;
+    stopHeartbeat();
   }
 
   function handleDisconnected(): void {
@@ -422,6 +430,7 @@ export function maybeStartSandboxControlClient(
 
   function handleConnected(active: SandboxControlClient): void {
     if (closed || options.isReady?.() === false) return;
+    if (sampleAbort.signal.aborted) sampleAbort = new AbortController();
     if (!active.sendEvent?.('sandbox.ready', { kiloReady: true, globalFeedAttached: true })) {
       handleDisconnected();
       return;
@@ -446,7 +455,16 @@ export function maybeStartSandboxControlClient(
     ...(env.wrapperInstanceId ? { wrapperInstanceId: env.wrapperInstanceId } : {}),
     wrapperVersion: options.wrapperVersion,
     log,
-    onDisconnected: handleDisconnected,
+    onConnectionLost: handleConnectionLost,
+    onReconnectExhausted: handleDisconnected,
+    ...(options.onEventReceiptFailure
+      ? { onEventReceiptFailure: options.onEventReceiptFailure }
+      : {}),
+    onConnected: () => {
+      connectedThroughCallback = true;
+      handleConnected(client);
+    },
+    ...(options.onReconcile ? { onReconcile: options.onReconcile } : {}),
     ...(options.onRequest ? { onRequest: options.onRequest } : {}),
     ...(options.onDiagnostic ? { onDiagnostic: options.onDiagnostic } : {}),
   });
@@ -461,7 +479,7 @@ export function maybeStartSandboxControlClient(
   void client
     .connect()
     .then(() => {
-      handleConnected(client);
+      if (!connectedThroughCallback) handleConnected(client);
     })
     .catch(() => {
       if (!closed) {

--- a/services/cloud-agent-next/wrapper/src/control/session-operation-cleanup.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-operation-cleanup.test.ts
@@ -439,7 +439,10 @@ describe('SessionOperation cleanup', () => {
         handlerDeps,
         authorization
       )
-    ).toEqual({ ok: true, result: { messageId: 'msg_1', status: 'existing' } });
+    ).toEqual({
+      ok: true,
+      result: { messageId: 'msg_1', status: 'existing', executionDeadlineAt: expect.any(Number) },
+    });
     expect(submissions).toBe(1);
 
     original.resolve(completion());

--- a/services/cloud-agent-next/wrapper/src/control/session-operation.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-operation.test.ts
@@ -55,6 +55,63 @@ function onlyOperation(handlerDeps: HandlerDeps) {
 }
 
 describe('operation results and delivery', () => {
+  it('keeps native-tagged live events separate from sealed result delivery after replacement', async () => {
+    const releaseDelivery = Promise.withResolvers<void>();
+    const sending = Promise.withResolvers<void>();
+    const emitted: Array<Parameters<HandlerDeps['emitSessionEvent']>[2]> = [];
+    const handlerDeps = deps({
+      runAutoCommit: async options => {
+        options.onEvent({
+          streamEventType: 'autocommit_completed',
+          data: { success: true, messageId: options.messageId, commitHash: 'original' },
+          timestamp: new Date().toISOString(),
+        });
+        return { success: true };
+      },
+      emitSessionEvent: (_session, _event, options) => emitted.push(options),
+      sendOperationResult: async (_session, delivery) => {
+        sending.resolve();
+        await releaseDelivery.promise;
+        return acknowledgeOperation(delivery);
+      },
+    });
+    const runtimes = handlerDeps.kiloRuntimes;
+    const original = runtimes?.get(session.directory);
+    if (!runtimes || !original) throw new Error('Missing original runtime');
+    const authorization = operationAuthorization();
+    await handleControlRequest(
+      'session.prompt',
+      session,
+      { ...promptPayload, finalization: { autoCommit: true } },
+      handlerDeps,
+      authorization
+    );
+    const record = onlyOperation(handlerDeps);
+    try {
+      await record.done;
+      await sending.promise;
+      const sealed = record.deliveryResult();
+      expect(emitted).toEqual([{ retained: true, nativeRuntimeId: original.runtimeId }]);
+      const replacement = { ...original, runtimeId: crypto.randomUUID(), kiloClient: fakeKilo() };
+      runtimes.get = () => replacement;
+      expect(
+        await handleControlRequest('session.operation.get', session, authorization, handlerDeps)
+      ).toEqual({
+        ok: true,
+        result: { state: 'completed', delivery: sealed },
+      });
+      releaseDelivery.resolve();
+      await record.waitForDelivery();
+      expect(record.deliveryResult()).toEqual(sealed);
+      expect(record.snapshot().delivery?.state).toBe('acknowledged');
+      expect(sealed?.events).toHaveLength(1);
+      expect(sealed).not.toHaveProperty('nativeRuntimeId');
+    } finally {
+      releaseDelivery.resolve();
+      await record.waitForDelivery();
+    }
+  });
+
   it.each([{ data: undefined }, { data: null }, { data: [] }, { data: 'invalid' }, { data: 1 }])(
     'rejects malformed finalization notification data without changing the producer result: %j',
     async ({ data }) => {
@@ -570,7 +627,10 @@ describe('operation results and delivery', () => {
         handlerDeps,
         authorization
       )
-    ).toEqual({ ok: true, result: { messageId: 'msg_1', status: 'existing' } });
+    ).toEqual({
+      ok: true,
+      result: { messageId: 'msg_1', status: 'existing', executionDeadlineAt: expect.any(Number) },
+    });
     expect(finalizations).toBe(1);
   });
 

--- a/services/cloud-agent-next/wrapper/src/control/session-operation.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-operation.ts
@@ -105,7 +105,10 @@ export type SessionOperationDependencies = {
   prepareForNewWork?: () => boolean;
   verifyQuiescence: (target: NativeOperationTarget, deadlineAt: number) => Promise<boolean>;
   retireRuntime: (reason: string, deadlineAt: number, target?: NativeOperationTarget) => void;
-  emitSessionEvent: (payload: SessionEventPayload, options?: { retained?: true }) => void;
+  emitSessionEvent: (
+    payload: SessionEventPayload,
+    options?: { retained?: true; nativeRuntimeId?: string }
+  ) => unknown;
   sendOperationResult?: OperationResultSender;
   onLocalCompletion: (retain: boolean) => void;
   onCleanupConfirmed: () => void;
@@ -423,10 +426,7 @@ export class SessionOperation {
             : undefined;
         if (this.authorization && isRetainedOperationPreparing(event) && !retained) return;
         try {
-          work.emitPreparing?.(
-            retained ?? event,
-            this.authorization ? { retained: true } : undefined
-          );
+          work.emitPreparing?.(retained ?? event, this.eventOptions());
         } catch {
           if (!this.authorization) throw new Error('Preparation event delivery failed');
         }
@@ -455,6 +455,13 @@ export class SessionOperation {
     };
   }
 
+  private eventOptions(): { retained?: true; nativeRuntimeId?: string } {
+    return {
+      ...(this.authorization ? { retained: true } : {}),
+      ...(this.target ? { nativeRuntimeId: this.target.runtimeId } : {}),
+    };
+  }
+
   private emitFinalizationEvent(event: IngestEvent): void {
     const payload = sessionEventPayloadSchema.safeParse({
       type: event.streamEventType,
@@ -470,10 +477,9 @@ export class SessionOperation {
         : undefined;
     if (this.authorization && requiresRetention && !retained) return;
     try {
-      this.deps.emitSessionEvent(
-        retained ?? payload.data,
-        this.authorization ? { retained: true } : undefined
-      );
+      const delivered = this.deps.emitSessionEvent(retained ?? payload.data, this.eventOptions());
+      if (delivered === false && !this.authorization)
+        throw new Error('Finalization event delivery failed');
     } catch {
       if (!this.authorization) throw new Error('Finalization event delivery failed');
     }
@@ -772,7 +778,16 @@ export class SessionOperation {
     if (!this.authorization) {
       try {
         diagnostic('outcome_sending', outcome.status);
-        this.deps.emitSessionEvent({ type: 'session.message.outcome', properties: this.outcome });
+        if (
+          this.deps.emitSessionEvent(
+            {
+              type: 'session.message.outcome',
+              properties: this.outcome,
+            },
+            this.eventOptions()
+          ) === false
+        )
+          throw new Error('Session outcome delivery failed');
         diagnostic('outcome_sent', outcome.status);
       } catch {
         diagnostic('outcome_failed', outcome.status);

--- a/services/cloud-agent-next/wrapper/src/control/worktree-feed.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-feed.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, it, spyOn } from 'bun:test';
-import { SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS } from '../../../src/shared/sandbox-control-protocol';
+import {
+  SANDBOX_CONTROL_RECOVERY_MAX_ATTEMPTS,
+  sandboxEventPublicationPayloadSchema,
+  type ControlFrame,
+} from '../../../src/shared/sandbox-control-protocol';
+import { createSandboxControlClient } from './sandbox-control-client';
+import { eventKiloSessionId, sessionEventIdentity } from './feed';
+import { forgetAttachedRoot, rememberAttachedRoot } from './session-directories';
 import * as controlRuntime from './sandbox-control-runtime';
-import { createWorktreeFeed } from './worktree-feed';
+import { createWorktreeFeed, type KiloFeedEvent } from './worktree-feed';
 
 type FeedOptions = Parameters<typeof controlRuntime.startSandboxControlEventFeed>[0];
 
@@ -58,8 +65,7 @@ function fixture(rejectReconnections = false) {
   };
   const attempts: ReturnType<typeof nativeFeed>[] = [];
   const failures: string[] = [];
-  const events: Array<{ type: string; properties: Record<string, unknown>; directory?: string }> =
-    [];
+  const events: KiloFeedEvent[] = [];
   const start = spyOn(controlRuntime, 'startSandboxControlEventFeed').mockImplementation(
     async options => {
       if (rejectReconnections && attempts.length > 0) throw new Error('Feed unavailable');
@@ -85,6 +91,178 @@ afterEach(() => {
 });
 
 describe('createWorktreeFeed', () => {
+  it.each([true, false])(
+    'preserves producer lifetime with event receipts=%s',
+    async eventReceipts => {
+      const sockets: Array<ReturnType<typeof socket>> = [];
+      function socket() {
+        const events = new EventTarget();
+        return Object.assign(events, {
+          readyState: 1,
+          sent: [] as ControlFrame[],
+          send(data: string) {
+            if (data === 'ping') return;
+            const frame = JSON.parse(data) as ControlFrame;
+            this.sent.push(frame);
+            if (frame.type !== 'request') return;
+            const result =
+              frame.operation === 'sandbox.hello'
+                ? {
+                    protocolVersion: 1,
+                    handshakeComplete: true,
+                    capabilities: { connectionRecovery: true, eventReceipts },
+                  }
+                : frame.operation === 'sandbox.event.publish'
+                  ? {
+                      receiptId: sandboxEventPublicationPayloadSchema.parse(frame.payload)
+                        .receiptId,
+                      applied: true,
+                    }
+                  : undefined;
+            if (!result) return;
+            events.dispatchEvent(
+              new MessageEvent('message', {
+                data: JSON.stringify({
+                  type: 'response',
+                  requestId: frame.requestId,
+                  ok: true,
+                  result,
+                }),
+              })
+            );
+            if (frame.operation === 'sandbox.hello')
+              events.dispatchEvent(
+                new MessageEvent('message', {
+                  data: JSON.stringify({
+                    type: 'request',
+                    requestId: 'probe',
+                    operation: 'sandbox.status',
+                    payload: {},
+                  }),
+                })
+              );
+          },
+          close() {
+            this.readyState = 3;
+            events.dispatchEvent(new Event('close'));
+          },
+        });
+      }
+      const client = createSandboxControlClient({
+        url: 'wss://example.test/control',
+        credential: 'test',
+        providerInstanceId: 'test',
+        reconnectDelayMs: () => 0,
+        openWebSocket: () => {
+          const next = socket();
+          if (sockets.length > 0) next.readyState = 0;
+          sockets.push(next);
+          return next as unknown as WebSocket;
+        },
+      });
+      const h = fixture();
+      const feeds: ReturnType<typeof createWorktreeFeed>[] = [];
+      const start = () => {
+        const feed = createWorktreeFeed({
+          source: h.source,
+          isCurrent: runtimeId => runtimeId === h.source.runtimeId,
+          onEvent: async event => {
+            const identity = sessionEventIdentity({
+              ...event,
+              sessionId: eventKiloSessionId(event.properties),
+              runtimeDirectory: h.source.directory,
+            });
+            if (!identity) throw new Error('Missing event identity');
+            expect(
+              await client.publishSessionEvent?.(
+                { type: event.type, properties: event.properties },
+                identity
+              )
+            ).toBe(true);
+          },
+          onFailure: reason => h.failures.push(reason),
+        });
+        feeds.push(feed);
+        return feed.open();
+      };
+      const envelope = {
+        directory: h.source.directory,
+        nativeRuntimeId: crypto.randomUUID(),
+        payload: {
+          type: 'session.status',
+          properties: { sessionID: 'receipt_root', status: { type: 'idle' } },
+        },
+      };
+      rememberAttachedRoot('receipt_root', h.source.directory);
+      try {
+        await client.connect();
+        const originalSocket = sockets[0];
+        if (!originalSocket) throw new Error('Missing original socket');
+        if (eventReceipts) originalSocket.close();
+        await start();
+        const originalId = h.source.runtimeId;
+        await h.attempts[0]?.emit(envelope);
+        h.source.runtimeId = crypto.randomUUID();
+        await start();
+        await h.attempts[0]?.emit(envelope);
+        await h.attempts[1]?.emit(envelope);
+        const frames = () =>
+          sockets
+            .flatMap(item => item.sent)
+            .filter(frame => frame.type === 'request' || frame.type === 'event')
+            .filter(frame =>
+              eventReceipts
+                ? frame.type === 'request' && frame.operation === 'sandbox.event.publish'
+                : frame.type === 'event'
+            );
+        if (eventReceipts) {
+          expect(frames()).toEqual([]);
+          await waitFor(() => sockets.length === 2);
+          const replacement = sockets[1];
+          if (!replacement) throw new Error('Missing replacement socket');
+          replacement.readyState = 1;
+          replacement.dispatchEvent(new Event('open'));
+        }
+        await waitFor(() => frames().length === 2);
+        if (eventReceipts) {
+          expect(sockets).toHaveLength(2);
+          const publications = frames().map(frame =>
+            sandboxEventPublicationPayloadSchema.parse(frame.payload)
+          );
+          expect(publications.map(item => item.session.nativeRuntimeId)).toEqual([
+            originalId,
+            h.source.runtimeId,
+          ]);
+          expect(publications.map(item => item.sequence)).toEqual([1, 2]);
+          expect(
+            originalSocket.sent.some(
+              frame => frame.type === 'request' && frame.operation === 'sandbox.event.publish'
+            )
+          ).toBe(false);
+        } else {
+          expect(sockets).toHaveLength(1);
+          for (const frame of frames())
+            expect(frame).toEqual({
+              type: 'event',
+              event: 'session.event',
+              session: {
+                directory: h.source.directory,
+                kiloSessionId: 'receipt_root',
+                rootKiloSessionId: 'receipt_root',
+              },
+              payload: envelope.payload,
+            });
+        }
+        expect(h.failures).toEqual([]);
+      } finally {
+        for (const feed of feeds) feed.close();
+        client.close();
+        h.start.mockRestore();
+        forgetAttachedRoot('receipt_root');
+      }
+    }
+  );
+
   it.each(['feed_ended', 'feed_failed', 'feed_stale', 'feed_reconnected'] as const)(
     'replaces a %s subscription without stopping the native process',
     async reason => {
@@ -114,6 +292,7 @@ describe('createWorktreeFeed', () => {
       expect(h.events).toEqual([
         {
           directory: h.source.directory,
+          nativeRuntimeId: h.source.runtimeId,
           type: 'session.updated',
           properties: { sessionID: 'current' },
         },

--- a/services/cloud-agent-next/wrapper/src/control/worktree-feed.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-feed.ts
@@ -20,6 +20,7 @@ export type KiloFeedEvent = {
   type: string;
   properties: Record<string, unknown>;
   directory?: string;
+  nativeRuntimeId: string;
 };
 
 export type WorktreeFeedSource = Readonly<{
@@ -53,7 +54,7 @@ type Recovery = {
 export function createWorktreeFeed(options: {
   source: WorktreeFeedSource;
   isCurrent: (runtimeId: string, client: WorktreeFeedSource['kiloClient']) => boolean;
-  onEvent?: (event: KiloFeedEvent) => void;
+  onEvent?: (event: KiloFeedEvent) => unknown;
   onFailure: (reason: KiloEventFeedError['reason']) => void;
   onStateChange?: () => void;
   onDiagnostic?: ControlDiagnosticReporter;
@@ -133,7 +134,7 @@ export function createWorktreeFeed(options: {
       consume: async stream => {
         for await (const event of unfilteredKiloEvents(stream)) {
           if (!isCurrentAttempt(attempt)) return;
-          options.onEvent?.(event);
+          await options.onEvent?.({ ...event, nativeRuntimeId: runtimeId });
         }
       },
       onUnexpectedClose: error => {

--- a/services/cloud-agent-next/wrapper/src/control/worktree-mutation-notifications.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-mutation-notifications.test.ts
@@ -300,7 +300,12 @@ function expectedHint(kiloSessionId = 'root', worktree = directory): Parameters<
   return [
     'session.event',
     { type: WORKTREE_CHANGED_EVENT, properties: {} },
-    { directory: worktree, kiloSessionId, rootKiloSessionId: kiloSessionId },
+    {
+      directory: worktree,
+      kiloSessionId,
+      rootKiloSessionId: kiloSessionId,
+      nativeRuntimeId: expect.any(String),
+    },
   ];
 }
 
@@ -863,6 +868,7 @@ describe('worktree mutation notifications', () => {
     h.notifications.observe(replacement.runtime, { ...fileEdited, directory });
     jest.advanceTimersByTime(5_000);
     expect(h.sendEvent.mock.calls).toEqual([expectedHint()]);
+    expect(h.sendEvent.mock.calls[0]?.[2].nativeRuntimeId).toBe(replacement.runtime.runtimeId);
   });
 
   it('never queues while aborted, disposed, deleting, or without an attached snapshot', async () => {

--- a/services/cloud-agent-next/wrapper/src/control/worktree-mutation-notifications.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-mutation-notifications.ts
@@ -13,6 +13,7 @@ type KiloEvent = {
 };
 
 type NotificationIdentity = {
+  nativeRuntimeId: string;
   directory: string;
   kiloSessionId: string;
   rootKiloSessionId: string;
@@ -26,6 +27,7 @@ type Target = {
 
 type Pending = {
   runtime: WorktreeKiloRuntime;
+  nativeRuntimeId: string;
   kiloClient: WorktreeKiloRuntime['kiloClient'];
   targets: Map<HandlerSessionSnapshot, Target>;
   quietTimer?: ReturnType<typeof setTimeout>;
@@ -205,6 +207,7 @@ export function createWorktreeMutationNotifications(options: {
             { type: WORKTREE_CHANGED_EVENT, properties: {} },
             {
               directory: entry.runtime.directory,
+              nativeRuntimeId: entry.nativeRuntimeId,
               kiloSessionId: target.kiloSessionId,
               rootKiloSessionId: target.kiloSessionId,
             }
@@ -271,6 +274,7 @@ export function createWorktreeMutationNotifications(options: {
         if (!entry) {
           const created: Pending = {
             runtime,
+            nativeRuntimeId: runtime.runtimeId,
             kiloClient: runtime.kiloClient,
             targets,
             onAbort: () => remove(created),

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
@@ -26,15 +26,17 @@ import type { NativeOperationTarget, NativeRetirement } from './session-operatio
 import { retireWorktreeRuntime } from './worktree-runtime-cleanup.js';
 import { forgetAttachedRoot, rememberAttachedRoot } from './session-directories.js';
 import { withKiloRequestDeadline, type KiloEventFeedError } from './sandbox-control-runtime.js';
-import { createWorktreeFeed, type WorktreeFeed } from './worktree-feed.js';
+import { createWorktreeFeed, type KiloFeedEvent, type WorktreeFeed } from './worktree-feed.js';
 
 export type WorktreeKiloAuth = NonNullable<SessionAttachPayload['kilo']>;
 
 type WorktreeKiloFailure = {
+  retirementId: string;
   directory: string;
   reason: KiloEventFeedError['reason'] | 'process_exited' | 'credential_refresh_failed';
   runtimeId: string;
   cleanup: 'confirmed' | 'unconfirmed';
+  cleanupDeadlineAt: number;
 };
 
 export type WorktreeKiloRuntime = {
@@ -83,11 +85,7 @@ export type WorktreeKiloRuntimes = {
   shutdown(): void;
 };
 
-type WorktreeKiloEvent = {
-  type: string;
-  properties: Record<string, unknown>;
-  directory?: string;
-};
+type WorktreeKiloEvent = KiloFeedEvent;
 
 type ServerOptions = {
   directory: string;
@@ -332,7 +330,7 @@ export function createWorktreeKiloRuntimes(options: {
   homeRoot?: string;
   inheritedEnv?: NodeJS.ProcessEnv;
   startServer?: (options: ServerOptions) => Promise<WorktreeKiloServerHandle>;
-  onEvent?: (runtime: WorktreeKiloRuntime, event: WorktreeKiloEvent) => void;
+  onEvent?: (runtime: WorktreeKiloRuntime, event: WorktreeKiloEvent) => unknown;
   onDiagnostic?: ControlDiagnosticReporter;
   onUnexpectedClose: (failure: WorktreeKiloFailure) => void;
 }): WorktreeKiloRuntimes {
@@ -421,10 +419,12 @@ export function createWorktreeKiloRuntimes(options: {
     void retire(entry, deadlineAt).then(result => {
       if (result === 'unconfirmed') failedDirectories.add(entry.directory);
       options.onUnexpectedClose({
+        retirementId: crypto.randomUUID(),
         directory: entry.directory,
         reason,
         runtimeId,
         cleanup: result === 'unconfirmed' ? 'unconfirmed' : 'confirmed',
+        cleanupDeadlineAt: deadlineAt,
       });
     });
   }


### PR DESCRIPTION
## Summary
- Recover control connections using event receipts instead of replaying an unbounded stream.
- Preserve scoped recovery lifetimes so a newer connection cannot be failed by an older runtime's cleanup.

## Stack
Control-plane recovery stack. Merge from the bottom. Each PR targets its parent, not `main` (except #5912).

1. #5912 `eshurakov/recovery-observation` → `main`
2. #5913 `eshurakov/recovery-results` → `eshurakov/recovery-observation`
3. #5914 `eshurakov/recovery-stop-scope` → `eshurakov/recovery-results`
4. #5915 `eshurakov/recovery-native-cleanup` → `eshurakov/recovery-stop-scope`
5. #5916 `eshurakov/recovery-session-delivery` → `eshurakov/recovery-native-cleanup`
6. #5917 `eshurakov/recovery-native-feed` → `eshurakov/recovery-session-delivery`
7. #5918 `eshurakov/recovery-control-connection` → `eshurakov/recovery-native-feed`
8. #5919 `eshurakov/recovery-stack` → `eshurakov/recovery-control-connection`
9. #5920 `eshurakov/recovery-not-ready-retry` → `eshurakov/recovery-stack`

Do not merge out of order.


## Reviewer Notes
Two commits. Unique vs parent.