### PR TITLE
fix(mobile): keep account loaded after a failed identity refetch

### DIFF
--- a/apps/mobile/src/lib/hooks/use-current-user-id.test.ts
+++ b/apps/mobile/src/lib/hooks/use-current-user-id.test.ts
@@ -51,4 +51,15 @@ describe('useCurrentUserId', () => {
 
     expect(useCurrentUserId().isError).toBe(false);
   });
+
+  it('does not treat a refetch failure as missing identity when the user is cached', () => {
+    Object.assign(query, {
+      data: { id: 'user-1', email: 'user@example.com' },
+      isError: true,
+      isFetched: true,
+    });
+
+    expect(useCurrentUserId().isError).toBe(false);
+    expect(useCurrentUserId().userId).toBe('user-1');
+  });
 });

--- a/apps/mobile/src/lib/hooks/use-current-user-id.ts
+++ b/apps/mobile/src/lib/hooks/use-current-user-id.ts
@@ -17,7 +17,7 @@ export function useCurrentUserId(options: UseCurrentUserIdOptions = {}) {
     userId: data?.id,
     email: data?.email,
     isLoading,
-    isError: isError || (isLoading && isFetched),
+    isError: data === undefined && (isError || (isLoading && isFetched)),
     refetch: () => {
       void refetch();
     },


### PR DESCRIPTION
**Review and merge.** After a long background, a failed `user.getMe` refresh no longer replaces the app with Could not load account.

## Cause
- Foreground refresh invalidates `user.getMe`.
- A transient refetch error (radio not up yet) set `isError` even when the cached user was present.
- Bootstrap treated that as a missing account. Retry then succeeded with the same cache.

## Change
- `useCurrentUserId` reports an identity error only when `data` is missing.
- A cached user keeps the app up. Retry is still shown when there is no identity.

## Test
- `apps/mobile`: `vitest run src/lib/hooks/use-current-user-id.test.ts` — 5 passed.