### PR TITLE
fix(cloud-agent-next): restore session diffs with workspace-relative patch paths

### DIFF
--- a/services/cloud-agent-next/wrapper/src/restore-session.test.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.test.ts
@@ -1060,34 +1060,6 @@ await Bun.write(process.env.RESTORE_CAPTURE_PATH, JSON.stringify({
   });
 
   it('prefers top-level patch session diffs over legacy message summaries', async () => {
-    const repo = path.join(tmpDir, 'repo');
-    fs.mkdirSync(path.join(repo, 'src'), { recursive: true });
-    Bun.spawnSync(['git', 'init'], { cwd: repo, stdout: 'pipe', stderr: 'pipe' });
-    Bun.spawnSync(['git', 'config', 'user.email', 'test@example.com'], {
-      cwd: repo,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    Bun.spawnSync(['git', 'config', 'user.name', 'Test User'], {
-      cwd: repo,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    fs.writeFileSync(path.join(repo, 'src/index.ts'), 'before\n');
-    Bun.spawnSync(['git', 'add', '.'], { cwd: repo, stdout: 'pipe', stderr: 'pipe' });
-    Bun.spawnSync(['git', 'commit', '-m', 'initial'], {
-      cwd: repo,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    fs.writeFileSync(path.join(repo, 'src/index.ts'), 'after\n');
-    const proc = Bun.spawnSync(['git', 'diff', '--src-prefix=a/', '--dst-prefix=b/'], {
-      cwd: repo,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    const patch = new TextDecoder().decode(proc.stdout);
-
     fs.mkdirSync(path.join(workspace, 'src'), { recursive: true });
     Bun.spawnSync(['git', 'init'], { cwd: workspace, stdout: 'pipe', stderr: 'pipe' });
     Bun.spawnSync(['git', 'config', 'user.email', 'test@example.com'], {
@@ -1107,6 +1079,17 @@ await Bun.write(process.env.RESTORE_CAPTURE_PATH, JSON.stringify({
       stdout: 'pipe',
       stderr: 'pipe',
     });
+    const absoluteFile = path.join(workspace, 'src/index.ts');
+    const patch = [
+      `Index: ${absoluteFile}`,
+      '===================================================================',
+      `--- ${absoluteFile}`,
+      `+++ ${absoluteFile}`,
+      '@@ -1 +1 @@',
+      '-before',
+      '+after',
+      '',
+    ].join('\n');
     mockFetchOk(makeSessionDiffSnapshot(patch));
 
     const result = await restoreSession(SESSION_ID, workspace);
@@ -1271,6 +1254,49 @@ await Bun.write(process.env.RESTORE_CAPTURE_PATH, JSON.stringify({
       diffs: { applied: 0, skipped: 1, total: 1 },
     });
     expect(fs.existsSync(path.join(workspace, 'src/index.ts'))).toBe(false);
+  });
+
+  it('logs patch structure and Git parser diagnostics without patch contents', async () => {
+    fs.mkdirSync(path.join(workspace, 'src'), { recursive: true });
+    Bun.spawnSync(['git', 'init'], { cwd: workspace, stdout: 'pipe', stderr: 'pipe' });
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => undefined);
+    mockFetchOk(
+      JSON.stringify({
+        info: snapshotInfo(),
+        sessionDiff: [
+          {
+            file: 'src/index.ts',
+            patch: 'not a git patch with private source content',
+            status: 'modified',
+          },
+        ],
+      })
+    );
+
+    try {
+      await restoreSession(SESSION_ID, workspace);
+
+      const logs = errorSpy.mock.calls.map(args => String(args[0]));
+      expect(
+        logs.some(
+          message =>
+            message.includes('patch metadata file=src/index.ts phase=raw') &&
+            message.includes('finalNewline=false') &&
+            message.includes('eofMarkers=0') &&
+            message.includes('hunkHeaders=0')
+        )
+      ).toBe(true);
+      for (const mode of ['stat', 'recount-stat', 'check', 'recount-check']) {
+        expect(
+          logs.some(message =>
+            message.includes(`git patch diagnostic file=src/index.ts mode=${mode}`)
+          )
+        ).toBe(true);
+      }
+      expect(logs.every(message => !message.includes('private source content'))).toBe(true);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('unlinks a deleted file when its patch cannot be applied', async () => {

--- a/services/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { createHash } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { Writable } from 'node:stream';
@@ -665,18 +666,108 @@ async function runGitApply(
   return { exitCode, stderr: stderr.trim() };
 }
 
+function describePatch(patch: string): string {
+  const eofMarkers = patch.match(/^\\ No newline at end of file(?:\r?\n|$)/gm)?.length ?? 0;
+  const absoluteHeaders =
+    (patch.match(/^(?:Index: |--- |\+\+\+ )\//gm)?.length ?? 0) +
+    (patch.match(/^diff --git \//gm)?.length ?? 0);
+
+  return [
+    `sha256=${createHash('sha256').update(patch).digest('hex')}`,
+    `bytes=${Buffer.byteLength(patch, 'utf8')}`,
+    `finalNewline=${patch.endsWith('\n')}`,
+    `eofMarkers=${eofMarkers}`,
+    `hunkHeaders=${patch.match(/^@@ /gm)?.length ?? 0}`,
+    `absoluteHeaders=${absoluteHeaders}`,
+  ].join(' ');
+}
+
+function logPatchMetadata(file: string, phase: 'raw' | 'normalized', patch: string): void {
+  log(`patch metadata file=${file} phase=${phase} ${describePatch(patch)}`);
+}
+
+function resolveWorkspaceRelativePath(workspacePath: string, file: string): string | null {
+  const resolvedWorkspace = path.resolve(workspacePath);
+  const resolvedFile = path.resolve(resolvedWorkspace, file);
+  const relativeFile = path.relative(resolvedWorkspace, resolvedFile);
+  const normalizedFile = relativeFile.split(path.sep).join('/');
+
+  if (
+    normalizedFile.length === 0 ||
+    normalizedFile === '..' ||
+    normalizedFile.startsWith('../') ||
+    path.isAbsolute(relativeFile)
+  ) {
+    return null;
+  }
+
+  return normalizedFile;
+}
+
+function normalizePatchForWorkspace(workspacePath: string, diff: SnapshotDiff): string | null {
+  if (!diff.patch) return null;
+
+  const relativeFile = resolveWorkspaceRelativePath(workspacePath, diff.file);
+  if (!relativeFile) {
+    log(`skipping patch outside workspace file=${diff.file}`);
+    return null;
+  }
+
+  logPatchMetadata(relativeFile, 'raw', diff.patch);
+
+  // Kilo's session.diff patches use absolute sandbox paths. Git treats those
+  // as patch pathnames, not filesystem paths, so rewrite every patch header to
+  // the workspace-relative file before applying it.
+  const normalizedPatch = diff.patch
+    .replace(/^diff --git [^\r\n]*$/m, `diff --git a/${relativeFile} b/${relativeFile}`)
+    .replace(/^Index: [^\r\n]*$/m, `Index: ${relativeFile}`)
+    .replace(/^--- [^\r\n]*$/m, `--- a/${relativeFile}`)
+    .replace(/^\+\+\+ [^\r\n]*$/m, `+++ b/${relativeFile}`);
+
+  if (normalizedPatch !== diff.patch) {
+    log(`normalized patch paths file=${relativeFile}`);
+    logPatchMetadata(relativeFile, 'normalized', normalizedPatch);
+  }
+
+  return normalizedPatch;
+}
+
+async function logGitPatchDiagnostics(
+  workspacePath: string,
+  patchFile: string,
+  file: string,
+  signal?: AbortSignal,
+  env?: NodeJS.ProcessEnv
+): Promise<void> {
+  const checks: Array<{ mode: string; args: string[] }> = [
+    { mode: 'stat', args: ['--stat'] },
+    { mode: 'recount-stat', args: ['--recount', '--stat'] },
+    { mode: 'check', args: ['--check'] },
+    { mode: 'recount-check', args: ['--recount', '--check'] },
+  ];
+
+  for (const check of checks) {
+    const result = await runGitApply(workspacePath, patchFile, check.args, signal, env);
+    const stderr = result.stderr.replace(/\s+/g, ' ').slice(0, 512);
+    log(
+      `git patch diagnostic file=${file} mode=${check.mode} exitCode=${result.exitCode}${stderr ? ` stderr=${stderr}` : ''}`
+    );
+  }
+}
+
 async function applyPatch(
   workspacePath: string,
   diff: SnapshotDiff,
   signal?: AbortSignal,
   env?: NodeJS.ProcessEnv
 ): Promise<boolean> {
-  if (!diff.patch) return false;
+  const normalizedPatch = normalizePatchForWorkspace(workspacePath, diff);
+  if (!normalizedPatch) return false;
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-session-diff-'));
   const file = path.join(dir, 'change.patch');
   try {
     signal?.throwIfAborted();
-    fs.writeFileSync(file, diff.patch);
+    fs.writeFileSync(file, normalizedPatch);
     const threeWay = await runGitApply(workspacePath, file, ['--3way'], signal, env);
     signal?.throwIfAborted();
     if (threeWay.exitCode === 0) return true;
@@ -702,6 +793,8 @@ async function applyPatch(
       );
       return false;
     }
+
+    await logGitPatchDiagnostics(workspacePath, file, diff.file, signal, env);
 
     const plain = await runGitApply(workspacePath, file, [], signal, env);
     signal?.throwIfAborted();


### PR DESCRIPTION
## Summary

- Kilo `session.diff` patches use absolute sandbox paths. `git apply` treats those as patch pathnames, so snapshot restore fails on a new workspace.
- Normalize `Index`, `diff --git`, `---`, and `+++` headers to workspace-relative paths immediately before apply.
- Reject patch files whose resolved path is outside the workspace.
- Keep existing `after`-content and deletion fallbacks, plus partial-restore telemetry.
- After a failed three-way apply, log patch hashes/structure and read-only Git `stat`/`check` diagnostics (with and without `--recount`) without logging patch contents.

## Verification

- Wrapper restore-session tests covering the absolute-path regression and diagnostic logging
- `pnpm --filter @kilocode/cloud-agent-wrapper test` (previously in this worktree)
- Service lint and typecheck (previously in this worktree)

## Visual Changes

N/A