### PR TITLE
Alert admins about actionable GDPR queue items

### DIFF
--- a/apps/web/src/app/api/cron/user-deletion-attention-summary/route.test.ts
+++ b/apps/web/src/app/api/cron/user-deletion-attention-summary/route.test.ts
@@ -1,0 +1,61 @@
+jest.mock('@/lib/config.server', () => ({ CRON_SECRET: 'cron-secret' }));
+jest.mock('@/lib/user/deletion-queue/deletion-attention-slack-summary', () => ({
+  sendUserDeletionAttentionSlackSummary: jest.fn(),
+}));
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
+
+import { captureException } from '@sentry/nextjs';
+import { sendUserDeletionAttentionSlackSummary } from '@/lib/user/deletion-queue/deletion-attention-slack-summary';
+import { GET } from './route';
+
+const mockSendSummary = jest.mocked(sendUserDeletionAttentionSlackSummary);
+const mockCaptureException = jest.mocked(captureException);
+
+function request(authorization?: string): Request {
+  return new Request('http://localhost:3000/api/cron/user-deletion-attention-summary', {
+    headers: authorization ? { authorization } : undefined,
+  });
+}
+
+describe('GET /api/cron/user-deletion-attention-summary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects unauthorized requests without reading the summary', async () => {
+    const response = await GET(request('Bearer wrong-secret'));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    expect(mockSendSummary).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['an empty current-state summary', { checked: 4, actionable: 0, listed: 0 }],
+    ['a configuration-skipped summary', { checked: 4, actionable: 2, listed: 2 }],
+  ])('returns 200 for %s', async (_description, counts) => {
+    mockSendSummary.mockResolvedValue(counts);
+
+    const response = await GET(request('Bearer cron-secret'));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ success: true, counts });
+    expect(mockSendSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures summary query or delivery failures and returns 500', async () => {
+    const error = new Error('Slack unavailable');
+    mockSendSummary.mockRejectedValue(error);
+
+    const response = await GET(request('Bearer cron-secret'));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: 'Failed to send user deletion attention summary',
+    });
+    expect(mockCaptureException).toHaveBeenCalledWith(error, {
+      tags: { endpoint: 'cron/user-deletion-attention-summary' },
+    });
+  });
+});

