### PR TITLE
chore: remove BYOK provider debug log

### DIFF
--- a/apps/web/src/lib/ai-gateway/byok/index.ts
+++ b/apps/web/src/lib/ai-gateway/byok/index.ts
@@ -36,7 +36,6 @@ export async function getModelUserByokProviders(modelId: string): Promise<UserBy
   if (isCodestralModel(modelId)) {
     providers.unshift('codestral');
   }
-  console.debug('[getModelUserByokProviders] found user byok providers for %s', modelId, providers);
   return providers;
 }
 


### PR DESCRIPTION
## Summary
- remove the successful BYOK provider lookup debug log
- retain diagnostics for missing metadata and unavailable providers

## Testing
- not run locally; CI will validate the change