### PR TITLE
fix(mobile): hide pull Updating, keep one Live Activity, fix sheet header

### DIFF
--- a/apps/mobile/src/app/(app)/pr-review/[owner]/[repo]/[number]/_layout.tsx
+++ b/apps/mobile/src/app/(app)/pr-review/[owner]/[repo]/[number]/_layout.tsx
@@ -69,6 +69,10 @@ export default function PrReviewNumberLayout() {
         draftEntityKey={draftEntityKey}
       >
         <Stack screenLayout={appUnlockScreenLayout} screenOptions={{ headerShown: false }}>
+          {/* Register the overview first: unregistered routes sort after
+              registered siblings, so without this the initial screen is the
+              comment-composer formSheet instead of the PR overview. */}
+          <Stack.Screen name="index" />
           <Stack.Screen name="comment-composer" options={sheetOptions} />
           <Stack.Screen name="review-submit" options={sheetOptions} />
           <Stack.Screen name="merge" options={sheetOptions} />

--- a/apps/mobile/src/components/agents/session-history-screen.pull-failure.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/session-history-screen.pull-failure.mounted.test.tsx
@@ -283,13 +283,16 @@ describe('SessionHistoryScreen pull-to-refresh with the API down', () => {
     });
     expect(refreshControl().refreshing).toBe(true);
 
-    // The in-flight pull announces Updating instead of a bare native spinner.
+    // The in-flight pull announces Updating without drawing the copy.
     await vi.waitFor(
       () => {
         expect(text()).toContain('Updating');
       },
       { timeout: 2000, interval: 10 }
     );
+    expect(
+      nodes('Text').find(node => node.children.includes('Updating'))?.props.className
+    ).toContain('absolute');
 
     // The refetch settles into the query error state with the rows kept.
     // The error flag lands through the screen's data hook (in production the

--- a/apps/mobile/src/components/agents/session-list-refresh-status.tsx
+++ b/apps/mobile/src/components/agents/session-list-refresh-status.tsx
@@ -6,7 +6,7 @@ import { Text } from '@/components/ui/text';
 import { cn } from '@/lib/utils';
 
 type SessionListRefreshStatusProps = {
-  /** A pull or retry is in flight: show the visible "Updating" line. */
+  /** A pull or retry is in flight: announce Updating; the spinner is the visual. */
   busy: boolean;
   /** The last refresh failed: show "Couldn't refresh" with an inline Retry. */
   failed: boolean;
@@ -16,9 +16,10 @@ type SessionListRefreshStatusProps = {
 
 /**
  * The Agents lists' reserved refresh-status line. It always occupies the
- * height of its final (failure) state, so Updating -> idle and
- * idle -> "Couldn't refresh" swaps never move the rows below it (the UX
- * rule the invisible 1x1 status nodes broke on device).
+ * height of its final (failure) state, so idle -> "Couldn't refresh" swaps
+ * never move the rows below it (the UX rule the invisible 1x1 status nodes
+ * broke on device). Pull-in-flight copy is screen-reader only: the native
+ * spinner already shows the gesture.
  */
 export function SessionListRefreshStatus({
   busy,
@@ -43,7 +44,7 @@ export function SessionListRefreshStatus({
       <AccessibleStatus
         message={message}
         tone={busy ? 'status' : 'error'}
-        className="flex-1 shrink text-xs"
+        className={busy ? 'absolute size-px overflow-hidden' : 'flex-1 shrink text-xs'}
       />
       {showRetry ? (
         <Pressable

--- a/apps/mobile/src/components/agents/session-list-screen.pull-failure.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/session-list-screen.pull-failure.mounted.test.tsx
@@ -335,8 +335,8 @@ describe('AgentSessionListScreen pull-to-refresh with the API down', () => {
     });
     expect(refreshControl().refreshing).toBe(true);
 
-    // The in-flight pull shows the visible Updating status line (reserved
-    // space beside the rows, announced to assistive tech).
+    // The in-flight pull announces Updating (reserved space beside the
+    // rows) without drawing the copy; the native spinner is the visual.
     await act(async () => {
       await vi.waitFor(
         () => {
@@ -345,6 +345,9 @@ describe('AgentSessionListScreen pull-to-refresh with the API down', () => {
         { timeout: 2000, interval: 10 }
       );
     });
+    expect(
+      nodes('Text').find(node => node.children.includes('Updating'))?.props.className
+    ).toContain('absolute');
 
     // The fetch then fails through the real query lifecycle. The rejected
     // pull holds the in-flight feedback through the beat first, so the

--- a/apps/mobile/src/components/home/agent-sessions-section.tsx
+++ b/apps/mobile/src/components/home/agent-sessions-section.tsx
@@ -228,9 +228,10 @@ export function LiveSessionFeedback({
           className="absolute size-px overflow-hidden"
         />
       )}
-      {/* The live tab's reserved status line: visible Updating while the pull
-          is in flight, visible "Couldn't refresh" + Retry when it failed.
-          Home passes no refresh state and keeps its a11y-only announcement. */}
+      {/* The live tab's reserved status line: screen-reader Updating while
+          the pull is in flight, visible "Couldn't refresh" + Retry when it
+          failed. Home passes no refresh state and keeps its a11y-only
+          announcement. */}
       {refresh && content === 'rows' ? (
         <SessionListRefreshStatus
           busy={refresh.busy}

--- a/apps/mobile/src/components/pr-review/pr-form-sheet-chrome.tsx
+++ b/apps/mobile/src/components/pr-review/pr-form-sheet-chrome.tsx
@@ -10,7 +10,8 @@
 // collapsable={false}: keep a stable native subview at index 0 (SheetHeader
 // pattern). No `modal` top inset and no `centerTitle`: the formSheet grabber
 // already clears the top edge, and the close caret stays on the title row.
-// `safeAreaTop={false}` leaves vertical padding to `pt-3`.
+// `safeAreaTop={false}` leaves vertical padding to `pt-5` (eight extra
+// logical pixels over the old `pt-3`, per PR 5972 owner feedback).
 //
 // Keyboard: ScrollView uses automaticallyAdjustKeyboardInsets. Footers must
 // NOT re-apply the full keyboard height (AppAwareKeyboardPaddingView double-
@@ -55,7 +56,7 @@ export function PrFormSheetHeader(props: { title: string; eyebrow: string; onBac
         backIcon="close"
         showBackButton
         safeAreaTop={false}
-        className="pt-3"
+        className="pt-5"
       />
     </View>
   );

--- a/apps/mobile/src/components/pr-review/pr-form-sheet-chrome.tsx
+++ b/apps/mobile/src/components/pr-review/pr-form-sheet-chrome.tsx
@@ -8,9 +8,9 @@
 // OUTSIDE the ScrollView so keyboard focus does not scroll the title off-screen.
 //
 // collapsable={false}: keep a stable native subview at index 0 (SheetHeader
-// pattern). No `modal` top inset: the formSheet grabber already clears the
-// top edge; the modal 32pt pad left a transparent band content showed through
-// (that band + parent PR "Go back" is the stray ‹ root cause).
+// pattern). No `modal` top inset and no `centerTitle`: the formSheet grabber
+// already clears the top edge, and the close caret stays on the title row.
+// `safeAreaTop={false}` leaves vertical padding to `pt-3`.
 //
 // Keyboard: ScrollView uses automaticallyAdjustKeyboardInsets. Footers must
 // NOT re-apply the full keyboard height (AppAwareKeyboardPaddingView double-
@@ -51,9 +51,10 @@ export function PrFormSheetHeader(props: { title: string; eyebrow: string; onBac
       <ScreenHeader
         title={props.title}
         eyebrow={props.eyebrow}
-        centerTitle
         onBack={props.onBack}
         backIcon="close"
+        showBackButton
+        safeAreaTop={false}
         className="pt-3"
       />
     </View>

--- a/apps/mobile/src/components/screen-header.mounted.test.tsx
+++ b/apps/mobile/src/components/screen-header.mounted.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as composer-paste-button.mounted.test.tsx) */
+/* eslint-disable typescript-eslint/no-deprecated, max-lines -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as composer-paste-button.mounted.test.tsx) */
 import { type ComponentProps, createElement } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -337,5 +337,22 @@ describe('ScreenHeader mounted', () => {
         expect(title.parent?.parent?.parent).toBe(back.parent?.parent?.parent);
       }
     }
+  });
+
+  it('keeps the close control on the title row when the sheet skips the safe-area inset', () => {
+    const renderer = renderHeader({
+      title: 'Submit review',
+      eyebrow: 'KILO-ORG/CLOUD#5058',
+      onBack: () => undefined,
+      backIcon: 'close',
+      showBackButton: true,
+      safeAreaTop: false,
+      className: 'pt-3',
+    });
+    const back = findBackPressable(renderer.root);
+    const title = renderer.root.findByProps({ accessibilityRole: 'header' });
+    expect(title.parent?.parent).toBe(back.parent);
+    expect(renderer.root.props.style).toBeUndefined();
+    expect(renderer.root.props.className).toContain('pt-3');
   });
 });

--- a/apps/mobile/src/components/screen-header.tsx
+++ b/apps/mobile/src/components/screen-header.tsx
@@ -41,6 +41,11 @@ type ScreenHeaderProps = {
    */
   onTitlePressAccessibilityLabel?: string;
   backIcon?: 'back' | 'close';
+  /**
+   * Apply the status-bar safe-area inset. Form sheets already clear the
+   * grabber; passing false leaves vertical padding to `className`.
+   */
+  safeAreaTop?: boolean;
   /** Extra classes on the outer header container. Overrides the default `px-4` for screens that need a different horizontal inset. */
   className?: string;
 };
@@ -63,6 +68,7 @@ export function ScreenHeader({
   onTitlePress,
   onTitlePressAccessibilityLabel,
   backIcon,
+  safeAreaTop = true,
   className,
 }: Readonly<ScreenHeaderProps>) {
   const insets = useSafeAreaInsets();
@@ -151,7 +157,10 @@ export function ScreenHeader({
   const separateHeading = centerTitle && (Boolean(title) || Boolean(eyebrow));
 
   return (
-    <View className={cn('bg-background px-4 pb-3', className)} style={{ paddingTop }}>
+    <View
+      className={cn('bg-background px-4 pb-3', className)}
+      style={safeAreaTop ? { paddingTop } : undefined}
+    >
       {separateHeading && <View className="min-h-11 flex-row items-center">{heading}</View>}
       <View className="flex-row items-center">
         <View className="min-w-0 flex-1 flex-row items-center gap-1">

--- a/apps/mobile/src/glanceable-ios/ending-activities.ts
+++ b/apps/mobile/src/glanceable-ios/ending-activities.ts
@@ -5,6 +5,7 @@
  */
 import { type GlanceableLiveActivityContentState } from '@kilocode/notifications';
 import { after, type LiveActivity } from 'expo-widgets';
+import { AppState } from 'react-native';
 
 export type Activity = LiveActivity<Partial<GlanceableLiveActivityContentState>>;
 
@@ -108,22 +109,54 @@ export function endExtra(instance: Activity, id: string): void {
 }
 
 let idleEndTimer: ReturnType<typeof setTimeout> | null = null;
+/**
+ * Temporary AppState watch for a pending idle-end debounce. JavaScript can
+ * suspend the moment the app stops being active, so the timer would never
+ * fire and the card would never retire. Leaving active submits the same end
+ * at once; every other exit path removes the watch below.
+ */
+let idleEndAppState: { remove: () => void } | null = null;
+
+function clearIdleEndAppState(): void {
+  idleEndAppState?.remove();
+  idleEndAppState = null;
+}
 
 export function cancelIdleEnd(): void {
   if (idleEndTimer !== null) {
     clearTimeout(idleEndTimer);
     idleEndTimer = null;
   }
+  clearIdleEndAppState();
 }
 
 export function scheduleIdleEnd(end: () => void, delayMs: number): void {
+  // Already inactive or background, JavaScript can suspend before any timer
+  // fires: submit the idle end at once so a background caller can await it.
+  if (AppState.currentState !== 'active') {
+    end();
+    return;
+  }
   if (idleEndTimer !== null) {
     return;
   }
   idleEndTimer = setTimeout(() => {
     idleEndTimer = null;
+    clearIdleEndAppState();
     end();
   }, delayMs);
+  // While active, a later transition out of active must flush the pending end
+  // before iOS suspends the JavaScript context. Every other exit path above
+  // and in `cancelIdleEnd` removes this watch.
+  idleEndAppState = AppState.addEventListener('change', state => {
+    if (state === 'active' || idleEndTimer === null) {
+      return;
+    }
+    clearTimeout(idleEndTimer);
+    idleEndTimer = null;
+    clearIdleEndAppState();
+    end();
+  });
 }
 
 export function endOtherVisible(keptId: string, instances: readonly Activity[]): void {

--- a/apps/mobile/src/glanceable-ios/ending-activities.ts
+++ b/apps/mobile/src/glanceable-ios/ending-activities.ts
@@ -106,3 +106,31 @@ export function endExtra(instance: Activity, id: string): void {
   endingActivities.set(id, ending);
   void scheduleEnd(ending);
 }
+
+let idleEndTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function cancelIdleEnd(): void {
+  if (idleEndTimer !== null) {
+    clearTimeout(idleEndTimer);
+    idleEndTimer = null;
+  }
+}
+
+export function scheduleIdleEnd(end: () => void, delayMs: number): void {
+  if (idleEndTimer !== null) {
+    return;
+  }
+  idleEndTimer = setTimeout(() => {
+    idleEndTimer = null;
+    end();
+  }, delayMs);
+}
+
+export function endOtherVisible(keptId: string, instances: readonly Activity[]): void {
+  for (const instance of instances) {
+    const id = instance.getInfo().id;
+    if (id !== keptId && instance.getInfo().state !== 'dismissed') {
+      endExtra(instance, id);
+    }
+  }
+}

--- a/apps/mobile/src/glanceable-ios/ios-sink.native.test.ts
+++ b/apps/mobile/src/glanceable-ios/ios-sink.native.test.ts
@@ -80,6 +80,35 @@ const native = vi.hoisted(() => {
   return { records, ignoredUpdates, snapshots, failures, add, wrap };
 });
 
+// The sink and its ending helpers read the foreground state and watch for the
+// app leaving active while an idle-end debounce is pending.
+const appState = vi.hoisted(() => ({
+  currentState: 'active' as string,
+  listeners: new Set<(state: string) => void>(),
+  emit(next: string) {
+    this.currentState = next;
+    for (const listener of this.listeners) {
+      listener(next);
+    }
+  },
+  reset() {
+    this.currentState = 'active';
+    this.listeners.clear();
+  },
+}));
+
+vi.mock('react-native', () => ({
+  AppState: {
+    get currentState() {
+      return appState.currentState;
+    },
+    addEventListener: (_name: string, listener: (state: string) => void) => {
+      appState.listeners.add(listener);
+      return { remove: () => appState.listeners.delete(listener) };
+    },
+  },
+}));
+
 vi.mock('expo-widgets', async () => {
   const { after } = await import('expo-widgets/src/Widgets');
   return { after, widgetsDirectory: 'file:///app-group/ExpoWidgets/' };
@@ -155,6 +184,7 @@ beforeEach(() => {
   vi.resetModules();
   vi.useFakeTimers();
   vi.setSystemTime(NOW);
+  appState.reset();
   native.records.length = 0;
   native.ignoredUpdates.length = 0;
   native.snapshots.length = 0;
@@ -349,6 +379,22 @@ describe('native adapter idle window', () => {
     expect(firstActivity()).toMatchObject({
       state: 'ended',
       dismissAt: NOW + GLANCEABLE_IDLE_END_DEBOUNCE_MS + GLANCEABLE_IDLE_ONLY_MS,
+      props: { running: 0, idle: 1 },
+      policies: ['after'],
+    });
+  });
+
+  it('submits the idle dismissal at once for a background publish without advancing timers', async () => {
+    const sink = await loadSink();
+    sink.startOrUpdate(snapshot([{ status: 'busy' }]), CTX);
+    appState.currentState = 'background';
+
+    sink.publish(snapshot([{ status: 'idle' }], 1));
+    await sink.waitForNativeTerminal?.();
+
+    expect(firstActivity()).toMatchObject({
+      state: 'ended',
+      dismissAt: NOW + GLANCEABLE_IDLE_ONLY_MS,
       props: { running: 0, idle: 1 },
       policies: ['after'],
     });

--- a/apps/mobile/src/glanceable-ios/ios-sink.native.test.ts
+++ b/apps/mobile/src/glanceable-ios/ios-sink.native.test.ts
@@ -3,6 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildGlanceableSnapshot,
+  GLANCEABLE_IDLE_END_DEBOUNCE_MS,
+  GLANCEABLE_IDLE_ONLY_MS,
+  GLANCEABLE_TERMINAL_MS,
   type GlanceableAgentsSnapshot,
 } from '@kilocode/app-shared/glanceable-agents-snapshot';
 import { type GlanceableLiveActivityContentState } from '@kilocode/notifications';
@@ -157,7 +160,10 @@ beforeEach(() => {
   native.snapshots.length = 0;
   native.failures.info = false;
 });
-afterEach(() => vi.useRealTimers());
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
 
 describe('native adapter recovery', () => {
   it.each(['publish then start', 'start only'])(
@@ -337,13 +343,31 @@ describe('native adapter idle window', () => {
     const sink = await loadSink();
     sink.startOrUpdate(snapshot([{ status: 'busy' }, { status: 'idle' }]), CTX);
     sink.publish(snapshot([{ status: 'idle' }], 1));
+    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
     await sink.waitForNativeTerminal?.();
 
     expect(firstActivity()).toMatchObject({
       state: 'ended',
-      dismissAt: NOW + 600_000,
+      dismissAt: NOW + GLANCEABLE_IDLE_END_DEBOUNCE_MS + GLANCEABLE_IDLE_ONLY_MS,
       props: { running: 0, idle: 1 },
       policies: ['after'],
+    });
+  });
+
+  it('keeps the same card when work resumes before the idle-end debounce', async () => {
+    const sink = await loadSink();
+    sink.startOrUpdate(snapshot([{ status: 'busy' }]), CTX);
+    sink.publish(snapshot([{ status: 'idle' }], 1));
+    const resumed = snapshot([{ status: 'busy' }], 2);
+    sink.publish(resumed);
+    sink.startOrUpdate(resumed, CTX);
+    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
+    await sink.waitForNativeTerminal?.();
+
+    expect(native.records).toHaveLength(1);
+    expect(firstActivity()).toMatchObject({
+      state: 'active',
+      props: { running: 1, idle: 0 },
     });
   });
 
@@ -351,6 +375,7 @@ describe('native adapter idle window', () => {
     const sink = await loadSink();
     sink.startOrUpdate(snapshot([{ status: 'busy' }]), CTX);
     sink.publish(snapshot([{ status: 'idle' }], 1));
+    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
     await sink.waitForNativeTerminal?.();
 
     const resumed = snapshot([{ status: 'busy' }], 2);
@@ -374,18 +399,24 @@ describe('native adapter idle window shortening', () => {
     const sink = await loadSink();
     sink.startOrUpdate(snapshot([{ status: 'busy' }]), CTX);
     sink.publish(snapshot([{ status: 'idle' }], 1));
+    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
     await sink.waitForNativeTerminal?.();
-    expect(firstActivity().dismissAt).toBe(NOW + 600_000);
+    expect(firstActivity().dismissAt).toBe(
+      NOW + GLANCEABLE_IDLE_END_DEBOUNCE_MS + GLANCEABLE_IDLE_ONLY_MS
+    );
 
     sink.publish(snapshot([], 2));
     await sink.waitForNativeTerminal?.();
-    expect(firstActivity().dismissAt).toBe(NOW + 8000);
+    expect(firstActivity().dismissAt).toBe(
+      NOW + GLANCEABLE_IDLE_END_DEBOUNCE_MS + GLANCEABLE_TERMINAL_MS
+    );
   });
 
   it('holds the replacement card until the idle card is dismissed', async () => {
     const sink = await loadSink();
     sink.startOrUpdate(snapshot([{ status: 'busy' }]), CTX);
     sink.publish(snapshot([{ status: 'idle' }], 1));
+    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
     await sink.waitForNativeTerminal?.();
 
     const resumed = snapshot([{ status: 'busy' }], 2);

--- a/apps/mobile/src/glanceable-ios/ios-sink.test.ts
+++ b/apps/mobile/src/glanceable-ios/ios-sink.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildGlanceableSnapshot,
+  GLANCEABLE_IDLE_END_DEBOUNCE_MS,
+  GLANCEABLE_IDLE_ONLY_MS,
   GLANCEABLE_STALE_MS,
   type GlanceableAgentsSnapshot,
 } from '@kilocode/app-shared/glanceable-agents-snapshot';
@@ -52,7 +54,31 @@ vi.mock('@expo/ui/swift-ui/modifiers', () => ({
   frame: () => ({}),
   widgetURL: () => ({}),
 }));
-vi.mock('react-native', () => ({ PlatformColor: (name: string) => name }));
+// The sink reads the foreground state at publish and watches for the app
+// leaving active while an idle-end debounce is pending.
+const mockAppState = vi.hoisted(() => ({
+  currentState: 'active' as string,
+  listeners: new Set<(state: string) => void>(),
+  leaveActive(next: string) {
+    this.currentState = next;
+    for (const listener of this.listeners) {
+      listener(next);
+    }
+  },
+}));
+
+vi.mock('react-native', () => ({
+  PlatformColor: (name: string) => name,
+  AppState: {
+    get currentState() {
+      return mockAppState.currentState;
+    },
+    addEventListener: (_type: string, listener: (state: string) => void) => {
+      mockAppState.listeners.add(listener);
+      return { remove: () => mockAppState.listeners.delete(listener) };
+    },
+  },
+}));
 
 const mockState = vi.hoisted(() => ({
   startError: null as { code: string; message: string } | null,
@@ -174,6 +200,8 @@ function snapshotFor(
 beforeEach(() => {
   _resetLiveActivitySwitchForTests();
   _resetIosSinkForTests();
+  mockAppState.currentState = 'active';
+  mockAppState.listeners.clear();
   subscriptions.clear();
   mockState.startError = null;
   mockState.instancesError = null;
@@ -944,6 +972,63 @@ describe('iosSink Live Activity content-state', () => {
     ]);
     expect(mockState.updated.length).toBe(0);
     expect(subscriptions.has('activity')).toBe(false);
+  });
+});
+
+describe('iosSink idle end scheduling', () => {
+  it('submits the idle native end at once when the app is already background', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    iosSink.startOrUpdate(snapshotFor([{ status: 'busy' }], 0), CTX);
+    mockAppState.currentState = 'background';
+
+    iosSink.publish(snapshotFor([{ status: 'idle' }], 1));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockState.started[0]).toMatchObject({
+      ended: true,
+      dismissAt: NOW + GLANCEABLE_IDLE_ONLY_MS,
+      props: { status: 'happy', running: 0, idle: 1 },
+    });
+  });
+
+  it('flushes a pending idle end when the app leaves active during the debounce', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    iosSink.startOrUpdate(snapshotFor([{ status: 'busy' }], 0), CTX);
+    iosSink.publish(snapshotFor([{ status: 'idle' }], 1));
+    expect(mockState.started[0]?.ended).toBe(false);
+
+    mockAppState.leaveActive('background');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockState.started[0]).toMatchObject({
+      ended: true,
+      dismissAt: NOW + GLANCEABLE_IDLE_ONLY_MS,
+    });
+
+    // The debounce is gone with its watch: no second end ever fires.
+    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
+    expect(mockState.ended).toHaveLength(1);
+    expect(mockAppState.listeners.size).toBe(0);
+  });
+
+  it('cancels the pending idle end and its watch when work resumes', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    iosSink.startOrUpdate(snapshotFor([{ status: 'busy' }], 0), CTX);
+    iosSink.publish(snapshotFor([{ status: 'idle' }], 1));
+    const resumed = snapshotFor([{ status: 'busy' }], 2);
+    iosSink.publish(resumed);
+    iosSink.startOrUpdate(resumed, CTX);
+
+    mockAppState.leaveActive('background');
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
+
+    expect(mockState.started[0]).toMatchObject({ ended: false, props: { running: 1, idle: 0 } });
+    expect(mockState.ended).toEqual([]);
+    expect(mockAppState.listeners.size).toBe(0);
   });
 });
 

--- a/apps/mobile/src/glanceable-ios/ios-sink.ts
+++ b/apps/mobile/src/glanceable-ios/ios-sink.ts
@@ -1,4 +1,5 @@
 import {
+  GLANCEABLE_IDLE_END_DEBOUNCE_MS,
   GLANCEABLE_IDLE_ONLY_MS,
   GLANCEABLE_STALE_MS,
   GLANCEABLE_TERMINAL_MS,
@@ -20,10 +21,13 @@ import { getLiveActivityEnabled } from '@/lib/glanceable/live-activity-switch';
 import { ActiveAgentsLiveActivity, OPEN_AGENTS_URL } from './active-agents-live-activity';
 import {
   type Activity,
+  cancelIdleEnd,
   endExtra,
   endingActivities,
+  endOtherVisible,
   readEndingToken,
   scheduleEnd,
+  scheduleIdleEnd,
   settleEnds,
 } from './ending-activities';
 import { ActiveAgentsWidget } from './active-agents-widget';
@@ -31,7 +35,7 @@ import {
   buildExpiredWidgetProps,
   buildGlanceableLiveActivityContentState,
   buildGlanceableViewProps,
-  buildStaleWidgetProps,
+  staleTimelineFrame,
   toWidgetProps,
 } from './view-props';
 
@@ -78,18 +82,25 @@ function startCard(
   ctx: GlanceableSinkContext
 ): void {
   try {
-    activity = ActiveAgentsLiveActivity.start(contentState, OPEN_AGENTS_URL, STALE_AFTER_SECONDS);
+    const started = ActiveAgentsLiveActivity.start(
+      contentState,
+      OPEN_AGENTS_URL,
+      STALE_AFTER_SECONDS
+    );
+    activity = started;
     inFlightUpdate = null;
+    lastProps = contentState;
+    revision = snapshot.revision;
+    getGlanceableDelivery().registerTokens(snapshot, ctx.organizationId, ctx.userId, started);
+    // A push-to-start or an idle card still waiting out its dismissal can share
+    // the Lock Screen with this start. Retire every other visible instance now.
+    endOtherVisible(started.getInfo().id, ActiveAgentsLiveActivity.getInstances(true));
   } catch (error) {
     // Only ActivityKit unavailability is permanent; transient starts retry later.
     if (isActivityKitUnavailable(error)) {
       activityKitDeniedState = true;
     }
-    return;
   }
-  lastProps = contentState;
-  revision = snapshot.revision;
-  getGlanceableDelivery().registerTokens(snapshot, ctx.organizationId, ctx.userId, activity);
 }
 
 /** Recheck native state even when JavaScript missed the remote terminal snapshot. */
@@ -147,6 +158,7 @@ function endNow(
   props: Partial<GlanceableLiveActivityContentState> | null = lastProps,
   reachEnded = dismissMs === null
 ): Promise<void> | null {
+  cancelIdleEnd();
   const targets = new Map<string, Activity>();
   if (reachEnded) {
     try {
@@ -262,23 +274,7 @@ export function _resetIosSinkForTests(): void {
   pendingStart = null;
   pendingStartInput = null;
   pendingStartAt = 0;
-}
-
-/**
- * The delayed frame, when there is a claim worth retracting. Counts only: an
- * empty or waiting surface asserts nothing that can go out of date, and a
- * `stale` frame after `expiresAt` would only undo the expiry frame behind it.
- */
-function staleTimelineFrame(
-  snapshot: GlanceableAgentsSnapshot
-): { date: Date; props: Partial<ReturnType<typeof buildGlanceableViewProps>> }[] {
-  if (snapshot.status !== 'happy') {
-    return [];
-  }
-  const staleAt = Date.parse(snapshot.updatedAt) + GLANCEABLE_STALE_MS;
-  return staleAt >= Date.parse(snapshot.expiresAt)
-    ? []
-    : [{ date: new Date(staleAt), props: buildStaleWidgetProps(snapshot, translate) }];
+  cancelIdleEnd();
 }
 
 export const iosSink: GlanceableSink = {
@@ -302,7 +298,7 @@ export const iosSink: GlanceableSink = {
         // never delivered at all. Hand it the frame that stops asserting the
         // counts as current, so a widget nothing has refreshed reads as delayed
         // rather than as fact.
-        ...staleTimelineFrame(snapshot),
+        ...staleTimelineFrame(snapshot, translate),
         { date: new Date(snapshot.expiresAt), props: buildExpiredWidgetProps(snapshot, translate) },
       ]);
     }
@@ -322,14 +318,15 @@ export const iosSink: GlanceableSink = {
       lastProps = contentState;
       inFlightUpdate = activity.update(lastProps, STALE_AFTER_SECONDS);
       if (isIdleOnlyGlanceableWork(snapshot)) {
-        // Everything went idle: hand ActivityKit the dismissal date and stop
-        // owning the surface. A JavaScript timer would never fire — the app is
-        // asleep whenever this matters — and an idle agent produces no further
-        // snapshot to check a deadline against. `endNow` awaits the update
-        // above, so the card keeps the idle counts until it is removed. Work
-        // resuming inside the window starts a fresh card, and `startOrUpdate`
-        // dismisses this one first.
-        void endNow(GLANCEABLE_IDLE_ONLY_MS, contentState);
+        // Brief idle↔busy flips must not tear the card down. Debounce, then
+        // hand ActivityKit the dismissal date so the surface still retires
+        // if JavaScript stops. Work that resumes before the timer fires
+        // updates this same card.
+        scheduleIdleEnd(() => {
+          void endNow(GLANCEABLE_IDLE_ONLY_MS, lastProps);
+        }, GLANCEABLE_IDLE_END_DEBOUNCE_MS);
+      } else {
+        cancelIdleEnd();
       }
     }
   },
@@ -396,6 +393,9 @@ export const iosSink: GlanceableSink = {
     // publish can adopt an activity before this method sees it. Bind its token
     // listener here too; delivery deduplicates the sink's stable native handle.
     getGlanceableDelivery().registerTokens(snapshot, ctx.organizationId, ctx.userId, activity);
+    if (isStartableGlanceableWork(snapshot)) {
+      cancelIdleEnd();
+    }
     // The publisher coalesces and guards revisions, but keep the sink monotonic
     // so a late or replayed emit can never move the surface backwards.
     if (snapshot.revision <= revision) {

--- a/apps/mobile/src/glanceable-ios/ios-sink.ts
+++ b/apps/mobile/src/glanceable-ios/ios-sink.ts
@@ -318,10 +318,12 @@ export const iosSink: GlanceableSink = {
       lastProps = contentState;
       inFlightUpdate = activity.update(lastProps, STALE_AFTER_SECONDS);
       if (isIdleOnlyGlanceableWork(snapshot)) {
-        // Brief idle↔busy flips must not tear the card down. Debounce, then
-        // hand ActivityKit the dismissal date so the surface still retires
-        // if JavaScript stops. Work that resumes before the timer fires
-        // updates this same card.
+        // Brief idle↔busy flips must not tear the card down: the end waits out
+        // a debounce, then hands ActivityKit the dismissal date so the surface
+        // still retires if JavaScript stops. Work that resumes before the
+        // timer fires updates this same card. While inactive or background,
+        // scheduleIdleEnd submits the end at once instead, so a background
+        // wake can await it through `waitForNativeTerminal`.
         scheduleIdleEnd(() => {
           void endNow(GLANCEABLE_IDLE_ONLY_MS, lastProps);
         }, GLANCEABLE_IDLE_END_DEBOUNCE_MS);

--- a/apps/mobile/src/glanceable-ios/view-props.ts
+++ b/apps/mobile/src/glanceable-ios/view-props.ts
@@ -1,4 +1,7 @@
-import { type GlanceableAgentsSnapshot } from '@kilocode/app-shared/glanceable-agents-snapshot';
+import {
+  GLANCEABLE_STALE_MS,
+  type GlanceableAgentsSnapshot,
+} from '@kilocode/app-shared/glanceable-agents-snapshot';
 import { type GlanceableLiveActivityContentState } from '@kilocode/notifications';
 
 import {
@@ -88,11 +91,29 @@ export function toWidgetProps(props: GlanceableViewProps): Partial<GlanceableVie
  * refresh. The counts stay — they are still the last thing the device knew —
  * and only the claim that they are current is dropped.
  */
-export function buildStaleWidgetProps(
+function buildStaleWidgetProps(
   snapshot: GlanceableAgentsSnapshot,
   translate: (key: string) => string
 ): Partial<GlanceableViewProps> {
   return toWidgetProps(buildGlanceableViewProps({ ...snapshot, status: 'stale' }, {}, translate));
+}
+
+/**
+ * The delayed frame, when there is a claim worth retracting. Counts only: an
+ * empty or waiting surface asserts nothing that can go out of date, and a
+ * `stale` frame after `expiresAt` would only undo the expiry frame behind it.
+ */
+export function staleTimelineFrame(
+  snapshot: GlanceableAgentsSnapshot,
+  translate: (key: string) => string
+): { date: Date; props: Partial<GlanceableViewProps> }[] {
+  if (snapshot.status !== 'happy') {
+    return [];
+  }
+  const staleAt = Date.parse(snapshot.updatedAt) + GLANCEABLE_STALE_MS;
+  return staleAt >= Date.parse(snapshot.expiresAt)
+    ? []
+    : [{ date: new Date(staleAt), props: buildStaleWidgetProps(snapshot, translate) }];
 }
 
 /**

--- a/apps/mobile/src/lib/notifications.test.ts
+++ b/apps/mobile/src/lib/notifications.test.ts
@@ -34,6 +34,7 @@ type ResponseListener = (response: Response) => void;
 
 const mocks = vi.hoisted(() => ({
   platform: { OS: 'android' as string },
+  appState: { currentState: 'active' as string },
   setBadgeCountAsync: vi.fn(),
   setNotificationChannelAsync: vi.fn(),
   setNotificationHandler: vi.fn(),
@@ -59,6 +60,12 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('react-native', () => ({
   Platform: mocks.platform,
+  AppState: {
+    get currentState() {
+      return mocks.appState.currentState;
+    },
+    addEventListener: vi.fn(() => ({ remove: vi.fn() })),
+  },
 }));
 
 vi.mock('expo-notifications', () => ({
@@ -204,6 +211,7 @@ async function flushMicrotasks(): Promise<void> {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.platform.OS = 'android';
+  mocks.appState.currentState = 'active';
   mocks.setBadgeCountAsync.mockResolvedValue(true);
   mocks.setNotificationChannelAsync.mockResolvedValue(undefined);
   mocks.getPermissionsAsync.mockResolvedValue({ status: 'denied' });
@@ -1325,6 +1333,8 @@ describe('cold iOS background delivery', () => {
     props: null as string | null,
     contentDate: null as number | null,
     policies: [] as string[],
+    // Counted at end() entry, before any gate: proves submission happened.
+    endCalls: 0,
     observers: new Set<(token: string) => void>(),
   };
 
@@ -1433,6 +1443,7 @@ describe('cold iOS background delivery', () => {
     native.props = null;
     native.contentDate = null;
     native.policies = [];
+    native.endCalls = 0;
     native.observers.clear();
     mocks.nativeInstances.mockImplementation((includeEnded = false) => {
       if (
@@ -1488,6 +1499,7 @@ describe('cold iOS background delivery', () => {
           },
           // eslint-disable-next-line max-params -- match the installed expo-widgets native end contract
           end: async (policy: string, afterDate?: number, props?: string, contentDate?: number) => {
+            native.endCalls += 1;
             await native.endRead;
             if (isDismissed()) {
               throw Object.assign(new Error('Live Activity not found'), {
@@ -1697,6 +1709,38 @@ describe('cold iOS background delivery', () => {
       needsInputSince: null,
     });
     expect(rows.has('scope-token')).toBe(true);
+  });
+
+  it('waits for an idle-only push to submit its native end before background completion', async () => {
+    vi.setSystemTime(Date.parse('2026-01-02T00:00:00.000Z'));
+    mocks.appState.currentState = 'background';
+    const end = deferred();
+    native.endRead = end.promise;
+    const background = await loadColdBackground();
+    let completed = false;
+    const applying = (async () => {
+      const result = await background.deliver({
+        status: 'happy',
+        running: 0,
+        needsInput: 0,
+        idle: 1,
+        needsInputSince: null,
+      });
+      completed = true;
+      return result;
+    })();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The idle end is submitted during publish, and the background task cannot
+    // finish before ActivityKit accepts it.
+    expect(native.endCalls).toBe(1);
+    expect(completed).toBe(false);
+
+    end.resolve();
+    expect(await applying).toBe(0);
+    expect(native.exists).toBe(false);
+    expect(native.dismissAt).toBe(Date.parse('2026-01-02T00:10:00.000Z'));
+    expect(JSON.parse(native.props ?? '{}')).toMatchObject({ status: 'happy', idle: 1 });
   });
 
   it('immediately dismisses an ended adopted handle and rejects old-scope work after privacy', async () => {

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -22,6 +22,7 @@ import {
   GLANCEABLE_TERMINAL_MS,
   type GlanceableAgentsSnapshot,
   isEligibleGlanceableWork,
+  isIdleOnlyGlanceableWork,
 } from '@kilocode/app-shared/glanceable-agents-snapshot';
 
 import { captureEvent } from '@/lib/analytics/posthog';
@@ -222,6 +223,7 @@ export async function applyGlanceablePushData(
 
   const ctx = { userId, organizationId };
   const eligible = isEligibleGlanceableWork(snapshot);
+  const idleOnly = isIdleOnlyGlanceableWork(snapshot);
   if (eligible) {
     cancelGlanceableTerminalEnd();
     for (const sink of getGlanceableSinks()) {
@@ -240,8 +242,11 @@ export async function applyGlanceablePushData(
     await appBadgeWrite;
   }
   // Do not finish a background task before ActivityKit accepts the native end.
-  // All publication happens before this await, so it cannot restore an old scope.
-  if (!eligible) {
+  // All publication happens before this await, so it cannot restore an old
+  // scope. An idle-only eligible snapshot also schedules its native end during
+  // publish (at once, because a background wake can suspend before the
+  // foreground debounce timer fires), so it waits here too.
+  if (!eligible || idleOnly) {
     await Promise.all(
       getGlanceableSinks().map((sink): Promise<void> | undefined => sink.waitForNativeTerminal?.())
     );

--- a/packages/app-shared/src/glanceable-agents-snapshot.ts
+++ b/packages/app-shared/src/glanceable-agents-snapshot.ts
@@ -26,6 +26,11 @@ export const GLANCEABLE_TERMINAL_MS = 8000;
  */
 export const GLANCEABLE_IDLE_ONLY_MS = 600_000;
 /**
+ * Delay before an idle-only Live Activity is handed to ActivityKit. Brief
+ * idle↔busy flips must update the same card, not end it and start another.
+ */
+export const GLANCEABLE_IDLE_END_DEBOUNCE_MS = 5_000;
+/**
  * A Live Activity that has taken no update for this long reads as unknown, not
  * as current: ActivityKit dims stale content. Every real transition pushes an
  * update well inside the window, and an idle card is already gone by then.


### PR DESCRIPTION
## Summary

- Hide the visible **Updating** label on the Agents live list during pull-to-refresh. The spinner stays. Screen readers still hear Updating. The reserved line still shows **Couldn't refresh** + Retry on failure.
- Do not throttle Live Activities. Debounce idle-end by 5s while the app is active so brief idle transitions preserve the same card. Background transitions submit the native dismissal immediately. Resume inside that window updates the same card. A new start also ends every other visible ActivityKit instance.
- Fix the submit-review form sheet header: close caret on the same row as the title and eyebrow, and 20 logical pixels of top padding below the grabber.

## Test plan

- [ ] Agents live list: pull to refresh. Confirm no visible Updating. Confirm the spinner shows. Confirm VoiceOver still announces Updating.
- [ ] Agents live list: fail a pull. Confirm Couldn't refresh + Retry. Confirm Retry works.
- [x] iOS: native ActivityKit identity stays unchanged across a measured 3.1-second busy → idle → busy transition.
- [x] iOS: backgrounding inside the five-second idle delay retains the card for ten minutes, then dismisses it.
- [x] iOS review, comment, and merge sheets: title and caret alignment, added top padding, keyboard layout, and dismissal.
- [x] Android review, comment, and merge sheets: header spacing, visible keyboard, action placement, and dismissal.

## Local verification — 2026-09-08

**Earlier run; Android verification is completed below.** Header fix pushed in `84b0c009b213b537db1a6500ed9b7a1871e79844`.

- Added eight logical pixels to the shared sheet header (`pt-3` → `pt-5`).
- Registered the PR overview before the sheet routes. Direct PR links now open the overview without a background Add comment header.
- iOS: review and comment typing, merge keyboard focus, and all three dismissals passed. Screenshots show the final commit contents on iPhone 17, iOS 26.5.
- iOS history refresh smoke passed with stored rows retained. This does not prove live-list failure handling or VoiceOver behavior.
- Focused checks passed: 5 suites, 42 tests; mobile type checking, lint, and changed-file formatting.
- `check:unused` was not run because its command loads a dotenv file, which the local runbook prohibits.
- Earlier Android preparation failed at sign-in and Appium. The matching native build and recovery below resolved the setup blockers.
- Live-list failure/retry and VoiceOver/TalkBack checks remain unverified. The later lifecycle run below established a real remote session.

## Visual changes

The recording shows review opening, keyboard typing, and dismissal. No review, comment, or merge was submitted.

[Review sheet recording](https://github.com/user-attachments/assets/7dc3703a-084c-4b83-82a3-6c771664e045)

![iOS review header spacing](https://github.com/user-attachments/assets/f69e003d-ed0e-4178-ae92-e3ea1a3c67ee)

![iOS review with keyboard](https://github.com/user-attachments/assets/1f957bee-ecc3-44c5-9c4d-6786362850b0)

![iOS comment with keyboard](https://github.com/user-attachments/assets/07f2ed55-666b-4c31-ae6b-0584c55c1907)

![iOS merge with keyboard](https://github.com/user-attachments/assets/aa702e54-d11b-4049-8346-5db6773bb560)


## Kilobot finding fixed

- Commit `276f658a2` submits idle dismissal immediately when the app is inactive or backgrounded.
- Leaving the foreground flushes a pending idle delay. Resuming work cancels the delay and its listener.
- The background push handler waits for ActivityKit to accept the idle end before it returns.
- Regression checks reproduced four failures before the fix. All 162 focused tests, type checking, lint, and formatting now pass.
- This repair does not change the sheet visuals. The device lifecycle results appear below.

## iOS lifecycle verification — head `276f658a2`

- Passed on iPhone 17, iOS 26.5, with the native development build and a real CLI session.
- The native card displayed one working session and one idle session.
- A foreground busy → idle → busy transition took 3,061 ms. The same native card stayed active.
- The app entered the background and stopped within 2,879 ms of opening, before the five-second idle delay expired.
- The idle card remained visible at 300 and 590 seconds. It disappeared by 615 seconds without foreground reopening.
- After observation, iOS reported the app suspended in the background. This does not prove continuous process termination.
- Simulator APNs acceptance did not prove background notification consumption. That delivery path remains unverified on a device.
- The recording covers 599.4 seconds because the recorder has a ten-minute cap. The final screenshot proves dismissal after the recording ends.
- The separate rapid-transition recording failed. Read-only native observations below prove card identity; the existing unit tests cover cancellation.

Native observations from the real foreground session:

```text
1788891688507 busy: C1F1EA77-1B3A-4172-9A18-CB85477A8BD0 active
1788891689925 idle: C1F1EA77-1B3A-4172-9A18-CB85477A8BD0 active
1788891692986 busy: C1F1EA77-1B3A-4172-9A18-CB85477A8BD0 active
```

[Idle retention recording; capped before final dismissal](https://github.com/user-attachments/assets/ab081295-1332-4fcf-8312-693eb6a97e2d)

![Idle card immediately after closing the app](https://github.com/user-attachments/assets/6626e353-f6ca-4804-b83a-e576a9308b2c)

![Idle card retained at 590 seconds](https://github.com/user-attachments/assets/467dc69e-0f4b-4c37-8c57-dc7b7d8ae4b1)

![Idle card dismissed by 615 seconds](https://github.com/user-attachments/assets/23e6339f-2c47-4b4d-9a4e-e6a2313ac06d)

## Android verification — head `276f658a2`

- Passed all nine checks across the review, comment, and merge sheets on Android API 36.1.
- Confirmed header top padding and caret alignment, typing or focus with the visible software keyboard, visible actions, and dismissal.
- Installed the matching native build after the restored emulator lacked `ExpoBattery`. OTP sign-in then passed.
- Fixed shell quoting in the local workflow helper so Android comment links retain all query parameters. A focused regression check passed.
- No product code changed during this verification. The fixture received no review, comment, or merge submission.
- Real background push delivery and the earlier live-list failure/retry and accessibility checks remain outside this device result.

[Android review recording](https://github.com/user-attachments/assets/9c71d20d-a4e4-44b7-9cab-5e24a59d0b72)

[Android comment recording](https://github.com/user-attachments/assets/a3e35634-2aa0-4c59-b036-6eb45fb43437)

[Android merge recording](https://github.com/user-attachments/assets/a2b8e961-6f2c-4f33-aeaa-2b9fb0f2b45e)

![Android review header](https://github.com/user-attachments/assets/b7c36536-d730-4182-a55a-747e3cd7c36b)

![Android review keyboard](https://github.com/user-attachments/assets/1e06f7d5-396d-4751-9ecb-4e783426cc59)

![Android comment keyboard](https://github.com/user-attachments/assets/9e7beb86-3ed1-40e8-a2b3-bf8adfd3b50b)

![Android merge keyboard](https://github.com/user-attachments/assets/abe595aa-a201-4b00-80ce-39e76c0bd94e)
