### PR TITLE
fix(cloud-agent-next): slim persisted message events

### DIFF
--- a/services/cloud-agent-next/src/sandbox-session/sandbox-control-event.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/sandbox-control-event.test.ts
@@ -88,6 +88,7 @@ describe('persistSandboxControlSessionEvent', () => {
           part: {
             type: 'text',
             id: 'part_1',
+            sessionID: 'kilo_1',
             messageID: 'msg_1',
             text: 'Assistant reply',
             metadata: { diff: 'large diff' },
@@ -106,7 +107,13 @@ describe('persistSandboxControlSessionEvent', () => {
       event: 'message.part.updated',
       properties: {
         sessionID: 'kilo_1',
-        part: { type: 'text', id: 'part_1', messageID: 'msg_1', text: 'Assistant reply' },
+        part: {
+          type: 'text',
+          id: 'part_1',
+          sessionID: 'kilo_1',
+          messageID: 'msg_1',
+          text: 'Assistant reply',
+        },
       },
     });
     expect(broadcast).toHaveBeenCalledWith(

--- a/services/cloud-agent-next/src/sandbox-session/sandbox-control-event.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/sandbox-control-event.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { persistSandboxControlSessionEvent } from './sandbox-control-event.js';
 
 describe('persistSandboxControlSessionEvent', () => {
-  it('upserts message.updated by entity id', () => {
+  it('upserts a slim message.updated payload while broadcasting the live payload', () => {
     const upsert = vi.fn().mockReturnValue(12);
     const insert = vi.fn();
     const broadcast = vi.fn();
@@ -11,28 +11,108 @@ describe('persistSandboxControlSessionEvent', () => {
       sessionId: 'agent_1',
       payload: {
         type: 'message.updated',
-        properties: { info: { id: 'msg_1' } },
+        properties: {
+          info: {
+            id: 'msg_1',
+            role: 'assistant',
+            parentID: 'user_1',
+            sessionID: 'kilo_1',
+            time: { completed: 123 },
+            error: { data: { message: 'failed', responseBody: 'private' } },
+            summary: { diffs: [{ before: 'large diff' }] },
+          },
+        },
         timestamp: '2026-08-20T00:00:00.000Z',
       },
       eventQueries: { upsert, insert },
       broadcast,
     });
 
+    const persistedPayload = upsert.mock.calls[0]?.[0]?.payload;
+    expect(persistedPayload).toBeTypeOf('string');
+    if (typeof persistedPayload !== 'string') return;
     expect(upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: 'agent_1',
         streamEventType: 'kilocode',
         entityId: 'message/msg_1',
+      })
+    );
+    expect(JSON.parse(persistedPayload)).toEqual({
+      type: 'message.updated',
+      event: 'message.updated',
+      properties: {
+        info: {
+          id: 'msg_1',
+          role: 'assistant',
+          parentID: 'user_1',
+          sessionID: 'kilo_1',
+          time: { completed: 123 },
+          error: 'Assistant request failed',
+        },
+      },
+    });
+    expect(insert).not.toHaveBeenCalled();
+    expect(broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 12,
+        session_id: 'agent_1',
         payload: JSON.stringify({
           type: 'message.updated',
           event: 'message.updated',
-          properties: { info: { id: 'msg_1' } },
+          properties: {
+            info: {
+              id: 'msg_1',
+              role: 'assistant',
+              parentID: 'user_1',
+              sessionID: 'kilo_1',
+              time: { completed: 123 },
+              error: { data: { message: 'failed', responseBody: 'private' } },
+              summary: { diffs: [{ before: 'large diff' }] },
+            },
+          },
         }),
       })
     );
-    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('upserts text-only message parts while broadcasting the live part payload', () => {
+    const upsert = vi.fn().mockReturnValue(12);
+    const broadcast = vi.fn();
+    persistSandboxControlSessionEvent({
+      sessionId: 'agent_1',
+      payload: {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'kilo_1',
+          part: {
+            type: 'text',
+            id: 'part_1',
+            messageID: 'msg_1',
+            text: 'Assistant reply',
+            metadata: { diff: 'large diff' },
+          },
+        },
+      },
+      eventQueries: { upsert, insert: vi.fn() },
+      broadcast,
+    });
+
+    const persistedPayload = upsert.mock.calls[0]?.[0]?.payload;
+    expect(persistedPayload).toBeTypeOf('string');
+    if (typeof persistedPayload !== 'string') return;
+    expect(JSON.parse(persistedPayload)).toEqual({
+      type: 'message.part.updated',
+      event: 'message.part.updated',
+      properties: {
+        sessionID: 'kilo_1',
+        part: { type: 'text', id: 'part_1', messageID: 'msg_1', text: 'Assistant reply' },
+      },
+    });
     expect(broadcast).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 12, session_id: 'agent_1' })
+      expect.objectContaining({
+        payload: expect.stringContaining('large diff'),
+      })
     );
   });
 

--- a/services/cloud-agent-next/src/sandbox-session/sandbox-control-event.ts
+++ b/services/cloud-agent-next/src/sandbox-session/sandbox-control-event.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { extractEntityId } from '../session/ingest-handlers/entity-id.js';
 import type { EventId } from '../types/ids.js';
 import type { StoredEvent } from '../websocket/types.js';
+import { slimPersistedKilocodeEvent } from '../shared/ingest-frame.js';
 
 const PERSISTED_KILO_EVENT_NAMES: ReadonlySet<string> = new Set([
   'message.removed',
@@ -97,7 +98,7 @@ export function persistSandboxControlSessionEvent(params: {
   broadcast: (event: StoredEvent) => void;
 }): { applied: true } {
   const timestamp = params.payload.timestamp ? Date.parse(params.payload.timestamp) : Date.now();
-  const payload = JSON.stringify({
+  const livePayload = JSON.stringify({
     type: params.payload.type,
     event: params.payload.type,
     properties: params.payload.properties,
@@ -109,11 +110,18 @@ export function persistSandboxControlSessionEvent(params: {
       : extractEntityId(params.payload.type, { properties: params.payload.properties });
   let eventId: EventId = 0;
   if (entityId) {
+    const persistedPayload = JSON.stringify(
+      slimPersistedKilocodeEvent({
+        type: params.payload.type,
+        event: params.payload.type,
+        properties: params.payload.properties,
+      })
+    );
     eventId = params.eventQueries.upsert({
       executionId: '',
       sessionId: params.sessionId,
       streamEventType: 'kilocode',
-      payload,
+      payload: persistedPayload,
       timestamp: Number.isFinite(timestamp) ? timestamp : Date.now(),
       entityId,
     });
@@ -122,7 +130,7 @@ export function persistSandboxControlSessionEvent(params: {
       executionId: '',
       sessionId: params.sessionId,
       streamEventType: 'kilocode',
-      payload,
+      payload: livePayload,
       timestamp: Number.isFinite(timestamp) ? timestamp : Date.now(),
     });
   }
@@ -132,7 +140,7 @@ export function persistSandboxControlSessionEvent(params: {
     execution_id: '',
     session_id: params.sessionId,
     stream_event_type: 'kilocode',
-    payload,
+    payload: livePayload,
     timestamp: Number.isFinite(timestamp) ? timestamp : Date.now(),
   });
   return { applied: true };

--- a/services/cloud-agent-next/src/shared/ingest-frame.test.ts
+++ b/services/cloud-agent-next/src/shared/ingest-frame.test.ts
@@ -103,6 +103,7 @@ describe('prepareIngestFrame', () => {
           part: {
             type: 'tool',
             id: 'part_1',
+            sessionID: 'sess_1',
             messageID: 'msg_1',
             state: {
               status: 'completed',
@@ -129,6 +130,7 @@ describe('prepareIngestFrame', () => {
     expect(sent.streamEventType).toBe('kilocode');
     const part = sent.data.properties.part;
     expect(part.id).toBe('part_1');
+    expect(part.sessionID).toBe('sess_1');
     expect(part.messageID).toBe('msg_1');
     expect(part.state.status).toBe('completed');
   });

--- a/services/cloud-agent-next/src/shared/ingest-frame.ts
+++ b/services/cloud-agent-next/src/shared/ingest-frame.ts
@@ -150,6 +150,20 @@ function compactTerminalData(streamEventType: StreamEventType, data: unknown): u
   }
 }
 
+function compactMessagePart(part: Record<string, unknown>): Record<string, unknown> {
+  const compactPart: Record<string, unknown> = {};
+  if (typeof part.type === 'string') compactPart.type = part.type;
+  if (typeof part.id === 'string') compactPart.id = part.id;
+  if (typeof part.sessionID === 'string') compactPart.sessionID = part.sessionID;
+  if (typeof part.messageID === 'string') compactPart.messageID = part.messageID;
+  if (typeof part.status === 'string') compactPart.status = part.status;
+  const state = part.state;
+  if (isRecord(state) && typeof state.status === 'string') {
+    compactPart.state = { status: state.status };
+  }
+  return compactPart;
+}
+
 function compactMessagePartUpdated(data: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = { event: data.event, type: data.type };
   const properties = data.properties;
@@ -157,18 +171,7 @@ function compactMessagePartUpdated(data: Record<string, unknown>): Record<string
     const compactProps: Record<string, unknown> = {};
     if (typeof properties.sessionID === 'string') compactProps.sessionID = properties.sessionID;
     const part = properties.part;
-    if (isRecord(part)) {
-      const compactPart: Record<string, unknown> = {};
-      if (typeof part.type === 'string') compactPart.type = part.type;
-      if (typeof part.id === 'string') compactPart.id = part.id;
-      if (typeof part.messageID === 'string') compactPart.messageID = part.messageID;
-      if (typeof part.status === 'string') compactPart.status = part.status;
-      const state = part.state;
-      if (isRecord(state) && typeof state.status === 'string') {
-        compactPart.state = { status: state.status };
-      }
-      compactProps.part = compactPart;
-    }
+    if (isRecord(part)) compactProps.part = compactMessagePart(part);
     out.properties = compactProps;
   }
   return out;
@@ -215,17 +218,8 @@ export function slimPersistedKilocodeEvent(data: unknown): unknown {
 
   const part = properties.part;
   if (isRecord(part)) {
-    const compactPart: Record<string, unknown> = {};
-    if (typeof part.type === 'string') compactPart.type = part.type;
-    if (typeof part.id === 'string') compactPart.id = part.id;
-    if (typeof part.messageID === 'string') compactPart.messageID = part.messageID;
-    if (typeof part.status === 'string') compactPart.status = part.status;
+    const compactPart = compactMessagePart(part);
     if (part.type === 'text' && typeof part.text === 'string') compactPart.text = part.text;
-
-    const state = part.state;
-    if (isRecord(state) && typeof state.status === 'string') {
-      compactPart.state = { status: state.status };
-    }
     compactProperties.part = compactPart;
   }
   out.properties = compactProperties;

--- a/services/cloud-agent-next/src/shared/ingest-frame.ts
+++ b/services/cloud-agent-next/src/shared/ingest-frame.ts
@@ -194,6 +194,44 @@ function compactMessageUpdated(data: Record<string, unknown>): Record<string, un
   return out;
 }
 
+/**
+ * Reduces entity-upserted message events to the fields that the Durable Object
+ * coordinator needs for replay and assistant-message lookups. Live clients
+ * receive the separately trimmed, complete event payload.
+ */
+export function slimPersistedKilocodeEvent(data: unknown): unknown {
+  if (!isRecord(data)) return data;
+
+  const eventName = kiloEventNameOf(data);
+  if (eventName === 'message.updated') return compactMessageUpdated(data);
+  if (eventName !== 'message.part.updated') return data;
+
+  const out: Record<string, unknown> = { event: data.event, type: data.type };
+  const properties = data.properties;
+  if (!isRecord(properties)) return out;
+
+  const compactProperties: Record<string, unknown> = {};
+  if (typeof properties.sessionID === 'string') compactProperties.sessionID = properties.sessionID;
+
+  const part = properties.part;
+  if (isRecord(part)) {
+    const compactPart: Record<string, unknown> = {};
+    if (typeof part.type === 'string') compactPart.type = part.type;
+    if (typeof part.id === 'string') compactPart.id = part.id;
+    if (typeof part.messageID === 'string') compactPart.messageID = part.messageID;
+    if (typeof part.status === 'string') compactPart.status = part.status;
+    if (part.type === 'text' && typeof part.text === 'string') compactPart.text = part.text;
+
+    const state = part.state;
+    if (isRecord(state) && typeof state.status === 'string') {
+      compactPart.state = { status: state.status };
+    }
+    compactProperties.part = compactPart;
+  }
+  out.properties = compactProperties;
+  return out;
+}
+
 function compactCommandsAvailable(data: Record<string, unknown>): Record<string, unknown> {
   const commands = data.commands;
   if (!Array.isArray(commands)) return { commands: [] };

--- a/services/cloud-agent-next/src/websocket/ingest.test.ts
+++ b/services/cloud-agent-next/src/websocket/ingest.test.ts
@@ -213,6 +213,143 @@ describe('createIngestHandler', () => {
       expect(broadcastFn).toHaveBeenCalledWith(expect.objectContaining({ id: 42 }));
     });
 
+    it('persists a slim assistant message update while broadcasting the live payload', async () => {
+      const eventQueries = createFakeEventQueries();
+      const broadcast = vi.fn();
+      const handler = createIngestHandler(
+        createFakeState(),
+        eventQueries,
+        SESSION_ID,
+        broadcast,
+        createFakeDOContext()
+      );
+      const ws = createFakeWebSocket(makeAttachment());
+      const properties = {
+        info: {
+          id: 'asst_1',
+          role: 'assistant',
+          parentID: 'user_1',
+          sessionID: 'kilo_1',
+          time: { completed: 123 },
+          error: { data: { message: 'rate limited', responseBody: 'private' } },
+          summary: { diffs: [{ before: 'large diff' }] },
+          metadata: 'large metadata',
+        },
+      };
+
+      await handler.handleIngestMessage(ws, makeKilocodeMessage('message.updated', properties));
+
+      const persisted = JSON.parse(vi.mocked(eventQueries.upsert).mock.calls[0][0].payload);
+      expect(persisted).toEqual({
+        event: 'message.updated',
+        properties: {
+          info: {
+            id: 'asst_1',
+            role: 'assistant',
+            parentID: 'user_1',
+            sessionID: 'kilo_1',
+            time: { completed: 123 },
+            error: 'Assistant request failed',
+          },
+        },
+      });
+      expect(broadcast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: JSON.stringify({
+            event: 'message.updated',
+            properties: {
+              info: {
+                ...properties.info,
+                error: 'Assistant request failed',
+              },
+            },
+          }),
+        })
+      );
+    });
+
+    it.each([
+      [
+        'tool',
+        { metadata: { diff: 'large tool diff' }, input: 'large input', output: 'large output' },
+      ],
+      ['file', { url: 'data:image/png;base64,large-image', source: { content: 'large source' } }],
+      ['patch', { patch: 'large patch body' }],
+      ['reasoning', { text: 'large reasoning body' }],
+    ])('persists slim %s parts while broadcasting their live payload', async (type, extraPart) => {
+      const eventQueries = createFakeEventQueries();
+      const broadcast = vi.fn();
+      const handler = createIngestHandler(
+        createFakeState(),
+        eventQueries,
+        SESSION_ID,
+        broadcast,
+        createFakeDOContext()
+      );
+      const ws = createFakeWebSocket(makeAttachment());
+      const properties = {
+        sessionID: 'kilo_1',
+        part: {
+          type,
+          id: `${type}_1`,
+          messageID: 'asst_1',
+          status: 'running',
+          state: { status: 'running', metadata: { diff: 'large state diff' } },
+          ...extraPart,
+        },
+      };
+
+      await handler.handleIngestMessage(
+        ws,
+        makeKilocodeMessage('message.part.updated', properties)
+      );
+
+      expect(JSON.parse(vi.mocked(eventQueries.upsert).mock.calls[0][0].payload)).toEqual({
+        event: 'message.part.updated',
+        properties: {
+          sessionID: 'kilo_1',
+          part: {
+            type,
+            id: `${type}_1`,
+            messageID: 'asst_1',
+            status: 'running',
+            state: { status: 'running' },
+          },
+        },
+      });
+      expect(broadcast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: JSON.stringify({ event: 'message.part.updated', properties }),
+        })
+      );
+    });
+
+    it('persists text content for text parts', async () => {
+      const eventQueries = createFakeEventQueries();
+      const handler = createIngestHandler(
+        createFakeState(),
+        eventQueries,
+        SESSION_ID,
+        vi.fn(),
+        createFakeDOContext()
+      );
+      const ws = createFakeWebSocket(makeAttachment());
+
+      await handler.handleIngestMessage(
+        ws,
+        makeKilocodeMessage('message.part.updated', {
+          part: { type: 'text', id: 'part_1', messageID: 'asst_1', text: 'Assistant reply' },
+        })
+      );
+
+      expect(JSON.parse(vi.mocked(eventQueries.upsert).mock.calls[0][0].payload)).toEqual({
+        event: 'message.part.updated',
+        properties: {
+          part: { type: 'text', id: 'part_1', messageID: 'asst_1', text: 'Assistant reply' },
+        },
+      });
+    });
+
     // --- kilocode events: plain insert path (PERSISTED_KILO_EVENT_NAMES) ---
 
     it.each([
@@ -1218,8 +1355,20 @@ describe('createIngestHandler', () => {
         },
       });
       expect(eventQueries.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({ entityId: 'message/asst_333', payload: safePayload })
+        expect.objectContaining({ entityId: 'message/asst_333' })
       );
+      expect(JSON.parse(vi.mocked(eventQueries.upsert).mock.calls[0][0].payload)).toEqual({
+        event: 'message.updated',
+        properties: {
+          info: {
+            id: 'asst_333',
+            sessionID: 'kilo_session_333',
+            role: 'assistant',
+            parentID: 'msg_user_333',
+            error: 'Assistant request was rate limited',
+          },
+        },
+      });
       expect(broadcast).toHaveBeenCalledWith(expect.objectContaining({ payload: safePayload }));
       expect(JSON.stringify(vi.mocked(broadcast).mock.calls)).not.toContain('secret-token');
       expect(JSON.stringify(vi.mocked(eventQueries.upsert).mock.calls)).not.toContain(

--- a/services/cloud-agent-next/src/websocket/ingest.test.ts
+++ b/services/cloud-agent-next/src/websocket/ingest.test.ts
@@ -292,6 +292,7 @@ describe('createIngestHandler', () => {
         part: {
           type,
           id: `${type}_1`,
+          sessionID: 'kilo_1',
           messageID: 'asst_1',
           status: 'running',
           state: { status: 'running', metadata: { diff: 'large state diff' } },
@@ -311,6 +312,7 @@ describe('createIngestHandler', () => {
           part: {
             type,
             id: `${type}_1`,
+            sessionID: 'kilo_1',
             messageID: 'asst_1',
             status: 'running',
             state: { status: 'running' },

--- a/services/cloud-agent-next/src/websocket/ingest.ts
+++ b/services/cloud-agent-next/src/websocket/ingest.ts
@@ -49,6 +49,7 @@ import {
   classifyAttentionKilocodeEvent,
   type AttentionEvent,
 } from './ingest-attention-classifier.js';
+import { slimPersistedKilocodeEvent } from '../shared/ingest-frame.js';
 
 // ---------------------------------------------------------------------------
 // Ingest Attachment
@@ -660,11 +661,12 @@ export function createIngestHandler(
           const data = ingestEvent.data as Record<string, unknown>;
           const entityId = extractEntityId(kiloEventName ?? '', data);
           if (entityId) {
+            const persistedPayload = JSON.stringify(slimPersistedKilocodeEvent(publicEventData));
             eventId = eventQueries.upsert({
               executionId: eventSourceId,
               sessionId,
               streamEventType: eventType,
-              payload,
+              payload: persistedPayload,
               timestamp,
               entityId,
             });


### PR DESCRIPTION
## Summary
- Persist slim projections for entity-upserted `message.updated` and `message.part.updated` events.
- Preserve the sanitized live payload for stream broadcasts.
- Apply the same projection in wrapper ingest and SandboxControl persistence paths.
- Add regression coverage for retained fields, text parts, and live payloads.

## Tests
- `pnpm --filter cloud-agent-next run test`
- `pnpm --filter cloud-agent-next run typecheck`
- `pnpm --filter cloud-agent-next run lint`
- `pnpm --filter cloud-agent-next run format:check`
- `git diff --check`