### PR TITLE
fix(mobile): one Live Activity, native pull spinner, tighter spacing

### DIFF
--- a/apps/mobile/src/components/agents/session-list-content.tsx
+++ b/apps/mobile/src/components/agents/session-list-content.tsx
@@ -3,7 +3,6 @@ import { useFocusEffect, useScrollToTop } from 'expo-router';
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Platform, SectionList, useWindowDimensions, View } from 'react-native';
 import { RefreshControl } from '@/components/ui/refresh-control';
-import { RefreshProgress } from '@/components/ui/refresh-progress';
 import { ActivityIndicator } from '@/components/ui/activity-indicator';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
@@ -312,7 +311,6 @@ export function AgentSessionListContent({
         renderSectionHeader={renderSectionHeader}
         keyExtractor={keyExtractor}
         extraData={attentionFocusRevision}
-        ListHeaderComponent={<RefreshProgress refreshControl={refreshControl} />}
         ListEmptyComponent={emptyComponent}
         ListFooterComponent={
           isFetchingNextPage ? (

--- a/apps/mobile/src/components/agents/session-list-refresh-status.tsx
+++ b/apps/mobile/src/components/agents/session-list-refresh-status.tsx
@@ -15,11 +15,9 @@ type SessionListRefreshStatusProps = {
 };
 
 /**
- * The Agents lists' reserved refresh-status line. It always occupies the
- * height of its final (failure) state, so idle -> "Couldn't refresh" swaps
- * never move the rows below it (the UX rule the invisible 1x1 status nodes
- * broke on device). Pull-in-flight copy is screen-reader only: the native
- * spinner already shows the gesture.
+ * Agents-list refresh status. Pull-in-flight copy is screen-reader only and
+ * takes no layout: the native spinner is the visual. Failure shows
+ * "Couldn't refresh" + Retry on its own line.
  */
 export function SessionListRefreshStatus({
   busy,
@@ -29,36 +27,36 @@ export function SessionListRefreshStatus({
 }: Readonly<SessionListRefreshStatusProps>) {
   const { t } = useTranslation();
   const showRetry = failed && !busy;
-  let message: string | null = null;
   if (busy) {
-    message = t('agents.sessionList.updating');
-  } else if (showRetry) {
-    // The line's full accessibility label must stay exactly this copy: the
-    // device verifier asserts the full label, not a substring. The shared
-    // `common.couldNotRefresh` carries the pull-down guidance for the toast
-    // screens; this line has its own Retry action beside it instead.
-    message = t('agents.sessionList.couldNotRefresh');
+    return (
+      <AccessibleStatus
+        message={t('agents.sessionList.updating')}
+        tone="status"
+        className="absolute size-px overflow-hidden"
+      />
+    );
+  }
+  if (!showRetry) {
+    return null;
   }
   return (
     <View className={cn('h-5 flex-row items-center gap-2', className)}>
       <AccessibleStatus
-        message={message}
-        tone={busy ? 'status' : 'error'}
-        className={busy ? 'absolute size-px overflow-hidden' : 'flex-1 shrink text-xs'}
+        message={t('agents.sessionList.couldNotRefresh')}
+        tone="error"
+        className="flex-1 shrink text-xs"
       />
-      {showRetry ? (
-        <Pressable
-          onPress={onRetry}
-          accessibilityRole="button"
-          accessibilityLabel={t('common.retry')}
-          hitSlop={12}
-          className="justify-center active:opacity-70"
-        >
-          <Text className="font-mono-medium text-[11px] uppercase tracking-[1.5px] text-primary">
-            {t('common.retry')}
-          </Text>
-        </Pressable>
-      ) : null}
+      <Pressable
+        onPress={onRetry}
+        accessibilityRole="button"
+        accessibilityLabel={t('common.retry')}
+        hitSlop={12}
+        className="justify-center active:opacity-70"
+      >
+        <Text className="font-mono-medium text-[11px] uppercase tracking-[1.5px] text-primary">
+          {t('common.retry')}
+        </Text>
+      </Pressable>
     </View>
   );
 }

--- a/apps/mobile/src/components/agents/session-list-screen.tsx
+++ b/apps/mobile/src/components/agents/session-list-screen.tsx
@@ -1,7 +1,6 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppState, FlatList, Platform, Pressable, useWindowDimensions, View } from 'react-native';
 import { RefreshControl } from '@/components/ui/refresh-control';
-import { RefreshProgress } from '@/components/ui/refresh-progress';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { Bot, Plus } from '@/components/ui/icons';
@@ -237,7 +236,6 @@ export function AgentSessionListScreen() {
         keyExtractor={item => item.id}
         extraData={attentionFocusRevision}
         contentContainerStyle={listPadding}
-        ListHeaderComponent={<RefreshProgress refreshControl={refreshControl} />}
         refreshControl={refreshControl}
         maintainVisibleContentPosition={{ minIndexForVisible: 0, autoscrollToTopThreshold: 10 }}
       />

--- a/apps/mobile/src/components/home/home-screen.tsx
+++ b/apps/mobile/src/components/home/home-screen.tsx
@@ -61,7 +61,7 @@ export function HomeScreen() {
         }
         size="large"
         showBackButton={false}
-        className="px-[22px]"
+        className="px-[22px] pb-1"
       />
       {centerFeedback ? (
         <LiveSessionFeedback

--- a/apps/mobile/src/components/home/section-header.tsx
+++ b/apps/mobile/src/components/home/section-header.tsx
@@ -12,7 +12,7 @@ type SectionHeaderProps = {
 
 export function SectionHeader({ label, actionLabel, onActionPress }: Readonly<SectionHeaderProps>) {
   return (
-    <View className="flex-row flex-wrap items-center justify-between gap-2 px-4 pb-2 pt-5">
+    <View className="flex-row flex-wrap items-center justify-between gap-2 px-4 pb-2 pt-2">
       <Text variant="eyebrow" className="max-w-full grow">
         {label}
       </Text>

--- a/apps/mobile/src/components/tab-screen.tsx
+++ b/apps/mobile/src/components/tab-screen.tsx
@@ -1,7 +1,6 @@
 import { Platform, ScrollView, type ScrollViewProps, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { RefreshProgress } from '@/components/ui/refresh-progress';
 import { getEffectiveTabBarHeight } from '@/lib/tab-bar-layout';
 
 const TAB_SCREEN_BOTTOM_GAP = 16;
@@ -36,7 +35,6 @@ export function TabScreenScrollView({
       refreshControl={refreshControl}
       style={[style, { marginBottom: paddingBottom }]}
     >
-      {refreshControl ? <RefreshProgress refreshControl={refreshControl} /> : null}
       {children}
     </ScrollView>
   );

--- a/apps/mobile/src/glanceable-ios/ending-activities.ts
+++ b/apps/mobile/src/glanceable-ios/ending-activities.ts
@@ -5,7 +5,6 @@
  */
 import { type GlanceableLiveActivityContentState } from '@kilocode/notifications';
 import { after, type LiveActivity } from 'expo-widgets';
-import { AppState } from 'react-native';
 
 export type Activity = LiveActivity<Partial<GlanceableLiveActivityContentState>>;
 
@@ -106,57 +105,6 @@ export function endExtra(instance: Activity, id: string): void {
   };
   endingActivities.set(id, ending);
   void scheduleEnd(ending);
-}
-
-let idleEndTimer: ReturnType<typeof setTimeout> | null = null;
-/**
- * Temporary AppState watch for a pending idle-end debounce. JavaScript can
- * suspend the moment the app stops being active, so the timer would never
- * fire and the card would never retire. Leaving active submits the same end
- * at once; every other exit path removes the watch below.
- */
-let idleEndAppState: { remove: () => void } | null = null;
-
-function clearIdleEndAppState(): void {
-  idleEndAppState?.remove();
-  idleEndAppState = null;
-}
-
-export function cancelIdleEnd(): void {
-  if (idleEndTimer !== null) {
-    clearTimeout(idleEndTimer);
-    idleEndTimer = null;
-  }
-  clearIdleEndAppState();
-}
-
-export function scheduleIdleEnd(end: () => void, delayMs: number): void {
-  // Already inactive or background, JavaScript can suspend before any timer
-  // fires: submit the idle end at once so a background caller can await it.
-  if (AppState.currentState !== 'active') {
-    end();
-    return;
-  }
-  if (idleEndTimer !== null) {
-    return;
-  }
-  idleEndTimer = setTimeout(() => {
-    idleEndTimer = null;
-    clearIdleEndAppState();
-    end();
-  }, delayMs);
-  // While active, a later transition out of active must flush the pending end
-  // before iOS suspends the JavaScript context. Every other exit path above
-  // and in `cancelIdleEnd` removes this watch.
-  idleEndAppState = AppState.addEventListener('change', state => {
-    if (state === 'active' || idleEndTimer === null) {
-      return;
-    }
-    clearTimeout(idleEndTimer);
-    idleEndTimer = null;
-    clearIdleEndAppState();
-    end();
-  });
 }
 
 export function endOtherVisible(keptId: string, instances: readonly Activity[]): void {

--- a/apps/mobile/src/glanceable-ios/ios-sink.native.test.ts
+++ b/apps/mobile/src/glanceable-ios/ios-sink.native.test.ts
@@ -3,8 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildGlanceableSnapshot,
-  GLANCEABLE_IDLE_END_DEBOUNCE_MS,
-  GLANCEABLE_IDLE_ONLY_MS,
   GLANCEABLE_TERMINAL_MS,
   type GlanceableAgentsSnapshot,
 } from '@kilocode/app-shared/glanceable-agents-snapshot';
@@ -369,45 +367,27 @@ describe('native adapter idle window', () => {
     expect(native.records).toEqual([]);
   });
 
-  it('hands ActivityKit the idle dismissal date once every agent goes idle', async () => {
+  it('keeps the same card when every agent goes idle', async () => {
     const sink = await loadSink();
     sink.startOrUpdate(snapshot([{ status: 'busy' }, { status: 'idle' }]), CTX);
     sink.publish(snapshot([{ status: 'idle' }], 1));
-    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
     await sink.waitForNativeTerminal?.();
 
+    expect(native.records).toHaveLength(1);
     expect(firstActivity()).toMatchObject({
-      state: 'ended',
-      dismissAt: NOW + GLANCEABLE_IDLE_END_DEBOUNCE_MS + GLANCEABLE_IDLE_ONLY_MS,
+      state: 'active',
+      dismissAt: null,
       props: { running: 0, idle: 1 },
-      policies: ['after'],
     });
   });
 
-  it('submits the idle dismissal at once for a background publish without advancing timers', async () => {
-    const sink = await loadSink();
-    sink.startOrUpdate(snapshot([{ status: 'busy' }]), CTX);
-    appState.currentState = 'background';
-
-    sink.publish(snapshot([{ status: 'idle' }], 1));
-    await sink.waitForNativeTerminal?.();
-
-    expect(firstActivity()).toMatchObject({
-      state: 'ended',
-      dismissAt: NOW + GLANCEABLE_IDLE_ONLY_MS,
-      props: { running: 0, idle: 1 },
-      policies: ['after'],
-    });
-  });
-
-  it('keeps the same card when work resumes before the idle-end debounce', async () => {
+  it('updates the same card when work resumes after idle', async () => {
     const sink = await loadSink();
     sink.startOrUpdate(snapshot([{ status: 'busy' }]), CTX);
     sink.publish(snapshot([{ status: 'idle' }], 1));
     const resumed = snapshot([{ status: 'busy' }], 2);
     sink.publish(resumed);
     sink.startOrUpdate(resumed, CTX);
-    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
     await sink.waitForNativeTerminal?.();
 
     expect(native.records).toHaveLength(1);
@@ -417,58 +397,14 @@ describe('native adapter idle window', () => {
     });
   });
 
-  it('replaces the idle card when work resumes inside its window', async () => {
+  it('applies the terminal window once idle work goes empty', async () => {
     const sink = await loadSink();
     sink.startOrUpdate(snapshot([{ status: 'busy' }]), CTX);
     sink.publish(snapshot([{ status: 'idle' }], 1));
-    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
     await sink.waitForNativeTerminal?.();
-
-    const resumed = snapshot([{ status: 'busy' }], 2);
-    sink.publish(resumed);
-    sink.startOrUpdate(resumed, CTX);
-    await sink.waitForNativeTerminal?.();
-
-    expect(firstActivity()).toMatchObject({
-      state: 'dismissed',
-      policies: ['after', 'immediate'],
-    });
-    expect(native.records.filter(record => record.state === 'active')).toMatchObject([
-      { props: { running: 1, idle: 0 } },
-    ]);
-    expect(native.records).toHaveLength(2);
-  });
-});
-
-describe('native adapter idle window shortening', () => {
-  it('shrinks a submitted idle dismissal to the terminal one once work goes empty', async () => {
-    const sink = await loadSink();
-    sink.startOrUpdate(snapshot([{ status: 'busy' }]), CTX);
-    sink.publish(snapshot([{ status: 'idle' }], 1));
-    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
-    await sink.waitForNativeTerminal?.();
-    expect(firstActivity().dismissAt).toBe(
-      NOW + GLANCEABLE_IDLE_END_DEBOUNCE_MS + GLANCEABLE_IDLE_ONLY_MS
-    );
 
     sink.publish(snapshot([], 2));
     await sink.waitForNativeTerminal?.();
-    expect(firstActivity().dismissAt).toBe(
-      NOW + GLANCEABLE_IDLE_END_DEBOUNCE_MS + GLANCEABLE_TERMINAL_MS
-    );
-  });
-
-  it('holds the replacement card until the idle card is dismissed', async () => {
-    const sink = await loadSink();
-    sink.startOrUpdate(snapshot([{ status: 'busy' }]), CTX);
-    sink.publish(snapshot([{ status: 'idle' }], 1));
-    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
-    await sink.waitForNativeTerminal?.();
-
-    const resumed = snapshot([{ status: 'busy' }], 2);
-    sink.publish(resumed);
-    sink.startOrUpdate(resumed, CTX);
-    const onScreen = native.records.filter(record => record.state !== 'dismissed');
-    expect(onScreen).toHaveLength(1);
+    expect(firstActivity().dismissAt).toBe(NOW + GLANCEABLE_TERMINAL_MS);
   });
 });

--- a/apps/mobile/src/glanceable-ios/ios-sink.test.ts
+++ b/apps/mobile/src/glanceable-ios/ios-sink.test.ts
@@ -989,7 +989,7 @@ describe('iosSink idle updates', () => {
     expect(mockState.ended).toEqual([]);
   });
 
-  it('updates the same card when work resumes after idle', async () => {
+  it('updates the same card when work resumes after idle', () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
     iosSink.startOrUpdate(snapshotFor([{ status: 'busy' }], 0), CTX);

--- a/apps/mobile/src/glanceable-ios/ios-sink.test.ts
+++ b/apps/mobile/src/glanceable-ios/ios-sink.test.ts
@@ -3,8 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildGlanceableSnapshot,
-  GLANCEABLE_IDLE_END_DEBOUNCE_MS,
-  GLANCEABLE_IDLE_ONLY_MS,
   GLANCEABLE_STALE_MS,
   type GlanceableAgentsSnapshot,
 } from '@kilocode/app-shared/glanceable-agents-snapshot';
@@ -54,8 +52,8 @@ vi.mock('@expo/ui/swift-ui/modifiers', () => ({
   frame: () => ({}),
   widgetURL: () => ({}),
 }));
-// The sink reads the foreground state at publish and watches for the app
-// leaving active while an idle-end debounce is pending.
+// The sink used to watch AppState for idle-end debounce. Keep the mock so
+// leftover listeners in this suite still resolve.
 const mockAppState = vi.hoisted(() => ({
   currentState: 'active' as string,
   listeners: new Set<(state: string) => void>(),
@@ -975,45 +973,23 @@ describe('iosSink Live Activity content-state', () => {
   });
 });
 
-describe('iosSink idle end scheduling', () => {
-  it('submits the idle native end at once when the app is already background', async () => {
+describe('iosSink idle updates', () => {
+  it('keeps the same card when every agent goes idle', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
     iosSink.startOrUpdate(snapshotFor([{ status: 'busy' }], 0), CTX);
-    mockAppState.currentState = 'background';
-
     iosSink.publish(snapshotFor([{ status: 'idle' }], 1));
     await vi.advanceTimersByTimeAsync(0);
 
+    expect(mockState.started).toHaveLength(1);
     expect(mockState.started[0]).toMatchObject({
-      ended: true,
-      dismissAt: NOW + GLANCEABLE_IDLE_ONLY_MS,
+      ended: false,
       props: { status: 'happy', running: 0, idle: 1 },
     });
+    expect(mockState.ended).toEqual([]);
   });
 
-  it('flushes a pending idle end when the app leaves active during the debounce', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-    iosSink.startOrUpdate(snapshotFor([{ status: 'busy' }], 0), CTX);
-    iosSink.publish(snapshotFor([{ status: 'idle' }], 1));
-    expect(mockState.started[0]?.ended).toBe(false);
-
-    mockAppState.leaveActive('background');
-    await vi.advanceTimersByTimeAsync(0);
-
-    expect(mockState.started[0]).toMatchObject({
-      ended: true,
-      dismissAt: NOW + GLANCEABLE_IDLE_ONLY_MS,
-    });
-
-    // The debounce is gone with its watch: no second end ever fires.
-    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
-    expect(mockState.ended).toHaveLength(1);
-    expect(mockAppState.listeners.size).toBe(0);
-  });
-
-  it('cancels the pending idle end and its watch when work resumes', async () => {
+  it('updates the same card when work resumes after idle', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
     iosSink.startOrUpdate(snapshotFor([{ status: 'busy' }], 0), CTX);
@@ -1022,13 +998,9 @@ describe('iosSink idle end scheduling', () => {
     iosSink.publish(resumed);
     iosSink.startOrUpdate(resumed, CTX);
 
-    mockAppState.leaveActive('background');
-    await vi.advanceTimersByTimeAsync(0);
-    await vi.advanceTimersByTimeAsync(GLANCEABLE_IDLE_END_DEBOUNCE_MS);
-
+    expect(mockState.started).toHaveLength(1);
     expect(mockState.started[0]).toMatchObject({ ended: false, props: { running: 1, idle: 0 } });
     expect(mockState.ended).toEqual([]);
-    expect(mockAppState.listeners.size).toBe(0);
   });
 });
 

--- a/apps/mobile/src/glanceable-ios/ios-sink.ts
+++ b/apps/mobile/src/glanceable-ios/ios-sink.ts
@@ -1,11 +1,9 @@
+/* eslint-disable max-lines -- one ActivityKit sink: adopt, start, update, and end */
 import {
-  GLANCEABLE_IDLE_END_DEBOUNCE_MS,
-  GLANCEABLE_IDLE_ONLY_MS,
   GLANCEABLE_STALE_MS,
   GLANCEABLE_TERMINAL_MS,
   type GlanceableAgentsSnapshot,
   isEligibleGlanceableWork,
-  isIdleOnlyGlanceableWork,
   isStartableGlanceableWork,
 } from '@kilocode/app-shared/glanceable-agents-snapshot';
 import { type GlanceableLiveActivityContentState } from '@kilocode/notifications';
@@ -21,13 +19,11 @@ import { getLiveActivityEnabled } from '@/lib/glanceable/live-activity-switch';
 import { ActiveAgentsLiveActivity, OPEN_AGENTS_URL } from './active-agents-live-activity';
 import {
   type Activity,
-  cancelIdleEnd,
   endExtra,
   endingActivities,
   endOtherVisible,
   readEndingToken,
   scheduleEnd,
-  scheduleIdleEnd,
   settleEnds,
 } from './ending-activities';
 import { ActiveAgentsWidget } from './active-agents-widget';
@@ -82,6 +78,24 @@ function startCard(
   ctx: GlanceableSinkContext
 ): void {
   try {
+    // Adopt a card that appeared while we waited. A second start stacks Lock
+    // Screen cards that Activity.activities cannot see after process death.
+    if (!refreshActivity()) {
+      return;
+    }
+    if (activity !== null) {
+      lastProps = contentState;
+      revision = snapshot.revision;
+      getGlanceableDelivery().registerTokens(snapshot, ctx.organizationId, ctx.userId, activity);
+      inFlightUpdate = activity.update(contentState, STALE_AFTER_SECONDS);
+      return;
+    }
+    const remaining = ActiveAgentsLiveActivity.getInstances(true).filter(
+      instance => instance.getInfo().state !== 'dismissed'
+    );
+    if (remaining.length > 0) {
+      return;
+    }
     const started = ActiveAgentsLiveActivity.start(
       contentState,
       OPEN_AGENTS_URL,
@@ -92,8 +106,6 @@ function startCard(
     lastProps = contentState;
     revision = snapshot.revision;
     getGlanceableDelivery().registerTokens(snapshot, ctx.organizationId, ctx.userId, started);
-    // A push-to-start or an idle card still waiting out its dismissal can share
-    // the Lock Screen with this start. Retire every other visible instance now.
     endOtherVisible(started.getInfo().id, ActiveAgentsLiveActivity.getInstances(true));
   } catch (error) {
     // Only ActivityKit unavailability is permanent; transient starts retry later.
@@ -117,19 +129,19 @@ function refreshActivity(): boolean {
       }
     }
     // Wrappers change on discovery; only native IDs identify pending ends.
-    const live = ActiveAgentsLiveActivity.getInstances().filter(
-      instance => !endingActivities.has(instance.getInfo().id)
-    );
+    // Include ended-but-visible cards so a later start cannot stack beside them.
+    const visible = ActiveAgentsLiveActivity.getInstances(true).filter(instance => {
+      const info = instance.getInfo();
+      return info.state !== 'dismissed' && !endingActivities.has(info.id);
+    });
+    const live = visible.filter(instance => {
+      const state = instance.getInfo().state;
+      return state === 'active' || state === 'stale';
+    });
     activity ??= live.at(-1) ?? null;
-    // Exactly one card may ever be on screen. A push-to-start that raced a
-    // local start, or a card left behind by an earlier organization scope, is
-    // adopted by nobody: it is never updated and never ended, so it sits frozen
-    // on the Lock Screen for the whole 8 hour lifetime. Retire every instance
-    // except the adopted one here, in the one native read every path shares.
-    // Which one is adopted does not matter — native order is a dictionary
-    // order, not a start order — only that the others do not survive it.
+    // Exactly one card may ever be on screen. Retire every other instance here.
     const keptId = activity?.getInfo().id;
-    for (const instance of live) {
+    for (const instance of visible) {
       const id = instance.getInfo().id;
       if (id !== keptId) {
         endExtra(instance, id);
@@ -158,7 +170,6 @@ function endNow(
   props: Partial<GlanceableLiveActivityContentState> | null = lastProps,
   reachEnded = dismissMs === null
 ): Promise<void> | null {
-  cancelIdleEnd();
   const targets = new Map<string, Activity>();
   if (reachEnded) {
     try {
@@ -274,7 +285,6 @@ export function _resetIosSinkForTests(): void {
   pendingStart = null;
   pendingStartInput = null;
   pendingStartAt = 0;
-  cancelIdleEnd();
 }
 
 export const iosSink: GlanceableSink = {
@@ -317,19 +327,6 @@ export const iosSink: GlanceableSink = {
     if (refreshActivity() && activity !== null) {
       lastProps = contentState;
       inFlightUpdate = activity.update(lastProps, STALE_AFTER_SECONDS);
-      if (isIdleOnlyGlanceableWork(snapshot)) {
-        // Brief idle↔busy flips must not tear the card down: the end waits out
-        // a debounce, then hands ActivityKit the dismissal date so the surface
-        // still retires if JavaScript stops. Work that resumes before the
-        // timer fires updates this same card. While inactive or background,
-        // scheduleIdleEnd submits the end at once instead, so a background
-        // wake can await it through `waitForNativeTerminal`.
-        scheduleIdleEnd(() => {
-          void endNow(GLANCEABLE_IDLE_ONLY_MS, lastProps);
-        }, GLANCEABLE_IDLE_END_DEBOUNCE_MS);
-      } else {
-        cancelIdleEnd();
-      }
     }
   },
 
@@ -381,10 +378,13 @@ export const iosSink: GlanceableSink = {
         pendingStart = (async () => {
           await dismissal;
           const input = pendingStartInput;
-          pendingStart = null;
-          pendingStartInput = null;
-          pendingStartAt = 0;
-          startCard(input.contentState, input.snapshot, input.ctx);
+          try {
+            startCard(input.contentState, input.snapshot, input.ctx);
+          } finally {
+            pendingStart = null;
+            pendingStartInput = null;
+            pendingStartAt = 0;
+          }
         })();
         return;
       }
@@ -395,9 +395,6 @@ export const iosSink: GlanceableSink = {
     // publish can adopt an activity before this method sees it. Bind its token
     // listener here too; delivery deduplicates the sink's stable native handle.
     getGlanceableDelivery().registerTokens(snapshot, ctx.organizationId, ctx.userId, activity);
-    if (isStartableGlanceableWork(snapshot)) {
-      cancelIdleEnd();
-    }
     // The publisher coalesces and guards revisions, but keep the sink monotonic
     // so a late or replayed emit can never move the surface backwards.
     if (snapshot.revision <= revision) {

--- a/apps/mobile/src/lib/notifications.test.ts
+++ b/apps/mobile/src/lib/notifications.test.ts
@@ -1711,35 +1711,22 @@ describe('cold iOS background delivery', () => {
     expect(rows.has('scope-token')).toBe(true);
   });
 
-  it('waits for an idle-only push to submit its native end before background completion', async () => {
+  it('keeps the adopted card when an idle-only push arrives in the background', async () => {
     vi.setSystemTime(Date.parse('2026-01-02T00:00:00.000Z'));
     mocks.appState.currentState = 'background';
-    const end = deferred();
-    native.endRead = end.promise;
     const background = await loadColdBackground();
-    let completed = false;
-    const applying = (async () => {
-      const result = await background.deliver({
+    expect(
+      await background.deliver({
         status: 'happy',
         running: 0,
         needsInput: 0,
         idle: 1,
         needsInputSince: null,
-      });
-      completed = true;
-      return result;
-    })();
+      })
+    ).toBe(0);
     await vi.advanceTimersByTimeAsync(0);
-
-    // The idle end is submitted during publish, and the background task cannot
-    // finish before ActivityKit accepts it.
-    expect(native.endCalls).toBe(1);
-    expect(completed).toBe(false);
-
-    end.resolve();
-    expect(await applying).toBe(0);
-    expect(native.exists).toBe(false);
-    expect(native.dismissAt).toBe(Date.parse('2026-01-02T00:10:00.000Z'));
+    expect(native.endCalls).toBe(0);
+    expect(native.exists).toBe(true);
     expect(JSON.parse(native.props ?? '{}')).toMatchObject({ status: 'happy', idle: 1 });
   });
 

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -22,7 +22,6 @@ import {
   GLANCEABLE_TERMINAL_MS,
   type GlanceableAgentsSnapshot,
   isEligibleGlanceableWork,
-  isIdleOnlyGlanceableWork,
 } from '@kilocode/app-shared/glanceable-agents-snapshot';
 
 import { captureEvent } from '@/lib/analytics/posthog';
@@ -223,7 +222,6 @@ export async function applyGlanceablePushData(
 
   const ctx = { userId, organizationId };
   const eligible = isEligibleGlanceableWork(snapshot);
-  const idleOnly = isIdleOnlyGlanceableWork(snapshot);
   if (eligible) {
     cancelGlanceableTerminalEnd();
     for (const sink of getGlanceableSinks()) {
@@ -241,12 +239,9 @@ export async function applyGlanceablePushData(
   if (appBadgeWrite) {
     await appBadgeWrite;
   }
-  // Do not finish a background task before ActivityKit accepts the native end.
-  // All publication happens before this await, so it cannot restore an old
-  // scope. An idle-only eligible snapshot also schedules its native end during
-  // publish (at once, because a background wake can suspend before the
-  // foreground debounce timer fires), so it waits here too.
-  if (!eligible || idleOnly) {
+  // Do not finish a background task before ActivityKit accepts a native end.
+  // Idle work keeps the same card, so only ineligible snapshots wait here.
+  if (!eligible) {
     await Promise.all(
       getGlanceableSinks().map((sink): Promise<void> | undefined => sink.waitForNativeTerminal?.())
     );


### PR DESCRIPTION
**Review and merge this PR.** Assigned to @iscekic.

## Cause

[#5972](https://github.com/Kilo-Org/cloud/pull/5972) ended idle Live Activities with a 10-minute dismissal. After process death, ActivityKit no longer lists those ended cards, so the next start stacked a frozen card on the Lock Screen.

[#5899](https://github.com/Kilo-Org/cloud/pull/5899) added `RefreshProgress` inside lists that already have native `RefreshControl`. That produced a second spinner and extra space under search and under the Home logo.

## Changes

- Idle work updates the same Live Activity. Do not end it. Do not start a second card while any instance is visible.
- Agents lists and Home use only the native pull spinner.
- The refresh status line takes height only on failure.
- Home header and section spacing are tighter.

## Tests

`vitest` on ios-sink, notifications, session-list, and home suites: 239 + 236 passed.