### PR TITLE
fix(cloud-agent-next): hide slim replay reasoning with no text

### DIFF
--- a/apps/mobile/src/components/agents/part-types.test.ts
+++ b/apps/mobile/src/components/agents/part-types.test.ts
@@ -139,4 +139,10 @@ describe('shouldRenderReasoningPart', () => {
     expect(isPartStreaming(part)).toBe(true);
     expect(shouldRenderReasoningPart(part, false)).toBe(false);
   });
+
+  it('does not render a reasoning part with no text', () => {
+    const part = makeReasoningPart('thinking');
+    delete (part as { text?: unknown }).text;
+    expect(shouldRenderReasoningPart(part, false)).toBe(false);
+  });
 });

--- a/apps/mobile/src/components/agents/part-types.ts
+++ b/apps/mobile/src/components/agents/part-types.ts
@@ -64,9 +64,10 @@ export function isPartStreaming(part: Part): boolean {
   return false;
 }
 
+function hasReasoningText(text: string | undefined): boolean {
+  return text != null && text.trim() !== '';
+}
+
 export function shouldRenderReasoningPart(part: Part, _isStreaming: boolean): boolean {
-  if (!isReasoningPart(part)) {
-    return false;
-  }
-  return part.text.trim() !== '';
+  return isReasoningPart(part) && hasReasoningText(part.text);
 }

--- a/apps/web/src/components/cloud-agent-next/message-presentation.test.ts
+++ b/apps/web/src/components/cloud-agent-next/message-presentation.test.ts
@@ -381,6 +381,14 @@ describe('getVisibleAssistantParts', () => {
     ]);
   });
 
+  it('hides a reasoning part with no text and keeps the rest of the message', () => {
+    const slim = reasoningPart('slim-reasoning');
+    delete (slim as { text?: unknown }).text;
+    const answer = textPart('answer');
+
+    expect(getVisibleAssistantParts([slim, answer])).toEqual([answer]);
+  });
+
   it('preserves visible part identity without changing frozen parts or their input array', () => {
     const visible = [reasoningPart('reasoning-1'), toolPart('read-1'), textPart('answer')];
     const parts = [reasoningPart('hidden', '[REDACTED]'), ...visible];

--- a/apps/web/src/components/cloud-agent-next/types.test.ts
+++ b/apps/web/src/components/cloud-agent-next/types.test.ts
@@ -150,6 +150,12 @@ describe('shouldRenderReasoningPart', () => {
   it('does not render a non-reasoning part', () => {
     expect(shouldRenderReasoningPart(makeTextPart('hello'))).toBe(false);
   });
+
+  it('does not render a reasoning part with no text', () => {
+    const part = makeReasoningPart('thinking');
+    delete (part as { text?: unknown }).text;
+    expect(shouldRenderReasoningPart(part)).toBe(false);
+  });
 });
 
 describe('getCloudSessionCreationOperation', () => {

--- a/apps/web/src/components/cloud-agent-next/types.ts
+++ b/apps/web/src/components/cloud-agent-next/types.ts
@@ -169,16 +169,20 @@ export function isReasoningPart(part: Part): part is ReasoningPart {
   return part.type === 'reasoning';
 }
 
-/** Whether the reasoning expander has content worth showing. */
-export function shouldRenderReasoningPart(part: Part): boolean {
+function hasVisibleReasoningText(text: string | undefined): boolean {
+  if (text == null) return false;
   return (
-    isReasoningPart(part) &&
-    part.text
+    text
       .replaceAll('[REDACTED]', '')
       .replace(/<!--[\s\S]*?-->/g, '')
       .replace('<!--', '')
       .trim() !== ''
   );
+}
+
+/** Whether the reasoning expander has content worth showing. */
+export function shouldRenderReasoningPart(part: Part): boolean {
+  return isReasoningPart(part) && hasVisibleReasoningText(part.text);
 }
 
 /** Check if a part is a StepStartPart */


### PR DESCRIPTION
## Summary

### Why

PR #5939 persist-slimmed `message.part.updated` with an allowlist that kept `text` only for `type === 'text'`. Reasoning parts in those SQLite rows have no `text`. PR #5956 stopped the stream crash on missing `model`/`time`, so catch-up now reaches the UI.

`MessageBubble` → `getVisibleAssistantParts` → `shouldRenderReasoningPart` runs outside the part error boundary and called `part.text.replaceAll(...)`. The message appeared, then the message error boundary replaced it with "Failed to render message".

This affects chats persisted after #5939 and before #5956. Those rows are not rewritten.

### What was done

- Treat missing reasoning text as not renderable in `shouldRenderReasoningPart` (web and mobile).
- Keep the existing empty/redacted/comment hiding rules.
- Add regression coverage for a slim reasoning part next to a text part.

Live broadcast and persist slimming are unchanged. Reasoning text from those old rows stays hidden.

### High-level architecture

```mermaid
sequenceDiagram
  participant SQLite as Session DO SQLite
  participant Client
  participant UI as shouldRenderReasoningPart
  SQLite->>Client: replay #5939 reasoning part (no text)
  Client->>UI: getVisibleAssistantParts
  UI-->>Client: hide part (do not throw)
```

## Verification

- [x] `pnpm --filter web exec jest --runInBand src/components/cloud-agent-next/types.test.ts src/components/cloud-agent-next/message-presentation.test.ts` (96 passed)
- [x] `pnpm --filter kilo-app exec vitest run src/components/agents/part-types.test.ts` (16 passed)
- [x] oxlint on the changed files
- [ ] No live replay against a #5939 session

## Reviewer Notes

- Completed slim tool parts can still fail inside the part boundary (`state.input` missing). That is a separate path (`Failed to render tool part`).