### PR TITLE
fix(ai-gateway): respect policy for efficient fallback

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -386,6 +386,14 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
         clientIp: ipAddress ?? null,
         efficientDecision,
         organizationContext: organizationContextPromise,
+        isAutoEfficientFallbackAllowed: async modelId => {
+          const access = await resolveAccessCheck(modelId);
+          return (
+            !access.modelRestrictionError &&
+            access.groupModelAllowed &&
+            access.groupProvidersAllowed
+          );
+        },
         isAutoFreeCandidateAllowed: async modelId => {
           const policy = await organizationGroupPolicyPromise;
           return policy ? (await getEffectiveModelDecision(policy, modelId)).allowed : true;
@@ -397,6 +405,9 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     );
     if (autoResult.kind === 'no_free_models_available') {
       return noFreeModelsAvailableResponse();
+    }
+    if (autoResult.kind === 'no_allowed_efficient_fallback') {
+      return efficientPoolBlockedResponse();
     }
     if (autoResult.kind === 'organization_auto_configuration_error') {
       return organizationAutoConfigurationResponse(autoResult.message);

--- a/apps/web/src/lib/ai-gateway/auto-model/index.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/index.ts
@@ -10,6 +10,7 @@ import {
   type Verbosity,
 } from '@kilocode/db/schema-types';
 import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
+import { QWEN37_PLUS_MODEL_ID } from '@/lib/ai-gateway/providers/qwen';
 
 export type AutoModelPricing = {
   prompt: string;
@@ -81,16 +82,24 @@ export const FRONTIER_MODE_TO_MODEL: Record<Mode, ResolvedAutoModel> = {
   code: SONNET_FRONTIER,
 };
 
-// INVARIANT: the efficient static fallback must remain image-capable.
+// INVARIANT: efficient static fallbacks must remain image-capable.
 // The capability-aware routing filter relies on this guarantee to make
 // image requests succeed even when no benchmark candidate is capable.
-// Whoever changes this model constant must re-verify image support
+// Whoever changes these model constants must re-verify image support
 // (via live OpenRouter data or the `model_stats` table) before
 // swapping it — do not assume parity with the prior value.
 export const BALANCED_FALLBACK_MODEL: ResolvedAutoModel = {
   model: KIMI_CURRENT_MODEL_ID,
   reasoning: { enabled: true },
 };
+
+export const BALANCED_FALLBACK_MODELS = [
+  BALANCED_FALLBACK_MODEL,
+  {
+    model: QWEN37_PLUS_MODEL_ID,
+    reasoning: { enabled: true },
+  },
+] as const satisfies ReadonlyArray<ResolvedAutoModel>;
 
 const UNKNOWN_PRICING: AutoModelPricing = {
   prompt: '-1',

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -7,6 +7,7 @@ jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
 import { resolveAutoModel } from './resolution';
 import {
   BALANCED_FALLBACK_MODEL,
+  BALANCED_FALLBACK_MODELS,
   FRONTIER_MODE_TO_MODEL,
   KILO_AUTO_BALANCED_MODEL,
   KILO_AUTO_EFFICIENT_MODEL,
@@ -150,6 +151,37 @@ describe('resolveAutoModel — kilo-auto/efficient branch', () => {
       });
     }
   );
+
+  it('uses the secondary fallback when organization policy denies Kimi K3', async () => {
+    const [, secondaryFallback] = BALANCED_FALLBACK_MODELS;
+    const result = await resolveAutoModel(
+      {
+        ...baseParams,
+        apiKind: 'chat_completions',
+        efficientDecision: async () => null,
+        isAutoEfficientFallbackAllowed: async modelId => modelId !== BALANCED_FALLBACK_MODEL.model,
+      },
+      nullUserPromise,
+      zeroBalancePromise
+    );
+
+    expect(result).toEqual({ kind: 'ok', resolved: secondaryFallback });
+  });
+
+  it('fails closed when organization policy denies every static fallback', async () => {
+    const result = await resolveAutoModel(
+      {
+        ...baseParams,
+        apiKind: 'chat_completions',
+        efficientDecision: async () => null,
+        isAutoEfficientFallbackAllowed: async () => false,
+      },
+      nullUserPromise,
+      zeroBalancePromise
+    );
+
+    expect(result).toEqual({ kind: 'no_allowed_efficient_fallback' });
+  });
 
   it('falls back to BALANCED_FALLBACK_MODEL when the worker returns a virtual auto model', async () => {
     const result = await resolveAutoModel(

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -21,6 +21,7 @@ import {
   KILO_AUTO_EFFICIENT_MODEL,
   modeSchema,
   BALANCED_FALLBACK_MODEL,
+  BALANCED_FALLBACK_MODELS,
   FRONTIER_MODE_TO_MODEL,
   FRONTIER_CODE_MODEL,
   type ResolvedAutoModel,
@@ -51,6 +52,7 @@ type ResolveAutoModelParams = {
   apiKind: GatewayRequest['kind'] | null;
   clientIp: string | null;
   isAutoFreeCandidateAllowed: ((modelId: string) => Promise<boolean>) | null;
+  isAutoEfficientFallbackAllowed?: (modelId: string) => Promise<boolean>;
   // Lazily fetches the auto-routing worker's decision (route.ts owns the request-body capture).
   efficientDecision?: () => Promise<AutoRoutingDecision | null>;
   organizationContext?: Promise<{
@@ -136,7 +138,19 @@ function resolveOrganizationAutoRouteTarget(
 export type ResolveAutoModelResult =
   | { kind: 'ok'; resolved: ResolvedAutoModel; routingTarget?: string }
   | { kind: 'no_free_models_available' }
+  | { kind: 'no_allowed_efficient_fallback' }
   | { kind: 'organization_auto_configuration_error'; message: string };
+
+async function resolveBalancedFallback(
+  isAllowed: ResolveAutoModelParams['isAutoEfficientFallbackAllowed']
+): Promise<ResolvedAutoModel | null> {
+  if (!isAllowed) return BALANCED_FALLBACK_MODEL;
+
+  for (const fallback of BALANCED_FALLBACK_MODELS) {
+    if (await isAllowed(fallback.model)) return fallback;
+  }
+  return null;
+}
 
 async function resolveOrganizationAutoModel(
   params: ResolveAutoModelParams,
@@ -320,6 +334,10 @@ export async function resolveAutoModel(
     };
   }
   if (model === KILO_AUTO_EFFICIENT_MODEL.id || model === KILO_AUTO_BALANCED_MODEL.id) {
+    const fallback = async (): Promise<ResolveAutoModelResult> => {
+      const resolved = await resolveBalancedFallback(params.isAutoEfficientFallbackAllowed);
+      return resolved ? { kind: 'ok', resolved } : { kind: 'no_allowed_efficient_fallback' };
+    };
     const decision = params.efficientDecision ? await params.efficientDecision() : null;
     if (decision && !isVirtualAutoModelId(decision.model)) {
       const resolvedFromDecision = await resolveEfficientDecisionModel(decision);
@@ -328,10 +346,10 @@ export async function resolveAutoModel(
       }
       // Exact catalog variant missing or removed: never serve the chosen model
       // with implicit defaults — same balanced fallback as the no-decision path.
-      return { kind: 'ok', resolved: BALANCED_FALLBACK_MODEL };
+      return await fallback();
     }
     // Static fallback when the worker is slow or unavailable.
-    return { kind: 'ok', resolved: BALANCED_FALLBACK_MODEL };
+    return await fallback();
   }
   const mode = resolveMode(modeHeader, featureHeader);
   return {


### PR DESCRIPTION
## Summary
- Keep Kimi K3 as the preferred Auto Efficient / Balanced static fallback.
- If organization policy blocks K3 or leaves it without an eligible provider route, use the previous image-capable Qwen 3.7 Plus fallback instead.
- Fail closed with the existing Efficient-pool response when the organization allows neither fallback.

## What causes the fallback
Auto Efficient uses the static fallback whenever the auto-routing worker does not yield a usable concrete decision. This can happen when worker configuration or credentials are missing, request normalization fails, the worker times out or returns an invalid/non-success response, the worker returns `decision: null` or a virtual auto model, or the selected model variant is no longer present in the current catalog. A null decision can also be returned when no routing table/route is available or all candidates are removed by policy or capability filtering.

Previously every one of these paths selected Kimi K3 before the final organization access check. An organization that did not allow K3 therefore received an error even when it allowed the prior Qwen fallback. Fallback selection now consults the same effective model and provider policy used by the final gateway access check.

## Verification
- Changed-file formatting: passed.
- Changed-file oxlint: passed with 0 warnings and 0 errors.
- `git diff --check`: passed.
- Test suites were left to CI as requested.