### PR TITLE
Update GPT-5.6 Sol pricing

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -138,19 +138,19 @@ describe('isFreeModel', () => {
         {
           start_context_length: 0,
           pricing: {
-            prompt_per_million: 2.5,
-            completion_per_million: 15,
-            input_cache_read_per_million: 0.25,
-            input_cache_write_per_million: 3.125,
+            prompt_per_million: 2,
+            completion_per_million: 10,
+            input_cache_read_per_million: 0.2,
+            input_cache_write_per_million: 2.5,
           },
         },
         {
           start_context_length: 272_000,
           pricing: {
-            prompt_per_million: 5,
-            completion_per_million: 22.5,
-            input_cache_read_per_million: 0.5,
-            input_cache_write_per_million: 6.25,
+            prompt_per_million: 4,
+            completion_per_million: 15,
+            input_cache_read_per_million: 0.4,
+            input_cache_write_per_million: 5,
           },
         },
       ]);

--- a/apps/web/src/lib/ai-gateway/providers/openai-exclusive.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openai-exclusive.ts
@@ -16,19 +16,19 @@ export const gpt_5_6_sol_discounted_model: KiloExclusiveModel = {
       {
         start_context_length: 0,
         pricing: {
-          prompt_per_million: 2.5,
-          completion_per_million: 15,
-          input_cache_read_per_million: 0.25,
-          input_cache_write_per_million: 3.125,
+          prompt_per_million: 2,
+          completion_per_million: 10,
+          input_cache_read_per_million: 0.2,
+          input_cache_write_per_million: 2.5,
         },
       },
       {
         start_context_length: 272_000,
         pricing: {
-          prompt_per_million: 5,
-          completion_per_million: 22.5,
-          input_cache_read_per_million: 0.5,
-          input_cache_write_per_million: 6.25,
+          prompt_per_million: 4,
+          completion_per_million: 15,
+          input_cache_read_per_million: 0.4,
+          input_cache_write_per_million: 5,
         },
       },
     ],


### PR DESCRIPTION
## Summary
- update GPT-5.6 Sol pricing to match the OpenRouter `openai` endpoint
- preserve the existing 50% promotional branding and presentation
- update pricing test expectations

Source: https://openrouter.ai/api/v1/models/openai/gpt-5.6-sol/endpoints

## Testing
- Not run locally; CI will handle tests as requested.