### PR TITLE
chore(web): remove unavailable OpenRouter models

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -787,6 +787,8 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
   it.each(['google/gemma-4-26b-a4b-it:free', 'google/gemma-4-31b-it:free'])(
     'rejects the unavailable free model %s before upstream',
     async modelId => {
+      mockedCheckFreeModelRateLimit.mockResolvedValue({ allowed: true, requestCount: 0 });
+
       const { POST } = await import('./route');
       const response = await POST(makeRequest(makeBody(modelId)) as never);
 

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -784,8 +784,8 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     expect(mockedUpstreamRequest).not.toHaveBeenCalled();
   });
 
-  it.each(['tencent/hy3:free', 'meituan/longcat-2.0-free'])(
-    'rejects the removed free model %s before upstream',
+  it.each(['google/gemma-4-26b-a4b-it:free', 'google/gemma-4-31b-it:free'])(
+    'rejects the unavailable free model %s before upstream',
     async modelId => {
       const { POST } = await import('./route');
       const response = await POST(makeRequest(makeBody(modelId)) as never);

--- a/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.test.ts
+++ b/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.test.ts
@@ -87,7 +87,7 @@ describe('GET /api/openrouter/models/[provider]/[model]/endpoints', () => {
     });
   });
 
-  test.each(['openai/gpt-oss-20b:free', 'tencent/hy3:free', 'meituan/longcat-2.0-free'])(
+  test.each(['google/gemma-4-26b-a4b-it:free', 'google/gemma-4-31b-it:free'])(
     'returns 404 for unavailable model %s without reading cached metadata',
     async modelId => {
       mockedGetOpenRouterModelsMetadataFromDatabase.mockClear();

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -80,11 +80,11 @@ describe('isFreeModel', () => {
     });
 
     test.each(['tencent/hy3:free', 'meituan/longcat-2.0-free'])(
-      'removes %s from exclusive, Auto Free, and preferred models while keeping it unavailable',
+      'removes %s from exclusive, Auto Free, and preferred models without restricting availability',
       modelId => {
         expect(kiloExclusiveModels.some(model => model.public_id === modelId)).toBe(false);
         expect(findKiloExclusiveModel(modelId)).toBeNull();
-        expect(isUnavailableModel(modelId)).toBe(true);
+        expect(isUnavailableModel(modelId)).toBe(false);
         expect(autoFreeModels.map(({ model }) => model)).not.toContain(modelId);
         expect(preferredModels).not.toContain(modelId);
       }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/free-endpoint-data-policy.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/free-endpoint-data-policy.test.ts
@@ -217,14 +217,14 @@ describe('applyFreeEndpointDataPolicy', () => {
   });
 
   test('ignores unavailable OpenRouter and exclusive free models', () => {
-    const freeVariant = offering('openai/gpt-oss-20b', true);
-    const model = offering('openai/gpt-oss-20b');
+    const freeVariant = offering('google/gemma-4-31b-it:free', true);
+    const model = offering('google/gemma-4-31b-it');
     const providerModelData = [{ provider: { slug: 'darkbloom' }, models: [freeVariant, model] }];
 
     applyFreeEndpointDataPolicy({
       providerModelData,
       openRouterFreeEndpoints: getOpenRouterFreeEndpoints(providerModelData),
-      kiloExclusiveModels: [freeExclusiveModel('openai/gpt-oss-20b:free', [])],
+      kiloExclusiveModels: [freeExclusiveModel('google/gemma-4-31b-it:free', [])],
     });
 
     expect(freeVariant.endpoint?.data_policy).toEqual({ training: false, retainsPrompts: false });

--- a/apps/web/src/lib/ai-gateway/unavailable-models.test.ts
+++ b/apps/web/src/lib/ai-gateway/unavailable-models.test.ts
@@ -6,20 +6,17 @@ import {
 
 describe('unavailable models', () => {
   test('keeps exact matching for request rejection', () => {
-    expect(isUnavailableModel('openai/gpt-oss-20b:free')).toBe(true);
-    expect(isUnavailableModel('sakana/fugu-ultra')).toBe(false);
+    expect(isUnavailableModel('google/gemma-4-26b-a4b-it:free')).toBe(true);
     expect(isUnavailableModel('google/gemma-4-31b-it:free')).toBe(true);
-    expect(isUnavailableModel('openai/gpt-oss-20b')).toBe(false);
-    expect(isUnavailableModel('tencent/hy3:free')).toBe(true);
-    expect(isUnavailableModel('tencent/hy3')).toBe(false);
-    expect(isUnavailableModel('meituan/longcat-2.0-free')).toBe(true);
+    expect(isUnavailableModel('google/gemma-4-31b-it')).toBe(false);
+    expect(isUnavailableModel('openai/gpt-oss-20b:free')).toBe(false);
   });
 
   test('matches normalized families for provider metadata', () => {
-    expect(familyHasUnavailableFreeModel('openai/gpt-oss-20b:free')).toBe(true);
-    expect(familyHasUnavailableFreeModel('openai/gpt-oss-20b')).toBe(true);
+    expect(familyHasUnavailableFreeModel('google/gemma-4-26b-a4b-it:free')).toBe(true);
+    expect(familyHasUnavailableFreeModel('google/gemma-4-26b-a4b-it')).toBe(true);
+    expect(familyHasUnavailableFreeModel('google/gemma-4-31b-it:free')).toBe(true);
+    expect(familyHasUnavailableFreeModel('google/gemma-4-31b-it')).toBe(true);
     expect(familyHasUnavailableFreeModel('cohere/north-mini-code')).toBe(false);
-    expect(familyHasUnavailableFreeModel('tencent/hy3:free')).toBe(true);
-    expect(familyHasUnavailableFreeModel('tencent/hy3')).toBe(true);
   });
 });

--- a/apps/web/src/lib/ai-gateway/unavailable-models.ts
+++ b/apps/web/src/lib/ai-gateway/unavailable-models.ts
@@ -3,13 +3,6 @@ import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
 const unavailableModelIds: ReadonlySet<string> = new Set([
   'google/gemma-4-26b-a4b-it:free', // usable through kilo-auto
   'google/gemma-4-31b-it:free',
-  'meituan/longcat-2.0-free',
-  'nvidia/nemotron-3-nano-30b-a3b:free',
-  'nvidia/nemotron-nano-12b-v2-vl:free',
-  'nvidia/nemotron-nano-9b-v2:free',
-  'openai/gpt-oss-20b:free',
-  'tencent/hy3:free',
-  'z-ai/glm-5.2:free',
 ]);
 
 export function isUnavailableModel(modelId: string): boolean {

--- a/apps/web/src/tests/openrouter-models.test.ts
+++ b/apps/web/src/tests/openrouter-models.test.ts
@@ -282,19 +282,21 @@ describe('GET /api/openrouter/models', () => {
     expect(Array.isArray(responseData.data)).toBe(true);
   });
 
-  test('excludes retired free Tencent and LongCat models advertised upstream while retaining paid Tencent', async () => {
+  test('excludes unavailable free Gemma models advertised upstream while retaining paid Gemma', async () => {
     const original = mockOpenRouterModels.data.find(model => model.id === 'some-other-model');
     if (!original) throw new Error('Expected catalog fixture');
     const upstream = {
       data: [
         ...mockOpenRouterModels.data,
-        { ...original, id: 'tencent/hy3', name: 'Tencent: HY3' },
-        ...['tencent/hy3:free', 'meituan/longcat-2.0-free'].map(id => ({
-          ...original,
-          id,
-          name: id,
-          pricing: { ...original.pricing, prompt: '0', completion: '0' },
-        })),
+        { ...original, id: 'google/gemma-4-31b-it', name: 'Google: Gemma 4 31B IT' },
+        ...['google/gemma-4-26b-a4b-it:free', 'google/gemma-4-31b-it:free'].map(
+          id => ({
+            ...original,
+            id,
+            name: id,
+            pricing: { ...original.pricing, prompt: '0', completion: '0' },
+          })
+        ),
       ],
     };
     global.fetch = jest
@@ -307,9 +309,9 @@ describe('GET /api/openrouter/models', () => {
 
     expect(captureException).not.toHaveBeenCalled();
     expect(response.status).toBe(200);
-    expect(modelIds).not.toContain('tencent/hy3:free');
-    expect(modelIds).not.toContain('meituan/longcat-2.0-free');
-    expect(modelIds).toContain('tencent/hy3');
+    expect(modelIds).not.toContain('google/gemma-4-26b-a4b-it:free');
+    expect(modelIds).not.toContain('google/gemma-4-31b-it:free');
+    expect(modelIds).toContain('google/gemma-4-31b-it');
   });
 
   test('should include publishable Terminal Bench summaries for canonical models', async () => {

--- a/apps/web/src/tests/openrouter-models.test.ts
+++ b/apps/web/src/tests/openrouter-models.test.ts
@@ -289,14 +289,12 @@ describe('GET /api/openrouter/models', () => {
       data: [
         ...mockOpenRouterModels.data,
         { ...original, id: 'google/gemma-4-31b-it', name: 'Google: Gemma 4 31B IT' },
-        ...['google/gemma-4-26b-a4b-it:free', 'google/gemma-4-31b-it:free'].map(
-          id => ({
-            ...original,
-            id,
-            name: id,
-            pricing: { ...original.pricing, prompt: '0', completion: '0' },
-          })
-        ),
+        ...['google/gemma-4-26b-a4b-it:free', 'google/gemma-4-31b-it:free'].map(id => ({
+          ...original,
+          id,
+          name: id,
+          pricing: { ...original.pricing, prompt: '0', completion: '0' },
+        })),
       ],
     };
     global.fetch = jest


### PR DESCRIPTION
## Summary
- remove unavailable-model entries that are absent from OpenRouter's live model catalog
- retain the two denylisted Gemma models still exposed by OpenRouter

## Validation
- not run locally per request; CI will validate the change