### PR TITLE
Remove unused AI gateway Redis mirrors

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
@@ -1,7 +1,5 @@
 import { DirectUserByokInferenceProviderIdSchema } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import { db } from '@/lib/drizzle';
-import { redisClient } from '@/lib/redis';
-import { directByokModelsRedisKey } from '@/lib/redis-keys';
 import { direct_byok_model_lists } from '@kilocode/db/schema';
 import { eq, inArray } from 'drizzle-orm';
 import type { DirectByokModel } from './types';
@@ -10,10 +8,6 @@ import {
   parseOpenAICompatibleProviderModels,
   syncDirectByokModels,
 } from './sync-direct-byok';
-
-jest.mock('@/lib/redis', () => ({
-  redisClient: { set: jest.fn() },
-}));
 
 describe('parseOpenAICompatibleProviderModels', () => {
   test('parses Morph OpenAI-compatible model metadata', () => {
@@ -314,8 +308,6 @@ describe('parseModelsDevProviderModels', () => {
 
 describe('syncDirectByokModels database snapshots', () => {
   const providerId = 'nvidia-byok';
-  const providerKey = directByokModelsRedisKey(providerId);
-  const redisSet = jest.mocked(redisClient.set);
   const oldSyncedAt = '2020-01-02T03:04:05.000Z';
   const downloadedModels = {
     reasoner: {
@@ -362,7 +354,6 @@ describe('syncDirectByokModels database snapshots', () => {
           DirectUserByokInferenceProviderIdSchema.options
         )
       );
-    redisSet.mockReset().mockResolvedValue('OK');
     providerModels = downloadedModels;
     fetchAvailableModels = async () =>
       Response.json({ data: Object.values(providerModels).map(({ id }) => ({ id })) });
@@ -406,37 +397,7 @@ describe('syncDirectByokModels database snapshots', () => {
       .where(eq(direct_byok_model_lists.provider_id, providerId));
   }
 
-  function expectCachedModels(models: DirectByokModel[]) {
-    const cachedWrite = redisSet.mock.calls.find(([key]) => key === providerKey);
-    expect(cachedWrite?.[2]).toEqual({ ex: 604_800 });
-    const cachedModels = cachedWrite?.[1];
-    if (typeof cachedModels !== 'string') {
-      throw new Error('Expected a Redis SET with a serialized model list');
-    }
-    expect(JSON.parse(cachedModels)).toStrictEqual(models);
-  }
-
-  function waitForOtherProviderWrites(redisError?: Error) {
-    const pendingKeys = new Set(
-      redisSet.mock.calls.map(([key]) => key).filter(key => key !== providerKey)
-    );
-    const completed = Promise.withResolvers<void>();
-    redisSet.mockClear();
-    redisSet.mockImplementation(async key => {
-      if (key === providerKey) {
-        await completed.promise;
-        if (redisError) throw redisError;
-      } else {
-        pendingKeys.delete(key);
-        if (pendingKeys.size === 0) completed.resolve();
-      }
-      return 'OK';
-    });
-    if (pendingKeys.size === 0) completed.resolve();
-    return completed.promise;
-  }
-
-  test('persists the normalized download, defaults, and nested variants in PostgreSQL and Redis', async () => {
+  test('persists the normalized download, defaults, and nested variants in PostgreSQL', async () => {
     const startedAt = Date.now();
     const counts = await syncDirectByokModels();
     const snapshot = await readSnapshot();
@@ -448,12 +409,6 @@ describe('syncDirectByokModels database snapshots', () => {
     expect(Object.values(counts).reduce((sum, count) => sum + count, 0)).toBe(
       normalizedModels.length
     );
-    expectCachedModels(normalizedModels);
-    expect(redisSet).toHaveBeenCalledTimes(Object.keys(counts).length);
-    for (const [, , options] of redisSet.mock.calls) {
-      expect(options).toEqual({ ex: 604_800 });
-    }
-
     const snapshots = await db.select().from(direct_byok_model_lists);
     expect(snapshots.map(row => row.provider_id).sort()).toEqual(Object.keys(counts).sort());
     expect(snapshots.filter(row => row.provider_id !== providerId).map(row => row.models)).toEqual(
@@ -474,7 +429,6 @@ describe('syncDirectByokModels database snapshots', () => {
         limit: { context: 128_000, output: 64_000 },
       },
     };
-    redisSet.mockClear();
     const startedAt = Date.now();
 
     const counts = await syncDirectByokModels();
@@ -492,31 +446,25 @@ describe('syncDirectByokModels database snapshots', () => {
     expect(Date.parse(snapshot.synced_at)).toBeGreaterThanOrEqual(startedAt);
     expect(Date.parse(snapshot.synced_at)).toBeLessThanOrEqual(Date.now());
     expect(counts[providerId]).toBe(1);
-    expectCachedModels(snapshot.models);
   });
 
   test('persists a successful empty list over the previous snapshot', async () => {
     await syncDirectByokModels();
     await backdateSnapshot();
     fetchAvailableModels = async () => Response.json({ data: [] });
-    redisSet.mockClear();
-
     const counts = await syncDirectByokModels();
     const snapshot = await readSnapshot();
 
     expect(snapshot.models).toStrictEqual([]);
     expect(new Date(snapshot.synced_at).toISOString()).not.toBe(oldSyncedAt);
     expect(counts[providerId]).toBe(0);
-    expect(redisSet).toHaveBeenCalledWith(providerKey, '[]', { ex: 604_800 });
   });
 
   test('rejects an upstream failure without replacing the last successful snapshot', async () => {
     await syncDirectByokModels();
     await backdateSnapshot();
     const previousSnapshot = await readSnapshot();
-    const otherProvidersWritten = waitForOtherProviderWrites();
     fetchAvailableModels = async () => {
-      await otherProvidersWritten;
       return new Response(null, { status: 503, statusText: 'Service Unavailable' });
     };
 
@@ -525,20 +473,5 @@ describe('syncDirectByokModels database snapshots', () => {
     );
 
     expect(await readSnapshot()).toStrictEqual(previousSnapshot);
-    expect(redisSet.mock.calls.some(([key]) => key === providerKey)).toBe(false);
-  });
-
-  test('retains the database write when the subsequent Redis write fails', async () => {
-    providerModels = {};
-    await syncDirectByokModels();
-    const redisError = new Error('Redis unavailable');
-    const otherProvidersWritten = waitForOtherProviderWrites(redisError);
-    providerModels = downloadedModels;
-
-    await expect(syncDirectByokModels()).rejects.toThrow(redisError);
-    await otherProvidersWritten;
-
-    expect((await readSnapshot()).models).toStrictEqual(normalizedModels);
-    expectCachedModels(normalizedModels);
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -6,8 +6,6 @@ import {
 import type { DirectUserByokInferenceProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import { db } from '@/lib/drizzle';
 import { direct_byok_model_lists } from '@kilocode/db/schema';
-import { redisClient } from '@/lib/redis';
-import { directByokModelsRedisKey } from '@/lib/redis-keys';
 import {
   ReasoningEffortSchema,
   VerbositySchema,
@@ -336,9 +334,6 @@ async function syncProvider(fetcher: ProviderFetcher, ctx: SyncContext): Promise
       set: { models, synced_at },
     });
 
-  await redisClient.set(directByokModelsRedisKey(fetcher.providerId), JSON.stringify(models), {
-    ex: 7 * 24 * 60 * 60,
-  });
   return models.length;
 }
 

--- a/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
@@ -40,11 +40,7 @@ export const getOpenRouterModelsMetadataFromDatabase = createStoredModelsFromDat
   'OpenRouter'
 );
 
-/**
- * The ids of language models, including those with no endpoints. This is the
- * list mirrored to the lightweight `*-model-ids` Redis keys so existence checks
- * can avoid loading the full model catalog.
- */
+/** The ids of language models, including those with no endpoints. */
 export function getLanguageModelIds(models: StoredModelMap): string[] {
   return Object.values(models)
     .filter(model => (model.type ?? 'language') === 'language')

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -23,16 +23,7 @@ import type { Provider } from '@/lib/ai-gateway/providers/types';
 import type { StoredModel } from '@kilocode/db/schema-types';
 import { EndpointsSchema, ModelsSchema } from '@kilocode/db/schema-types';
 import { redisClient } from '@/lib/redis';
-import {
-  GATEWAY_METADATA_REDIS_KEYS,
-  type RedisKey,
-  SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY,
-  vercelInferenceProvidersRedisKey,
-} from '@/lib/redis-keys';
-import {
-  extractVercelInferenceProviderIdsFromModel,
-  getLanguageModelIds,
-} from '@/lib/ai-gateway/providers/gateway-models-cache';
+import { SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY } from '@/lib/redis-keys';
 import { syncDirectByokModels } from '@/lib/ai-gateway/providers/direct-byok/sync-direct-byok';
 import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attribution-headers';
 import {
@@ -51,19 +42,6 @@ import { injectSupportedFimModels } from '@/lib/ai-gateway/supported-fim-models'
  * logs for the same diff. Auto-releases on transaction commit/rollback.
  */
 const SYNC_PROVIDERS_SNAPSHOT_LOCK_KEY = 'sync-providers:snapshot';
-const UNUSED_GATEWAY_METADATA_TTL_SECONDS = 7 * 24 * 60 * 60;
-
-async function mirrorVercelInferenceProvidersToRedis(vercelModels: Record<string, StoredModel>) {
-  const pipeline = redisClient.pipeline();
-  for (const model of Object.values(vercelModels)) {
-    pipeline.set(
-      vercelInferenceProvidersRedisKey(model.id),
-      JSON.stringify(extractVercelInferenceProviderIdsFromModel(model)),
-      { ex: UNUSED_GATEWAY_METADATA_TTL_SECONDS }
-    );
-  }
-  await pipeline.exec();
-}
 
 async function fetchGatewayModels(gateway: Provider) {
   const headers = {
@@ -323,27 +301,6 @@ async function syncProviders(
   return result;
 }
 
-async function mirrorToRedis(values: {
-  providers: NormalizedOpenRouterResponse;
-  openrouter: Record<string, StoredModel>;
-  vercel: Record<string, StoredModel>;
-  openrouterProviders: OpenRouterProvider[];
-}): Promise<void> {
-  const expiringEntries: [RedisKey, unknown][] = [
-    [GATEWAY_METADATA_REDIS_KEYS.allProviders, values.providers],
-    [GATEWAY_METADATA_REDIS_KEYS.openrouterModelIds, getLanguageModelIds(values.openrouter)],
-    [GATEWAY_METADATA_REDIS_KEYS.vercelModelIds, getLanguageModelIds(values.vercel)],
-    [GATEWAY_METADATA_REDIS_KEYS.openrouterProviders, values.openrouterProviders],
-  ];
-  await Promise.all([
-    ...expiringEntries.map(([key, value]) => {
-      const serializedValue = JSON.stringify(value);
-      return redisClient.set(key, serializedValue, { ex: UNUSED_GATEWAY_METADATA_TTL_SECONDS });
-    }),
-    mirrorVercelInferenceProvidersToRedis(values.vercel),
-  ]);
-}
-
 /**
  * Apply a freshly-synced OpenRouter snapshot to the database and emit
  * per-org audit log entries describing how it affects each enterprise
@@ -432,13 +389,6 @@ export async function syncAndStoreProviders() {
     providers,
     openrouter_data,
     vercel_data,
-  });
-
-  await mirrorToRedis({
-    providers,
-    openrouter: openrouter_data,
-    vercel: vercel_data,
-    openrouterProviders,
   });
 
   const direct_byok_model_counts = await syncDirectByokModels();

--- a/apps/web/src/lib/redis-keys.test.ts
+++ b/apps/web/src/lib/redis-keys.test.ts
@@ -3,18 +3,11 @@ import {
   gitLabOAuthCredentialsRedisKey,
   REQUEST_LOGGING_OPT_INS_REDIS_KEY,
   SYNC_PROVIDERS_STALE_ALERT_LAST_POSTED_AT_REDIS_KEY,
-  vercelInferenceProvidersRedisKey,
 } from './redis-keys';
 
 describe('Redis key namespaces', () => {
   test('groups GitLab OAuth credentials under auth credentials', () => {
     expect(gitLabOAuthCredentialsRedisKey('ref-123')).toBe('auth-credentials:gitlab:ref-123');
-  });
-
-  test('creates a separate Vercel inference provider key per model', () => {
-    expect(vercelInferenceProvidersRedisKey('anthropic/claude-sonnet-4.5')).toBe(
-      'ai-gateway.metadata:vercel-inference-providers:anthropic/claude-sonnet-4.5'
-    );
   });
 
   test('uses one key for the request logging opt-in array', () => {

--- a/apps/web/src/lib/redis-keys.ts
+++ b/apps/web/src/lib/redis-keys.ts
@@ -5,8 +5,6 @@
  * collisions when adding new features.
  */
 
-import type { DirectUserByokInferenceProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
-
 declare const redisKeyBrand: unique symbol;
 
 export type RedisKey = string & {
@@ -26,21 +24,6 @@ export const SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY = redisKey(
 export const SYNC_PROVIDERS_STALE_ALERT_LAST_POSTED_AT_REDIS_KEY = redisKey(
   'ai-gateway:sync-providers:stale-alert-last-posted-at'
 );
-
-export const GATEWAY_METADATA_REDIS_KEYS = {
-  allProviders: redisKey('ai-gateway.metadata:all-providers'),
-  // Lightweight lists of language model ids used for existence checks without
-  // loading every model's metadata and endpoints.
-  openrouterModelIds: redisKey('ai-gateway.metadata:openrouter-model-ids'),
-  vercelModelIds: redisKey('ai-gateway.metadata:vercel-model-ids'),
-  openrouterProviders: redisKey('ai-gateway.metadata:openrouter-providers'),
-} as const;
-
-export const vercelInferenceProvidersRedisKey = (modelId: string) =>
-  redisKey(`ai-gateway.metadata:vercel-inference-providers:${modelId}`);
-
-export const directByokModelsRedisKey = (providerId: DirectUserByokInferenceProviderId) =>
-  redisKey(`ai-gateway.metadata.direct-byok-models:${providerId}`);
 
 export const posthogQueryRedisKey = (name: string) => redisKey(`posthog-query:${name}`);
 


### PR DESCRIPTION
## Summary
- stop mirroring gateway provider metadata and model IDs to Redis after their readers moved to PostgreSQL
- stop mirroring direct-BYOK model lists to Redis
- remove obsolete Redis key definitions and Redis-specific test coverage
- retain the actively consumed provider-sync completion timestamp in Redis

The obsolete keys received seven-day TTLs in #5942, so existing values will expire naturally.

## Verification
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- formatting with `oxfmt`
- `git diff --check`

Database-backed Jest integration suites were not run because the local PostgreSQL service was unavailable.