### PR TITLE
fix(mobile): keep the composer toolbar on one line

### DIFF
--- a/apps/mobile/src/components/agents/chat-toolbar.test.ts
+++ b/apps/mobile/src/components/agents/chat-toolbar.test.ts
@@ -85,6 +85,24 @@ describe('ChatToolbar', () => {
     expect(props.disabled).toBe(false);
   });
 
+  it('keeps mode, model, and paste on one row', () => {
+    const onPaste = vi.fn(() => undefined);
+    // eslint-disable-next-line new-cap -- plain function call, matching repo test convention
+    const element = ChatToolbar({ ...defaultProps(), onPaste }) as Node;
+
+    const className =
+      element !== null &&
+      typeof element === 'object' &&
+      typeof element.props?.className === 'string'
+        ? element.props.className
+        : '';
+    expect(className).toContain('flex-row');
+    expect(className).not.toContain('flex-wrap');
+
+    const pasteButtonProps = findElementByType(element, 'ComposerPasteButton') ?? {};
+    expect(pasteButtonProps.className).toContain('shrink-0');
+  });
+
   it('locks only the model picker when modelLocked is true', () => {
     // eslint-disable-next-line new-cap -- plain function call, matching repo test convention
     const element = ChatToolbar({

--- a/apps/mobile/src/components/agents/chat-toolbar.tsx
+++ b/apps/mobile/src/components/agents/chat-toolbar.tsx
@@ -73,11 +73,7 @@ export function ChatToolbar({
 
   return (
     <View
-      className={cn(
-        'flex-row flex-wrap items-center gap-2 px-3 py-2.5',
-        disabled && 'opacity-50',
-        className
-      )}
+      className={cn('flex-row items-center gap-2 px-3 py-2.5', disabled && 'opacity-50', className)}
     >
       {order === 'model-first' ? modelSelector : modeSelector}
       {order === 'model-first' ? modeSelector : modelSelector}
@@ -86,7 +82,7 @@ export function ChatToolbar({
           size="sm"
           onPress={onPaste}
           disabled={pasteDisabled}
-          className="ml-auto"
+          className="ml-auto shrink-0"
         />
       ) : null}
     </View>

--- a/apps/mobile/src/components/agents/mode-selector.tsx
+++ b/apps/mobile/src/components/agents/mode-selector.tsx
@@ -68,12 +68,14 @@ export function ModeSelector({
       accessibilityLabel={t('agentChat.modeSelector.accessibility', { label: selectedLabel })}
       accessibilityState={{ disabled }}
       className={cn(
-        'flex-row items-center gap-1.5 rounded-full bg-secondary px-3 py-1.5 active:opacity-70',
+        'shrink-0 flex-row items-center gap-1.5 rounded-full bg-secondary px-3 py-1.5 active:opacity-70',
         disabled && 'opacity-50'
       )}
     >
       <ModeIcon size={14} color={colors.foreground} />
-      <Text className="text-sm font-medium text-foreground">{selectedLabel}</Text>
+      <Text className="text-sm font-medium text-foreground" numberOfLines={1}>
+        {selectedLabel}
+      </Text>
       <ChevronDown size={14} color={colors.mutedForeground} />
     </Pressable>
   );

--- a/apps/mobile/src/components/agents/model-selector.tsx
+++ b/apps/mobile/src/components/agents/model-selector.tsx
@@ -83,16 +83,6 @@ function toSessionModelOption(option: ModelOption | SessionModelOption): Session
   return { ...option, displayId: option.id, showGatewayMetadata: true };
 }
 
-function compactThinkingEffortLabel(variant: string) {
-  if (variant === 'xhigh') {
-    return i18n.t('agentChat.modelSelector.thinkingEffortXhigh');
-  }
-  if (variant === 'medium') {
-    return i18n.t('agentChat.modelSelector.thinkingEffortMedium');
-  }
-  return thinkingEffortLabel(variant);
-}
-
 export function openModelPicker(
   router: ImperativeRouter,
   params: {
@@ -146,7 +136,6 @@ export function ModelSelector({
   const { byok, collectsData } = modelSelectorBadges(selectedModel);
   const hasVariants = selectedModel ? selectedModel.variants.length > 1 : false;
   const variantLabel = variant ? thinkingEffortLabel(variant) : '';
-  const compactVariantLabel = variant ? compactThinkingEffortLabel(variant) : '';
   const dataLabel = collectsData ? getFreeModelDataAccessibilityLabel(label) : label;
   const modelLabel = byok ? `${dataLabel}, ${BYOK_MODEL_LABEL}` : dataLabel;
   const accessibilityLabel =
@@ -159,7 +148,7 @@ export function ModelSelector({
     (lockLabel && disabled ? t('agentChat.modelSelector.lockedByAgent', { agent: lockLabel }) : '');
   // A pinned variant is meaningful even when the locked option carries a single
   // variant, so surface the badge whenever a lock label is present.
-  const showVariantBadge = compactVariantLabel !== '' && (hasVariants || Boolean(lockLabel));
+  const showVariantBadge = variantLabel !== '' && (hasVariants || Boolean(lockLabel));
 
   function handlePress() {
     if (effectivelyDisabled) {
@@ -182,7 +171,7 @@ export function ModelSelector({
       accessibilityLabel={accessibilityLabel}
       accessibilityState={{ disabled: effectivelyDisabled }}
       className={cn(
-        'max-w-[240px] shrink flex-row items-center gap-1.5 rounded-full bg-secondary px-3 py-1.5 active:opacity-70',
+        'max-w-[240px] min-w-0 shrink flex-row items-center gap-1.5 rounded-full bg-secondary px-3 py-1.5 active:opacity-70',
         effectivelyDisabled && 'opacity-50'
       )}
     >
@@ -205,7 +194,7 @@ export function ModelSelector({
           <View className="flex-row items-center gap-1 rounded-full bg-neutral-200 px-1.5 py-0.5 dark:bg-neutral-800">
             <Brain size={12} color={colors.mutedForeground} />
             <Text className="text-xs font-medium text-muted-foreground" numberOfLines={1}>
-              {compactVariantLabel}
+              {variantLabel}
             </Text>
           </View>
         ) : null}

--- a/apps/mobile/src/i18n/locales/af.json
+++ b/apps/mobile/src/i18n/locales/af.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Vergrendel deur agent \"{{agent}}\"",
       "addToFavorites": "Voeg {{name}} by gunstelinge",
       "removeFromFavorites": "Verwyder {{name}} uit gunstelinge",
-      "thinkingEffortXhigh": "EH",
-      "thinkingEffortMedium": "Matig",
       "sessionModel": "Sessiemodel"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/am.json
+++ b/apps/mobile/src/i18n/locales/am.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": "፣ በወኪሉ «{{agent}}» ተቆልፏል",
       "addToFavorites": "{{name}}ን ወደ ተወዳጆች ያክሉ",
       "removeFromFavorites": "{{name}}ን ከተወዳጆች ያስወግዱ",
-      "thinkingEffortXhigh": "እጅግ ከፍ",
-      "thinkingEffortMedium": "መካከለኛ",
       "sessionModel": "የክፍለ ጊዜ ሞዴል"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ar.json
+++ b/apps/mobile/src/i18n/locales/ar.json
@@ -1940,8 +1940,6 @@
       "lockedByAgent": "، مقفل بواسطة الوكيل \"{{agent}}\"",
       "addToFavorites": "إضافة {{name}} إلى المفضلة",
       "removeFromFavorites": "إزالة {{name}} من المفضلة",
-      "thinkingEffortXhigh": "عالٍ جدًا",
-      "thinkingEffortMedium": "متوسط",
       "sessionModel": "نموذج الجلسة"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/az.json
+++ b/apps/mobile/src/i18n/locales/az.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", «{{agent}}» agenti tərəfindən kilidlənib",
       "addToFavorites": "{{name}} modelini sevimlilərə əlavə et",
       "removeFromFavorites": "{{name}} modelini sevimlilərdən sil",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Orta",
       "sessionModel": "Sessiya modeli"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/be.json
+++ b/apps/mobile/src/i18n/locales/be.json
@@ -2359,8 +2359,6 @@
       "lockedByAgent": ", Заблакавана агентам «{{agent}}»",
       "addToFavorites": "Дадаць {{name}} у абранае",
       "removeFromFavorites": "Прыбраць {{name}} з абранага",
-      "thinkingEffortXhigh": "ВВ",
-      "thinkingEffortMedium": "Сяр.",
       "sessionModel": "Мадэль сеанса"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/bg.json
+++ b/apps/mobile/src/i18n/locales/bg.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Заключено от агента „{{agent}}“",
       "addToFavorites": "Добави {{name}} към любимите",
       "removeFromFavorites": "Премахни {{name}} от любимите",
-      "thinkingEffortXhigh": "МВ",
-      "thinkingEffortMedium": "Сред.",
       "sessionModel": "Модел на сесията"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/bn.json
+++ b/apps/mobile/src/i18n/locales/bn.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", \"{{agent}}\" এজেন্ট লক করেছে",
       "addToFavorites": "{{name}} পছন্দের তালিকায় যোগ করুন",
       "removeFromFavorites": "{{name}} পছন্দের তালিকা থেকে সরান",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "মাঝারি",
       "sessionModel": "সেশনের মডেল"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/bs.json
+++ b/apps/mobile/src/i18n/locales/bs.json
@@ -2339,8 +2339,6 @@
       "lockedByAgent": ", Zaključao agent „{{agent}}“",
       "addToFavorites": "Dodaj {{name}} u omiljene",
       "removeFromFavorites": "Ukloni {{name}} iz omiljenih",
-      "thinkingEffortXhigh": "IV",
-      "thinkingEffortMedium": "Sred.",
       "sessionModel": "Model sesije"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ca.json
+++ b/apps/mobile/src/i18n/locales/ca.json
@@ -2339,8 +2339,6 @@
       "lockedByAgent": ", Bloquejat per l'agent «{{agent}}»",
       "addToFavorites": "Afegeix {{name}} als preferits",
       "removeFromFavorites": "Treu {{name}} dels preferits",
-      "thinkingEffortXhigh": "MA",
-      "thinkingEffortMedium": "Mitjà",
       "sessionModel": "Model de la sessió"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ckb.json
+++ b/apps/mobile/src/i18n/locales/ckb.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": "، لەلایەن ئەجێنتی «{{agent}}» ـەوە قوفڵ کراوە",
       "addToFavorites": "زیادکردنی {{name}} بۆ دڵخوازەکان",
       "removeFromFavorites": "لابردنی {{name}} لە دڵخوازەکان",
-      "thinkingEffortXhigh": "زۆر بەرز",
-      "thinkingEffortMedium": "مامناوەند",
       "sessionModel": "مۆدێلی سێشن"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/cs.json
+++ b/apps/mobile/src/i18n/locales/cs.json
@@ -2359,8 +2359,6 @@
       "lockedByAgent": ", Uzamčeno agentem „{{agent}}“",
       "addToFavorites": "Přidat {{name}} do oblíbených",
       "removeFromFavorites": "Odebrat {{name}} z oblíbených",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Stř.",
       "sessionModel": "Model relace"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/cy.json
+++ b/apps/mobile/src/i18n/locales/cy.json
@@ -2399,8 +2399,6 @@
       "lockedByAgent": ", Wedi'i gloi gan yr asiant \"{{agent}}\"",
       "addToFavorites": "Ychwanegu {{name}} i'r ffefrynnau",
       "removeFromFavorites": "Tynnu {{name}} o'r ffefrynnau",
-      "thinkingEffortXhigh": "UI",
-      "thinkingEffortMedium": "Can",
       "sessionModel": "Model y sesiwn"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/da.json
+++ b/apps/mobile/src/i18n/locales/da.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Låst af agenten \"{{agent}}\"",
       "addToFavorites": "Tilføj {{name}} til favoritter",
       "removeFromFavorites": "Fjern {{name}} fra favoritter",
-      "thinkingEffortXhigh": "EH",
-      "thinkingEffortMedium": "Mid.",
       "sessionModel": "Sessionsmodel"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/de.json
+++ b/apps/mobile/src/i18n/locales/de.json
@@ -1888,8 +1888,6 @@
       "lockedByAgent": ", Durch den Agenten „{{agent}}“ gesperrt",
       "addToFavorites": "{{name}} zu den Favoriten hinzufügen",
       "removeFromFavorites": "{{name}} aus den Favoriten entfernen",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Mittel",
       "sessionModel": "Sitzungsmodell"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/el.json
+++ b/apps/mobile/src/i18n/locales/el.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Κλειδωμένο από τον πράκτορα «{{agent}}»",
       "addToFavorites": "Προσθήκη του {{name}} στα αγαπημένα",
       "removeFromFavorites": "Αφαίρεση του {{name}} από τα αγαπημένα",
-      "thinkingEffortXhigh": "ΠΥ",
-      "thinkingEffortMedium": "Μέσ.",
       "sessionModel": "Μοντέλο συνεδρίας"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -2343,8 +2343,6 @@
       "lockedByAgent": ", Locked by agent \"{{agent}}\"",
       "addToFavorites": "Add {{name}} to favorites",
       "removeFromFavorites": "Remove {{name}} from favorites",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Med",
       "sessionModel": "Session model"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/es.json
+++ b/apps/mobile/src/i18n/locales/es.json
@@ -1901,8 +1901,6 @@
       "lockedByAgent": ", Bloqueado por el agente «{{agent}}»",
       "addToFavorites": "Añadir {{name}} a favoritos",
       "removeFromFavorites": "Quitar {{name}} de favoritos",
-      "thinkingEffortXhigh": "MA",
-      "thinkingEffortMedium": "Med.",
       "sessionModel": "Modelo de la sesión"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/et.json
+++ b/apps/mobile/src/i18n/locales/et.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Lukustanud agent „{{agent}}“",
       "addToFavorites": "Lisa {{name}} lemmikutesse",
       "removeFromFavorites": "Eemalda {{name}} lemmikutest",
-      "thinkingEffortXhigh": "VK",
-      "thinkingEffortMedium": "Kesk",
       "sessionModel": "Seansi mudel"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/eu.json
+++ b/apps/mobile/src/i18n/locales/eu.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", \"{{agent}}\" agenteak blokeatuta",
       "addToFavorites": "Gehitu {{name}} gogokoetara",
       "removeFromFavorites": "Kendu {{name}} gogokoetatik",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Ert.",
       "sessionModel": "Saioaren modeloa"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/fa.json
+++ b/apps/mobile/src/i18n/locales/fa.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": "، قفل‌شده توسط عامل «{{agent}}»",
       "addToFavorites": "افزودن {{name}} به موارد دلخواه",
       "removeFromFavorites": "حذف {{name}} از موارد دلخواه",
-      "thinkingEffortXhigh": "خیلی زیاد",
-      "thinkingEffortMedium": "متوسط",
       "sessionModel": "مدل نشست"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/fi.json
+++ b/apps/mobile/src/i18n/locales/fi.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Agentin \"{{agent}}\" lukitsema",
       "addToFavorites": "Lisää {{name}} suosikkeihin",
       "removeFromFavorites": "Poista {{name}} suosikeista",
-      "thinkingEffortXhigh": "EK",
-      "thinkingEffortMedium": "Keski",
       "sessionModel": "Istunnon malli"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/fil.json
+++ b/apps/mobile/src/i18n/locales/fil.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Ni-lock ng ahenteng \"{{agent}}\"",
       "addToFavorites": "Idagdag ang {{name}} sa mga paborito",
       "removeFromFavorites": "Alisin ang {{name}} sa mga paborito",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Kat.",
       "sessionModel": "Modelo ng sesyon"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/fr.json
+++ b/apps/mobile/src/i18n/locales/fr.json
@@ -1813,8 +1813,6 @@
       "lockedByAgent": ", Verrouillé par l'agent « {{agent}} »",
       "addToFavorites": "Ajouter {{name}} aux favoris",
       "removeFromFavorites": "Retirer {{name}} des favoris",
-      "thinkingEffortXhigh": "TÉ",
-      "thinkingEffortMedium": "Moy.",
       "sessionModel": "Modèle de la session"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ga.json
+++ b/apps/mobile/src/i18n/locales/ga.json
@@ -2379,8 +2379,6 @@
       "lockedByAgent": ", Glasáilte ag an ngníomhaire \"{{agent}}\"",
       "addToFavorites": "Cuir {{name}} leis na cinn is fearr leat",
       "removeFromFavorites": "Bain {{name}} ó na cinn is fearr leat",
-      "thinkingEffortXhigh": "AN-ARD",
-      "thinkingEffortMedium": "Meán",
       "sessionModel": "Samhail an tseisiúin"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/gl.json
+++ b/apps/mobile/src/i18n/locales/gl.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Bloqueado polo axente «{{agent}}»",
       "addToFavorites": "Engadir {{name}} aos favoritos",
       "removeFromFavorites": "Eliminar {{name}} dos favoritos",
-      "thinkingEffortXhigh": "MA",
-      "thinkingEffortMedium": "Med.",
       "sessionModel": "Modelo da sesión"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/gu.json
+++ b/apps/mobile/src/i18n/locales/gu.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", એજન્ટ \"{{agent}}\" દ્વારા લૉક કરેલ",
       "addToFavorites": "{{name}}ને મનપસંદમાં ઉમેરો",
       "removeFromFavorites": "{{name}}ને મનપસંદમાંથી દૂર કરો",
-      "thinkingEffortXhigh": "અતિ ઉચ્ચ",
-      "thinkingEffortMedium": "મધ્યમ",
       "sessionModel": "સત્રનું મોડલ"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ha.json
+++ b/apps/mobile/src/i18n/locales/ha.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Wakili \"{{agent}}\" ya kulle shi",
       "addToFavorites": "Ƙara {{name}} cikin waɗanda ka fi so",
       "removeFromFavorites": "Cire {{name}} daga waɗanda ka fi so",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Mats.",
       "sessionModel": "Samfurin zaman"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/he.json
+++ b/apps/mobile/src/i18n/locales/he.json
@@ -1901,8 +1901,6 @@
       "lockedByAgent": ", נעול על ידי הסוכן \"{{agent}}\"",
       "addToFavorites": "הוספת {{name}} למועדפים",
       "removeFromFavorites": "הסרת {{name}} מהמועדפים",
-      "thinkingEffortXhigh": "גבוה מאוד",
-      "thinkingEffortMedium": "בינוני",
       "sessionModel": "המודל של הסשן"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/hi.json
+++ b/apps/mobile/src/i18n/locales/hi.json
@@ -1862,8 +1862,6 @@
       "lockedByAgent": ", एजेंट \"{{agent}}\" द्वारा लॉक",
       "addToFavorites": "{{name}} को पसंदीदा में जोड़ें",
       "removeFromFavorites": "{{name}} को पसंदीदा से हटाएँ",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "मध्यम",
       "sessionModel": "सत्र का मॉडल"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/hr.json
+++ b/apps/mobile/src/i18n/locales/hr.json
@@ -2339,8 +2339,6 @@
       "lockedByAgent": ", Zaključao agent „{{agent}}”",
       "addToFavorites": "Dodaj {{name}} u favorite",
       "removeFromFavorites": "Ukloni {{name}} iz favorita",
-      "thinkingEffortXhigh": "V. VIS.",
-      "thinkingEffortMedium": "Sred.",
       "sessionModel": "Model sesije"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ht.json
+++ b/apps/mobile/src/i18n/locales/ht.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Bloke pa ajan \"{{agent}}\"",
       "addToFavorites": "Ajoute {{name}} nan favori",
       "removeFromFavorites": "Retire {{name}} nan favori",
-      "thinkingEffortXhigh": "TW",
-      "thinkingEffortMedium": "Mway.",
       "sessionModel": "Modèl sesyon"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/hu.json
+++ b/apps/mobile/src/i18n/locales/hu.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Zároló ügynök: „{{agent}}”",
       "addToFavorites": "{{name}} hozzáadása a kedvencekhez",
       "removeFromFavorites": "{{name}} eltávolítása a kedvencekből",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Köz.",
       "sessionModel": "A munkamenet modellje"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/hy.json
+++ b/apps/mobile/src/i18n/locales/hy.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Կողպված է «{{agent}}» գործակալի կողմից",
       "addToFavorites": "Ավելացնել {{name}}-ը նախընտրածներին",
       "removeFromFavorites": "Հեռացնել {{name}}-ը նախընտրածներից",
-      "thinkingEffortXhigh": "ՇԲ",
-      "thinkingEffortMedium": "Միջ.",
       "sessionModel": "Նիստի մոդել"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/id.json
+++ b/apps/mobile/src/i18n/locales/id.json
@@ -1888,8 +1888,6 @@
       "lockedByAgent": ", Dikunci oleh agen \"{{agent}}\"",
       "addToFavorites": "Tambahkan {{name}} ke favorit",
       "removeFromFavorites": "Hapus {{name}} dari favorit",
-      "thinkingEffortXhigh": "ST",
-      "thinkingEffortMedium": "Sdg",
       "sessionModel": "Model sesi"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ig.json
+++ b/apps/mobile/src/i18n/locales/ig.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Onye nnọchi anya \"{{agent}}\" kpọchiri ya",
       "addToFavorites": "Tinye {{name}} n'ihe kacha amasị gị",
       "removeFromFavorites": "Wepụ {{name}} n'ihe kacha amasị gị",
-      "thinkingEffortXhigh": "ELU+",
-      "thinkingEffortMedium": "Etiti",
       "sessionModel": "Ihe nlereanya nnọkọ"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/is.json
+++ b/apps/mobile/src/i18n/locales/is.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Læst af fulltrúanum „{{agent}}“",
       "addToFavorites": "Bæta {{name}} við eftirlæti",
       "removeFromFavorites": "Fjarlægja {{name}} úr eftirlæti",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Miðl.",
       "sessionModel": "Lotulíkan"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/it.json
+++ b/apps/mobile/src/i18n/locales/it.json
@@ -1878,8 +1878,6 @@
       "lockedByAgent": ", Bloccato dall'agente \"{{agent}}\"",
       "addToFavorites": "Aggiungi {{name}} ai preferiti",
       "removeFromFavorites": "Rimuovi {{name}} dai preferiti",
-      "thinkingEffortXhigh": "MA",
-      "thinkingEffortMedium": "Med.",
       "sessionModel": "Modello della sessione"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ja.json
+++ b/apps/mobile/src/i18n/locales/ja.json
@@ -1888,8 +1888,6 @@
       "lockedByAgent": "、エージェント「{{agent}}」によってロックされています",
       "addToFavorites": "{{name}}をお気に入りに追加",
       "removeFromFavorites": "{{name}}をお気に入りから削除",
-      "thinkingEffortXhigh": "超高",
-      "thinkingEffortMedium": "中",
       "sessionModel": "セッションのモデル"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ka.json
+++ b/apps/mobile/src/i18n/locales/ka.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", ჩაკეტილია აგენტის „{{agent}}“ მიერ",
       "addToFavorites": "{{name}}-ის რჩეულებში დამატება",
       "removeFromFavorites": "{{name}}-ის რჩეულებიდან ამოღება",
-      "thinkingEffortXhigh": "ძ. მაღ.",
-      "thinkingEffortMedium": "საშ.",
       "sessionModel": "სესიის მოდელი"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/kk.json
+++ b/apps/mobile/src/i18n/locales/kk.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", «{{agent}}» агенті бекіткен",
       "addToFavorites": "{{name}} моделін таңдаулыларға қосу",
       "removeFromFavorites": "{{name}} моделін таңдаулылардан алып тастау",
-      "thinkingEffortXhigh": "ӨЖ",
-      "thinkingEffortMedium": "Орта",
       "sessionModel": "Сессия моделі"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/km.json
+++ b/apps/mobile/src/i18n/locales/km.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", បានចាក់សោដោយភ្នាក់ងារ \"{{agent}}\"",
       "addToFavorites": "បន្ថែម {{name}} ទៅចំណូលចិត្ត",
       "removeFromFavorites": "ដក {{name}} ចេញពីចំណូលចិត្ត",
-      "thinkingEffortXhigh": "ខ្ពស់ខ្លាំង",
-      "thinkingEffortMedium": "មធ្យម",
       "sessionModel": "ម៉ូដែលរបស់វគ្គ"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/kn.json
+++ b/apps/mobile/src/i18n/locales/kn.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", \"{{agent}}\" ಏಜೆಂಟ್ ಬದಲಾವಣೆಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿದೆ",
       "addToFavorites": "{{name}} ಅನ್ನು ಮೆಚ್ಚಿನವುಗಳಿಗೆ ಸೇರಿಸಿ",
       "removeFromFavorites": "{{name}} ಅನ್ನು ಮೆಚ್ಚಿನವುಗಳಿಂದ ತೆಗೆದುಹಾಕಿ",
-      "thinkingEffortXhigh": "ಅತಿಹೆಚ್ಚು",
-      "thinkingEffortMedium": "ಮಧ್ಯಮ",
       "sessionModel": "ಸೆಶನ್ ಮಾದರಿ"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ko.json
+++ b/apps/mobile/src/i18n/locales/ko.json
@@ -1888,8 +1888,6 @@
       "lockedByAgent": ", 에이전트 \"{{agent}}\"에서 고정한 설정",
       "addToFavorites": "{{name}} 즐겨찾기에 추가",
       "removeFromFavorites": "{{name}} 즐겨찾기에서 제거",
-      "thinkingEffortXhigh": "매우 높음",
-      "thinkingEffortMedium": "보통",
       "sessionModel": "세션 모델"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/lo.json
+++ b/apps/mobile/src/i18n/locales/lo.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", ລັອກໂດຍເອເຈນ \"{{agent}}\"",
       "addToFavorites": "ເພີ່ມ {{name}} ໃສ່ລາຍການທີ່ມັກ",
       "removeFromFavorites": "ເອົາ {{name}} ອອກຈາກລາຍການທີ່ມັກ",
-      "thinkingEffortXhigh": "ສູງພິເສດ",
-      "thinkingEffortMedium": "ປານກາງ",
       "sessionModel": "ໂມເດວຂອງເຊດຊັນ"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/lt.json
+++ b/apps/mobile/src/i18n/locales/lt.json
@@ -2359,8 +2359,6 @@
       "lockedByAgent": ", Užrakino agentas „{{agent}}“",
       "addToFavorites": "Įtraukti {{name}} į mėgstamiausius",
       "removeFromFavorites": "Pašalinti {{name}} iš mėgstamiausių",
-      "thinkingEffortXhigh": "YA",
-      "thinkingEffortMedium": "Vid.",
       "sessionModel": "Sesijos modelis"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/lv.json
+++ b/apps/mobile/src/i18n/locales/lv.json
@@ -2339,8 +2339,6 @@
       "lockedByAgent": ", Bloķējis aģents „{{agent}}”",
       "addToFavorites": "Pievienot {{name}} izlasei",
       "removeFromFavorites": "Noņemt {{name}} no izlases",
-      "thinkingEffortXhigh": "ĪA",
-      "thinkingEffortMedium": "Vid.",
       "sessionModel": "Sesijas modelis"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/mg.json
+++ b/apps/mobile/src/i18n/locales/mg.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Nohidin'ny mpanampy \"{{agent}}\"",
       "addToFavorites": "Ampio ao amin'ny ankafizinao ny {{name}}",
       "removeFromFavorites": "Esory ao amin'ny ankafizinao ny {{name}}",
-      "thinkingEffortXhigh": "AVO BE",
-      "thinkingEffortMedium": "Ant.",
       "sessionModel": "Modelin'ny fotoam-piasana"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/mi.json
+++ b/apps/mobile/src/i18n/locales/mi.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Kua maukatihia e te māngai \"{{agent}}\"",
       "addToFavorites": "Tāpirihia a {{name}} ki ngā makau",
       "removeFromFavorites": "Tangohia {{name}} i ngā makau",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Waenga",
       "sessionModel": "Te tauira o te wātū"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/mk.json
+++ b/apps/mobile/src/i18n/locales/mk.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Заклучено од агентот „{{agent}}“",
       "addToFavorites": "Додај {{name}} во омилени",
       "removeFromFavorites": "Отстрани {{name}} од омилени",
-      "thinkingEffortXhigh": "МВ",
-      "thinkingEffortMedium": "Сред.",
       "sessionModel": "Модел на сесијата"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ml.json
+++ b/apps/mobile/src/i18n/locales/ml.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", \"{{agent}}\" എന്ന ഏജന്റ് ലോക്ക് ചെയ്തു",
       "addToFavorites": "{{name}} പ്രിയപ്പെട്ടവയിലേക്ക് ചേർക്കുക",
       "removeFromFavorites": "{{name}} പ്രിയപ്പെട്ടവയിൽ നിന്ന് നീക്കം ചെയ്യുക",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "ഇടത്തരം",
       "sessionModel": "സെഷൻ മോഡൽ"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/mn.json
+++ b/apps/mobile/src/i18n/locales/mn.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", «{{agent}}» агент түгжсэн",
       "addToFavorites": "{{name}} загварыг дуртай загваруудад нэмэх",
       "removeFromFavorites": "{{name}} загварыг дуртай загваруудаас хасах",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Дунд",
       "sessionModel": "Сессийн загвар"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/mr.json
+++ b/apps/mobile/src/i18n/locales/mr.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", \"{{agent}}\" या एजंटने लॉक केलेले",
       "addToFavorites": "{{name}} आवडत्या मॉडेलमध्ये जोडा",
       "removeFromFavorites": "{{name}} आवडत्या मॉडेलमधून काढा",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "मध्यम",
       "sessionModel": "सत्राचे मॉडेल"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ms.json
+++ b/apps/mobile/src/i18n/locales/ms.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Dikunci oleh ejen \"{{agent}}\"",
       "addToFavorites": "Tambah {{name}} ke kegemaran",
       "removeFromFavorites": "Buang {{name}} daripada kegemaran",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Sederhana",
       "sessionModel": "Model sesi"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/mt.json
+++ b/apps/mobile/src/i18n/locales/mt.json
@@ -2379,8 +2379,6 @@
       "lockedByAgent": ", Imsakkar mill-aġent \"{{agent}}\"",
       "addToFavorites": "Żid {{name}} mal-favoriti",
       "removeFromFavorites": "Neħħi {{name}} mill-favoriti",
-      "thinkingEffortXhigh": "GĦ+",
-      "thinkingEffortMedium": "Med.",
       "sessionModel": "Mudell tas-sessjoni"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/my.json
+++ b/apps/mobile/src/i18n/locales/my.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": "၊ အေးဂျင့် “{{agent}}” က ပြောင်းလဲခွင့်ပိတ်ထားသည်",
       "addToFavorites": "{{name}} ကို စိတ်ကြိုက်များသို့ ထည့်ပါ",
       "removeFromFavorites": "{{name}} ကို စိတ်ကြိုက်များမှ ဖယ်ရှားပါ",
-      "thinkingEffortXhigh": "အလွန်မြင့်",
-      "thinkingEffortMedium": "အလယ်အလတ်",
       "sessionModel": "စက်ရှင်မော်ဒယ်"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/nb.json
+++ b/apps/mobile/src/i18n/locales/nb.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Låst av agenten «{{agent}}»",
       "addToFavorites": "Legg {{name}} til favoritter",
       "removeFromFavorites": "Fjern {{name}} fra favoritter",
-      "thinkingEffortXhigh": "EH",
-      "thinkingEffortMedium": "Mid.",
       "sessionModel": "Øktmodell"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ne.json
+++ b/apps/mobile/src/i18n/locales/ne.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", एजेन्ट \"{{agent}}\" ले परिवर्तन गर्न नमिल्ने बनाएको",
       "addToFavorites": "मनपर्नेमा {{name}} थप्नुहोस्",
       "removeFromFavorites": "मनपर्नेबाट {{name}} हटाउनुहोस्",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "मध्यम",
       "sessionModel": "सत्रको मोडेल"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/nl.json
+++ b/apps/mobile/src/i18n/locales/nl.json
@@ -1888,8 +1888,6 @@
       "lockedByAgent": ", Vergrendeld door agent \"{{agent}}\"",
       "addToFavorites": "{{name}} aan favorieten toevoegen",
       "removeFromFavorites": "{{name}} uit favorieten verwijderen",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Gem",
       "sessionModel": "Sessiemodel"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/om.json
+++ b/apps/mobile/src/i18n/locales/om.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Ergamaa \"{{agent}}\" dhaan cufame",
       "addToFavorites": "{{name}} kan jaallattetti dabali",
       "removeFromFavorites": "{{name}} kan jaallatte keessaa baasi",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Giddu",
       "sessionModel": "Moodela turtii"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/or.json
+++ b/apps/mobile/src/i18n/locales/or.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", ଏଜେଣ୍ଟ \"{{agent}}\" ଦ୍ୱାରା ଲକ୍ ହୋଇଛି",
       "addToFavorites": "{{name}} କୁ ପସନ୍ଦର ମଡେଲ୍ ତାଲିକାରେ ଯୋଡ଼ନ୍ତୁ",
       "removeFromFavorites": "{{name}} କୁ ପସନ୍ଦର ମଡେଲ୍ ତାଲିକାରୁ ହଟାନ୍ତୁ",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "ମଧ୍ୟମ",
       "sessionModel": "ସେସନ୍ ମଡେଲ୍"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/pa.json
+++ b/apps/mobile/src/i18n/locales/pa.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", ਏਜੰਟ \"{{agent}}\" ਦੁਆਰਾ ਲਾਕ ਕੀਤਾ ਗਿਆ",
       "addToFavorites": "{{name}} ਨੂੰ ਪਸੰਦੀਦਾ ਸੂਚੀ ਵਿੱਚ ਜੋੜੋ",
       "removeFromFavorites": "{{name}} ਨੂੰ ਪਸੰਦੀਦਾ ਸੂਚੀ ਤੋਂ ਹਟਾਓ",
-      "thinkingEffortXhigh": "ਬਹੁਤ ਉੱਚਾ",
-      "thinkingEffortMedium": "ਦਰਮਿਆਨਾ",
       "sessionModel": "ਸੈਸ਼ਨ ਦਾ ਮਾਡਲ"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/pl.json
+++ b/apps/mobile/src/i18n/locales/pl.json
@@ -1914,8 +1914,6 @@
       "lockedByAgent": ", Zablokowane przez agenta „{{agent}}”",
       "addToFavorites": "Dodaj {{name}} do ulubionych",
       "removeFromFavorites": "Usuń {{name}} z ulubionych",
-      "thinkingEffortXhigh": "B. WYS.",
-      "thinkingEffortMedium": "Śr.",
       "sessionModel": "Model sesji"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ps.json
+++ b/apps/mobile/src/i18n/locales/ps.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": "، د «{{agent}}» ایجنټ له خوا قلف شوی",
       "addToFavorites": "{{name}} د خوښې ماډلونو ته زیات کړئ",
       "removeFromFavorites": "{{name}} د خوښې ماډلونو له لېست څخه لرې کړئ",
-      "thinkingEffortXhigh": "ډېر لوړ",
-      "thinkingEffortMedium": "منځنی",
       "sessionModel": "د ناستې ماډل"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/pt-BR.json
+++ b/apps/mobile/src/i18n/locales/pt-BR.json
@@ -1878,8 +1878,6 @@
       "lockedByAgent": ", Bloqueado pelo agente \"{{agent}}\"",
       "addToFavorites": "Adicionar {{name}} aos favoritos",
       "removeFromFavorites": "Remover {{name}} dos favoritos",
-      "thinkingEffortXhigh": "MA",
-      "thinkingEffortMedium": "Méd.",
       "sessionModel": "Modelo da sessão"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/pt.json
+++ b/apps/mobile/src/i18n/locales/pt.json
@@ -2339,8 +2339,6 @@
       "lockedByAgent": ", Bloqueado pelo agente \"{{agent}}\"",
       "addToFavorites": "Adicionar {{name}} aos favoritos",
       "removeFromFavorites": "Remover {{name}} dos favoritos",
-      "thinkingEffortXhigh": "MA",
-      "thinkingEffortMedium": "Méd.",
       "sessionModel": "Modelo da sessão"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ro.json
+++ b/apps/mobile/src/i18n/locales/ro.json
@@ -2339,8 +2339,6 @@
       "lockedByAgent": ", Blocat de agentul „{{agent}}”",
       "addToFavorites": "Adaugă {{name}} la favorite",
       "removeFromFavorites": "Elimină {{name}} din favorite",
-      "thinkingEffortXhigh": "F. RID.",
-      "thinkingEffortMedium": "Med.",
       "sessionModel": "Modelul sesiunii"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ru.json
+++ b/apps/mobile/src/i18n/locales/ru.json
@@ -1914,8 +1914,6 @@
       "lockedByAgent": ", Заблокировано агентом «{{agent}}»",
       "addToFavorites": "Добавить {{name}} в избранное",
       "removeFromFavorites": "Убрать {{name}} из избранного",
-      "thinkingEffortXhigh": "ОЧ. ВЫС.",
-      "thinkingEffortMedium": "Сред.",
       "sessionModel": "Модель сеанса"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/si.json
+++ b/apps/mobile/src/i18n/locales/si.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", \"{{agent}}\" නියෝජිතයා විසින් අගුළු දමා ඇත",
       "addToFavorites": "ප්‍රියතමයන්ට {{name}} එක් කරන්න",
       "removeFromFavorites": "ප්‍රියතමයන්ගෙන් {{name}} ඉවත් කරන්න",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "මධ්‍යම",
       "sessionModel": "සැසියේ මාදිලිය"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/sk.json
+++ b/apps/mobile/src/i18n/locales/sk.json
@@ -2359,8 +2359,6 @@
       "lockedByAgent": ", Uzamknuté agentom „{{agent}}“",
       "addToFavorites": "Pridať {{name}} do obľúbených",
       "removeFromFavorites": "Odstrániť {{name}} z obľúbených",
-      "thinkingEffortXhigh": "EXTR.",
-      "thinkingEffortMedium": "Str.",
       "sessionModel": "Model relácie"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/sl.json
+++ b/apps/mobile/src/i18n/locales/sl.json
@@ -2359,8 +2359,6 @@
       "lockedByAgent": ", Zaklenil agent »{{agent}}«",
       "addToFavorites": "Dodaj {{name}} med priljubljene",
       "removeFromFavorites": "Odstrani {{name}} s seznama priljubljenih",
-      "thinkingEffortXhigh": "ZV",
-      "thinkingEffortMedium": "Sred.",
       "sessionModel": "Model seje"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/so.json
+++ b/apps/mobile/src/i18n/locales/so.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Waxaa xiray wakiilka \"{{agent}}\"",
       "addToFavorites": "Ku dar {{name}} kuwa la jecel yahay",
       "removeFromFavorites": "Ka saar {{name}} kuwa la jecel yahay",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Dhexe",
       "sessionModel": "Moodeelka kalfadhiga"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/sq.json
+++ b/apps/mobile/src/i18n/locales/sq.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", I bllokuar nga agjenti «{{agent}}»",
       "addToFavorites": "Shto {{name}} te të preferuarat",
       "removeFromFavorites": "Hiq {{name}} nga të preferuarat",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Mes",
       "sessionModel": "Modeli i seancës"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/sr.json
+++ b/apps/mobile/src/i18n/locales/sr.json
@@ -2339,8 +2339,6 @@
       "lockedByAgent": ", Zaključano od strane agenta „{{agent}}“",
       "addToFavorites": "Dodaj {{name}} u omiljene",
       "removeFromFavorites": "Ukloni {{name}} iz omiljenih",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Sred.",
       "sessionModel": "Model sesije"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/sv.json
+++ b/apps/mobile/src/i18n/locales/sv.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Låst av agenten ”{{agent}}”",
       "addToFavorites": "Lägg till {{name}} i favoriter",
       "removeFromFavorites": "Ta bort {{name}} från favoriter",
-      "thinkingEffortXhigh": "EH",
-      "thinkingEffortMedium": "Med",
       "sessionModel": "Sessionmodell"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/sw.json
+++ b/apps/mobile/src/i18n/locales/sw.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Imefungwa na wakala \"{{agent}}\"",
       "addToFavorites": "Ongeza {{name}} kwenye vipendwa",
       "removeFromFavorites": "Ondoa {{name}} kwenye vipendwa",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Wast.",
       "sessionModel": "Modeli ya kikao"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ta.json
+++ b/apps/mobile/src/i18n/locales/ta.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", \"{{agent}}\" ஏஜென்ட்டால் மாற்ற முடியாதபடி அமைக்கப்பட்டது",
       "addToFavorites": "{{name}}-ஐப் பிடித்தவற்றில் சேர்க்கவும்",
       "removeFromFavorites": "{{name}}-ஐப் பிடித்தவற்றிலிருந்து அகற்றவும்",
-      "thinkingEffortXhigh": "மிக அதிகம்",
-      "thinkingEffortMedium": "நடுத்தரம்",
       "sessionModel": "அமர்வு மாதிரி"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/te.json
+++ b/apps/mobile/src/i18n/locales/te.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", \"{{agent}}\" ఏజెంట్ దీన్ని మార్చకుండా లాక్ చేసింది",
       "addToFavorites": "{{name}}ను ఇష్టమైనవాటికి జోడించండి",
       "removeFromFavorites": "{{name}}ను ఇష్టమైనవాటి నుండి తీసివేయండి",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "మధ్యస్థం",
       "sessionModel": "సెషన్ మోడల్"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/th.json
+++ b/apps/mobile/src/i18n/locales/th.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", ถูกล็อกโดยเอเจนต์ \"{{agent}}\"",
       "addToFavorites": "เพิ่ม {{name}} ในรายการโปรด",
       "removeFromFavorites": "นำ {{name}} ออกจากรายการโปรด",
-      "thinkingEffortXhigh": "สูงมาก",
-      "thinkingEffortMedium": "กลาง",
       "sessionModel": "โมเดลของเซสชัน"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/tr.json
+++ b/apps/mobile/src/i18n/locales/tr.json
@@ -1888,8 +1888,6 @@
       "lockedByAgent": ", \"{{agent}}\" ajanı tarafından kilitlendi",
       "addToFavorites": "{{name}} modelini favorilere ekle",
       "removeFromFavorites": "{{name}} modelini favorilerden kaldır",
-      "thinkingEffortXhigh": "ÇY",
-      "thinkingEffortMedium": "Orta",
       "sessionModel": "Oturum modeli"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/uk.json
+++ b/apps/mobile/src/i18n/locales/uk.json
@@ -1914,8 +1914,6 @@
       "lockedByAgent": ", Заблоковано агентом «{{agent}}»",
       "addToFavorites": "Додати {{name}} до обраного",
       "removeFromFavorites": "Прибрати {{name}} з обраного",
-      "thinkingEffortXhigh": "ДВ",
-      "thinkingEffortMedium": "Сер.",
       "sessionModel": "Модель сеансу"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/ur.json
+++ b/apps/mobile/src/i18n/locales/ur.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": "، ایجنٹ \"{{agent}}\" نے مقفل کیا ہے",
       "addToFavorites": "{{name}} کو پسندیدہ میں شامل کریں",
       "removeFromFavorites": "{{name}} کو پسندیدہ سے ہٹائیں",
-      "thinkingEffortXhigh": "بہت زیادہ",
-      "thinkingEffortMedium": "درمیانی",
       "sessionModel": "سیشن کا ماڈل"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/uz.json
+++ b/apps/mobile/src/i18n/locales/uz.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", \"{{agent}}\" agenti tomonidan o'zgartirish cheklangan",
       "addToFavorites": "{{name}} modelini sevimlilarga qo'shish",
       "removeFromFavorites": "{{name}} modelini sevimlilardan olib tashlash",
-      "thinkingEffortXhigh": "JY",
-      "thinkingEffortMedium": "O'rt.",
       "sessionModel": "Sessiya modeli"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/vi.json
+++ b/apps/mobile/src/i18n/locales/vi.json
@@ -1888,8 +1888,6 @@
       "lockedByAgent": ", Do tác nhân \"{{agent}}\" khóa",
       "addToFavorites": "Thêm {{name}} vào mục yêu thích",
       "removeFromFavorites": "Xóa {{name}} khỏi mục yêu thích",
-      "thinkingEffortXhigh": "RẤT CAO",
-      "thinkingEffortMedium": "TB",
       "sessionModel": "Mô hình của phiên"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/yo.json
+++ b/apps/mobile/src/i18n/locales/yo.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Aṣojú \"{{agent}}\" ti tì í pa",
       "addToFavorites": "Fi {{name}} kún àwọn àyànfẹ́",
       "removeFromFavorites": "Yọ {{name}} kúrò nínú àwọn àyànfẹ́",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Àárín",
       "sessionModel": "Àwòṣe ìgbà iṣẹ́"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/zh-Hans.json
+++ b/apps/mobile/src/i18n/locales/zh-Hans.json
@@ -1888,8 +1888,6 @@
       "lockedByAgent": "，已由智能体“{{agent}}”锁定",
       "addToFavorites": "将 {{name}} 添加到收藏",
       "removeFromFavorites": "从收藏中移除 {{name}}",
-      "thinkingEffortXhigh": "超高",
-      "thinkingEffortMedium": "中",
       "sessionModel": "会话模型"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/zh-Hant.json
+++ b/apps/mobile/src/i18n/locales/zh-Hant.json
@@ -1888,8 +1888,6 @@
       "lockedByAgent": "，已由智慧代理「{{agent}}」鎖定",
       "addToFavorites": "將 {{name}} 加入我的最愛",
       "removeFromFavorites": "將 {{name}} 從我的最愛移除",
-      "thinkingEffortXhigh": "極高",
-      "thinkingEffortMedium": "中",
       "sessionModel": "工作階段模型"
     },
     "attachmentPreview": {

--- a/apps/mobile/src/i18n/locales/zu.json
+++ b/apps/mobile/src/i18n/locales/zu.json
@@ -2319,8 +2319,6 @@
       "lockedByAgent": ", Kukhiywe umenzeli othi \"{{agent}}\"",
       "addToFavorites": "Engeza {{name}} kokuthandwayo",
       "removeFromFavorites": "Susa {{name}} kokuthandwayo",
-      "thinkingEffortXhigh": "XH",
-      "thinkingEffortMedium": "Maph.",
       "sessionModel": "Imodeli yeseshini"
     },
     "attachmentPreview": {


### PR DESCRIPTION
## Summary

Keep the mode, model, and paste chips on one row above the composer.
Long locale labels no longer wrap the paste control onto a second line.

Show Extra High from `models.thinkingEffort.xhigh` on the model chip.
Remove the compact `XH` / `Med` keys. Serbian now shows Veoma visok, not XH.

## Verification

- [ ] I did not run the app on a device.
- [x] Unit tests cover the one-row className and paste `shrink-0`.

## Visual Changes

No after screenshot. Expected:

| Before | After |
|---|---|
| Mode + model wrap. Paste sits on a second line. Extra High shows as XH. | One row. Model name truncates. Extra High uses the localized thinking-effort label. |

## Reviewer Notes

The chip is wider with Extra High than with XH. `min-w-0 shrink` on the model chip and no `flex-wrap` on the toolbar keep the row at one line.