### PR TITLE
fix(auto-routing): increase Auto Efficient decision timeout

### DIFF
--- a/apps/web/src/lib/ai-gateway/auto-routing-decision.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-routing-decision.test.ts
@@ -11,7 +11,7 @@ jest.mock('@/lib/utils.server', () => ({
   warnExceptInTest: (...args: unknown[]) => mockedWarnExceptInTest(...args),
 }));
 
-import { fetchEfficientAutoDecision } from './auto-routing-decision';
+import { EFFICIENT_DECISION_TIMEOUT_MS, fetchEfficientAutoDecision } from './auto-routing-decision';
 import type { EfficientDecisionParams } from './auto-routing-decision';
 import {
   detectRequiredInputModalities,
@@ -88,6 +88,10 @@ describe('fetchEfficientAutoDecision', () => {
     expect(headers.get('authorization')).toBe('Bearer classifier-token');
     expect(headers.get('content-type')).toBe('application/json');
     expect(result).toEqual({ decision: validDecision, costUsd: 0.001 });
+  });
+
+  it('allows the current worker miss path five seconds to complete', () => {
+    expect(EFFICIENT_DECISION_TIMEOUT_MS).toBe(5_000);
   });
 
   it('includes denied model ids in the worker payload', async () => {

--- a/apps/web/src/lib/ai-gateway/auto-routing-decision.ts
+++ b/apps/web/src/lib/ai-gateway/auto-routing-decision.ts
@@ -9,7 +9,7 @@ import type { ClassifierApiKind, MirrorPayload } from '@kilocode/auto-routing-co
 import { AUTO_ROUTING_WORKER_URL, INTERNAL_API_SECRET } from '@/lib/config.server';
 import { warnExceptInTest } from '@/lib/utils.server';
 
-export const EFFICIENT_DECISION_TIMEOUT_MS = 2_000;
+export const EFFICIENT_DECISION_TIMEOUT_MS = 5_000;
 
 export type EfficientDecisionParams = {
   apiKind: ClassifierApiKind;
@@ -74,9 +74,9 @@ function buildDecidePayload(params: EfficientDecisionParams): MirrorPayload | nu
   };
 }
 
-// kilo-auto/efficient waits for the worker's routing decision (cache hits
-// ~20ms, classifier misses ~1.2s) and falls back to the static default on
-// timeout or error.
+// kilo-auto/efficient waits for the worker's routing decision and falls back
+// to the static default on timeout or error. Do not retry an ambiguous timeout:
+// the worker may already have completed a billable classifier call.
 export async function fetchEfficientAutoDecision(
   params: EfficientDecisionParams,
   options: FetchEfficientDecisionOptions = {}

--- a/docs/adr/0002-auto-routing-efficient.md
+++ b/docs/adr/0002-auto-routing-efficient.md
@@ -56,7 +56,8 @@ replays the exact code production runs.
    `benchmarkUserId`.
 3. **Graceful degradation at every layer.** Corrupt KV → treated as a miss;
    origin failure → previous behavior (stale table stays live); classifier
-   failure / `/decide` timeout (2s) → null decision → balanced fallback; publish
+   failure / `/decide` timeout (5s, single attempt) → null decision → balanced
+   fallback; publish
    with any empty tier → skipped, previous table stays live. An
    `efficient` request must never degrade *below* balanced.
 4. **Results are reproducible.** Grading is mechanical only (`exact` /

--- a/services/auto-routing/src/model-capabilities.ts
+++ b/services/auto-routing/src/model-capabilities.ts
@@ -72,7 +72,7 @@ const MODEL_CAPABILITIES_IN_MEMORY_TTL_MS = 60_000;
 const MODEL_CAPABILITIES_KV_TTL_SECONDS = 3_600;
 
 // Hard ceiling for the whole lookup (in-memory check + KV read + DB query).
-// 500ms leaves headroom inside the gateway's 2s /decide budget when other
+// 500ms leaves headroom inside the gateway's 5s /decide budget when other
 // steps are slow; the `statement_timeout: 2_000` on the Postgres side alone
 // could otherwise let a slow-failing Hyperdrive connection eat the entire
 // request budget.


### PR DESCRIPTION
## Summary

- increase the efficient auto-routing decision budget from 2 seconds to 5 seconds
- keep a single attempt because a timed-out worker request may already have completed a billable classifier call
- update the routing ADR and worker budget comment, with a regression assertion for the timeout

## Cause

The gateway aborts `/decide` after 2 seconds and logs `Efficient auto decision request failed` when `fetch` rejects with the resulting `TimeoutError`. The worker now has sequential settings, cache, coding-plan, and classifier work; its coding-plan database query alone permits a 2-second statement timeout, so the original end-to-end budget is too tight for cold or classifier-miss paths.

## Verification

- `node_modules/.bin/oxfmt apps/web/src/lib/ai-gateway/auto-routing-decision.ts apps/web/src/lib/ai-gateway/auto-routing-decision.test.ts services/auto-routing/src/model-capabilities.ts docs/adr/0002-auto-routing-efficient.md`
- `git diff --check`
- automated tests and type checks left to CI as requested