### PR TITLE
feat(ai-gateway): discount Gemini 3.8 Flash pricing

### DIFF
--- a/apps/web/src/lib/ai-gateway/custom-pricing.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from '@jest/globals';
 import { captureMessage } from '@sentry/nextjs';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
 import { PERPLEXITY_KIMI_PUBLIC_ID } from '@/lib/ai-gateway/providers/partner/constants';
+import { GEMINI_FLASH_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/google';
 import {
   applyCustomPricingToPricing,
   applyCustomPricingToModel,
@@ -45,6 +46,27 @@ const makeUsage = (overrides: Partial<Parameters<typeof calculateCustomCost_mUsd
 });
 
 describe('custom model pricing', () => {
+  test('replaces upstream Gemini 3.8 Flash pricing with the promotional rates', () => {
+    const model = applyCustomPricingToModel({
+      ...makeModel(GEMINI_FLASH_CURRENT_MODEL_ID),
+      name: 'Google: Gemini 3.8 Flash',
+    });
+
+    expect(model.name).toBe('Google: Gemini 3.8 Flash (50% off)');
+    expect(model.pricing).toEqual({
+      prompt: '0.000000750000',
+      completion: '0.000003750000',
+      input_cache_read: '0.000000075000',
+      input_cache_write: '0.000000041667',
+    });
+    expect(
+      calculateCustomCost_mUsd(
+        GEMINI_FLASH_CURRENT_MODEL_ID,
+        makeUsage({ inputTokens: 100, cost_mUsd: 999 })
+      )
+    ).toBe(Math.round(100 * 0.75));
+  });
+
   test('replaces upstream Qwen3.7 Max pricing in the model list', () => {
     const model = applyCustomPricingToModel(makeModel(QWEN37_MAX_MODEL_ID));
 

--- a/apps/web/src/lib/ai-gateway/custom-pricing.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.ts
@@ -1,6 +1,7 @@
 import { captureMessage } from '@sentry/nextjs';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
 import type { JustTheCostsUsageStats } from '@/lib/ai-gateway/processUsage.types';
+import { GEMINI_FLASH_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/google';
 import { QWEN37_MAX_MODEL_ID, QWEN37_PLUS_MODEL_ID } from '@/lib/ai-gateway/providers/qwen';
 import { partnerPricingByModelId } from '@/lib/ai-gateway/providers/partner/pricing';
 import {
@@ -23,6 +24,21 @@ export type CustomPricing = {
 };
 
 export const customPricingByModelId: Record<string, CustomPricing> = {
+  // Google's 50% promotional discount is available through the end of 2026.
+  [GEMINI_FLASH_CURRENT_MODEL_ID]: {
+    discountPercentage: 50,
+    pricing: [
+      {
+        start_context_length: 0,
+        pricing: {
+          prompt_per_million: 0.75,
+          completion_per_million: 3.75,
+          input_cache_read_per_million: 0.075,
+          input_cache_write_per_million: 0.0416666666667,
+        },
+      },
+    ],
+  },
   [QWEN37_MAX_MODEL_ID]: {
     discountPercentage: 50,
     pricing: [


### PR DESCRIPTION
## Summary
- set non-fallback custom pricing for `google/gemini-3.8-flash` using OpenRouter's 50%-discounted standard endpoint rates
- mark the promotional pricing as available through the end of 2026
- cover displayed rates and cost recalculation when upstream reports a market cost

Pricing source: https://openrouter.ai/api/v1/models/google/gemini-3.8-flash/endpoints

## Testing
- Not run locally; left to CI as requested