### PR TITLE
fix(mobile): show working sessions as running in the live list and glanceable

### DIFF
--- a/apps/mobile/src/components/agents/remote-session-row.tsx
+++ b/apps/mobile/src/components/agents/remote-session-row.tsx
@@ -132,10 +132,14 @@ export function RemoteSessionRow({
         });
   const spokenPrNumber = variant === 'card' ? null : (session.associatedPr?.number ?? null);
 
+  // Tray rows are always live: the eyebrow draws the status glyph from the
+  // shared derivation, so the platform glyph has no slot beside it (and the
+  // spoken label withholds the platform with the icon).
   const { iconKind: platformIconKind, spokenPlatform } = selectRowPlatformPresentation({
     platform: session.createdOnPlatform,
     variant,
     needsInput,
+    statusGlyph: true,
     gitUrl: session.gitUrl,
   });
   const platformIcon =
@@ -218,6 +222,10 @@ export function RemoteSessionRow({
         accessibilityLabel={sessionRowAccessibilityLabel({
           title,
           needsInput,
+          // Tray rows are always live: the glyph below draws the shared
+          // derivation's kind, and the spoken label names the same state.
+          live: true,
+          statusKind: glanceableStatusKind(session.status),
           badge: agentLabel,
           meta: spokenMeta,
           subtitle: session.gitBranch ?? null,

--- a/apps/mobile/src/components/agents/session-platform-icon.test.ts
+++ b/apps/mobile/src/components/agents/session-platform-icon.test.ts
@@ -62,6 +62,7 @@ describe('selectRowPlatformPresentation', () => {
         platform: 'cli',
         variant: 'list',
         needsInput: false,
+        statusGlyph: false,
         gitUrl: repoGitUrl,
       })
     ).toEqual({ iconKind: 'terminal', spokenPlatform: 'cli' });
@@ -73,6 +74,21 @@ describe('selectRowPlatformPresentation', () => {
         platform: 'cli',
         variant: 'card',
         needsInput: false,
+        statusGlyph: false,
+        gitUrl: repoGitUrl,
+      })
+    ).toEqual({ iconKind: null, spokenPlatform: undefined });
+  });
+
+  it('suppresses the icon and speech when the eyebrow draws the status glyph', () => {
+    // Live rows: the status mark is the one glyph in the cluster; a platform
+    // glyph beside it reads as a stray second mark.
+    expect(
+      selectRowPlatformPresentation({
+        platform: 'cli',
+        variant: 'list',
+        needsInput: false,
+        statusGlyph: true,
         gitUrl: repoGitUrl,
       })
     ).toEqual({ iconKind: null, spokenPlatform: undefined });
@@ -84,6 +100,7 @@ describe('selectRowPlatformPresentation', () => {
         platform: 'cli',
         variant: 'list',
         needsInput: true,
+        statusGlyph: false,
         gitUrl: repoGitUrl,
       })
     ).toEqual({ iconKind: 'terminal', spokenPlatform: undefined });
@@ -95,6 +112,7 @@ describe('selectRowPlatformPresentation', () => {
         platform: 'cli',
         variant: 'list',
         needsInput: false,
+        statusGlyph: false,
         gitUrl: null,
       })
     ).toEqual({ iconKind: 'terminal', spokenPlatform: undefined });
@@ -104,6 +122,7 @@ describe('selectRowPlatformPresentation', () => {
         platform: 'cli',
         variant: 'list',
         needsInput: false,
+        statusGlyph: false,
         gitUrl: undefined,
       })
     ).toEqual({ iconKind: 'terminal', spokenPlatform: undefined });
@@ -113,6 +132,7 @@ describe('selectRowPlatformPresentation', () => {
         platform: 'cli',
         variant: 'list',
         needsInput: false,
+        statusGlyph: false,
         gitUrl: '',
       })
     ).toEqual({ iconKind: 'terminal', spokenPlatform: undefined });
@@ -125,6 +145,7 @@ describe('selectRowPlatformPresentation', () => {
         platform: 'cloud-agent',
         variant: 'list',
         needsInput: false,
+        statusGlyph: false,
         gitUrl: 'https://github.com/org/stored-repo.git',
       })
     ).toEqual({ iconKind: 'cloud', spokenPlatform: 'cloud-agent' });
@@ -137,6 +158,7 @@ describe('selectRowPlatformPresentation', () => {
         platform: 'cli',
         variant: 'list',
         needsInput: false,
+        statusGlyph: false,
         gitUrl: 'git@github.com:org/live-repo.git',
       })
     ).toEqual({ iconKind: 'terminal', spokenPlatform: 'cli' });
@@ -148,6 +170,7 @@ describe('selectRowPlatformPresentation', () => {
         platform: 'linear',
         variant: 'list',
         needsInput: false,
+        statusGlyph: false,
         gitUrl: repoGitUrl,
       })
     ).toEqual({ iconKind: null, spokenPlatform: undefined });

--- a/apps/mobile/src/components/agents/session-platform-icon.tsx
+++ b/apps/mobile/src/components/agents/session-platform-icon.tsx
@@ -37,6 +37,15 @@ type RowPlatformPresentationInput = Readonly<{
   platform: string | null | undefined;
   variant: 'list' | 'card';
   needsInput: boolean;
+  /**
+   * True when the eyebrow draws the live status glyph (the row is live and
+   * not needs-input). The eyebrow decision
+   * (`selectSessionRowEyebrowRight`) suppresses the platform glyph there —
+   * a glyph beside the status mark reads as a stray second mark — so the
+   * spoken platform is withheld with it: VoiceOver must not name an icon
+   * the row does not draw.
+   */
+  statusGlyph: boolean;
   gitUrl: string | null | undefined;
 }>;
 
