### PR TITLE
fix(web): deduplicate Cloud Agent repository picker across GitHub installations

### DIFF
--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.test.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.test.ts
@@ -212,6 +212,47 @@ describe('github-integration-helpers', () => {
       ]);
     });
 
+    it('lists a repository shared by two installations exactly once, from the primary installation', async () => {
+      mockGetIntegrationsByOrganization.mockResolvedValue([
+        buildIntegration({
+          id: 'integration-1',
+          platform_account_login: 'acme-core',
+          repositories: [
+            { id: 1, name: 'api', full_name: 'acme-core/api', private: true },
+            { id: 2, name: 'shared', full_name: 'acme-core/shared', private: false },
+          ],
+        }),
+        buildIntegration({
+          id: 'integration-2',
+          platform_installation_id: 'installation-2',
+          platform_account_login: 'acme-labs',
+          repositories: [
+            { id: 3, name: 'scanner', full_name: 'acme-labs/scanner', private: true },
+            { id: 2, name: 'shared', full_name: 'acme-core/shared', private: false },
+          ],
+        }),
+      ]);
+
+      const { fetchAllGitHubRepositoriesForOrganization } =
+        await import('./github-integration-helpers');
+      const result = await fetchAllGitHubRepositoriesForOrganization('org-123');
+
+      expect(result.repositories).toEqual([
+        expect.objectContaining({
+          fullName: 'acme-core/api',
+          platformIntegrationId: 'integration-1',
+        }),
+        expect.objectContaining({
+          fullName: 'acme-core/shared',
+          platformIntegrationId: 'integration-1',
+        }),
+        expect.objectContaining({
+          fullName: 'acme-labs/scanner',
+          platformIntegrationId: 'integration-2',
+        }),
+      ]);
+    });
+
     it('returns repositories from healthy installations when a sibling fetch fails', async () => {
       mockGetIntegrationsByOrganization.mockResolvedValue([
         buildIntegration({

--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
@@ -61,6 +61,23 @@ const missingIntegrationResponse = (message: string): GitHubRepositoriesResult =
   errorMessage: message,
 });
 
+/**
+ * A repository can be reachable from more than one installation. Keep the
+ * first occurrence: integrations arrive oldest-first, matching the primary
+ * installation a session resolves by default.
+ */
+const dedupeRepositories = (
+  repositories: GitHubRepositoriesResult['repositories']
+): GitHubRepositoriesResult['repositories'] => {
+  const seen = new Set<string>();
+  return repositories.filter(repo => {
+    const key = repo.fullName.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
 export async function getGitHubTokenForOrganization(
   organizationId: string
 ): Promise<string | undefined> {
@@ -235,7 +252,7 @@ async function fetchRepositoriesForIntegrations(
     }
     return {
       integrationInstalled: true,
-      repositories: results.flatMap(result => result.repositories),
+      repositories: dedupeRepositories(results.flatMap(result => result.repositories)),
       syncedAt: results
         .map(result => result.syncedAt)
         .filter((value): value is string => value !== null)


### PR DESCRIPTION
> **kwf trial run.** This PR came from a workflow trial request, not from a tracked work item. Review it as you would any other PR; the label `kwf-trial` marks where it came from.

## Request

> Surface: web (apps/web) — Kilo-Org/cloud issue 5887.
> 
> The Cloud Agent repository picker lists the same repository once per GitHub installation that can see it, so an organization with several connected installations sees duplicates.
> 
> Repro: as an organization with more than one GitHub App installation connected, open Cloud Agent, start a new thread, and open the repository picker. A repository reachable from two installations appears twice.
> 
> Cause named in the issue: `fetchAllGitHubRepositoriesForOrganization` in apps/web/src/lib/cloud-agent/github-integration-helpers.ts unions the repository lists of every healthy GitHub integration without deduplicating.
> 
> Expected: each repository appears exactly once, resolved to the installation the session will actually use.
> 
> Rule: reproduce first. If it does not reproduce on main, answer no_change with the evidence.

## Changelog for users
- The Cloud Agent repository picker no longer lists the same repository once per connected GitHub App installation: a repository reachable from multiple installations appears exactly once.
- A repository shared across installations is listed under the installation the session actually uses (the primary one), so picking it resolves against that installation.

## Changelog for maintainers
- `fetchAllGitHubRepositoriesForOrganization` now passes merged results through a new `dedupeRepositories` helper that keeps the first occurrence per lowercased `fullName` (apps/web/src/lib/cloud-agent/github-integration-helpers.ts), so the surviving entry carries the first-listed integration's id.
- The fix relies on integrations arriving oldest-first, matching the installation a session resolves by default; that ordering assumption is the main thing to review.
- Case-insensitive keying also collapses entries that differ only in case across installations — acceptable for GitHub full names, but it is a contract of this change.
- A unit test locks the overlap behavior: two installations exposing the same repository yield one entry attributed to the primary integration.
- Verification was a live capture, not an automated test: the e2e index has no web repo-picker test id, and no UX-DEFECT was filed on the changed picker.

## E2E proof

![[e1] Rule: reproduce first. — e2e-web/e1-main-picker.png](https://github.com/user-attachments/assets/df928fd0-b64c-4087-bfee-2f55b2fe5b12)

![[e1] Rule: reproduce first. — e2e-web/e1-packed-picker.png](https://github.com/user-attachments/assets/14435f7c-28fc-44a4-bd13-6a83538d703c)