--- a/apps/web/src/app/api/cron/user-deletion-attention-summary/route.ts
+++ b/apps/web/src/app/api/cron/user-deletion-attention-summary/route.ts
@@ -1,0 +1,35 @@
+import { captureException } from '@sentry/nextjs';
+import { NextResponse } from 'next/server';
+
+import { CRON_SECRET } from '@/lib/config.server';
+import { isCronAuthorizationValid } from '@/lib/cron-auth';
+import { sendUserDeletionAttentionSlackSummary } from '@/lib/user/deletion-queue/deletion-attention-slack-summary';
+
+if (!CRON_SECRET) {
+  throw new Error('CRON_SECRET is not configured in environment variables');
+}
+
+export async function GET(request: Request) {
+  if (!isCronAuthorizationValid(request.headers.get('authorization'), CRON_SECRET)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const counts = await sendUserDeletionAttentionSlackSummary();
+    console.info('[cron/user-deletion-attention-summary] completed', counts);
+
+    return NextResponse.json({ success: true, counts, timestamp: new Date().toISOString() });
+  } catch (error) {
+    console.error('[cron/user-deletion-attention-summary] failed', {
+      errorName: error instanceof Error ? error.name : 'UnknownError',
+    });
+    captureException(error, {
+      tags: { endpoint: 'cron/user-deletion-attention-summary' },
+    });
+
+    return NextResponse.json(
+      { success: false, error: 'Failed to send user deletion attention summary' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/lib/user/deletion-queue/deletion-attention-slack-summary.test.ts
+++ b/apps/web/src/lib/user/deletion-queue/deletion-attention-slack-summary.test.ts
@@ -1,0 +1,265 @@
+import { eq, sql } from 'drizzle-orm';
+import { user_deletion_requests, user_deletion_steps } from '@kilocode/db/schema';
+import { UserDeletionRequestStatus, UserDeletionStepStatus } from '@kilocode/db/schema-types';
+import { cleanupDbForTest, db } from '@/lib/drizzle';
+import { enqueueUserDeletionTargets } from '@/lib/user/deletion-queue/deletion-enqueue';
+import {
+  buildUserDeletionAttentionSlackNotification,
+  getUserDeletionAttentionSnapshot,
+  sendUserDeletionAttentionSlackSummary,
+  type UserDeletionAttentionSnapshot,
+} from '@/lib/user/deletion-queue/deletion-attention-slack-summary';
+import { DUPLICATE_OF_ACTIVE_REQUEST_ATTENTION_CODE } from '@/lib/user/deletion-queue/deletion-types';
+
+async function enqueueRequest(): Promise<string> {
+  const email = `deletion-attention-${crypto.randomUUID()}@example.com`;
+  const [result] = await enqueueUserDeletionTargets({
+    actor: { kiloUserId: null },
+    targets: [{ email }],
+  });
+  expect(result).toMatchObject({ status: 'enqueued' });
+  if (result?.status !== 'enqueued') throw new Error('Expected a deletion request');
+  return result.requestId;
+}
+
+async function setStepAttention(
+  requestId: string,
+  status: UserDeletionStepStatus,
+  stepOffset = 0
+): Promise<void> {
+  const steps = await db
+    .select({ id: user_deletion_steps.id })
+    .from(user_deletion_steps)
+    .where(eq(user_deletion_steps.request_id, requestId));
+  const step = steps[stepOffset];
+  if (!step) throw new Error('Expected a deletion step');
+  await db.update(user_deletion_steps).set({ status }).where(eq(user_deletion_steps.id, step.id));
+}
+
+function snapshot(
+  overrides: Partial<UserDeletionAttentionSnapshot> = {}
+): UserDeletionAttentionSnapshot {
+  return {
+    snapshotAt: '2026-01-03T03:04:00.000Z',
+    checked: 2,
+    actionable: 2,
+    statusCounts: { pending: 1, inProgress: 1, finalizing: 0 },
+    attentionSourceCounts: { preflight: 1, steps: 2, overlapping: 1 },
+    details: [
+      {
+        requestId: 'request-one',
+        status: UserDeletionRequestStatus.Pending,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        hasPreflightAttention: true,
+        hasStepAttention: false,
+      },
+      {
+        requestId: 'request-two',
+        status: UserDeletionRequestStatus.InProgress,
+        createdAt: '2026-01-03T00:59:00.000Z',
+        hasPreflightAttention: true,
+        hasStepAttention: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('getUserDeletionAttentionSnapshot', () => {
+  beforeEach(async () => {
+    await cleanupDbForTest();
+  });
+
+  it('classifies active requests once at request level', async () => {
+    const duplicateOnly = await enqueueRequest();
+    const duplicateWithBlockedStep = await enqueueRequest();
+    const preflightAttention = await enqueueRequest();
+    const inProgressBlockedStep = await enqueueRequest();
+    const finalizingBlockedStep = await enqueueRequest();
+    const severalBlockedSteps = await enqueueRequest();
+    const overlappingAttention = await enqueueRequest();
+    const terminalAttention = await enqueueRequest();
+
+    await db
+      .update(user_deletion_requests)
+      .set({ preflight_attention_code: DUPLICATE_OF_ACTIVE_REQUEST_ATTENTION_CODE })
+      .where(eq(user_deletion_requests.id, duplicateOnly));
+    await db
+      .update(user_deletion_requests)
+      .set({ preflight_attention_code: DUPLICATE_OF_ACTIVE_REQUEST_ATTENTION_CODE })
+      .where(eq(user_deletion_requests.id, duplicateWithBlockedStep));
+    await setStepAttention(duplicateWithBlockedStep, UserDeletionStepStatus.NeedsAttention);
+
+    await db
+      .update(user_deletion_requests)
+      .set({ preflight_attention_code: 'missing_target_email' })
+      .where(eq(user_deletion_requests.id, preflightAttention));
+
+    await db
+      .update(user_deletion_requests)
+      .set({ status: UserDeletionRequestStatus.InProgress })
+      .where(eq(user_deletion_requests.id, inProgressBlockedStep));
+    await setStepAttention(inProgressBlockedStep, UserDeletionStepStatus.NeedsAttention);
+
+    await db
+      .update(user_deletion_requests)
+      .set({ status: UserDeletionRequestStatus.Finalizing })
+      .where(eq(user_deletion_requests.id, finalizingBlockedStep));
+    await setStepAttention(finalizingBlockedStep, UserDeletionStepStatus.ManualActionRequired);
+
+    await setStepAttention(severalBlockedSteps, UserDeletionStepStatus.NeedsAttention);
+    await setStepAttention(severalBlockedSteps, UserDeletionStepStatus.ManualActionRequired, 1);
+
+    await db
+      .update(user_deletion_requests)
+      .set({ preflight_attention_code: 'protected_self' })
+      .where(eq(user_deletion_requests.id, overlappingAttention));
+    await setStepAttention(overlappingAttention, UserDeletionStepStatus.NeedsAttention);
+
+    await db
+      .update(user_deletion_requests)
+      .set({
+        status: UserDeletionRequestStatus.Completed,
+        completed_at: sql`now()`,
+        target_email: null,
+        preflight_attention_code: 'protected_self',
+      })
+      .where(eq(user_deletion_requests.id, terminalAttention));
+    await setStepAttention(terminalAttention, UserDeletionStepStatus.NeedsAttention);
+
+    const result = await getUserDeletionAttentionSnapshot();
+
+    expect(result).toMatchObject({
+      checked: 7,
+      actionable: 6,
+      statusCounts: { pending: 4, inProgress: 1, finalizing: 1 },
+      attentionSourceCounts: { preflight: 2, steps: 5, overlapping: 1 },
+    });
+    expect(result.details).toHaveLength(6);
+    expect(result.details.map(detail => detail.requestId)).toEqual(
+      expect.arrayContaining([
+        duplicateWithBlockedStep,
+        preflightAttention,
+        inProgressBlockedStep,
+        finalizingBlockedStep,
+        severalBlockedSteps,
+        overlappingAttention,
+      ])
+    );
+    expect(result.details.map(detail => detail.requestId)).not.toEqual(
+      expect.arrayContaining([duplicateOnly, terminalAttention])
+    );
+
+    const notification = buildUserDeletionAttentionSlackNotification(result);
+    expect(JSON.stringify(notification)).not.toContain('deletion-attention-');
+  });
+
+  it('keeps exact counts when a detail-only attention source is omitted', async () => {
+    for (let index = 0; index < 25; index += 1) {
+      const requestId = await enqueueRequest();
+      await db
+        .update(user_deletion_requests)
+        .set({
+          created_at: sql`now() - interval '1 day'`,
+          preflight_attention_code: 'missing_target_email',
+        })
+        .where(eq(user_deletion_requests.id, requestId));
+    }
+    const omittedStepOnly = await enqueueRequest();
+    await setStepAttention(omittedStepOnly, UserDeletionStepStatus.NeedsAttention);
+
+    const result = await getUserDeletionAttentionSnapshot();
+
+    expect(result).toMatchObject({
+      checked: 26,
+      actionable: 26,
+      statusCounts: { pending: 26, inProgress: 0, finalizing: 0 },
+      attentionSourceCounts: { preflight: 25, steps: 1, overlapping: 0 },
+    });
+    expect(result.details).toHaveLength(25);
+    expect(result.details.map(detail => detail.requestId)).not.toContain(omittedStepOnly);
+  });
+});
+
+describe('buildUserDeletionAttentionSlackNotification', () => {
+  it('renders totals, bounded linked details, deterministic ages, and no PII', () => {
+    const fixtureEmail = 'must-not-appear@example.com';
+    const statuses = [
+      UserDeletionRequestStatus.Pending,
+      UserDeletionRequestStatus.InProgress,
+      UserDeletionRequestStatus.Finalizing,
+    ];
+    const details = Array.from({ length: 25 }, (_, index) => ({
+      requestId: `request-${index + 1}`,
+      status: statuses[index % statuses.length] ?? UserDeletionRequestStatus.Pending,
+      createdAt: index === 0 ? '2026-01-01T00:00:00.000Z' : '2026-01-03T00:59:00.000Z',
+      hasPreflightAttention: true,
+      hasStepAttention: index % 2 === 0,
+    }));
+    const notification = buildUserDeletionAttentionSlackNotification(
+      snapshot({
+        checked: 28,
+        actionable: 28,
+        statusCounts: { pending: 10, inProgress: 9, finalizing: 9 },
+        attentionSourceCounts: { preflight: 20, steps: 15, overlapping: 7 },
+        details,
+      })
+    );
+    const rendered = JSON.stringify(notification);
+
+    expect(notification.text).toContain('GDPR deletion attention: 28 actionable requests.');
+    expect(notification.text).toContain('pending 10, in progress 9, finalizing 9');
+    expect(notification.text).toContain('request-1> · pending · 2d 3h');
+    expect(rendered).toContain('request-2> · in_progress · 2h 5m');
+    expect(rendered).toContain('request-3> · finalizing · 2h 5m');
+    expect(rendered).toContain('request-25> · pending · 2h 5m');
+    expect(rendered).toContain('/admin/deletion-queue/request-25');
+    expect(rendered).toContain('3 additional actionable requests not shown.');
+    expect(rendered).not.toContain(fixtureEmail);
+    expect(notification.blocks).toHaveLength(10);
+    expect(notification.blocks?.length).toBeLessThanOrEqual(50);
+    expect(notification.unfurl_links).toBe(false);
+    expect(notification.unfurl_media).toBe(false);
+  });
+});
+
+describe('sendUserDeletionAttentionSlackSummary', () => {
+  it('skips the sender for an empty current-state snapshot', async () => {
+    const sendNotification = jest.fn();
+    const result = await sendUserDeletionAttentionSlackSummary({
+      getSnapshot: jest
+        .fn()
+        .mockResolvedValue(snapshot({ checked: 4, actionable: 0, details: [] })),
+      sendNotification,
+    });
+
+    expect(result).toEqual({ checked: 4, actionable: 0, listed: 0 });
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('sends one normal-config notification for actionable requests', async () => {
+    const sendNotification = jest.fn().mockResolvedValue(undefined);
+    const result = await sendUserDeletionAttentionSlackSummary({
+      getSnapshot: jest.fn().mockResolvedValue(snapshot()),
+      sendNotification,
+    });
+
+    expect(result).toEqual({ checked: 2, actionable: 2, listed: 2 });
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    expect(sendNotification.mock.calls[0]).toHaveLength(1);
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ unfurl_links: false, unfurl_media: false })
+    );
+  });
+
+  it('propagates sender failures for the next cron run', async () => {
+    const error = new Error('Slack unavailable');
+
+    await expect(
+      sendUserDeletionAttentionSlackSummary({
+        getSnapshot: jest.fn().mockResolvedValue(snapshot()),
+        sendNotification: jest.fn().mockRejectedValue(error),
+      })
+    ).rejects.toBe(error);
+  });
+});

--- a/apps/web/src/lib/user/deletion-queue/deletion-attention-slack-summary.ts
+++ b/apps/web/src/lib/user/deletion-queue/deletion-attention-slack-summary.ts
@@ -1,0 +1,349 @@
+import 'server-only';
+
+import { sql } from 'drizzle-orm';
+import { user_deletion_requests, user_deletion_steps } from '@kilocode/db/schema';
+import { UserDeletionRequestStatus, UserDeletionStepStatus } from '@kilocode/db/schema-types';
+import { APP_URL } from '@/lib/constants';
+import { db } from '@/lib/drizzle';
+import {
+  sendAdminSlackNotification,
+  type AdminSlackNotification,
+} from '@/lib/slack/admin-notifications';
+import {
+  ACTIVE_REQUEST_STATUSES,
+  DUPLICATE_OF_ACTIVE_REQUEST_ATTENTION_CODE,
+} from '@/lib/user/deletion-queue/deletion-types';
+
+const DETAIL_LIMIT = 25;
+const DETAILS_PER_BLOCK = 5;
+
+type DatabaseCount = string | number | bigint;
+
+type UserDeletionAttentionQueryRow = {
+  id: string | null;
+  status: UserDeletionRequestStatus | null;
+  created_at: string | Date | null;
+  snapshot_at: string | Date;
+  has_preflight_attention: boolean | null;
+  has_step_attention: boolean | null;
+  checked: DatabaseCount;
+  actionable: DatabaseCount;
+  pending: DatabaseCount;
+  in_progress: DatabaseCount;
+  finalizing: DatabaseCount;
+  preflight: DatabaseCount;
+  steps: DatabaseCount;
+  overlapping: DatabaseCount;
+};
+
+export type UserDeletionAttentionDetail = {
+  requestId: string;
+  status: UserDeletionRequestStatus;
+  createdAt: string;
+  hasPreflightAttention: boolean;
+  hasStepAttention: boolean;
+};
+
+export type UserDeletionAttentionSnapshot = {
+  snapshotAt: string;
+  checked: number;
+  actionable: number;
+  statusCounts: {
+    pending: number;
+    inProgress: number;
+    finalizing: number;
+  };
+  attentionSourceCounts: {
+    preflight: number;
+    steps: number;
+    overlapping: number;
+  };
+  details: UserDeletionAttentionDetail[];
+};
+
+export type UserDeletionAttentionSlackSummaryResult = {
+  checked: number;
+  actionable: number;
+  listed: number;
+};
+
+function normalizeCount(value: DatabaseCount): number {
+  const normalized = Number(value);
+  if (!Number.isSafeInteger(normalized) || normalized < 0) {
+    throw new Error('User deletion attention count is outside the supported range');
+  }
+  return normalized;
+}
+
+function normalizeTimestamp(value: string | Date): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('User deletion attention snapshot contains an invalid timestamp');
+  }
+  return date.toISOString();
+}
+
+function emptySnapshot(snapshotAt: string): UserDeletionAttentionSnapshot {
+  return {
+    snapshotAt,
+    checked: 0,
+    actionable: 0,
+    statusCounts: { pending: 0, inProgress: 0, finalizing: 0 },
+    attentionSourceCounts: { preflight: 0, steps: 0, overlapping: 0 },
+    details: [],
+  };
+}
+
+/**
+ * Reads a strongly consistent, request-root snapshot. Correlated EXISTS checks
+ * prevent multiple blocked steps from inflating request-level totals.
+ */
+export async function getUserDeletionAttentionSnapshot(): Promise<UserDeletionAttentionSnapshot> {
+  const activeStatuses = sql.join(
+    ACTIVE_REQUEST_STATUSES.map(status => sql`${status}`),
+    sql`, `
+  );
+  const attentionStepStatuses = sql.join(
+    [UserDeletionStepStatus.NeedsAttention, UserDeletionStepStatus.ManualActionRequired].map(
+      status => sql`${status}`
+    ),
+    sql`, `
+  );
+
+  const { rows } = await db.execute<UserDeletionAttentionQueryRow>(sql`
+    WITH request_attention AS (
+      SELECT
+        ${user_deletion_requests.id} AS id,
+        ${user_deletion_requests.status} AS status,
+        ${user_deletion_requests.created_at} AS created_at,
+        now() AS snapshot_at,
+        (
+          ${user_deletion_requests.preflight_attention_code} IS NOT NULL
+          AND ${user_deletion_requests.preflight_attention_code} <> ${DUPLICATE_OF_ACTIVE_REQUEST_ATTENTION_CODE}
+        ) AS has_preflight_attention,
+        EXISTS (
+          SELECT 1
+          FROM ${user_deletion_steps}
+          WHERE ${user_deletion_steps.request_id} = ${user_deletion_requests.id}
+            AND ${user_deletion_steps.status} IN (${attentionStepStatuses})
+        ) AS has_step_attention
+      FROM ${user_deletion_requests}
+      WHERE ${user_deletion_requests.status} IN (${activeStatuses})
+    ),
+    totals AS (
+      SELECT
+        COALESCE(MAX(snapshot_at), now()) AS snapshot_at,
+        COUNT(*) AS checked,
+        COUNT(*) FILTER (WHERE has_preflight_attention OR has_step_attention) AS actionable,
+        COUNT(*) FILTER (
+          WHERE (has_preflight_attention OR has_step_attention)
+            AND status = ${UserDeletionRequestStatus.Pending}
+        ) AS pending,
+        COUNT(*) FILTER (
+          WHERE (has_preflight_attention OR has_step_attention)
+            AND status = ${UserDeletionRequestStatus.InProgress}
+        ) AS in_progress,
+        COUNT(*) FILTER (
+          WHERE (has_preflight_attention OR has_step_attention)
+            AND status = ${UserDeletionRequestStatus.Finalizing}
+        ) AS finalizing,
+        COUNT(*) FILTER (WHERE has_preflight_attention) AS preflight,
+        COUNT(*) FILTER (WHERE has_step_attention) AS steps,
+        COUNT(*) FILTER (WHERE has_preflight_attention AND has_step_attention) AS overlapping
+      FROM request_attention
+    ),
+    details AS (
+      SELECT id, status, created_at, has_preflight_attention, has_step_attention
+      FROM request_attention
+      WHERE has_preflight_attention OR has_step_attention
+      ORDER BY created_at ASC, id ASC
+      LIMIT ${DETAIL_LIMIT}
+    )
+    SELECT
+      NULL::uuid AS id,
+      NULL::text AS status,
+      NULL::timestamptz AS created_at,
+      snapshot_at,
+      NULL::boolean AS has_preflight_attention,
+      NULL::boolean AS has_step_attention,
+      checked,
+      actionable,
+      pending,
+      in_progress,
+      finalizing,
+      preflight,
+      steps,
+      overlapping
+    FROM totals
+    UNION ALL
+    SELECT
+      details.id,
+      details.status,
+      details.created_at,
+      totals.snapshot_at,
+      details.has_preflight_attention,
+      details.has_step_attention,
+      totals.checked,
+      totals.actionable,
+      totals.pending,
+      totals.in_progress,
+      totals.finalizing,
+      totals.preflight,
+      totals.steps,
+      totals.overlapping
+    FROM details
+    CROSS JOIN totals
+    ORDER BY created_at ASC NULLS FIRST, id ASC NULLS FIRST
+  `);
+
+  const totals = rows[0];
+  if (!totals) {
+    throw new Error('User deletion attention snapshot did not return totals');
+  }
+
+  const snapshot = emptySnapshot(normalizeTimestamp(totals.snapshot_at));
+  snapshot.checked = normalizeCount(totals.checked);
+  snapshot.actionable = normalizeCount(totals.actionable);
+  snapshot.statusCounts = {
+    pending: normalizeCount(totals.pending),
+    inProgress: normalizeCount(totals.in_progress),
+    finalizing: normalizeCount(totals.finalizing),
+  };
+  snapshot.attentionSourceCounts = {
+    preflight: normalizeCount(totals.preflight),
+    steps: normalizeCount(totals.steps),
+    overlapping: normalizeCount(totals.overlapping),
+  };
+
+  snapshot.details = rows.slice(1).flatMap(row => {
+    if (!row.id || !row.status || !row.created_at) {
+      throw new Error('User deletion attention snapshot contains an invalid detail row');
+    }
+    return [
+      {
+        requestId: row.id,
+        status: row.status,
+        createdAt: normalizeTimestamp(row.created_at),
+        hasPreflightAttention: row.has_preflight_attention === true,
+        hasStepAttention: row.has_step_attention === true,
+      },
+    ];
+  });
+
+  return snapshot;
+}
+
+function formatAge(snapshotAt: string, createdAt: string): string {
+  const ageMinutes = Math.max(
+    0,
+    Math.floor((new Date(snapshotAt).getTime() - new Date(createdAt).getTime()) / 60_000)
+  );
+  const days = Math.floor(ageMinutes / (24 * 60));
+  const hours = Math.floor((ageMinutes % (24 * 60)) / 60);
+  const minutes = ageMinutes % 60;
+
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m`;
+  return 'under 1m';
+}
+
+function requestLink(requestId: string): string {
+  return `${APP_URL}/admin/deletion-queue/${encodeURIComponent(requestId)}`;
+}
+
+function detailLine(detail: UserDeletionAttentionDetail, snapshotAt: string): string {
+  return `<${requestLink(detail.requestId)}|${detail.requestId}> · ${detail.status} · ${formatAge(snapshotAt, detail.createdAt)}`;
+}
+
+export function buildUserDeletionAttentionSlackNotification(
+  snapshot: UserDeletionAttentionSnapshot
+): AdminSlackNotification {
+  const listedDetails = snapshot.details.slice(0, DETAIL_LIMIT);
+  const listedLines = listedDetails.map(detail => detailLine(detail, snapshot.snapshotAt));
+  const omitted = snapshot.actionable - listedDetails.length;
+  const text = [
+    `GDPR deletion attention: ${snapshot.actionable} actionable request${snapshot.actionable === 1 ? '' : 's'}.`,
+    `Status: pending ${snapshot.statusCounts.pending}, in progress ${snapshot.statusCounts.inProgress}, finalizing ${snapshot.statusCounts.finalizing}.`,
+    `Sources: preflight ${snapshot.attentionSourceCounts.preflight}, blocked steps ${snapshot.attentionSourceCounts.steps}, both ${snapshot.attentionSourceCounts.overlapping}.`,
+    ...listedLines,
+    omitted > 0 ? `${omitted} additional request${omitted === 1 ? '' : 's'} omitted.` : null,
+    `Queue: ${APP_URL}/admin/deletion-queue`,
+  ]
+    .filter((line): line is string => line !== null)
+    .join('\n');
+
+  const blocks: NonNullable<AdminSlackNotification['blocks']> = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: 'GDPR deletion attention', emoji: true },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*${snapshot.actionable} actionable request${snapshot.actionable === 1 ? '' : 's'}* · Pending ${snapshot.statusCounts.pending} · In progress ${snapshot.statusCounts.inProgress} · Finalizing ${snapshot.statusCounts.finalizing}`,
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Attention sources* · Preflight ${snapshot.attentionSourceCounts.preflight} · Blocked steps ${snapshot.attentionSourceCounts.steps} · Both ${snapshot.attentionSourceCounts.overlapping}`,
+      },
+    },
+  ];
+
+  for (let index = 0; index < listedLines.length; index += DETAILS_PER_BLOCK) {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: listedLines.slice(index, index + DETAILS_PER_BLOCK).join('\n'),
+      },
+    });
+  }
+
+  if (omitted > 0) {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `_${omitted} additional actionable request${omitted === 1 ? '' : 's'} not shown._`,
+      },
+    });
+  }
+
+  blocks.push({
+    type: 'context',
+    elements: [
+      {
+        type: 'mrkdwn',
+        text: `Snapshot: ${snapshot.snapshotAt} · <${APP_URL}/admin/deletion-queue|Open deletion queue>`,
+      },
+    ],
+  });
+
+  return { text, blocks, unfurl_links: false, unfurl_media: false };
+}
+
+type UserDeletionAttentionSlackSummaryDependencies = {
+  getSnapshot?: typeof getUserDeletionAttentionSnapshot;
+  sendNotification?: typeof sendAdminSlackNotification;
+};
+
+export async function sendUserDeletionAttentionSlackSummary({
+  getSnapshot = getUserDeletionAttentionSnapshot,
+  sendNotification = sendAdminSlackNotification,
+}: UserDeletionAttentionSlackSummaryDependencies = {}): Promise<UserDeletionAttentionSlackSummaryResult> {
+  const snapshot = await getSnapshot();
+  const result = {
+    checked: snapshot.checked,
+    actionable: snapshot.actionable,
+    listed: snapshot.details.length,
+  };
+  if (snapshot.actionable === 0) return result;
+
+  await sendNotification(buildUserDeletionAttentionSlackNotification(snapshot));
+  return result;
+}

--- a/apps/web/src/lib/user/deletion-queue/deletion-preflight.ts
+++ b/apps/web/src/lib/user/deletion-queue/deletion-preflight.ts
@@ -18,6 +18,7 @@ import {
 import { resolveTicketEmail } from '@/lib/user/deletion-queue/deletion-ticket-resolve';
 import {
   ACTIVE_REQUEST_STATUSES,
+  DUPLICATE_OF_ACTIVE_REQUEST_ATTENTION_CODE,
   type DeletionPreflightOutcome,
 } from '@/lib/user/deletion-queue/deletion-types';
 
@@ -135,7 +136,10 @@ async function applyResolvedTicketEmail(
     )
     .limit(1);
   if (collision && collision.id !== request.id) {
-    return { kind: 'needs_attention', errorCode: 'duplicate_of_active_request' };
+    return {
+      kind: 'needs_attention',
+      errorCode: DUPLICATE_OF_ACTIVE_REQUEST_ATTENTION_CODE,
+    };
   }
 
   const currentUsers = (

--- a/apps/web/src/lib/user/deletion-queue/deletion-types.ts
+++ b/apps/web/src/lib/user/deletion-queue/deletion-types.ts
@@ -87,3 +87,5 @@ export const ACTIVE_REQUEST_STATUSES = [
   UserDeletionRequestStatus.InProgress,
   UserDeletionRequestStatus.Finalizing,
 ] as const;
+
+export const DUPLICATE_OF_ACTIVE_REQUEST_ATTENTION_CODE = 'duplicate_of_active_request';

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -97,6 +97,10 @@
       "schedule": "* * * * *"
     },
     {
+      "path": "/api/cron/user-deletion-attention-summary",
+      "schedule": "0 12 * * *"
+    },
+    {
       "path": "/api/cron/dispatch-pending-code-reviews",
       "schedule": "*/10 * * * *"
     },


### PR DESCRIPTION
## Summary
- add a daily Slack summary for active GDPR deletion requests that need operator attention
- exclude duplicate-only preflight collisions while retaining independently blocked tasks
- keep messages PII-minimal and link operators to the existing admin queue

## Verification
- `pnpm --filter web exec jest --runInBand apps/web/src/lib/user/deletion-queue/deletion-preflight.test.ts apps/web/src/lib/user/deletion-queue/deletion-attention-slack-summary.test.ts apps/web/src/lib/slack/admin-notifications.test.ts apps/web/src/app/api/cron/user-deletion-attention-summary/route.test.ts` (22 tests passed)
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- changed-file formatting, `git diff --check`, and cron JSON validation
- local authenticated cron E2E with isolated PostgreSQL and loopback webhook capture: actionable requests sent once; duplicate-only and terminal requests excluded; empty second run sent no webhook

## Limitation
- webhook payload delivery was verified through a local capture endpoint; Slack channel rendering was not exercised