### PR TITLE
fix(cloud-agent-next): use readable control-plane branches

### DIFF
--- a/services/cloud-agent-next/src/persistence/SandboxControl.ts
+++ b/services/cloud-agent-next/src/persistence/SandboxControl.ts
@@ -176,6 +176,7 @@ import {
   resolveSessionCredential,
   type SessionCredentialGrant,
 } from '../sandbox-control/session-credentials.js';
+import { adaptSessionAttachPayloadForWrapper } from '../sandbox-session/attach-payload.js';
 import { parseControlPlaneCredential } from '../sandbox-control/managed-credential.js';
 import {
   diagnosticCause,
@@ -897,12 +898,17 @@ export class SandboxControl extends DurableObject<Env> {
       return response;
     }
     const outbound =
-      input.operation === 'session.attach' && this.supportsNativeRuntimeRetirement()
+      input.operation === 'session.attach'
         ? {
             ...input,
             payload: {
-              ...sessionAttachPayloadSchema.parse(input.payload),
-              captureNativeRuntimeId: true,
+              ...adaptSessionAttachPayloadForWrapper(
+                sessionAttachPayloadSchema.parse(input.payload),
+                this.socketHandler.supportsWorkingBranches?.() === true
+              ),
+              ...(this.supportsNativeRuntimeRetirement()
+                ? { captureNativeRuntimeId: true as const }
+                : {}),
             },
           }
         : input;

--- a/services/cloud-agent-next/src/router/handlers/session-worktree.test.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-worktree.test.ts
@@ -679,6 +679,22 @@ describe('createWorktreeChat ownership, metadata, and control-plane routing', ()
     expect(registration?.repository).not.toHaveProperty('token');
     expect(registration?.auth.kilocodeToken).toBe(CURRENT_AUTH_TOKEN);
   });