@@ -47,17 +56,19 @@ type RowPlatformPresentation = Readonly<{
 
 /**
  * Shared list/card platform glyph + VoiceOver rule for stored and live rows.
- * Icon only for `variant === 'list'` with a mapped platform. Platform is
- * spoken only when an icon is shown, the row is not needs-input, and the
- * eyebrow is a repo name (so the badge does not already speak the platform).
+ * Icon only for `variant === 'list'` while the eyebrow draws no status
+ * glyph. Platform is spoken only when an icon is shown, the row is not
+ * needs-input, and the eyebrow is a repo name (so the badge does not
+ * already speak the platform).
  */
 export function selectRowPlatformPresentation({
   platform,
   variant,
   needsInput,
+  statusGlyph,
   gitUrl,
 }: RowPlatformPresentationInput): RowPlatformPresentation {
-  const iconKind = variant === 'list' ? sessionPlatformIconKind(platform) : null;
+  const iconKind = variant === 'list' && !statusGlyph ? sessionPlatformIconKind(platform) : null;
   const spokenPlatform =
     iconKind != null && !needsInput && repoNameFromGitUrl(gitUrl) != null
       ? (platform ?? undefined)

--- a/apps/mobile/src/components/agents/session-row-accessibility-label.test.ts
+++ b/apps/mobile/src/components/agents/session-row-accessibility-label.test.ts
@@ -135,6 +135,86 @@ describe('sessionRowAccessibilityLabel', () => {
     ).toBe('Fix login bug, needs input, and CLI');
   });
 
+  describe('live statusKind — the state word the glyph draws', () => {
+    it('speaks Working for a running live row', () => {
+      expect(
+        sessionRowAccessibilityLabel({
+          title: 'Fix login bug',
+          needsInput: false,
+          live: true,
+          statusKind: 'running',
+          badge: 'CLI',
+          meta: '5 minutes ago',
+        })
+      ).toBe('Fix login bug, Working, CLI, and 5 minutes ago');
+    });
+
+    it('speaks Idle for an idle live row', () => {
+      expect(
+        sessionRowAccessibilityLabel({
+          title: 'Fix login bug',
+          needsInput: false,
+          live: true,
+          statusKind: 'idle',
+          badge: 'CLI',
+          meta: '5 minutes ago',
+        })
+      ).toBe('Fix login bug, Idle, CLI, and 5 minutes ago');
+    });
+
+    it('keeps needs input above the state word', () => {
+      expect(
+        sessionRowAccessibilityLabel({
+          title: 'Fix login bug',
+          needsInput: true,
+          live: true,
+          statusKind: 'running',
+          badge: 'CLI',
+          meta: null,
+        })
+      ).toBe('Fix login bug, needs input, and CLI');
+    });
+
+    it('keeps the static LIVE word when no statusKind is passed (byte-identical output)', () => {
+      expect(
+        sessionRowAccessibilityLabel({
+          title: 'Fix login bug',
+          needsInput: false,
+          live: true,
+          badge: 'CLI',
+          meta: '5 minutes ago',
+        })
+      ).toBe('Fix login bug, LIVE, CLI, and 5 minutes ago');
+      // Explicit null behaves like omission.
+      expect(
+        sessionRowAccessibilityLabel({
+          title: 'Fix login bug',
+          needsInput: false,
+          live: true,
+          statusKind: null,
+          badge: 'CLI',
+          meta: '5 minutes ago',
+        })
+      ).toBe('Fix login bug, LIVE, CLI, and 5 minutes ago');
+    });
+
+    it('speaks Working for a needsInput kind when attention is not raised (the drawn glyph)', () => {
+      // The ui row draws the running glyph for any set kind but idle, so an
+      // acked question or a `retry` row (needs-input flag down, kind
+      // `needsInput`) draws running; the label names that drawn state.
+      expect(
+        sessionRowAccessibilityLabel({
+          title: 'Fix login bug',
+          needsInput: false,
+          live: true,
+          statusKind: 'needsInput',
+          badge: 'CLI',
+          meta: null,
+        })
+      ).toBe('Fix login bug, Working, and CLI');
+    });
+  });
+
   describe('needs-input variant — StoredSessionRow (meta omitted)', () => {
     it('produces "title, needs input, badge" with meta=null', () => {
       // Stored row, needs-input eyebrow wins: meta is NOT rendered.

--- a/apps/mobile/src/components/agents/session-row-accessibility-label.ts
+++ b/apps/mobile/src/components/agents/session-row-accessibility-label.ts
@@ -1,3 +1,5 @@
+import { type GlanceableStatusKind } from '@kilocode/app-shared/glanceable-agents-snapshot';
+
 import { i18n } from '@/i18n';
 import { formatList, formatNumber } from '@/lib/format';
 import { platformLabel } from '@/lib/platform-label';
@@ -89,6 +91,16 @@ type SessionRowAccessibilityLabelInputs = {
   /** Opt-in live status for stored list rows; needs-input speech takes priority. */
   live?: boolean;
   /**
+   * The row glyph's kind from the one shared derivation
+   * (`glanceableStatusKind(session.status)` — the exact value the row passes
+   * to its status glyph). When set on a live row whose needs-input flag is
+   * down, the label names the state the glyph draws instead of the static
+   * LIVE eyebrow word: `common.working` for running, `common.idle` for idle.
+   * Omit it (or pass null) to keep the static word, so callers that do not
+   * pass it are byte-identical to before.
+   */
+  statusKind?: GlanceableStatusKind | null;
+  /**
    * Left-eyebrow badge text, always visible (e.g. "CLI", "VSCODE", "LIVE",
    * "CLOUD AGENT"). Pass an empty string only as a defensive fallback —
    * the row always supplies a non-empty badge today.
@@ -125,7 +137,9 @@ type SessionRowAccessibilityLabelInputs = {
 /**
  * Compose the screen-reader label for a `SessionRow`, mirroring its visible
  * content in the order the row renders parts: title, then `needs input`
- * (or localized live status when opted in), then the branch subtitle
+ * (or, on a live row, the state word the status glyph draws when the caller
+ * passes `statusKind` from the shared derivation — else the static LIVE
+ * eyebrow word), then the branch subtitle
  * (when present), then the `pull request <number>` phrase (when `prNumber`
  * is set), then the always-visible left-eyebrow badge, then the meta text
  * (only when the row visibly renders meta), then an optional platform origin
@@ -147,6 +161,7 @@ export function sessionRowAccessibilityLabel({
   title,
   needsInput,
   live = false,
+  statusKind = null,
   badge,
   meta,
   subtitle,
@@ -157,7 +172,14 @@ export function sessionRowAccessibilityLabel({
   if (needsInput) {
     parts.push(i18n.t('agents.sessionRow.needsInput'));
   } else if (live) {
-    parts.push(i18n.t('agents.sessionList.live'));
+    if (statusKind != null) {
+      // Name the state the glyph draws. The ui row renders the running glyph
+      // for any set kind but idle, so a `needsInput` kind with the attention
+      // flag down (acked, or `retry`) draws running and is spoken as working.
+      parts.push(i18n.t(statusKind === 'idle' ? 'common.idle' : 'common.working'));
+    } else {
+      parts.push(i18n.t('agents.sessionList.live'));
+    }
   }
   if (subtitle) {
     parts.push(subtitle);

--- a/apps/mobile/src/components/agents/session-row.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/session-row.mounted.test.tsx
@@ -1,13 +1,17 @@
-/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer mounts the real stored row and its native presentation without a DOM. */
+/* eslint-disable max-lines, typescript-eslint/no-deprecated -- one cohesive mounted suite: stored row, share list, and remote row share the mock harness; react-test-renderer mounts the real rows and their native presentation without a DOM. */
 import { createElement, type ReactElement } from 'react';
+import { type QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import TestRenderer, { act } from 'react-test-renderer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { makeCached } from '@/lib/active-sessions-live-sync.test-helpers';
 import { ShareDestinationList } from '@/components/share/share-destination-list';
 import { type ShareDestinationRow } from '@/components/share/share-destinations';
+import { createKiloAppQueryClient } from '@/lib/query-client';
 import { i18n } from '@/i18n';
-import { type StoredSession } from '@/lib/hooks/use-agent-sessions';
+import { type ActiveSession, type StoredSession } from '@/lib/hooks/use-agent-sessions';
 import { __resetSessionAttentionForTests } from '@/lib/session-attention';
+import { RemoteSessionRow } from './remote-session-row';
 import { StoredSessionRow } from './session-row';
 
 vi.mock('react-native', async () => {
@@ -79,6 +83,31 @@ vi.mock('./session-row-actions', () => ({
   showDeleteConfirm: vi.fn(),
   showRenamePrompt: vi.fn(),
   showSessionActionMenu: vi.fn(),
+}));
+vi.mock('@/lib/organization-context', () => ({
+  useOrganization: () => ({ organizationId: null, isLoaded: true }),
+}));
+vi.mock('@/lib/trpc', () => {
+  const trpc = {
+    activeSessions: {
+      list: {
+        queryKey: (input: unknown) => [['activeSessions', 'list'], { input, type: 'query' }],
+      },
+    },
+  };
+  return { useTRPC: () => trpc };
+});
+vi.mock('@/components/agents/user-web-connection-provider', () => ({
+  useUserWebConnection: () => ({ sendCommand: vi.fn() }),
+}));
+vi.mock('@/lib/hooks/use-session-mutations', () => ({
+  useSessionMutations: () => ({ renameSession: vi.fn() }),
+}));
+vi.mock('./exit-remote-session-from-list', () => ({
+  exitRemoteSessionFromList: vi.fn(),
+}));
+vi.mock('./remote-session-exit-alert', () => ({
+  showRemoteSessionExitConfirmation: vi.fn().mockResolvedValue(true),
 }));
 
 const session: StoredSession = {
@@ -182,6 +211,30 @@ describe('StoredSessionRow live speech', () => {
     expect(hosts(renderer, 'SessionStatusIcon')).toHaveLength(0);
   });
 
+  it('keeps the live eyebrow to the status glyph alone (no platform mark beside it)', () => {
+    // A platform glyph beside the status mark reads as a stray second mark
+    // crowding the meta, so a live row draws the status glyph only. The
+    // stored (non-live) row keeps its platform mark.
+    const withRepo = { ...session, git_url: 'git@github.com:org/my-repo.git' };
+    const liveRenderer = mount(row({ session: withRepo, live: true, metaWhileLive: true }));
+    expect(liveRenderer.root.findAllByProps({ testID: 'platform-icon-terminal' })).toHaveLength(0);
+    expect(hosts(liveRenderer, 'SessionStatusIcon').map(glyph => glyph.props)).toEqual([
+      { kind: 'running' },
+    ]);
+    expect(hosts(liveRenderer, 'Pressable')[0]?.props.accessibilityLabel).toBe(
+      'Fix login bug, LIVE, feature/live, MY-REPO, and cost 12 cents, 5 minutes ago'
+    );
+
+    const storedRenderer = mount(row({ session: withRepo, live: false }));
+    expect(storedRenderer.root.findAllByProps({ testID: 'platform-icon-terminal' })).toHaveLength(
+      1
+    );
+    expect(hosts(storedRenderer, 'SessionStatusIcon')).toHaveLength(0);
+    expect(hosts(storedRenderer, 'Pressable')[0]?.props.accessibilityLabel).toBe(
+      'Fix login bug, feature/live, MY-REPO, cost 12 cents, 5 minutes ago, and from CLI'
+    );
+  });
+
   it('updates an existing live row to localized speech and locale-aware list composition', async () => {
     const renderer = mount(
       row({
@@ -272,4 +325,110 @@ describe('StoredSessionRow live speech', () => {
       expect(selectedId).toBe(destinationsDisabled ? null : 'stored-1');
     }
   );
+});
+
+describe('RemoteSessionRow live speech', () => {
+  let client: QueryClient = createKiloAppQueryClient();
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    __resetSessionAttentionForTests();
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-08-28T12:00:00.000Z'));
+    client = createKiloAppQueryClient();
+    client.setDefaultOptions({ queries: { retry: false, gcTime: Infinity } });
+  });
+  afterEach(async () => {
+    act(() => {
+      for (const renderer of mounted) {
+        renderer.unmount();
+      }
+    });
+    mounted.length = 0;
+    vi.restoreAllMocks();
+    await i18n.changeLanguage('en');
+  });
+
+  function mountRemote(overrides: Partial<ActiveSession> = {}) {
+    return mount(
+      createElement(
+        QueryClientProvider,
+        { client },
+        createElement(RemoteSessionRow, {
+          session: {
+            ...makeCached({
+              id: 'remote-1',
+              status: 'busy',
+              title: 'Live work',
+              createdOnPlatform: 'cli',
+              gitBranch: 'feature/live',
+              updatedAt: '2026-08-28T11:55:00.000Z',
+            }),
+            ...overrides,
+          },
+          onPress: () => undefined,
+        })
+      )
+    );
+  }
+
+  it('speaks Working for a working row, drawn and spoken from one derivation', () => {
+    const renderer = mountRemote();
+    expect(hosts(renderer, 'Pressable')[0]?.props.accessibilityLabel).toBe(
+      'Live work, Working, feature/live, CLI, and 5 minutes ago'
+    );
+    expect(hosts(renderer, 'SessionStatusIcon').map(glyph => glyph.props)).toEqual([
+      { kind: 'running' },
+    ]);
+    expect(texts(renderer)).toContain('5 MINUTES AGO');
+    expect(texts(renderer)).toContain('feature/live');
+  });
+
+  it('speaks Idle once the agent stops working', () => {
+    const renderer = mountRemote({ status: 'idle' });
+    expect(hosts(renderer, 'Pressable')[0]?.props.accessibilityLabel).toBe(
+      'Live work, Idle, feature/live, CLI, and 5 minutes ago'
+    );
+    expect(hosts(renderer, 'SessionStatusIcon').map(glyph => glyph.props)).toEqual([
+      { kind: 'idle' },
+    ]);
+  });
+
+  it('keeps the needs-input speech above the state word', () => {
+    const renderer = mountRemote({ status: 'question' });
+    expect(hosts(renderer, 'Pressable')[0]?.props.accessibilityLabel).toBe(
+      'Live work, needs input, feature/live, and CLI'
+    );
+    expect(hosts(renderer, 'SessionStatusIcon').map(glyph => glyph.props)).toEqual([
+      { kind: 'needsInput' },
+    ]);
+    expect(texts(renderer)).toContain('NEEDS INPUT');
+  });
+
+  it('speaks Working for an unrecognized status, agreeing with the drawn glyph', () => {
+    const renderer = mountRemote({ status: 'mystery' });
+    expect(hosts(renderer, 'Pressable')[0]?.props.accessibilityLabel).toBe(
+      'Live work, Working, feature/live, CLI, and 5 minutes ago'
+    );
+    expect(hosts(renderer, 'SessionStatusIcon').map(glyph => glyph.props)).toEqual([
+      { kind: 'running' },
+    ]);
+  });
+
+  it('draws the idle tray row with the status glyph alone (no platform mark)', () => {
+    // SPOT-DEFECT (e1): the finished row's status cluster showed a stray
+    // second mark beside the idle circle — the platform glyph. The tray row
+    // always draws the status glyph, so the platform glyph is withheld.
+    const renderer = mountRemote({
+      status: 'idle',
+      createdOnPlatform: 'cli',
+      gitUrl: 'git@github.com:org/live-repo.git',
+    });
+    expect(renderer.root.findAllByProps({ testID: 'platform-icon-terminal' })).toHaveLength(0);
+    expect(hosts(renderer, 'SessionStatusIcon').map(glyph => glyph.props)).toEqual([
+      { kind: 'idle' },
+    ]);
+    expect(hosts(renderer, 'Pressable')[0]?.props.accessibilityLabel).toBe(
+      'Live work, Idle, feature/live, LIVE-REPO, and 5 minutes ago'
+    );
+  });
 });

--- a/apps/mobile/src/components/agents/session-row.tsx
+++ b/apps/mobile/src/components/agents/session-row.tsx
@@ -177,13 +177,16 @@ export function StoredSessionRow({
         });
   const spokenPrNumber = variant === 'card' ? null : (session.associatedPr?.number ?? null);
 
-  // Platform icon only on the Agents list variant. Home cards stay
-  // byte-identical (platformIcon defaults to undefined).
+  // Platform icon only on the Agents list variant, and only while the
+  // eyebrow draws no live status glyph (a glyph beside the status mark
+  // reads as a stray second mark). Home cards stay byte-identical
+  // (platformIcon defaults to undefined).
   const { iconKind: platformIconKind, spokenPlatform: a11yPlatform } =
     selectRowPlatformPresentation({
       platform: session.created_on_platform,
       variant,
       needsInput,
+      statusGlyph: live,
       gitUrl: session.git_url,
     });
   const platformIcon =

--- a/apps/mobile/src/components/ui/session-row-eyebrow-right.test.ts
+++ b/apps/mobile/src/components/ui/session-row-eyebrow-right.test.ts
@@ -147,7 +147,7 @@ describe('selectSessionRowEyebrowRight', () => {
       ).toEqual({ kind: 'needs-input', showPlatformIcon: false });
     });
 
-    it('live-and-meta shows the icon iff hasPlatformIcon', () => {
+    it('live-and-meta suppresses the icon: the status glyph owns the cluster', () => {
       expect(
         selectSessionRowEyebrowRight({
           needsInput: false,
@@ -155,20 +155,11 @@ describe('selectSessionRowEyebrowRight', () => {
           hasMeta: true,
           metaWhileLive: true,
           hasPlatformIcon: true,
-        })
-      ).toEqual({ kind: 'live-and-meta', showPlatformIcon: true });
-      expect(
-        selectSessionRowEyebrowRight({
-          needsInput: false,
-          live: true,
-          hasMeta: true,
-          metaWhileLive: true,
-          hasPlatformIcon: false,
         })
       ).toEqual({ kind: 'live-and-meta', showPlatformIcon: false });
     });
 
-    it('live shows the icon iff hasPlatformIcon', () => {
+    it('live suppresses the icon: the status glyph owns the cluster', () => {
       expect(
         selectSessionRowEyebrowRight({
           needsInput: false,
@@ -176,14 +167,6 @@ describe('selectSessionRowEyebrowRight', () => {
           hasMeta: false,
           metaWhileLive: false,
           hasPlatformIcon: true,
-        })
-      ).toEqual({ kind: 'live', showPlatformIcon: true });
-      expect(
-        selectSessionRowEyebrowRight({
-          needsInput: false,
-          live: true,
-          hasMeta: false,
-          metaWhileLive: false,
         })
       ).toEqual({ kind: 'live', showPlatformIcon: false });
     });

--- a/apps/mobile/src/components/ui/session-row-eyebrow-right.ts
+++ b/apps/mobile/src/components/ui/session-row-eyebrow-right.ts
@@ -8,9 +8,12 @@
  *  - a meta text alone
  *  - nothing
  *
- * Plus an independent `showPlatformIcon` flag: true when a platform icon
- * was provided AND the kind is not `needs-input` (attention treatment
- * keeps priority and suppresses the icon).
+ * Plus an independent `showPlatformIcon` flag. The platform glyph renders
+ * only when NO state glyph is drawn: needs-input suppresses it (attention
+ * keeps priority), and the live kinds draw the session's status glyph —
+ * the one mark that names the state — so a platform-origin glyph beside it
+ * reads as a stray second mark crowding the meta. Kinds `meta`/`none`
+ * (no status glyph) show the icon iff one was provided.
  *
  * Home and the Agents list both call this, but only the Agents tray
  * opts into `metaWhileLive`. Keeping the rule here makes it testable
@@ -38,10 +41,12 @@ export function selectSessionRowEyebrowRight(inputs: {
     return { kind: 'needs-input', showPlatformIcon: false };
   }
   if (live && hasMeta && metaWhileLive) {
-    return { kind: 'live-and-meta', showPlatformIcon: hasPlatformIcon };
+    // The status glyph draws here; a platform glyph beside it would read as
+    // a stray second mark in the cluster.
+    return { kind: 'live-and-meta', showPlatformIcon: false };
   }
   if (live) {
-    return { kind: 'live', showPlatformIcon: hasPlatformIcon };
+    return { kind: 'live', showPlatformIcon: false };
   }
   if (hasMeta) {
     return { kind: 'meta', showPlatformIcon: hasPlatformIcon };

--- a/apps/mobile/src/components/ui/session-row.mounted.test.tsx
+++ b/apps/mobile/src/components/ui/session-row.mounted.test.tsx
@@ -81,6 +81,16 @@ describe('SessionRow mounted layout', () => {
     expect(text.props.maxFontSizeMultiplier).toBeUndefined();
     expect(text.children).toEqual([meta]);
 
+    // The eyebrow label yields before the timestamp: flex-1 basis 0 sizes
+    // the right cluster at its full natural width first, so a long agent
+    // label truncates instead of ellipsizing the relative time (SPOT-DEFECT:
+    // rows clipped "1 HOUR AGO" to "1 HOUR A...").
+    const label = textNode(root, content.agentLabel);
+    expect(label.props.numberOfLines).toBe(1);
+    expect((label.props.className as string).split(' ')).toEqual(
+      expect.arrayContaining(['min-w-0', 'flex-1'])
+    );
+
     if (live) {
       const cluster = root.findByProps({ kind: 'running' }).parent;
       expect((cluster?.props.className as string | undefined)?.split(' ')).toEqual(
@@ -88,8 +98,14 @@ describe('SessionRow mounted layout', () => {
       );
     }
     if (icon) {
-      const cluster = root.findByProps({ testID: 'platform-icon' }).parent;
-      expect((cluster?.props.className as string | undefined)?.split(' ')).toContain('shrink');
+      if (live) {
+        // The live status glyph owns the eyebrow cluster; the platform mark
+        // is suppressed rather than drawn beside it.
+        expect(root.findAllByProps({ testID: 'platform-icon' })).toHaveLength(0);
+      } else {
+        const cluster = root.findByProps({ testID: 'platform-icon' }).parent;
+        expect((cluster?.props.className as string | undefined)?.split(' ')).toContain('shrink');
+      }
     }
   });
 
@@ -123,7 +139,7 @@ describe('SessionRow mounted layout', () => {
       visibleMeta: true,
       needsInput: false,
       kind: 'running',
-      icon: true,
+      icon: false,
     },
     {
       name: 'live without metadata opt-in',
@@ -131,7 +147,7 @@ describe('SessionRow mounted layout', () => {
       visibleMeta: false,
       needsInput: false,
       kind: 'running',
-      icon: true,
+      icon: false,
     },
     {
       name: 'live without metadata',

--- a/apps/mobile/src/components/ui/session-row.tsx
+++ b/apps/mobile/src/components/ui/session-row.tsx
@@ -46,7 +46,9 @@ type SessionRowProps = {
   /**
    * Optional platform-origin icon rendered in the eyebrow-right cluster.
    * When unset, existing callers (incl. Home `variant='card'`) stay
-   * bit-for-bit identical. Suppressed entirely for needs-input rows.
+   * bit-for-bit identical. Suppressed entirely for needs-input rows and
+   * for live rows, whose eyebrow draws the status glyph — the one mark
+   * the cluster shows there.
    */
   platformIcon?: React.ReactNode;
   onPress?: () => void;
@@ -180,7 +182,12 @@ export function SessionRow({
       )}
       <View className="min-w-0 flex-1">
         <View className="mb-[3px] flex-row items-center justify-between">
-          <Eyebrow className={color.hueTextClass}>{agentLabel}</Eyebrow>
+          {/* flex-1 basis 0: the right cluster is sized first at its full
+              natural width, so a long agent label truncates instead of
+              crowding the status glyph and relative time out of the row. */}
+          <Eyebrow className={cn('min-w-0 flex-1', color.hueTextClass)} numberOfLines={1}>
+            {agentLabel}
+          </Eyebrow>
           {eyebrowRight}
         </View>
         <Text className="text-sm font-medium tracking-tight text-foreground" numberOfLines={2}>

--- a/apps/mobile/src/components/ui/session-status-icon.tsx
+++ b/apps/mobile/src/components/ui/session-status-icon.tsx
@@ -13,8 +13,9 @@ type SessionStatusIconProps = {
  * in progress, a hollow ring for a connected agent doing nothing. The shapes
  * differ as well as the colors, so the state reads without color.
  *
- * Sized to the platform icon beside it in the eyebrow, not to the dot it
- * replaced, so the cluster keeps one optical weight.
+ * Sized to the 12px platform glyph that shares the eyebrow cluster on
+ * stored rows — the eyebrow decision never pairs the two on a live row —
+ * so either mark alone keeps the cluster's optical weight.
  */
 export function SessionStatusIcon({ kind }: Readonly<SessionStatusIconProps>) {
   const colors = useThemeColors();

--- a/apps/mobile/src/lib/glanceable/publisher.test.ts
+++ b/apps/mobile/src/lib/glanceable/publisher.test.ts
@@ -5,6 +5,7 @@ import {
   buildGlanceableSnapshot,
   GLANCEABLE_SNAPSHOT_EXPIRY_MS,
   type GlanceableAgentsSnapshot,
+  isStartableGlanceableWork,
 } from '@kilocode/app-shared/glanceable-agents-snapshot';
 
 import { getTerminalBlankEpoch, writeSignedOutSnapshotAndEnd } from './cleanup';
@@ -97,6 +98,23 @@ describe('GlanceablePublisher', () => {
     const publisher = new GlanceablePublisher({ sinks: [sink], now: () => NOW });
     publisher.handleSessions([{ status: 'busy' }], PUB_CTX);
     expect(count(calls, 'startOrUpdate')).toBe(1);
+    publisher.dispose();
+  });
+
+  it('counts an unrecognized status as running, matching what the row glyph draws', () => {
+    // One session, unknown status: the shared kind map folds every non-idle,
+    // non-needs-input status into running, and the list row's glyph draws the
+    // same kind (`statusKind === 'idle' ? 'idle' : 'running'`), so the tray
+    // and the glanceable sinks can never disagree about this session. A row
+    // the list draws as working must also be startable work for the Live
+    // Activity, and must never be counted idle while it works.
+    const { sink, calls } = makeSink();
+    const publisher = new GlanceablePublisher({ sinks: [sink], now: () => NOW });
+    publisher.handleSessions([{ status: 'mystery' }], PUB_CTX);
+    const snapshot = lastSnapshot(calls, 'startOrUpdate');
+    expect(snapshot.running).toBe(1);
+    expect(snapshot.idle).toBe(0);
+    expect(isStartableGlanceableWork(snapshot)).toBe(true);
     publisher.dispose();
   });
 

--- a/apps/web/src/lib/active-sessions-list.ts
+++ b/apps/web/src/lib/active-sessions-list.ts
@@ -125,6 +125,13 @@ type CloudCandidateRow = EnrichmentRow & {
   git_url: string | null;
   git_branch: string | null;
   cloud_agent_session_id: string | null;
+  /**
+   * The tray's own liveness proof, selected alongside the candidate columns
+   * with the same EXISTS clause the WHERE liveness predicate uses: true when
+   * the session has a run with no `terminal_at` — the agent is working right
+   * now, whatever the asynchronously-synced stored status says.
+   */
+  run_open: boolean;
 };
 
 /**
@@ -170,6 +177,29 @@ export function resolveActiveSessionStatus(
     return storedStatus;
   }
   return liveStatus;
+}
+
+/**
+ * Resolve a cloud candidate's status. `cli_sessions_v2.status` syncs
+ * asynchronously and reads `idle` (or null) while the agent works, so the
+ * open run — the tray's own liveness proof (`cloud_agent_session_runs.
+ * terminal_at IS NULL`) — wins: a non-attention stored status reports `busy`
+ * while the run is open. Attention statuses pass through unchanged (a run
+ * open while the agent waits on the user must still show needs-input), and a
+ * row without an open run keeps its stored status, so the finished state
+ * (terminal run + fresh idle) still reads idle in the warm-idle window.
+ */
+export function resolveCloudCandidateStatus(
+  storedStatus: string | null | undefined,
+  runOpen: boolean
+): string {
+  if (storedStatus === 'question' || storedStatus === 'permission' || storedStatus === 'retry') {
+    return storedStatus;
+  }
+  if (runOpen) {
+    return 'busy';
+  }
+  return storedStatus ?? '';
 }
 
 /**
@@ -229,9 +259,11 @@ function mapEnrichedHeartbeatSession(
 function mapCloudCandidateRow(row: CloudCandidateRow): ActiveSession {
   const mapped: ActiveSession = {
     id: row.session_id,
-    // Cloud rows have no live heartbeat source — use the stored status as-is
-    // (do NOT run resolveActiveSessionStatus).
-    status: row.status ?? '',
+    // Cloud rows have no live heartbeat source (do NOT run
+    // resolveActiveSessionStatus): the stored status is synced
+    // asynchronously, so an open run upgrades a non-attention stored status
+    // to busy — a working session must never render idle.
+    status: resolveCloudCandidateStatus(row.status, row.run_open),
     title: row.title ?? '',
     connectionId: CLOUD_AGENT_CONNECTION_ID,
     gitUrl: row.git_url ?? undefined,
@@ -454,6 +486,13 @@ export async function listActiveSessions({
           status_updated_at: cli_sessions_v2.status_updated_at,
           total_cost_microdollars: cli_sessions_v2.total_cost_microdollars,
           cloud_agent_session_id: cli_sessions_v2.cloud_agent_session_id,
+          // Same EXISTS clause the WHERE livePredicate uses, so the row
+          // carries the proof of its own liveness into the mapping.
+          run_open: sql<boolean>`EXISTS (
+            SELECT 1 FROM ${cloud_agent_session_runs}
+            WHERE ${cloud_agent_session_runs.cloud_agent_session_id} = ${cli_sessions_v2.cloud_agent_session_id}
+              AND ${cloud_agent_session_runs.terminal_at} IS NULL
+          )`,
           session_pr_platform: cli_sessions_v2.platform,
           session_pr_url: cli_sessions_v2.pr_url,
           session_pr_number: cli_sessions_v2.pr_number,

--- a/apps/web/src/routers/active-sessions-router.cloud.test.ts
+++ b/apps/web/src/routers/active-sessions-router.cloud.test.ts
@@ -10,6 +10,7 @@ import {
 import { eq, inArray } from 'drizzle-orm';
 import type { User } from '@kilocode/db/schema';
 import { CLOUD_AGENT_CONNECTION_ID, resolveActiveSessionStatus } from './active-sessions-router';
+import { resolveCloudCandidateStatus } from '@/lib/active-sessions-list';
 
 jest.mock('@/lib/config.server', () => {
   const actual: Record<string, unknown> = jest.requireActual('@/lib/config.server');
@@ -226,6 +227,29 @@ describe('active-sessions-router.list cloud merge', () => {
 
     expect(result.sessions.map(s => s.id)).toEqual([sessionId]);
     expect(result.sessions[0]?.status).toBe('idle');
+  });
+
+  it('flag on + open run + stored idle → reported busy (run-open wins)', async () => {
+    // The stored status syncs asynchronously and reads `idle` while the agent
+    // works. The open run is the repo's proof the session is working, so the
+    // row must report busy — never the stale idle.
+    const sessionId = nextId('run-open-idle');
+    const casId = nextId('cas');
+    await seedCloudSession({
+      sessionId,
+      cloudAgentSessionId: casId,
+      kiloUserId: regularUser.id,
+      status: 'idle',
+      title: 'Working, status not yet synced',
+      run: { terminalAt: null },
+    });
+
+    fetchSpy = mockWorkerSessions([]);
+    const caller = await createCallerForUser(regularUser.id);
+    const result = await caller.activeSessions.list({ includeCloudAgentSessions: true });
+
+    expect(result.sessions.map(s => s.id)).toEqual([sessionId]);
+    expect(result.sessions[0]?.status).toBe('busy');
   });
 
   it('flag on + terminal run + stale idle → excluded', async () => {
@@ -483,7 +507,7 @@ describe('active-sessions-router.list cloud merge', () => {
     expect(byId.get(cloudNull)).not.toHaveProperty('lastActivityAt');
   });
 
-  it('NULL title/status on cloud rows map to empty string', async () => {
+  it('NULL title maps to empty string; NULL status with an open run reads busy', async () => {
     const sessionId = nextId('null-fields');
     const casId = nextId('cas');
     await seedCloudSession({
@@ -499,7 +523,7 @@ describe('active-sessions-router.list cloud merge', () => {
     const caller = await createCallerForUser(regularUser.id);
     const result = await caller.activeSessions.list({ includeCloudAgentSessions: true });
 
-    expect(result.sessions[0]).toMatchObject({ status: '', title: '' });
+    expect(result.sessions[0]).toMatchObject({ status: 'busy', title: '' });
   });
 
   it('cloud rows are not run through resolveActiveSessionStatus', async () => {
@@ -766,5 +790,29 @@ describe('active-sessions-router.list cloud merge', () => {
 
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0]?.totalCostMicrodollars).toBe(0);
+  });
+});
+
+describe('resolveCloudCandidateStatus', () => {
+  it('reports a non-attention stored status as busy while the run is open', () => {
+    expect(resolveCloudCandidateStatus('idle', true)).toBe('busy');
+    expect(resolveCloudCandidateStatus('busy', true)).toBe('busy');
+    expect(resolveCloudCandidateStatus('starting', true)).toBe('busy');
+  });
+
+  it('reports an unknown or empty stored status as busy while the run is open', () => {
+    expect(resolveCloudCandidateStatus(null, true)).toBe('busy');
+    expect(resolveCloudCandidateStatus('', true)).toBe('busy');
+  });
+
+  it('passes attention statuses through unchanged while the run is open', () => {
+    expect(resolveCloudCandidateStatus('question', true)).toBe('question');
+    expect(resolveCloudCandidateStatus('permission', true)).toBe('permission');
+    expect(resolveCloudCandidateStatus('retry', true)).toBe('retry');
+  });
+
+  it('keeps the stored status when no run is open (warm-idle window)', () => {
+    expect(resolveCloudCandidateStatus('idle', false)).toBe('idle');
+    expect(resolveCloudCandidateStatus(null, false)).toBe('');
   });
 });

--- a/packages/app-shared/src/glanceable-agents-snapshot.test.ts
+++ b/packages/app-shared/src/glanceable-agents-snapshot.test.ts
@@ -5,6 +5,7 @@ import {
   buildOpaqueScopeKey,
   countGlanceableSessions,
   GLANCEABLE_SNAPSHOT_EXPIRY_MS,
+  glanceableStatusKind,
   isEligibleGlanceableWork,
   oldestNeedsInputSince,
   shouldDiscardGlanceableRevision,
@@ -23,9 +24,6 @@ describe('countGlanceableSessions', () => {
       { status: 'retry' },
       { status: 'idle' },
       { status: 'idle' },
-      { status: 'completed' },
-      { status: 'failed' },
-      { status: 'mystery' },
     ]);
     expect(counts).toEqual({ running: 2, needsInput: 4, idle: 2 });
   });
@@ -48,10 +46,36 @@ describe('countGlanceableSessions', () => {
     });
   });
 
-  it('ignores a completed or unknown status entirely', () => {
+  it('counts completed, failed, unknown, and empty statuses as running', () => {
     expect(
-      countGlanceableSessions([{ status: 'completed' }, { status: 'failed' }, { status: 'nope' }])
-    ).toEqual({ running: 0, needsInput: 0, idle: 0 });
+      countGlanceableSessions([
+        { status: 'completed' },
+        { status: 'failed' },
+        { status: 'mystery' },
+        { status: '' },
+      ])
+    ).toEqual({ running: 4, needsInput: 0, idle: 0 });
+  });
+});
+
+describe('glanceableStatusKind', () => {
+  // The one matrix every glanceable sink reads — the platform-specific sinks
+  // (iOS Live Activity, Android widget) all consume these counts and kinds.
+  it('maps busy, starting, unknown, and empty to running', () => {
+    expect(glanceableStatusKind('busy')).toBe('running');
+    expect(glanceableStatusKind('starting')).toBe('running');
+    expect(glanceableStatusKind('mystery')).toBe('running');
+    expect(glanceableStatusKind('')).toBe('running');
+  });
+
+  it('maps question/permission/retry to needsInput', () => {
+    expect(glanceableStatusKind('question')).toBe('needsInput');
+    expect(glanceableStatusKind('permission')).toBe('needsInput');
+    expect(glanceableStatusKind('retry')).toBe('needsInput');
+  });
+
+  it('maps idle to idle', () => {
+    expect(glanceableStatusKind('idle')).toBe('idle');
   });
 });
 
@@ -117,7 +141,10 @@ describe('buildGlanceableSnapshot', () => {
 
   it('clears needsInputSince when no session is connected', () => {
     const snapshot = buildGlanceableSnapshot({
-      sessions: [{ status: 'completed' }],
+      // No rows at all: with the total status map every row counts as
+      // something (unknown counts as running), so only an empty list is
+      // "nothing connected".
+      sessions: [],
       userId: 'u1',
       organizationId: null,
       now: NOW,

--- a/packages/app-shared/src/glanceable-agents-snapshot.ts
+++ b/packages/app-shared/src/glanceable-agents-snapshot.ts
@@ -97,24 +97,26 @@ export type GlanceableStatusKind = 'needsInput' | 'running' | 'idle';
 
 /**
  * Map one session status to the kind the glanceable surfaces and the session
- * lists both show, or null when the status means nothing to either. The counts
- * below and the list rows share this map, so a row can never disagree with the
- * widget beside it.
+ * lists both show. Total on strings: needs-input statuses → `needsInput`,
+ * `idle` → `idle`, everything else → `running` (starting, empty, unknown
+ * included). A session is idle only when the agent is not working and not
+ * waiting on the user, so a working session can never render idle and a row
+ * can never disagree with the widget beside it. Callers pass null only when
+ * a row has no status at all.
  */
-export function glanceableStatusKind(status: string): GlanceableStatusKind | null {
-  if (status === 'busy') {
-    return 'running';
-  }
+export function glanceableStatusKind(status: string): GlanceableStatusKind {
   if (NEEDS_INPUT_STATUSES.has(status)) {
     return 'needsInput';
   }
-  return status === 'idle' ? 'idle' : null;
+  return status === 'idle' ? 'idle' : 'running';
 }
 
 /**
  * Map session rows to the three glanceable counts. `busy` → running,
- * `question`/`permission`/`retry` → needs-input, `idle` → idle, and any
- * unknown status is ignored. Do not call `isCompletedStatus` here.
+ * `question`/`permission`/`retry` → needs-input, `idle` → idle, and any other
+ * status (starting, empty, unknown, completed) counts as running: a session
+ * is idle only when the agent says so, and no row is dropped from the count
+ * its list row shows.
  *
  * `retry` folds into needs-input because it means one thing to the user: the
  * agent is waiting and cannot go on alone. Session-ingest writes it when a CLI
@@ -126,11 +128,7 @@ export function countGlanceableSessions(
 ): GlanceableCounts {
   const counts = { running: 0, needsInput: 0, idle: 0 };
   for (const session of sessions) {
-    // An unknown status contributes nothing.
-    const kind = glanceableStatusKind(session.status);
-    if (kind !== null) {
-      counts[kind] += 1;
-    }
+    counts[glanceableStatusKind(session.status)] += 1;
   }
   return counts;
 }


### PR DESCRIPTION
## Request

> Fix the live session list showing a session as idle while it is doing work.
> 
> Surface: the mobile app (apps/mobile).
> 
> Reported by the owner from live use: in the live session list, sessions that
> are actually working show up as idle. Glanceables show the same wrong state,
> so one status derivation is very likely feeding both.
> 
> Reproduce first, on a live build. Start a session, give the agent work that
> runs long enough to observe, and watch the row and the glanceable while the
> agent is mid-turn. Do not fix anything until you can see the wrong state on a
> device.
> 
> Where to start reading, not a diagnosis:
> - apps/mobile/src/lib/active-sessions-live.ts and
>   active-sessions-live-sync.ts hold the live session state.
> - apps/mobile/src/components/ui/session-row.tsx derives the row's live glyph
>   from `statusKind` (`statusKind === 'idle' ? 'idle' : 'running'`).
> - apps/mobile/src/lib/glanceable/publisher.ts and presentation.ts publish the
>   glanceable snapshot.
> 
> Name the root cause in the PR body. A session is idle only when the agent is
> not working; anything else is running. Fix the derivation both surfaces read,
> not the two call sites: the list and the glanceable must never disagree about
> one session, and a fix in the row alone leaves the widget wrong.
> 
> Cover the states a session moves through, including the transitions: starting,
> mid-turn, waiting for input, finished, and reconnecting after the app was
> backgrounded. A stale status after a reconnect is the same defect.
> 
> Add tests that fail against the current code and pass after the fix.
> 
> Prove it live in the PR body on whichever platform this round runs: the row
> showing running while the agent works, and idle only once it stops. The
> glanceable sinks are platform-specific, so cover the shared derivation both
> of them read with tests, and say in the PR body which platform you proved
> live and which one the tests cover.

## Changelog for users

- A session the agent is working on now shows as running in the live session list for the entire turn, and shows idle only once the agent stops.
- The glanceable agrees with the list: a mid-turn session counts as running and is never shown as idle, and starting, empty, or unknown states count as running instead of vanishing from the counts.
- After backgrounding the app mid-turn and returning, the row shows the fresh running state instead of a stale idle.
- When the agent asks a question, the row shows NEEDS INPUT (spoken before any state word) and the widget's needs-input count increments.
- Screen readers on live rows now hear the real state ("Working" or "Idle") instead of a static "LIVE".
- Live rows no longer draw a stray platform icon beside the status glyph, and a long agent label truncates instead of clipping the relative time ("1 hour ago" no longer becomes "1 hour a…").

## Changelog for maintainers

- Root cause: `cli_sessions_v2.status` syncs asynchronously and still reads `idle` (or null) while the agent is mid-turn, and the shared kind map returned null for every status that was not exactly `busy`, a needs-input status, or `idle` — dropping such rows from the glanceable counts and letting the stale stored status render idle in both the list row and the widget.
- The one derivation both surfaces read, `glanceableStatusKind` in `packages/app-shared/src/glanceable-agents-snapshot.ts`, is now total on strings: needs-input statuses → `needsInput`, exactly `idle` → `idle`, everything else (starting, empty, unknown, completed) → `running`; `countGlanceableSessions` counts every row, so the row glyph (`statusKind === 'idle' ? 'idle' : 'running'`) and every glanceable sink can never disagree about one session.
- Server truth: `apps/web/src/lib/active-sessions-list.ts` selects `run_open` (an EXISTS on `cloud_agent_session_runs.terminal_at IS NULL`, the same clause the liveness WHERE uses) and the new `resolveCloudCandidateStatus` upgrades a non-attention stored status to `busy` while the run is open; attention statuses pass through (needs-input still wins over an open run) and a closed run keeps the stored status for the warm-idle window.
- `sessionRowAccessibilityLabel` takes an optional `statusKind`; live rows pass `glanceableStatusKind(session.status)` and the label speaks `common.working`/`common.idle` — the state the glyph draws — while callers that omit it stay byte-identical (including the static LIVE fallback).
- Live rows draw the status glyph alone in the eyebrow-right cluster: `selectSessionRowEyebrowRight` suppresses the platform icon for live kinds, and `selectRowPlatformPresentation` gains a `statusGlyph` flag that also withholds the spoken platform so the screen reader never names an icon the row does not draw.
- The eyebrow label gets `min-w-0 flex-1 numberOfLines={1}` so a long agent label truncates and the status glyph and timestamp keep their space.
- Platform coverage: proved live on Android; the tests cover the shared derivation in `packages/app-shared` that both platform-specific sinks (iOS Live Activity, Android widget) consume, plus the mobile publisher and the web router.
- Review hints: start with `glanceableStatusKind`/`countGlanceableSessions` (the shared contract), then `resolveCloudCandidateStatus` and the `run_open` EXISTS clause (data contract), then the mounted `RemoteSessionRow` suite in `session-row.mounted.test.tsx`; the new tests fail on the old code (unknown statuses were dropped, the stale stored idle won) and pass after the fix.

## E2E proof

**Recording of the verified flow** (waits trimmed)

https://github.com/user-attachments/assets/3450bdfe-71a7-45e3-84f9-be2cd3f9d1cd

**Recording of the verified flow** (waits trimmed)

https://github.com/user-attachments/assets/aabf2411-308d-4523-8e67-885e8c472030

**Recording of the verified flow** (waits trimmed)

https://github.com/user-attachments/assets/1519bb89-0ae7-4844-bc59-6667fab1b1f4

**Recording of the verified flow** (waits trimmed)

https://github.com/user-attachments/assets/e955b1b0-e6c7-4d76-8bc1-473586e714ad

![[p1] mid-turn row shows Working, finished row shows Idle: while the agent works the Agents tray row reads Working and only after the turn ends does it read Idle, with the row title never blanking or… — prior/p1-idle.png](https://github.com/user-attachments/assets/6ff2364d-1bd0-4c6d-8df6-0a18cde86823)

![[p1] mid-turn row shows Working, finished row shows Idle: while the agent works the Agents tray row reads Working and only after the turn ends does it read Idle, with the row title never blanking or… — e2e-mobile-app/p1-working.png](https://github.com/user-attachments/assets/dbb3ed6c-c377-4649-826d-9b73755a3973)

## Follow-ups (not changed here)
- 01-login-verify-code-FAIL.png — Unstyled system “Refreshing…” bar on a blank white screen instead of a branded loading or error state
- e1-allow-back.png — Conflicting “Reconnecting…” and “Agent connection lost” statuses stack with a third “Failed to respond to permission” banner, duplicating failure/loading indicators on one screen.
- e1-composer.png — Connect GitLab helper copy is clipped mid-sentence at the keyboard edge.
- e1-idle.png — Relative time is clipped to "2 MINUTE…" because the long session name is not truncated.
- e1-working-row.png,e1-working.png — The running glyph and "3 MINUTE…" timestamp collide with the untruncated session name.
- not proved live: glanceable sink agrees with the row: [needs:recording] with the same session mid-turn the platform sink (iOS Live Activity / Dynamic Island or the Android widget) shows Working 1, and after the turn Idle 1; the shared derivation both sinks read is proven by the app-shared status matrix in s1, which runs on both platforms — the PR body names which platform was proved live and which the tests cover — no fixture: no local push on Android (needs a real FCM token); prove the state through the needs-input fixture and a foreground refresh instead