### PR TITLE
Update Auto Free model pool

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -101,15 +101,10 @@ describe('isFreeModel', () => {
       }
     );
 
-    test('preserves MiniMax Auto Free and preferred model membership', () => {
+    test('keeps MiniMax free models outside Auto Free and preferred models', () => {
       for (const model of ['minimax/minimax-m3:free', 'minimax/minimax-m2.7:free']) {
-        expect(autoFreeModels).toContainEqual(
-          expect.objectContaining({
-            model,
-            reasoning: { enabled: true, effort: 'high' },
-          })
-        );
-        expect(preferredModels).toContain(model);
+        expect(autoFreeModels.map(candidate => candidate.model)).not.toContain(model);
+        expect(preferredModels).not.toContain(model);
       }
     });
 
@@ -203,27 +198,23 @@ describe('isFreeModel', () => {
       ).toEqual({
         'stepfun/step-3.7-flash:free': { enabled: true, effort: 'high' },
         'poolside/laguna-s-2.1:free': { enabled: true, effort: 'high' },
-        'minimax/minimax-m3:free': { enabled: true, effort: 'high' },
-        'minimax/minimax-m2.7:free': { enabled: true, effort: 'high' },
+        'nvidia/nemotron-3-ultra-550b-a55b:free': { enabled: true, effort: 'high' },
         'dots-studio/dots-3-note-preview:free': { enabled: true, effort: 'high' },
       });
     });
 
-    test('keeps Step and MiniMax M2.7 at one-third of Auto Free selections each', () => {
+    test('keeps Step at half of Auto Free selections', () => {
       const weights = Object.fromEntries(
         autoFreeModels.map(({ model, weight }) => [model, weight])
       );
       expect(weights).toEqual({
         'stepfun/step-3.7-flash:free': 3,
         'poolside/laguna-s-2.1:free': 1,
-        'minimax/minimax-m3:free': 1,
-        'minimax/minimax-m2.7:free': 3,
+        'nvidia/nemotron-3-ultra-550b-a55b:free': 1,
         'dots-studio/dots-3-note-preview:free': 1,
       });
-      const oneThirdOfTotalWeight =
-        autoFreeModels.reduce((total, { weight }) => total + weight, 0) / 3;
-      expect(weights['stepfun/step-3.7-flash:free']).toBe(oneThirdOfTotalWeight);
-      expect(weights['minimax/minimax-m2.7:free']).toBe(oneThirdOfTotalWeight);
+      const halfOfTotalWeight = autoFreeModels.reduce((total, { weight }) => total + weight, 0) / 2;
+      expect(weights['stepfun/step-3.7-flash:free']).toBe(halfOfTotalWeight);
     });
 
     test('uses autoFreeModels weights when selecting a model', () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -56,13 +56,8 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
     reasoning: { enabled: true, effort: 'high' },
   } satisfies AutoFreeModel,
   {
-    model: 'minimax/minimax-m3:free',
+    model: 'nvidia/nemotron-3-ultra-550b-a55b:free',
     weight: 1,
-    reasoning: { enabled: true, effort: 'high' },
-  } satisfies AutoFreeModel,
-  {
-    model: 'minimax/minimax-m2.7:free',
-    weight: 3,
     reasoning: { enabled: true, effort: 'high' },
   } satisfies AutoFreeModel,
   {


### PR DESCRIPTION
## Summary
- remove the MiniMax models from Auto Free routing
- add `nvidia/nemotron-3-ultra-550b-a55b:free`
- weight `stepfun/step-3.7-flash:free` at 3/6 (50%)

## Testing
- not run locally; CI will validate the change