### PR TITLE
Move AI gateway state source of truth from Redis to PostgreSQL

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert.test.ts
@@ -237,7 +237,7 @@ describe('sendTestStaleSyncAlertNotification', () => {
 });
 
 describe('alertIfSyncProvidersStale', () => {
-  it('posts once and stores the alert timestamp with a seven-day TTL', async () => {
+  it('posts once and stores the alert timestamp with a three-day TTL', async () => {
     const sendNotification = jest.fn(
       async (_notification: AdminSlackNotification) => 'posted' as const
     );
@@ -256,7 +256,7 @@ describe('alertIfSyncProvidersStale', () => {
       buildStaleSyncAlertNotification({ lastCompletedAt: STALE_SYNC, now: NOW })
     );
     expect(setLastAlertAt).toHaveBeenCalledWith(NOW.toISOString());
-    expect(SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS).toBe(7 * 24 * 60 * 60);
+    expect(SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS).toBe(3 * 24 * 60 * 60);
     expect(SYNC_PROVIDERS_STALE_AFTER_MS).toBe(60 * 60 * 1000);
   });
 

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert.test.ts
@@ -34,6 +34,7 @@ const FRESH_SYNC = new Date(NOW.getTime() - SYNC_PROVIDERS_STALE_AFTER_MS + 1);
 const STALE_SYNC = new Date(NOW.getTime() - SYNC_PROVIDERS_STALE_AFTER_MS);
 const OLDER_ALERT = new Date(STALE_SYNC.getTime() - 60_000);
 const NEWER_ALERT = new Date(STALE_SYNC.getTime() + 60_000);
+const EXPIRED_ALERT = new Date(NOW.getTime() - SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS * 1000);
 
 afterEach(() => {
   jest.restoreAllMocks();
@@ -107,6 +108,16 @@ describe('shouldPostStaleSyncAlert', () => {
         now: NOW,
       })
     ).toBe(false);
+  });
+
+  it('alerts again when the last alert has expired', () => {
+    expect(
+      shouldPostStaleSyncAlert({
+        lastCompletedAt: null,
+        lastAlertAt: EXPIRED_ALERT,
+        now: NOW,
+      })
+    ).toBe(true);
   });
 
   it('alerts again after a newer full sync goes stale', () => {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert.test.ts
@@ -226,7 +226,7 @@ describe('sendTestStaleSyncAlertNotification', () => {
 });
 
 describe('alertIfSyncProvidersStale', () => {
-  it('posts once and stores the alert timestamp with a three-day TTL', async () => {
+  it('posts once and stores the alert timestamp with a seven-day TTL', async () => {
     const sendNotification = jest.fn(
       async (_notification: AdminSlackNotification) => 'posted' as const
     );
@@ -245,7 +245,7 @@ describe('alertIfSyncProvidersStale', () => {
       buildStaleSyncAlertNotification({ lastCompletedAt: STALE_SYNC, now: NOW })
     );
     expect(setLastAlertAt).toHaveBeenCalledWith(NOW.toISOString());
-    expect(SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS).toBe(3 * 24 * 60 * 60);
+    expect(SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS).toBe(7 * 24 * 60 * 60);
     expect(SYNC_PROVIDERS_STALE_AFTER_MS).toBe(60 * 60 * 1000);
   });
 
@@ -267,7 +267,7 @@ describe('alertIfSyncProvidersStale', () => {
     expect(setLastAlertAt).not.toHaveBeenCalled();
   });
 
-  it('swallows Redis failures so the cron can continue', async () => {
+  it('swallows state read failures so the cron can continue', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const sendNotification = jest.fn(
       async (_notification: AdminSlackNotification) => 'posted' as const
@@ -277,7 +277,7 @@ describe('alertIfSyncProvidersStale', () => {
       alertIfSyncProvidersStale({
         now: () => NOW,
         getLastCompletedAt: async () => {
-          throw new Error('redis down');
+          throw new Error('database down');
         },
         getLastAlertAt: async () => null,
         sendNotification,

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert.ts
@@ -6,16 +6,17 @@ import { APP_URL } from '@/lib/constants';
 import { db } from '@/lib/drizzle';
 import { redisClient } from '@/lib/redis';
 import {
-  SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY,
+  AI_GATEWAY_STATE_REDIS_TTL_SECONDS,
   SYNC_PROVIDERS_STALE_ALERT_LAST_POSTED_AT_REDIS_KEY,
 } from '@/lib/redis-keys';
 import {
   sendAdminSlackNotification,
   type AdminSlackNotification,
 } from '@/lib/slack/admin-notifications';
+import { eq } from 'drizzle-orm';
 
 export const SYNC_PROVIDERS_STALE_AFTER_MS = 60 * 60 * 1000;
-export const SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS = 3 * 24 * 60 * 60;
+export const SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS = AI_GATEWAY_STATE_REDIS_TTL_SECONDS;
 
 const STALE_WINDOW_LABEL = 'hour';
 const STATUS_COPY = `No full sync has completed within the past ${STALE_WINDOW_LABEL}.`;
@@ -167,17 +168,24 @@ type StaleAlertDependencies = {
 };
 
 async function defaultGetLastCompletedAt(): Promise<string | null> {
-  return redisClient.get<string>(SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY);
+  const [row] = await db
+    .select({ lastCompletedAt: ai_gateway_sync_providers_state.last_completed_at })
+    .from(ai_gateway_sync_providers_state)
+    .where(eq(ai_gateway_sync_providers_state.id, 1))
+    .limit(1);
+  return row?.lastCompletedAt ?? null;
 }
 
 async function defaultGetLastAlertAt(): Promise<string | null> {
-  return redisClient.get<string>(SYNC_PROVIDERS_STALE_ALERT_LAST_POSTED_AT_REDIS_KEY);
+  const [row] = await db
+    .select({ lastAlertAt: ai_gateway_sync_providers_state.stale_alert_last_posted_at })
+    .from(ai_gateway_sync_providers_state)
+    .where(eq(ai_gateway_sync_providers_state.id, 1))
+    .limit(1);
+  return row?.lastAlertAt ?? null;
 }
 
 async function defaultSetLastAlertAt(iso: string): Promise<unknown> {
-  const result = await redisClient.set(SYNC_PROVIDERS_STALE_ALERT_LAST_POSTED_AT_REDIS_KEY, iso, {
-    ex: SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS,
-  });
   await db
     .insert(ai_gateway_sync_providers_state)
     .values({ stale_alert_last_posted_at: iso })
@@ -185,7 +193,9 @@ async function defaultSetLastAlertAt(iso: string): Promise<unknown> {
       target: ai_gateway_sync_providers_state.id,
       set: { stale_alert_last_posted_at: iso },
     });
-  return result;
+  return redisClient.set(SYNC_PROVIDERS_STALE_ALERT_LAST_POSTED_AT_REDIS_KEY, iso, {
+    ex: SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS,
+  });
 }
 
 export async function postStaleSyncAlert(input: {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert.ts
@@ -17,6 +17,7 @@ import { eq } from 'drizzle-orm';
 
 export const SYNC_PROVIDERS_STALE_AFTER_MS = 60 * 60 * 1000;
 export const SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS = AI_GATEWAY_STATE_REDIS_TTL_SECONDS;
+const SYNC_PROVIDERS_STALE_ALERT_TTL_MS = SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS * 1000;
 
 const STALE_WINDOW_LABEL = 'hour';
 const STATUS_COPY = `No full sync has completed within the past ${STALE_WINDOW_LABEL}.`;
@@ -45,7 +46,11 @@ export function shouldPostStaleSyncAlert(input: {
   ) {
     return false;
   }
-  if (lastAlertAt !== null && (lastCompletedAt === null || lastAlertAt > lastCompletedAt)) {
+  if (
+    lastAlertAt !== null &&
+    (lastCompletedAt === null || lastAlertAt > lastCompletedAt) &&
+    now.getTime() - lastAlertAt.getTime() < SYNC_PROVIDERS_STALE_ALERT_TTL_MS
+  ) {
     return false;
   }
   return true;
@@ -186,15 +191,25 @@ async function defaultGetLastAlertAt(): Promise<string | null> {
 }
 
 async function defaultSetLastAlertAt(iso: string): Promise<unknown> {
-  await db
-    .insert(ai_gateway_sync_providers_state)
-    .values({ stale_alert_last_posted_at: iso })
-    .onConflictDoUpdate({
-      target: ai_gateway_sync_providers_state.id,
-      set: { stale_alert_last_posted_at: iso },
+  return db.transaction(async tx => {
+    await tx.insert(ai_gateway_sync_providers_state).values({ id: 1 }).onConflictDoNothing();
+    const [row] = await tx
+      .select({ lastAlertAt: ai_gateway_sync_providers_state.stale_alert_last_posted_at })
+      .from(ai_gateway_sync_providers_state)
+      .where(eq(ai_gateway_sync_providers_state.id, 1))
+      .for('update');
+    if (!row) throw new Error('Sync-providers state row is missing');
+
+    const current = parseIsoTimestamp(row.lastAlertAt);
+    const requested = new Date(iso);
+    const latestIso = current && current > requested ? current.toISOString() : iso;
+    await tx
+      .update(ai_gateway_sync_providers_state)
+      .set({ stale_alert_last_posted_at: latestIso })
+      .where(eq(ai_gateway_sync_providers_state.id, 1));
+    return redisClient.set(SYNC_PROVIDERS_STALE_ALERT_LAST_POSTED_AT_REDIS_KEY, latestIso, {
+      ex: SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS,
     });
-  return redisClient.set(SYNC_PROVIDERS_STALE_ALERT_LAST_POSTED_AT_REDIS_KEY, iso, {
-    ex: SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS,
   });
 }
 

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert.ts
@@ -5,10 +5,7 @@ import { ai_gateway_sync_providers_state } from '@kilocode/db/schema';
 import { APP_URL } from '@/lib/constants';
 import { db } from '@/lib/drizzle';
 import { redisClient } from '@/lib/redis';
-import {
-  AI_GATEWAY_STATE_REDIS_TTL_SECONDS,
-  SYNC_PROVIDERS_STALE_ALERT_LAST_POSTED_AT_REDIS_KEY,
-} from '@/lib/redis-keys';
+import { SYNC_PROVIDERS_STALE_ALERT_LAST_POSTED_AT_REDIS_KEY } from '@/lib/redis-keys';
 import {
   sendAdminSlackNotification,
   type AdminSlackNotification,
@@ -16,7 +13,7 @@ import {
 import { eq } from 'drizzle-orm';
 
 export const SYNC_PROVIDERS_STALE_AFTER_MS = 60 * 60 * 1000;
-export const SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS = AI_GATEWAY_STATE_REDIS_TTL_SECONDS;
+export const SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS = 3 * 24 * 60 * 60;
 const SYNC_PROVIDERS_STALE_ALERT_TTL_MS = SYNC_PROVIDERS_STALE_ALERT_TTL_SECONDS * 1000;
 
 const STALE_WINDOW_LABEL = 'hour';

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -15,7 +15,7 @@ import { OpenRouterProvidersResponse } from '@/lib/ai-gateway/providers/openrout
 import { fetchModelsForProvider } from '@/lib/ai-gateway/providers/openrouter/fetch-provider-models';
 import { ai_gateway_sync_providers_state, modelsByProvider } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
-import { desc, lt, sql } from 'drizzle-orm';
+import { desc, eq, lt, sql } from 'drizzle-orm';
 import { captureException } from '@sentry/nextjs';
 import { OPENROUTER, VERCEL_AI_GATEWAY } from '@/lib/ai-gateway/providers/provider-definitions';
 import { logAutoModelChangesForAllOrgs } from '@/lib/organizations/auto-model-change-log';
@@ -397,16 +397,24 @@ export async function syncAndStoreProviders() {
   const direct_byok_model_counts = await syncDirectByokModels();
   console.log('[syncAndStoreProviders] direct-byok model counts:', direct_byok_model_counts);
 
-  const completed_at = new Date().toISOString();
-  await db
-    .insert(ai_gateway_sync_providers_state)
-    .values({ last_completed_at: completed_at })
-    .onConflictDoUpdate({
-      target: ai_gateway_sync_providers_state.id,
-      set: { last_completed_at: completed_at },
+  const completed_at = await db.transaction(async tx => {
+    await tx.insert(ai_gateway_sync_providers_state).values({ id: 1 }).onConflictDoNothing();
+    const [row] = await tx
+      .select({ id: ai_gateway_sync_providers_state.id })
+      .from(ai_gateway_sync_providers_state)
+      .where(eq(ai_gateway_sync_providers_state.id, 1))
+      .for('update');
+    if (!row) throw new Error('Sync-providers state row is missing');
+
+    const completedAt = new Date().toISOString();
+    await tx
+      .update(ai_gateway_sync_providers_state)
+      .set({ last_completed_at: completedAt })
+      .where(eq(ai_gateway_sync_providers_state.id, 1));
+    await redisClient.set(SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY, completedAt, {
+      ex: AI_GATEWAY_STATE_REDIS_TTL_SECONDS,
     });
-  await redisClient.set(SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY, completed_at, {
-    ex: AI_GATEWAY_STATE_REDIS_TTL_SECONDS,
+    return completedAt;
   });
 
   return {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -23,7 +23,10 @@ import type { Provider } from '@/lib/ai-gateway/providers/types';
 import type { StoredModel } from '@kilocode/db/schema-types';
 import { EndpointsSchema, ModelsSchema } from '@kilocode/db/schema-types';
 import { redisClient } from '@/lib/redis';
-import { SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY } from '@/lib/redis-keys';
+import {
+  AI_GATEWAY_STATE_REDIS_TTL_SECONDS,
+  SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY,
+} from '@/lib/redis-keys';
 import { syncDirectByokModels } from '@/lib/ai-gateway/providers/direct-byok/sync-direct-byok';
 import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attribution-headers';
 import {
@@ -395,7 +398,6 @@ export async function syncAndStoreProviders() {
   console.log('[syncAndStoreProviders] direct-byok model counts:', direct_byok_model_counts);
 
   const completed_at = new Date().toISOString();
-  await redisClient.set(SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY, completed_at);
   await db
     .insert(ai_gateway_sync_providers_state)
     .values({ last_completed_at: completed_at })
@@ -403,6 +405,9 @@ export async function syncAndStoreProviders() {
       target: ai_gateway_sync_providers_state.id,
       set: { last_completed_at: completed_at },
     });
+  await redisClient.set(SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY, completed_at, {
+    ex: AI_GATEWAY_STATE_REDIS_TTL_SECONDS,
+  });
 
   return {
     id: result.id,

--- a/apps/web/src/lib/ai-gateway/providers/routing-config.ts
+++ b/apps/web/src/lib/ai-gateway/providers/routing-config.ts
@@ -5,8 +5,9 @@ import {
   DEFAULT_VERCEL_PERCENTAGE_FREE,
   GatewayRoutingConfigSchema,
 } from '@/lib/ai-gateway/gateway-config';
-import { redisClient } from '@/lib/redis';
-import { VERCEL_ROUTING_REDIS_KEY } from '@/lib/redis-keys';
+import { db } from '@/lib/drizzle';
+import { ai_gateway_config } from '@kilocode/db/schema';
+import { eq } from 'drizzle-orm';
 
 export type RuntimeGatewayRoutingConfig = {
   vercelPaid: number;
@@ -24,10 +25,14 @@ const DEFAULT_RUNTIME_GATEWAY_ROUTING_CONFIG: RuntimeGatewayRoutingConfig = {
 
 export const getRuntimeGatewayRoutingConfig = createCachedFetch<RuntimeGatewayRoutingConfig>(
   async () => {
-    const raw = await redisClient.get<string>(VERCEL_ROUTING_REDIS_KEY);
-    if (!raw) return DEFAULT_RUNTIME_GATEWAY_ROUTING_CONFIG;
+    const [row] = await db
+      .select({ config: ai_gateway_config.config })
+      .from(ai_gateway_config)
+      .where(eq(ai_gateway_config.id, 1))
+      .limit(1);
+    if (!row) return DEFAULT_RUNTIME_GATEWAY_ROUTING_CONFIG;
 
-    const config = GatewayRoutingConfigSchema.parse(JSON.parse(raw));
+    const config = GatewayRoutingConfigSchema.parse(row.config);
     return {
       vercelPaid: config.vercel_routing_percentage ?? DEFAULT_VERCEL_PERCENTAGE,
       vercelFree: config.vercel_routing_percentage_free ?? DEFAULT_VERCEL_PERCENTAGE_FREE,

--- a/apps/web/src/lib/ai-gateway/request-logging-opt-ins.ts
+++ b/apps/web/src/lib/ai-gateway/request-logging-opt-ins.ts
@@ -3,7 +3,11 @@ import { ai_gateway_request_logging_opt_ins } from '@kilocode/db/schema';
 import { createCachedFetch } from '@/lib/cached-fetch';
 import { db } from '@/lib/drizzle';
 import { redisClient } from '@/lib/redis';
-import { REQUEST_LOGGING_OPT_INS_REDIS_KEY } from '@/lib/redis-keys';
+import {
+  AI_GATEWAY_STATE_REDIS_TTL_SECONDS,
+  REQUEST_LOGGING_OPT_INS_REDIS_KEY,
+} from '@/lib/redis-keys';
+import { eq } from 'drizzle-orm';
 
 export const RequestLoggingOptInSchema = z.object({
   id: z.string().uuid(),
@@ -17,45 +21,6 @@ export const RequestLoggingOptInSchema = z.object({
 export const RequestLoggingOptInsSchema = z.array(RequestLoggingOptInSchema).max(500);
 
 export type RequestLoggingOptIn = z.infer<typeof RequestLoggingOptInSchema>;
-
-const CREATE_OPT_IN_SCRIPT = `
-local entries = {}
-local raw = redis.call('GET', KEYS[1])
-if raw then entries = cjson.decode(raw) end
-local new_entry = cjson.decode(ARGV[1])
-for _, entry in ipairs(entries) do
-  if entry.target_type == new_entry.target_type and entry.target_id == new_entry.target_id then
-    return 0
-  end
-end
-if #entries >= 500 then return -1 end
-table.insert(entries, new_entry)
-redis.call('SET', KEYS[1], cjson.encode(entries))
-return 1
-`;
-
-const DELETE_OPT_IN_SCRIPT = `
-local raw = redis.call('GET', KEYS[1])
-if not raw then return 0 end
-local entries = cjson.decode(raw)
-local remaining = {}
-local deleted = 0
-for _, entry in ipairs(entries) do
-  if entry.id == ARGV[1] then
-    deleted = 1
-  else
-    table.insert(remaining, entry)
-  end
-end
-if deleted == 1 then
-  if #remaining == 0 then
-    redis.call('DEL', KEYS[1])
-  else
-    redis.call('SET', KEYS[1], cjson.encode(remaining))
-  end
-end
-return deleted
-`;
 
 const REQUEST_LOGGING_OPT_INS_CACHE_TTL_MS = process.env.NODE_ENV === 'test' ? 0 : 10_000;
 
@@ -71,9 +36,12 @@ export function hasMatchingRequestLoggingOptIn(
 }
 
 export async function getRequestLoggingOptIns(): Promise<RequestLoggingOptIn[]> {
-  const raw = await redisClient.get<string>(REQUEST_LOGGING_OPT_INS_REDIS_KEY);
-  if (!raw) return [];
-  return RequestLoggingOptInsSchema.parse(JSON.parse(raw));
+  const [row] = await db
+    .select({ optIns: ai_gateway_request_logging_opt_ins.opt_ins })
+    .from(ai_gateway_request_logging_opt_ins)
+    .where(eq(ai_gateway_request_logging_opt_ins.id, 1))
+    .limit(1);
+  return RequestLoggingOptInsSchema.parse(row?.optIns ?? []);
 }
 
 const getCachedRequestLoggingOptIns = createCachedFetch<RequestLoggingOptIn[]>(
@@ -82,42 +50,71 @@ const getCachedRequestLoggingOptIns = createCachedFetch<RequestLoggingOptIn[]>(
   []
 );
 
-async function mirrorRequestLoggingOptInsToDatabase(): Promise<void> {
-  const optIns = await getRequestLoggingOptIns();
-  await db
-    .insert(ai_gateway_request_logging_opt_ins)
-    .values({ opt_ins: optIns })
-    .onConflictDoUpdate({
-      target: ai_gateway_request_logging_opt_ins.id,
-      set: { opt_ins: optIns },
-    });
+async function mirrorRequestLoggingOptInsToRedis(optIns: RequestLoggingOptIn[]): Promise<void> {
+  await redisClient.set(REQUEST_LOGGING_OPT_INS_REDIS_KEY, JSON.stringify(optIns), {
+    ex: AI_GATEWAY_STATE_REDIS_TTL_SECONDS,
+  });
 }
 
 export async function createRequestLoggingOptIn(
   entry: RequestLoggingOptIn
 ): Promise<'created' | 'duplicate' | 'full'> {
   const validated = RequestLoggingOptInSchema.parse(entry);
-  const result = await redisClient.eval<[string], number>(
-    CREATE_OPT_IN_SCRIPT,
-    [REQUEST_LOGGING_OPT_INS_REDIS_KEY],
-    [JSON.stringify(validated)]
-  );
-  if (result === 1) {
-    await mirrorRequestLoggingOptInsToDatabase();
-    return 'created';
-  }
-  if (result === 0) return 'duplicate';
-  return 'full';
+  const mutation = await db.transaction(async tx => {
+    await tx
+      .insert(ai_gateway_request_logging_opt_ins)
+      .values({ opt_ins: [] })
+      .onConflictDoNothing();
+    const [row] = await tx
+      .select({ optIns: ai_gateway_request_logging_opt_ins.opt_ins })
+      .from(ai_gateway_request_logging_opt_ins)
+      .where(eq(ai_gateway_request_logging_opt_ins.id, 1))
+      .for('update');
+    if (!row) throw new Error('Request logging opt-in state row is missing');
+
+    const optIns = RequestLoggingOptInsSchema.parse(row.optIns);
+    if (
+      optIns.some(
+        optIn =>
+          optIn.target_type === validated.target_type && optIn.target_id === validated.target_id
+      )
+    ) {
+      return { result: 'duplicate' as const, optIns: null };
+    }
+    if (optIns.length >= 500) return { result: 'full' as const, optIns: null };
+
+    const updatedOptIns = [...optIns, validated];
+    await tx
+      .update(ai_gateway_request_logging_opt_ins)
+      .set({ opt_ins: updatedOptIns })
+      .where(eq(ai_gateway_request_logging_opt_ins.id, 1));
+    return { result: 'created' as const, optIns: updatedOptIns };
+  });
+  if (mutation.optIns) await mirrorRequestLoggingOptInsToRedis(mutation.optIns);
+  return mutation.result;
 }
 
 export async function deleteRequestLoggingOptIn(id: string): Promise<boolean> {
-  const result = await redisClient.eval<[string], number>(
-    DELETE_OPT_IN_SCRIPT,
-    [REQUEST_LOGGING_OPT_INS_REDIS_KEY],
-    [id]
-  );
-  if (result !== 1) return false;
-  await mirrorRequestLoggingOptInsToDatabase();
+  const updatedOptIns = await db.transaction(async tx => {
+    const [row] = await tx
+      .select({ optIns: ai_gateway_request_logging_opt_ins.opt_ins })
+      .from(ai_gateway_request_logging_opt_ins)
+      .where(eq(ai_gateway_request_logging_opt_ins.id, 1))
+      .for('update');
+    if (!row) return null;
+
+    const optIns = RequestLoggingOptInsSchema.parse(row.optIns);
+    const remaining = optIns.filter(entry => entry.id !== id);
+    if (remaining.length === optIns.length) return null;
+
+    await tx
+      .update(ai_gateway_request_logging_opt_ins)
+      .set({ opt_ins: remaining })
+      .where(eq(ai_gateway_request_logging_opt_ins.id, 1));
+    return remaining;
+  });
+  if (!updatedOptIns) return false;
+  await mirrorRequestLoggingOptInsToRedis(updatedOptIns);
   return true;
 }
 

--- a/apps/web/src/lib/ai-gateway/request-logging-opt-ins.ts
+++ b/apps/web/src/lib/ai-gateway/request-logging-opt-ins.ts
@@ -60,7 +60,7 @@ export async function createRequestLoggingOptIn(
   entry: RequestLoggingOptIn
 ): Promise<'created' | 'duplicate' | 'full'> {
   const validated = RequestLoggingOptInSchema.parse(entry);
-  const mutation = await db.transaction(async tx => {
+  return db.transaction(async tx => {
     await tx
       .insert(ai_gateway_request_logging_opt_ins)
       .values({ opt_ins: [] })
@@ -79,43 +79,40 @@ export async function createRequestLoggingOptIn(
           optIn.target_type === validated.target_type && optIn.target_id === validated.target_id
       )
     ) {
-      return { result: 'duplicate' as const, optIns: null };
+      return 'duplicate' as const;
     }
-    if (optIns.length >= 500) return { result: 'full' as const, optIns: null };
+    if (optIns.length >= 500) return 'full' as const;
 
     const updatedOptIns = [...optIns, validated];
     await tx
       .update(ai_gateway_request_logging_opt_ins)
       .set({ opt_ins: updatedOptIns })
       .where(eq(ai_gateway_request_logging_opt_ins.id, 1));
-    return { result: 'created' as const, optIns: updatedOptIns };
+    await mirrorRequestLoggingOptInsToRedis(updatedOptIns);
+    return 'created' as const;
   });
-  if (mutation.optIns) await mirrorRequestLoggingOptInsToRedis(mutation.optIns);
-  return mutation.result;
 }
 
 export async function deleteRequestLoggingOptIn(id: string): Promise<boolean> {
-  const updatedOptIns = await db.transaction(async tx => {
+  return db.transaction(async tx => {
     const [row] = await tx
       .select({ optIns: ai_gateway_request_logging_opt_ins.opt_ins })
       .from(ai_gateway_request_logging_opt_ins)
       .where(eq(ai_gateway_request_logging_opt_ins.id, 1))
       .for('update');
-    if (!row) return null;
+    if (!row) return false;
 
     const optIns = RequestLoggingOptInsSchema.parse(row.optIns);
     const remaining = optIns.filter(entry => entry.id !== id);
-    if (remaining.length === optIns.length) return null;
+    if (remaining.length === optIns.length) return false;
 
     await tx
       .update(ai_gateway_request_logging_opt_ins)
       .set({ opt_ins: remaining })
       .where(eq(ai_gateway_request_logging_opt_ins.id, 1));
-    return remaining;
+    await mirrorRequestLoggingOptInsToRedis(remaining);
+    return true;
   });
-  if (!updatedOptIns) return false;
-  await mirrorRequestLoggingOptInsToRedis(updatedOptIns);
-  return true;
 }
 
 export async function isDynamicallyOptedIntoRequestLogging(params: {

--- a/apps/web/src/lib/redis-keys.ts
+++ b/apps/web/src/lib/redis-keys.ts
@@ -15,6 +15,8 @@ const redisKey = <const Key extends string>(key: Key): Key & RedisKey => key as 
 
 export const BLACKLIST_DOMAINS_REDIS_KEY = redisKey('admin:blacklisted-domains');
 
+export const AI_GATEWAY_STATE_REDIS_TTL_SECONDS = 7 * 24 * 60 * 60;
+
 export const VERCEL_ROUTING_REDIS_KEY = redisKey('ai-gateway:vercel-routing-percentage');
 
 export const SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY = redisKey(

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -26,6 +26,7 @@ import {
   kiloclaw_instances,
   organizations,
   modelsByProvider,
+  ai_gateway_sync_providers_state,
   api_request_log,
 } from '@kilocode/db/schema';
 import { isGoneOrDeletingBlockedReason } from '@kilocode/db/user-soft-delete';
@@ -34,8 +35,6 @@ import { fetchSessionSnapshot } from '@/lib/session-ingest-client';
 import { sortSessionMessagesForDisplay } from '@/lib/cloud-agent-next/message-ordering';
 import { postTestStaleSyncAlert } from '@/lib/ai-gateway/providers/openrouter/sync-providers-stale-alert';
 import { syncAndStoreProviders } from '@/lib/ai-gateway/providers/openrouter/sync-providers';
-import { redisClient } from '@/lib/redis';
-import { SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY } from '@/lib/redis-keys';
 import { adminAppBuilderRouter } from '@/routers/admin-app-builder-router';
 import { adminDeploymentsRouter } from '@/routers/admin-deployments-router';
 import { adminKiloclawInstancesRouter } from '@/routers/admin-kiloclaw-instances-router';
@@ -2303,14 +2302,19 @@ export const adminRouter = createTRPCRouter({
       return { delivery };
     }),
     getLastSync: adminProcedure.query(async () => {
-      const [[latest], lastCompletedAt] = await Promise.all([
+      const [[latest], [syncState]] = await Promise.all([
         db
           .select({ id: modelsByProvider.id, data: modelsByProvider.data })
           .from(modelsByProvider)
           .orderBy(desc(modelsByProvider.id))
           .limit(1),
-        redisClient.get<string>(SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY),
+        db
+          .select({ lastCompletedAt: ai_gateway_sync_providers_state.last_completed_at })
+          .from(ai_gateway_sync_providers_state)
+          .where(eq(ai_gateway_sync_providers_state.id, 1))
+          .limit(1),
       ]);
+      const lastCompletedAt = syncState?.lastCompletedAt ?? null;
       if (!latest && !lastCompletedAt) return null;
       return {
         id: latest?.id ?? null,

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -2315,11 +2315,12 @@ export const adminRouter = createTRPCRouter({
           .limit(1),
       ]);
       const lastCompletedAt = syncState?.lastCompletedAt ?? null;
+      const completedAtIso = lastCompletedAt ? new Date(lastCompletedAt).toISOString() : null;
       if (!latest && !lastCompletedAt) return null;
       return {
         id: latest?.id ?? null,
         generated_at: latest?.data.generated_at ?? null,
-        completed_at: lastCompletedAt ?? null,
+        completed_at: completedAtIso,
         total_providers: latest?.data.total_providers ?? 0,
         total_models: latest?.data.total_models ?? 0,
       };

--- a/apps/web/src/routers/admin/gateway-config-router.ts
+++ b/apps/web/src/routers/admin/gateway-config-router.ts
@@ -47,19 +47,21 @@ export const adminGatewayConfigRouter = createTRPCRouter({
       updated_by_email: ctx.user.google_user_email,
       note: input.note,
     };
-    await db.insert(ai_gateway_config).values({ config }).onConflictDoUpdate({
-      target: ai_gateway_config.id,
-      set: { config },
-    });
-    const written = await redisClient.set(VERCEL_ROUTING_REDIS_KEY, JSON.stringify(config), {
-      ex: AI_GATEWAY_STATE_REDIS_TTL_SECONDS,
-    });
-    if (!written) {
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'Redis is not configured — cannot mirror routing override',
+    await db.transaction(async tx => {
+      await tx.insert(ai_gateway_config).values({ config }).onConflictDoUpdate({
+        target: ai_gateway_config.id,
+        set: { config },
       });
-    }
+      const written = await redisClient.set(VERCEL_ROUTING_REDIS_KEY, JSON.stringify(config), {
+        ex: AI_GATEWAY_STATE_REDIS_TTL_SECONDS,
+      });
+      if (!written) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Redis is not configured — cannot mirror routing override',
+        });
+      }
+    });
     return config;
   }),
 });

--- a/apps/web/src/routers/admin/gateway-config-router.ts
+++ b/apps/web/src/routers/admin/gateway-config-router.ts
@@ -5,17 +5,22 @@ import {
   GatewayConfigInputSchema,
   DEFAULT_GATEWAY_CONFIG,
 } from '@/lib/ai-gateway/gateway-config';
-import { VERCEL_ROUTING_REDIS_KEY } from '@/lib/redis-keys';
+import { AI_GATEWAY_STATE_REDIS_TTL_SECONDS, VERCEL_ROUTING_REDIS_KEY } from '@/lib/redis-keys';
 import type { GatewayConfig } from '@/lib/ai-gateway/gateway-config';
 import { TRPCError } from '@trpc/server';
 import { ai_gateway_config } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
+import { eq } from 'drizzle-orm';
 
 async function readConfig(): Promise<GatewayConfig> {
   try {
-    const raw = await redisClient.get<string>(VERCEL_ROUTING_REDIS_KEY);
-    if (!raw) return DEFAULT_GATEWAY_CONFIG;
-    return GatewayConfigSchema.parse(JSON.parse(raw));
+    const [row] = await db
+      .select({ config: ai_gateway_config.config })
+      .from(ai_gateway_config)
+      .where(eq(ai_gateway_config.id, 1))
+      .limit(1);
+    if (!row) return DEFAULT_GATEWAY_CONFIG;
+    return GatewayConfigSchema.parse(row.config);
   } catch {
     return DEFAULT_GATEWAY_CONFIG;
   }
@@ -42,17 +47,19 @@ export const adminGatewayConfigRouter = createTRPCRouter({
       updated_by_email: ctx.user.google_user_email,
       note: input.note,
     };
-    const written = await redisClient.set(VERCEL_ROUTING_REDIS_KEY, JSON.stringify(config));
-    if (!written) {
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'Redis is not configured — cannot save routing override',
-      });
-    }
     await db.insert(ai_gateway_config).values({ config }).onConflictDoUpdate({
       target: ai_gateway_config.id,
       set: { config },
     });
+    const written = await redisClient.set(VERCEL_ROUTING_REDIS_KEY, JSON.stringify(config), {
+      ex: AI_GATEWAY_STATE_REDIS_TTL_SECONDS,
+    });
+    if (!written) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Redis is not configured — cannot mirror routing override',
+      });
+    }
     return config;
   }),
 });


### PR DESCRIPTION
## Summary
- read gateway routing config, provider-sync timestamps, and request-logging opt-ins from the PostgreSQL singleton tables added in #5965
- enforce request-logging opt-in mutations against a row-locked database record instead of Redis
- keep Redis compatibility mirrors for migrated state, using a 7-day TTL except for the existing 3-day stale-alert TTL
- serialize authoritative database mutations with their Redis mirrors so failed or concurrent writes cannot leave stale mirrors
- preserve three-day stale-sync reminders and normalize database timestamps at the API boundary

## Verification
- formatted changed files with `oxfmt`
- `git diff --check`
- test, typecheck, and lint suites intentionally left to CI