+
+  it('preserves the legacy branch fallback for branchless source metadata', async () => {
+    const metadata = sourceMetadata();
+    if (!metadata.workspace || !metadata.repository) throw new Error('Missing source metadata');
+    delete metadata.workspace.branchName;
+    delete metadata.repository.upstreamBranch;
+
+    const { caller, input, destinationStub } = fixture({ metadata });
+    await caller.createWorktreeChat(input);
+
+    expect(destinationStub.registerSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace: expect.objectContaining({ branchName: `session/${WORKTREE_ID}` }),
+      })
+    );
+  });
 });
 
 describe('createWorktreeChat operation-ledger replay and conflict handling', () => {

--- a/services/cloud-agent-next/src/router/handlers/session-worktree.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-worktree.ts
@@ -297,6 +297,14 @@ function resultFromProgress(progress: OperationProgress, replayed = false): Work
   return replayed ? { ...result, replayed: true } : result;
 }
 
+function sourceWorktreeBranchName(source: WorktreeSource): string {
+  return (
+    source.workspace.branchName ??
+    source.repository.upstreamBranch ??
+    `session/${source.worktreeId}`
+  );
+}
+
 function buildRegistrationInput(
   source: WorktreeSource,
   ctx: TRPCContext,
@@ -307,6 +315,7 @@ function buildRegistrationInput(
 
   const workspace = { ...source.workspace };
   delete workspace.providerRuntime;
+  workspace.branchName = sourceWorktreeBranchName(source);
 
   return {
     identity: { ...source.metadata.identity, sessionId: progress.cloudAgentSessionId },
@@ -340,7 +349,7 @@ function assertRegisteredMetadata(
     workspace.workspacePath !== source.workspace.workspacePath ||
     workspace.sandboxId !== source.workspace.sandboxId ||
     workspace.sandboxProvider !== source.workspace.sandboxProvider ||
-    workspace.branchName !== source.workspace.branchName ||
+    workspace.branchName !== sourceWorktreeBranchName(source) ||
     JSON.stringify(workspace.sandboxRoute) !== JSON.stringify(source.workspace.sandboxRoute) ||
     !metadata.repository ||
     canonicalRepositoryUrl(metadata.repository) !== canonicalRepositoryUrl(source.repository) ||

--- a/services/cloud-agent-next/src/sandbox-control/socket.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/socket.test.ts
@@ -63,7 +63,7 @@ function helloFrame(
   providerInstanceId: string,
   wrapperInstanceId?: string,
   requestId = 'req_hello',
-  capabilities?: { nativeRuntimeRetirement?: boolean }
+  capabilities?: { nativeRuntimeRetirement?: boolean; workingBranches?: boolean }
 ): string {
   return JSON.stringify({
     type: 'request',
@@ -379,6 +379,20 @@ describe('sandbox control socket handler', () => {
     );
 
     expect(handler.supportsNativeRuntimeRetirement()).toBe(true);
+  });
+
+  it('reads the working branch capability from the wrapper handshake', async () => {
+    const incoming = createFakeWebSocket();
+    const handler = createSandboxControlSocketHandler(createFakeState([incoming]), 'sbx_test');
+
+    await handler.handleMessage(
+      asWs(incoming),
+      helloFrame('inst_1', WRAPPER_INSTANCE_ID, 'req_working_branches', {
+        workingBranches: true,
+      })
+    );
+
+    expect(handler.supportsWorkingBranches?.()).toBe(true);
   });
 
   it('rejects duplicate hellos without replacing the current connection', async () => {

--- a/services/cloud-agent-next/src/sandbox-control/socket.ts
+++ b/services/cloud-agent-next/src/sandbox-control/socket.ts
@@ -125,6 +125,7 @@ export type SandboxControlSocketHandler = {
   supportsOperationResults(): boolean;
   supportsScopedStopAbort(): boolean;
   supportsNativeRuntimeRetirement(): boolean;
+  supportsWorkingBranches?(): boolean;
   supportsConnectionRecovery(): boolean;
   getConnectionIdentity(): SandboxControlConnectionIdentity | null;
   getReadySocket(): WebSocket | null;
@@ -367,6 +368,13 @@ export function createSandboxControlSocketHandler(
       return (
         current !== null &&
         readAttachment(current.socket)?.capabilities?.nativeRuntimeRetirement === true
+      );
+    },
+
+    supportsWorkingBranches(): boolean {
+      const current = currentHandshakenSocket(state);
+      return (
+        current !== null && readAttachment(current.socket)?.capabilities?.workingBranches === true
       );
     },
 

--- a/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
+++ b/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
@@ -3,6 +3,7 @@ import type {
   GetWorktreeChangesOutput,
   RefreshWorktreeChangesOutput,
 } from '@kilocode/worker-utils/cloud-agent-worktree-changes';
+import { generateBranchSlug } from '@kilocode/worker-utils/deployment-slug';
 import { TRPCError } from '@trpc/server';
 import { withTimeout } from '@kilocode/worker-utils';
 import { z } from 'zod';
@@ -1792,6 +1793,8 @@ export class SandboxSession extends DurableObject<Env> {
             upstreamBranch: input.repository.upstreamBranch ?? input.repository.branch,
           }
         : input.repository;
+    const branchName =
+      input.workspace?.branchName ?? repository?.upstreamBranch ?? `kilo/${generateBranchSlug()}`;
     const metadata = parseSessionMetadata({
       metadataSchemaVersion: 2,
       identity: input.identity,
@@ -1799,7 +1802,7 @@ export class SandboxSession extends DurableObject<Env> {
       agent: input.agent,
       ...(repository ? { repository } : {}),
       ...(initialMessage ? { initialMessage } : {}),
-      workspace: input.workspace ?? {},
+      workspace: { ...(input.workspace ?? {}), branchName },
       ...(input.callback ? { callback: input.callback } : {}),
       ...(input.profile ? { profile: input.profile } : {}),
       ...(input.finalization ? { finalization: input.finalization } : {}),

--- a/services/cloud-agent-next/src/sandbox-session/attach-payload.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/attach-payload.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { parseSessionMetadata } from '../persistence/session-metadata.js';
 import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../shared/runtime-environment.js';
 import { envVarsSchema } from '../types.js';
-import { buildSessionAttachPayload } from './attach-payload.js';
+import {
+  adaptSessionAttachPayloadForWrapper,
+  buildSessionAttachPayload,
+} from './attach-payload.js';
 
 describe('buildSessionAttachPayload', () => {
   it('packs directory, git clone, branch, snapshot identity, and session env', () => {
@@ -53,6 +56,39 @@ describe('buildSessionAttachPayload', () => {
       env: { KILOCODE_TOKEN: 'cap_1' },
       setupCommands: ['pnpm install'],
       preparation: { attemptId: 'att_1', triggerMessageId: 'msg_1' },
+    });
+  });
+
+  it('marks a generated workspace branch as a working branch', () => {
+    const metadata = parseSessionMetadata({
+      metadataSchemaVersion: 2,
+      identity: {
+        sessionId: 'workspace_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        userId: 'user-1',
+      },
+      auth: { kiloSessionId: 'kilo_1', kilocodeToken: 'cap_1' },
+      agent: { mode: 'code', model: 'kilo/test' },
+      repository: { type: 'github', repo: 'acme/demo' },
+      workspace: { branchName: 'kilo/quiet-forest-abc' },
+      lifecycle: { version: 1, timestamp: 1 },
+    });
+
+    expect(buildSessionAttachPayload(metadata)).toMatchObject({
+      branch: 'kilo/quiet-forest-abc',
+      branchMode: 'working',
+    });
+  });
+
+  it('drops working-branch fields for a legacy wrapper', () => {
+    const payload = {
+      branch: 'kilo/quiet-forest-abc',
+      branchMode: 'working' as const,
+      directory: '/workspace/a',
+    };
+
+    expect(adaptSessionAttachPayloadForWrapper(payload, true)).toEqual(payload);
+    expect(adaptSessionAttachPayloadForWrapper(payload, false)).toEqual({
+      directory: '/workspace/a',
     });
   });
 

--- a/services/cloud-agent-next/src/sandbox-session/attach-payload.ts
+++ b/services/cloud-agent-next/src/sandbox-session/attach-payload.ts
@@ -59,6 +59,10 @@ export function buildSessionAttachPayload(
     );
   const git = gitFromMetadata(metadata);
   const branch = metadata.workspace?.branchName ?? metadata.repository?.upstreamBranch;
+  const branchMode =
+    branch && metadata.workspace?.branchName === branch && !metadata.repository?.upstreamBranch
+      ? 'working'
+      : undefined;
   const profile = readProfileBundle(metadata);
   validateControlSessionOptions(metadata);
   const env = {
@@ -69,10 +73,21 @@ export function buildSessionAttachPayload(
   return {
     directory,
     ...(branch ? { branch } : {}),
+    ...(branchMode ? { branchMode } : {}),
     ...(metadata.auth.kiloSessionId ? { snapshotIdentity: metadata.auth.kiloSessionId } : {}),
     ...(git ? { git } : {}),
     ...(Object.keys(env).length > 0 ? { env } : {}),
     ...(profile.setupCommands?.length ? { setupCommands: profile.setupCommands } : {}),
     ...(preparation ? { preparation } : {}),
   };
+}
+
+export function adaptSessionAttachPayloadForWrapper(
+  payload: SessionAttachPayload,
+  supportsWorkingBranches: boolean
+): SessionAttachPayload {
+  if (supportsWorkingBranches || payload.branchMode !== 'working') return payload;
+
+  const { branch: _branch, branchMode: _branchMode, ...legacyPayload } = payload;
+  return legacyPayload;
 }

--- a/services/cloud-agent-next/src/shared/sandbox-control-protocol.ts
+++ b/services/cloud-agent-next/src/shared/sandbox-control-protocol.ts
@@ -172,6 +172,7 @@ export const sandboxHelloPayloadSchema = z.object({
       nativeRuntimeRetirement: z.boolean().optional(),
       connectionRecovery: z.boolean().optional(),
       eventReceipts: z.boolean().optional(),
+      workingBranches: z.boolean().optional(),
     })
     .optional(),
 });
@@ -326,6 +327,7 @@ export const sessionAttachPayloadSchema = z
     snapshotIdentity: z.string().min(1).max(512).optional(),
     directory: z.string().min(1).max(1024).optional(),
     branch: z.string().min(1).max(256).optional(),
+    branchMode: z.literal('working').optional(),
     kilo: z
       .object({
         scopeId: z.string().min(1).max(256),
@@ -898,6 +900,7 @@ export const sandboxControlSocketAttachmentSchema = z.object({
       scopedStopAbort: z.boolean().optional(),
       nativeRuntimeRetirement: z.boolean().optional(),
       connectionRecovery: z.boolean().optional(),
+      workingBranches: z.boolean().optional(),
     })
     .optional(),
   providerInstanceId: z.string().min(1).max(256).optional(),

--- a/services/cloud-agent-next/test/integration/sandbox-control.test.ts
+++ b/services/cloud-agent-next/test/integration/sandbox-control.test.ts
@@ -354,8 +354,16 @@ function sendHello(
     wrapperInstanceId?: string;
     sessionOperationResults?: boolean;
     nativeRuntimeRetirement?: boolean;
+    workingBranches?: boolean;
   } = {}
 ): void {
+  const capabilities = {
+    ...(identity.sessionOperationResults || identity.nativeRuntimeRetirement
+      ? { sessionOperationResults: true }
+      : {}),
+    ...(identity.nativeRuntimeRetirement ? { nativeRuntimeRetirement: true } : {}),
+    ...(identity.workingBranches ? { workingBranches: true } : {}),
+  };
   ws.send(
     JSON.stringify({
       type: 'request',
@@ -365,17 +373,7 @@ function sendHello(
         protocolVersion: 1,
         providerInstanceId:
           identity.providerInstanceId ?? cloudflareRef(socketSandboxIds.get(ws) ?? sandboxId),
-        ...(identity.sessionOperationResults
-          ? { capabilities: { sessionOperationResults: true } }
-          : {}),
-        ...(identity.nativeRuntimeRetirement
-          ? {
-              capabilities: {
-                sessionOperationResults: true,
-                nativeRuntimeRetirement: true,
-              },
-            }
-          : {}),
+        ...(Object.keys(capabilities).length > 0 ? { capabilities } : {}),
         ...(identity.wrapperInstanceId ? { wrapperInstanceId: identity.wrapperInstanceId } : {}),
       },
     })
@@ -390,6 +388,7 @@ async function completeHello(
     wrapperInstanceId?: string;
     sessionOperationResults?: boolean;
     nativeRuntimeRetirement?: boolean;
+    workingBranches?: boolean;
   } = {}
 ): Promise<void> {
   sendHello(ws, requestId, identity);
@@ -2373,7 +2372,10 @@ describe('SandboxControl contained Vercel lifecycle', () => {
     const previousRef = launch.env.PROVIDER_INSTANCE_ID;
     const previous = await connect(credential, sandboxId);
     try {
-      await completeHello(previous, 'hello-previous-wrapper', { providerInstanceId: previousRef });
+      await completeHello(previous, 'hello-previous-wrapper', {
+        providerInstanceId: previousRef,
+        workingBranches: true,
+      });
       signalWrapperReady(previous);
       await vi.waitFor(async () => {
         await expect(control.getStatus()).resolves.toMatchObject({ connection: 'ready' });
@@ -2477,6 +2479,7 @@ describe('SandboxControl contained Vercel lifecycle', () => {
       try {
         await completeHello(replacement, 'hello-replacement-wrapper', {
           providerInstanceId: replacementLaunch.env.PROVIDER_INSTANCE_ID,
+          workingBranches: true,
         });
         signalWrapperReady(replacement);
         await vi.waitFor(async () => {
@@ -3082,7 +3085,10 @@ describe('SandboxControl mandatory worktree credentials', () => {
     expectCredentialFreeLaunch(launch, broker);
     const ws = await connect(launch.env.SANDBOX_CONTROL_CREDENTIAL, fixture.sandboxId);
     try {
-      await completeHello(ws, 'hello-joined-containment', { providerInstanceId: providerRef });
+      await completeHello(ws, 'hello-joined-containment', {
+        providerInstanceId: providerRef,
+        workingBranches: true,
+      });
       const stale = await connect(launch.env.SANDBOX_CONTROL_CREDENTIAL, fixture.sandboxId);
       await rejectHello(
         stale,

--- a/services/cloud-agent-next/test/integration/session/prepared-admission-control-plane.test.ts
+++ b/services/cloud-agent-next/test/integration/session/prepared-admission-control-plane.test.ts
@@ -140,4 +140,41 @@ describe('SandboxSession prepared initial admission (control plane)', () => {
     if (result.success) return;
     expect(result.code).toBe('BAD_REQUEST');
   });
+
+  it('persists a readable default branch for a new control-plane session', async () => {
+    const sessionId = cloudId();
+    const stub = env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`);
+
+    const metadata = await runInDurableObject(stub, async instance => {
+      await instance.registerSession({
+        identity: { sessionId, userId },
+        auth: { kiloSessionId, kilocodeToken: 'test-session-token' },
+        agent: { mode: 'code', model: 'test-model' },
+        repository: { type: 'github', repo: 'acme/demo' },
+        workspace: { sandboxId, sandboxProvider: 'cloudflare' as const },
+      });
+      return instance.getMetadata();
+    });
+
+    expect(metadata?.workspace?.branchName).toMatch(/^kilo\/[a-z0-9-]+$/);
+  });
+
+  it('preserves an explicitly requested repository branch', async () => {
+    const sessionId = cloudId();
+    const stub = env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`);
+
+    const metadata = await runInDurableObject(stub, async instance => {
+      await instance.registerSession({
+        identity: { sessionId, userId },
+        auth: { kiloSessionId, kilocodeToken: 'test-session-token' },
+        agent: { mode: 'code', model: 'test-model' },
+        repository: { type: 'github', repo: 'acme/demo', branch: 'main' },
+        workspace: { sandboxId, sandboxProvider: 'cloudflare' as const },
+      });
+      return instance.getMetadata();
+    });
+
+    expect(metadata?.workspace?.branchName).toBe('main');
+    expect(metadata?.repository?.upstreamBranch).toBe('main');
+  });
 });

--- a/services/cloud-agent-next/wrapper/src/control/apply-attach.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/apply-attach.test.ts
@@ -233,6 +233,18 @@ describe('applySessionAttach', () => {
       expect(setupBranches).toEqual(['session/worktree_a']);
     });
 
+    it('creates a requested working branch when it is absent from the remote', async () => {
+      const branch = 'kilo/quiet-forest-abc';
+      const result = await applySessionAttach(
+        { ...session, directory },
+        { ...payload, branch, branchMode: 'working' },
+        deps
+      );
+
+      expect(result).toEqual({ ok: true, result: { attached: true } });
+      expect(await currentBranch()).toBe(branch);
+    });
+
     it.each(['main', 'feature/existing'])(
       'honors the explicitly requested branch %s',
       async branch => {

--- a/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
+++ b/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
@@ -422,7 +422,7 @@ async function executeSessionAttach(
             }
             const branch = attach.branch ?? `session/${attach.kilo.scopeId}`;
             let checkoutArgs = ['checkout', '-B', branch, `origin/${branch}`];
-            if (!attach.branch) {
+            if (!attach.branch || attach.branchMode === 'working') {
               const existingBranch = await runGit(
                 ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
                 directory,

--- a/services/cloud-agent-next/wrapper/src/control/operation-intent.ts
+++ b/services/cloud-agent-next/wrapper/src/control/operation-intent.ts
@@ -15,8 +15,17 @@ export function operationIntent(operation: 'session.attach' | 'session.prompt', 
       })),
     };
   }
-  const { kilo, git, env, snapshotIdentity, directory, branch, setupCommands, preparation } =
-    sessionAttachPayloadSchema.parse(payload);
+  const {
+    kilo,
+    git,
+    env,
+    snapshotIdentity,
+    directory,
+    branch,
+    branchMode,
+    setupCommands,
+    preparation,
+  } = sessionAttachPayloadSchema.parse(payload);
   const credentials = new Set([
     'KILOCODE_TOKEN',
     'KILOCODE_ORGANIZATION_ID',
@@ -31,6 +40,7 @@ export function operationIntent(operation: 'session.attach' | 'session.prompt', 
     snapshotIdentity,
     directory,
     branch,
+    branchMode,
     setupCommands,
     preparation,
     kilo: kilo

--- a/services/cloud-agent-next/wrapper/src/control/operation-registry.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/operation-registry.test.ts
@@ -27,6 +27,7 @@ import {
   session,
   type Completion,
 } from './control-test-fixtures';
+import { operationIntent } from './operation-intent';
 import { rememberAttachedRoot, resetSessionDirectoryState } from './session-directories';
 import { resetDirectoryOperationState } from './worktree-operations';
 
@@ -230,6 +231,23 @@ describe('operation admission and lookup', () => {
     await prompt.done;
     await prompt.waitForDelivery();
     expect(handlerDeps.operations.abortTarget(session, 'msg_1')).toBe(prompt);
+  });
+
+  it('includes working branch mode in attach idempotency intent', () => {
+    const workingBranchPayload = {
+      kilo,
+      branch: 'kilo/quiet-forest-abc',
+      branchMode: 'working' as const,
+    };
+    const { branchMode: _branchMode, ...legacyPayload } = workingBranchPayload;
+
+    expect(operationIntent('session.attach', workingBranchPayload)).toMatchObject({
+      branch: 'kilo/quiet-forest-abc',
+      branchMode: 'working',
+    });
+    expect(operationIntent('session.attach', workingBranchPayload)).not.toEqual(
+      operationIntent('session.attach', legacyPayload)
+    );
   });
 });
 

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.test.ts
@@ -363,6 +363,7 @@ describe('createSandboxControlClient', () => {
           nativeRuntimeRetirement?: boolean;
           connectionRecovery?: boolean;
           eventReceipts?: boolean;
+          workingBranches?: boolean;
         };
       };
     };
@@ -377,6 +378,7 @@ describe('createSandboxControlClient', () => {
         nativeRuntimeRetirement: true,
         connectionRecovery: true,
         eventReceipts: true,
+        workingBranches: true,
       },
     });
     fake.respond(

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.ts
@@ -521,6 +521,7 @@ export function createSandboxControlClient(
               nativeRuntimeRetirement: true,
               connectionRecovery: true,
               eventReceipts: true,
+              workingBranches: true,
             },
             ...(wrapperInstanceId ? { wrapperInstanceId } : {}),
             ...(options.wrapperVersion ? { wrapperVersion: options.wrapperVersion } : {}),


### PR DESCRIPTION
## Summary

- Generate readable `kilo/<slug>` branches for new control-plane worktree sessions.
- Negotiate working-branch support and downgrade attach payloads for legacy wrappers.
- Include branch mode in wrapper idempotency intent.
- Preserve the legacy branch fallback when reconciling branchless historical worktree metadata.

## Verification

- `pnpm run test` in `services/cloud-agent-next`: 5,797 passed, 3 skipped.
- `pnpm run test:wrapper`: 1,242 passed.
- Focused Worker tests: 147 passed.
- Focused wrapper tests: 122 passed.
- `pnpm run typecheck` passed.
- `pnpm run lint` passed.
- `pnpm format:check` passed.