### PR TITLE
fix(ai-gateway): detail efficient routing failures

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -1193,7 +1193,8 @@ describe('kilo-auto/efficient classifier billing', () => {
     await Promise.resolve();
 
     expect(mockedFetchEfficientAutoDecision).toHaveBeenCalledWith(
-      expect.objectContaining({ requestedModel: 'kilo-auto/balanced' })
+      expect.objectContaining({ requestedModel: 'kilo-auto/balanced' }),
+      expect.objectContaining({ onFailure: expect.any(Function) })
     );
     expect(mockedLogMicrodollarUsage).toHaveBeenCalledTimes(1);
     const [, ctx] = mockedLogMicrodollarUsage.mock.calls[0];
@@ -1345,7 +1346,8 @@ describe('kilo-auto/efficient classifier billing', () => {
     expect(mockedFetchEfficientAutoDecision).toHaveBeenCalledWith(
       expect.objectContaining({
         deniedModelIds: ['openai/gpt-4o'],
-      })
+      }),
+      expect.objectContaining({ onFailure: expect.any(Function) })
     );
   });
 
@@ -1385,7 +1387,8 @@ describe('kilo-auto/efficient classifier billing', () => {
     expect(mockedFetchEfficientAutoDecision).toHaveBeenCalledWith(
       expect.objectContaining({
         deniedModelIds: ['google/gemini-2.5-flash'],
-      })
+      }),
+      expect.objectContaining({ onFailure: expect.any(Function) })
     );
   });
 
