### PR TITLE
Add Nex N2.5 Pro to Auto Free

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -200,21 +200,21 @@ describe('isFreeModel', () => {
         'poolside/laguna-s-2.1:free': { enabled: true, effort: 'high' },
         'nvidia/nemotron-3-ultra-550b-a55b:free': { enabled: true, effort: 'high' },
         'dots-studio/dots-3-note-preview:free': { enabled: true, effort: 'high' },
+        'nex-agi/nex-n2.5-pro:free': { enabled: true, effort: 'high' },
       });
     });
 
-    test('keeps Step at half of Auto Free selections', () => {
+    test('weights every Auto Free model equally', () => {
       const weights = Object.fromEntries(
         autoFreeModels.map(({ model, weight }) => [model, weight])
       );
       expect(weights).toEqual({
-        'stepfun/step-3.7-flash:free': 3,
+        'stepfun/step-3.7-flash:free': 1,
         'poolside/laguna-s-2.1:free': 1,
         'nvidia/nemotron-3-ultra-550b-a55b:free': 1,
         'dots-studio/dots-3-note-preview:free': 1,
+        'nex-agi/nex-n2.5-pro:free': 1,
       });
-      const halfOfTotalWeight = autoFreeModels.reduce((total, { weight }) => total + weight, 0) / 2;
-      expect(weights['stepfun/step-3.7-flash:free']).toBe(halfOfTotalWeight);
     });
 
     test('uses autoFreeModels weights when selecting a model', () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -45,7 +45,7 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
     ? [
         {
           model: stepfun_37_flash_free_model.public_id,
-          weight: 3,
+          weight: 1,
           reasoning: { enabled: true, effort: 'high' },
         } satisfies AutoFreeModel,
       ]
@@ -62,6 +62,11 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
   } satisfies AutoFreeModel,
   {
     model: 'dots-studio/dots-3-note-preview:free',
+    weight: 1,
+    reasoning: { enabled: true, effort: 'high' },
+  } satisfies AutoFreeModel,
+  {
+    model: 'nex-agi/nex-n2.5-pro:free',
     weight: 1,
     reasoning: { enabled: true, effort: 'high' },
   } satisfies AutoFreeModel,


### PR DESCRIPTION
## Summary
- add `nex-agi/nex-n2.5-pro:free` to the Auto Free pool
- assign equal selection weight to every Auto Free candidate
- update Auto Free model assertions

## Testing
- Not run locally; CI will handle validation.