### PR TITLE
fix(mobile-android): detect busy emulator console ports on Linux via the kernel socket table

### DIFF
--- a/dev/local/mobile-android.test.ts
+++ b/dev/local/mobile-android.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -10,20 +12,201 @@ import {
   commandMatchesRecordedEmulator,
   findAvailableEmulatorPort,
   isValidEmulatorRecord,
+  launchedProcessOwnsConsolePort,
   parseEmulatorStartArgs,
+  portIsListening,
   processOwnsListeningPort,
+  procListeningPorts,
   readGradleWrapperVersion,
   releaseAndroidDevice,
   releaseWorktreeAndroidDevices,
   resolveAndroidEnvironment,
   signalProcessIfPresent,
 } from './mobile-android';
+import type { AndroidEnvironment } from './mobile-android';
+
+const listeningEnv = { emulator: '/opt/android-sdk/emulator/emulator' } as AndroidEnvironment;
+
+async function listenOn(port: number): Promise<net.Server> {
+  const server = net.createServer(() => {});
+  await new Promise<void>(resolve => server.listen(port, '127.0.0.1', resolve));
+  return server;
+}
+
+async function closeServer(server: net.Server): Promise<void> {
+  await new Promise<void>(resolve => server.close(() => resolve()));
+}
 
 test('allocates the first free even emulator console port', () => {
   const occupied = new Set([5554, 5556]);
   assert.equal(
     findAvailableEmulatorPort(port => occupied.has(port)),
     5558
+  );
+});
+
+test('reads listening ports from the kernel socket table without asking lsof', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-proc-net-'));
+  const tcp = path.join(root, 'tcp');
+  const tcp6 = path.join(root, 'tcp6');
+  fs.writeFileSync(
+    tcp,
+    [
+      '  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode',
+      '   0: 0100007F:15B2 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1001        0 59022068 1 0000000000000000 100 0 0 10 0',
+      '   1: 0100007F:15B3 00000000:0000 06 00000000:00000000 00:00000000 00000000  1001        0 59022069 1 0000000000000000 100 0 0 10 0',
+      '',
+    ].join('\n')
+  );
+  fs.writeFileSync(
+    tcp6,
+    [
+      '  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode',
+      '   2: 00000000000000000000000001000000:15B2 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1001        0 59022069 1 0000000000000000 100 0 0 10 0',
+      '',
+    ].join('\n')
+  );
+
+  assert.deepEqual([...procListeningPorts([tcp, tcp6])!].sort(), [5554]);
+});
+
+test('distinguishes an empty socket table from an unreadable one', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-proc-net-'));
+  const tcp = path.join(root, 'tcp');
+  fs.writeFileSync(
+    tcp,
+    '  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n'
+  );
+  assert.deepEqual([...procListeningPorts([tcp])!].sort(), []);
+  assert.equal(procListeningPorts([path.join(root, 'missing')]), undefined);
+});
+
+test('probes the socket, not the process, to decide a port is listening', async () => {
+  const server = await listenOn(0);
+  const port = (server.address() as net.AddressInfo).port;
+  try {
+    assert.equal(portIsListening(port), true);
+  } finally {
+    await closeServer(server);
+  }
+  assert.equal(portIsListening(port), false);
+});
+
+test('skips a bound console port when scanning for a free one', async () => {
+  const candidate = findAvailableEmulatorPort();
+  assert.ok(candidate !== undefined);
+  const server = await listenOn(candidate);
+  try {
+    assert.notEqual(findAvailableEmulatorPort(), candidate);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('reports a listening port whose owning process lsof cannot inspect', async t => {
+  if (process.platform !== 'linux') return t.skip('setgid exec is a Linux mechanism');
+  if (spawnSync('sg', ['kvm', '-c', 'true']).status !== 0)
+    return t.skip('the kvm group is not available through sg');
+  const listenerSource = [
+    "const net = require('node:net');",
+    'const server = net.createServer(() => {});',
+    "server.listen(0, '127.0.0.1', () => console.log(server.address().port));",
+  ].join(';');
+  // sg clears the process dumpable flag on its setgid exec, the same effect
+  // the real emulator launch produces through `sg kvm`: /proc/<pid>/fd becomes
+  // root-owned and lsof cannot list the listener's sockets any more.
+  const child = spawn(
+    'sg',
+    ['kvm', '-c', `${process.execPath} -e ${JSON.stringify(listenerSource)}`],
+    { detached: true, stdio: ['ignore', 'pipe', 'ignore'] }
+  );
+  const port = await new Promise<number>((resolve, reject) => {
+    let out = '';
+    const timer = setTimeout(() => reject(new Error(`no port printed; got ${out}`)), 5000);
+    child.stdout!.on('data', chunk => {
+      out += chunk;
+      const match = out.match(/^\d+/);
+      if (match) {
+        clearTimeout(timer);
+        resolve(Number(match[0]));
+      }
+    });
+    child.on('error', error => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+  try {
+    if (
+      spawnSync('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN'], { stdio: 'ignore' }).status === 0
+    )
+      return t.skip('lsof can inspect the sg kvm child on this host; mechanism absent');
+    assert.equal(portIsListening(port), true);
+  } finally {
+    try {
+      process.kill(-child.pid!, 'SIGKILL');
+    } catch {
+      child.kill('SIGKILL');
+    }
+  }
+});
+
+test('accepts a launched emulator pid by identity when lsof cannot attribute the port', () => {
+  const command =
+    '/opt/android-sdk/emulator/qemu/linux-x86_64/qemu-system-x86_64 -avd Pixel_9 -port 5554 -no-snapshot-save';
+  assert.equal(
+    launchedProcessOwnsConsolePort(listeningEnv, 'Pixel_9', 5554, 123, () => [123]),
+    true
+  );
+  assert.equal(
+    launchedProcessOwnsConsolePort(listeningEnv, 'Pixel_9', 5554, 123, () => [456]),
+    false
+  );
+  assert.equal(
+    launchedProcessOwnsConsolePort(
+      listeningEnv,
+      'Pixel_9',
+      5554,
+      process.pid,
+      () => [],
+      () => command
+    ),
+    true
+  );
+  assert.equal(
+    launchedProcessOwnsConsolePort(
+      listeningEnv,
+      'Pixel_9',
+      5556,
+      process.pid,
+      () => [],
+      () => command
+    ),
+    false
+  );
+  assert.equal(
+    launchedProcessOwnsConsolePort(
+      listeningEnv,
+      'Pixel_8',
+      5554,
+      process.pid,
+      () => [],
+      () => command
+    ),
+    false
+  );
+  const exited = spawnSync('true');
+  assert.ok(exited.pid && exited.pid > 0);
+  assert.equal(
+    launchedProcessOwnsConsolePort(
+      listeningEnv,
+      'Pixel_9',
+      5554,
+      exited.pid,
+      () => [],
+      () => command
+    ),
+    false
   );
 });
 

--- a/dev/local/mobile-android.ts
+++ b/dev/local/mobile-android.ts
@@ -177,7 +177,41 @@ function emulatorRecordPath(worktreeRoot: string): string {
   );
 }
 
+// The emulator starts through `sg kvm` on Linux, and a setgid exec clears the
+// process dumpable flag: /proc/<pid>/fd becomes root-owned, so lsof cannot
+// list that process's sockets and every port reads as free — a second
+// emulator then reuses the first one's console port and dies. Probe the
+// socket, not the process: the kernel's socket table is world-readable and
+// lists every listener regardless of who owns it. TCP_LISTEN is state 0A and
+// the local port is the second field of local_address, in hex.
+const procNetTcpPaths = ['/proc/net/tcp', '/proc/net/tcp6'];
+
+function procListeningPorts(paths: string[] = procNetTcpPaths): Set<number> | undefined {
+  const ports = new Set<number>();
+  let readable = false;
+  for (const filePath of paths) {
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      continue;
+    }
+    readable = true;
+    for (const line of content.split('\n')) {
+      const fields = line.trim().split(/\s+/);
+      if (!/^\d+:$/.test(fields[0] ?? '') || fields[3] !== '0A') continue;
+      const port = Number.parseInt(fields[1].split(':')[1] ?? '', 16);
+      if (Number.isInteger(port)) ports.add(port);
+    }
+  }
+  return readable ? ports : undefined;
+}
+
 function portIsListening(port: number): boolean {
+  if (process.platform === 'linux') {
+    const listeners = procListeningPorts();
+    if (listeners) return listeners.has(port);
+  }
   return (
     spawnSync('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN'], { stdio: 'ignore' }).status === 0
   );
@@ -201,6 +235,37 @@ function processOwnsListeningPort(
   listeners: (port: number) => number[] = listeningProcessIds
 ): boolean {
   return listeners(port).includes(pid);
+}
+
+function pidCommand(pid: number): string {
+  return (
+    spawnSync('ps', ['-p', String(pid), '-o', 'command='], {
+      encoding: 'utf8',
+    }).stdout?.trim() ?? ''
+  );
+}
+
+// lsof cannot attribute a listening port to a process whose dumpable flag a
+// setgid exec cleared: the emulator starts through `sg kvm` on Linux, so its
+// /proc/<pid>/fd is root-owned and lsof lists no sockets for it. When nothing
+// on the port is attributable at all, accept the launched pid on identity
+// instead — the port is listening, the pid is alive, and its command line is
+// the exact emulator invocation for this AVD and port, so a foreign emulator
+// (attributable to another pid, or alive under another command line) is still
+// refused. The caller checks portIsListening(port) before asking.
+function launchedProcessOwnsConsolePort(
+  env: AndroidEnvironment,
+  avd: string,
+  port: number,
+  pid: number,
+  listeners: (port: number) => number[] = listeningProcessIds,
+  commandOfPid: (pid: number) => string = pidCommand
+): boolean {
+  const attributed = listeners(port);
+  if (attributed.includes(pid)) return true;
+  if (attributed.length > 0) return false;
+  if (!processIsAlive(pid)) return false;
+  return commandMatchesRecordedEmulator(commandOfPid(pid), env.emulator, avd, port);
 }
 
 function findAvailableEmulatorPort(isListening = portIsListening): number | undefined {
@@ -255,11 +320,12 @@ function commandMatchesRecordedEmulator(
 
 function recordedEmulatorStillOwnsPid(record: EmulatorRecord, env: AndroidEnvironment): boolean {
   if (!processIsAlive(record.pid)) return false;
-  const command =
-    spawnSync('ps', ['-p', String(record.pid), '-o', 'command='], {
-      encoding: 'utf8',
-    }).stdout?.trim() ?? '';
-  return commandMatchesRecordedEmulator(command, env.emulator, record.avd, record.port);
+  return commandMatchesRecordedEmulator(
+    pidCommand(record.pid),
+    env.emulator,
+    record.avd,
+    record.port
+  );
 }
 
 const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
@@ -374,7 +440,7 @@ async function startAndroidEmulator(
         }
         if (!portIsListening(port))
           throw new Error(`${session} did not bind console port ${port} within 30s; see ${log}`);
-        if (!processIsAlive(pid) || !processOwnsListeningPort(port, pid))
+        if (!launchedProcessOwnsConsolePort(env, avd, port, pid))
           throw new Error(
             `${session} does not own console port ${port}; refusing to record a foreign emulator`
           );
@@ -887,8 +953,11 @@ export {
   commandMatchesRecordedEmulator,
   findAvailableEmulatorPort,
   isValidEmulatorRecord,
+  launchedProcessOwnsConsolePort,
   parseEmulatorStartArgs,
+  portIsListening,
   processOwnsListeningPort,
+  procListeningPorts,
   readGradleWrapperVersion,
   releaseAndroidDevice,
   releaseWorktreeAndroidDevices,


### PR DESCRIPTION
## Request

> The Android emulator port allocator in dev/local/mobile-android.ts cannot see a
> busy console port on Linux, so a second emulator never starts.
> 
> Reproduce first, on a Linux host with one emulator already running:
> 1. Start an emulator: `pnpm dev:mobile:android emulator-start <avd> --wait`.
> 2. `ss -ltn | grep 5554` shows 127.0.0.1:5554 LISTENING.
> 3. `lsof -nP -iTCP:5554 -sTCP:LISTEN` prints nothing.
> 4. Start a second emulator on a different AVD. It dies with
>    "did not bind console port 5554 within 30s".
> 
> Root cause: `portIsListening()` shells out to `lsof`. The emulator starts
> through `sg kvm`, and a setgid exec clears the process dumpable flag, so
> /proc/<pid>/fd becomes root-owned and lsof cannot list that process's sockets.
> `findAvailableEmulatorPort()` then reads every port as free and always returns
> 5554.
> 
> Must: `portIsListening(port)` reports true for a listening port that belongs to
> a process the caller cannot inspect. Probe the socket, not the process: attempt
> a TCP connect to 127.0.0.1:port, or read /proc/net/tcp, rather than asking lsof
> who owns it. Keep the existing behaviour on macOS.
> 
> Must: two emulators on two AVDs start concurrently on one Linux host and take
> different console ports.
> 
> Prove it live: with one emulator already running, start a second one on another
> AVD and show both serials in `adb devices` with different ports.

## Changelog for users
- On Linux, the Android emulator port allocator now sees a console port that is busy even when the owning process cannot be inspected (an emulator launched through `sg kvm` has a root-owned `/proc/<pid>/fd`, so lsof lists no sockets for it). A second emulator therefore takes the next free even console port instead of always being handed 5554 and dying with "did not bind console port 5554 within 30s".
- Two emulators on two AVDs can now start concurrently on one Linux host and each keeps its own port and serial: the live run recorded the second AVD on port 5556 / `emulator-5556` while the first stayed on `emulator-5554`, and `adb devices` listed both.
- macOS port detection is unchanged.

## Changelog for maintainers
- Start at `portIsListening()` in dev/local/mobile-android.ts: on Linux it now reads the world-readable kernel socket table (`/proc/net/tcp`, `/proc/net/tcp6`, listening state `0A`, hex local port) and only falls back to the existing lsof call when neither file is readable; macOS keeps the lsof path.
- `procListeningPorts()` distinguishes an empty socket table from an unreadable one (returns `undefined` only when no path could be read), so "cannot read" never reads as "nothing is listening".
- The ownership check after the 30s wait is now `launchedProcessOwnsConsolePort()`: when lsof attributes the listening port to no process at all, it accepts the launched pid on identity — pid alive and its `ps -o command=` line matching the emulator binary, AVD, and port. This is the trust boundary to review: an uninspectable process with a matching command line is accepted; any attributable foreign pid, a mismatched AVD/port, or a dead pid is refused.
- `recordedEmulatorStillOwnsPid` now shares the extracted `pidCommand()` helper — refactor, no behavior change.
- New exports `portIsListening`, `procListeningPorts`, and `launchedProcessOwnsConsolePort` back the new tests.
- Tests cover /proc parsing (listening vs TIME_WAIT rows, empty vs missing file), a live probe of a real socket, the allocator skipping a bound candidate, and a Linux-only case that spawns a listener under `sg kvm` and asserts `portIsListening` is true while lsof finds nothing (skips when `sg kvm` is unavailable or lsof can inspect the child).

## E2E proof

![[e1] Prove it live: with one emulator already running, start a second one on another AVD and show both serials in `adb devices` with different ports. — e2e-mobile-app/e1-android-emulator-5556.png](https://github.com/user-attachments/assets/516698f9-569f-44af-b0d6-f0dc87950f01)

## Follow-ups (not changed here)
- 01-login-request-code-FAIL.png — System UI ANR and Expo developer menu overlap and obscure the Welcome to Kilo login screen.
- 01-login-verify-code-FAIL.png — Blue Refreshing banner overlaps the consent header while Accept and continue also shows a loading dot, and the header avatar is clipped.
- 01-settle-app-FAIL.png — Blank white screen with no loading, empty, or error state.