@@ -1405,6 +1408,54 @@ describe('kilo-auto/efficient classifier billing', () => {
     expect(mockedLogMicrodollarUsage).toHaveBeenCalledTimes(1);
     const [stats] = mockedLogMicrodollarUsage.mock.calls[0];
     expect(stats.cost_mUsd).toBe(1000); // toMicrodollars(0.001)
+  });
+
+  it('reports decision failure details when organization fallbacks are blocked', async () => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: {
+        id: 'user-123',
+        google_user_email: 'test@example.com',
+        microdollars_used: 0,
+      } as User,
+      authFailedResponse: null,
+      organizationId: 'org-123',
+    });
+    mockedGetBalanceAndOrgSettings.mockResolvedValue({
+      balance: 1000,
+      settings: {},
+      plan: 'enterprise',
+    });
+    mockedGetEffectiveModelDecision.mockResolvedValue({
+      allowed: false,
+      denialSource: 'group_model',
+    });
+    mockedFetchEfficientAutoDecision.mockImplementation(async (_params, options) => {
+      options?.onFailure?.({ reason: 'worker_http_error', workerStatus: 502 });
+      return null;
+    });
+    mockedApplyResolvedAutoModel.mockImplementation(async (params, request) => {
+      await params.efficientDecision?.();
+      params.onEfficientFallback?.({
+        reason: 'worker_returned_no_decision',
+        modelId: 'moonshotai/kimi-k3',
+      });
+      request.body.model = 'moonshotai/kimi-k3';
+      return { kind: 'ok', resolved: { model: 'moonshotai/kimi-k3' } };
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody('kilo-auto/efficient')) as never);
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      error_type: 'temporarily_unavailable',
+      details: {
+        reason: 'worker_http_error',
+        blocked_fallback_model_ids: ['moonshotai/kimi-k3'],
+        worker_status: 502,
+      },
+    });
+    expect(mockedUpstreamRequest).not.toHaveBeenCalled();
   });
 
   it('guides teams that block every pool model to configure a custom Efficient pool', async () => {
@@ -1511,7 +1562,8 @@ describe('auto-routing shadow classifier', () => {
     expect(response.status).toBe(200);
     expect(mockedUpstreamRequest).toHaveBeenCalledTimes(1);
     expect(mockedFetchEfficientAutoDecision).toHaveBeenCalledWith(
-      expect.objectContaining({ requestedModel: 'kilo-auto/balanced' })
+      expect.objectContaining({ requestedModel: 'kilo-auto/balanced' }),
+      expect.objectContaining({ onFailure: expect.any(Function) })
     );
     expect(mockedAfter).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -1458,6 +1458,56 @@ describe('kilo-auto/efficient classifier billing', () => {
     expect(mockedUpstreamRequest).not.toHaveBeenCalled();
   });
 
+  it('does not report stale fallback details when quarantine replaces the fallback model', async () => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: {
+        id: 'user-123',
+        google_user_email: 'test@example.com',
+        microdollars_used: 0,
+      } as User,
+      authFailedResponse: null,
+      organizationId: 'org-123',
+    });
+    mockedGetBalanceAndOrgSettings.mockResolvedValue({
+      balance: 1000,
+      settings: {},
+      plan: 'enterprise',
+    });
+    mockedGetEffectiveModelDecision.mockResolvedValue({
+      allowed: false,
+      denialSource: 'group_model',
+    });
+    mockedGetOpenRouterModels.mockResolvedValue(new Set([stepfun_37_flash_free_model.public_id]));
+    mockedRedisGet.mockResolvedValue(cachedRulesEngineAction('quarantine-3'));
+    mockedClassifyAbuse.mockResolvedValue(classifyResult('quarantine-3'));
+    mockedFetchEfficientAutoDecision.mockImplementation(async (_params, options) => {
+      options?.onFailure?.({ reason: 'worker_timeout' });
+      return null;
+    });
+    mockedApplyResolvedAutoModel.mockImplementation(async (params, request) => {
+      await params.efficientDecision?.();
+      params.onEfficientFallback?.({
+        reason: 'worker_returned_no_decision',
+        modelId: 'moonshotai/kimi-k3',
+      });
+      request.body.model = 'moonshotai/kimi-k3';
+      return { kind: 'ok', resolved: { model: 'moonshotai/kimi-k3' } };
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody('kilo-auto/efficient')) as never);
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toMatchObject({ error_type: 'model_not_allowed' });
+    expect(body).not.toHaveProperty('details');
+    expect(mockedWarnExceptInTest).not.toHaveBeenCalledWith(
+      expect.stringContaining('[efficientRoutingUnavailableResponse]'),
+      expect.anything()
+    );
+    expect(mockedUpstreamRequest).not.toHaveBeenCalled();
+  });
+
   it('guides teams that block every pool model to configure a custom Efficient pool', async () => {
     mockedGetUserFromAuth.mockResolvedValue({
       user: {

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -47,6 +47,7 @@ import {
   modelDoesNotExistResponse,
   modelNotAllowedResponse,
   efficientPoolBlockedResponse,
+  efficientRoutingUnavailableResponse,
   extractHeaderAndLimitLength,
   noFreeModelsAvailableResponse,
   organizationAutoConfigurationResponse,
@@ -99,8 +100,14 @@ import {
   KILO_AUTO_EFFICIENT_MODEL,
   ORG_AUTO_MODEL,
 } from '@/lib/ai-gateway/auto-model';
-import { applyResolvedAutoModel } from '@/lib/ai-gateway/auto-model/resolution';
-import { fetchEfficientAutoDecision } from '@/lib/ai-gateway/auto-routing-decision';
+import {
+  applyResolvedAutoModel,
+  type EfficientFallbackReason,
+} from '@/lib/ai-gateway/auto-model/resolution';
+import {
+  fetchEfficientAutoDecision,
+  type EfficientDecisionFailure,
+} from '@/lib/ai-gateway/auto-routing-decision';
 import { collectDeniedAutoRoutingModelIds } from '@/lib/ai-gateway/auto-routing-denied-models';
 import type {
   MicrodollarUsageContext,
@@ -323,6 +330,10 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   // validation after resolution.
   let routingTarget: string | null = null;
   let classifierCostUsd = 0;
+  const efficientDecisionState: {
+    failure: EfficientDecisionFailure | null;
+    fallback: { reason: EfficientFallbackReason; modelId: string } | null;
+  } = { failure: null, fallback: null };
   // Efficient/balanced requests resolve through the auto-routing pool. Kept for
   // the org policy check below so a team that blocks every pool model gets
   // guidance to configure a custom Efficient model pool instead of the generic
@@ -357,21 +368,24 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
               })
             : [];
           const deniedModelIds = [...new Set([...deniedFromSettings, ...deniedFromPolicy])];
-          const result = await fetchEfficientAutoDecision({
-            apiKind: requestBodyParsed.kind,
-            body: requestBodyParsed.body,
-            requestedModel,
-            providerHints: autoRoutingProviderHints,
-            bodyBytes: Buffer.byteLength(requestBodyText),
-            userId: user.id,
-            organizationId: organizationId ?? null,
-            sessionId: taskId ?? sessionHeader,
-            machineId: machineIdHeader,
-            clientRequestId,
-            mode: modeHeader,
-            userAgent: extractHeaderAndLimitLength(request, 'user-agent'),
-            deniedModelIds,
-          });
+          const result = await fetchEfficientAutoDecision(
+            {
+              apiKind: requestBodyParsed.kind,
+              body: requestBodyParsed.body,
+              requestedModel,
+              providerHints: autoRoutingProviderHints,
+              bodyBytes: Buffer.byteLength(requestBodyText),
+              userId: user.id,
+              organizationId: organizationId ?? null,
+              sessionId: taskId ?? sessionHeader,
+              machineId: machineIdHeader,
+              clientRequestId,
+              mode: modeHeader,
+              userAgent: extractHeaderAndLimitLength(request, 'user-agent'),
+              deniedModelIds,
+            },
+            { onFailure: failure => (efficientDecisionState.failure = failure) }
+          );
           classifierCostUsd = result?.costUsd ?? 0;
           return result?.decision ?? null;
         }
@@ -386,6 +400,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
         clientIp: ipAddress ?? null,
         efficientDecision,
         organizationContext: organizationContextPromise,
+        onEfficientFallback: fallback => (efficientDecisionState.fallback = fallback),
         isAutoFreeCandidateAllowed: async modelId => {
           const policy = await organizationGroupPolicyPromise;
           return policy ? (await getEffectiveModelDecision(policy, modelId)).allowed : true;
@@ -864,14 +879,35 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
 
     // Organization model/provider restrictions check
     // Provider/model access policy applies to Enterprise plans; data collection applies to all plans.
+    const efficientFallbackBlockedResponse = () => {
+      const fallback = efficientDecisionState.fallback;
+      if (!isAutoEfficientRequest || !fallback) return null;
+
+      const decisionFailure = efficientDecisionState.failure;
+      return efficientRoutingUnavailableResponse({
+        reason: decisionFailure?.reason ?? fallback.reason,
+        blockedFallbackModelIds: [fallback.modelId],
+        ...(decisionFailure?.workerStatus === undefined
+          ? {}
+          : { workerStatus: decisionFailure.workerStatus }),
+      });
+    };
     if (modelRestrictionError) {
-      return isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelRestrictionError;
+      return (
+        efficientFallbackBlockedResponse() ??
+        (isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelRestrictionError)
+      );
     }
 
     if (!groupModelAllowed) {
-      return isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelNotAllowedResponse();
+      return (
+        efficientFallbackBlockedResponse() ??
+        (isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelNotAllowedResponse())
+      );
     }
-    if (!groupProvidersAllowed) return modelNotAllowedResponse();
+    if (!groupProvidersAllowed) {
+      return efficientFallbackBlockedResponse() ?? modelNotAllowedResponse();
+    }
 
     // Experiment traffic captures prompts to R2 for partner evaluation, which
     // is a form of data collection that the gateway-pinned `data_collection`

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -879,9 +879,16 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
 
     // Organization model/provider restrictions check
     // Provider/model access policy applies to Enterprise plans; data collection applies to all plans.
+    const isAutoEfficientAccessCheck = isAutoEfficientRequest && abuseDowngradedFrom === null;
     const efficientFallbackBlockedResponse = () => {
       const fallback = efficientDecisionState.fallback;
-      if (!isAutoEfficientRequest || !fallback) return null;
+      if (
+        !isAutoEfficientAccessCheck ||
+        !fallback ||
+        effectiveModelIdLowerCased !== fallback.modelId
+      ) {
+        return null;
+      }
 
       const decisionFailure = efficientDecisionState.failure;
       return efficientRoutingUnavailableResponse({
@@ -895,14 +902,14 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     if (modelRestrictionError) {
       return (
         efficientFallbackBlockedResponse() ??
-        (isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelRestrictionError)
+        (isAutoEfficientAccessCheck ? efficientPoolBlockedResponse() : modelRestrictionError)
       );
     }
 
     if (!groupModelAllowed) {
       return (
         efficientFallbackBlockedResponse() ??
-        (isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelNotAllowedResponse())
+        (isAutoEfficientAccessCheck ? efficientPoolBlockedResponse() : modelNotAllowedResponse())
       );
     }
     if (!groupProvidersAllowed) {

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -151,6 +151,26 @@ describe('resolveAutoModel — kilo-auto/efficient branch', () => {
     }
   );
 
+  it('reports why the static fallback was selected', async () => {
+    const onEfficientFallback = jest.fn();
+
+    await resolveAutoModel(
+      {
+        ...baseParams,
+        apiKind: 'chat_completions',
+        efficientDecision: async () => null,
+        onEfficientFallback,
+      },
+      nullUserPromise,
+      zeroBalancePromise
+    );
+
+    expect(onEfficientFallback).toHaveBeenCalledWith({
+      reason: 'worker_returned_no_decision',
+      modelId: BALANCED_FALLBACK_MODEL.model,
+    });
+  });
+
   it('falls back to BALANCED_FALLBACK_MODEL when the worker returns a virtual auto model', async () => {
     const result = await resolveAutoModel(
       {

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -43,6 +43,12 @@ import {
 import { getModelVariants } from '@/lib/ai-gateway/providers/model-settings';
 import type { OpenCodeVariant } from '@kilocode/db/schema-types';
 
+export type EfficientFallbackReason =
+  | 'decision_unavailable'
+  | 'worker_returned_no_decision'
+  | 'virtual_model_decision'
+  | 'catalog_variant_unavailable';
+
 type ResolveAutoModelParams = {
   model: string;
   modeHeader: string | null;
@@ -51,6 +57,7 @@ type ResolveAutoModelParams = {
   apiKind: GatewayRequest['kind'] | null;
   clientIp: string | null;
   isAutoFreeCandidateAllowed: ((modelId: string) => Promise<boolean>) | null;
+  onEfficientFallback?: (fallback: { reason: EfficientFallbackReason; modelId: string }) => void;
   // Lazily fetches the auto-routing worker's decision (route.ts owns the request-body capture).
   efficientDecision?: () => Promise<AutoRoutingDecision | null>;
   organizationContext?: Promise<{
@@ -328,8 +335,20 @@ export async function resolveAutoModel(
       }
       // Exact catalog variant missing or removed: never serve the chosen model
       // with implicit defaults — same balanced fallback as the no-decision path.
+      params.onEfficientFallback?.({
+        reason: 'catalog_variant_unavailable',
+        modelId: BALANCED_FALLBACK_MODEL.model,
+      });
       return { kind: 'ok', resolved: BALANCED_FALLBACK_MODEL };
     }
+    params.onEfficientFallback?.({
+      reason: decision
+        ? 'virtual_model_decision'
+        : params.efficientDecision
+          ? 'worker_returned_no_decision'
+          : 'decision_unavailable',
+      modelId: BALANCED_FALLBACK_MODEL.model,
+    });
     // Static fallback when the worker is slow or unavailable.
     return { kind: 'ok', resolved: BALANCED_FALLBACK_MODEL };
   }

--- a/apps/web/src/lib/ai-gateway/auto-routing-decision.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-routing-decision.test.ts
@@ -118,60 +118,85 @@ describe('fetchEfficientAutoDecision', () => {
 
   it('returns null and calls onError on a non-OK response', async () => {
     const onError = jest.fn();
+    const onFailure = jest.fn();
     mockedFetch.mockResolvedValueOnce(new Response('Internal Server Error', { status: 500 }));
 
-    const result = await fetchEfficientAutoDecision(makeParams(), { ...options, onError });
+    const result = await fetchEfficientAutoDecision(makeParams(), {
+      ...options,
+      onError,
+      onFailure,
+    });
 
     expect(result).toBeNull();
     expect(onError).toHaveBeenCalledWith('Efficient auto decision request failed', {
       error: 'status 500',
     });
+    expect(onFailure).toHaveBeenCalledWith({ reason: 'worker_http_error', workerStatus: 500 });
   });
 
   it('returns null and calls onError when fetch rejects (timeout/abort)', async () => {
     const onError = jest.fn();
-    mockedFetch.mockRejectedValueOnce(new Error('The operation was aborted'));
+    const onFailure = jest.fn();
+    const timeout = new Error('The operation was aborted');
+    timeout.name = 'TimeoutError';
+    mockedFetch.mockRejectedValueOnce(timeout);
 
-    const result = await fetchEfficientAutoDecision(makeParams(), { ...options, onError });
+    const result = await fetchEfficientAutoDecision(makeParams(), {
+      ...options,
+      onError,
+      onFailure,
+    });
 
     expect(result).toBeNull();
     expect(onError).toHaveBeenCalledWith('Efficient auto decision request failed', {
       error: 'The operation was aborted',
     });
+    expect(onFailure).toHaveBeenCalledWith({ reason: 'worker_timeout' });
   });
 
   it('returns null and calls onError on a schema-invalid response body', async () => {
     const onError = jest.fn();
+    const onFailure = jest.fn();
     mockedFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ unexpected: 'shape' }), { status: 200 })
     );
 
-    const result = await fetchEfficientAutoDecision(makeParams(), { ...options, onError });
+    const result = await fetchEfficientAutoDecision(makeParams(), {
+      ...options,
+      onError,
+      onFailure,
+    });
 
     expect(result).toBeNull();
     expect(onError).toHaveBeenCalledWith('Efficient auto decision response invalid', {
       error: 'invalid_response',
     });
+    expect(onFailure).toHaveBeenCalledWith({ reason: 'worker_response_invalid' });
   });
 
   it('returns null when normalization fails (unclassifiable body)', async () => {
+    const onFailure = jest.fn();
     const result = await fetchEfficientAutoDecision(
       { ...makeParams(), body: { stream: true } },
-      options
+      { ...options, onFailure }
     );
 
     expect(mockedFetch).not.toHaveBeenCalled();
     expect(result).toBeNull();
+    expect(onFailure).toHaveBeenCalledWith({ reason: 'request_normalization_failed' });
   });
 
   it('returns null when workerUrl is not configured', async () => {
+    const onFailure = jest.fn();
     const result = await fetchEfficientAutoDecision(makeParams(), {
       ...options,
       workerUrl: '',
+      onFailure,
     });
 
     expect(mockedFetch).not.toHaveBeenCalled();
     expect(result).toBeNull();
+    expect(onFailure).toHaveBeenCalledWith({ reason: 'worker_not_configured' });
   });
 
   it('returns null when authToken is not configured', async () => {

--- a/apps/web/src/lib/ai-gateway/auto-routing-decision.ts
+++ b/apps/web/src/lib/ai-gateway/auto-routing-decision.ts
@@ -32,6 +32,18 @@ type FetchEfficientDecisionOptions = {
   authToken?: string;
   timeoutMs?: number;
   onError?: (message: string, data: { error: string }) => void;
+  onFailure?: (failure: EfficientDecisionFailure) => void;
+};
+
+export type EfficientDecisionFailure = {
+  reason:
+    | 'worker_not_configured'
+    | 'request_normalization_failed'
+    | 'worker_timeout'
+    | 'worker_http_error'
+    | 'worker_response_invalid'
+    | 'worker_request_failed';
+  workerStatus?: number;
 };
 
 function buildDecidePayload(params: EfficientDecisionParams): MirrorPayload | null {
@@ -84,10 +96,16 @@ export async function fetchEfficientAutoDecision(
   const workerUrl = options.workerUrl ?? AUTO_ROUTING_WORKER_URL;
   const authToken = options.authToken ?? INTERNAL_API_SECRET;
   const onError = options.onError ?? warnExceptInTest;
-  if (!workerUrl || !authToken) return null;
+  if (!workerUrl || !authToken) {
+    options.onFailure?.({ reason: 'worker_not_configured' });
+    return null;
+  }
 
   const payload = buildDecidePayload(params);
-  if (!payload) return null;
+  if (!payload) {
+    options.onFailure?.({ reason: 'request_normalization_failed' });
+    return null;
+  }
 
   try {
     const response = await fetch(`${workerUrl}/decide`, {
@@ -101,17 +119,33 @@ export async function fetchEfficientAutoDecision(
     });
     if (!response.ok) {
       onError('Efficient auto decision request failed', { error: `status ${response.status}` });
+      options.onFailure?.({ reason: 'worker_http_error', workerStatus: response.status });
       return null;
     }
-    const parsed = AutoRoutingDecisionResponseSchema.safeParse(await response.json());
+    let responseBody: unknown;
+    try {
+      responseBody = await response.json();
+    } catch {
+      onError('Efficient auto decision response invalid', { error: 'invalid_json' });
+      options.onFailure?.({ reason: 'worker_response_invalid' });
+      return null;
+    }
+    const parsed = AutoRoutingDecisionResponseSchema.safeParse(responseBody);
     if (!parsed.success) {
       onError('Efficient auto decision response invalid', { error: 'invalid_response' });
+      options.onFailure?.({ reason: 'worker_response_invalid' });
       return null;
     }
     return { decision: parsed.data.decision, costUsd: parsed.data.cost };
   } catch (error) {
     onError('Efficient auto decision request failed', {
       error: error instanceof Error ? error.message : String(error),
+    });
+    options.onFailure?.({
+      reason:
+        error instanceof Error && error.name === 'TimeoutError'
+          ? 'worker_timeout'
+          : 'worker_request_failed',
     });
     return null;
   }

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
@@ -4,12 +4,18 @@ import type { GatewayRequest } from './providers/openrouter/types';
 import { CLAUDE_SONNET_LATEST_MODEL_ALIAS } from './latest-model-aliases';
 
 let mockInceptionPromoRunning = true;
+const mockedWarnExceptInTest = jest.fn();
 
 jest.mock('@/lib/constants', () => ({
   ...(jest.requireActual('@/lib/constants') as Record<string, unknown>),
   get INCEPTION_PROMO_RUNNING() {
     return mockInceptionPromoRunning;
   },
+}));
+
+jest.mock('@/lib/utils.server', () => ({
+  ...(jest.requireActual('@/lib/utils.server') as Record<string, unknown>),
+  warnExceptInTest: (...args: unknown[]) => mockedWarnExceptInTest(...args),
 }));
 
 // `countAndStoreEditUsage` schedules the usage write through `next/server`'s
@@ -38,6 +44,7 @@ import {
   checkOrganizationModelRestrictions,
   countAndStoreEditUsage,
   countAndStoreFimUsage,
+  efficientRoutingUnavailableResponse,
   extractEditPromptInfo,
   extractEmbeddingPromptInfo,
   extractHeaderAndLimitLength,
@@ -46,6 +53,37 @@ import {
   parseEditUsageFromResponse,
   parseTranscriptionUsageFromResponse,
 } from './llm-proxy-helpers';
+
+describe('efficientRoutingUnavailableResponse', () => {
+  it('includes non-sensitive decision failure details', async () => {
+    const response = efficientRoutingUnavailableResponse({
+      reason: 'worker_http_error',
+      blockedFallbackModelIds: ['moonshotai/kimi-k3', 'qwen/qwen3.7-plus'],
+      workerStatus: 503,
+    });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: 'Auto Efficient routing is temporarily unavailable.',
+      error_type: 'temporarily_unavailable',
+      message:
+        'Auto Efficient could not select a model, and your organization does not allow any configured fallback model. Please retry. If the problem continues, ask your organization administrator to allow a fallback model.',
+      details: {
+        reason: 'worker_http_error',
+        blocked_fallback_model_ids: ['moonshotai/kimi-k3', 'qwen/qwen3.7-plus'],
+        worker_status: 503,
+      },
+    });
+    expect(mockedWarnExceptInTest).toHaveBeenCalledWith(
+      expect.stringContaining('[efficientRoutingUnavailableResponse]'),
+      {
+        reason: 'worker_http_error',
+        blocked_fallback_model_ids: ['moonshotai/kimi-k3', 'qwen/qwen3.7-plus'],
+        worker_status: 503,
+      }
+    );
+  });
+});
 
 describe('checkOrganizationModelRestrictions', () => {
   describe('enterprise plan - model deny list restrictions', () => {

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -42,6 +42,8 @@ import type {
 } from '@/lib/ai-gateway/processUsage.types';
 import { detectContextOverflow } from '@/lib/ai-gateway/context-overflow';
 import { KILO_AUTO_BALANCED_MODEL, KILO_AUTO_FREE_MODEL } from '@/lib/ai-gateway/auto-model';
+import type { EfficientFallbackReason } from '@/lib/ai-gateway/auto-model/resolution';
+import type { EfficientDecisionFailure } from '@/lib/ai-gateway/auto-routing-decision';
 import type { GatewayChatApiKind, ProviderId } from '@/lib/ai-gateway/providers/types';
 import { computeOpenRouterCostFields } from '@/lib/ai-gateway/processUsage.shared';
 import { persistExperimentAttribution } from '@/lib/ai-gateway/experiments/persist';
@@ -341,6 +343,31 @@ export function efficientPoolBlockedResponse() {
       message,
     },
     { status: 404 }
+  );
+}
+
+export function efficientRoutingUnavailableResponse(details: {
+  reason: EfficientDecisionFailure['reason'] | EfficientFallbackReason;
+  blockedFallbackModelIds: string[];
+  workerStatus?: number;
+}) {
+  const error = 'Auto Efficient routing is temporarily unavailable.';
+  const message =
+    'Auto Efficient could not select a model, and your organization does not allow any configured fallback model. Please retry. If the problem continues, ask your organization administrator to allow a fallback model.';
+  const responseDetails = {
+    reason: details.reason,
+    blocked_fallback_model_ids: details.blockedFallbackModelIds,
+    ...(details.workerStatus === undefined ? {} : { worker_status: details.workerStatus }),
+  };
+  warnExceptInTest(`[efficientRoutingUnavailableResponse] ${message}`, responseDetails);
+  return NextResponse.json(
+    {
+      error,
+      error_type: ProxyErrorType.temporarily_unavailable,
+      message,
+      details: responseDetails,
+    },
+    { status: 503 }
   );
 }
 


### PR DESCRIPTION
## Summary
- Return a 503 routing-unavailable response instead of the misleading “organization blocks every model in the auto-routing pool” response when Auto Efficient falls back after decision-making fails and organization policy rejects that fallback.
- Include non-sensitive failure details: a stable reason code, the blocked fallback model ID, and the worker HTTP status when available.
- Log the same message and structured details through `warnExceptInTest`, matching the original error helper’s warning behavior.
- Preserve failure causes for missing worker configuration, request normalization failure, timeout, transport failure, non-2xx responses, invalid worker responses, valid responses with no decision, virtual-model decisions, and missing catalog variants.

## Why
A routing failure is not evidence that the organization blocks every model in the Efficient pool. The prior message conflated two separate facts: decision-making did not produce a usable model, and organization policy rejected the static fallback. The new response and warning log state both facts directly.

Example details:
```json
{
  "reason": "worker_http_error",
  "blocked_fallback_model_ids": [
    "moonshotai/kimi-k3"
  ],
  "worker_status": 502
}
```

Only stable, non-sensitive fields are returned and logged. Exception text, response bodies, worker URLs, credentials, user IDs, and organization IDs are excluded.

## Verification
- Changed-file formatting: passed.
- Changed-file oxlint: passed with 0 warnings and 0 errors.
- `pnpm --filter web exec tsgo --noEmit`: passed (with the local Node 26 versus required Node 24 engine warning).
- `git diff --check`: passed.
- Test suites were left to CI.