### PR TITLE
feat: support Azure user BYOK via Vercel

### DIFF
--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -58,7 +58,7 @@ import * as z from 'zod';
 // VercelUserByokInferenceProviderIdSchema.
 const VERCEL_BYOK_PROVIDER_NAMES = {
   anthropic: 'Anthropic',
-  azure: 'Azure Foundry',
+  azure: 'Azure Foundry (experimental)',
   bedrock: 'AWS Bedrock',
   deepseek: 'DeepSeek',
   openai: 'OpenAI',

--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -58,7 +58,7 @@ import * as z from 'zod';
 // VercelUserByokInferenceProviderIdSchema.
 const VERCEL_BYOK_PROVIDER_NAMES = {
   anthropic: 'Anthropic',
-  azure: 'Azure OpenAI',
+  azure: 'Azure Foundry',
   bedrock: 'AWS Bedrock',
   deepseek: 'DeepSeek',
   openai: 'OpenAI',

--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -43,12 +43,14 @@ import {
   DirectUserByokInferenceProviderIdSchema,
   UserByokProviderIdSchema,
   VercelUserByokInferenceProviderIdSchema,
+  AzureCredentialsSchema,
   BedrockCredentialsSchema,
   VertexCredentialsSchema,
   type VercelUserByokInferenceProviderId,
 } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import { DIRECT_BYOK_PROVIDERS_META } from '@/lib/ai-gateway/providers/direct-byok/direct-byok-meta';
 import { getCodingPlanManagedKeyLabel } from '@/components/subscriptions/coding-plans/coding-plan-provider';
+import { cn } from '@/lib/utils';
 import * as z from 'zod';
 
 // Exhaustive map of Vercel BYOK providers to their display names. The `satisfies`
@@ -56,6 +58,7 @@ import * as z from 'zod';
 // VercelUserByokInferenceProviderIdSchema.
 const VERCEL_BYOK_PROVIDER_NAMES = {
   anthropic: 'Anthropic',
+  azure: 'Azure OpenAI',
   bedrock: 'AWS Bedrock',
   deepseek: 'DeepSeek',
   openai: 'OpenAI',
@@ -279,11 +282,13 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
   const validateStructuredCredentials = (providerId: string, value: string): string | null => {
     if (!value) return null;
     const schema =
-      providerId === VercelUserByokInferenceProviderIdSchema.enum.bedrock
-        ? BedrockCredentialsSchema
-        : providerId === VercelUserByokInferenceProviderIdSchema.enum.vertex
-          ? VertexCredentialsSchema
-          : null;
+      providerId === VercelUserByokInferenceProviderIdSchema.enum.azure
+        ? AzureCredentialsSchema
+        : providerId === VercelUserByokInferenceProviderIdSchema.enum.bedrock
+          ? BedrockCredentialsSchema
+          : providerId === VercelUserByokInferenceProviderIdSchema.enum.vertex
+            ? VertexCredentialsSchema
+            : null;
     if (!schema) return null;
     let parsed: unknown;
     try {
@@ -293,6 +298,11 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
     }
     const result = schema.safeParse(parsed);
     if (!result.success) {
+      if (providerId === VercelUserByokInferenceProviderIdSchema.enum.azure) {
+        return result.error.issues.some(issue => issue.path[0] === 'modelMappings')
+          ? 'Each model mapping must include gatewayModelSlug and customModelId.'
+          : 'Enter JSON with apiKey and resourceName.';
+      }
       if (providerId === VercelUserByokInferenceProviderIdSchema.enum.bedrock) {
         return 'Enter JSON with apiKey and region, or accessKeyId, secretAccessKey, and region. Use only one authentication method.';
       }
@@ -394,6 +404,10 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
   const getProviderModels = (providerId: string): string[] => {
     return supportedModels?.[providerId] ?? [];
   };
+  const usesStructuredCredentials =
+    selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.azure ||
+    selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.bedrock ||
+    selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.vertex;
   return (
     <div className="space-y-4">
       <BYOKDescription showsCodingPlanKey={showsCodingPlanKey} />
@@ -579,42 +593,71 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
 
               <div className="space-y-2">
                 <Label htmlFor="apiKey">
-                  {selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.bedrock
-                    ? 'AWS Bedrock Credentials'
-                    : selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.vertex
-                      ? 'Google Vertex Credentials'
-                      : 'API Key'}
+                  {selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.azure
+                    ? 'Azure OpenAI Credentials'
+                    : selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.bedrock
+                      ? 'AWS Bedrock Credentials'
+                      : selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.vertex
+                        ? 'Google Vertex Credentials'
+                        : 'API Key'}
                 </Label>
-                {selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.bedrock ||
-                selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.vertex ? (
+                {usesStructuredCredentials ? (
                   <>
-                    <textarea
-                      id="apiKey"
-                      value={apiKey}
-                      onChange={e => {
-                        setApiKey(e.target.value);
-                        setCredentialError(null);
-                      }}
-                      onBlur={e =>
-                        setCredentialError(
-                          validateStructuredCredentials(selectedProvider, e.target.value)
-                        )
-                      }
-                      placeholder={
-                        selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.bedrock
-                          ? '{"accessKeyId": "...", "secretAccessKey": "...", "region": "us-east-1"}'
-                          : '{"project": "...", "location": "global", "googleCredentials": {"clientEmail": "...", "privateKey": "..."}}'
-                      }
-                      className="border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-20 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-                      rows={6}
-                      aria-label={
-                        selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.bedrock
-                          ? 'AWS credentials'
-                          : 'Google Vertex credentials'
-                      }
-                      aria-invalid={credentialError ? true : undefined}
-                      aria-describedby={credentialError ? 'credential-error' : undefined}
-                    />
+                    <div className="relative">
+                      <textarea
+                        id="apiKey"
+                        name="provider-credentials"
+                        value={apiKey}
+                        onChange={e => {
+                          setApiKey(e.target.value);
+                          setCredentialError(null);
+                        }}
+                        onBlur={e =>
+                          setCredentialError(
+                            validateStructuredCredentials(selectedProvider, e.target.value)
+                          )
+                        }
+                        placeholder={
+                          selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.azure
+                            ? '{"apiKey": "...", "resourceName": "..."}'
+                            : selectedProvider ===
+                                VercelUserByokInferenceProviderIdSchema.enum.bedrock
+                              ? '{"accessKeyId": "...", "secretAccessKey": "...", "region": "us-east-1"}'
+                              : '{"project": "...", "location": "global", "googleCredentials": {"clientEmail": "...", "privateKey": "..."}}'
+                        }
+                        className={cn(
+                          'border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-20 w-full rounded-md border px-3 py-2 pr-10 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+                          showApiKey ? '' : '[-webkit-text-security:disc] [text-security:disc]'
+                        )}
+                        rows={6}
+                        autoComplete="off"
+                        autoCorrect="off"
+                        autoCapitalize="off"
+                        spellCheck={false}
+                        data-1p-ignore="true"
+                        data-lpignore="true"
+                        data-form-type="other"
+                        aria-label={
+                          selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.azure
+                            ? 'Azure OpenAI credentials'
+                            : selectedProvider ===
+                                VercelUserByokInferenceProviderIdSchema.enum.bedrock
+                              ? 'AWS credentials'
+                              : 'Google Vertex credentials'
+                        }
+                        aria-invalid={credentialError ? true : undefined}
+                        aria-describedby={credentialError ? 'credential-error' : undefined}
+                      />
+                      <button
+                        type="button"
+                        aria-label={showApiKey ? 'Hide credentials' : 'Reveal credentials'}
+                        aria-pressed={showApiKey}
+                        onClick={() => setShowApiKey(!showApiKey)}
+                        className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 absolute top-0 right-0 flex size-10 items-center justify-center rounded-tr-md focus-visible:ring-2 focus-visible:outline-none"
+                      >
+                        {showApiKey ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+                      </button>
+                    </div>
                     {credentialError && (
                       <Alert id="credential-error" variant="destructive">
                         <AlertDescription className="whitespace-break-spaces">
@@ -644,6 +687,28 @@ export function BYOKKeysManager({ organizationId }: BYOKKeysManagerProps) {
                       {showApiKey ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
                     </Button>
                   </div>
+                )}
+                {selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.azure && (
+                  <Alert>
+                    <Info className="size-4" />
+                    <AlertDescription>
+                      <p>Enter your Azure OpenAI API key and resource name as JSON:</p>
+                      <code className="mt-1 block text-xs break-all">
+                        {'{"apiKey": "...", "resourceName": "..."}'}
+                      </code>
+                      <p className="mt-1">
+                        The resource name is the subdomain from your Azure OpenAI endpoint, for
+                        example <code className="text-xs">my-resource</code> from{' '}
+                        <code className="text-xs">my-resource.openai.azure.com</code>.
+                      </p>
+                      <p className="mt-1">
+                        For custom deployment names, add{' '}
+                        <code className="text-xs">modelMappings</code> with{' '}
+                        <code className="text-xs">gatewayModelSlug</code> and{' '}
+                        <code className="text-xs">customModelId</code> entries.
+                      </p>
+                    </AlertDescription>
+                  </Alert>
                 )}
                 {selectedProvider === VercelUserByokInferenceProviderIdSchema.enum.bedrock && (
                   <Alert>

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/inference-provider-id.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/inference-provider-id.test.ts
@@ -1,4 +1,5 @@
 import {
+  AzureCredentialsSchema,
   BedrockCredentialsSchema,
   DirectUserByokInferenceProviderIdSchema,
   getVercelUserByokProviderIdForEndpoint,
@@ -9,6 +10,40 @@ import {
   VercelNonUserByokInferenceProviderIdSchema,
   VercelUserByokInferenceProviderIdSchema,
 } from './inference-provider-id';
+
+describe('AzureCredentialsSchema', () => {
+  test('accepts Azure credentials with optional model mappings', () => {
+    const credentials = {
+      apiKey: 'azure-api-key',
+      resourceName: 'example-resource',
+      modelMappings: [
+        {
+          gatewayModelSlug: 'openai/gpt-5.4-nano',
+          customModelId: 'custom-gpt-5.4-nano',
+        },
+      ],
+    };
+
+    expect(AzureCredentialsSchema.parse(credentials)).toEqual(credentials);
+  });
+
+  test.each([
+    null,
+    'azure-api-key',
+    {},
+    { apiKey: 'azure-api-key' },
+    { resourceName: 'example-resource' },
+    { apiKey: '', resourceName: 'example-resource' },
+    { apiKey: 'azure-api-key', resourceName: '' },
+    {
+      apiKey: 'azure-api-key',
+      resourceName: 'example-resource',
+      modelMappings: [{ gatewayModelSlug: 'openai/gpt-5.4-nano' }],
+    },
+  ])('rejects incomplete or invalid Azure credentials: %j', credentials => {
+    expect(AzureCredentialsSchema.safeParse(credentials).success).toBe(false);
+  });
+});
 
 describe('BedrockCredentialsSchema', () => {
   test.each([
@@ -74,6 +109,12 @@ describe('inference provider ids', () => {
     expect(VercelUserByokInferenceProviderIdSchema.safeParse('vertex').success).toBe(true);
     expect(VercelNonUserByokInferenceProviderIdSchema.safeParse('vertex').success).toBe(false);
     expect(openRouterToVercelInferenceProviderId('google-vertex')).toBe('vertex');
+  });
+
+  test('promotes Azure to a user BYOK provider', () => {
+    expect(VercelUserByokInferenceProviderIdSchema.safeParse('azure').success).toBe(true);
+    expect(VercelNonUserByokInferenceProviderIdSchema.safeParse('azure').success).toBe(false);
+    expect(getVercelUserByokProviderIdForEndpoint('azure')).toBe('azure');
   });
 
   test('uses the Vertex user key for Vertex Anthropic endpoints', () => {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/inference-provider-id.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/inference-provider-id.ts
@@ -81,6 +81,7 @@ export const OpenRouterInferenceProviderIdSchema = z.enum([
 
 export const VercelUserByokInferenceProviderIdSchema = z.enum([
   'anthropic',
+  'azure',
   'bedrock',
   'deepseek',
   'fireworks',
@@ -136,6 +137,7 @@ export type UserByokProviderId = z.infer<typeof UserByokProviderIdSchema>;
 
 export const UserByokTestModels = {
   [VercelUserByokInferenceProviderIdSchema.enum.anthropic]: 'anthropic/claude-haiku-4.5',
+  [VercelUserByokInferenceProviderIdSchema.enum.azure]: 'openai/gpt-5.4-nano',
   [VercelUserByokInferenceProviderIdSchema.enum.bedrock]: 'anthropic/claude-haiku-4.5',
   [VercelUserByokInferenceProviderIdSchema.enum.deepseek]: 'deepseek/deepseek-v3.2',
   [VercelUserByokInferenceProviderIdSchema.enum.fireworks]: 'openai/gpt-oss-20b',
@@ -178,7 +180,6 @@ export const UserByokTestModels = {
 export const VercelNonUserByokInferenceProviderIdSchema = z.enum([
   'alibaba',
   'arcee-ai',
-  'azure',
   'baseten',
   'bfl',
   'blackbox',
@@ -304,6 +305,21 @@ export const BedrockCredentialsSchema = z.union([
 ]);
 
 export type BedrockCredentials = z.infer<typeof BedrockCredentialsSchema>;
+
+export const AzureCredentialsSchema = z.object({
+  apiKey: z.string().trim().min(1),
+  resourceName: z.string().trim().min(1),
+  modelMappings: z
+    .array(
+      z.object({
+        gatewayModelSlug: z.string().trim().min(1),
+        customModelId: z.string().trim().min(1),
+      })
+    )
+    .optional(),
+});
+
+export type AzureCredentials = z.infer<typeof AzureCredentialsSchema>;
 
 export const VertexCredentialsSchema = z.object({
   project: z.string().min(1),

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
@@ -3,6 +3,7 @@ import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import type { ReasoningDetailUnion } from '@/lib/ai-gateway/custom-llm/reasoning-details';
 import type {
+  AzureCredentials,
   BedrockCredentials,
   VertexCredentials,
 } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
@@ -27,6 +28,7 @@ export function isOpenRouterProviderConfig(value: unknown): value is OpenRouterP
 
 export type VercelInferenceProviderConfig =
   | { apiKey: string; baseURL?: string }
+  | AzureCredentials
   | BedrockCredentials
   | VertexCredentials;
 

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -395,6 +395,16 @@ describe('applyVercelSettings BYOK pinning', () => {
     secretAccessKey: 'secret',
     region: 'us-east-1',
   });
+  const azureCredentials = JSON.stringify({
+    apiKey: 'azure-api-key',
+    resourceName: 'example-resource',
+    modelMappings: [
+      {
+        gatewayModelSlug: 'openai/gpt-5.4-nano',
+        customModelId: 'custom-gpt-5.4-nano',
+      },
+    ],
+  });
   const vertexCredentials = JSON.stringify({
     project: 'example-project',
     location: 'us-east5',
@@ -509,6 +519,27 @@ describe('applyVercelSettings BYOK pinning', () => {
 
     expect(request.body.providerOptions?.gateway?.byok).toEqual({ bedrock: [credentials] });
     expect(request.body.providerOptions?.gateway?.only).toEqual(['bedrock']);
+  });
+
+  it('forwards structured Azure credentials', async () => {
+    const request = byokRequest([]);
+
+    await applyVercelSettings('openai/gpt-5.4-nano', request, [
+      { decryptedAPIKey: azureCredentials, providerId: 'azure' },
+    ]);
+
+    expect(request.body.providerOptions?.gateway?.byok).toEqual({
+      azure: [JSON.parse(azureCredentials)],
+    });
+    expect(request.body.providerOptions?.gateway?.only).toEqual(['azure']);
+  });
+
+  it('rejects malformed Azure credentials without including credential contents', async () => {
+    await expect(
+      applyVercelSettings('openai/gpt-5.4-nano', byokRequest([]), [
+        { decryptedAPIKey: '{"apiKey":"secret"}', providerId: 'azure' },
+      ])
+    ).rejects.toEqual(new Error('Failed to parse Azure credentials'));
   });
 
   it.each([

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -190,27 +190,15 @@ export function convertProviderOptions(
   };
 }
 
-function parseBedrockCredentials(input: string) {
+function parseCredentials<T>(
+  input: string,
+  schema: { parse(input: unknown): T },
+  providerName: string
+): T {
   try {
-    return BedrockCredentialsSchema.parse(JSON.parse(input));
+    return schema.parse(JSON.parse(input));
   } catch {
-    throw new Error('Failed to parse AWS credentials');
-  }
-}
-
-function parseAzureCredentials(input: string) {
-  try {
-    return AzureCredentialsSchema.parse(JSON.parse(input));
-  } catch {
-    throw new Error('Failed to parse Azure credentials');
-  }
-}
-
-function parseVertexCredentials(input: string) {
-  try {
-    return VertexCredentialsSchema.parse(JSON.parse(input));
-  } catch {
-    throw new Error('Failed to parse Google Vertex credentials');
+    throw new Error(`Failed to parse ${providerName} credentials`);
   }
 }
 
@@ -254,11 +242,11 @@ export function getVercelInferenceProviderConfigForUserByok(
   }
 
   if (key === VercelUserByokInferenceProviderIdSchema.enum.azure) {
-    list.push(parseAzureCredentials(provider.decryptedAPIKey));
+    list.push(parseCredentials(provider.decryptedAPIKey, AzureCredentialsSchema, 'Azure'));
   } else if (key === VercelUserByokInferenceProviderIdSchema.enum.bedrock) {
-    list.push(parseBedrockCredentials(provider.decryptedAPIKey));
+    list.push(parseCredentials(provider.decryptedAPIKey, BedrockCredentialsSchema, 'AWS'));
   } else if (key === VercelUserByokInferenceProviderIdSchema.enum.vertex) {
-    list.push(parseVertexCredentials(provider.decryptedAPIKey));
+    list.push(parseCredentials(provider.decryptedAPIKey, VertexCredentialsSchema, 'Google Vertex'));
   } else {
     list.push({ apiKey: provider.decryptedAPIKey });
   }

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -2,6 +2,7 @@ import type { BYOKResult } from '@/lib/ai-gateway/providers/types';
 import type { VercelUserByokInferenceProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import {
   DirectUserByokInferenceProviderIdSchema,
+  AzureCredentialsSchema,
   BedrockCredentialsSchema,
   normalizeVercelInferenceProviderIdForRouting,
   openRouterToVercelInferenceProviderId,
@@ -197,6 +198,14 @@ function parseBedrockCredentials(input: string) {
   }
 }
 
+function parseAzureCredentials(input: string) {
+  try {
+    return AzureCredentialsSchema.parse(JSON.parse(input));
+  } catch {
+    throw new Error('Failed to parse Azure credentials');
+  }
+}
+
 function parseVertexCredentials(input: string) {
   try {
     return VertexCredentialsSchema.parse(JSON.parse(input));
@@ -244,7 +253,9 @@ export function getVercelInferenceProviderConfigForUserByok(
     });
   }
 
-  if (key === VercelUserByokInferenceProviderIdSchema.enum.bedrock) {
+  if (key === VercelUserByokInferenceProviderIdSchema.enum.azure) {
+    list.push(parseAzureCredentials(provider.decryptedAPIKey));
+  } else if (key === VercelUserByokInferenceProviderIdSchema.enum.bedrock) {
     list.push(parseBedrockCredentials(provider.decryptedAPIKey));
   } else if (key === VercelUserByokInferenceProviderIdSchema.enum.vertex) {
     list.push(parseVertexCredentials(provider.decryptedAPIKey));

--- a/apps/web/src/routers/byok-router.test.ts
+++ b/apps/web/src/routers/byok-router.test.ts
@@ -24,6 +24,11 @@ const VERTEX_CREDENTIALS = JSON.stringify({
   },
 });
 
+const AZURE_CREDENTIALS = JSON.stringify({
+  apiKey: 'azure-api-key',
+  resourceName: 'example-resource',
+});
+
 const BEDROCK_IAM_CREDENTIALS = {
   accessKeyId: 'AKIAEXAMPLE',
   secretAccessKey: 'bedrock-test-secret',
@@ -201,6 +206,30 @@ describe('BYOK Router', () => {
       });
 
       expect(result.provider_id).toBe('vertex');
+    });
+
+    test('should create an Azure BYOK credential', async () => {
+      const caller = await createCallerForUser(ownerUser.id);
+
+      const result = await caller.byok.create({
+        organizationId: organizationA.id,
+        provider_id: 'azure',
+        api_key: AZURE_CREDENTIALS,
+      });
+
+      expect(result.provider_id).toBe('azure');
+    });
+
+    test('should reject malformed Azure credentials', async () => {
+      const caller = await createCallerForUser(ownerUser.id);
+
+      await expect(
+        caller.byok.create({
+          organizationId: organizationA.id,
+          provider_id: 'azure',
+          api_key: '{"apiKey":"secret"}',
+        })
+      ).rejects.toThrow('Invalid credentials for provider: azure');
     });
 
     test('should reject malformed Vertex credentials', async () => {

--- a/apps/web/src/routers/byok-router.ts
+++ b/apps/web/src/routers/byok-router.ts
@@ -23,7 +23,6 @@ import {
 import {
   UserByokProviderIdSchema,
   UserByokTestModels,
-  AzureCredentialsSchema,
   getVercelUserByokProviderIdForEndpoint,
   VercelUserByokInferenceProviderIdSchema,
 } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
@@ -435,25 +434,17 @@ export const byokRouter = createTRPCRouter({
 
       function setup() {
         const provider = UserByokProviderIdSchema.parse(decryptedKey.providerId);
-        const defaultModel = UserByokTestModels[provider];
+        const model = UserByokTestModels[provider];
 
         const directByokProvider = DIRECT_BYOK_PROVIDERS.find(plan => plan.id === provider);
         if (directByokProvider) {
           return {
             finalProvider: provider,
-            model: createAiSdkProvider(
-              directByokProvider,
-              decryptedKey.decryptedAPIKey
-            )(defaultModel),
+            model: createAiSdkProvider(directByokProvider, decryptedKey.decryptedAPIKey)(model),
           };
         }
 
         const [finalProvider, byokList] = getVercelInferenceProviderConfigForUserByok(decryptedKey);
-        const model =
-          finalProvider === VercelUserByokInferenceProviderIdSchema.enum.azure
-            ? (AzureCredentialsSchema.parse(byokList[0]).modelMappings?.[0]?.gatewayModelSlug ??
-              defaultModel)
-            : defaultModel;
         return {
           finalProvider,
           model: createGateway({

--- a/apps/web/src/routers/byok-router.ts
+++ b/apps/web/src/routers/byok-router.ts
@@ -30,7 +30,7 @@ import {
   getVercelModelsMetadataFromDatabase,
   getOpenRouterModelsMetadataFromDatabase,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
-import { AISDKError, createGateway, generateText } from 'ai';
+import { createGateway, generateText } from 'ai';
 import { VERCEL_AI_GATEWAY } from '@/lib/ai-gateway/providers/provider-definitions';
 import { getVercelInferenceProviderConfigForUserByok } from '@/lib/ai-gateway/providers/vercel';
 import { decryptByokRow } from '@/lib/ai-gateway/byok';
@@ -484,7 +484,7 @@ export const byokRouter = createTRPCRouter({
           message: `API key test success. Provider: ${metadata?.finalProvider ?? finalProvider}. Model: ${metadata?.originalModelId ?? model.modelId}.`,
         };
       } catch (e) {
-        const message = AISDKError.isInstance(e) ? e.message : undefined;
+        const message = e instanceof Error ? e.message : undefined;
         logByokWarning('BYOK key test request failed', {
           providerId: decryptedKey.providerId,
           message,

--- a/apps/web/src/routers/byok-router.ts
+++ b/apps/web/src/routers/byok-router.ts
@@ -23,6 +23,7 @@ import {
 import {
   UserByokProviderIdSchema,
   UserByokTestModels,
+  AzureCredentialsSchema,
   getVercelUserByokProviderIdForEndpoint,
   VercelUserByokInferenceProviderIdSchema,
 } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
@@ -434,17 +435,25 @@ export const byokRouter = createTRPCRouter({
 
       function setup() {
         const provider = UserByokProviderIdSchema.parse(decryptedKey.providerId);
-        const model = UserByokTestModels[provider];
+        const defaultModel = UserByokTestModels[provider];
 
         const directByokProvider = DIRECT_BYOK_PROVIDERS.find(plan => plan.id === provider);
         if (directByokProvider) {
           return {
             finalProvider: provider,
-            model: createAiSdkProvider(directByokProvider, decryptedKey.decryptedAPIKey)(model),
+            model: createAiSdkProvider(
+              directByokProvider,
+              decryptedKey.decryptedAPIKey
+            )(defaultModel),
           };
         }
 
         const [finalProvider, byokList] = getVercelInferenceProviderConfigForUserByok(decryptedKey);
+        const model =
+          finalProvider === VercelUserByokInferenceProviderIdSchema.enum.azure
+            ? (AzureCredentialsSchema.parse(byokList[0]).modelMappings?.[0]?.gatewayModelSlug ??
+              defaultModel)
+            : defaultModel;
         return {
           finalProvider,
           model: createGateway({


### PR DESCRIPTION
## Summary
- expose Azure OpenAI as a user BYOK provider for Vercel-backed models
- validate and forward Azure `apiKey`, `resourceName`, and optional deployment model mappings
- add masked structured-credential entry and Azure setup guidance to the BYOK UI
- cover Azure credential validation and Vercel request transformation

## Verification
- `pnpm exec oxfmt` on changed files
- `git diff --check`
- local test suites intentionally not run; CI will handle tests