### PR TITLE
Return retryable error for auto-routing selection failures

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -1431,7 +1431,7 @@ describe('kilo-auto/efficient classifier billing', () => {
     const { POST } = await import('./route');
     const response = await POST(makeRequest(makeBody('kilo-auto/efficient')) as never);
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(503);
     expect(await response.json()).toMatchObject({
       error_type: 'model_not_allowed',
       message: expect.stringContaining('Auto-routing could not select an eligible model'),
@@ -1464,7 +1464,7 @@ describe('kilo-auto/efficient classifier billing', () => {
     const { POST } = await import('./route');
     const response = await POST(makeRequest(makeBody('kilo-auto/efficient')) as never);
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(503);
     expect(await response.json()).toMatchObject({
       error_type: 'model_not_allowed',
       message: expect.stringContaining('Auto-routing could not select an eligible model'),

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -1407,7 +1407,7 @@ describe('kilo-auto/efficient classifier billing', () => {
     expect(stats.cost_mUsd).toBe(1000); // toMicrodollars(0.001)
   });
 
-  it('guides teams that block every pool model to configure a custom Efficient pool', async () => {
+  it('reports an auto-routing selection failure when a group blocks every pool model', async () => {
     mockedGetUserFromAuth.mockResolvedValue({
       user: {
         id: 'user-123',
@@ -1434,12 +1434,12 @@ describe('kilo-auto/efficient classifier billing', () => {
     expect(response.status).toBe(404);
     expect(await response.json()).toMatchObject({
       error_type: 'model_not_allowed',
-      message: expect.stringContaining('custom Efficient model pool'),
+      message: expect.stringContaining('Auto-routing could not select an eligible model'),
     });
     expect(mockedUpstreamRequest).not.toHaveBeenCalled();
   });
 
-  it('guides enterprise teams whose baseline blocks every pool model to configure a custom Efficient pool', async () => {
+  it('reports an auto-routing selection failure when an organization blocks every pool model', async () => {
     mockedGetUserFromAuth.mockResolvedValue({
       user: {
         id: 'user-123',
@@ -1467,7 +1467,7 @@ describe('kilo-auto/efficient classifier billing', () => {
     expect(response.status).toBe(404);
     expect(await response.json()).toMatchObject({
       error_type: 'model_not_allowed',
-      message: expect.stringContaining('custom Efficient model pool'),
+      message: expect.stringContaining('Auto-routing could not select an eligible model'),
     });
     expect(mockedUpstreamRequest).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -324,9 +324,8 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   let routingTarget: string | null = null;
   let classifierCostUsd = 0;
   // Efficient/balanced requests resolve through the auto-routing pool. Kept for
-  // the org policy check below so a team that blocks every pool model gets
-  // guidance to configure a custom Efficient model pool instead of the generic
-  // model-not-allowed error.
+  // the org policy check below so a failed routing decision gets a specific
+  // auto-routing error instead of the generic model-not-allowed error.
   let isAutoEfficientRequest = false;
   if (isKiloAutoModel(requestedModelLowerCased)) {
     autoModel = requestedModelLowerCased;

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -338,7 +338,7 @@ export function efficientPoolBlockedResponse() {
       error_type: ProxyErrorType.model_not_allowed,
       message,
     },
-    { status: 404 }
+    { status: 503 }
   );
 }
 

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -328,10 +328,8 @@ export function modelNotAllowedResponse() {
 }
 
 export function efficientPoolBlockedResponse() {
-  const error = 'Your organization blocks every model in the auto-routing pool.';
-  const message =
-    `${error} Configure a custom Efficient model pool with allowed models, ` +
-    `or adjust your organization model restrictions.`;
+  const error = 'Auto-routing could not select an eligible model for this request.';
+  const message = `${error} Please try again or contact support if the problem persists.`;
   const logMessage = `[efficientPoolBlockedResponse] ${message}`;
   warnExceptInTest(logMessage);
   return NextResponse.json(


### PR DESCRIPTION
## Summary
- describe the failure as an auto-routing selection problem instead of blaming organization model restrictions
- return HTTP 503 so clients can treat the failed routing decision as transient and retryable
- align routing comments and focused test expectations with the new behavior

## Testing
- Local tests were not run, as requested; CI handles validation.
- `git diff --check` passed.