### PR TITLE
Add Inkling to Auto Free

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -200,6 +200,7 @@ describe('isFreeModel', () => {
         'poolside/laguna-s-2.1:free': { enabled: true, effort: 'high' },
         'nvidia/nemotron-3-ultra-550b-a55b:free': { enabled: true, effort: 'high' },
         'dots-studio/dots-3-note-preview:free': { enabled: true, effort: 'high' },
+        'thinkingmachines/inkling:free': { enabled: true, effort: 'high' },
       });
     });
 
@@ -208,10 +209,11 @@ describe('isFreeModel', () => {
         autoFreeModels.map(({ model, weight }) => [model, weight])
       );
       expect(weights).toEqual({
-        'stepfun/step-3.7-flash:free': 3,
+        'stepfun/step-3.7-flash:free': 4,
         'poolside/laguna-s-2.1:free': 1,
         'nvidia/nemotron-3-ultra-550b-a55b:free': 1,
         'dots-studio/dots-3-note-preview:free': 1,
+        'thinkingmachines/inkling:free': 1,
       });
       const halfOfTotalWeight = autoFreeModels.reduce((total, { weight }) => total + weight, 0) / 2;
       expect(weights['stepfun/step-3.7-flash:free']).toBe(halfOfTotalWeight);

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -45,7 +45,7 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
     ? [
         {
           model: stepfun_37_flash_free_model.public_id,
-          weight: 3,
+          weight: 4,
           reasoning: { enabled: true, effort: 'high' },
         } satisfies AutoFreeModel,
       ]
@@ -62,6 +62,11 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
   } satisfies AutoFreeModel,
   {
     model: 'dots-studio/dots-3-note-preview:free',
+    weight: 1,
+    reasoning: { enabled: true, effort: 'high' },
+  } satisfies AutoFreeModel,
+  {
+    model: 'thinkingmachines/inkling:free',
     weight: 1,
     reasoning: { enabled: true, effort: 'high' },
   } satisfies AutoFreeModel,


### PR DESCRIPTION
## Summary
- add `thinkingmachines/inkling:free` to the Auto Free pool
- raise the Step weight to keep its selection share at 50%
- update Auto Free configuration expectations

## Testing
- Not run locally; left to CI as requested.