### PR TITLE
fix(cloud-agent-next): keep cheap fields on persisted replay events

### DIFF
--- a/apps/mobile/src/components/agents/part-types.test.ts
+++ b/apps/mobile/src/components/agents/part-types.test.ts
@@ -87,6 +87,14 @@ describe('isPatchPart', () => {
   });
 });
 
+describe('isPartStreaming', () => {
+  it('does not treat a reasoning part with no time as streaming', () => {
+    const part = makeReasoningPart('thinking');
+    delete (part as { time?: unknown }).time;
+    expect(isPartStreaming(part)).toBe(false);
+  });
+});
+
 describe('shouldRenderReasoningPart', () => {
   it('does not render a completed reasoning part with empty text', () => {
     const part = makeReasoningPart('', true);

--- a/apps/mobile/src/components/agents/part-types.ts
+++ b/apps/mobile/src/components/agents/part-types.ts
@@ -52,7 +52,7 @@ export function isPartStreaming(part: Part): boolean {
     return !part.time?.end;
   }
   if (part.type === 'reasoning') {
-    return !part.time.end;
+    return part.time !== undefined && !part.time.end;
   }
   if (part.type === 'tool') {
     return part.state.status === 'pending' || part.state.status === 'running';

--- a/apps/mobile/src/components/agents/part-types.ts
+++ b/apps/mobile/src/components/agents/part-types.ts
@@ -47,12 +47,16 @@ export function isCompactionPart(part: Part): part is CompactionPart {
   return part.type === 'compaction';
 }
 
+function isOpenEndedTime(time: { end?: number } | undefined): boolean {
+  return time !== undefined && !time.end;
+}
+
 export function isPartStreaming(part: Part): boolean {
   if (part.type === 'text') {
     return !part.time?.end;
   }
   if (part.type === 'reasoning') {
-    return part.time !== undefined && !part.time.end;
+    return isOpenEndedTime(part.time);
   }
   if (part.type === 'tool') {
     return part.state.status === 'pending' || part.state.status === 'running';

--- a/apps/web/src/components/cloud-agent-next/reasoning-presentation.test.ts
+++ b/apps/web/src/components/cloud-agent-next/reasoning-presentation.test.ts
@@ -1,6 +1,7 @@
 import { getReasoningHeader, getReasoningPresentation } from './reasoning-presentation';
 
 it.each([
+  [undefined, undefined, false, 'Thought'],
   [undefined, { start: 0 }, true, 'Thinking'],
   ['Inspect the parser', { start: 0 }, true, 'Thinking: Inspect the parser'],
   [undefined, { start: 0 }, false, 'Thought'],

--- a/apps/web/src/components/cloud-agent-next/reasoning-presentation.ts
+++ b/apps/web/src/components/cloud-agent-next/reasoning-presentation.ts
@@ -10,12 +10,12 @@ function formatReasoningDuration(ms: number): string {
 
 export function getReasoningHeader(
   title: string | undefined,
-  time: ReasoningPart['time'],
+  time: ReasoningPart['time'] | undefined,
   streaming: boolean
 ): string {
   const label = streaming ? 'Thinking' : 'Thought';
   const duration =
-    !streaming && time.end !== undefined
+    !streaming && time?.end !== undefined
       ? formatReasoningDuration(Math.max(0, time.end - time.start))
       : undefined;
   const detail = [title, duration].filter(Boolean).join(' · ');

--- a/apps/web/src/components/cloud-agent-next/types.test.ts
+++ b/apps/web/src/components/cloud-agent-next/types.test.ts
@@ -51,6 +51,14 @@ const encryptedMetadata = [
   },
 ] satisfies { name: string; metadata: ReasoningPart['metadata'] }[];
 
+describe('isPartStreaming', () => {
+  it('does not treat a reasoning part with no time as streaming', () => {
+    const part = makeReasoningPart('thinking');
+    delete (part as { time?: unknown }).time;
+    expect(isPartStreaming(part)).toBe(false);
+  });
+});
+
 describe('shouldRenderReasoningPart', () => {
   it.each([
     { name: 'empty', text: '' },

--- a/apps/web/src/components/cloud-agent-next/types.ts
+++ b/apps/web/src/components/cloud-agent-next/types.ts
@@ -221,13 +221,8 @@ export function isAssistantMessage(message: OpenCodeMessage): message is OpenCod
  * V2 streaming detection: absence of time.end indicates streaming.
  */
 export function isPartStreaming(part: Part): boolean {
-  // TextPart has optional time
-  if (isTextPart(part)) {
+  if (isTextPart(part) || isReasoningPart(part)) {
     return part.time !== undefined && part.time.end === undefined;
-  }
-  // ReasoningPart has required time
-  if (isReasoningPart(part)) {
-    return part.time.end === undefined;
   }
   // ToolPart - check state
   if (isToolPart(part)) {

--- a/packages/cloud-agent-sdk/src/session-manager.test.ts
+++ b/packages/cloud-agent-sdk/src/session-manager.test.ts
@@ -24,7 +24,7 @@ import type {
 } from './session';
 import type { JotaiSessionStorage } from './storage/jotai';
 import { createChatProcessor } from './chat-processor';
-import type { AssistantMessage, UserMessage, TextPart } from '@kilocode/app-shared/opencode';
+import type { AssistantMessage, UserMessage, TextPart, Part } from '@kilocode/app-shared/opencode';
 import { kiloId, cloudAgentId, stubUserMessage, stubTextPart, makeSnapshot } from './test-helpers';
 import type {
   CloudStatus,
@@ -1163,6 +1163,58 @@ describe('createSessionManager', () => {
         model: { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
         variant: 'high',
       });
+    });
+
+    it('ignores a live user message that omits model', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-1'));
+      mockSessionCallbacks.onSessionCreated?.({
+        id: 'ses-1',
+        model: { providerID: 'openai', id: 'gpt-5' },
+      });
+      mockSessionCallbacks.onReplayComplete?.();
+
+      const info = stubUserMessage({
+        id: 'msg-slim',
+        sessionID: 'ses-1',
+      });
+      delete (info as { model?: unknown }).model;
+
+      expect(() => {
+        mockSessionCallbacks.onEvent?.({ type: 'message.updated', info });
+      }).not.toThrow();
+      expect(atomValue(config.store, mgr.atoms.observedModel)).toEqual({
+        model: { providerID: 'openai', modelID: 'gpt-5' },
+      });
+    });
+
+    it('splits messages when a completed reasoning part omits time', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      mockSession.connect.mockImplementation(() => {
+        mockSessionCallbacks.onSessionCreated?.({ id: 'ses-root' });
+      });
+      await mgr.switchSession(kiloId('ses-root'));
+      if (!latestStorage) throw new Error('expected session storage');
+
+      const completed = createStoredAssistantMessage('msg-slim', 'ses-root', {
+        time: { created: 1, completed: 2 },
+      });
+      latestStorage.upsertMessage(completed.info);
+      latestStorage.upsertPart(completed.info.id, {
+        type: 'reasoning',
+        id: 'part-slim',
+        sessionID: 'ses-root',
+        messageID: completed.info.id,
+        text: 'thinking',
+      } as Part);
+
+      expect(() => atomValue(config.store, mgr.atoms.staticMessages)).not.toThrow();
+      expect(atomValue<StoredMessage[]>(config.store, mgr.atoms.staticMessages)).toHaveLength(1);
+      expect(atomValue<StoredMessage[]>(config.store, mgr.atoms.dynamicMessages)).toHaveLength(0);
     });
 
     it('keeps session metadata above the catalog current model', async () => {

--- a/packages/cloud-agent-sdk/src/session-manager.ts
+++ b/packages/cloud-agent-sdk/src/session-manager.ts
@@ -543,8 +543,8 @@ function isMessageStreaming(msg: StoredMessage): boolean {
   if (msg.info.role === 'assistant' && msg.info.error) return false;
   if (msg.info.role === 'assistant' && !msg.info.time.completed) return true;
   return msg.parts.some(part => {
-    if (part.type === 'text') return part.time !== undefined && part.time.end === undefined;
-    if (part.type === 'reasoning') return part.time.end === undefined;
+    if (part.type === 'text' || part.type === 'reasoning')
+      return part.time !== undefined && part.time.end === undefined;
     if (part.type === 'tool')
       return part.state.status === 'pending' || part.state.status === 'running';
     return false;
@@ -1911,7 +1911,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
                 }
               }
             }
-            if (canApplyMessageObservation) {
+            if (canApplyMessageObservation && event.info.model) {
               const selection = toModelSelection(event.info.model, event.info.variant);
               updateObservedModel(selection, 'message');
               clearOverrideIfDiverged(selection);

--- a/services/cloud-agent-next/src/shared/ingest-frame.test.ts
+++ b/services/cloud-agent-next/src/shared/ingest-frame.test.ts
@@ -6,6 +6,7 @@ import {
   estimateSerializedBytes,
   isLifecycleIngestEvent,
   prepareIngestFrame,
+  slimPersistedKilocodeEvent,
 } from './ingest-frame.js';
 import { MAX_INLINE_FILE_URL_LENGTH } from './trim-payload.js';
 import type { IngestEvent } from './protocol.js';
@@ -630,5 +631,208 @@ describe('IngestEventBuffer', () => {
         data: {},
       })
     ).toBe(false);
+  });
+});
+
+describe('slimPersistedKilocodeEvent', () => {
+  it('keeps cheap user message fields and drops summary diffs plus raw errors', () => {
+    expect(
+      slimPersistedKilocodeEvent({
+        event: 'message.updated',
+        properties: {
+          info: {
+            id: 'msg_user',
+            sessionID: 'kilo_1',
+            role: 'user',
+            model: { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+            variant: 'high',
+            agent: 'code',
+            time: { created: 1 },
+            summary: { title: 'compact', diffs: [{ before: 'large diff' }] },
+            error: { data: { message: 'failed', responseBody: 'private' } },
+          },
+        },
+      })
+    ).toEqual({
+      event: 'message.updated',
+      properties: {
+        info: {
+          id: 'msg_user',
+          sessionID: 'kilo_1',
+          role: 'user',
+          model: { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+          variant: 'high',
+          agent: 'code',
+          time: { created: 1 },
+          summary: { title: 'compact' },
+          error: 'Assistant request failed',
+        },
+      },
+    });
+  });
+
+  it('keeps cheap assistant identity fields', () => {
+    expect(
+      slimPersistedKilocodeEvent({
+        event: 'message.updated',
+        properties: {
+          info: {
+            id: 'msg_asst',
+            sessionID: 'kilo_1',
+            role: 'assistant',
+            parentID: 'msg_user',
+            providerID: 'anthropic',
+            modelID: 'claude-sonnet-4',
+            agent: 'code',
+            variant: 'high',
+            time: { created: 1, completed: 2 },
+          },
+        },
+      })
+    ).toEqual({
+      event: 'message.updated',
+      properties: {
+        info: {
+          id: 'msg_asst',
+          sessionID: 'kilo_1',
+          role: 'assistant',
+          parentID: 'msg_user',
+          providerID: 'anthropic',
+          modelID: 'claude-sonnet-4',
+          agent: 'code',
+          variant: 'high',
+          time: { created: 1, completed: 2 },
+        },
+      },
+    });
+  });
+
+  it('keeps reasoning text and time while dropping patch, snapshot, and data URLs', () => {
+    expect(
+      slimPersistedKilocodeEvent({
+        event: 'message.part.updated',
+        properties: {
+          sessionID: 'kilo_1',
+          part: {
+            type: 'reasoning',
+            id: 'part_1',
+            sessionID: 'kilo_1',
+            messageID: 'msg_asst',
+            text: 'thinking',
+            time: { start: 1 },
+            metadata: { diff: 'large' },
+            snapshot: { huge: true },
+            patch: 'large patch',
+            url: 'data:image/png;base64,abc',
+            source: { content: 'large source', text: { value: 'secret', start: 0, end: 1 } },
+          },
+        },
+      })
+    ).toEqual({
+      event: 'message.part.updated',
+      properties: {
+        sessionID: 'kilo_1',
+        part: {
+          type: 'reasoning',
+          id: 'part_1',
+          sessionID: 'kilo_1',
+          messageID: 'msg_asst',
+          text: 'thinking',
+          time: { start: 1 },
+          url: '',
+          source: { text: { value: '', start: 0, end: 1 } },
+        },
+      },
+    });
+  });
+
+  it('keeps trimmed tool input/output and drops tool metadata', () => {
+    expect(
+      slimPersistedKilocodeEvent({
+        event: 'message.part.updated',
+        properties: {
+          part: {
+            type: 'tool',
+            id: 'part_tool',
+            messageID: 'msg_asst',
+            state: {
+              status: 'running',
+              input: { path: 'src/a.ts' },
+              output: 'ok',
+              metadata: { diff: 'large' },
+            },
+          },
+        },
+      })
+    ).toEqual({
+      event: 'message.part.updated',
+      properties: {
+        part: {
+          type: 'tool',
+          id: 'part_tool',
+          messageID: 'msg_asst',
+          state: {
+            status: 'running',
+            input: { path: 'src/a.ts' },
+            output: 'ok',
+          },
+        },
+      },
+    });
+  });
+
+  it('drops wrapper top-level info and part aliases from persist payload', () => {
+    const info = {
+      id: 'msg_user',
+      role: 'user',
+      model: { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+      summary: { diffs: [{ before: 'large diff' }] },
+      error: { data: { message: 'failed', responseBody: 'private' } },
+    };
+    const messageProperties = { info };
+    expect(
+      slimPersistedKilocodeEvent({
+        ...messageProperties,
+        event: 'message.updated',
+        type: 'message.updated',
+        properties: messageProperties,
+      })
+    ).toEqual({
+      event: 'message.updated',
+      type: 'message.updated',
+      properties: {
+        info: {
+          id: 'msg_user',
+          role: 'user',
+          model: { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+          error: 'Assistant request failed',
+        },
+      },
+    });
+
+    const part = {
+      type: 'reasoning',
+      id: 'part_1',
+      text: 'thinking',
+      time: { start: 1 },
+      snapshot: { huge: true },
+      patch: 'large patch',
+    };
+    const partProperties = { sessionID: 'kilo_1', part };
+    expect(
+      slimPersistedKilocodeEvent({
+        ...partProperties,
+        event: 'message.part.updated',
+        type: 'message.part.updated',
+        properties: partProperties,
+      })
+    ).toEqual({
+      event: 'message.part.updated',
+      type: 'message.part.updated',
+      properties: {
+        sessionID: 'kilo_1',
+        part: { type: 'reasoning', id: 'part_1', text: 'thinking', time: { start: 1 } },
+      },
+    });
   });
 });

--- a/services/cloud-agent-next/src/shared/ingest-frame.ts
+++ b/services/cloud-agent-next/src/shared/ingest-frame.ts
@@ -197,33 +197,94 @@ function compactMessageUpdated(data: Record<string, unknown>): Record<string, un
   return out;
 }
 
+function omitExpensiveMessageInfo(info: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...info };
+  if (isRecord(out.summary)) {
+    const { diffs: _diffs, ...summaryRest } = out.summary;
+    if (Object.keys(summaryRest).length > 0) out.summary = summaryRest;
+    else delete out.summary;
+  }
+  if (out.error !== undefined && out.error !== null) {
+    const safeError = projectSafeAssistantError(out.error);
+    if (safeError !== undefined) out.error = safeError;
+    else delete out.error;
+  }
+  return out;
+}
+
+function omitExpensivePart(part: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...part };
+  delete out.snapshot;
+  delete out.patch;
+  delete out.metadata;
+
+  if (typeof out.url === 'string' && out.url.startsWith('data:')) {
+    out.url = '';
+  }
+
+  const source = out.source;
+  if (isRecord(source)) {
+    const nextSource: Record<string, unknown> = { ...source };
+    delete nextSource.content;
+    if (isRecord(nextSource.text)) {
+      nextSource.text = { ...nextSource.text, value: '' };
+    }
+    if (Object.keys(nextSource).length > 0) out.source = nextSource;
+    else delete out.source;
+  }
+
+  if (isRecord(out.state)) {
+    const { metadata: _metadata, ...stateRest } = out.state;
+    const state: Record<string, unknown> = { ...stateRest };
+    if (Array.isArray(state.attachments)) {
+      state.attachments = state.attachments.map((attachment): unknown =>
+        isRecord(attachment) ? omitExpensivePart(attachment) : attachment
+      );
+    }
+    out.state = state;
+  }
+
+  return out;
+}
+
+function persistedKilocodeEnvelope(
+  data: Record<string, unknown>,
+  properties: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { properties };
+  if (data.event !== undefined) out.event = data.event;
+  if (data.type !== undefined) out.type = data.type;
+  return out;
+}
+
 /**
- * Reduces entity-upserted message events to the fields that the Durable Object
- * coordinator needs for replay and assistant-message lookups. Live clients
- * receive the separately trimmed, complete event payload.
+ * Drops expensive blobs from entity-upserted message events before SQLite
+ * persist. Client stream replay uses this payload, so cheap fields (model,
+ * variant, time, text, tool status) stay. Live broadcasts still use the
+ * unspecialized public payload. Oversized ingest compaction is separate.
+ * Persist keeps only event, type, and sanitized properties so wrapper
+ * top-level info/part aliases are not stored.
  */
 export function slimPersistedKilocodeEvent(data: unknown): unknown {
   if (!isRecord(data)) return data;
 
   const eventName = kiloEventNameOf(data);
-  if (eventName === 'message.updated') return compactMessageUpdated(data);
+  if (eventName === 'message.updated') {
+    const properties = data.properties;
+    if (!isRecord(properties) || !isRecord(properties.info)) return data;
+    return persistedKilocodeEnvelope(data, {
+      ...properties,
+      info: omitExpensiveMessageInfo(properties.info),
+    });
+  }
   if (eventName !== 'message.part.updated') return data;
 
-  const out: Record<string, unknown> = { event: data.event, type: data.type };
   const properties = data.properties;
-  if (!isRecord(properties)) return out;
-
-  const compactProperties: Record<string, unknown> = {};
-  if (typeof properties.sessionID === 'string') compactProperties.sessionID = properties.sessionID;
-
-  const part = properties.part;
-  if (isRecord(part)) {
-    const compactPart = compactMessagePart(part);
-    if (part.type === 'text' && typeof part.text === 'string') compactPart.text = part.text;
-    compactProperties.part = compactPart;
-  }
-  out.properties = compactProperties;
-  return out;
+  if (!isRecord(properties) || !isRecord(properties.part)) return data;
+  return persistedKilocodeEnvelope(data, {
+    ...properties,
+    part: omitExpensivePart(properties.part),
+  });
 }
 
 function compactCommandsAvailable(data: Record<string, unknown>): Record<string, unknown> {

--- a/services/cloud-agent-next/src/websocket/ingest.test.ts
+++ b/services/cloud-agent-next/src/websocket/ingest.test.ts
@@ -250,6 +250,7 @@ describe('createIngestHandler', () => {
             sessionID: 'kilo_1',
             time: { completed: 123 },
             error: 'Assistant request failed',
+            metadata: 'large metadata',
           },
         },
       });
@@ -272,42 +273,29 @@ describe('createIngestHandler', () => {
       [
         'tool',
         { metadata: { diff: 'large tool diff' }, input: 'large input', output: 'large output' },
+        { input: 'large input', output: 'large output' },
       ],
-      ['file', { url: 'data:image/png;base64,large-image', source: { content: 'large source' } }],
-      ['patch', { patch: 'large patch body' }],
-      ['reasoning', { text: 'large reasoning body' }],
-    ])('persists slim %s parts while broadcasting their live payload', async (type, extraPart) => {
-      const eventQueries = createFakeEventQueries();
-      const broadcast = vi.fn();
-      const handler = createIngestHandler(
-        createFakeState(),
-        eventQueries,
-        SESSION_ID,
-        broadcast,
-        createFakeDOContext()
-      );
-      const ws = createFakeWebSocket(makeAttachment());
-      const properties = {
-        sessionID: 'kilo_1',
-        part: {
-          type,
-          id: `${type}_1`,
-          sessionID: 'kilo_1',
-          messageID: 'asst_1',
-          status: 'running',
-          state: { status: 'running', metadata: { diff: 'large state diff' } },
-          ...extraPart,
-        },
-      };
-
-      await handler.handleIngestMessage(
-        ws,
-        makeKilocodeMessage('message.part.updated', properties)
-      );
-
-      expect(JSON.parse(vi.mocked(eventQueries.upsert).mock.calls[0][0].payload)).toEqual({
-        event: 'message.part.updated',
-        properties: {
+      [
+        'file',
+        { url: 'data:image/png;base64,large-image', source: { content: 'large source' } },
+        { url: '' },
+      ],
+      ['patch', { patch: 'large patch body' }, {}],
+      ['reasoning', { text: 'large reasoning body' }, { text: 'large reasoning body' }],
+    ])(
+      'persists slim %s parts while broadcasting their live payload',
+      async (type, extraPart, persistedExtra) => {
+        const eventQueries = createFakeEventQueries();
+        const broadcast = vi.fn();
+        const handler = createIngestHandler(
+          createFakeState(),
+          eventQueries,
+          SESSION_ID,
+          broadcast,
+          createFakeDOContext()
+        );
+        const ws = createFakeWebSocket(makeAttachment());
+        const properties = {
           sessionID: 'kilo_1',
           part: {
             type,
@@ -315,16 +303,38 @@ describe('createIngestHandler', () => {
             sessionID: 'kilo_1',
             messageID: 'asst_1',
             status: 'running',
-            state: { status: 'running' },
+            state: { status: 'running', metadata: { diff: 'large state diff' } },
+            ...extraPart,
           },
-        },
-      });
-      expect(broadcast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          payload: JSON.stringify({ event: 'message.part.updated', properties }),
-        })
-      );
-    });
+        };
+
+        await handler.handleIngestMessage(
+          ws,
+          makeKilocodeMessage('message.part.updated', properties)
+        );
+
+        expect(JSON.parse(vi.mocked(eventQueries.upsert).mock.calls[0][0].payload)).toEqual({
+          event: 'message.part.updated',
+          properties: {
+            sessionID: 'kilo_1',
+            part: {
+              type,
+              id: `${type}_1`,
+              sessionID: 'kilo_1',
+              messageID: 'asst_1',
+              status: 'running',
+              state: { status: 'running' },
+              ...persistedExtra,
+            },
+          },
+        });
+        expect(broadcast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            payload: JSON.stringify({ event: 'message.part.updated', properties }),
+          })
+        );
+      }
+    );
 
     it('persists text content for text parts', async () => {
       const eventQueries = createFakeEventQueries();
@@ -1367,6 +1377,8 @@ describe('createIngestHandler', () => {
             sessionID: 'kilo_session_333',
             role: 'assistant',
             parentID: 'msg_user_333',
+            modelID: 'vendor/model',
+            providerID: 'kilo',
             error: 'Assistant request was rate limited',
           },
         },


### PR DESCRIPTION
## Summary

### Why

PR #5939 persist-slimmed entity-upserted kilocode events with an allowlist. Client `/stream` catch-up replays those SQLite rows, so user `message.updated` lost `model` and reasoning parts lost `time`. Replay then crashed (`providerID` / `end` on undefined). Live broadcast was unaffected. Persist still needs to drop expensive blobs, but cheap replay fields have to survive.

### What was done

- Change persist slim from an allowlist to a denylist of expensive blobs (`summary.diffs`, snapshots, patches, metadata, `data:` URLs, `source.content` / `source.text.value`, raw assistant errors).
- Keep cheap replay fields: `model`, `variant`, `agent`, `providerID`, `modelID`, `time`, text, tool input/output/status.
- Persist only `event`, `type`, and sanitized `properties`. Wrapper ingest duplicates `info`/`part` at the top level; those aliases are not stored.
- Leave live broadcast and oversized ingest compaction unchanged.

### High-level architecture

```mermaid
sequenceDiagram
  participant Wrapper
  participant Ingest as CA ingest WS
  participant SQLite as Session DO SQLite
  participant Client
  Wrapper->>Ingest: kilocode event (properties plus top-level aliases)
  Ingest->>Client: live broadcast (full public payload)
  Ingest->>SQLite: slimPersistedKilocodeEvent (denylist, no aliases)
  Client->>Ingest: /stream catch-up fromId=0
  Ingest->>Client: replay stored slim payload
```

### Architecture decision

**Decision:** Persist slim copies the event and drops known expensive fields; it does not allowlist coordinator fields.

**Context:** Stream catch-up uses the persisted payload as the client event. An allowlist that is sufficient for DO lookups is not sufficient for UI replay.

**Rationale:** Cheap fields are small and required by the client. A denylist matches “remove expensive blobs, keep the rest” without re-deriving the client contract in persist.

**Alternatives considered:**

- **Keep the allowlist and add model/time/text.** Would still omit the next cheap field the client needs, and would keep two sources of “what replay requires”.
- **Stop slimming persist.** Would restore replay but put snapshots, diffs, and data URLs back in SQLite.

**Consequences:** New expensive fields that are not on the denylist will be persisted until listed. Oversized ingest compaction remains an allowlist. Existing #5939 rows are not rewritten.

## Verification

- [ ] No manual replay against a live session. Confidence is from unit tests of `slimPersistedKilocodeEvent` and ingest persist/broadcast.

## Visual Changes

N/A

## Reviewer Notes

- Wrapper shape under test: `{ ...properties, event, type, properties }` from `wrapper/src/connection.ts`.
- Oversized compact (`compactMessageUpdated` / `compactMessagePartUpdated`) still drops `model` and `time` by design.
- Sessions that already stored #5939 allowlist rows will keep those thin payloads until the entity is upserted again.
- Automated checks run locally: `oxfmt` on the three files; `pnpm lint` in `cloud-agent-next`; `vitest run src/shared/ingest-frame.test.ts src/websocket/ingest.test.ts` (178 passed, 3 skipped); `tsgo --noEmit`.