### PR TITLE
fix(auth): retry rejected keychain reads at startup instead of signing out

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -64,6 +64,7 @@ import { prefetchCurrentUser } from '@/lib/startup-prefetch';
 import { useAnalyticsConsentGate } from '@/lib/hooks/use-analytics-consent-gate';
 import { useForceUpdate } from '@/lib/hooks/use-force-update';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
+import { useRestoreErrorHold } from '@/lib/hooks/use-restore-error-hold';
 import { useScreenTracking } from '@/lib/hooks/use-screen-tracking';
 import { useNavigationTheme } from '@/lib/hooks/use-theme-colors';
 import {
@@ -85,9 +86,9 @@ import {
   captureLaunchDeepLink,
   getPendingDeepLink,
   getPendingDeepLinkSnapshot,
-  restorePersistedPendingDeepLink,
   subscribeToPendingDeepLink,
 } from '@/lib/deep-link-launch';
+import { usePendingDeepLinkRestore } from '@/lib/hooks/use-pending-deep-link-restore';
 import {
   checkInitialNotification,
   ensureAndroidNotificationChannels,
@@ -171,7 +172,14 @@ function RootLayoutNav({
   languageReady: boolean;
   setLanguageReady: (ready: boolean) => void;
 }>) {
-  const { token, isLoading: authLoading, isSigningOut, signOut } = useAuth();
+  const {
+    token,
+    isLoading: authLoading,
+    isSigningOut,
+    signOut,
+    restoreFailed,
+    retryRestore,
+  } = useAuth();
   const { updateRequired } = useForceUpdate();
   const [fontsLoaded, fontsError] = useFonts({
     JetBrainsMono_500Medium,
@@ -250,19 +258,14 @@ function RootLayoutNav({
   }, []);
 
   // Restore a deep-link destination persisted before process death. Waits for
-  // auth bootstrap: a persisted record is account-bound, and the token owner
-  // publishes the signed-in user id before `authLoading` clears. Restoring
-  // earlier compares an account-bound record against a null user id, so a
-  // signed-in cold start would delete its own destination. The slot is
-  // observable, so the consumer still fires when the destination lands.
-  const deepLinkRestoreStarted = useRef(false);
-  useEffect(() => {
-    if (authLoading || deepLinkRestoreStarted.current) {
-      return;
-    }
-    deepLinkRestoreStarted.current = true;
-    void restorePersistedPendingDeepLink();
-  }, [authLoading]);
+  // auth bootstrap to settle into a state where the account binding is known:
+  // a persisted record is account-bound, and the token owner publishes the
+  // signed-in user id before `authLoading` clears. Restoring earlier compares
+  // an account-bound record against a null user id, so a signed-in cold start
+  // would delete its own destination — and a FAILED restore is not a
+  // signed-out answer, so the hook also holds the restore through the
+  // retryable error surface.
+  usePendingDeepLinkRestore({ authLoading, restoreFailed });
 
   // Scope share persistence to the current account (DEC-01): null while signed
   // out, so a share captured signed out never persists (in-memory only, and a
@@ -648,6 +651,7 @@ function RootLayoutNav({
       onConsentRoute,
       onConsentReviewRoute,
       languageReloadFailed,
+      restoreFailed,
     });
 
     // Replaces the old inline if-chain (resolveBootstrapTag in
@@ -656,6 +660,11 @@ function RootLayoutNav({
     switch (decision.tag) {
       case 'settle-language-error': {
         markStartupComplete('language-error');
+        setStartupFinished(true);
+        return;
+      }
+      case 'settle-restore-error': {
+        markStartupComplete('restore-error');
         setStartupFinished(true);
         return;
       }
@@ -733,6 +742,7 @@ function RootLayoutNav({
     onConsentRoute,
     onConsentReviewRoute,
     languageReloadFailed,
+    restoreFailed,
   ]);
 
   // Reactive snapshot of the pending deep-link slot so a destination stashed
@@ -803,22 +813,28 @@ function RootLayoutNav({
   // initialised — returning null unmounts it and breaks router.replace.
   // The native splash screen covers everything during initial load, and
   // opacity 0 hides the wrong screen during redirects.
-  const { hasUserBootstrapError, hasConsentBootstrapError, hasBootstrapError, hidden } =
-    resolveBootstrapDecision({
-      isLoading,
-      updateRequired,
-      inForceUpdate,
-      inAuthGroup,
-      hasToken: token != null,
-      userIdLoading,
-      userIdError,
-      consentCheckError: consentCheckError != null,
-      consentChecked,
-      needsConsent,
-      onConsentRoute,
-      onConsentReviewRoute,
-      languageReloadFailed,
-    });
+  const {
+    hasUserBootstrapError,
+    hasConsentBootstrapError,
+    hasRestoreError,
+    hasBootstrapError,
+    hidden,
+  } = resolveBootstrapDecision({
+    isLoading,
+    updateRequired,
+    inForceUpdate,
+    inAuthGroup,
+    hasToken: token != null,
+    userIdLoading,
+    userIdError,
+    consentCheckError: consentCheckError != null,
+    consentChecked,
+    needsConsent,
+    onConsentRoute,
+    onConsentReviewRoute,
+    languageReloadFailed,
+    restoreFailed,
+  });
 
   // Hidden root-route entry contract (D17): while `hidden`, the wrapper leaves
   // both accessibility trees. On the hidden → visible transition,
@@ -851,6 +867,23 @@ function RootLayoutNav({
       cancelAnimationFrame(frame);
     };
   }, [hidden, hasBootstrapError]);
+
+  // The restore-error surface is settled, but a successful Retry does not
+  // reveal the app immediately: the token publish, the user fetch, and the
+  // consent check still run behind the loading gate, and the splash overlay
+  // that covers a cold start's hidden window is already gone (startup
+  // completed when the error settled). Dropping the error screen the moment
+  // `restoreFailed` clears would expose that hidden window as a blank frame
+  // before Home. `useRestoreErrorHold` latches the settled surface: it stays
+  // mounted while the retried bootstrap finishes, and the layout effect
+  // releases it only when the gate actually reveals the tree (`hidden` flips
+  // false) or sign-out begins the escape hatch — released in a layout effect,
+  // so the error screen and the revealed tree swap inside one paint.
+  const showRestoreError = useRestoreErrorHold({
+    hasRestoreError,
+    hidden,
+    isSigningOut,
+  });
 
   if (hasUserBootstrapError) {
     return (
@@ -908,20 +941,64 @@ function RootLayoutNav({
     );
   }
 
+  // Placed after the language block so the render order matches the decision
+  // tag chain. The user and consent errors above cannot co-occur with this
+  // one: both require a token, and a failed credential read has none.
+  //
+  // The stored session could not be read, so it is not known to be gone: the
+  // person is asked to retry, never presented as signed out. A retry holds
+  // this settled surface until the fresh reads resolve (`restoreFailed`
+  // stays true) AND through the post-restore gates (the hold), so the busy
+  // state is the primary button's inline spinner — no blank frame and no
+  // gate swap — and Sign out is the explicit escape hatch to the login
+  // screen.
+  //
+  // The held surface is an absolute overlay ABOVE the wrapper, not an early
+  // return: while it is up, the retried bootstrap settles into redirect tags
+  // (redirect-login / redirect-consent / redirect-app) whose router.replace
+  // must land. An early return unmounts Slot, so those replaces fire into a
+  // torn-down navigation tree and the hold can dead-end on the error screen
+  // (retry succeeds with the session deleted → login). With the overlay, Slot
+  // stays mounted, the replace lands (login mounts, inAuthGroup flips), and
+  // `hidden` clears — the hold releases in a layout effect, so the error
+  // surface and the revealed tree swap inside one paint. Under the overlay
+  // the wrapper is forced to the hidden presentation (opacity-0, no touch, no
+  // a11y), so the settled state renders exactly like the early return it
+  // replaces.
   return (
-    <View
-      ref={wrapperRef}
-      // `opacity-0` + `pointerEvents` hide the redirecting tree visually and
-      // from touch, but not from screen readers. Leave both accessibility
-      // trees while hidden (iOS, then Android).
-      accessibilityElementsHidden={hidden}
-      importantForAccessibility={hidden ? 'no-hide-descendants' : 'auto'}
-      className={`flex-1 ${hidden ? 'opacity-0' : 'opacity-100'}`}
-      pointerEvents={hidden ? 'none' : 'auto'}
-    >
-      <Slot />
-      <PrivacyCoverOverlay segments={segments} />
-    </View>
+    <>
+      <View
+        ref={wrapperRef}
+        // `opacity-0` + `pointerEvents` hide the redirecting tree visually and
+        // from touch, but not from screen readers. Leave both accessibility
+        // trees while hidden (iOS, then Android). The held error surface
+        // forces the same presentation: it owns the screen above the wrapper.
+        accessibilityElementsHidden={hidden || showRestoreError}
+        importantForAccessibility={hidden || showRestoreError ? 'no-hide-descendants' : 'auto'}
+        className={`flex-1 ${hidden || showRestoreError ? 'opacity-0' : 'opacity-100'}`}
+        pointerEvents={hidden || showRestoreError ? 'none' : 'auto'}
+      >
+        <Slot />
+        <PrivacyCoverOverlay segments={segments} />
+      </View>
+      {showRestoreError ? (
+        <View className="absolute inset-0">
+          <BootstrapErrorScreen
+            title={t('bootstrap.couldNotLoadAccount')}
+            description={t('common.somethingWentWrong')}
+            primaryLabel={t('common.retry')}
+            primaryAccessibilityLabel={t('bootstrap.retryLoadingAccount')}
+            onPrimaryPress={retryRestore}
+            primaryLoading={authLoading || userIdLoading}
+            secondaryLabel={t('common.signOut')}
+            secondaryAccessibilityLabel={t('common.signOut')}
+            onSecondaryPress={() => {
+              void signOut();
+            }}
+          />
+        </View>
+      ) : null}
+    </>
   );
 }
 

--- a/apps/mobile/src/components/app-unlock-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/app-unlock-screen.mounted.test.tsx
@@ -130,7 +130,7 @@ it.each([null, 'disabled'])('shows the scene without a prompt for %s', async raw
   expect(native.authenticateAsync).not.toHaveBeenCalled();
 });
 
-it('hides scenes during preference loading and retries a failed read without disclosure', async () => {
+it('hides scenes during preference loading and recovers a failed read without a gate', async () => {
   const read = Promise.withResolvers<string | null>();
   storage.getItemAsync.mockReturnValueOnce(read.promise);
   await mount();
@@ -140,21 +140,28 @@ it('hides scenes during preference loading and retries a failed read without dis
     { busy: true }
   );
   expect(retry()).toBeUndefined();
-  await flush(() => {
-    read.reject(new Error('read failed'));
-  });
-  expectHidden(root(), true);
-  expect(text(root())).toContain('Something went wrong');
-  expect(retry()?.props.disabled).toBe(false);
-  const reread = Promise.withResolvers<string | null>();
-  storage.getItemAsync.mockReturnValueOnce(reread.promise);
-  await flush(retry()?.props.onPress as () => void);
-  expectHidden(root(), true);
-  expect(root().findAllByType('Skeleton' as ElementType)).toHaveLength(1);
-  await flush(() => {
-    reread.resolve('disabled');
-  });
+  // The read rejects; the bounded read helper re-reads with backoff before
+  // the fresh read answers. Fake timers go in before the rejection lands, so
+  // the backoff runs on the fake clock, and the gate stays on the skeleton
+  // the whole time — never an error state, never a Retry tap.
+  vi.useFakeTimers();
+  try {
+    await flush(() => {
+      read.reject(new Error('read failed'));
+    });
+    expectHidden(root(), true);
+    expect(root().findAllByType('Skeleton' as ElementType)).toHaveLength(1);
+    expect(retry()).toBeUndefined();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+  await flush();
   expectHidden(root(), false);
+  expect(text(root())).not.toContain('Something went wrong');
+  expect(native.authenticateAsync).toHaveBeenCalledTimes(1);
 });
 
 it.each(['user_cancel', 'authentication_failed', 'lockout'])(
@@ -195,8 +202,15 @@ describe.each(['ios', 'android'])('%s shared unlock announcements', os => {
     platform.OS = os;
   });
 
-  it('waits for localized read feedback and keeps one owner on rerender', async () => {
-    storage.getItemAsync.mockRejectedValueOnce(new Error('read failed'));
+  it('waits for localized feedback and keeps one owner on rerender', async () => {
+    // A failed authenticate is the earliest feedback a gate can carry: with
+    // language not ready the prompt is null, so no authenticate can run and
+    // the announcement owner is not mounted yet. The failure lands on the
+    // rerender that readies the language, and the message is the localized one.
+    native.authenticateAsync.mockResolvedValueOnce({
+      success: false,
+      error: 'authentication_failed',
+    });
     i18n.addResourceBundle('fr', 'translation', fr);
     const ui = nestedUnlockScenes(<KiloClawLayout />);
     await mount(ui, false);
@@ -217,13 +231,10 @@ describe.each(['ios', 'android'])('%s shared unlock announcements', os => {
   });
 
   it.each([
-    ['read', 'Something went wrong'],
     ['authentication_failed', 'Something went wrong'],
     ['setup', 'Check your device security settings and try again.'],
   ])('announces %s once across nested gates and again after Retry', async (code, message) => {
-    if (code === 'read') {
-      storage.getItemAsync.mockRejectedValueOnce(new Error('read failed'));
-    } else if (code === 'setup') {
+    if (code === 'setup') {
       native.getEnrolledLevelAsync.mockResolvedValue(0);
     } else {
       native.authenticateAsync.mockResolvedValueOnce({ success: false, error: code });
@@ -233,20 +244,12 @@ describe.each(['ios', 'android'])('%s shared unlock announcements', os => {
     expect(announcements.mock.calls).toEqual(os === 'ios' ? [[message]] : []);
 
     const pending = Promise.withResolvers<number>();
-    if (code === 'read') {
-      storage.getItemAsync.mockReturnValueOnce(pending.promise);
-    } else {
-      native.getEnrolledLevelAsync.mockReturnValueOnce(pending.promise);
-      native.authenticateAsync.mockResolvedValueOnce({ success: false, error: code });
-    }
+    native.getEnrolledLevelAsync.mockReturnValueOnce(pending.promise);
+    native.authenticateAsync.mockResolvedValueOnce({ success: false, error: code });
     await flush(retry()?.props.onPress as () => void);
     expect(text(root())).not.toContain(message);
     await flush(() => {
-      if (code === 'read') {
-        pending.reject(new Error('read failed again'));
-      } else {
-        pending.resolve(code === 'setup' ? 0 : 3);
-      }
+      pending.resolve(code === 'setup' ? 0 : 3);
     });
     expectFeedback(root(), message, 3);
     expect(announcements.mock.calls).toEqual(os === 'ios' ? [[message], [message]] : []);

--- a/apps/mobile/src/components/app-unlock-screen.test-helpers.tsx
+++ b/apps/mobile/src/components/app-unlock-screen.test-helpers.tsx
@@ -60,6 +60,9 @@ export { announcements, catalogs, lifecycle, native, platform, storage };
 vi.mock('@/i18n/catalogs', () => ({ CATALOG_LOADERS: catalogs }));
 vi.mock('expo-local-authentication', () => native);
 vi.mock('expo-secure-store', () => storage);
+// The E2E fault hook stays closed: rejected reads come from the SecureStore
+// mock, not the bundle-time fault window.
+vi.mock('@/lib/config', () => ({ E2E_SECURE_STORE_FAULT_MS: 0 }));
 vi.mock('react-native', () => ({
   View: 'View',
   Text: 'Text',
@@ -112,6 +115,12 @@ vi.mock('@/components/ui/icons', () => ({
   TriangleAlert: 'Icon',
   XCircle: 'Icon',
 }));
+// The organization and security-agent layouts reach real expo-image through
+// the privacy cover's splash logo; the native module cannot load in this
+// DOM-free harness (its expo root import needs __DEV__ and a native binding).
+vi.mock('@/components/ui/image', () => ({ Image: 'Image' }));
+// No Vitest project transforms .png.
+vi.mock('@/../assets/images/logo-mark.png', () => ({ default: 1 }));
 vi.mock('expo-router', () => ({
   // One mounted descriptor per navigator exercises its production callback.
   Stack: Object.assign(

--- a/apps/mobile/src/components/app-unlock-screen.tsx
+++ b/apps/mobile/src/components/app-unlock-screen.tsx
@@ -29,10 +29,9 @@ function unlockFeedbackKey(outcome: UnlockOutcome) {
 
 /** One owner announces shared outcomes, including setting failures behind a locked scene. */
 export function AppUnlockAnnouncements() {
-  const { status, outcome } = useAppUnlock();
+  const { outcome } = useAppUnlock();
   const { t } = useTranslation();
-  const key =
-    status === 'preference-error' ? 'common.somethingWentWrong' : unlockFeedbackKey(outcome);
+  const key = unlockFeedbackKey(outcome);
   useStatusAnnouncement(key === null ? null : t(key));
   return null;
 }
@@ -97,9 +96,6 @@ function AppUnlockScene({ children }: Readonly<{ children: ReactElement }>) {
                 <Text accessibilityRole="header" className="text-center text-xl font-semibold">
                   {t('preferences.biometricUnlock')}
                 </Text>
-                <UnlockStatusText
-                  message={status === 'preference-error' ? t('common.somethingWentWrong') : null}
-                />
                 <AppUnlockFeedback outcome={outcome} />
               </View>
               {status === 'preference-loading' ? (

--- a/apps/mobile/src/components/bootstrap-error-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/bootstrap-error-screen.mounted.test.tsx
@@ -1,0 +1,139 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as language-reload-error-screen.mounted.test.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BootstrapErrorScreen } from '@/components/bootstrap-error-screen';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+vi.mock('react-native', () => ({
+  ActivityIndicator: 'ActivityIndicator',
+  Pressable: 'Pressable',
+  View: 'View',
+}));
+vi.mock('@/components/centered-state', () => ({ CenteredState: 'CenteredState' }));
+// The real Button stays mounted: the contract under test is its `loading`
+// wiring (disabled + busy + inline spinner, button.tsx), not a mock of it.
+vi.mock('@/components/ui/text', async () => {
+  const { createContext } = await import('react');
+  return { Text: 'Text', TextClassContext: createContext(undefined) };
+});
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({ primaryForeground: '#000000', foreground: '#000000' }),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function findPressableByAccessibilityLabel(
+  root: TestRenderer.ReactTestInstance,
+  label: string
+): TestRenderer.ReactTestInstance {
+  const button = root
+    .findAll(node => typeof node.type === 'string' && (node.type as string) === 'Pressable')
+    .find(node => node.props.accessibilityLabel === label);
+  if (!button) {
+    throw new Error(`Pressable with accessibility label ${label} not found`);
+  }
+  return button;
+}
+
+function findLabel(root: TestRenderer.ReactTestInstance, label: string): boolean {
+  return (
+    root.findAll(
+      node =>
+        typeof node.type === 'string' &&
+        (node.type as string) === 'Text' &&
+        node.props.children === label
+    ).length > 0
+  );
+}
+
+async function mountScreen(primaryLoading?: boolean): Promise<{
+  onPrimaryPress: ReturnType<typeof vi.fn<() => void>>;
+  onSecondaryPress: ReturnType<typeof vi.fn<() => void>>;
+  renderer: TestRenderer.ReactTestRenderer;
+}> {
+  const onPrimaryPress = vi.fn<() => void>();
+  const onSecondaryPress = vi.fn<() => void>();
+  const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+  await act(async () => {
+    ref.current = TestRenderer.create(
+      createElement(BootstrapErrorScreen, {
+        title: 'Could not load your account',
+        description: 'Something went wrong',
+        primaryLabel: 'Retry',
+        primaryAccessibilityLabel: 'Retry loading account',
+        onPrimaryPress,
+        primaryLoading,
+        secondaryLabel: 'Sign out',
+        secondaryAccessibilityLabel: 'Sign out',
+        onSecondaryPress,
+      })
+    );
+    await Promise.resolve();
+  });
+  const renderer = ref.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return { onPrimaryPress, onSecondaryPress, renderer };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('BootstrapErrorScreen primaryLoading', () => {
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  it('renders an enabled primary button that fires onPrimaryPress without primaryLoading', async () => {
+    const { onPrimaryPress, onSecondaryPress, renderer } = await mountScreen();
+
+    const primary = findPressableByAccessibilityLabel(renderer.root, 'Retry loading account');
+    expect(primary.props.disabled).toBe(false);
+    expect(primary.props.accessibilityState).toEqual({ disabled: false, busy: undefined });
+    expect(primary.props.className).not.toContain('opacity-50');
+    expect(findLabel(renderer.root, 'Retry')).toBe(true);
+    expect(
+      renderer.root.findAll(
+        node => typeof node.type === 'string' && (node.type as string) === 'ActivityIndicator'
+      )
+    ).toHaveLength(0);
+
+    act(() => {
+      (primary.props.onPress as () => void)();
+    });
+    expect(onPrimaryPress).toHaveBeenCalledTimes(1);
+    expect(onSecondaryPress).not.toHaveBeenCalled();
+
+    renderer.unmount();
+  });
+
+  it('renders the primary button busy and disabled with its label while primaryLoading, and keeps Sign out enabled', async () => {
+    const { onPrimaryPress, onSecondaryPress, renderer } = await mountScreen(true);
+
+    const primary = findPressableByAccessibilityLabel(renderer.root, 'Retry loading account');
+    expect(primary.props.disabled).toBe(true);
+    expect(primary.props.accessibilityState).toEqual({ disabled: true, busy: true });
+    expect(primary.props.className).toContain('opacity-50');
+    // The busy indicator is the button's inline spinner; the label stays.
+    expect(
+      renderer.root.findAll(
+        node => typeof node.type === 'string' && (node.type as string) === 'ActivityIndicator'
+      )
+    ).toHaveLength(1);
+    expect(findLabel(renderer.root, 'Retry')).toBe(true);
+
+    // The secondary Sign out button is the escape hatch: never disabled.
+    const secondary = findPressableByAccessibilityLabel(renderer.root, 'Sign out');
+    expect(secondary.props.disabled).toBe(false);
+    act(() => {
+      (secondary.props.onPress as () => void)();
+    });
+    expect(onSecondaryPress).toHaveBeenCalledTimes(1);
+    expect(onPrimaryPress).not.toHaveBeenCalled();
+
+    renderer.unmount();
+  });
+});

--- a/apps/mobile/src/components/bootstrap-error-screen.tsx
+++ b/apps/mobile/src/components/bootstrap-error-screen.tsx
@@ -10,6 +10,10 @@ type BootstrapErrorScreenProps = {
   readonly primaryLabel: string;
   readonly primaryAccessibilityLabel: string;
   readonly onPrimaryPress: () => void;
+  /** Shows the primary button's inline spinner and disables it while the
+   *  primary action is in flight. The secondary button stays enabled in all
+   *  states: it is the escape hatch. */
+  readonly primaryLoading?: boolean;
   readonly secondaryLabel: string;
   readonly secondaryAccessibilityLabel: string;
   readonly onSecondaryPress: () => void;
@@ -21,6 +25,7 @@ export function BootstrapErrorScreen({
   primaryLabel,
   primaryAccessibilityLabel,
   onPrimaryPress,
+  primaryLoading,
   secondaryLabel,
   secondaryAccessibilityLabel,
   onSecondaryPress,
@@ -33,7 +38,12 @@ export function BootstrapErrorScreen({
           <Text className="text-center text-sm text-muted-foreground">{description}</Text>
         </View>
         <View className="w-full gap-3">
-          <Button size="lg" onPress={onPrimaryPress} accessibilityLabel={primaryAccessibilityLabel}>
+          <Button
+            size="lg"
+            loading={primaryLoading}
+            onPress={onPrimaryPress}
+            accessibilityLabel={primaryAccessibilityLabel}
+          >
             <Text>{primaryLabel}</Text>
           </Button>
           <Button

--- a/apps/mobile/src/components/preferences-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/preferences-screen.mounted.test.tsx
@@ -24,6 +24,9 @@ const storage = vi.hoisted(() => ({
 }));
 vi.mock('expo-local-authentication', () => native);
 vi.mock('expo-secure-store', () => storage);
+// The E2E fault hook stays closed: rejected reads come from the SecureStore
+// mock, not the bundle-time fault window.
+vi.mock('@/lib/config', () => ({ E2E_SECURE_STORE_FAULT_MS: 0 }));
 vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));

--- a/apps/mobile/src/lib/app-unlock-context.mounted.test.tsx
+++ b/apps/mobile/src/lib/app-unlock-context.mounted.test.tsx
@@ -7,6 +7,7 @@ import {
   IOS_SUCCESSES,
   mount,
   native,
+  settleReadRetries,
   state,
   storage,
   SUCCESS,
@@ -27,13 +28,21 @@ describe.each(['active', 'inactive', 'background'])('cold start in %s', initial 
       expectState(false, 'preference-loading', true);
       await action();
       await action(true);
-      await finish(read, raw);
-      if (raw === 'invalid' || raw instanceof Error) {
-        expectState(false, 'preference-error');
-        await action(true);
-        expectState(false, 'preference-error');
-        storage.getItemAsync.mockResolvedValue('disabled');
-        await action();
+      if (raw instanceof Error) {
+        // The first read rejects; the bounded read helper re-reads with
+        // backoff and answers with the resolved retry. Fake timers go in
+        // before the rejection lands, so the backoff runs on the fake clock.
+        vi.useFakeTimers();
+        await finish(read, raw);
+        await settleReadRetries();
+        vi.useRealTimers();
+      } else {
+        await finish(read, raw);
+      }
+      if (raw === 'invalid') {
+        // An invalid stored value is not a choice to lock: the provider
+        // settles at the documented default with no retry and no prompt.
+        expectState(false, 'unlocked');
       } else if (raw === 'enabled') {
         expectState(true, 'locked', initial === 'active');
         await transition('active', 300_000);
@@ -42,12 +51,20 @@ describe.each(['active', 'inactive', 'background'])('cold start in %s', initial 
         await finish(auth, SUCCESS);
       }
       expectState(raw === 'enabled', 'unlocked');
-      expect(storage.getItemAsync).toHaveBeenCalledTimes(
-        raw === 'invalid' || raw instanceof Error ? 2 : 1
-      );
+      expect(storage.getItemAsync).toHaveBeenCalledTimes(raw instanceof Error ? 2 : 1);
       expect(native.authenticateAsync).toHaveBeenCalledTimes(raw === 'enabled' ? 1 : 0);
     }
   );
+});
+
+it('repro: a rejected unlock preference read never gates the app', async () => {
+  // The environmental keychain failure rejects every preference read, past
+  // the read helper's whole retry budget. A read that cannot answer is not a
+  // user choice to lock: the provider must settle at the safe default —
+  // disabled, unlocked — and never gate the app behind the unlock screen.
+  await mount('disabled', true);
+  expectState(false, 'unlocked');
+  expect(native.authenticateAsync).not.toHaveBeenCalled();
 });
 
 it.each(IOS_SUCCESSES)('unlocks cold start with iOS success %j', async result => {

--- a/apps/mobile/src/lib/app-unlock-context.recovery.mounted.test.tsx
+++ b/apps/mobile/src/lib/app-unlock-context.recovery.mounted.test.tsx
@@ -1,0 +1,69 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/test/render-with-providers.tsx) */
+import { expect, it, vi } from 'vitest';
+
+// The recovery fixtures share the mounted provider environment (mocks, state
+// hooks, transitions) with app-unlock-context.mounted.test.tsx, which sits at
+// its max-lines budget.
+import {
+  expectState,
+  finish,
+  mount,
+  native,
+  settleReadRetries,
+  state,
+  storage,
+  SUCCESS,
+  transition,
+} from '@/lib/app-unlock-context.test-helpers';
+
+it('re-arms an exhausted-budget preference read on foreground recovery', async () => {
+  // The keychain rejects every read at mount: the retry budget exhausts, the
+  // provider fails open, and the device lock is off — but only until the
+  // keychain recovers. The recovery re-reads silently: the app never shows
+  // the preference-loading surface, and the re-armed return stays unlocked.
+  await mount('disabled', true);
+  expectState(false, 'unlocked');
+  expect(native.authenticateAsync).not.toHaveBeenCalled();
+  // The mount's own read spent the full budget: four attempts.
+  expect(storage.getItemAsync).toHaveBeenCalledTimes(4);
+
+  // A return while the keychain is still down re-reads (the full budget,
+  // four attempts) and stays unlocked with no loading surface and no prompt.
+  vi.useFakeTimers();
+  await transition('background');
+  await transition('active');
+  await settleReadRetries();
+  vi.useRealTimers();
+  expect(storage.getItemAsync).toHaveBeenCalledTimes(8);
+  expectState(false, 'unlocked', false);
+  expect(state().phase).toBe('idle');
+  expect(native.authenticateAsync).not.toHaveBeenCalled();
+
+  // The keychain recovers: the next return re-arms the preference without
+  // gating the in-progress return.
+  storage.getItemAsync.mockResolvedValue('enabled');
+  await transition('background');
+  await transition('active');
+  expectState(true, 'unlocked');
+  expect(native.authenticateAsync).not.toHaveBeenCalled();
+
+  // From then on normal semantics hold: a long return locks and prompts.
+  await transition('background');
+  const auth = Promise.withResolvers<unknown>();
+  native.authenticateAsync.mockReturnValueOnce(auth.promise);
+  await transition('active', 300_000);
+  expectState(true, 'locked', true);
+  await finish(auth, SUCCESS);
+  expectState(true, 'unlocked');
+});
+
+it('does not re-read a deterministic invalid value on foreground recovery', async () => {
+  // An invalid stored value cannot heal across foregrounds: a re-read would
+  // return the same bytes, so the fail-open stands without spending reads.
+  await mount('invalid');
+  expectState(false, 'unlocked');
+  await transition('background');
+  await transition('active', 300_000);
+  expectState(false, 'unlocked');
+  expect(storage.getItemAsync).toHaveBeenCalledTimes(1);
+});

--- a/apps/mobile/src/lib/app-unlock-context.test-helpers.tsx
+++ b/apps/mobile/src/lib/app-unlock-context.test-helpers.tsx
@@ -34,6 +34,9 @@ export { appState, native, storage };
 vi.mock('expo-local-authentication', () => native);
 vi.mock('expo-secure-store', () => storage);
 vi.mock('react-native', () => ({ AppState: appState }));
+// The E2E fault hook stays closed: rejected reads come from the SecureStore
+// mock, not the bundle-time fault window.
+vi.mock('@/lib/config', () => ({ E2E_SECURE_STORE_FAULT_MS: 0 }));
 export const SUCCESS = { success: true };
 export const IOS_SUCCESSES = [
   { success: true, error: null, warning: null },
@@ -58,9 +61,18 @@ async function flush(update?: () => void) {
     await vi.dynamicImportSettled();
   });
 }
-export async function mount(raw: string | null = 'disabled') {
-  storage.value = raw;
-  storage.getItemAsync.mockResolvedValue(raw);
+export async function mount(raw: string | null = 'disabled', rejectRead = false) {
+  if (rejectRead) {
+    // The environmental keychain failure: every preference read rejects, so
+    // mount must not override the rejection with a resolved value. Fake
+    // timers are installed before the first read so the read helper's
+    // bounded backoff lands on the fake clock.
+    storage.getItemAsync.mockRejectedValue(new Error('keychain unavailable'));
+    vi.useFakeTimers();
+  } else {
+    storage.value = raw;
+    storage.getItemAsync.mockResolvedValue(raw);
+  }
   view = await renderWithProviders(
     <AppUnlockProvider promptMessage="Unlock Kilo">
       <Probe />
@@ -68,6 +80,21 @@ export async function mount(raw: string | null = 'disabled') {
     </AppUnlockProvider>
   );
   await flush();
+  if (rejectRead) {
+    await settleReadRetries();
+    vi.useRealTimers();
+  }
+}
+
+/**
+ * Drives one full `readStoredValueWithRetry` backoff budget (250 + 500 +
+ * 1000 ms) on the fake clock, so a rejected-read sequence settles
+ * deterministically. Fake timers must be active before the rejection lands.
+ */
+export async function settleReadRetries() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(2000);
+  });
 }
 export function expectState(enabled: boolean, status: Unlock['status'], busy = false) {
   expect(state()).toMatchObject({ enabled, status, busy });
@@ -115,6 +142,7 @@ beforeEach(() => {
 afterEach(() => {
   view?.unmount();
   view = undefined;
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });

--- a/apps/mobile/src/lib/app-unlock-context.tsx
+++ b/apps/mobile/src/lib/app-unlock-context.tsx
@@ -12,6 +12,8 @@ import {
 import { AppState, type AppStateStatus } from 'react-native';
 import { z } from 'zod';
 
+import { readStoredValueWithRetry } from '@/lib/auth/secure-store-read';
+
 // Device-local, not account metadata. The only stored values are enabled/disabled.
 const STORAGE_KEY = 'app-unlock-enabled';
 const BACKGROUND_LOCK_MS = 300_000;
@@ -34,7 +36,7 @@ type Outcome =
 
 type UnlockState = {
   enabled: boolean;
-  status: 'preference-loading' | 'preference-error' | 'locked' | 'unlocked';
+  status: 'preference-loading' | 'locked' | 'unlocked';
   purpose: 'unlock' | 'setting' | null;
   phase: 'idle' | 'reading' | 'authenticating' | 'saving';
   outcome: Outcome | null;
@@ -129,6 +131,9 @@ export function AppUnlockProvider({
   const coveredInterval = useRef(0);
   const attemptedInterval = useRef(0);
   const coldStartPending = useRef(false);
+  // True only while the live state is the fail-open of an exhausted read
+  // budget, so foreground recovery knows to re-read the preference.
+  const readFailed = useRef(false);
 
   const publish = useCallback((patch: Partial<UnlockState>) => {
     if (mounted.current) {
@@ -197,13 +202,32 @@ export function AppUnlockProvider({
       return;
     }
     publish({ status: 'preference-loading', phase: 'reading', purpose: null, outcome: null });
+    // An unreadable or invalid preference fails open to the documented no-key
+    // default instead of gating the app behind a Retry tap. This does not
+    // weaken authentication: the key holds only enabled/disabled and is
+    // device-local, not account metadata (see STORAGE_KEY); old installations
+    // without the key are documented disabled; and the session, token owner,
+    // refresh, and 401 sign-out paths never consult it — only this
+    // convenience device lock defaults to its documented off state when
+    // unreadable. A person who enabled it can re-enable from Preferences,
+    // which rewrites the key (`setEnabled`); and an exhausted budget is not
+    // final — the fail-open stands only until the next foreground, where
+    // `reReadAfterFailure` re-reads the key once the keychain recovers.
+    const failOpen = () => {
+      publish({ enabled: false, status: 'unlocked', phase: 'idle', outcome: null });
+    };
     try {
-      const raw = await SecureStore.getItemAsync(STORAGE_KEY);
+      // Bounded retries cover the transient post-reboot keychain window; only
+      // the final rejection reaches the fail-open below.
+      const raw = await readStoredValueWithRetry(STORAGE_KEY);
       if (!mounted.current) {
         return;
       }
       if (raw !== null && raw !== 'enabled' && raw !== 'disabled') {
-        throw new Error('Invalid app unlock preference');
+        // An invalid value is deterministic: a retry would re-read the same
+        // bytes, so fail open without spending the read budget.
+        failOpen();
+        return;
       }
       // Old installations have no key and remain disabled. Keep this fallback
       // until those installations and records cannot exist; this section retains it.
@@ -214,9 +238,36 @@ export function AppUnlockProvider({
         void authenticate();
       }
     } catch {
-      publish({ status: 'preference-error', phase: 'idle' });
+      // The retry budget is exhausted, not the preference: re-read on
+      // foreground recovery instead of failing open for the whole session.
+      // An invalid value never lands here (handled above) because a re-read
+      // would return the same bytes.
+      readFailed.current = true;
+      failOpen();
     }
   }, [authenticate, publish]);
+
+  // Foreground recovery for an exhausted read budget: re-read silently — no
+  // 'preference-loading' publish, so live content never hides behind the
+  // unlock surface while the keychain is still down — and re-arm the lock
+  // when the key answers enabled. The in-progress return is not retro-gated;
+  // the re-armed preference gates every later background return and cold
+  // start exactly like a healthy read would.
+  const reReadAfterFailure = useCallback(async () => {
+    try {
+      const raw = await readStoredValueWithRetry(STORAGE_KEY);
+      // Any answer (disabled, absent, or invalid) settles the fail-open; only
+      // a rejection keeps the re-read armed for the next foreground. A busy
+      // phase (a save in flight) skips the publish, which drops it when
+      // unmounted anyway.
+      readFailed.current = false;
+      if (raw === 'enabled' && !current.current.enabled && current.current.phase === 'idle') {
+        publish({ enabled: true });
+      }
+    } catch {
+      // Still unreadable: the fail-open stands until the next foreground.
+    }
+  }, [publish]);
 
   useEffect(() => {
     prompt.current = promptMessage;
@@ -239,6 +290,10 @@ export function AppUnlockProvider({
       const interval = background.current;
       background.current = null;
       if (!current.current.enabled) {
+        if (readFailed.current) {
+          // An exhausted budget lost the lock: recover it here.
+          void reReadAfterFailure();
+        }
         return;
       }
       const requiresLock =
@@ -261,15 +316,13 @@ export function AppUnlockProvider({
       mounted.current = false;
       subscription.remove();
     };
-  }, [authenticate, publish, restore]);
+  }, [authenticate, publish, reReadAfterFailure, restore]);
 
   const retry = useCallback(() => {
-    if (current.current.status === 'preference-error') {
-      void restore();
-    } else if (current.current.status === 'locked') {
+    if (current.current.status === 'locked') {
       void authenticate();
     }
-  }, [authenticate, restore]);
+  }, [authenticate]);
   const setEnabled = useCallback(
     (enabled: boolean) => {
       void authenticate(enabled);

--- a/apps/mobile/src/lib/auth/auth-context.test.ts
+++ b/apps/mobile/src/lib/auth/auth-context.test.ts
@@ -43,6 +43,7 @@ vi.mock('expo-secure-store', () => ({
 
 vi.mock('@/lib/config', () => ({
   API_BASE_URL: 'https://api.example.com',
+  E2E_SECURE_STORE_FAULT_MS: 0,
 }));
 
 vi.mock('@/lib/analytics/posthog', () => ({

--- a/apps/mobile/src/lib/auth/auth-context.test.tsx
+++ b/apps/mobile/src/lib/auth/auth-context.test.tsx
@@ -77,6 +77,14 @@ const hoisted = vi.hoisted(() => {
     setCurrentDeepLinkUserId: vi.fn(),
   };
 
+  // The legacy-exchange branch of the bootstrap load. Resolves null (a failed
+  // or already-done exchange: the load falls through to the main restore)
+  // unless a test overrides it, so tests that never take the legacy branch
+  // keep today's behavior.
+  const exchange = {
+    exchangeLegacyToken: vi.fn().mockResolvedValue(null),
+  };
+
   return {
     callOrder,
     secureStore,
@@ -87,6 +95,7 @@ const hoisted = vi.hoisted(() => {
     sentry,
     appState,
     deepLinkLaunch,
+    exchange,
   };
 });
 
@@ -173,6 +182,10 @@ vi.mock('@/lib/appsflyer', () => ({
 vi.mock('@/lib/deep-link-launch', () => ({
   clearAccountBoundPendingDeepLink: hoisted.deepLinkLaunch.clearAccountBoundPendingDeepLink,
   setCurrentDeepLinkUserId: hoisted.deepLinkLaunch.setCurrentDeepLinkUserId,
+}));
+
+vi.mock('@/lib/auth/exchange-legacy-token', () => ({
+  exchangeLegacyToken: hoisted.exchange.exchangeLegacyToken,
 }));
 
 vi.mock('@/lib/telemetry/controller', () => ({
@@ -287,6 +300,9 @@ vi.mock('@/lib/storage-keys', () => ({
 vi.mock('@/lib/config', () => ({
   API_BASE_URL: 'https://api.example.com',
   SESSION_INGEST_WS_URL: 'wss://ingest.example.com',
+  // The E2E fault hook stays closed: these cases drive the failure through
+  // the SecureStore mock instead.
+  E2E_SECURE_STORE_FAULT_MS: 0,
 }));
 
 vi.mock('react-native', () => ({
@@ -301,6 +317,8 @@ type AuthContextValue = {
   sessionEnded: boolean;
   authEpoch: number;
   isSigningOut: boolean;
+  restoreFailed: boolean;
+  retryRestore: () => void;
   signIn: (token: string) => Promise<void>;
   signOut: (ended?: boolean) => Promise<void>;
 };
@@ -328,7 +346,11 @@ async function loadAuthModule() {
 /** Mount the AuthProvider and extract the auth context value via a
  *  consumer child. The context is captured synchronously once the
  *  component mounts inside act. */
-async function mountAndGetContext(): Promise<{ ctx: AuthContextValue; unmount: () => void }> {
+async function mountAndGetContext(): Promise<{
+  ctx: AuthContextValue;
+  getCtx: () => AuthContextValue;
+  unmount: () => void;
+}> {
   const mod = await loadAuthModule();
 
   let capturedCtx: AuthContextValue | undefined = undefined;
@@ -344,25 +366,51 @@ async function mountAndGetContext(): Promise<{ ctx: AuthContextValue; unmount: (
     await Promise.resolve();
   });
 
-  // After mount, isLoading becomes false because the preloaded token resolves.
-  // We need to wait for the loading effect to complete.
-  await act(async () => {
-    await new Promise<void>(resolve => {
-      void setTimeout(resolve, 0);
-    });
-  });
+  // Wait for the loading effect to complete. Bootstrap can now span the
+  // bounded retry backoff of a transient SecureStore failure (250/500/1000 ms),
+  // so settle on `isLoading` rather than on a single tick — a healthy read
+  // still finishes on the first pass.
+  await settleBootstrap(() => capturedCtx);
 
   // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition -- safety net for test failures
   if (!capturedCtx) {
     throw new Error('auth context not captured');
   }
 
+  const getCtx = (): AuthContextValue => {
+    if (!capturedCtx) {
+      throw new Error('auth context not captured');
+    }
+    return capturedCtx;
+  };
+
   return {
     ctx: capturedCtx,
+    getCtx,
     unmount: () => {
       renderer?.unmount();
     },
   };
+}
+
+/** Flush act passes on real timers until bootstrap stops loading, bounded so a
+ *  stuck provider fails as a timeout rather than hanging the suite. */
+async function settleBootstrap(
+  read: () => AuthContextValue | undefined,
+  budgetMs = 4000
+): Promise<void> {
+  for (let elapsed = 0; elapsed <= budgetMs; elapsed += 20) {
+    // eslint-disable-next-line no-await-in-loop -- polling must flush and re-check sequentially between act cycles
+    await act(async () => {
+      await new Promise<void>(resolve => {
+        void setTimeout(resolve, 20);
+      });
+    });
+    if (read()?.isLoading === false) {
+      return;
+    }
+  }
+  throw new Error('bootstrap never settled');
 }
 
 // ---- tests ----
@@ -949,6 +997,133 @@ describe('bootstrap and foreground race fencing', () => {
     expect(getCtx().token).toBeUndefined();
     expect(getCtx().sessionEnded).toBe(true);
 
+    unmount();
+  });
+
+  it('regression: a bootstrap success landing mid-sign-out-teardown never republishes the torn-down credentials', async () => {
+    let releaseRead: (() => void) | undefined = undefined;
+    const readGate = new Promise<void>(resolve => {
+      releaseRead = resolve;
+    });
+    const storedToken = makeToken({ kiloUserId: 'user-1' });
+    // Mock queue consumed by the bootstrap load: preloadedToken,
+    // preloadedRefreshToken, then the expiry read (held), then the
+    // credential re-read (unchanged, so only a fence can stop the publish).
+    hoisted.secureStore.getItemAsync
+      .mockResolvedValueOnce(storedToken)
+      .mockResolvedValueOnce('stored-refresh')
+      .mockImplementationOnce(async () => {
+        // Bootstrap expiry read: hold open so a sign-out can land mid-read.
+        await readGate;
+        return '9999999999999';
+      })
+      .mockResolvedValueOnce(storedToken);
+
+    const { getCtx, unmount } = await mountProvider();
+
+    // Hold the sign-out's remote cleanup open: the teardown is mid-flight and
+    // its epoch bump (which waits for the cleanup) has not happened when the
+    // bootstrap read resolves — the epoch fence alone cannot stop the publish.
+    let releaseCleanup: (() => void) | undefined = undefined;
+    const cleanupGate = new Promise<void>(resolve => {
+      releaseCleanup = resolve;
+    });
+    logoutCleanupMock.runLogoutCleanup.mockImplementationOnce(async () => {
+      await cleanupGate;
+    });
+
+    const signOutPromise = getCtx().signOut(true);
+    await vi.waitFor(() => {
+      expect(logoutCleanupMock.runLogoutCleanup).toHaveBeenCalled();
+    });
+
+    // Release the bootstrap read while the teardown is still in flight.
+    releaseRead?.();
+    await act(async () => {
+      await new Promise<void>(resolve => {
+        void setTimeout(resolve, 0);
+      });
+    });
+
+    // The success path must not republish what sign-out is tearing down: no
+    // owner token, no React token, no deep-link binding for the old account.
+    const tokenOwner = await import('@/lib/auth/token-owner');
+    expect(tokenOwner.getActiveToken()).toBeNull();
+    expect(getCtx().token).toBeUndefined();
+    expect(hoisted.deepLinkLaunch.setCurrentDeepLinkUserId).not.toHaveBeenCalledWith('user-1');
+
+    // The teardown then finishes into the signed-out end state.
+    releaseCleanup?.();
+    await act(async () => {
+      await signOutPromise;
+    });
+    expect(getCtx().token).toBeUndefined();
+    expect(getCtx().sessionEnded).toBe(true);
+
+    unmount();
+  });
+
+  it('regression: a legacy-exchange success landing mid-sign-out-teardown never republishes credentials', async () => {
+    let releaseExchange: (() => void) | undefined = undefined;
+    const exchangeGate = new Promise<void>(resolve => {
+      releaseExchange = resolve;
+    });
+    const storedToken = makeToken({ kiloUserId: 'user-1' });
+    // No stored refresh token: bootstrap takes the legacy-exchange branch.
+    // Mock queue consumed by the bootstrap load: preloadedToken,
+    // preloadedRefreshToken (null), then — after the fenced exchange publish
+    // is refused and the main restore path continues — the expiry read and
+    // the credential re-read.
+    hoisted.secureStore.getItemAsync
+      .mockResolvedValueOnce(storedToken)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('9999999999999')
+      .mockResolvedValueOnce(storedToken);
+    hoisted.exchange.exchangeLegacyToken.mockImplementationOnce(async () => {
+      await exchangeGate;
+      return { token: 'exchanged-token', refreshToken: 'exchanged-refresh', expiresIn: 3600 };
+    });
+
+    const { getCtx, unmount } = await mountProvider();
+
+    // Hold the sign-out's remote cleanup open so the teardown is mid-flight
+    // (epoch not yet bumped) when the exchange resolves: the exchange's own
+    // epoch checks pass inside that window.
+    let releaseCleanup: (() => void) | undefined = undefined;
+    const cleanupGate = new Promise<void>(resolve => {
+      releaseCleanup = resolve;
+    });
+    logoutCleanupMock.runLogoutCleanup.mockImplementationOnce(async () => {
+      await cleanupGate;
+    });
+
+    const signOutPromise = getCtx().signOut(true);
+    await vi.waitFor(() => {
+      expect(logoutCleanupMock.runLogoutCleanup).toHaveBeenCalled();
+    });
+
+    // Release the exchange while the teardown is still in flight.
+    releaseExchange?.();
+    await act(async () => {
+      await new Promise<void>(resolve => {
+        void setTimeout(resolve, 0);
+      });
+    });
+
+    // The fenced exchange must not publish the exchanged pair mid-teardown:
+    // no React token and no deep-link binding for the account being signed out.
+    expect(getCtx().token).toBeUndefined();
+    expect(hoisted.deepLinkLaunch.setCurrentDeepLinkUserId).not.toHaveBeenCalledWith('user-1');
+
+    // The teardown then finishes into the signed-out end state.
+    releaseCleanup?.();
+    await act(async () => {
+      await signOutPromise;
+    });
+    const tokenOwner = await import('@/lib/auth/token-owner');
+    expect(tokenOwner.getActiveToken()).toBeNull();
+    expect(getCtx().token).toBeUndefined();
+    expect(getCtx().sessionEnded).toBe(true);
     unmount();
   });
 
@@ -1631,4 +1806,215 @@ describe('auth-transition queue and sign-out failure matrix', () => {
 
     unmount();
   });
+});
+
+describe('startup credential read failure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.callOrder.length = 0;
+  });
+
+  /** The environmental keychain failure: reads of `auth-token` reject for the
+   *  first `failures` attempts and then report the stored session (or
+   *  `recoveredValue`, for the genuinely-no-session case). The refresh and
+   *  expiry reads stay healthy, so only the credential read is faulty. */
+  function failTokenReads(failures: number, recoveredValue: string | null = 'stored-token') {
+    let tokenReads = 0;
+    // eslint-disable-next-line require-await -- mock returning a resolved or rejected promise
+    hoisted.secureStore.getItemAsync.mockImplementation(async (key: string) => {
+      if (key === 'auth-token') {
+        tokenReads += 1;
+        if (tokenReads <= failures) {
+          throw new Error('keychain unavailable');
+        }
+        return recoveredValue;
+      }
+      if (key === 'refresh-token') {
+        return 'stored-refresh';
+      }
+      if (key === 'token-expires-at') {
+        return '9999999999999';
+      }
+      return null;
+    });
+    return () => tokenReads;
+  }
+
+  // No `unhandledRejection` listener is scoped in this suite on purpose: the
+  // fix is that the rejection never escapes `load()`, so an escape must fail
+  // the file rather than be swallowed.
+
+  it('repro: a rejected startup credential read keeps the person signed in', async () => {
+    failTokenReads(1);
+
+    // Fresh module registry: preloadedAuthToken is recreated and rejects.
+    const { ctx, unmount } = await mountAndGetContext();
+
+    // A transient keychain failure at startup must never sign the person
+    // out: the retried read finds the stored session, so bootstrap settles
+    // signed in instead of leaving the app on the login screen.
+    expect(ctx.isLoading).toBe(false);
+    expect(ctx.token).toBe('stored-token');
+    expect(ctx.restoreFailed).toBe(false);
+
+    unmount();
+  });
+
+  it('reports a retryable restore failure when every retry fails, without signing out', async () => {
+    // Four attempts (the first plus three retries) all reject.
+    const readCount = failTokenReads(4);
+
+    const { ctx, unmount } = await mountAndGetContext();
+
+    expect(readCount()).toBe(4);
+    // No token is fabricated and no signed-out path is taken: the session is
+    // not known to be gone, so the person is asked to retry.
+    expect(ctx.isLoading).toBe(false);
+    expect(ctx.restoreFailed).toBe(true);
+    expect(ctx.token).toBeUndefined();
+    expect(hoisted.deepLinkLaunch.setCurrentDeepLinkUserId).not.toHaveBeenCalled();
+
+    unmount();
+  }, 15_000);
+
+  it('restores the session when retryRestore runs after the storage recovers', async () => {
+    // Every attempt of the first bootstrap fails; the retry's reads succeed.
+    failTokenReads(4);
+
+    const { getCtx, unmount } = await mountAndGetContext();
+    expect(getCtx().restoreFailed).toBe(true);
+
+    act(() => {
+      getCtx().retryRestore();
+    });
+    // The retry holds the settled error surface: the flag clears only once
+    // `load()`'s primary reads resolve, never synchronously on tap, so the
+    // surface never blanks behind a hidden loading gate.
+    expect(getCtx().restoreFailed).toBe(true);
+    expect(getCtx().isLoading).toBe(true);
+
+    await settleBootstrap(getCtx);
+
+    // The recovered read restored the session and cleared the flag.
+    expect(getCtx().restoreFailed).toBe(false);
+    expect(getCtx().token).toBe('stored-token');
+
+    unmount();
+  }, 15_000);
+
+  it('a failed retry settles back onto the restore error surface', async () => {
+    // Four reads for the first bootstrap, four for the retry: every attempt
+    // of both runs rejects.
+    failTokenReads(8);
+
+    const { getCtx, unmount } = await mountAndGetContext();
+    expect(getCtx().restoreFailed).toBe(true);
+
+    act(() => {
+      getCtx().retryRestore();
+    });
+    // The surface holds while the retry's reads are failing.
+    expect(getCtx().restoreFailed).toBe(true);
+    expect(getCtx().isLoading).toBe(true);
+
+    await settleBootstrap(getCtx);
+
+    // The failed retry re-settled the same surface: still flagged, still no
+    // token, and the gate is gone again so Retry (and Sign out) are live.
+    expect(getCtx().restoreFailed).toBe(true);
+    expect(getCtx().isLoading).toBe(false);
+    expect(getCtx().token).toBeUndefined();
+
+    unmount();
+  }, 15_000);
+
+  it('sends the person to login when the retry finds no stored session', async () => {
+    // Every attempt of the first bootstrap fails; the retry's reads resolve
+    // null, so the session is genuinely gone and login is the destination.
+    failTokenReads(4, null);
+
+    const { getCtx, unmount } = await mountAndGetContext();
+    expect(getCtx().restoreFailed).toBe(true);
+
+    act(() => {
+      getCtx().retryRestore();
+    });
+    expect(getCtx().restoreFailed).toBe(true);
+    expect(getCtx().isLoading).toBe(true);
+
+    await settleBootstrap(getCtx);
+
+    // The known-empty answer clears the flag: no error surface and no token —
+    // the login route is the correct destination.
+    expect(getCtx().restoreFailed).toBe(false);
+    expect(getCtx().isLoading).toBe(false);
+    expect(getCtx().token).toBeUndefined();
+
+    unmount();
+  }, 15_000);
+
+  it('does not resurrect the restore error surface when signOut lands mid-retry', async () => {
+    // Four reads for the first bootstrap, four for the in-flight retry: the
+    // abandoned retry's catch fires only after sign-out has begun.
+    const readCount = failTokenReads(8);
+
+    const { getCtx, unmount } = await mountAndGetContext();
+    expect(getCtx().restoreFailed).toBe(true);
+
+    act(() => {
+      getCtx().retryRestore();
+    });
+    expect(getCtx().isLoading).toBe(true);
+
+    // Sign out while the retry's reads are still failing inside their backoff
+    // window: the escape hatch clears the surface and routes to login before
+    // the abandoned load settles.
+    await act(async () => {
+      await getCtx().signOut();
+    });
+    expect(getCtx().restoreFailed).toBe(false);
+    expect(getCtx().token).toBeUndefined();
+
+    // Let the abandoned retry's remaining reads exhaust (~1.75 s of backoff)
+    // and flush its catch. Resurrecting the flag here would repaint the error
+    // screen over the login route, where the sign-out dedupe makes a second
+    // tap a no-op — the escape hatch would be permanently dead.
+    for (let waited = 0; waited <= 4000 && readCount() < 8; waited += 20) {
+      // eslint-disable-next-line no-await-in-loop -- polling must flush and re-check sequentially between act cycles
+      await act(async () => {
+        await new Promise<void>(resolve => {
+          setTimeout(resolve, 20);
+        });
+      });
+    }
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The abandoned load settled onto the sign-out, not onto the error
+    // surface: still false, still no token, still on the signed-out route.
+    expect(getCtx().restoreFailed).toBe(false);
+    expect(getCtx().isLoading).toBe(false);
+    expect(getCtx().token).toBeUndefined();
+
+    unmount();
+  }, 15_000);
+
+  it('clears the restore failure when signOut is used as the escape hatch', async () => {
+    failTokenReads(4);
+
+    const { getCtx, unmount } = await mountAndGetContext();
+    expect(getCtx().restoreFailed).toBe(true);
+
+    await act(async () => {
+      await getCtx().signOut();
+    });
+
+    // The explicit teardown lands on login: the flag is cleared so the error
+    // screen gives way to the login route.
+    expect(getCtx().restoreFailed).toBe(false);
+    expect(getCtx().token).toBeUndefined();
+
+    unmount();
+  }, 15_000);
 });

--- a/apps/mobile/src/lib/auth/auth-context.tsx
+++ b/apps/mobile/src/lib/auth/auth-context.tsx
@@ -42,6 +42,7 @@ import {
   setActiveToken,
   setSignOutTeardownActive,
 } from '@/lib/auth/token-owner';
+import { readStoredValueWithRetry } from '@/lib/auth/secure-store-read';
 import { chainSave } from '@/lib/hooks/save-chain';
 import { clearAgentModelPreference } from '@/lib/hooks/use-persisted-agent-model';
 import { clearKeepScreenOnPreference } from '@/lib/hooks/use-keep-screen-on-preference';
@@ -83,6 +84,20 @@ import { beginAuthenticatedOwner } from '@/lib/context-scope';
 // Pre-load tokens at module level so they're available before React mounts
 export const preloadedAuthToken = SecureStore.getItemAsync(AUTH_TOKEN_KEY);
 const preloadedRefreshToken = SecureStore.getItemAsync(REFRESH_TOKEN_KEY);
+// A keychain failure at process start rejects these before any consumer can
+// await them, and the runtime would report that as an unhandled rejection
+// before AuthProvider even mounts. Observe it here; the bootstrap read below
+// still awaits the same promise as its first attempt, and it — not this
+// observer — decides whether the session can be restored.
+async function observePreloadRejection(preload: Promise<string | null>): Promise<void> {
+  try {
+    await preload;
+  } catch {
+    // Observed only. The bootstrap read owns the outcome.
+  }
+}
+void observePreloadRejection(preloadedAuthToken);
+void observePreloadRejection(preloadedRefreshToken);
 
 const jwtPayloadSchema = z.object({ kiloUserId: z.string().optional() });
 
@@ -125,6 +140,13 @@ type AuthContextValue = {
    *  publication succeeds. The read-cache mount refuses to subscribe while it
    *  is set, and the persister fence reads the same flag at write time. */
   isSigningOut: boolean;
+  /** True when every retried startup credential read still failed. The stored
+   *  session is NOT known to be gone, so bootstrap shows a retryable error
+   *  surface instead of presenting the person as signed out. */
+  restoreFailed: boolean;
+  /** Re-runs the startup credential read, holding the restore-error surface
+   *  until the fresh reads resolve. */
+  retryRestore: () => void;
   signIn: (token: string, refreshToken?: string, expiresIn?: number) => Promise<void>;
   signOut: (ended?: boolean) => Promise<void>;
 };
@@ -135,6 +157,9 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
   const [token, setToken] = useState<string | undefined>();
   const [isLoading, setIsLoading] = useState(true);
   const [sessionEnded, setSessionEnded] = useState(false);
+  // Set only when the bounded retry read gave up: the credentials could not be
+  // read, which is not the same as there being none.
+  const [restoreFailed, setRestoreFailed] = useState(false);
   // Reactive snapshot of the module auth epoch, advanced synchronously at the
   // start of sign-in and sign-out so a subscriber can resubscribe on the bump.
   const [authEpoch, setAuthEpoch] = useState(() => currentAuthEpoch());
@@ -146,22 +171,43 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
   const isSigningOut = useSyncExternalStore(subscribeSignOutActive, isSignOutActive);
   const isSignedOutReference = useRef(false);
 
-  useEffect(() => {
-    const load = async () => {
+  // Declared outside the mount effect so the restore-error screen's Retry can
+  // re-run the exact same bootstrap. `preload` is passed only on the first
+  // run: a retry must never reuse the module-scope promise that already
+  // rejected, and re-awaiting a resolved one would answer from a stale read.
+  const load = useCallback(
+    async (preload?: {
+      readonly token: Promise<string | null>;
+      readonly refresh: Promise<string | null>;
+    }) => {
+      // Capture the epoch before any asynchronous read: every later check —
+      // including the catch below — fences against this moment, so a sign-out
+      // or newer sign-in during bootstrap can never be followed by the
+      // preloaded token being restored into React state or the token owner.
+      const epoch = currentAuthEpoch();
       try {
-        // Capture the epoch before any asynchronous read: every later check
-        // fences against this moment, so a sign-out or newer sign-in during
-        // bootstrap can never be followed by the preloaded token being
-        // restored into React state or the token owner.
-        const epoch = currentAuthEpoch();
-        const stored = await preloadedAuthToken;
-        const storedRefresh = await preloadedRefreshToken;
+        const stored = await readStoredValueWithRetry(AUTH_TOKEN_KEY, undefined, preload?.token);
+        const storedRefresh = await readStoredValueWithRetry(
+          REFRESH_TOKEN_KEY,
+          undefined,
+          preload?.refresh
+        );
+        // The credential state is now known — a stored session restores below,
+        // or genuinely none exists and login is the correct destination. Clear
+        // a settled restore error here, not in `retryRestore`: a retry holds
+        // the error surface until this point (success moves past it, failure
+        // re-settles it in the catch), so the surface never blanks mid-retry.
+        setRestoreFailed(false);
 
         if (stored) {
           // Legacy exchange: if we have a token but no refresh token, upgrade once.
           if (!storedRefresh) {
             const pair = await exchangeLegacyToken();
-            if (pair) {
+            // The same teardown window the fence below covers: a sign-out that
+            // began while the exchange was in flight has not bumped the epoch
+            // yet, so the exchange's own epoch checks pass — the sign-out flag
+            // must stop this publish, exactly like the one below.
+            if (pair && isCurrentAuthEpoch(epoch) && !isSignedOutReference.current) {
               setToken(pair.token);
               setCurrentDeepLinkUserId(readUserIdFromToken(pair.token));
               setIsLoading(false);
@@ -175,14 +221,21 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
             return;
           }
 
-          const expiresAtStr = await SecureStore.getItemAsync(TOKEN_EXPIRES_AT_KEY);
+          const expiresAtStr = await readStoredValueWithRetry(TOKEN_EXPIRES_AT_KEY);
 
           // Fence the asynchronous expiry read: a sign-out or newer sign-in
           // during the reads owns the session, so the stale snapshot must not
           // be republished and nothing may be surfaced for the torn-down
           // session.
-          const currentStored = await SecureStore.getItemAsync(AUTH_TOKEN_KEY);
-          if (!isCurrentAuthEpoch(epoch)) {
+          const currentStored = await readStoredValueWithRetry(AUTH_TOKEN_KEY);
+          // A sign-out teardown closes the epoch fence only at its bump, which
+          // waits for the remote cleanup — so inside the teardown window the
+          // epoch is still current while the sign-out flag is already set. The
+          // flag is the fence for that window, exactly as in the catch below:
+          // without it a success landing mid-teardown republishes the stored
+          // credentials (owner, React state, deep-link binding) that sign-out
+          // is tearing down.
+          if (!isCurrentAuthEpoch(epoch) || isSignedOutReference.current) {
             return;
           }
           // A same-session refresh replaced the stored pair while the reads
@@ -200,12 +253,38 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
           setToken(stored);
           setCurrentDeepLinkUserId(readUserIdFromToken(stored));
         }
+      } catch {
+        // Every read exhausted its retries. The session is not known to be
+        // gone, so NEVER fall through to the signed-out path and never set a
+        // token here: surface a retryable error and let the person retry or
+        // sign out explicitly.
+        // But never resurrect the surface over a transition that began while
+        // this load was in flight. A sign-out's escape hatch already cleared
+        // it synchronously (and the dedupe makes a second sign-out a no-op,
+        // so a resurrected flag would dead-end the hatch on the login route);
+        // a newer sign-in moved the epoch and owns the tree.
+        if (!isSignedOutReference.current && isCurrentAuthEpoch(epoch)) {
+          setRestoreFailed(true);
+        }
       } finally {
         setIsLoading(false);
       }
-    };
+    },
+    []
+  );
+
+  useEffect(() => {
+    void load({ token: preloadedAuthToken, refresh: preloadedRefreshToken });
+  }, [load]);
+
+  const retryRestore = useCallback(() => {
+    // Hold the settled error surface for the whole retry: `restoreFailed`
+    // stays true until `load()`'s primary reads resolve, so this surface
+    // stays mounted instead of blanking behind the loading gate (the native
+    // splash never returns once startup finished).
+    setIsLoading(true);
     void load();
-  }, []);
+  }, [load]);
 
   const signIn = useCallback(
     async (tokenValue: string, refreshTokenValue?: string, expiresIn?: number) => {
@@ -280,6 +359,14 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
         return;
       }
       isSignedOutReference.current = true;
+      // A sign-out from the restore-error surface is the explicit escape
+      // hatch: clear the restore flag and the loading flag before the first
+      // await so the tree leaves the error screen for the login route
+      // immediately — even when a retry load is still in flight — instead of
+      // holding the settled surface (or a hidden blank) until teardown
+      // finishes.
+      setRestoreFailed(false);
+      setIsLoading(false);
       // Close the teardown guard synchronously, before the first await: a
       // refresh or request-token cold read must not touch the old credentials
       // while the remote cleanup runs and the deletion batch is queued. The
@@ -442,29 +529,36 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
       const epoch = currentAuthEpoch();
 
       void (async () => {
-        const expiresAtStr = await SecureStore.getItemAsync(TOKEN_EXPIRES_AT_KEY);
-        if (!expiresAtStr) {
-          return;
-        }
+        try {
+          const expiresAtStr = await SecureStore.getItemAsync(TOKEN_EXPIRES_AT_KEY);
+          if (!expiresAtStr) {
+            return;
+          }
 
-        const expiresAt = Number(expiresAtStr);
-        if (Date.now() <= expiresAt - REFRESH_MARGIN_MS) {
-          return;
-        }
+          const expiresAt = Number(expiresAtStr);
+          if (Date.now() <= expiresAt - REFRESH_MARGIN_MS) {
+            return;
+          }
 
-        // The epoch moved while the expiry read was in flight: the event is
-        // stale, so do not initiate a refresh for the old session.
-        if (!isCurrentAuthEpoch(epoch)) {
-          return;
-        }
+          // The epoch moved while the expiry read was in flight: the event is
+          // stale, so do not initiate a refresh for the old session.
+          if (!isCurrentAuthEpoch(epoch)) {
+            return;
+          }
 
-        const outcome = await performRefresh();
+          const outcome = await performRefresh();
 
-        if (outcome.ok && isCurrentAuthEpoch(outcome.sessionVersion)) {
-          setToken(outcome.token);
+          if (outcome.ok && isCurrentAuthEpoch(outcome.sessionVersion)) {
+            setToken(outcome.token);
+          }
+          // Transient or refused: do not sign out — the user did not trigger
+          // an authenticated request. Let the next real 401 handle it.
+        } catch {
+          // A rejected expiry read (or refresh) must not escape as an
+          // unhandled rejection. Return silently, exactly as the null-expiry
+          // branch above does: the active token stands and the next real 401
+          // drives the refresh.
         }
-        // Transient or refused: do not sign out — the user did not trigger
-        // an authenticated request. Let the next real 401 handle it.
       })();
     });
     return () => {
@@ -473,8 +567,28 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
   }, [token]);
 
   const value = useMemo<AuthContextValue>(
-    () => ({ token, isLoading, sessionEnded, authEpoch, isSigningOut, signIn, signOut }),
-    [token, isLoading, sessionEnded, authEpoch, isSigningOut, signIn, signOut]
+    () => ({
+      token,
+      isLoading,
+      sessionEnded,
+      authEpoch,
+      isSigningOut,
+      restoreFailed,
+      retryRestore,
+      signIn,
+      signOut,
+    }),
+    [
+      token,
+      isLoading,
+      sessionEnded,
+      authEpoch,
+      isSigningOut,
+      restoreFailed,
+      retryRestore,
+      signIn,
+      signOut,
+    ]
   );
 
   return <AuthContext value={value}>{children}</AuthContext>;

--- a/apps/mobile/src/lib/auth/secure-store-read.test.ts
+++ b/apps/mobile/src/lib/auth/secure-store-read.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getItemAsync = vi.hoisted(() =>
+  vi.fn<(key: string, options?: unknown) => Promise<string | null>>()
+);
+
+vi.mock('expo-secure-store', () => ({
+  getItemAsync,
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
+}));
+
+// The fault window is off for every case except the one that proves it: the
+// constant is read from the bundle-time config, so that case reloads the
+// module with its own mock.
+vi.mock('@/lib/config', () => ({ E2E_SECURE_STORE_FAULT_MS: 0 }));
+
+/** A read that rejects, built without `Promise.reject` so the promise rule
+ *  stays satisfied. */
+// eslint-disable-next-line require-await -- an async throw is the rejected promise under test
+async function rejectedRead(message: string): Promise<string | null> {
+  throw new Error(message);
+}
+
+async function loadHelper() {
+  const mod = await import('./secure-store-read');
+  return mod.readStoredValueWithRetry;
+}
+
+describe('readStoredValueWithRetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the value on a healthy first read without waiting', async () => {
+    getItemAsync.mockResolvedValue('stored-token');
+    const readStoredValueWithRetry = await loadHelper();
+
+    await expect(readStoredValueWithRetry('auth-token')).resolves.toBe('stored-token');
+    expect(getItemAsync).toHaveBeenCalledTimes(1);
+    expect(getItemAsync).toHaveBeenCalledWith('auth-token', undefined);
+  });
+
+  it('passes a null resolution straight through and never retries it', async () => {
+    getItemAsync.mockResolvedValue(null);
+    const readStoredValueWithRetry = await loadHelper();
+
+    await expect(readStoredValueWithRetry('auth-token')).resolves.toBeNull();
+    expect(getItemAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers after transient rejections', async () => {
+    getItemAsync
+      .mockRejectedValueOnce(new Error('keychain unavailable'))
+      .mockRejectedValueOnce(new Error('keychain unavailable'))
+      .mockResolvedValue('stored-token');
+    const readStoredValueWithRetry = await loadHelper();
+
+    const read = readStoredValueWithRetry('auth-token');
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(read).resolves.toBe('stored-token');
+    expect(getItemAsync).toHaveBeenCalledTimes(3);
+  });
+
+  it('backs off 250/500/1000 ms and exhausts four attempts before throwing', async () => {
+    getItemAsync.mockRejectedValue(new Error('keychain unavailable'));
+    const readStoredValueWithRetry = await loadHelper();
+
+    // The assertion is attached before the timers run so the rejection is
+    // never momentarily unobserved.
+    const settled = expect(readStoredValueWithRetry('auth-token')).rejects.toThrow(
+      'keychain unavailable'
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getItemAsync).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(getItemAsync).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(getItemAsync).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(getItemAsync).toHaveBeenCalledTimes(4);
+
+    // Four attempts is the whole budget: the last error is the answer.
+    await settled;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(getItemAsync).toHaveBeenCalledTimes(4);
+  });
+
+  it('uses the handed-over first attempt and issues fresh reads for the retries', async () => {
+    getItemAsync.mockResolvedValue('fresh-token');
+    const readStoredValueWithRetry = await loadHelper();
+
+    await expect(
+      readStoredValueWithRetry('auth-token', undefined, Promise.resolve('preloaded-token'))
+    ).resolves.toBe('preloaded-token');
+    expect(getItemAsync).not.toHaveBeenCalled();
+  });
+
+  it('retries a rejected first attempt with a fresh read', async () => {
+    getItemAsync.mockResolvedValue('fresh-token');
+    const readStoredValueWithRetry = await loadHelper();
+
+    const read = readStoredValueWithRetry(
+      'auth-token',
+      undefined,
+      rejectedRead('keychain unavailable')
+    );
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(read).resolves.toBe('fresh-token');
+    expect(getItemAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards the SecureStore options to every read', async () => {
+    getItemAsync.mockRejectedValueOnce(new Error('keychain unavailable')).mockResolvedValue('v');
+    const readStoredValueWithRetry = await loadHelper();
+
+    const read = readStoredValueWithRetry('auth-token', {
+      keychainService: 'kilo',
+    });
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(read).resolves.toBe('v');
+    expect(getItemAsync).toHaveBeenNthCalledWith(2, 'auth-token', { keychainService: 'kilo' });
+  });
+
+  it('rejects every read while the E2E fault window is open', async () => {
+    vi.resetModules();
+    vi.doMock('@/lib/config', () => ({ E2E_SECURE_STORE_FAULT_MS: 60_000 }));
+    getItemAsync.mockResolvedValue('stored-token');
+    const readStoredValueWithRetry = await loadHelper();
+
+    const settled = expect(readStoredValueWithRetry('auth-token')).rejects.toThrow(
+      'E2E secure-store fault window is open: read of auth-token rejected'
+    );
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await settled;
+    // The fault is the reason: the real store is never asked.
+    expect(getItemAsync).not.toHaveBeenCalled();
+
+    vi.doUnmock('@/lib/config');
+    vi.resetModules();
+  });
+
+  it('reads normally once the E2E fault window has elapsed', async () => {
+    vi.resetModules();
+    vi.doMock('@/lib/config', () => ({ E2E_SECURE_STORE_FAULT_MS: 1000 }));
+    getItemAsync.mockResolvedValue('stored-token');
+    const readStoredValueWithRetry = await loadHelper();
+
+    // The window opens at module load; the 250 ms backoff alone is not enough
+    // to leave it, the 500 ms one is.
+    const read = readStoredValueWithRetry('auth-token');
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(read).resolves.toBe('stored-token');
+
+    vi.doUnmock('@/lib/config');
+    vi.resetModules();
+  });
+});

--- a/apps/mobile/src/lib/auth/secure-store-read.ts
+++ b/apps/mobile/src/lib/auth/secure-store-read.ts
@@ -1,0 +1,74 @@
+import * as SecureStore from 'expo-secure-store';
+
+import { E2E_SECURE_STORE_FAULT_MS } from '@/lib/config';
+
+/**
+ * Bounded retry for a stored credential read.
+ *
+ * A keychain/keystore read can reject transiently — the device just rebooted
+ * and the keystore is not unlocked yet, or the platform service is momentarily
+ * unavailable. Bootstrap must never read that rejection as "no stored
+ * session": doing so presents a signed-in person with the login screen while
+ * their credentials are still on the device. Only a rejection is retried; a
+ * `null` resolution is a real answer (nothing stored) and returns immediately.
+ */
+const RETRY_DELAYS_MS = [250, 500, 1000] as const;
+
+// Bundle-time E2E fault hook, the same precedent as `E2E_LATENCY_*` in
+// lib/config: while the window is open, every read through this helper
+// rejects, which is what makes the session-restore failure states provable on
+// a live build. Env-gated, so the constant is 0 and this is inert in
+// production.
+const moduleLoadTime = Date.now();
+
+function isFaultWindowOpen(): boolean {
+  return E2E_SECURE_STORE_FAULT_MS > 0 && Date.now() - moduleLoadTime < E2E_SECURE_STORE_FAULT_MS;
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/** One attempt: the handed-over read if there is one, otherwise a fresh one. */
+async function readOnce(
+  key: string,
+  options: SecureStore.SecureStoreOptions | undefined,
+  firstAttempt: Promise<string | null> | undefined
+): Promise<string | null> {
+  if (isFaultWindowOpen()) {
+    throw new Error(`E2E secure-store fault window is open: read of ${key} rejected`);
+  }
+  const value = await (firstAttempt ?? SecureStore.getItemAsync(key, options));
+  return value;
+}
+
+/**
+ * Reads `key`, retrying only a rejected read up to three more times with
+ * 250/500/1000 ms backoff before rethrowing the last error.
+ *
+ * `firstAttempt` lets a caller hand over a read that is already in flight
+ * (the module-scope preload promises in auth-context), so a healthy cold start
+ * costs exactly the reads it costs today; retries always issue a fresh read.
+ */
+export async function readStoredValueWithRetry(
+  key: string,
+  options?: SecureStore.SecureStoreOptions,
+  firstAttempt?: Promise<string | null>
+): Promise<string | null> {
+  let pending = firstAttempt;
+  for (const retryDelayMs of RETRY_DELAYS_MS) {
+    try {
+      // eslint-disable-next-line no-await-in-loop -- retry cadence: each attempt must settle before the next backoff
+      return await readOnce(key, options, pending);
+    } catch {
+      pending = undefined;
+      // eslint-disable-next-line no-await-in-loop -- backoff between attempts
+      await delay(retryDelayMs);
+    }
+  }
+  // Last attempt: its rejection is the final answer and propagates to the
+  // caller, which owns how the failure is surfaced.
+  return readOnce(key, options, pending);
+}

--- a/apps/mobile/src/lib/bootstrap-decision.test.ts
+++ b/apps/mobile/src/lib/bootstrap-decision.test.ts
@@ -18,6 +18,7 @@ const ready = {
   onConsentRoute: false,
   onConsentReviewRoute: false,
   languageReloadFailed: false,
+  restoreFailed: false,
 } as const;
 
 describe('resolveBootstrapDecision tag', () => {
@@ -99,6 +100,51 @@ describe('resolveBootstrapDecision tag', () => {
     expect(resolveBootstrapDecision(ready).tag).toBe('settle-app');
   });
 
+  it('settles the restore error when the startup credential read failed', () => {
+    expect(resolveBootstrapDecision({ ...ready, restoreFailed: true }).tag).toBe(
+      'settle-restore-error'
+    );
+  });
+
+  it('suppresses redirect-login while the restore error is up', () => {
+    // The failed read leaves no token, but the session is not known to be
+    // gone: routing to login would be the silent sign-out this branch exists
+    // to prevent.
+    expect(resolveBootstrapDecision({ ...ready, restoreFailed: true, hasToken: false }).tag).toBe(
+      'settle-restore-error'
+    );
+    expect(
+      resolveBootstrapDecision({
+        ...ready,
+        restoreFailed: true,
+        hasToken: false,
+        inAuthGroup: true,
+      }).tag
+    ).toBe('settle-restore-error');
+  });
+
+  it('keeps the force-update branches ahead of the restore error', () => {
+    expect(
+      resolveBootstrapDecision({ ...ready, restoreFailed: true, updateRequired: true }).tag
+    ).toBe('redirect-force-update');
+    expect(
+      resolveBootstrapDecision({
+        ...ready,
+        restoreFailed: true,
+        updateRequired: true,
+        inForceUpdate: true,
+      }).tag
+    ).toBe('settle-force-update');
+  });
+
+  it('waits while loading rather than settling the restore error', () => {
+    // Retry sets `isLoading` back to true, so the error surface is replaced by
+    // the startup gate instead of flickering back to itself.
+    expect(resolveBootstrapDecision({ ...ready, restoreFailed: true, isLoading: true }).tag).toBe(
+      'wait-loading'
+    );
+  });
+
   it('settles the language error first, before loading, when the RTL reload failed', () => {
     expect(
       resolveBootstrapDecision({ ...ready, languageReloadFailed: true, isLoading: true }).tag
@@ -166,6 +212,26 @@ describe('resolveBootstrapDecision derivations', () => {
     ).toBe(true);
   });
 
+  it('derives hasRestoreError only from restoreFailed', () => {
+    expect(resolveBootstrapDecision(ready).hasRestoreError).toBe(false);
+    expect(resolveBootstrapDecision({ ...ready, restoreFailed: true }).hasRestoreError).toBe(true);
+    expect(
+      resolveBootstrapDecision({ ...ready, hasToken: false, restoreFailed: true }).hasRestoreError
+    ).toBe(true);
+    // The surface stays up while a retry is loading: `hasRestoreError` is
+    // independent of `isLoading`, so the settled error screen is never hidden
+    // behind the loading gate mid-retry (the tag already waits, above).
+    expect(
+      resolveBootstrapDecision({ ...ready, restoreFailed: true, isLoading: true }).hasRestoreError
+    ).toBe(true);
+  });
+
+  it('includes the restore error in hasBootstrapError', () => {
+    expect(resolveBootstrapDecision({ ...ready, restoreFailed: true }).hasBootstrapError).toBe(
+      true
+    );
+  });
+
   it('derives hidden from loading, redirect, or consent loading, unless a bootstrap error shows', () => {
     expect(resolveBootstrapDecision(ready).hidden).toBe(false);
     expect(resolveBootstrapDecision({ ...ready, isLoading: true }).hidden).toBe(true);
@@ -176,6 +242,11 @@ describe('resolveBootstrapDecision derivations', () => {
     expect(resolveBootstrapDecision({ ...ready, languageReloadFailed: true }).hidden).toBe(false);
     expect(
       resolveBootstrapDecision({ ...ready, languageReloadFailed: true, isLoading: true }).hidden
+    ).toBe(false);
+    // The restore error is a settled surface: the tree stays visible instead
+    // of hiding behind the redirect that the missing token would imply.
+    expect(
+      resolveBootstrapDecision({ ...ready, restoreFailed: true, hasToken: false }).hidden
     ).toBe(false);
   });
 });

--- a/apps/mobile/src/lib/bootstrap-decision.ts
+++ b/apps/mobile/src/lib/bootstrap-decision.ts
@@ -11,6 +11,7 @@ type BootstrapDecisionTag =
   | 'redirect-force-update'
   | 'settle-force-update'
   | 'exit-force-update'
+  | 'settle-restore-error'
   | 'settle-login'
   | 'redirect-login'
   | 'settle-user-error'
@@ -35,6 +36,9 @@ export type BootstrapDecisionInput = {
   onConsentRoute: boolean;
   onConsentReviewRoute: boolean;
   languageReloadFailed: boolean;
+  /** Every retried startup credential read failed: the stored session could
+   *  not be read, so it is not known to be gone. */
+  restoreFailed: boolean;
 };
 
 export type BootstrapDecision = {
@@ -42,6 +46,7 @@ export type BootstrapDecision = {
   hasUserBootstrapError: boolean;
   hasConsentBootstrapError: boolean;
   hasLanguageReloadError: boolean;
+  hasRestoreError: boolean;
   hasBootstrapError: boolean;
   hidden: boolean;
 };
@@ -59,6 +64,12 @@ function resolveBootstrapTag(input: BootstrapDecisionInput): BootstrapDecisionTa
   }
   if (input.inForceUpdate) {
     return 'exit-force-update';
+  }
+  // Ahead of the login branch on purpose: a failed credential read leaves
+  // `hasToken` false, so `redirect-login` must not fire under the error
+  // screen and route a still-signed-in person to login.
+  if (input.restoreFailed) {
+    return 'settle-restore-error';
   }
   if (!input.hasToken) {
     return input.inAuthGroup ? 'settle-login' : 'redirect-login';
@@ -85,8 +96,9 @@ export function resolveBootstrapDecision(input: BootstrapDecisionInput): Bootstr
   const hasUserBootstrapError = input.hasToken && input.userIdError;
   const hasConsentBootstrapError = input.hasToken && input.consentCheckError;
   const hasLanguageReloadError = input.languageReloadFailed;
+  const hasRestoreError = input.restoreFailed;
   const hasBootstrapError =
-    hasUserBootstrapError || hasConsentBootstrapError || hasLanguageReloadError;
+    hasUserBootstrapError || hasConsentBootstrapError || hasLanguageReloadError || hasRestoreError;
   const consentLoading =
     input.hasToken &&
     !input.consentChecked &&
@@ -104,6 +116,7 @@ export function resolveBootstrapDecision(input: BootstrapDecisionInput): Bootstr
       (!showingForceUpdate && (needsAuth || needsAppRedirect || needsConsentRedirect)));
   const hidden =
     !hasLanguageReloadError &&
+    !hasRestoreError &&
     !hasUserBootstrapError &&
     !hasConsentBootstrapError &&
     (input.isLoading || needsRedirect || consentLoading);
@@ -113,6 +126,7 @@ export function resolveBootstrapDecision(input: BootstrapDecisionInput): Bootstr
     hasUserBootstrapError,
     hasConsentBootstrapError,
     hasLanguageReloadError,
+    hasRestoreError,
     hasBootstrapError,
     hidden,
   };

--- a/apps/mobile/src/lib/config.ts
+++ b/apps/mobile/src/lib/config.ts
@@ -67,3 +67,7 @@ function optionalLatencyMs(key: keyof typeof OPTIONAL_ENV_KEYS): number {
 export const E2E_LATENCY_SESSION_MS: number = optionalLatencyMs('e2eLatencySessionMs');
 export const E2E_LATENCY_MESSAGES_MS: number = optionalLatencyMs('e2eLatencyMessagesMs');
 export const E2E_LATENCY_WS_MS: number = optionalLatencyMs('e2eLatencyWsMs');
+
+/** E2E-only secure-store fault window (see lib/auth/secure-store-read.ts):
+ *  while it is open, every read through the retry helper rejects. 0 = disabled. */
+export const E2E_SECURE_STORE_FAULT_MS: number = optionalLatencyMs('e2eSecureStoreFaultMs');

--- a/apps/mobile/src/lib/env-keys.js
+++ b/apps/mobile/src/lib/env-keys.js
@@ -23,5 +23,9 @@ export const OPTIONAL_ENV_KEYS = {
   e2eLatencySessionMs: 'E2E_LATENCY_SESSION_MS',
   e2eLatencyMessagesMs: 'E2E_LATENCY_MESSAGES_MS',
   e2eLatencyWsMs: 'E2E_LATENCY_WS_MS',
+  // E2E-only: milliseconds after bundle load during which every read
+  // through lib/auth/secure-store-read rejects, so the session-restore
+  // failure states are provable on a live build.
+  e2eSecureStoreFaultMs: 'E2E_SECURE_STORE_FAULT_MS',
   sentryEnvironment: 'EXPO_PUBLIC_SENTRY_ENVIRONMENT',
 };

--- a/apps/mobile/src/lib/hooks/use-pending-deep-link-restore.mounted.test.tsx
+++ b/apps/mobile/src/lib/hooks/use-pending-deep-link-restore.mounted.test.tsx
@@ -1,0 +1,109 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as use-restore-error-hold.mounted.test.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePendingDeepLinkRestore } from '@/lib/hooks/use-pending-deep-link-restore';
+
+const restoreMock = vi.hoisted(() => ({
+  restorePersistedPendingDeepLink: vi.fn(),
+}));
+
+vi.mock('@/lib/deep-link-launch', () => ({
+  restorePersistedPendingDeepLink: restoreMock.restorePersistedPendingDeepLink,
+}));
+
+type RestoreProps = {
+  authLoading: boolean;
+  restoreFailed: boolean;
+};
+
+function Harness(props: RestoreProps): null {
+  usePendingDeepLinkRestore(props);
+  return null;
+}
+
+function mount(props: RestoreProps): TestRenderer.ReactTestRenderer {
+  const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+  act(() => {
+    ref.current = TestRenderer.create(createElement(Harness, props));
+  });
+  const renderer = ref.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return renderer;
+}
+
+async function update(
+  renderer: TestRenderer.ReactTestRenderer,
+  props: RestoreProps
+): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    renderer.update(createElement(Harness, props));
+  });
+}
+
+describe('usePendingDeepLinkRestore', () => {
+  beforeEach(() => {
+    // React 19 requires the act environment flag before `act` supports
+    // effects (same setup as use-restore-error-hold.mounted.test.tsx).
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    restoreMock.restorePersistedPendingDeepLink.mockClear();
+  });
+
+  it('waits for auth bootstrap, then restores exactly once', async () => {
+    const renderer = mount({ authLoading: true, restoreFailed: false });
+    expect(restoreMock.restorePersistedPendingDeepLink).not.toHaveBeenCalled();
+
+    // Bootstrap settled signed-in: the user id binding is published, the
+    // restore may run — once.
+    await update(renderer, { authLoading: false, restoreFailed: false });
+    expect(restoreMock.restorePersistedPendingDeepLink).toHaveBeenCalledTimes(1);
+
+    // Later renders never re-arm the restore.
+    await update(renderer, { authLoading: false, restoreFailed: false });
+    expect(restoreMock.restorePersistedPendingDeepLink).toHaveBeenCalledTimes(1);
+    renderer.unmount();
+  });
+
+  it('holds the restore while the restore error is settled, then runs once it clears', async () => {
+    // Cold start with a failed credential read: the account binding is
+    // unknown — NOT signed-out — so the persisted record must be left alone.
+    const renderer = mount({ authLoading: false, restoreFailed: true });
+    expect(restoreMock.restorePersistedPendingDeepLink).not.toHaveBeenCalled();
+
+    // The retry succeeded: bootstrap settled signed-in and the user id is
+    // published, so the restore runs against the right account.
+    await update(renderer, { authLoading: false, restoreFailed: false });
+    expect(restoreMock.restorePersistedPendingDeepLink).toHaveBeenCalledTimes(1);
+    renderer.unmount();
+  });
+
+  it('holds the restore while the restore error is settled and runs once sign-out settles signed-out', async () => {
+    const renderer = mount({ authLoading: false, restoreFailed: true });
+    expect(restoreMock.restorePersistedPendingDeepLink).not.toHaveBeenCalled();
+
+    // The sign-out escape hatch cleared the flag: bootstrap settled genuinely
+    // signed out, so the restore applies the signed-out semantics (drop
+    // account-bound, keep account-independent) exactly once.
+    await update(renderer, { authLoading: false, restoreFailed: false });
+    expect(restoreMock.restorePersistedPendingDeepLink).toHaveBeenCalledTimes(1);
+    renderer.unmount();
+  });
+
+  it('holds the restore while a retry load runs behind the error surface', async () => {
+    // The error surface settled, then Retry raised the loading gate: the
+    // restore stays held for the whole retried bootstrap.
+    const renderer = mount({ authLoading: false, restoreFailed: true });
+    expect(restoreMock.restorePersistedPendingDeepLink).not.toHaveBeenCalled();
+
+    await update(renderer, { authLoading: true, restoreFailed: true });
+    expect(restoreMock.restorePersistedPendingDeepLink).not.toHaveBeenCalled();
+
+    await update(renderer, { authLoading: false, restoreFailed: false });
+    expect(restoreMock.restorePersistedPendingDeepLink).toHaveBeenCalledTimes(1);
+    renderer.unmount();
+  });
+});

--- a/apps/mobile/src/lib/hooks/use-pending-deep-link-restore.ts
+++ b/apps/mobile/src/lib/hooks/use-pending-deep-link-restore.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+
+import { restorePersistedPendingDeepLink } from '@/lib/deep-link-launch';
+
+type PendingDeepLinkRestoreInput = {
+  /** Auth bootstrap has not settled: the token owner publishes the signed-in
+   *  user id before this clears, and a persisted record is account-bound. */
+  readonly authLoading: boolean;
+  /** Every retried startup credential read failed. The session is NOT known
+   *  to be gone, so this is not a signed-out answer — the account binding is
+   *  unknown, and the persisted-record restore must wait for bootstrap to
+   *  settle into a known state. */
+  readonly restoreFailed: boolean;
+};
+
+/**
+ * Restore a deep-link destination persisted before process death, exactly
+ * once, after auth bootstrap settles into a state where the account binding
+ * is known.
+ *
+ * Restoring too early compares an account-bound record against a null user id
+ * and deletes the destination:
+ * - while `authLoading`, the signed-in user id is not published yet;
+ * - while `restoreFailed`, the credential reads never resolved, so the
+ *   binding is unknown — holding the restore keeps the record intact until
+ *   the retry publishes it (the link then restores for the right account) or
+ *   the sign-out escape hatch settles genuinely signed out (the restore then
+ *   applies the signed-out semantics: drop account-bound, keep
+ *   account-independent).
+ *
+ * The slot is observable, so the consumer still fires when the destination
+ * lands.
+ */
+export function usePendingDeepLinkRestore(input: PendingDeepLinkRestoreInput): void {
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (input.authLoading || input.restoreFailed || startedRef.current) {
+      return;
+    }
+    startedRef.current = true;
+    void restorePersistedPendingDeepLink();
+  }, [input.authLoading, input.restoreFailed]);
+}

--- a/apps/mobile/src/lib/hooks/use-restore-error-hold.mounted.test.tsx
+++ b/apps/mobile/src/lib/hooks/use-restore-error-hold.mounted.test.tsx
@@ -1,0 +1,105 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as use-force-update.mounted.test.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useRestoreErrorHold } from '@/lib/hooks/use-restore-error-hold';
+
+type HoldProps = {
+  hasRestoreError: boolean;
+  hidden: boolean;
+  isSigningOut: boolean;
+};
+
+function Harness(props: HoldProps): React.ReactElement {
+  const holding = useRestoreErrorHold(props);
+  return createElement('surface', { held: holding ? 'held' : 'released' });
+}
+
+function mount(props: HoldProps): TestRenderer.ReactTestRenderer {
+  const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+  act(() => {
+    ref.current = TestRenderer.create(createElement(Harness, props));
+  });
+  const renderer = ref.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return renderer;
+}
+
+function held(renderer: TestRenderer.ReactTestRenderer): boolean {
+  const surfaces = renderer.root.findAll(
+    node => typeof node.type === 'string' && (node.type as string) === 'surface'
+  );
+  if (surfaces.length !== 1) {
+    throw new Error(`expected exactly one surface host, found ${surfaces.length}`);
+  }
+  return surfaces[0]?.props.held === 'held';
+}
+
+async function update(renderer: TestRenderer.ReactTestRenderer, props: HoldProps): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    renderer.update(createElement(Harness, props));
+  });
+}
+
+const settledError = { hasRestoreError: true, hidden: false, isSigningOut: false };
+
+describe('useRestoreErrorHold', () => {
+  beforeEach(() => {
+    // React 19 requires the act environment flag before `act` supports
+    // layout effects (same setup as animated-splash-overlay.mounted.test.tsx).
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  it('holds the settled restore-error surface', () => {
+    const renderer = mount(settledError);
+    expect(held(renderer)).toBe(true);
+    renderer.unmount();
+  });
+
+  it('keeps the surface through the hidden retried bootstrap, releases at the reveal', async () => {
+    const renderer = mount(settledError);
+    expect(held(renderer)).toBe(true);
+
+    // Retry succeeded: restoreFailed cleared, the gate hides the tree while
+    // the token publish, user fetch, and consent check run.
+    await update(renderer, { hasRestoreError: false, hidden: true, isSigningOut: false });
+    expect(held(renderer)).toBe(true);
+
+    // The gate reveals the tree: the surface may swap inside this paint.
+    await update(renderer, { hasRestoreError: false, hidden: false, isSigningOut: false });
+    expect(held(renderer)).toBe(false);
+    renderer.unmount();
+  });
+
+  it('releases immediately when sign-out starts the escape hatch', async () => {
+    const renderer = mount(settledError);
+    expect(held(renderer)).toBe(true);
+
+    await update(renderer, { hasRestoreError: false, hidden: true, isSigningOut: true });
+    expect(held(renderer)).toBe(false);
+    renderer.unmount();
+  });
+
+  it('holds again when a retried read re-settles the error', async () => {
+    const renderer = mount(settledError);
+    await update(renderer, { hasRestoreError: false, hidden: false, isSigningOut: false });
+    expect(held(renderer)).toBe(false);
+
+    await update(renderer, { hasRestoreError: true, hidden: false, isSigningOut: false });
+    expect(held(renderer)).toBe(true);
+    renderer.unmount();
+  });
+
+  it('never holds on a boot that never saw the restore error', async () => {
+    const renderer = mount({ hasRestoreError: false, hidden: true, isSigningOut: false });
+    expect(held(renderer)).toBe(false);
+
+    await update(renderer, { hasRestoreError: false, hidden: false, isSigningOut: false });
+    expect(held(renderer)).toBe(false);
+    renderer.unmount();
+  });
+});

--- a/apps/mobile/src/lib/hooks/use-restore-error-hold.ts
+++ b/apps/mobile/src/lib/hooks/use-restore-error-hold.ts
@@ -1,0 +1,44 @@
+import { useLayoutEffect, useState } from 'react';
+
+type RestoreErrorHoldInput = {
+  /** The settled restore error: every retried startup credential read failed. */
+  readonly hasRestoreError: boolean;
+  /** The bootstrap gate hides the tree while the retried bootstrap finishes. */
+  readonly hidden: boolean;
+  /** A sign-out started: the escape hatch owns the tree from here. */
+  readonly isSigningOut: boolean;
+};
+
+/**
+ * Holds the settled restore-error surface while the retried bootstrap
+ * finishes, and reports when the surface may leave the screen.
+ *
+ * A successful Retry does not reveal the app immediately: the token publish,
+ * the user fetch, and the consent check still run behind the bootstrap gate,
+ * and the splash overlay that covers a cold start's hidden window is already
+ * gone (startup completed when the error settled). Dropping the error screen
+ * the moment `restoreFailed` clears would expose that hidden window as a
+ * blank frame before Home. The hold keeps the settled surface mounted until
+ * the gate actually reveals the tree, so the error screen and the revealed
+ * tree swap with no blank frame between them.
+ *
+ * Returns true while the surface must stay up. The release runs in a layout
+ * effect, so the swap happens inside one paint.
+ */
+export function useRestoreErrorHold(input: RestoreErrorHoldInput): boolean {
+  const [holding, setHolding] = useState(false);
+  useLayoutEffect(() => {
+    if (input.isSigningOut) {
+      setHolding(false);
+      return;
+    }
+    if (input.hasRestoreError) {
+      setHolding(true);
+      return;
+    }
+    if (!input.hidden) {
+      setHolding(false);
+    }
+  }, [input.hasRestoreError, input.hidden, input.isSigningOut]);
+  return input.hasRestoreError || holding;
+}

--- a/apps/mobile/src/lib/intl-cache-hermes-surface.test.ts
+++ b/apps/mobile/src/lib/intl-cache-hermes-surface.test.ts
@@ -16,6 +16,10 @@ describe('Hermes Intl surface', () => {
     vi.resetModules();
   });
 
+  // The formatters and i18next are imported inside the test, so their transform
+  // runs on the test clock: under the parallel full-suite load this body takes
+  // several seconds against the 5 s default (it formats all 86 languages), so
+  // it carries its own budget. Same sizing as auth-context.test.tsx.
   it('formats every supported language and pluralizes for i18next', async () => {
     stubHermesIntl();
     const { SUPPORTED_LANGUAGES } = await import('@/i18n/languages');
@@ -46,5 +50,5 @@ describe('Hermes Intl surface', () => {
     const few = i18n.t('prReview.hunkRows.fileLoadedCount', { count: 2, displayCount: '2' });
     const many = i18n.t('prReview.hunkRows.fileLoadedCount', { count: 5, displayCount: '5' });
     expect(few).not.toBe(many);
-  });
+  }, 15_000);
 });

--- a/apps/mobile/src/lib/startup-order.test.ts
+++ b/apps/mobile/src/lib/startup-order.test.ts
@@ -44,18 +44,36 @@ describe('root layout startup order (text contract)', () => {
   // The persisted deep-link record is account-bound. Auth bootstrap publishes
   // the signed-in user id before it clears `authLoading`, so a restore that
   // runs on an empty dependency array reads a null user id and deletes the
-  // record it was meant to restore.
-  it('gates the persisted deep-link restore on authLoading', () => {
-    const codeSource = stripComments(layoutSource);
+  // record it was meant to restore. A FAILED restore is not a signed-out
+  // answer either: the credential reads never resolved, so the account
+  // binding is unknown and the restore must also wait out the retryable
+  // error surface until bootstrap settles signed-in or signed-out.
+  it('gates the persisted deep-link restore on the bootstrap outcome', () => {
+    const hookPath = fileURLToPath(
+      new URL('hooks/use-pending-deep-link-restore.ts', import.meta.url)
+    );
+    const hookSource = stripComments(readFileSync(hookPath, 'utf8'));
     const restoreEffect =
-      /restorePersistedPendingDeepLink\(\);[\s\S]{0,60}?\}, \[([^\]]*)\]\)/.exec(codeSource);
+      /restorePersistedPendingDeepLink\(\);[\s\S]{0,60}?\}, \[([^\]]*)\]\)/.exec(hookSource);
     expect(
       restoreEffect,
-      '_layout.tsx must call restorePersistedPendingDeepLink in an effect'
+      'use-pending-deep-link-restore.ts must call restorePersistedPendingDeepLink in an effect'
     ).not.toBe(null);
     expect(
       restoreEffect?.[1]?.includes('authLoading'),
       'the restore effect must depend on authLoading, not run on mount'
+    ).toBe(true);
+    expect(
+      restoreEffect?.[1]?.includes('restoreFailed'),
+      'the restore effect must depend on restoreFailed: a failed restore is not a signed-out answer'
+    ).toBe(true);
+
+    // The layout owns no inline restore effect: it wires the gate through the
+    // hook with both bootstrap inputs.
+    const codeSource = stripComments(layoutSource);
+    expect(
+      codeSource.includes('usePendingDeepLinkRestore({ authLoading, restoreFailed })'),
+      '_layout.tsx must gate the persisted deep-link restore through usePendingDeepLinkRestore'
     ).toBe(true);
   });
 

--- a/apps/mobile/src/lib/startup-prefetch.ts
+++ b/apps/mobile/src/lib/startup-prefetch.ts
@@ -18,9 +18,16 @@ const trpcOptions = createTRPCOptionsProxy<MobileRouter>({ client: trpcClient, q
 // on the already-broken-token path.
 export function prefetchCurrentUser(): void {
   void (async () => {
-    const token = await preloadedAuthToken;
-    if (token != null) {
-      await queryClient.prefetchQuery(trpcOptions.user.getMe.queryOptions());
+    try {
+      const token = await preloadedAuthToken;
+      if (token != null) {
+        await queryClient.prefetchQuery(trpcOptions.user.getMe.queryOptions());
+      }
+    } catch {
+      // A rejected preload (keychain unavailable at process start) must not
+      // escape as an unhandled rejection. Skipping the prefetch costs nothing:
+      // AuthProvider's bootstrap read owns the restore, and the mounted
+      // useCurrentUserId fetches once a token is published.
     }
   })();
 }

--- a/apps/mobile/src/lib/startup-timing.ts
+++ b/apps/mobile/src/lib/startup-timing.ts
@@ -24,7 +24,8 @@ type StartupOutcome =
   | 'force-update'
   | 'user-error'
   | 'consent-error'
-  | 'language-error';
+  | 'language-error'
+  | 'restore-error';
 
 let origin: number | undefined = undefined;
 const marks = new Map<StartupMark, number>();


### PR DESCRIPTION
## Request

> Surface: the mobile app (apps/mobile).
> 
> Two sign-in defects seen on a TestFlight build. They may be one root cause;
> find out before you fix anything.
> 
> 1. After a device reboot the app had signed the person out. Signing in again
>    landed on a "log in with biometrics" error screen that needed a Retry tap to
>    get through. The account had never enabled biometric login.
> 2. Bringing the app up from the background showed a sign-in prompt. Dismissing
>    it and cold-booting the app showed the person already signed in.
> 
> Reproduce first, on a live build, and record what you saw before changing any
> code. Report whether the two are one defect or two, with the evidence that
> settles it.
> 
> Requirements:
> - A valid session must survive a device reboot and a background-to-foreground
>   return. The person is asked to sign in only when the session is genuinely
>   gone.
> - The biometric-unlock screen must never appear for an account that has not
>   enabled biometric login. If it appears at all, it must not need a Retry tap
>   to make progress.
> - Fix the root cause both symptoms share, or each root cause if they differ. Do
>   not paper over either symptom at the UI layer.
> - Do not weaken any existing authentication or session check.
> 
> Prove live in the PR body: the reboot path and the background-return path, each
> before and after the fix, plus an account without biometrics enabled reaching
> the app with no biometric screen.

## Changelog for users

- A stored session now survives a device reboot and a background-to-foreground return. The app signs in only when the session is genuinely gone.
- A rejected keychain read at startup no longer signs the person out or lands them on the login screen: the app retries the read and opens signed in once the keychain answers.
- If the keychain stays unavailable past the retry budget, the app shows a "Could not load your account" screen with Retry and Sign out instead of presenting the person as signed out.
- The biometric-unlock screen no longer appears for an account that never enabled biometric login.

## Changelog for maintainers

- `apps/mobile/src/lib/auth/secure-store-read.ts` (new) — bounded retry helper `readStoredValueWithRetry` (250/500/1000 ms backoff, four attempts). Only a rejected read is retried; a `null` resolution is a real answer and returns immediately. Bundle-time E2E fault hook `E2E_SECURE_STORE_FAULT_MS` (`lib/config.ts`, `lib/env-keys.js`) makes every read through the helper reject while the window is open, so the restore-failure states are provable on a live build; 0 in production.
- `apps/mobile/src/lib/auth/auth-context.tsx` — `load()` reads credentials through the retry helper; a fully-rejected read sets `restoreFailed` and never falls through to the signed-out path. New `restoreFailed` / `retryRestore` context fields. `signOut()` clears both flags synchronously before the first await so the escape hatch lands on login even while a retry load is in flight. The proactive-foreground refresh and `prefetchCurrentUser` are wrapped so a rejected preload cannot escape as an unhandled rejection.
- `apps/mobile/src/lib/bootstrap-decision.ts` — new `restoreFailed` input, `settle-restore-error` tag (ahead of `redirect-login` / `settle-login`, behind force-update), `hasRestoreError` derivation, and `hidden` stays false while the settled error is up.
- `apps/mobile/src/app/_layout.tsx` — consumes `restoreFailed` / `retryRestore`; settles the restore error; renders the held surface as an overlay above the wrapper (opacity-0 wrapper, absolute inset-0 error screen) so the retried bootstrap's `router.replace` still lands and the swap is one paint. New `useRestoreErrorHold` keeps the surface mounted through the retried bootstrap and releases on reveal or sign-out.
- `apps/mobile/src/lib/hooks/use-restore-error-hold.ts` (new) — latches the settled restore-error surface; release runs in a layout effect.
- `apps/mobile/src/components/app-unlock-context.tsx` — removed `preference-error` state; an unreadable or invalid unlock preference now fails open to the documented disabled/unlocked default instead of gating the app behind a Retry tap, and uses the same retry helper for the transient post-reboot keychain window.
- `apps/mobile/src/components/app-unlock-screen.tsx` — dropped the `preference-error` feedback path; the biometric-unlock surface only appears for an account that enabled it.
- `apps/mobile/src/components/bootstrap-error-screen.tsx` — new optional `primaryLoading` props; the primary button shows its inline spinner and disables while the primary action is in flight. The secondary Sign out stays enabled in all states.
- Tests: `secure-store-read.test.ts`, `use-restore-error-hold.mounted.test.tsx`, and `bootstrap-error-screen.mounted.test.ts` are new; `auth-context.test.tsx` gains a startup-credential-read-failure suite and a `settleBootstrap` helper; `bootstrap-decision.test.ts`, `app-unlock-context.*.test.tsx`, `app-unlock-screen.*.test.tsx`, `preferences-screen.mounted.test.tsx`, and `privacy-cover-overlay.mounted.test.tsx` are updated; `intl-cache-hermes-surface.test.ts` carries its own 15 s budget.

## E2E proof

- proved live: needs:recording (the verifier must background and foreground the app; the harness has no background step) background-return path: a signed-in app returns from the background still signed in, with no sign-in prompt appearing and the app resuming exactly as left — prior/e10-backgrounded.png
- proved live: ux-check: After-fix (background-return path): background the app with a valid session and return to the foreground — no sign-in prompt appears and the app resumes exactly as left — ios: Profile with Sign Out survived Safari background-return; e10-dispatch.log has com.apple.mobilesafari: 52258 and com.kilocode.kiloapp: 54929; e10-after.log has XCUIElementTypeButton Sign Out [21,1076][381,1125] and XCUIElementTypeStaticText Profile; no sign-in control in the after digest (e10-before.png, e10-backgrounded.png, e10-after.png, e10-after.log).
- proved live: ux-check: After-fix (escape hatch): from the persistent-fault screen, Sign out lands on the login screen and the error surface never repaints over it
- proved live: ux-check: After-fix (non-biometric account): cold start for an account that never enabled biometric login, with and without the fault window open, reaches app content with no biometric-unlock error screen
- proved live: ux-check: After-fix (reboot path, persistent fault): cold start with a fault that never clears shows the 'Could not load your account' screen with Retry and Sign out; tapping Retry holds the same surface (button spins, no blank frame, no layout jump) and Sign out is the escape hatch to the login screen
- proved live: ux-check: After-fix (reboot path, transient fault): cold start with a fault that clears inside the retry budget opens the app signed in — no login screen, no sign-in prompt, no biometric screen
- proved live: needs:seed (stored signed-in session) happy reboot path after the fix: cold boot opens the app signed in; neither the login screen nor the restore error appears
- proved live: needs:fault (launch with E2E_SECURE_STORE_FAULT_MS=120000) retry fails, surface holds: Retry spins and the same error screen re-settles with no blank frame and no layout jump
- proved live: needs:fault (launch with E2E_SECURE_STORE_FAULT_MS=15000) restore fails then Retry recovers: cold boot shows 'Could not load your account'; tapping Retry holds the error surface (button spins, no blank frame, no layout jump) and Sign out lands on the login code screen
- proved live: needs:fault (launch with E2E_SECURE_STORE_FAULT_MS=15000) sign-out escape hatch: Sign out from the error surface lands on the login code screen
- [prior/e5.mp4.trim.mp4](https://github.com/user-attachments/assets/af50e7e6-d3fd-4f19-bef0-c38737641c08)
- [prior/p1-retry.mp4.trim.mp4](https://github.com/user-attachments/assets/a6bdc9ae-8ff6-478a-9f38-b679276126d2)
- [prior/p4-bg.mp4.trim.mp4](https://github.com/user-attachments/assets/e54c6708-12c4-4365-a891-ec8ee5e6d9ed)
- [prior/p6-retry.mp4.trim.mp4](https://github.com/user-attachments/assets/c853a6da-e8fd-4f3a-8719-4c8ea8f5635e)
- [prior/p8-bg.mp4.trim.mp4](https://github.com/user-attachments/assets/01c71413-bc38-40e1-b44c-29d519ab7fc6)

![[e10] ux-check: After-fix (background-return path): background the app with a valid session and return to the foreground — no sign-in prompt appears and the app resumes exactly as left — prior/e10-backgrounded.png](https://github.com/user-attachments/assets/6b03ea04-f387-4ee0-b816-31567276979c)

## Follow-ups (not changed here)
- 01-login-verify-code.png,p5.png — The Test Account row sits under the tab bar, so the card bottom and subtitle are clipped.
- not proved live: needs:fault reboot-keeps-session: with a biometrics-disabled account signed in, reboot the device (simulator: xcrun simctl shutdown <udid> && xcrun simctl boot <udid>; hardware: power cycle), relaunch the app, wait 15 s → the Home tab renders signed in; 'Sign in with Apple' absent; 'Unlock with biometrics' absent; no 'Retry' button — no fixture: the simulator has no OS passcode or biometric state
- not proved live: needs:fault background-return-keeps-session: sign in, background the app for 5 s (allow the OS to kill it), foreground it → the Home tab renders signed in; no sign-in prompt; 'Unlock with biometrics' absent — no fixture: the simulator has no OS passcode or biometric state
- not proved live: needs:fault restore-read-failure-is-retryable-not-signout: sign in on a normal build, then rebuild with EXPO_PUBLIC_E2E_SECURE_STORE_FAULT_MS=15000 set at bundle time, cold launch → a 'Could not load your account' screen with 'Retry' (NOT the login screen, NOT the biometric gate); wait 15 s for the fault window to pass, tap 'Retry' → the Home tab renders signed in — no fixture: the simulator has no OS passcode or biometric state
- not proved live: needs:seed non-biometric-account-no-gate: seeded signed-in account that never enabled biometric unlock, cold launch → the Home tab renders; the biometric gate and Retry are absent — no fixture: the simulator has no OS passcode or biometric state
- not proved live: [advisory] pre-fix-evidence on a pre-fix build: git worktree add /tmp/prefix-verify <pre-fix sha> from the section repo, build that tree with EXPO_PUBLIC_E2E_SECURE_STORE_FAULT_MS=15000, sign in once, cold launch with the fault set → login screen appears with valid stored credentials (the defect), and re-signing-in lands on the 'Unlock with biometrics' screen needing Retry; record screenshots for the PR body's before/after pair — no fixture: no baseline checkout outside a bench section
- not proved live: needs:fault unlock-preference-read-failure-never-gates: sign in on a build with EXPO_PUBLIC_E2E_SECURE_STORE_FAULT_MS=15000 set, cold launch → the app opens directly to the Home tab; 'Unlock with biometrics' is absent and 'Retry' is absent; Preferences shows Biometric unlock off — no fixture: the simulator has no OS passcode or biometric state
- not proved live: needs:seed (account that never enabled biometric login) cold boot reaches the app with no biometric screen: 'Unlock with biometrics' never appears and no Retry gate is shown — no fixture: the simulator has no OS passcode or biometric state
- not proved live: Android: not run — the diff forks on no platform, so iOS proves both