### PR TITLE
fix(mobile-android): kill emulator on failed launch and extend console-port wait

### DIFF
--- a/dev/local/mobile-android.test.ts
+++ b/dev/local/mobile-android.test.ts
@@ -8,6 +8,7 @@ import {
   androidEmulatorSession,
   claimAndroidDevice,
   commandMatchesRecordedEmulator,
+  DEFAULT_CONSOLE_PORT_WAIT_MS,
   findAvailableEmulatorPort,
   isValidEmulatorRecord,
   parseEmulatorStartArgs,
@@ -17,6 +18,7 @@ import {
   releaseWorktreeAndroidDevices,
   resolveAndroidEnvironment,
   signalProcessIfPresent,
+  startAndroidEmulator,
 } from './mobile-android';
 
 test('allocates the first free even emulator console port', () => {
@@ -369,4 +371,263 @@ test('reads the Gradle version from the worktree wrapper properties without laun
   );
 
   assert.equal(readGradleWrapperVersion(root), '8.14.3');
+});
+
+const launchEnv = {
+  adb: '/usr/bin/adb',
+  emulator: '/opt/android/emulator/emulator',
+  javaHome: '/usr/lib/jvm/temurin-17',
+  path: '/usr/bin',
+  sdkRoot: '/opt/android-sdk',
+};
+
+function launchHarness() {
+  const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-emulator-launch-'));
+  const session = androidEmulatorSession(worktreeRoot);
+  const slug = path.basename(worktreeRoot);
+  return {
+    worktreeRoot,
+    session,
+    pidFile: path.join(os.tmpdir(), `${session}.pid`),
+    recordPath: path.join(os.tmpdir(), 'kilo-mobile-android-emulators', `${slug}.json`),
+    cleanup: () => {
+      fs.rmSync(path.join(os.tmpdir(), `${session}.pid`), { force: true });
+      fs.rmSync(path.join(os.tmpdir(), 'kilo-mobile-android-emulators', `${slug}.json`), {
+        force: true,
+      });
+      fs.rmSync(
+        path.join(os.tmpdir(), 'kilo-mobile-android-emulators', `${slug}.json.${process.pid}.tmp`),
+        { force: true }
+      );
+      fs.rmSync(path.join(os.tmpdir(), `${session}.log`), { force: true });
+      fs.rmSync(worktreeRoot, { recursive: true, force: true });
+    },
+  };
+}
+
+type LaunchFakes = Parameters<typeof startAndroidEmulator>[4];
+// process.kill's signal parameter is `string | number | undefined`.
+type CapturedSignals = Array<string | number | undefined>;
+
+function liveEmulatorFakes(launched: { value: boolean }, signals: CapturedSignals): LaunchFakes {
+  return {
+    sleep: async () => {},
+    launchSession: (_session, _command, pidFile) => {
+      launched.value = true;
+      fs.writeFileSync(pidFile, '4242\n');
+    },
+    sessionExists: () => launched.value,
+    killSession: () => {},
+    portIsListening: () => launched.value,
+    listeningProcessIds: () => [4242],
+    processIsAlive: () => launched.value,
+    processCommand: () =>
+      '/opt/android/emulator/qemu/x86_64/qemu-system-x86_64-headless -avd Pixel_9 -port 5554',
+    signal: (_pid, signal) => {
+      signals.push(signal);
+      return true;
+    },
+  };
+}
+
+test('records an emulator once its process binds the console port', async () => {
+  const harness = launchHarness();
+  try {
+    const record = await startAndroidEmulator(
+      launchEnv,
+      harness.worktreeRoot,
+      'Pixel_9',
+      'host',
+      liveEmulatorFakes({ value: false }, [])
+    );
+
+    assert.equal(record.port, 5554);
+    assert.equal(record.serial, 'emulator-5554');
+    assert.equal(record.pid, 4242);
+    assert.equal(record.session, harness.session);
+    assert.equal(fs.existsSync(harness.recordPath), true);
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(harness.recordPath, 'utf8')),
+      JSON.parse(JSON.stringify(record))
+    );
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('a launch that misses the console-port budget kills the emulator it started', async () => {
+  const harness = launchHarness();
+  const launched = { value: false };
+  const signals: CapturedSignals = [];
+  const killedSessions: string[] = [];
+  try {
+    await assert.rejects(
+      startAndroidEmulator(launchEnv, harness.worktreeRoot, 'Pixel_9', 'host', {
+        ...liveEmulatorFakes(launched, signals),
+        portWaitMs: 200,
+        pollIntervalMs: 10,
+        report: () => {},
+        killSession: sessionName => killedSessions.push(sessionName),
+        portIsListening: () => false,
+      }),
+      /did not bind console port 5554 within 0\.2/
+    );
+    assert.deepEqual(killedSessions, [harness.session]);
+    assert.deepEqual(signals, ['SIGTERM', 'SIGKILL']);
+    assert.equal(fs.existsSync(harness.recordPath), false);
+    assert.equal(fs.existsSync(harness.pidFile), false);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('a launch whose emulator dies while waiting for the console port leaves no record', async () => {
+  const harness = launchHarness();
+  const launched = { value: false };
+  const signals: CapturedSignals = [];
+  const killedSessions: string[] = [];
+  try {
+    await assert.rejects(
+      startAndroidEmulator(launchEnv, harness.worktreeRoot, 'Pixel_9', 'host', {
+        ...liveEmulatorFakes(launched, signals),
+        pollIntervalMs: 10,
+        report: () => {},
+        killSession: sessionName => killedSessions.push(sessionName),
+        portIsListening: () => false,
+        processIsAlive: () => !launched.value,
+        signal: (_pid, signal) => {
+          signals.push(signal);
+          return true;
+        },
+      }),
+      /exited during launch/
+    );
+    assert.deepEqual(killedSessions, [harness.session]);
+    assert.deepEqual(signals, []);
+    assert.equal(fs.existsSync(harness.recordPath), false);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('a launch whose session never records its PID tears the session down', async () => {
+  const harness = launchHarness();
+  const launched = { value: false };
+  const signals: CapturedSignals = [];
+  const killedSessions: string[] = [];
+  try {
+    await assert.rejects(
+      startAndroidEmulator(launchEnv, harness.worktreeRoot, 'Pixel_9', 'host', {
+        ...liveEmulatorFakes(launched, signals),
+        pidWaitMs: 100,
+        pollIntervalMs: 10,
+        report: () => {},
+        killSession: sessionName => killedSessions.push(sessionName),
+        launchSession: () => {
+          launched.value = true;
+        },
+        signal: (_pid, signal) => {
+          signals.push(signal);
+          return true;
+        },
+      }),
+      /did not record its PID within 0\.1/
+    );
+    assert.deepEqual(killedSessions, [harness.session]);
+    assert.deepEqual(signals, []);
+    assert.equal(fs.existsSync(harness.recordPath), false);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('a launch that fails the ownership check kills the emulator it started', async () => {
+  const harness = launchHarness();
+  const launched = { value: false };
+  const signals: CapturedSignals = [];
+  const killedSessions: string[] = [];
+  try {
+    await assert.rejects(
+      startAndroidEmulator(launchEnv, harness.worktreeRoot, 'Pixel_9', 'host', {
+        ...liveEmulatorFakes(launched, signals),
+        pollIntervalMs: 10,
+        report: () => {},
+        killSession: sessionName => killedSessions.push(sessionName),
+        listeningProcessIds: () => [999],
+      }),
+      /does not own console port 5554/
+    );
+    assert.deepEqual(killedSessions, [harness.session]);
+    assert.deepEqual(signals, ['SIGTERM', 'SIGKILL']);
+    assert.equal(fs.existsSync(harness.recordPath), false);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('reports progress while the console-port wait runs', async () => {
+  const harness = launchHarness();
+  const launched = { value: false };
+  const signals: CapturedSignals = [];
+  const progress: string[] = [];
+  try {
+    await assert.rejects(
+      startAndroidEmulator(launchEnv, harness.worktreeRoot, 'Pixel_9', 'host', {
+        ...liveEmulatorFakes(launched, signals),
+        portWaitMs: 100,
+        pollIntervalMs: 10,
+        report: message => progress.push(message),
+        killSession: () => {},
+        portIsListening: () => false,
+      }),
+      /did not bind console port/
+    );
+    assert.equal(progress.length, 3);
+    for (const message of progress) assert.match(message, /console port 5554/);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('the console-port budget covers a cold boot by default and honors its override', async () => {
+  // Observed cold boots on the Linux VM bind the console port at 45-48 s.
+  assert.equal(DEFAULT_CONSOLE_PORT_WAIT_MS, 120_000);
+  assert.ok(DEFAULT_CONSOLE_PORT_WAIT_MS >= 60_000);
+
+  const harness = launchHarness();
+  const launched = { value: false };
+  const signals: CapturedSignals = [];
+  const envName = 'KILO_EMULATOR_CONSOLE_PORT_WAIT_MS';
+  process.env[envName] = '250';
+  try {
+    await assert.rejects(
+      startAndroidEmulator(launchEnv, harness.worktreeRoot, 'Pixel_9', 'host', {
+        ...liveEmulatorFakes(launched, signals),
+        report: () => {},
+        killSession: () => {},
+        portIsListening: () => false,
+      }),
+      /did not bind console port 5554 within 0\.25s/
+    );
+  } finally {
+    delete process.env[envName];
+    harness.cleanup();
+  }
+});
+
+test('rejects a console-port budget override that is not a positive number', async () => {
+  const harness = launchHarness();
+  const envName = 'KILO_EMULATOR_CONSOLE_PORT_WAIT_MS';
+  process.env[envName] = 'soon';
+  try {
+    await assert.rejects(
+      startAndroidEmulator(launchEnv, harness.worktreeRoot, 'Pixel_9', 'host', {
+        sleep: async () => {},
+      }),
+      /KILO_EMULATOR_CONSOLE_PORT_WAIT_MS must be a positive number of milliseconds/
+    );
+  } finally {
+    delete process.env[envName];
+    harness.cleanup();
+  }
 });

--- a/dev/local/mobile-android.ts
+++ b/dev/local/mobile-android.ts
@@ -253,16 +253,58 @@ function commandMatchesRecordedEmulator(
   );
 }
 
-function recordedEmulatorStillOwnsPid(record: EmulatorRecord, env: AndroidEnvironment): boolean {
-  if (!processIsAlive(record.pid)) return false;
-  const command =
-    spawnSync('ps', ['-p', String(record.pid), '-o', 'command='], {
+function readProcessCommand(pid: number): string {
+  return (
+    spawnSync('ps', ['-p', String(pid), '-o', 'command='], {
       encoding: 'utf8',
-    }).stdout?.trim() ?? '';
+    }).stdout?.trim() ?? ''
+  );
+}
+
+type EmulatorProcessDeps = {
+  processCommand: (pid: number) => string;
+  processIsAlive: (pid: number) => boolean;
+};
+
+function recordedEmulatorStillOwnsPid(
+  record: EmulatorRecord,
+  env: AndroidEnvironment,
+  deps?: Partial<EmulatorProcessDeps>
+): boolean {
+  const isAlive = deps?.processIsAlive ?? processIsAlive;
+  const processCommand = deps?.processCommand ?? readProcessCommand;
+  if (!isAlive(record.pid)) return false;
+  const command = processCommand(record.pid);
   return commandMatchesRecordedEmulator(command, env.emulator, record.avd, record.port);
 }
 
 const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+// A cold boot on the Linux VM binds its console port after 45-48 s, and a
+// loaded host stretches that further, so the default budget must cover a
+// cold boot with headroom. Set KILO_EMULATOR_CONSOLE_PORT_WAIT_MS (in
+// milliseconds) to override it for one launch.
+const DEFAULT_CONSOLE_PORT_WAIT_MS = 120_000;
+const DEFAULT_PID_WAIT_MS = 5_000;
+const DEFAULT_POLL_INTERVAL_MS = 100;
+
+function formatSeconds(ms: number): string {
+  const seconds = ms / 1000;
+  return Number.isInteger(seconds) ? String(seconds) : seconds.toFixed(2);
+}
+
+function requirePositiveMs(value: number, name: string): number {
+  if (!Number.isFinite(value) || value <= 0)
+    throw new Error(`${name} must be a positive number of milliseconds`);
+  return value;
+}
+
+function consolePortWaitMs(override?: number): number {
+  if (override !== undefined) return requirePositiveMs(override, 'portWaitMs');
+  const raw = process.env.KILO_EMULATOR_CONSOLE_PORT_WAIT_MS;
+  if (raw === undefined || raw === '') return DEFAULT_CONSOLE_PORT_WAIT_MS;
+  return requirePositiveMs(Number(raw), 'KILO_EMULATOR_CONSOLE_PORT_WAIT_MS');
+}
 
 function isValidEmulatorRecord(record: unknown, worktreeRoot: string): record is EmulatorRecord {
   if (typeof record !== 'object' || record === null) return false;
@@ -320,24 +362,63 @@ async function stopAndroidEmulator(env: AndroidEnvironment, worktreeRoot: string
   fs.rmSync(recordPath, { force: true });
 }
 
+type StartAndroidEmulatorOptions = {
+  // Milliseconds to wait for the console port to bind. Defaults to
+  // KILO_EMULATOR_CONSOLE_PORT_WAIT_MS, then DEFAULT_CONSOLE_PORT_WAIT_MS.
+  portWaitMs?: number;
+  // Milliseconds to wait for the tmux shell to record the emulator PID.
+  pidWaitMs?: number;
+  pollIntervalMs?: number;
+  // Receives progress lines while the console-port wait runs, so a long cold
+  // boot does not read as a hang. Defaults to stderr.
+  report?: (message: string) => void;
+  // Test seams. Defaults run tmux, lsof, ps, and signals on this host.
+  launchSession?: (session: string, command: string, pidFile: string) => void;
+  sessionExists?: (session: string) => boolean;
+  killSession?: (session: string) => void;
+  portIsListening?: (port: number) => boolean;
+  listeningProcessIds?: (port: number) => number[];
+  processIsAlive?: (pid: number) => boolean;
+  processCommand?: (pid: number) => string;
+  signal?: typeof process.kill;
+  sleep?: (ms: number) => Promise<void>;
+};
+
 async function startAndroidEmulator(
   env: AndroidEnvironment,
   worktreeRoot: string,
   avd: string,
-  gpu: string
+  gpu: string,
+  options: StartAndroidEmulatorOptions = {}
 ): Promise<EmulatorRecord> {
   const session = androidEmulatorSession(worktreeRoot);
+  const sessionExists = options.sessionExists ?? tmuxSessionExists;
+  const killSession = (sessionName: string): void => {
+    if (options.killSession) options.killSession(sessionName);
+    else spawnSync('tmux', ['kill-session', '-t', `=${sessionName}`], { stdio: 'ignore' });
+  };
+  const isPortListening = options.portIsListening ?? portIsListening;
+  const listeningPids = options.listeningProcessIds ?? listeningProcessIds;
+  const isProcessAlive = options.processIsAlive ?? processIsAlive;
+  const processCommand = options.processCommand ?? readProcessCommand;
+  const sleep = options.sleep ?? delay;
+  const report = options.report ?? ((message: string) => console.error(message));
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  requirePositiveMs(pollIntervalMs, 'pollIntervalMs');
+  const pidWaitMs = options.pidWaitMs ?? DEFAULT_PID_WAIT_MS;
+  const portWaitMs = consolePortWaitMs(options.portWaitMs);
+  const pollLimit = (budgetMs: number): number => Math.max(1, Math.ceil(budgetMs / pollIntervalMs));
 
   return withProcessLockAsync(
     path.join(os.tmpdir(), 'kilo-mobile-android-emulators', 'launch.lock'),
     'Android emulator launch',
     async () => {
       const recordPath = emulatorRecordPath(worktreeRoot);
-      if (tmuxSessionExists(session) || fs.existsSync(recordPath))
+      if (sessionExists(session) || fs.existsSync(recordPath))
         throw new Error(
           `${session} already exists; run pnpm dev:mobile:android emulator-stop before launching another`
         );
-      const port = findAvailableEmulatorPort();
+      const port = findAvailableEmulatorPort(isPortListening);
       if (port === undefined) throw new Error('No free Android emulator console port (5554-5680)');
       const serial = `emulator-${port}`;
       const log = path.join(os.tmpdir(), `${session}.log`);
@@ -358,23 +439,50 @@ async function startAndroidEmulator(
       const command = `echo $$ > ${shellQuote(pidFile)}; exec ${[env.emulator, ...emulatorArgs]
         .map(shellQuote)
         .join(' ')} >> ${shellQuote(log)} 2>&1`;
+      const launchSession = (sessionName: string, launchCommand: string): void => {
+        if (options.launchSession) options.launchSession(sessionName, launchCommand, pidFile);
+        else
+          execFileSync('tmux', [
+            'new-session',
+            '-d',
+            '-s',
+            sessionName,
+            '-c',
+            worktreeRoot,
+            launchCommand,
+          ]);
+      };
 
       let pid = 0;
       let sessionStarted = false;
       try {
-        execFileSync('tmux', ['new-session', '-d', '-s', session, '-c', worktreeRoot, command]);
+        launchSession(session, command);
         sessionStarted = true;
-        for (let i = 0; i < 50 && !fs.existsSync(pidFile); i++) await delay(100);
-        pid = Number(fs.readFileSync(pidFile, 'utf8').trim());
-        if (!Number.isInteger(pid) || pid <= 0)
-          throw new Error(`${session} did not record its PID`);
-        for (let i = 0; i < 300 && !portIsListening(port); i++) {
-          if (!processIsAlive(pid)) throw new Error(`${session} exited during launch; see ${log}`);
-          await delay(100);
+        for (let i = 0; i < pollLimit(pidWaitMs) && !fs.existsSync(pidFile); i++)
+          await sleep(pollIntervalMs);
+        try {
+          pid = Number(fs.readFileSync(pidFile, 'utf8').trim());
+        } catch (error) {
+          if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) throw error;
+          throw new Error(`${session} did not record its PID within ${formatSeconds(pidWaitMs)}s`);
         }
-        if (!portIsListening(port))
-          throw new Error(`${session} did not bind console port ${port} within 30s; see ${log}`);
-        if (!processIsAlive(pid) || !processOwnsListeningPort(port, pid))
+        if (!Number.isInteger(pid) || pid <= 0)
+          throw new Error(`${session} did not record its PID within ${formatSeconds(pidWaitMs)}s`);
+        const portPollLimit = pollLimit(portWaitMs);
+        const progressEvery = Math.max(1, Math.ceil(portPollLimit / 4));
+        for (let i = 0; i < portPollLimit && !isPortListening(port); i++) {
+          if (!isProcessAlive(pid)) throw new Error(`${session} exited during launch; see ${log}`);
+          if (i > 0 && i % progressEvery === 0)
+            report(
+              `Waiting for ${session} console port ${port}: ${Math.floor((i * pollIntervalMs) / 1000)}s of ${formatSeconds(portWaitMs)}s elapsed`
+            );
+          await sleep(pollIntervalMs);
+        }
+        if (!isPortListening(port))
+          throw new Error(
+            `${session} did not bind console port ${port} within ${formatSeconds(portWaitMs)}s; see ${log}`
+          );
+        if (!isProcessAlive(pid) || !processOwnsListeningPort(port, pid, listeningPids))
           throw new Error(
             `${session} does not own console port ${port}; refusing to record a foreign emulator`
           );
@@ -394,8 +502,9 @@ async function startAndroidEmulator(
         fs.renameSync(tempRecord, recordPath);
         return record;
       } catch (error) {
-        if (sessionStarted && tmuxSessionExists(session))
-          spawnSync('tmux', ['kill-session', '-t', `=${session}`], { stdio: 'ignore' });
+        // A launch that fails for any reason must not leave the emulator it
+        // started behind: no session, no orphan qemu, no record file.
+        if (sessionStarted && sessionExists(session)) killSession(session);
         if (pid > 0) {
           const partialRecord = {
             avd,
@@ -408,12 +517,17 @@ async function startAndroidEmulator(
             session,
             worktreeRoot,
           };
-          if (recordedEmulatorStillOwnsPid(partialRecord, env)) {
-            signalProcessIfPresent(pid, 'SIGTERM');
-            for (let i = 0; i < 50 && processIsAlive(pid); i++) await delay(100);
+          const stillOurs = () =>
+            recordedEmulatorStillOwnsPid(partialRecord, env, {
+              processCommand,
+              processIsAlive: isProcessAlive,
+            });
+          if (stillOurs()) {
+            signalProcessIfPresent(pid, 'SIGTERM', options.signal);
+            for (let i = 0; i < pollLimit(5_000) && isProcessAlive(pid); i++)
+              await sleep(pollIntervalMs);
           }
-          if (recordedEmulatorStillOwnsPid(partialRecord, env))
-            signalProcessIfPresent(pid, 'SIGKILL');
+          if (stillOurs()) signalProcessIfPresent(pid, 'SIGKILL', options.signal);
         }
         fs.rmSync(pidFile, { force: true });
         fs.rmSync(`${recordPath}.${process.pid}.tmp`, { force: true });
@@ -421,9 +535,9 @@ async function startAndroidEmulator(
         throw error;
       }
     },
-    // Two slow holders (pid-file wait + 30s port bind + teardown each) must
-    // not starve a third slot's healthy launch.
-    120_000
+    // Two slow holders (pid-file wait + full console-port budget + teardown
+    // each) must not starve a third slot's healthy launch.
+    300_000
   );
 }
 
@@ -885,6 +999,7 @@ export {
   androidEmulatorSession,
   claimAndroidDevice,
   commandMatchesRecordedEmulator,
+  DEFAULT_CONSOLE_PORT_WAIT_MS,
   findAvailableEmulatorPort,
   isValidEmulatorRecord,
   parseEmulatorStartArgs,
@@ -894,5 +1009,6 @@ export {
   releaseWorktreeAndroidDevices,
   resolveAndroidEnvironment,
   signalProcessIfPresent,
+  startAndroidEmulator,
 };
 export type { AndroidEnvironment };


### PR DESCRIPTION
## Request

> An emulator start that misses its console-port deadline leaves the emulator
> running, so the AVD stays busy forever.
> 
> In dev/local/mobile-android.ts, `emulator-start` waits 300 x 100 ms for the
> console port to listen, then throws "did not bind console port <port> within
> 30s". A cold boot on the Linux VM takes 45-48 s ("Boot completed in 44815 ms",
> "48490 ms" in the emulator logs), and under load the console port binds after
> the deadline. The launched emulator is never killed and no record file is
> written, so nothing can stop it and every later start reads the AVD as busy.
> 
> Two defects, both in that launch path:
> 
> 1. The wait is too short for a cold boot on a loaded host. Make it a settable
>    budget with a default that covers a cold boot, and keep reporting progress
>    so a long wait does not read as a hang.
> 
> 2. A launch that fails for ANY reason must kill the emulator it started before
>    it throws. Today the throw leaves an orphan with no record. Cover the whole
>    window: the PID wait, the port wait, and the ownership check.
> 
> Prove it live on the VM: start an emulator with the wait forced to a value it
> cannot meet, and show that the launch fails AND no qemu process for that AVD
> survives. Then start one normally and show it records and binds.

## Changelog for users
- A failed emulator start no longer leaves the emulator behind: if the launch fails at any point — waiting for the PID, waiting for the console port to bind, or the ownership check — the launcher kills the emulator it started and clears its PID file before throwing, so the AVD does not stay busy and later starts work.
- The console-port wait is now a settable budget defaulting to 120 s (was 30 s), covering the 45-48 s cold boots observed on the Linux VM; set `KILO_EMULATOR_CONSOLE_PORT_WAIT_MS` (milliseconds) to override it for a launch, and invalid values are rejected before anything starts.
- While waiting for the console port, the start reports periodic progress (elapsed vs. budget) instead of going silent, so a long cold boot does not read as a hang.

## Changelog for maintainers
- Where to look first: the whole change is the `emulator-start` launch path in dev/local/mobile-android.ts, with new launch tests beside it in mobile-android.test.ts.
- `startAndroidEmulator` takes a new `StartAndroidEmulatorOptions` argument — timing knobs (`portWaitMs`, `pidWaitMs`, `pollIntervalMs`), a `report` sink, and test seams (tmux launch/kill, port listening, listening PIDs, process liveness/command, signals, sleep) — and it and `DEFAULT_CONSOLE_PORT_WAIT_MS` (120000) are exported for tests; the port scan and the ownership check route through the same seams.
- `KILO_EMULATOR_CONSOLE_PORT_WAIT_MS` is validated before anything launches: unset or empty falls back to the default; a non-numeric or non-positive value throws "must be a positive number of milliseconds".
- The failure teardown covers every window (PID wait, port wait, ownership check): kill the tmux session, re-check ownership by matching the process command against the launched AVD and port before signaling (guards a recycled PID), SIGTERM with a 5 s grace loop then SIGKILL, then remove the PID file and temp record.
- Error text changed: a PID that never gets recorded now fails with "did not record its PID within <N>s" instead of a raw file-not-found, and the port timeout names the configured budget, e.g. "did not bind console port 5554 within 0.25s" — update anything that matched the old "within 30s".
- The launch lock timeout rose from 120 s to 300 s: two slow holders that each consume the full console-port budget plus teardown must not starve a third slot's launch.
- New unit tests drive the launch through fakes: record-on-bind, port-budget miss, emulator exit mid-wait, PID never recorded, foreign port owner, progress lines, default vs. env override, and invalid override.
- Proved live on the VM: an emulator start with the wait forced to a value it cannot meet failed, and no qemu process for that AVD survived.

## E2E proof — log excerpts

```
[e1] Prove it live on the VM: start an emulator with the wait forced to a value  -> pass :: Android AVD kwf: KILO_EMULATOR_CONSOLE_PORT_WAIT_MS=200 failed with 'did not bind console port 5554 within 0.20s' (e1-timeout-fail.log) and leftover qemu was go
```

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/an-emulator-start-that-misse-3da6/e2e-mobile-app/e1-timeout-fail.log</code></summary>

```
Waiting for kilo-e2e-android-an-emulator-start-that-misse-3da6 console port 5554: 0s of 0.20s elapsed
emulator-start attempt 1 failed: kilo-e2e-android-an-emulator-start-that-misse-3da6 did not bind console port 5554 within 0.20s; see /tmp/kilo-e2e-android-an-emulator-start-that-misse-3da6.log
stopping leftovers and retrying once with --gpu swiftshader_indirect
Waiting for kilo-e2e-android-an-emulator-start-that-misse-3da6 console port 5554: 0s of 0.20s elapsed
kilo-e2e-android-an-emulator-start-that-misse-3da6 did not bind console port 5554 within 0.20s; see /tmp/kilo-e2e-android-an-emulator-start-that-misse-3da6.log
```
</details>

## Follow-ups (not changed here)
- 01-dismiss-dialogs.png,01-login-verify-code.png — Completely black frame with no status bar, content, or loading indicator.