### PR TITLE
fix(extension): keep model picker search bar pinned while the model list scrolls

### DIFF
--- a/apps/extension/entrypoints/sidepanel/model-picker.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/model-picker.test.tsx
@@ -121,3 +121,71 @@ describe('model picker stored-model display', () => {
     expect(queryByRole('dialog', { name: 'Select model' })).toBeNull();
   });
 });
+
+describe('model picker pinned search bar', () => {
+  beforeEach(() => {
+    // jsdom implements no layout and defines no scrollIntoView to spy on.
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    mockUseModelPreferences.mockReturnValue({
+      favorites: new Set<string>(),
+      refetch: vi.fn(),
+      status: 'ready',
+      toggleError: false,
+      toggleFavorite: vi.fn(),
+    });
+  });
+
+  const longCatalog = Array.from({ length: 60 }, (_, index) =>
+    gatewayModel(`org/model-${index}`, `Model ${index}`)
+  );
+
+  const openPicker = (): ReturnType<typeof renderModelPicker> => {
+    const view = renderModelPicker({ model: 'org/model-0', modelOptions: longCatalog });
+    fireEvent.click(view.getByLabelText('Model'));
+    return view;
+  };
+
+  it('pins the search bar under the header so it stays visible while the list scrolls', () => {
+    const { getByLabelText } = openPicker();
+
+    const search = getByLabelText('Search models');
+    // jsdom has no layout engine, so the pin contract is the sticky positioning
+    // of the search bar's wrapper, the same mechanism as the dialog header.
+    // top-14 must keep matching the h-14 header height directly above it.
+    const pinnedBar = search.parentElement;
+    expect(pinnedBar?.classList.contains('sticky')).toBe(true);
+    expect(pinnedBar?.classList.contains('top-14')).toBe(true);
+    expect(pinnedBar?.classList.contains('z-10')).toBe(true);
+    // Rows scroll under the pinned bar, so it must paint its own background.
+    expect(pinnedBar?.classList.contains('bg-surface-background')).toBe(true);
+    // The pinned bar and the list live in the dialog's scroll container, whose
+    // chrome stays put while the rows move.
+    expect(pinnedBar?.parentElement?.classList.contains('overflow-y-auto')).toBe(true);
+  });
+
+  it('keeps the search focus and typed text while the model list scrolls', () => {
+    const { getByLabelText, getByRole } = openPicker();
+
+    const search = getByLabelText('Search models');
+    if (!(search instanceof HTMLInputElement)) {
+      throw new Error('Search models must be an input');
+    }
+
+    expect(document.activeElement).toBe(search);
+    fireEvent.change(search, { target: { value: 'model 5' } });
+
+    const dialog = getByRole('dialog', { name: 'Select model' });
+    fireEvent.scroll(dialog, { target: { scrollTop: 400 } });
+
+    const searchAfterScroll = getByLabelText('Search models');
+    if (!(searchAfterScroll instanceof HTMLInputElement)) {
+      throw new Error('Search models must be an input');
+    }
+
+    expect(document.activeElement).toBe(searchAfterScroll);
+    expect(searchAfterScroll.value).toBe('model 5');
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/model-picker.tsx
+++ b/apps/extension/entrypoints/sidepanel/model-picker.tsx
@@ -119,7 +119,9 @@ export const ModelPicker = ({
             </button>
           </div>
 
-          <div className="border-b border-border px-3 py-3">
+          {/* Pinned under the h-14 header so search stays visible while the model
+              list scrolls beneath it; the background hides rows passing under. */}
+          <div className="sticky top-14 z-10 border-b border-border bg-surface-background px-3 py-3">
             <input
               aria-label="Search models"
               className="h-9 w-full rounded-md border border-border-strong bg-input-bg px-3 type-label text-foreground outline-none transition placeholder:text-foreground-subtle focus-visible:ring-2 focus-visible:ring-brand-primary-ring ring-offset-2 ring-offset-surface-background"


### PR DESCRIPTION
## Request

> In the web extension model picker, keep the search bar pinned to the top of the list while the model list scrolls under it. The search field must stay visible and usable at every scroll position, keep its focus and typed text while scrolling, and must not overlap the first row or clip the list. Reproduce the current behaviour first (record the search bar scrolling out of view), then fix it and prove the fix on the same live picker with a recording that scrolls a long model list.

## Changelog for users

- In the web extension model picker, the search bar now stays pinned below the dialog header while the model list scrolls beneath it, so search is visible and usable at every scroll position.
- The pinned search bar keeps its focus and typed text while the list scrolls, so a query can be typed or refined from anywhere in the list.
- Rows scrolling under the pinned bar are hidden behind its opaque background instead of bleeding through the search input.

## Changelog for maintainers

- Start at the search-bar wrapper in `apps/extension/entrypoints/sidepanel/model-picker.tsx`: it is now `sticky top-14 z-10` with `bg-surface-background`; the `top-14` offset must keep matching the dialog header's `h-14` height, so change the two together.
- The pin relies on the search bar and the model list sharing the dialog's single `overflow-y-auto` scroll container; splitting the dialog into separate scroll panes detaches the bar.
- The opaque background is load-bearing: rows pass underneath the bar during scroll and would show through the input otherwise.
- New tests in `apps/extension/entrypoints/sidepanel/model-picker.test.tsx` pin the sticky contract via classes (jsdom has no layout engine and `scrollIntoView` is stubbed) and assert focus plus typed text survive a programmatic scroll; they cannot catch pixel-level overlap, which is what the live-picker captures cover.
- The e2e proof is two screenshots of the fixed picker at different scroll positions; no capture of the pre-fix behaviour is included, so the before/after contrast rests on the diff.

## E2E proof

![[e1] pinned search bar stays visible while the model list scrolls — e2e-web-extension/e1-scroll-mid.png](https://github.com/user-attachments/assets/08f9b3ab-5c74-4d36-9927-05e85fe374e7)

![[e1] pinned search bar stays visible while the model list scrolls — e2e-web-extension/e1-scrolled.png](https://github.com/user-attachments/assets/c0d153b1-81a9-43bc-8d32-736525debfb6)