### PR TITLE
fix(cloud-agent-next): isolate scoped Stop across the service boundary

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ catalogs:
       specifier: 1.0.0
       version: 1.0.0
     wrangler:
-      specifier: 4.127.1
-      version: 4.127.1
+      specifier: 4.112.0
+      version: 4.112.0
     zod:
       specifier: 4.4.3
       version: 4.4.3
@@ -1806,7 +1806,7 @@ importers:
         version: 5.9.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/app-builder:
     dependencies:
@@ -1864,7 +1864,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/auto-fix-infra:
     dependencies:
@@ -1892,7 +1892,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/auto-routing:
     dependencies:
@@ -1935,7 +1935,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/auto-routing-benchmark:
     dependencies:
@@ -1981,7 +1981,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/auto-triage-infra:
     dependencies:
@@ -2012,7 +2012,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/cloud-agent-next:
     dependencies:
@@ -2106,7 +2106,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       ws:
         specifier: 8.21.0
         version: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -2168,7 +2168,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/container-usage-meter:
     dependencies:
@@ -2202,7 +2202,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/db-proxy:
     dependencies:
@@ -2245,7 +2245,7 @@ importers:
         version: 5.9.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/deploy-infra/builder:
     dependencies:
@@ -2260,7 +2260,7 @@ importers:
         version: link:../../../packages/worker-utils
       '@sentry/cloudflare':
         specifier: 10.69.0
-        version: 10.69.0(@cloudflare/workers-types@4.20260605.1)(wrangler@4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        version: 10.69.0(@cloudflare/workers-types@4.20260605.1)(wrangler@4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260605.1)(@opentelemetry/api@1.9.1)(@types/pg@8.18.0)(@upstash/redis@1.38.0)(bun-types@1.3.14)(expo-sqlite@57.0.1(expo@57.0.15)(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(kysely@0.29.2)(pg@8.20.0)
@@ -2309,7 +2309,7 @@ importers:
         version: 5.9.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/deploy-infra/dispatcher:
     dependencies:
@@ -2358,7 +2358,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/event-service:
     dependencies:
@@ -2401,7 +2401,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/gastown:
     dependencies:
@@ -2474,7 +2474,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/gastown/container:
     dependencies:
@@ -2542,7 +2542,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/gmail-push:
     dependencies:
@@ -2570,7 +2570,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/images-mcp:
     dependencies:
@@ -2613,7 +2613,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/kilo-chat:
     dependencies:
@@ -2686,7 +2686,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/kilo-ops:
     dependencies:
@@ -2711,7 +2711,7 @@ importers:
         version: 5.9.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/kiloclaw:
     dependencies:
@@ -2772,7 +2772,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/kiloclaw-billing:
     dependencies:
@@ -2815,7 +2815,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/kiloclaw-inbound-email:
     dependencies:
@@ -2843,7 +2843,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/kiloclaw/controller:
     dependencies:
@@ -2957,7 +2957,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/model-eval-ingest:
     dependencies:
@@ -2991,7 +2991,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/notifications:
     dependencies:
@@ -3049,7 +3049,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/o11y:
     dependencies:
@@ -3086,7 +3086,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/security-auto-analysis:
     dependencies:
@@ -3123,7 +3123,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/security-sync:
     dependencies:
@@ -3157,7 +3157,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/session-ingest:
     dependencies:
@@ -3215,7 +3215,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/user-data-export:
     dependencies:
@@ -3255,7 +3255,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/wasteland:
     dependencies:
@@ -3310,7 +3310,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/webhook-agent-ingest:
     dependencies:
@@ -3365,7 +3365,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
 packages:
 
@@ -4527,12 +4527,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20260828.1':
-    resolution: {integrity: sha512-CVd+xPhqUESg8Xhq09TZx0wl4FSirfJGOzvbPz2yHhBIvmNHFFQkSN3rkd7wEwnhQQk37Xi0/aD6ykPLJbmGiQ==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
   '@cloudflare/workerd-darwin-arm64@1.20260603.1':
     resolution: {integrity: sha512-uBPK4LaWJNbbCYwPnUAehlHbbVulhVZPZsdcAhBPfZhHb3QAuAEPAQepO/P67R3V6Cni4YGx1fLbL8A5wwoaNA==}
     engines: {node: '>=16'}
@@ -4541,12 +4535,6 @@ packages:
 
   '@cloudflare/workerd-darwin-arm64@1.20260714.1':
     resolution: {integrity: sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20260828.1':
-    resolution: {integrity: sha512-5HDPXRM152vU5JveByGFk34X57TVyIsfp4cabepAf45DC0MKvm52ucJqAjW1h8bvW4X+zRw9GU35OHF9FEC9Ww==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -4563,12 +4551,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20260828.1':
-    resolution: {integrity: sha512-MQ1Ll9P7F72HHUKizbb7BlDfbY8fRoNMpbIpZoU6uKsSkneFICWSKv6UlgU9EQZ+w0i7TMa12iUgJ8l29eRI9A==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
   '@cloudflare/workerd-linux-arm64@1.20260603.1':
     resolution: {integrity: sha512-LJZ6x00rAjSrobV4m0ZW0TpH5ilBbKcWBzlH+y+KOUsIE/CpTuhAzKV43TbSnFLRX5+jrWKiz2v0hO91lPXy6A==}
     engines: {node: '>=16'}
@@ -4581,12 +4563,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260828.1':
-    resolution: {integrity: sha512-FBTaUQ1xcU9jcp4OyBPcH8x0QiFvc1iuZL2GkD8zp2q1WyTVHYOptRDQUU+cuHjt0rQ2EIKVPBjahPxfa0joBw==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
   '@cloudflare/workerd-windows-64@1.20260603.1':
     resolution: {integrity: sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA==}
     engines: {node: '>=16'}
@@ -4595,12 +4571,6 @@ packages:
 
   '@cloudflare/workerd-windows-64@1.20260714.1':
     resolution: {integrity: sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-
-  '@cloudflare/workerd-windows-64@1.20260828.1':
-    resolution: {integrity: sha512-yvr77hC7dUbvK5K+SCg062kkPq3sx+drV1PcgHslzHDYcJBtT0V3X80qLE49LW1vq2svaeNmsVQS+vHsqWu8cQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -15743,10 +15713,6 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
-  miniflare@5.20260828.0-alpha:
-    resolution: {integrity: sha512-6nbxhZEcz/UET3Y1OnYPsrAUjUmuFoib3ynUqteRdn1YnDxsLg8cwgZJZCk9QmtOmGzXwzXzgE/d/C0dJAPtVw==}
-    engines: {node: '>=22.0.0'}
-
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -19152,11 +19118,6 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20260828.1:
-    resolution: {integrity: sha512-pB9yvt0kkwZDAGZHmpY59r0o3hM0DzdW6BJERqwZOhunZ3ssOyDSgQxOQer2cSZW4YCFeOTIQYN1qwhK5wv/Cw==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   workers-tagged-logger@1.0.0:
     resolution: {integrity: sha512-tp5PAs48hSpF2GIbH0S186MBXuMe8u9uuHZR0Jmw/I8+NIiQblor5EpYJ5lOaE8u9s84mVme6Iv+ueC1C/beog==}
 
@@ -19166,16 +19127,6 @@ packages:
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^5.20260714.1
-    peerDependenciesMeta:
-      '@cloudflare/workers-types':
-        optional: true
-
-  wrangler@4.127.1:
-    resolution: {integrity: sha512-OzsiNgaI8i681L/+KnAKc+uEZ5D57xK5JuNvCOpRKICF4/5Q3Cu1oTGuUiT/f3GDUqQb3gzXNT0tfOHGMEtknw==}
-    engines: {node: '>=22.0.0'}
-    hasBin: true
-    peerDependencies:
-      '@cloudflare/workers-types': ^5.20260828.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -21132,12 +21083,6 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260714.1
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260828.1)':
-    dependencies:
-      unenv: 2.0.0-rc.24
-    optionalDependencies:
-      workerd: 1.20260828.1
-
   '@cloudflare/vitest-pool-workers@0.16.13(@cloudflare/workers-types@4.20260605.1)(@types/node@22.19.19)(@vitest/runner@4.1.6)(@vitest/snapshot@4.1.6)(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vitest@4.1.6)':
     dependencies:
       '@vitest/runner': 4.1.6
@@ -21208,16 +21153,10 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260714.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260828.1':
-    optional: true
-
   '@cloudflare/workerd-darwin-arm64@1.20260603.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260714.1':
-    optional: true
-
-  '@cloudflare/workerd-darwin-arm64@1.20260828.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260603.1':
@@ -21226,25 +21165,16 @@ snapshots:
   '@cloudflare/workerd-linux-64@1.20260714.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260828.1':
-    optional: true
-
   '@cloudflare/workerd-linux-arm64@1.20260603.1':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260714.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260828.1':
-    optional: true
-
   '@cloudflare/workerd-windows-64@1.20260603.1':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260714.1':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20260828.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260605.1': {}
@@ -26240,7 +26170,7 @@ snapshots:
       '@sentry/cli-win32-i686': 3.6.2
       '@sentry/cli-win32-x64': 3.6.2
 
-  '@sentry/cloudflare@10.69.0(@cloudflare/workers-types@4.20260605.1)(wrangler@4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@sentry/cloudflare@10.69.0(@cloudflare/workers-types@4.20260605.1)(wrangler@4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@sentry/core': 10.69.0
@@ -26248,7 +26178,7 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260605.1
-      wrangler: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      wrangler: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -34879,10 +34809,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  miniflare@4.20260714.0(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  miniflare@4.20260714.0(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.35.3(@types/node@24.12.4)
+      sharp: 0.35.4(@types/node@22.19.19)
       undici: 7.29.0
       workerd: 1.20260714.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -34892,25 +34822,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  miniflare@5.20260828.0-alpha(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.35.4(@types/node@22.19.19)
-      undici: 7.29.0
-      workerd: 1.20260828.1
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      youch: 4.1.0-beta.10
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - utf-8-validate
-
-  miniflare@5.20260828.0-alpha(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  miniflare@4.20260714.0(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.4(@types/node@24.12.4)
       undici: 7.29.0
-      workerd: 1.20260828.1
+      workerd: 1.20260714.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -34918,12 +34835,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  miniflare@5.20260828.0-alpha(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  miniflare@4.20260714.0(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.4(@types/node@25.5.2)
       undici: 7.29.0
-      workerd: 1.20260828.1
+      workerd: 1.20260714.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -39590,19 +39507,29 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260714.1
       '@cloudflare/workerd-windows-64': 1.20260714.1
 
-  workerd@1.20260828.1:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260828.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260828.1
-      '@cloudflare/workerd-linux-64': 1.20260828.1
-      '@cloudflare/workerd-linux-arm64': 1.20260828.1
-      '@cloudflare/workerd-windows-64': 1.20260828.1
-
   workers-tagged-logger@1.0.0:
     dependencies:
       zod: 4.4.3
     optionalDependencies:
       hono: 4.12.34
+
+  wrangler@4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260714.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.2
+      miniflare: 4.20260714.0(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      path-to-regexp: 8.4.2
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260714.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260605.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - utf-8-validate
 
   wrangler@4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
@@ -39622,52 +39549,16 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  wrangler@4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  wrangler@4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260828.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260714.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.2
-      miniflare: 5.20260828.0-alpha(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      miniflare: 4.20260714.0(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       path-to-regexp: 8.4.2
       unenv: 2.0.0-rc.24
-      workerd: 1.20260828.1
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20260605.1
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - utf-8-validate
-
-  wrangler@4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260828.1)
-      blake3-wasm: 2.1.5
-      esbuild: 0.28.2
-      miniflare: 5.20260828.0-alpha(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      path-to-regexp: 8.4.2
-      unenv: 2.0.0-rc.24
-      workerd: 1.20260828.1
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20260605.1
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - utf-8-validate
-
-  wrangler@4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260828.1)
-      blake3-wasm: 2.1.5
-      esbuild: 0.28.2
-      miniflare: 5.20260828.0-alpha(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      path-to-regexp: 8.4.2
-      unenv: 2.0.0-rc.24
-      workerd: 1.20260828.1
+      workerd: 1.20260714.1
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260605.1
       fsevents: 2.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,7 @@ catalog:
   ulid: 3.0.2
   vitest: 4.1.6
   workers-tagged-logger: 1.0.0
-  wrangler: 4.127.1
+  wrangler: 4.112.0
   zod: 4.4.3
 
 minimumReleaseAge: 6842

--- a/services/cloud-agent-next/src/persistence/SandboxControl.ts
+++ b/services/cloud-agent-next/src/persistence/SandboxControl.ts
@@ -875,6 +875,31 @@ export class SandboxControl extends DurableObject<Env> {
         throw error;
       }
       const result = response.ok ? sessionAbortResultSchema.safeParse(response.result) : undefined;
+      if (response.ok && !result?.success) {
+        if (retirementAttempt) await this.nativeRuntimeRetirement.defer(retirementAttempt);
+        return errorResponse(
+          response.requestId,
+          'protocol_error',
+          'Invalid session abort result',
+          false
+        );
+      }
+      if (result?.success && result.data.cleanupScope === 'root') {
+        if (
+          !this.socketHandler.supportsScopedCleanupResult?.() ||
+          result.data.runtimeRetired === true
+        ) {
+          if (retirementAttempt) await this.nativeRuntimeRetirement.defer(retirementAttempt);
+          return errorResponse(
+            response.requestId,
+            'protocol_error',
+            'Invalid root-scoped session abort result',
+            false
+          );
+        }
+        if (retirementAttempt) await this.nativeRuntimeRetirement.release(retirementAttempt);
+        return response;
+      }
       if (
         result?.success &&
         result.data.runtimeRetired === true &&

--- a/services/cloud-agent-next/src/sandbox-control/frames.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/frames.test.ts
@@ -69,6 +69,9 @@ describe('sandbox control frames', () => {
     expect(
       sandboxHelloResultSchema.safeParse({ ...helloResult(), handshakeComplete: false }).success
     ).toBe(false);
+    expect(
+      sandboxHelloResultSchema.parse(helloResult({ scopedCleanupResult: true })).capabilities
+    ).toMatchObject({ scopedCleanupResult: true });
   });
 
   it('accepts a valid request envelope', () => {

--- a/services/cloud-agent-next/src/sandbox-control/frames.ts
+++ b/services/cloud-agent-next/src/sandbox-control/frames.ts
@@ -186,6 +186,7 @@ export function errorResponse(
 export function helloResult(capabilities?: {
   connectionRecovery?: boolean;
   eventReceipts?: boolean;
+  scopedCleanupResult?: boolean;
 }): SandboxHelloResult {
   return {
     protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
@@ -197,6 +198,7 @@ export function helloResult(capabilities?: {
       nativeRuntimeRetirement: true,
       ...(capabilities?.connectionRecovery ? { connectionRecovery: true } : {}),
       ...(capabilities?.eventReceipts ? { eventReceipts: true } : {}),
+      ...(capabilities?.scopedCleanupResult ? { scopedCleanupResult: true } : {}),
     },
   };
 }

--- a/services/cloud-agent-next/src/sandbox-control/lifecycle.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/lifecycle.test.ts
@@ -2756,6 +2756,199 @@ describe('SandboxControl lifecycle boundaries', () => {
     ]);
   });
 
+  it('releases a negotiated unconfirmed root-scoped Stop without retiring the runtime', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const operationId = '33333333-3333-4333-8333-333333333333';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    const routeB = {
+      ...route,
+      sessionId: 'workspace_22222222-2222-4222-8222-222222222222',
+      kiloSessionId: 'ses_22222222222222222222222222',
+    };
+    h.records.set('session_routes', [
+      { ...route, nativeRuntimeId },
+      { ...routeB, nativeRuntimeId },
+    ]);
+    h.socket.supportsNativeRuntimeRetirement = () => true;
+    h.socket.supportsScopedStopAbort = () => true;
+    h.socket.supportsScopedCleanupResult = () => true;
+    const rootResult = {
+      type: 'response' as const,
+      requestId: 'stop_root_unconfirmed',
+      ok: true as const,
+      result: {
+        status: 'unconfirmed' as const,
+        cleanupScope: 'root' as const,
+        quiescent: false,
+      },
+    };
+    h.sendRequest.mockImplementationOnce(async () => {
+      expect(h.records.get('native_runtime_retirements')).toEqual([
+        expect.objectContaining({ operationId, state: 'pending' }),
+      ]);
+      return rootResult;
+    });
+
+    await expect(
+      h.control.request({
+        operation: 'session.abort',
+        session: {
+          sessionId: route.sessionId,
+          kiloSessionId: route.kiloSessionId,
+          directory: route.directory,
+        },
+        payload: {
+          messageId: 'message_root_unconfirmed',
+          operationId,
+          cleanupDeadlineAt: Date.now() + 1_000,
+        },
+        expectedWrapperInstanceId: identity.wrapperInstanceId,
+      })
+    ).resolves.toEqual(rootResult);
+    expect(h.records.get('native_runtime_retirements')).toEqual([
+      expect.objectContaining({
+        operationId,
+        state: 'released',
+        disposition: 'operation_only',
+      }),
+    ]);
+    const routesAfterRootRelease = await h.control.listRoutes();
+    expect(routesAfterRootRelease).toHaveLength(2);
+    for (const currentRoute of routesAfterRootRelease) {
+      expect(currentRoute.nativeRuntimeId).toBe(nativeRuntimeId);
+      expect(currentRoute.retiringNativeRuntimeId).toBeUndefined();
+    }
+    expect(h.session.invalidateTerminalRuntime).not.toHaveBeenCalled();
+
+    const bAdmission = {
+      type: 'response' as const,
+      requestId: 'prompt_b_after_root_release',
+      ok: true as const,
+      result: { status: 'accepted' as const },
+    };
+    h.sendRequest.mockResolvedValueOnce(bAdmission);
+    await expect(
+      h.control.request({
+        operation: 'session.prompt',
+        session: {
+          sessionId: routeB.sessionId,
+          kiloSessionId: routeB.kiloSessionId,
+          directory: routeB.directory,
+        },
+        payload: {
+          messageId: 'message_b_after_root_release',
+          turn: { type: 'prompt', prompt: 'B remains live' },
+          agent: { mode: 'code', model: 'test' },
+        },
+        expectedWrapperInstanceId: identity.wrapperInstanceId,
+      })
+    ).resolves.toEqual(bAdmission);
+
+    const requestsBeforeMaintenance = h.sendRequest.mock.calls.length;
+    await h.fireAlarm();
+    expect(h.sendRequest.mock.calls.length).toBe(requestsBeforeMaintenance);
+  });
+
+  it('releases a known superseded operation-only result through the operation-only disposition', async () => {
+    const h = await harness();
+    await h.create();
+    const identity = await h.ready();
+    const nativeRuntimeId = '11111111-1111-4111-8111-111111111111';
+    const operationId = '44444444-4444-4444-8444-444444444444';
+    const [route] = await h.control.listRoutes();
+    if (!route) throw new Error('Missing route');
+    const routeB = {
+      ...route,
+      sessionId: 'workspace_22222222-2222-4222-8222-222222222222',
+      kiloSessionId: 'ses_22222222222222222222222222',
+    };
+    h.records.set('session_routes', [
+      { ...route, nativeRuntimeId },
+      { ...routeB, nativeRuntimeId },
+    ]);
+    h.socket.supportsNativeRuntimeRetirement = () => true;
+    h.socket.supportsScopedStopAbort = () => true;
+    h.socket.supportsScopedCleanupResult = () => true;
+    const rootResult = {
+      type: 'response' as const,
+      requestId: 'stop_root',
+      ok: true as const,
+      result: {
+        status: 'already_idle' as const,
+        quiescent: false,
+      },
+    };
+    h.sendRequest.mockImplementationOnce(async () => {
+      expect(h.records.get('native_runtime_retirements')).toEqual([
+        expect.objectContaining({ operationId, state: 'pending' }),
+      ]);
+      return rootResult;
+    });
+
+    await expect(
+      h.control.request({
+        operation: 'session.abort',
+        session: {
+          sessionId: route.sessionId,
+          kiloSessionId: route.kiloSessionId,
+          directory: route.directory,
+        },
+        payload: {
+          messageId: 'message_root',
+          operationId,
+          cleanupDeadlineAt: Date.now() + 1_000,
+        },
+        expectedWrapperInstanceId: identity.wrapperInstanceId,
+      })
+    ).resolves.toEqual(rootResult);
+    expect(h.records.get('native_runtime_retirements')).toEqual([
+      expect.objectContaining({
+        operationId,
+        state: 'released',
+        disposition: 'operation_only',
+      }),
+    ]);
+    const routesAfterRootRelease = await h.control.listRoutes();
+    expect(routesAfterRootRelease).toHaveLength(2);
+    for (const currentRoute of routesAfterRootRelease) {
+      expect(currentRoute.nativeRuntimeId).toBe(nativeRuntimeId);
+      expect(currentRoute.retiringNativeRuntimeId).toBeUndefined();
+    }
+    expect(h.session.invalidateTerminalRuntime).not.toHaveBeenCalled();
+
+    const bAdmission = {
+      type: 'response' as const,
+      requestId: 'prompt_b',
+      ok: true as const,
+      result: { status: 'accepted' as const },
+    };
+    h.sendRequest.mockResolvedValueOnce(bAdmission);
+    await expect(
+      h.control.request({
+        operation: 'session.prompt',
+        session: {
+          sessionId: routeB.sessionId,
+          kiloSessionId: routeB.kiloSessionId,
+          directory: routeB.directory,
+        },
+        payload: {
+          messageId: 'message_b',
+          turn: { type: 'prompt', prompt: 'B remains live' },
+          agent: { mode: 'code', model: 'test' },
+        },
+        expectedWrapperInstanceId: identity.wrapperInstanceId,
+      })
+    ).resolves.toEqual(bAdmission);
+
+    const requestsBeforeMaintenance = h.sendRequest.mock.calls.length;
+    await h.fireAlarm();
+    expect(h.sendRequest.mock.calls.length).toBe(requestsBeforeMaintenance);
+  });
+
   it('keeps an operation-only Stop replay from blocking or changing a fresh native retirement', async () => {
     const h = await harness();
     await h.create();

--- a/services/cloud-agent-next/src/sandbox-control/scoped-stop-maintenance.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/scoped-stop-maintenance.test.ts
@@ -4,6 +4,10 @@ import {
   parseScopedStopMaintenance,
   stopAbortWirePayload,
 } from './scoped-stop-maintenance.js';
+import {
+  sessionAbortPayloadSchema,
+  sessionAbortResultSchema,
+} from '../shared/sandbox-control-protocol.js';
 
 const OPERATION_ID = '33333333-3333-4333-8333-333333333333';
 
@@ -42,5 +46,41 @@ describe('scoped Stop maintenance', () => {
       true
     );
     expect(hasScopedStopMaintenanceFields({ cleanupDeadlineAt: 11_000 })).toBe(true);
+  });
+
+  it('rejects root-scoped results that claim physical quiescence or retirement', () => {
+    expect(
+      sessionAbortResultSchema.safeParse({
+        status: 'aborted',
+        quiescent: true,
+        cleanupScope: 'root',
+      }).success
+    ).toBe(false);
+    expect(
+      sessionAbortResultSchema.safeParse({
+        status: 'aborted',
+        quiescent: false,
+        cleanupScope: 'root',
+        runtimeRetired: true,
+      }).success
+    ).toBe(false);
+    expect(
+      sessionAbortResultSchema.safeParse({
+        status: 'unconfirmed',
+        quiescent: false,
+        cleanupScope: 'root',
+      }).success
+    ).toBe(true);
+  });
+
+  it('does not accept request-side cleanup scope from a Stop caller', () => {
+    expect(
+      sessionAbortPayloadSchema.safeParse({
+        messageId: 'a',
+        operationId: '11111111-1111-4111-8111-111111111111',
+        cleanupDeadlineAt: Date.now() + 1_000,
+        cleanupScope: 'root',
+      }).success
+    ).toBe(false);
   });
 });

--- a/services/cloud-agent-next/src/sandbox-control/socket.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/socket.test.ts
@@ -64,7 +64,11 @@ function helloFrame(
   providerInstanceId: string,
   wrapperInstanceId?: string,
   requestId = 'req_hello',
-  capabilities?: { nativeRuntimeRetirement?: boolean; workingBranches?: boolean }
+  capabilities?: {
+    nativeRuntimeRetirement?: boolean;
+    scopedCleanupResult?: boolean;
+    workingBranches?: boolean;
+  }
 ): string {
   return JSON.stringify({
     type: 'request',
@@ -394,6 +398,23 @@ describe('sandbox control socket handler', () => {
     );
 
     expect(handler.supportsWorkingBranches?.()).toBe(true);
+  });
+
+  it('grants scoped cleanup results only to a reader that offers the capability', async () => {
+    const incoming = createFakeWebSocket();
+    const handler = createSandboxControlSocketHandler(createFakeState([incoming]), 'sbx_test');
+
+    await handler.handleMessage(
+      asWs(incoming),
+      helloFrame('inst_1', WRAPPER_INSTANCE_ID, 'req_scoped_cleanup', {
+        scopedCleanupResult: true,
+      })
+    );
+
+    expect(handler.supportsScopedCleanupResult?.()).toBe(true);
+    expect(incoming.send).toHaveBeenCalledWith(
+      expect.stringContaining('"scopedCleanupResult":true')
+    );
   });
 
   it('rejects duplicate hellos without replacing the current connection', async () => {

--- a/services/cloud-agent-next/src/sandbox-control/socket.ts
+++ b/services/cloud-agent-next/src/sandbox-control/socket.ts
@@ -124,6 +124,7 @@ export type SandboxControlSocketHandler = {
   hasHandshakenSocket(): boolean;
   supportsOperationResults(): boolean;
   supportsScopedStopAbort(): boolean;
+  supportsScopedCleanupResult?(): boolean;
   supportsNativeRuntimeRetirement(): boolean;
   supportsWorkingBranches?(): boolean;
   supportsConnectionRecovery(): boolean;
@@ -360,6 +361,14 @@ export function createSandboxControlSocketHandler(
       const current = currentHandshakenSocket(state);
       return (
         current !== null && readAttachment(current.socket)?.capabilities?.scopedStopAbort === true
+      );
+    },
+
+    supportsScopedCleanupResult(): boolean {
+      const current = currentHandshakenSocket(state);
+      return (
+        current !== null &&
+        readAttachment(current.socket)?.capabilities?.scopedCleanupResult === true
       );
     },
 
@@ -602,6 +611,7 @@ export function createSandboxControlSocketHandler(
             helloResult({
               connectionRecovery: payload.capabilities?.connectionRecovery === true,
               eventReceipts: payload.capabilities?.eventReceipts === true,
+              scopedCleanupResult: payload.capabilities?.scopedCleanupResult === true,
             })
           )
         );

--- a/services/cloud-agent-next/src/sandbox-session/session-stop-progress.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-stop-progress.test.ts
@@ -156,7 +156,7 @@ describe('Session Stop progress', () => {
     ]);
   });
 
-  it('does not terminalize an abort response without confirmed cleanup', async () => {
+  it('does not terminalize root-only abort evidence as runtime-wide cleanup', async () => {
     let messages: SessionMessageRecord[] = [
       {
         messageId: 'a',
@@ -183,7 +183,7 @@ describe('Session Stop progress', () => {
         messages = next;
         return true;
       },
-      abort: async () => ({ status: 'aborted', quiescent: false }),
+      abort: async () => ({ status: 'aborted', quiescent: false, cleanupScope: 'root' }),
       applyDelivery: async () => undefined,
     });
 

--- a/services/cloud-agent-next/src/shared/sandbox-control-protocol.ts
+++ b/services/cloud-agent-next/src/shared/sandbox-control-protocol.ts
@@ -189,6 +189,7 @@ export const sandboxHelloPayloadSchema = z.object({
       nativeRuntimeRetirement: z.boolean().optional(),
       connectionRecovery: z.boolean().optional(),
       eventReceipts: z.boolean().optional(),
+      scopedCleanupResult: z.boolean().optional(),
       workingBranches: z.boolean().optional(),
     })
     .optional(),
@@ -205,6 +206,7 @@ export const sandboxHelloResultSchema = z.object({
       nativeRuntimeRetirement: z.boolean().optional(),
       connectionRecovery: z.boolean().optional(),
       eventReceipts: z.boolean().optional(),
+      scopedCleanupResult: z.boolean().optional(),
     })
     .optional(),
 });
@@ -540,9 +542,33 @@ export const sessionAbortResultSchema = z
     quiescent: z.boolean().optional(),
     runtimeRetired: z.boolean().optional(),
     nativeRuntimeId: z.string().uuid().optional(),
+    cleanupScope: z.enum(['root', 'runtime']).optional(),
     delivery: z.lazy(() => sessionOperationDeliverySchema).optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((value, context) => {
+    if (value.cleanupScope === 'root' && value.nativeRuntimeId !== undefined) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Root cleanup results cannot identify a retired runtime',
+        path: ['nativeRuntimeId'],
+      });
+    }
+    if (value.cleanupScope === 'root' && value.runtimeRetired === true) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Root cleanup cannot retire the runtime',
+        path: ['runtimeRetired'],
+      });
+    }
+    if (value.cleanupScope === 'root' && value.quiescent === true) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Root cleanup cannot prove physical quiescence',
+        path: ['quiescent'],
+      });
+    }
+  });
 
 export const sessionNativeRuntimeRetirementPayloadSchema = z
   .object({
@@ -917,6 +943,7 @@ export const sandboxControlSocketAttachmentSchema = z.object({
       scopedStopAbort: z.boolean().optional(),
       nativeRuntimeRetirement: z.boolean().optional(),
       connectionRecovery: z.boolean().optional(),
+      scopedCleanupResult: z.boolean().optional(),
       workingBranches: z.boolean().optional(),
     })
     .optional(),

--- a/services/cloud-agent-next/test/e2e/fake-llm-server.ts
+++ b/services/cloud-agent-next/test/e2e/fake-llm-server.ts
@@ -114,7 +114,7 @@ const DIRECTIVE_PREFIX = '__fake__:';
  * remaining text (including any further colons) becomes a single trailing
  * argument. This keeps `echo:hello:world` → `{ scenario: 'echo', args: ['hello:world'] }`
  * so scenario payloads are free to contain colons. Scenarios that take a
- * fixed number of numeric args (e.g. `slow:<n>:<ms>`) split their trailing
+ * fixed number of numeric args (e.g. `slow:<n>:<ms>:<bytes>`) split their trailing
  * arg themselves if needed — the harness callers (`slow`) split on `:` and
  * take the first N.
  *
@@ -713,16 +713,23 @@ export const scenarioRegistry: Record<string, ScenarioHandler> = {
   async slow(args, ctx) {
     const raw = args[0] ?? '';
     const parts = raw.split(':');
-    const n = Math.max(1, Number.parseInt(parts[0] ?? '1', 10) || 1);
+    const n = Math.min(200, Math.max(1, Number.parseInt(parts[0] ?? '1', 10) || 1));
     const delayMs = Math.max(0, Number.parseInt(parts[1] ?? '0', 10) || 0);
-    const payload = 'slow-response';
+    const chunkBytes = Math.min(2048, Math.max(0, Number.parseInt(parts[2] ?? '0', 10) || 0));
     writeChunk(ctx.res, makeChunk(ctx.id, ctx.model, { role: 'assistant', content: '' }));
     let totalContent = 0;
     for (let i = 0; i < n; i++) {
-      const piece = payload.slice(
-        Math.floor((i * payload.length) / n),
-        Math.floor(((i + 1) * payload.length) / n)
-      );
+      let piece: string;
+      if (chunkBytes > 0) {
+        const token = ` w${i} `;
+        piece = token.repeat(Math.ceil(chunkBytes / token.length)).slice(0, chunkBytes);
+      } else {
+        const payload = 'slow-response';
+        piece = payload.slice(
+          Math.floor((i * payload.length) / n),
+          Math.floor(((i + 1) * payload.length) / n)
+        );
+      }
       totalContent += piece.length;
       writeChunk(ctx.res, makeChunk(ctx.id, ctx.model, { content: piece }));
       if (i < n - 1 && delayMs > 0) await sleep(delayMs);

--- a/services/cloud-agent-next/test/unit/fake-llm-server.test.ts
+++ b/services/cloud-agent-next/test/unit/fake-llm-server.test.ts
@@ -489,6 +489,19 @@ describe('fake-llm-server HTTP', () => {
     expect(contentChunks.length).toBeGreaterThanOrEqual(3);
   });
 
+  it('slow:4:1:8 streams four 8-byte content chunks', async () => {
+    const h = await start();
+    const res = await postChat(h.url, '__fake__:slow:4:1:8');
+    const chunks = await readAllSse(res.body!);
+    const parsed = chunks.slice(0, -1).map(c => JSON.parse(c.data));
+    const pieces = parsed
+      .map(p => p.choices[0].delta.content)
+      .filter((c): c is string => typeof c === 'string' && c.length > 0);
+    expect(pieces).toHaveLength(4);
+    expect(pieces.every(piece => piece.length === 8)).toBe(true);
+    expect(pieces.join('').length).toBe(32);
+  });
+
   it('gate:<tag> blocks until POST /test/release?tag=<tag>', async () => {
     const h = await start();
     const chatPromise = postChat(h.url, '__fake__:gate:t1').then(async res => {

--- a/services/cloud-agent-next/wrapper/src/control/control-event-outbox.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/control-event-outbox.test.ts
@@ -89,6 +89,71 @@ describe('control event outbox', () => {
     }
   });
 
+  it('recomputes retained bytes from the retained sequence width', async () => {
+    let failed: PreparedControlEventPublication | undefined;
+    let publishCount = 0;
+    const outbox = createControlEventOutbox({
+      publish: async () => {
+        publishCount += 1;
+        if (publishCount === 9) throw new ControlDeliveryError('rejected', false);
+      },
+      onFailure: failure => {
+        failed = failure.publication as PreparedControlEventPublication;
+      },
+    });
+    try {
+      for (let index = 0; index < 8; index += 1)
+        expect(
+          outbox.enqueue(
+            outbox.prepare({
+              event: 'session.event',
+              session,
+              payload: {
+                type: 'message.created',
+                properties: { messageId: `barrier_${index}` },
+              },
+            })
+          )
+        ).toBe(true);
+      const first = outbox.prepare({
+        event: 'session.event',
+        session,
+        payload: partUpdatedPayload('msg_1', 'part_1', 'first'),
+      });
+      const latest = outbox.prepare({
+        event: 'session.event',
+        session,
+        payload: partUpdatedPayload('msg_1', 'part_1', 'latest'),
+      });
+      expect(first.sequence).toBe(9);
+      expect(latest.sequence).toBe(10);
+      expect(outbox.enqueue(first)).toBe(true);
+      expect(outbox.enqueue(latest)).toBe(true);
+      expect(await outbox.resume()).toBe(true);
+      const retained = failed;
+      if (!retained) throw new Error('Missing retained publication');
+      const bytes = retained.bytes;
+      const wire: ControlEventPublication & { bytes?: number; deadlineAt?: number } = {
+        ...retained,
+      };
+      delete wire.bytes;
+      delete wire.deadlineAt;
+      expect(bytes).toBe(
+        Buffer.byteLength(
+          JSON.stringify({
+            type: 'request',
+            requestId: '00000000-0000-4000-8000-000000000000',
+            operation: 'sandbox.event.publish',
+            payload: wire,
+          })
+        )
+      );
+      expect(bytes).not.toBe(latest.bytes);
+    } finally {
+      outbox.close();
+    }
+  });
+
   it('squashes adjacent same-message updates to the latest payload', async () => {
     const clock = spyOn(Date, 'now').mockReturnValue(1_000);
     const delivered: Array<{ publication: ControlEventPublication; deadlineAt: number }> = [];
@@ -1159,6 +1224,42 @@ describe('control event outbox', () => {
       expect(await outbox.resume()).toBe(true);
       expect(published).toHaveBeenCalledTimes(1);
     } finally {
+      outbox.close();
+    }
+  });
+
+  it('wakes a pending cycle when paused without starting another lane', async () => {
+    const started = Promise.withResolvers<void>();
+    const held = Promise.withResolvers<void>();
+    const published = mock(async (publication: ControlEventPublication) => {
+      if (
+        typeof publication.payload === 'object' &&
+        publication.payload !== null &&
+        'type' in publication.payload &&
+        publication.payload.type === 'first'
+      )
+        started.resolve();
+      await held.promise;
+    });
+    const outbox = createControlEventOutbox({ publish: published, onFailure: mock() });
+    try {
+      outbox.enqueue(
+        outbox.prepare({ event: 'session.event', session, payload: { type: 'first' } })
+      );
+      const pumping = outbox.resume();
+      await started.promise;
+      outbox.pause();
+      expect(await pumping).toBe(false);
+      outbox.enqueue(
+        outbox.prepare({ event: 'session.event', session, payload: { type: 'second' } })
+      );
+      expect(published).toHaveBeenCalledTimes(1);
+      const resumed = outbox.resume();
+      held.resolve();
+      expect(await resumed).toBe(true);
+      expect(published).toHaveBeenCalledTimes(2);
+    } finally {
+      held.resolve();
       outbox.close();
     }
   });

--- a/services/cloud-agent-next/wrapper/src/control/control-event-outbox.ts
+++ b/services/cloud-agent-next/wrapper/src/control/control-event-outbox.ts
@@ -119,6 +119,22 @@ function sameSquashKey(left: SquashKey | undefined, right: SquashKey | undefined
   );
 }
 
+function serializedPublicationBytes(publication: ControlEventPublication): number {
+  const wire: ControlEventPublication & { bytes?: number; deadlineAt?: number } = {
+    ...publication,
+  };
+  delete wire.bytes;
+  delete wire.deadlineAt;
+  return Buffer.byteLength(
+    JSON.stringify({
+      type: 'request',
+      requestId: '00000000-0000-4000-8000-000000000000',
+      operation: 'sandbox.event.publish',
+      payload: wire,
+    })
+  );
+}
+
 function isRetryable(error: unknown): boolean {
   return (
     typeof error === 'object' && error !== null && 'retryable' in error && error.retryable === true
@@ -187,7 +203,10 @@ export function createControlEventOutbox(options: {
   ): boolean => {
     const entryCount = lane.entries.length - (replacement ? 1 : 0);
     const bytes = lane.bytes - (replacement?.bytes ?? 0);
-    if (entryCount >= MAX_EVENTS || bytes + publication.bytes > MAX_BYTES) return false;
+    const publicationBytes = replacement
+      ? serializedPublicationBytes({ ...replacement, payload: publication.payload })
+      : publication.bytes;
+    if (entryCount >= MAX_EVENTS || bytes + publicationBytes > MAX_BYTES) return false;
     const now = Date.now();
     for (const reserved of lane.spaceWaiters.keys()) {
       if (reserved.sequence < publication.sequence && now < reserved.deadlineAt) return false;
@@ -277,14 +296,7 @@ export function createControlEventOutbox(options: {
     const receiptId = crypto.randomUUID();
     nextSequence = sequence;
     const publication = { ...snapshot, sequence, receiptId };
-    const bytes = Buffer.byteLength(
-      JSON.stringify({
-        type: 'request',
-        requestId: '00000000-0000-4000-8000-000000000000',
-        operation: 'sandbox.event.publish',
-        payload: publication,
-      })
-    );
+    const bytes = serializedPublicationBytes(publication);
     if (bytes > MAX_SANDBOX_CONTROL_FRAME_BYTES)
       throw new Error('Control event exceeds the frame budget');
     return { ...publication, bytes, deadlineAt: Date.now() + 30_000 };
@@ -399,6 +411,7 @@ export function createControlEventOutbox(options: {
         }
         scheduleWakeup(lane);
         cleanupLane(lane);
+        signalCycle();
       });
     lane.pendingEntry = entry;
     lane.pending = pending;
@@ -423,12 +436,9 @@ export function createControlEventOutbox(options: {
           continue;
         }
 
-        const pending = [...lanes.values()]
-          .map(item => item.pending)
-          .filter((item): item is Promise<void> => item !== undefined);
-        if (pending.length > 0) {
+        if ([...lanes.values()].some(item => item.pending !== undefined)) {
           const wake = active.wake;
-          await Promise.race([...pending, wake]);
+          await wake;
           if (active.wake === wake) resetCycleWake(active);
           continue;
         }
@@ -477,12 +487,13 @@ export function createControlEventOutbox(options: {
       if (!hasSpaceFor(lane, publication, replacement)) return false;
       if (replacement) {
         const index = lane.entries.length - 1;
+        const bytes = serializedPublicationBytes({ ...replacement, payload: publication.payload });
         lane.entries[index] = {
           ...replacement,
           payload: publication.payload,
-          bytes: publication.bytes,
+          bytes,
         };
-        lane.bytes += publication.bytes - replacement.bytes;
+        lane.bytes += bytes - replacement.bytes;
       } else {
         lane.entries.push({ ...publication });
         lane.bytes += publication.bytes;
@@ -528,6 +539,7 @@ export function createControlEventOutbox(options: {
     pause() {
       paused = true;
       for (const lane of lanes.values()) scheduleWakeup(lane);
+      signalCycle();
     },
     resume() {
       paused = false;

--- a/services/cloud-agent-next/wrapper/src/control/control-event-transport.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/control-event-transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock, spyOn } from 'bun:test';
+import { beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import {
   createControlEventFailureHandler,
   createControlEventTransport,
@@ -7,6 +7,11 @@ import type { ControlEventOutboxFailure, ControlEventPublication } from './contr
 import { ControlDeliveryError } from './sandbox-control-client';
 import { createOperationRegistry } from './operation-registry';
 import { acknowledgeOperation, fakeKilo, operationAuthorization } from './control-test-fixtures';
+import {
+  rememberAttachedRoot,
+  rememberChildSession,
+  resetSessionDirectoryState,
+} from './session-directories';
 import type {
   SessionOperationAck,
   SessionOperationDelivery,
@@ -21,6 +26,11 @@ const session = {
 const payload = { type: 'session.idle', properties: {} };
 
 describe('native-scoped control event failures', () => {
+  beforeEach(() => {
+    resetSessionDirectoryState();
+    rememberAttachedRoot(session.kiloSessionId, session.directory);
+  });
+
   it.each([
     ['session.preparing', false],
     ['session.event', true],
@@ -189,6 +199,8 @@ describe('native-scoped control event failures', () => {
   });
 
   it('coalesces distinct roots only during registry cleanup and separates a reused native object incarnation', async () => {
+    rememberAttachedRoot('root_a', session.directory);
+    rememberAttachedRoot('root_b', session.directory);
     const runtime = { runtimeId: 'N1' };
     const cleanup = Promise.withResolvers<void>();
     const failures: ControlEventOutboxFailure[] = [];
@@ -348,5 +360,89 @@ describe('native-scoped control event failures', () => {
     } finally {
       transport.close();
     }
+  });
+
+  it('routes a child receipt failure through its root owner while preserving child identity', () => {
+    rememberAttachedRoot('root', '/root');
+    rememberChildSession({ childId: 'child', parentId: 'root', directory: '/child' });
+    const runtime = { runtimeId: 'native-root' };
+    const getRuntime = mock((directory: string) => (directory === '/root' ? runtime : undefined));
+    const onFailure = mock();
+    const handleFailure = createControlEventFailureHandler({ getRuntime, onFailure });
+    const failure: ControlEventOutboxFailure = {
+      reason: 'rejected',
+      publication: {
+        event: 'session.event',
+        receiptId: 'receipt_child',
+        sequence: 1,
+        session: {
+          directory: '/child',
+          kiloSessionId: 'child',
+          rootKiloSessionId: 'root',
+          nativeRuntimeId: runtime.runtimeId,
+        },
+        payload,
+      },
+    };
+
+    handleFailure(failure);
+
+    expect(getRuntime).toHaveBeenCalledWith('/root');
+    expect(onFailure).toHaveBeenCalledWith(failure, runtime);
+  });
+
+  it('routes an expired child receipt through the root owner before runtime lookup', () => {
+    rememberAttachedRoot('root', '/root');
+    rememberChildSession({ childId: 'child_expired', parentId: 'root', directory: '/child' });
+    const runtime = { runtimeId: 'native-root' };
+    const getRuntime = mock((directory: string) => (directory === '/root' ? runtime : undefined));
+    const onFailure = mock();
+    const handleFailure = createControlEventFailureHandler({ getRuntime, onFailure });
+    const failure: ControlEventOutboxFailure = {
+      reason: 'expired',
+      publication: {
+        event: 'session.event',
+        receiptId: 'receipt_child_expired',
+        sequence: 2,
+        session: {
+          directory: '/child',
+          kiloSessionId: 'child_expired',
+          rootKiloSessionId: 'root',
+          nativeRuntimeId: runtime.runtimeId,
+        },
+        payload,
+      },
+    };
+
+    handleFailure(failure);
+
+    expect(getRuntime).toHaveBeenCalledWith('/root');
+    expect(onFailure).toHaveBeenCalledWith(failure, runtime);
+  });
+
+  it('fails closed for an unresolved child receipt failure', () => {
+    rememberAttachedRoot('root', '/root');
+    const getRuntime = mock(() => ({ runtimeId: 'native-root' }));
+    const onFailure = mock();
+    const handleFailure = createControlEventFailureHandler({ getRuntime, onFailure });
+
+    handleFailure({
+      reason: 'rejected',
+      publication: {
+        event: 'session.event',
+        receiptId: 'receipt_unknown',
+        sequence: 1,
+        session: {
+          directory: '/child',
+          kiloSessionId: 'unknown-child',
+          rootKiloSessionId: 'root',
+          nativeRuntimeId: 'native-root',
+        },
+        payload,
+      },
+    });
+
+    expect(getRuntime).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
   });
 });

--- a/services/cloud-agent-next/wrapper/src/control/control-event-transport.ts
+++ b/services/cloud-agent-next/wrapper/src/control/control-event-transport.ts
@@ -4,6 +4,7 @@ import {
   type ControlEventOutboxFailure,
   type ControlEventPublication,
 } from './control-event-outbox.js';
+import { ownerDirectoryForSession } from './session-directories.js';
 
 type EventKind = 'session.event' | 'session.preparing';
 
@@ -15,11 +16,13 @@ export function createControlEventFailureHandler<Runtime extends { runtimeId: st
   return (failure?: ControlEventOutboxFailure): void => {
     if (!failure) return;
     if (failure.publication.event === 'session.preparing') return;
-    const { directory, nativeRuntimeId } = failure.publication.session;
+    const { nativeRuntimeId } = failure.publication.session;
     const root =
       failure.publication.session.rootKiloSessionId ?? failure.publication.session.kiloSessionId;
     if (!nativeRuntimeId || !root) return;
-    const runtime = options.getRuntime(directory);
+    const ownerDirectory = ownerDirectoryForSession(failure.publication.session);
+    if (!ownerDirectory) return;
+    const runtime = options.getRuntime(ownerDirectory);
     if (runtime?.runtimeId !== nativeRuntimeId) return;
     const key = JSON.stringify([nativeRuntimeId, root]);
     const keys = inFlight.get(runtime) ?? new Set<string>();

--- a/services/cloud-agent-next/wrapper/src/control/main.ts
+++ b/services/cloud-agent-next/wrapper/src/control/main.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../src/shared/sandbox-control-protocol.js';
 import { WRAPPER_VERSION } from '../../../src/shared/wrapper-version.js';
 import { logToFile } from '../utils.js';
-import { rootForSession } from './session-directories';
+import { ownerDirectoryForSession, rootForSession } from './session-directories';
 import {
   KILO_CONTROL_REQUEST_TIMEOUT_MS,
   maybeStartSandboxControlClient,
@@ -25,9 +25,12 @@ import {
   createWorktreeKiloRuntimes,
   type RootRuntimeDisappearance,
   type RootRuntimeRetirement,
+  type RootRuntimeRetirementStarted,
   type WorktreeKiloRuntime,
+  isRetirementReportCurrent,
 } from './worktree-runtime';
-import type { NativeRetirement, RootScopedCleanupResult } from './session-operation-cleanup';
+import type { RootScopedCleanupResult } from './session-operation-cleanup';
+import type { RootPublicationDisposition } from './operation-registry';
 import { createControlDiagnostics, type ControlDiagnostics } from './diagnostics';
 import { createControlFileLogUploader, type ControlFileLogUploader } from './file-log-uploader';
 import {
@@ -38,7 +41,7 @@ import {
 import { createWorktreeMutationNotifications } from './worktree-mutation-notifications';
 import { createControlEventFailureHandler } from './control-event-transport';
 
-type PublicationRetirementResult = RootScopedCleanupResult | NativeRetirement | 'shared';
+type PublicationRetirementResult = RootPublicationDisposition;
 
 type PublicationFailureAttempt = {
   cleanup: Promise<RootScopedCleanupResult>;
@@ -64,14 +67,67 @@ function main(
   let control: ReturnType<typeof maybeStartSandboxControlClient> = null;
   let shuttingDown = false;
   let heartbeatReason: SandboxHeartbeatPayload['kilo']['reason'];
+  const reportedRuntimeRetirements = new Set<string>();
   const settleRootRetirement = (retirement: RootRuntimeRetirement): void => {
     deps.operations.settleRootPublication(retirement);
+    if (!retirement.reportToService || retirement.result !== 'retired' || !retirement.retirementId)
+      return;
+    const current = kiloRuntimes.get(retirement.directory);
+    if (
+      !isRetirementReportCurrent(
+        kiloRuntimes.getEntryRuntimeId?.(retirement.directory),
+        retirement.nativeRuntimeId
+      ) ||
+      (current &&
+        (current.runtimeId !== retirement.nativeRuntimeId ||
+          (retirement.target.client !== undefined &&
+            current.kiloClient !== retirement.target.client)))
+    )
+      return;
+    if (reportedRuntimeRetirements.has(retirement.retirementId)) return;
+    const client = control;
+    if (!client?.reportNativeRuntimeRetirement) return;
+    reportedRuntimeRetirements.add(retirement.retirementId);
+    const reason = retirement.reason ?? 'Native runtime retirement completed';
+    void client
+      .reportNativeRuntimeRetirement({
+        retirementId: retirement.retirementId,
+        directory: retirement.directory,
+        nativeRuntimeId: retirement.nativeRuntimeId,
+        reason,
+        cleanupDeadlineAt: retirement.cleanupDeadlineAt ?? Date.now(),
+      })
+      .then(
+        reported => {
+          if (
+            !reported &&
+            isRetirementReportCurrent(
+              kiloRuntimes.getEntryRuntimeId?.(retirement.directory),
+              retirement.nativeRuntimeId
+            )
+          )
+            shutdown(1, reason);
+        },
+        () => {
+          if (
+            isRetirementReportCurrent(
+              kiloRuntimes.getEntryRuntimeId?.(retirement.directory),
+              retirement.nativeRuntimeId
+            )
+          )
+            shutdown(1, reason);
+        }
+      );
+  };
+  const markRootRetirementStarted = (retirement: RootRuntimeRetirementStarted): void => {
+    deps.operations.markRootRetirementStarted(retirement);
   };
   const notifyRootDisappeared = (disappearance: RootRuntimeDisappearance): void => {
     deps.operations.notifyRootDisappeared(disappearance);
   };
   const kiloRuntimes = createWorktreeKiloRuntimes({
     onDiagnostic: diagnostics.onDiagnostic,
+    onRootRetirementStarted: markRootRetirementStarted,
     onRootDisappeared: notifyRootDisappeared,
     onRootRetirement: settleRootRetirement,
     onEvent: (runtime, event) => {
@@ -155,6 +211,7 @@ function main(
     activity: createSessionActivityRegistry(),
     signal: abort.signal,
     ...(terminalRuntime ? { terminalRuntime } : {}),
+    scopedCleanupResult: () => control?.supportsScopedCleanupResult?.() === true,
     sendOperationResult: (session, delivery, signal, deadlineAt) => {
       if (!control?.sendOperationResult)
         throw new Error('Sandbox control operation result delivery unavailable');
@@ -188,13 +245,19 @@ function main(
     reason: string
   ): PublicationFailureAttempt | undefined {
     const root = identity.rootKiloSessionId ?? identity.kiloSessionId;
-    if (!root || (identity.nativeRuntimeId && identity.nativeRuntimeId !== runtime.runtimeId))
+    const ownerDirectory = ownerDirectoryForSession(identity);
+    if (
+      !root ||
+      !ownerDirectory ||
+      ownerDirectory !== runtime.directory ||
+      (identity.nativeRuntimeId && identity.nativeRuntimeId !== runtime.runtimeId)
+    )
       return undefined;
     const nativeRuntimeId = identity.nativeRuntimeId ?? runtime.runtimeId;
     const target = { runtimeId: runtime.runtimeId, client: runtime.kiloClient };
     const deadlineAt = Date.now() + KILO_CONTROL_REQUEST_TIMEOUT_MS;
     return deps.operations.escalateRootPublication({
-      directory: identity.directory,
+      directory: ownerDirectory,
       root,
       nativeRuntimeId,
       target,
@@ -209,7 +272,16 @@ function main(
     reason: string
   ): Promise<PublicationRetirementResult> {
     const attempt = beginPublicationFailure(runtime, identity, reason);
-    if (!attempt) return 'stale';
+    if (!attempt)
+      return {
+        scope: 'runtime',
+        status: 'unconfirmed',
+        cleanup: 'unconfirmed',
+        physical: 'stale',
+        quiescent: false,
+        runtimeRetired: false,
+        physicalAttemptStarted: false,
+      };
     return attempt.physical;
   }
 
@@ -229,7 +301,9 @@ function main(
   }
 
   function startPublicationFailure(identity: SessionEventIdentity, reason: string): void {
-    const runtime = kiloRuntimes.get(identity.directory);
+    const ownerDirectory = ownerDirectoryForSession(identity);
+    if (!ownerDirectory) return;
+    const runtime = kiloRuntimes.get(ownerDirectory);
     if (!runtime) return;
     const attempt = beginPublicationFailure(runtime, identity, reason);
     if (!attempt) return;
@@ -436,8 +510,10 @@ function main(
             }
             void attempt.physical.then(
               result => {
-                if (result === 'retired' || result === 'stale')
+                if (result.runtimeRetired || result.physical === 'stale')
                   reportOutboxRetirement(failure, runtime.runtimeId, 'retired', true);
+                else if (result.scope === 'root')
+                  reportOutboxRetirement(failure, runtime.runtimeId, 'failed', false);
                 else {
                   reportOutboxRetirement(failure, runtime.runtimeId, 'failed', false);
                   diagnostics.onDiagnostic('wrapper.lifecycle', { phase: 'failed' });

--- a/services/cloud-agent-next/wrapper/src/control/operation-registry.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/operation-registry.test.ts
@@ -12,6 +12,7 @@ import {
   sessionOperationLookupResultSchema,
 } from '../../../src/shared/sandbox-control-protocol';
 import {
+  createControlHandlerDeps,
   handleControlRequest,
   pruneControlOperations,
   type HandlerDeps,
@@ -242,6 +243,48 @@ describe('operation admission and lookup', () => {
     ).toMatchObject({ ok: true, result: { acknowledged: true } });
   });
 
+  it('uses unshared runtime retirement for operation-owned cleanup', async () => {
+    const running = Promise.withResolvers<Completion>();
+    const runtimeRetirement = mock(async () => 'unconfirmed' as const);
+    const unsharedRetirement = mock(async () => 'shared' as const);
+    const handlerDeps = deps({
+      kiloClient: fakeKilo({ sendPrompt: async () => running.promise }),
+    });
+    const runtimes = handlerDeps.kiloRuntimes;
+    if (!runtimes) throw new Error('Missing native runtimes');
+    runtimes.retireRuntime = runtimeRetirement;
+    runtimes.retireRuntimeIfUnshared = unsharedRetirement;
+    const request = handleControlRequest('session.prompt', session, promptPayload, handlerDeps);
+    let task: ReturnType<typeof handlerDeps.operations.active>;
+
+    try {
+      expect(await request).toMatchObject({
+        ok: true,
+        result: { messageId: promptPayload.messageId, status: 'accepted' },
+      });
+      task = handlerDeps.operations.active(session.kiloSessionId);
+      if (!task) throw new Error('Missing active operation');
+      for (let index = 0; index < 10 && !task.nativeTarget(); index += 1) await Promise.resolve();
+      if (!task.nativeTarget()) throw new Error('Missing native operation target');
+      task.requestRetirement('operation cleanup', Date.now() + 1_000);
+      for (let index = 0; index < 10 && unsharedRetirement.mock.calls.length === 0; index += 1)
+        await Promise.resolve();
+
+      expect(unsharedRetirement).toHaveBeenCalledWith(
+        session.directory,
+        expect.objectContaining({ runtimeId: 'native_1' }),
+        session.kiloSessionId,
+        expect.any(Number),
+        'operation cleanup'
+      );
+      expect(runtimeRetirement).not.toHaveBeenCalled();
+    } finally {
+      running.resolve(completion());
+      await Promise.allSettled([request]);
+      if (task) await task.done;
+    }
+  });
+
   it('retains terminal unconfirmed state across routing loss until explicit root notification', async () => {
     const handlerDeps = deps();
     const sessionA = { ...session, sessionId: 'ses_a', kiloSessionId: 'kilo_a' };
@@ -395,7 +438,11 @@ describe('operation admission and lookup', () => {
     const escalation = handlerDeps.operations.escalateRootPublication(input);
     handlerDeps.operations.notifyRootDisappeared(input);
     rememberAttachedRoot(sessionA.kiloSessionId, sessionA.directory);
-    expect(await escalation.physical).toBe('stale');
+    expect(await escalation.physical).toMatchObject({
+      scope: 'runtime',
+      physical: 'stale',
+      runtimeRetired: false,
+    });
     expect(gateCalls).toBe(0);
     expect(handlerDeps.operations.admission('session.prompt', sessionA, undefined).kind).toBe(
       'continue'
@@ -407,6 +454,615 @@ describe('operation admission and lookup', () => {
       nativeRuntimeId: runtime.runtimeId,
     });
     expect(gateCalls).toBe(0);
+  });
+
+  it.each(['unconfirmed', 'retired'] as const)(
+    'replaces a cached shared disposition when the runtime owner starts a physical attempt (%s)',
+    async result => {
+      const fixture = deps();
+      const runtime = fixture.kiloRuntimes?.get(session.directory);
+      if (!runtime) throw new Error('Missing native runtime');
+      const operations = createOperationRegistry({
+        native: {
+          get: () => runtime,
+          getRetained: () => runtime,
+          rootRetirementScope: () => 'shared',
+          retireRuntime: async () => 'unconfirmed',
+          retireRuntimeIfUnshared: async () => 'shared',
+          verifyQuiescence: async () => false,
+        },
+        onStarted: () => {},
+        onCompleted: () => {},
+        retireRuntime: () => {},
+      });
+      const target = { runtimeId: runtime.runtimeId, client: runtime.kiloClient };
+      const input = {
+        directory: session.directory,
+        root: session.kiloSessionId,
+        nativeRuntimeId: runtime.runtimeId,
+        target,
+        reason: 'deferred physical cleanup',
+        deadlineAt: Date.now() + 1_000,
+      };
+      const initial = operations.escalateRootPublication(input);
+      const initialDisposition = await initial.physical;
+      expect(initialDisposition).toMatchObject({
+        scope: 'root',
+        physical: 'shared',
+        runtimeRetired: false,
+      });
+
+      const retirementId = crypto.randomUUID();
+      operations.markRootRetirementStarted({ ...input, retirementId });
+      const retainedStop = operations.escalateRootPublication(input);
+      const originalDisposition = initial.disposition();
+      const retainedDisposition = retainedStop.disposition();
+      expect(originalDisposition).toMatchObject({
+        scope: 'runtime',
+        physical: 'pending',
+        physicalAttemptStarted: true,
+        runtimeRetired: false,
+      });
+      expect(retainedDisposition).toEqual(originalDisposition);
+      operations.settleRootPublication({ ...input, retirementId, result });
+      const settledDisposition = await retainedStop.physical;
+      expect(settledDisposition).toMatchObject({
+        scope: 'runtime',
+        physical: result,
+        runtimeRetired: result === 'retired',
+      });
+    }
+  );
+
+  it('starts a current runtime retirement after a cached root result loses membership', async () => {
+    const fixture = deps();
+    const runtime = fixture.kiloRuntimes?.get(session.directory);
+    if (!runtime) throw new Error('Missing native runtime');
+    let scope: 'shared' | 'sole' = 'shared';
+    let attempts = 0;
+    const retirement = Promise.withResolvers<'retired'>();
+    const operations = createOperationRegistry({
+      native: {
+        get: () => runtime,
+        getRetained: () => runtime,
+        rootRetirementScope: () => scope,
+        retireRuntime: async () => 'unconfirmed',
+        retireRuntimeIfUnshared: async () => {
+          attempts += 1;
+          if (attempts === 1) return 'shared';
+          return retirement.promise;
+        },
+        verifyQuiescence: async () => false,
+      },
+      onStarted: () => {},
+      onCompleted: () => {},
+      retireRuntime: () => {},
+    });
+    const target = { runtimeId: runtime.runtimeId, client: runtime.kiloClient };
+    const input = {
+      directory: session.directory,
+      root: session.kiloSessionId,
+      nativeRuntimeId: runtime.runtimeId,
+      target,
+      reason: 'deferred physical cleanup',
+      deadlineAt: Date.now() + 1_000,
+    };
+    try {
+      const initial = operations.escalateRootPublication(input);
+      expect(await initial.physical).toMatchObject({
+        scope: 'root',
+        physical: 'shared',
+        runtimeRetired: false,
+      });
+
+      scope = 'sole';
+      const retainedStop = operations.escalateRootPublication(input);
+      for (let index = 0; index < 10 && attempts < 2; index += 1) await Promise.resolve();
+      expect(attempts).toBe(2);
+      expect(retainedStop.disposition()).toMatchObject({
+        scope: 'runtime',
+        physical: 'pending',
+        runtimeRetired: false,
+      });
+      let settled = false;
+      const physical = retainedStop.physical.then(result => {
+        settled = true;
+        return result;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      retirement.resolve('retired');
+      expect(await physical).toMatchObject({
+        scope: 'runtime',
+        physical: 'retired',
+        runtimeRetired: true,
+      });
+    } finally {
+      retirement.resolve('retired');
+    }
+  });
+
+  it('does not let a superseded retained A1 Stop retire active A2 after confirmed root cleanup', async () => {
+    const runningA1 = Promise.withResolvers<Completion>();
+    const runningA2 = Promise.withResolvers<Completion>();
+    const startedA1 = Promise.withResolvers<void>();
+    const startedA2 = Promise.withResolvers<void>();
+    const sessionA = { ...session, sessionId: 'ses_a', kiloSessionId: 'kilo_a' };
+    const sessionB = { ...session, sessionId: 'ses_b', kiloSessionId: 'kilo_b' };
+    const client = fakeKilo({
+      sendPrompt: async options => {
+        if (options.messageId === 'message_a1') {
+          startedA1.resolve();
+          return runningA1.promise;
+        }
+        if (options.messageId === 'message_a2') {
+          startedA2.resolve();
+          return runningA2.promise;
+        }
+        return completion();
+      },
+      getSessionStatuses: async () => ({
+        [sessionA.kiloSessionId]: { type: 'idle' },
+        [sessionB.kiloSessionId]: { type: 'idle' },
+      }),
+      abortSession: async () => true,
+    });
+    const handlerDeps = deps({
+      kiloClient: client,
+      scopedCleanupResult: true,
+      sendOperationResult: (_session, delivery) => acknowledgeOperation(delivery),
+    });
+    rememberAttachedRoot(sessionA.kiloSessionId, sessionA.directory);
+    rememberAttachedRoot(sessionB.kiloSessionId, sessionB.directory);
+    const runtimes = handlerDeps.kiloRuntimes;
+    if (!runtimes) throw new Error('Missing worktree runtimes');
+    const runtime = runtimes.get(sessionA.directory);
+    if (!runtime) throw new Error('Missing native runtime');
+    const attachedRoots = new Set([sessionA.kiloSessionId, sessionB.kiloSessionId]);
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- capture before wrap
+    const originalDetach = runtimes.detach;
+    runtimes.detach = identity => {
+      attachedRoots.delete(identity.kiloSessionId);
+      return originalDetach.call(runtimes, identity);
+    };
+    runtimes.rootRetirementScope = (_directory, _target, retiringRoot) =>
+      attachedRoots.has(retiringRoot) ? (attachedRoots.size > 1 ? 'shared' : 'sole') : 'stale';
+    if (!runtimes.retireRuntime) throw new Error('Missing runtime retirement');
+    let retireRuntimeIfUnsharedCalls = 0;
+    runtimes.retireRuntimeIfUnshared = async (directory, target, retiringRoot, deadlineAt) => {
+      retireRuntimeIfUnsharedCalls += 1;
+      if (runtimes.rootRetirementScope?.(directory, target, retiringRoot) === 'shared')
+        return 'shared';
+      const retirement = await runtimes.retireRuntime?.(directory, deadlineAt, target);
+      if (retirement === undefined) throw new Error('Missing runtime retirement');
+      return retirement;
+    };
+    const integratedDeps = createControlHandlerDeps(handlerDeps);
+    const originalDeadlineAt = Date.now() + 5_000;
+    const input = {
+      directory: sessionA.directory,
+      root: sessionA.kiloSessionId,
+      nativeRuntimeId: runtime.runtimeId,
+      target: { runtimeId: runtime.runtimeId, client: runtime.kiloClient },
+      reason: 'confirmed publication cleanup',
+      deadlineAt: originalDeadlineAt,
+    };
+    const authorizationA1 = operationAuthorization('session.prompt', 'message_a1', sessionA);
+    const authorizationA2 = operationAuthorization('session.prompt', 'message_a2', sessionA);
+    const requestA1 = handleControlRequest(
+      'session.prompt',
+      sessionA,
+      { ...promptPayload, messageId: 'message_a1' },
+      integratedDeps,
+      authorizationA1
+    );
+    let requestA2: ReturnType<typeof handleControlRequest> | undefined;
+    try {
+      await startedA1.promise;
+      expect(await requestA1).toMatchObject({ ok: true, result: { status: 'accepted' } });
+      const publication = integratedDeps.operations.escalateRootPublication(input);
+      expect(await publication.physical).toMatchObject({
+        scope: 'root',
+        cleanup: 'confirmed',
+        physical: 'not_attempted',
+        runtimeRetired: false,
+      });
+
+      runningA1.resolve(
+        completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } })
+      );
+      const retainedA1 = integratedDeps.operations
+        .retained()
+        .find(operation => operation.messageId === 'message_a1');
+      if (!retainedA1) throw new Error('Missing retained A1 operation');
+      await retainedA1.done;
+      await retainedA1.waitForDelivery();
+
+      requestA2 = handleControlRequest(
+        'session.prompt',
+        sessionA,
+        { ...promptPayload, messageId: 'message_a2' },
+        integratedDeps,
+        authorizationA2
+      );
+      expect(await requestA2).toMatchObject({ ok: true, result: { status: 'accepted' } });
+      await startedA2.promise;
+      const a2 = integratedDeps.operations.active(sessionA.kiloSessionId);
+      if (!a2) throw new Error('Missing active A2 operation');
+      expect(integratedDeps.operations.retained()).toContain(retainedA1);
+      const supersededWithoutClaim = integratedDeps.operations.escalateRootPublication(input);
+      expect(supersededWithoutClaim.cleanup).not.toBe(publication.cleanup);
+      expect(a2.publicationScope()?.claim).toBeDefined();
+      expect(a2.signal.aborted).toBe(true);
+      expect(integratedDeps.operations.admission('session.prompt', sessionA, undefined).kind).toBe(
+        'reply'
+      );
+      expect(await supersededWithoutClaim.physical).toMatchObject({
+        scope: 'root',
+        status: 'aborted',
+        cleanup: 'confirmed',
+        physical: 'not_attempted',
+        quiescent: false,
+        runtimeRetired: false,
+      });
+      const unknownClaim = integratedDeps.operations.escalateRootPublication({
+        ...input,
+        expectedClaim: Symbol('unknown-claim'),
+      });
+      expect(await unknownClaim.physical).toMatchObject({
+        scope: 'runtime',
+        status: 'unconfirmed',
+        physical: 'stale',
+        quiescent: false,
+        runtimeRetired: false,
+      });
+
+      expect(
+        await handleControlRequest('session.detach', sessionB, {}, integratedDeps)
+      ).toMatchObject({
+        ok: true,
+        result: { detached: true },
+      });
+      const stopped = await handleControlRequest(
+        'session.abort',
+        sessionA,
+        {
+          messageId: 'message_a1',
+          operationId: '11111111-1111-4111-8111-111111111111',
+          cleanupDeadlineAt: originalDeadlineAt,
+        },
+        integratedDeps
+      );
+      expect(stopped).toMatchObject({
+        ok: true,
+        result: { status: 'already_idle', quiescent: false },
+      });
+      expect(stopped).not.toHaveProperty('result.cleanupScope');
+      expect(stopped).not.toHaveProperty('result.runtimeRetired');
+      expect(retireRuntimeIfUnsharedCalls).toBe(0);
+      expect(integratedDeps.kiloRuntimes?.get(sessionA.directory)).toBe(runtime);
+      expect(runtime.signal.aborted).toBe(false);
+      expect(a2.signal.aborted).toBe(true);
+
+      runningA2.resolve(
+        completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } })
+      );
+      await requestA2;
+    } finally {
+      runningA1.resolve(
+        completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } })
+      );
+      runningA2.resolve(
+        completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } })
+      );
+      await Promise.allSettled([requestA1, ...(requestA2 ? [requestA2] : [])]);
+      for (const operation of integratedDeps.operations.activeOperations()) await operation.done;
+    }
+  });
+
+  it('returns already_idle for a retained A1 Stop without aborting healthy active A2', async () => {
+    const runningA1 = Promise.withResolvers<Completion>();
+    const runningA2 = Promise.withResolvers<Completion>();
+    const startedA1 = Promise.withResolvers<void>();
+    const startedA2 = Promise.withResolvers<void>();
+    const sessionA = { ...session, sessionId: 'ses_a', kiloSessionId: 'kilo_a' };
+    const sessionB = { ...session, sessionId: 'ses_b', kiloSessionId: 'kilo_b' };
+    const client = fakeKilo({
+      sendPrompt: async options => {
+        if (options.messageId === 'message_a1') {
+          startedA1.resolve();
+          return runningA1.promise;
+        }
+        if (options.messageId === 'message_a2') {
+          startedA2.resolve();
+          return runningA2.promise;
+        }
+        return completion();
+      },
+      getSessionStatuses: async () => ({
+        [sessionA.kiloSessionId]: { type: 'idle' },
+        [sessionB.kiloSessionId]: { type: 'idle' },
+      }),
+      abortSession: async () => true,
+    });
+    const handlerDeps = deps({
+      kiloClient: client,
+      scopedCleanupResult: true,
+      sendOperationResult: (_session, delivery) => acknowledgeOperation(delivery),
+    });
+    rememberAttachedRoot(sessionA.kiloSessionId, sessionA.directory);
+    rememberAttachedRoot(sessionB.kiloSessionId, sessionB.directory);
+    const runtimes = handlerDeps.kiloRuntimes;
+    if (!runtimes) throw new Error('Missing worktree runtimes');
+    const runtime = runtimes.get(sessionA.directory);
+    if (!runtime) throw new Error('Missing native runtime');
+    const attachedRoots = new Set([sessionA.kiloSessionId, sessionB.kiloSessionId]);
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- capture before wrap
+    const originalDetach = runtimes.detach;
+    runtimes.detach = identity => {
+      attachedRoots.delete(identity.kiloSessionId);
+      return originalDetach.call(runtimes, identity);
+    };
+    runtimes.rootRetirementScope = (_directory, _target, retiringRoot) =>
+      attachedRoots.has(retiringRoot) ? (attachedRoots.size > 1 ? 'shared' : 'sole') : 'stale';
+    if (!runtimes.retireRuntime) throw new Error('Missing runtime retirement');
+    let retireRuntimeIfUnsharedCalls = 0;
+    runtimes.retireRuntimeIfUnshared = async (directory, target, retiringRoot, deadlineAt) => {
+      retireRuntimeIfUnsharedCalls += 1;
+      if (runtimes.rootRetirementScope?.(directory, target, retiringRoot) === 'shared')
+        return 'shared';
+      const retirement = await runtimes.retireRuntime?.(directory, deadlineAt, target);
+      if (retirement === undefined) throw new Error('Missing runtime retirement');
+      return retirement;
+    };
+    const integratedDeps = createControlHandlerDeps(handlerDeps);
+    const input = {
+      directory: sessionA.directory,
+      root: sessionA.kiloSessionId,
+      nativeRuntimeId: runtime.runtimeId,
+      target: { runtimeId: runtime.runtimeId, client: runtime.kiloClient },
+      reason: 'confirmed publication cleanup',
+      deadlineAt: Date.now() + 5_000,
+    };
+    const authorizationA1 = operationAuthorization('session.prompt', 'message_a1', sessionA);
+    const authorizationA2 = operationAuthorization('session.prompt', 'message_a2', sessionA);
+    const requestA1 = handleControlRequest(
+      'session.prompt',
+      sessionA,
+      { ...promptPayload, messageId: 'message_a1' },
+      integratedDeps,
+      authorizationA1
+    );
+    let requestA2: ReturnType<typeof handleControlRequest> | undefined;
+    try {
+      await startedA1.promise;
+      expect(await requestA1).toMatchObject({ ok: true, result: { status: 'accepted' } });
+      const publication = integratedDeps.operations.escalateRootPublication(input);
+      expect(await publication.physical).toMatchObject({
+        scope: 'root',
+        cleanup: 'confirmed',
+        physical: 'not_attempted',
+        runtimeRetired: false,
+      });
+
+      runningA1.resolve(
+        completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } })
+      );
+      const retainedA1 = integratedDeps.operations
+        .retained()
+        .find(operation => operation.messageId === 'message_a1');
+      if (!retainedA1) throw new Error('Missing retained A1 operation');
+      await retainedA1.done;
+      await retainedA1.waitForDelivery();
+
+      requestA2 = handleControlRequest(
+        'session.prompt',
+        sessionA,
+        { ...promptPayload, messageId: 'message_a2' },
+        integratedDeps,
+        authorizationA2
+      );
+      expect(await requestA2).toMatchObject({ ok: true, result: { status: 'accepted' } });
+      await startedA2.promise;
+      const a2 = integratedDeps.operations.active(sessionA.kiloSessionId);
+      if (!a2) throw new Error('Missing active A2 operation');
+      expect(a2.publicationScope()).toBeUndefined();
+      expect(integratedDeps.operations.retained()).toContain(retainedA1);
+
+      expect(
+        await handleControlRequest('session.detach', sessionB, {}, integratedDeps)
+      ).toMatchObject({
+        ok: true,
+        result: { detached: true },
+      });
+      const stopped = await handleControlRequest(
+        'session.abort',
+        sessionA,
+        {
+          messageId: 'message_a1',
+          operationId: '11111111-1111-4111-8111-111111111111',
+          cleanupDeadlineAt: input.deadlineAt,
+        },
+        integratedDeps
+      );
+      expect(stopped).toMatchObject({
+        ok: true,
+        result: { status: 'already_idle', quiescent: false },
+      });
+      expect(stopped).not.toHaveProperty('result.cleanupScope');
+      expect(stopped).not.toHaveProperty('result.runtimeRetired');
+      expect(retireRuntimeIfUnsharedCalls).toBe(0);
+      expect(integratedDeps.kiloRuntimes?.get(sessionA.directory)).toBe(runtime);
+      expect(runtime.signal.aborted).toBe(false);
+      expect(a2.signal.aborted).toBe(false);
+
+      runningA2.resolve(
+        completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } })
+      );
+      await requestA2;
+    } finally {
+      runningA1.resolve(
+        completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } })
+      );
+      runningA2.resolve(
+        completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } })
+      );
+      await Promise.allSettled([requestA1, ...(requestA2 ? [requestA2] : [])]);
+      for (const operation of integratedDeps.operations.activeOperations()) await operation.done;
+    }
+  });
+
+  it('bounds archived publication claims by their operation owners', async () => {
+    const createRun = () => ({
+      started: Promise.withResolvers<void>(),
+      finalizerStarted: Promise.withResolvers<void>(),
+      finalized: Promise.withResolvers<{ success: boolean }>(),
+    });
+    type Run = ReturnType<typeof createRun>;
+    const runs = new Map<string, Run>();
+    const pendingFinalizers: Run[] = [];
+    const client = fakeKilo({
+      sendPrompt: async options => {
+        const run = runs.get(options.messageId);
+        if (!run) throw new Error(`Missing run for ${options.messageId}`);
+        run.started.resolve();
+        pendingFinalizers.push(run);
+        return completion();
+      },
+      getSessionStatuses: async () => ({
+        kilo_a: { type: 'idle' },
+        kilo_b: { type: 'idle' },
+      }),
+      abortSession: async () => true,
+    });
+    const handlerDeps = deps({
+      kiloClient: client,
+      scopedCleanupResult: true,
+      sendOperationResult: (_session, delivery) => acknowledgeOperation(delivery),
+      runAutoCommit: async () => {
+        const run = pendingFinalizers.shift();
+        if (!run) throw new Error('Missing finalizer run');
+        run.finalizerStarted.resolve();
+        return run.finalized.promise;
+      },
+    });
+    const sessionA = { ...session, sessionId: 'ses_a', kiloSessionId: 'kilo_a' };
+    const sessionB = { ...session, sessionId: 'ses_b', kiloSessionId: 'kilo_b' };
+    rememberAttachedRoot(sessionA.kiloSessionId, sessionA.directory);
+    rememberAttachedRoot(sessionB.kiloSessionId, sessionB.directory);
+    const runtimes = handlerDeps.kiloRuntimes;
+    if (!runtimes) throw new Error('Missing worktree runtimes');
+    const runtime = runtimes.get(sessionA.directory);
+    if (!runtime) throw new Error('Missing native runtime');
+    runtimes.rootRetirementScope = () => 'shared';
+    const integratedDeps = createControlHandlerDeps(handlerDeps);
+    const base = Date.now();
+    const dispatchDeadlineAt = (index: number) =>
+      index === 1 ? base + 10_000_000 : base + index * 100_000;
+    const input = {
+      directory: sessionA.directory,
+      root: sessionA.kiloSessionId,
+      nativeRuntimeId: runtime.runtimeId,
+      target: { runtimeId: runtime.runtimeId, client: runtime.kiloClient },
+      reason: 'repeated publication cleanup',
+      deadlineAt: base + 5_000,
+    };
+    const start = async (index: number) => {
+      const messageId = `message_a${index}`;
+      const run = createRun();
+      runs.set(messageId, run);
+      const authorization = {
+        ...operationAuthorization('session.prompt', messageId, sessionA),
+        dispatchDeadlineAt: dispatchDeadlineAt(index),
+      };
+      const request = handleControlRequest(
+        'session.prompt',
+        sessionA,
+        { ...promptPayload, messageId, finalization: { autoCommit: true } },
+        integratedDeps,
+        authorization
+      );
+      await run.started.promise;
+      await run.finalizerStarted.promise;
+      expect(await request).toMatchObject({ ok: true, result: { status: 'accepted' } });
+      const operation = integratedDeps.operations.active(sessionA.kiloSessionId);
+      if (!operation) throw new Error(`Missing active operation for ${messageId}`);
+      return { operation, run };
+    };
+    const finish = async (
+      run: Run,
+      operation: ReturnType<typeof integratedDeps.operations.active>
+    ) => {
+      if (!operation) throw new Error('Missing operation to finish');
+      run.finalized.resolve({ success: true });
+      await operation.done;
+      await operation.waitForDelivery();
+    };
+    try {
+      const first = await start(1);
+      const firstPublication = integratedDeps.operations.escalateRootPublication(input);
+      expect(await firstPublication.physical).toMatchObject({
+        scope: 'root',
+        cleanup: 'confirmed',
+        physical: 'not_attempted',
+        runtimeRetired: false,
+      });
+      const firstClaim = first.operation.publicationScope()?.claim;
+      if (firstClaim === undefined) throw new Error('Missing first publication claim');
+      await finish(first.run, first.operation);
+
+      const second = await start(2);
+      const secondPublication = integratedDeps.operations.escalateRootPublication(input);
+      expect(second.operation.publicationScope()?.claim).toBeDefined();
+      expect(integratedDeps.operations.admission('session.prompt', sessionA, undefined).kind).toBe(
+        'reply'
+      );
+      expect(integratedDeps.operations.admission('session.prompt', sessionB, undefined).kind).toBe(
+        'continue'
+      );
+      expect(await secondPublication.physical).toMatchObject({
+        scope: 'root',
+        cleanup: 'confirmed',
+        physical: 'not_attempted',
+        runtimeRetired: false,
+      });
+      await finish(second.run, second.operation);
+      expect(integratedDeps.operations.counts().archived).toBe(1);
+      expect(
+        await integratedDeps.operations.escalateRootPublication({
+          ...input,
+          expectedClaim: firstClaim,
+        }).physical
+      ).toMatchObject({ status: 'already_idle', physical: 'not_attempted' });
+
+      let previous = second;
+      for (let index = 3; index <= 7; index += 1) {
+        const next = await start(index);
+        const previousClaim = previous.operation.publicationScope()?.claim;
+        if (previousClaim === undefined) throw new Error('Missing previous publication claim');
+        const publication = integratedDeps.operations.escalateRootPublication(input);
+        expect(await publication.physical).toMatchObject({
+          scope: 'root',
+          cleanup: 'confirmed',
+          physical: 'not_attempted',
+          runtimeRetired: false,
+        });
+        expect(integratedDeps.operations.counts().archived).toBe(2);
+        await finish(next.run, next.operation);
+        integratedDeps.operations.prune(base + (index - 1) * 100_000 + 1);
+        expect(integratedDeps.operations.counts().archived).toBe(1);
+        previous = next;
+      }
+
+      integratedDeps.operations.prune(base + 10_000_001);
+      expect(integratedDeps.operations.counts()).toEqual({ active: 0, retained: 0, archived: 0 });
+    } finally {
+      for (const run of runs.values()) run.finalized.resolve({ success: true });
+      await Promise.allSettled(
+        integratedDeps.operations.activeOperations().map(operation => operation.done)
+      );
+    }
   });
 
   it('does not let a retained A1 Stop reselect fresh active A2 after root invalidation', async () => {

--- a/services/cloud-agent-next/wrapper/src/control/operation-registry.ts
+++ b/services/cloud-agent-next/wrapper/src/control/operation-registry.ts
@@ -43,6 +43,11 @@ type OperationRegistryDependencies = {
       deadlineAt: number,
       reason?: string
     ): Promise<NativeRetirement | 'shared'>;
+    rootRetirementScope?(
+      directory: string,
+      target: NativeOperationTarget,
+      retiringRoot: string
+    ): 'shared' | 'sole' | 'stale';
     verifyQuiescence(
       directory: string,
       target: NativeOperationTarget,
@@ -70,9 +75,18 @@ type ScopedFailure = {
   target?: NativeOperationTarget;
   deadlineAt: number;
   cleanup: Promise<RootScopedCleanupResult>;
-  physical?: Promise<RootScopedCleanupResult | NativeRetirement | 'shared'>;
+  fullCleanup: Promise<RootScopedCleanupResult>;
+  physical?: PhysicalState;
   result?: RootScopedCleanupResult;
   claim: symbol;
+  superseded: boolean;
+};
+
+type PhysicalState = {
+  promise: Promise<RootPublicationDisposition>;
+  disposition?: RootPublicationDisposition;
+  attempt?: PromiseWithResolvers<RootPublicationDisposition>;
+  attemptId?: string;
 };
 
 type RootPublicationInput = {
@@ -85,12 +99,39 @@ type RootPublicationInput = {
   expectedClaim?: symbol;
 };
 
+export type RootPublicationDisposition = {
+  scope: 'root' | 'runtime';
+  status: 'aborted' | 'already_idle' | 'unconfirmed';
+  cleanup: RootScopedCleanupResult;
+  physical: NativeRetirement | 'shared' | 'pending' | 'not_attempted';
+  quiescent: boolean;
+  runtimeRetired: boolean;
+  physicalAttemptStarted: boolean;
+};
+
+type ArchivedScopedClaim = {
+  root: string;
+  nativeRuntimeId: string;
+  directory: string;
+  target?: NativeOperationTarget;
+  cleanup: Promise<RootScopedCleanupResult>;
+};
+
+type RootPhysicalAttempt = {
+  directory: string;
+  root: string;
+  nativeRuntimeId: string;
+  target: NativeOperationTarget;
+  retirementId: string;
+};
+
 type RootPublicationSettlement = {
   directory: string;
   root: string;
   nativeRuntimeId: string;
   target?: NativeOperationTarget;
   result: NativeRetirement;
+  retirementId?: string;
 };
 
 type RootPublicationDisappearance = Omit<RootPublicationSettlement, 'result'>;
@@ -111,12 +152,48 @@ function fail(code: string, message: string, retryable: boolean): ControlHandler
   return { ok: false, error: { code, message, retryable } };
 }
 
+function makeRootPublicationDisposition(
+  scope: 'root' | 'runtime',
+  cleanup: RootScopedCleanupResult,
+  physical: RootPublicationDisposition['physical'],
+  physicalAttemptStarted = physical === 'retired' || physical === 'unconfirmed'
+): RootPublicationDisposition {
+  const runtimeRetired = physical === 'retired';
+  return {
+    scope,
+    status:
+      scope === 'root' && cleanup === 'confirmed'
+        ? 'aborted'
+        : runtimeRetired
+          ? 'aborted'
+          : 'unconfirmed',
+    cleanup,
+    physical,
+    quiescent: runtimeRetired,
+    runtimeRetired,
+    physicalAttemptStarted,
+  };
+}
+
+function makeSupersededRootPublicationDisposition(): RootPublicationDisposition {
+  return {
+    scope: 'runtime',
+    status: 'already_idle',
+    cleanup: 'confirmed',
+    physical: 'not_attempted',
+    quiescent: false,
+    runtimeRetired: false,
+    physicalAttemptStarted: false,
+  };
+}
+
 const ROOT_SCOPED_WORK = new Set(['session.attach', 'session.prompt', 'session.terminal.create']);
 
 export function createOperationRegistry(deps: OperationRegistryDependencies) {
   const active = new Map<string, SessionOperation>();
   const retained = new Map<string, SessionOperation>();
   const scopedFailures = new Map<string, ScopedFailure>();
+  const archivedClaims = new Map<symbol, ArchivedScopedClaim>();
 
   function scopedFailureKey(root: string, nativeRuntimeId: string): string {
     return JSON.stringify([root, nativeRuntimeId]);
@@ -124,6 +201,39 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
 
   function currentRuntime(directory: string) {
     return deps.native.getRetained(directory) ?? deps.native.get(directory);
+  }
+
+  function installPhysical(
+    failure: ScopedFailure,
+    promise: Promise<RootPublicationDisposition>,
+    disposition?: RootPublicationDisposition
+  ): PhysicalState {
+    const physical: PhysicalState = { promise };
+    if (disposition !== undefined) physical.disposition = disposition;
+    failure.physical = physical;
+    if (disposition === undefined) {
+      void promise.then(
+        settled => {
+          if (failure.physical === physical) {
+            physical.disposition = settled;
+          }
+        },
+        () => undefined
+      );
+    }
+    return physical;
+  }
+
+  function installPhysicalAttempt(failure: ScopedFailure, retirementId: string): PhysicalState {
+    const attempt = Promise.withResolvers<RootPublicationDisposition>();
+    const physical: PhysicalState = {
+      promise: attempt.promise,
+      attempt,
+      attemptId: retirementId,
+    };
+    failure.physical = physical;
+    failure.result = 'unconfirmed';
+    return physical;
   }
 
   function compatibleTarget(
@@ -138,11 +248,52 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
     );
   }
 
+  function claimHasOwner(claim: symbol): boolean {
+    return (
+      [...active.values()].some(operation => operation.publicationScope()?.claim === claim) ||
+      [...retained.values()].some(operation => operation.publicationScope()?.claim === claim)
+    );
+  }
+
+  function removeOrphanedArchivedClaims(): void {
+    for (const claim of archivedClaims.keys()) {
+      if (!claimHasOwner(claim)) archivedClaims.delete(claim);
+    }
+  }
+
   function clearStaleScopedFailures(): void {
     for (const [id, failure] of scopedFailures) {
       const runtime = currentRuntime(failure.directory);
       if (runtime && runtime.runtimeId !== failure.nativeRuntimeId) scopedFailures.delete(id);
     }
+    removeOrphanedArchivedClaims();
+  }
+
+  function archiveSupersededFailure(failure: ScopedFailure): void {
+    if (!failure.superseded || failure.result !== 'confirmed') return;
+    if (!claimHasOwner(failure.claim)) {
+      archivedClaims.delete(failure.claim);
+      return;
+    }
+    archivedClaims.set(failure.claim, {
+      root: failure.root,
+      nativeRuntimeId: failure.nativeRuntimeId,
+      directory: failure.directory,
+      target: failure.target,
+      cleanup: failure.cleanup,
+    });
+  }
+
+  function archivedClaimMatches(
+    input: RootPublicationInput,
+    archived: ArchivedScopedClaim
+  ): boolean {
+    return (
+      archived.root === input.root &&
+      archived.nativeRuntimeId === input.nativeRuntimeId &&
+      archived.directory === input.directory &&
+      compatibleTarget(archived.target, input.target)
+    );
   }
 
   function matchingPublicationOperations(input: RootPublicationInput): SessionOperation[] {
@@ -172,19 +323,32 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
       );
       return results.every(result => result === 'confirmed') ? 'confirmed' : 'unconfirmed';
     })().catch(() => 'unconfirmed' as const);
+    const fullCleanup = (async (): Promise<RootScopedCleanupResult> => {
+      if (matching.length === 0) return 'unconfirmed';
+      const results = await Promise.all(
+        matching.map(operation => operation.waitForRootScopedCleanup())
+      );
+      return results.every(result => result === 'confirmed') ? 'confirmed' : 'unconfirmed';
+    })().catch(() => 'unconfirmed' as const);
     const failure: ScopedFailure = {
       root: input.root,
       nativeRuntimeId: input.nativeRuntimeId,
       directory: input.directory,
       cleanup,
+      fullCleanup,
       deadlineAt: input.deadlineAt,
       claim,
+      superseded: false,
     };
     failure.target = input.target;
     failure.deadlineAt = input.deadlineAt;
     failure.cleanup = cleanup;
     scopedFailures.set(scopedFailureKey(input.root, input.nativeRuntimeId), failure);
     void cleanup.then(result => {
+      if (scopedFailures.get(scopedFailureKey(input.root, input.nativeRuntimeId)) === failure)
+        failure.result = result;
+    });
+    void fullCleanup.then(result => {
       if (scopedFailures.get(scopedFailureKey(input.root, input.nativeRuntimeId)) === failure)
         failure.result = result;
     });
@@ -197,15 +361,20 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
     let existing = scopedFailures.get(id);
     if (input.expectedClaim !== undefined) {
       if (
-        !existing ||
-        existing.claim !== input.expectedClaim ||
-        !compatibleTarget(existing.target, input.target)
+        existing &&
+        existing.claim === input.expectedClaim &&
+        compatibleTarget(existing.target, input.target)
       )
-        return Promise.resolve('unconfirmed');
-      return existing.cleanup;
+        return existing.cleanup;
+      const archived = archivedClaims.get(input.expectedClaim);
+      return archived && archivedClaimMatches(input, archived)
+        ? archived.cleanup
+        : Promise.resolve('unconfirmed');
     }
+    if (existing) archiveSupersededFailure(existing);
     if (existing && !compatibleTarget(existing.target, input.target)) {
       scopedFailures.delete(id);
+      removeOrphanedArchivedClaims();
       existing = undefined;
     } else if (existing && existing.result !== 'confirmed') {
       return existing.cleanup;
@@ -216,40 +385,135 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
 
   function escalateRootPublication(input: RootPublicationInput): {
     cleanup: Promise<RootScopedCleanupResult>;
-    physical: Promise<RootScopedCleanupResult | NativeRetirement | 'shared'>;
+    physical: Promise<RootPublicationDisposition>;
+    disposition: () => RootPublicationDisposition;
   } {
     const id = scopedFailureKey(input.root, input.nativeRuntimeId);
+    clearStaleScopedFailures();
     const current = scopedFailures.get(id);
-    if (input.expectedClaim !== undefined && current?.claim !== input.expectedClaim)
-      return { cleanup: Promise.resolve('unconfirmed'), physical: Promise.resolve('stale') };
+    const scopeFor = (): 'root' | 'runtime' =>
+      deps.native.rootRetirementScope?.(
+        input.directory,
+        input.target ?? { runtimeId: input.nativeRuntimeId },
+        input.root
+      ) === 'shared'
+        ? 'root'
+        : 'runtime';
+    const staleDisposition = () =>
+      makeRootPublicationDisposition('runtime', 'unconfirmed', 'stale');
+    if (
+      current?.superseded === true &&
+      input.expectedClaim !== undefined &&
+      current.claim === input.expectedClaim &&
+      compatibleTarget(current.target, input.target)
+    ) {
+      return {
+        cleanup: current.cleanup,
+        physical: Promise.resolve(makeSupersededRootPublicationDisposition()),
+        disposition: makeSupersededRootPublicationDisposition,
+      };
+    }
+    const archived =
+      input.expectedClaim === undefined ? undefined : archivedClaims.get(input.expectedClaim);
+    if (archived && archivedClaimMatches(input, archived)) {
+      return {
+        cleanup: archived.cleanup,
+        physical: Promise.resolve(makeSupersededRootPublicationDisposition()),
+        disposition: makeSupersededRootPublicationDisposition,
+      };
+    }
+    if (current?.superseded === true && input.expectedClaim !== undefined) {
+      return {
+        cleanup: Promise.resolve('unconfirmed'),
+        physical: Promise.resolve(staleDisposition()),
+        disposition: staleDisposition,
+      };
+    }
+    if (input.expectedClaim !== undefined && current?.claim !== input.expectedClaim) {
+      return {
+        cleanup: Promise.resolve('unconfirmed'),
+        physical: Promise.resolve(staleDisposition()),
+        disposition: staleDisposition,
+      };
+    }
     const cleanup = retireRootPublication(input);
     const failure = scopedFailures.get(id);
-    if (!failure) return { cleanup, physical: Promise.resolve('unconfirmed') };
-    if (failure.physical) return { cleanup, physical: failure.physical };
-    failure.physical = cleanup.then(async cleanupResult => {
-      if (scopedFailures.get(id) !== failure) return 'stale';
-      if (cleanupResult === 'confirmed') return cleanupResult;
-      const retirement =
-        (await deps.native.retireRuntimeIfUnshared?.(
-          input.directory,
-          input.target ?? { runtimeId: input.nativeRuntimeId },
-          input.root,
-          input.deadlineAt,
-          input.reason
-        )) ?? 'unconfirmed';
-      if (retirement === 'retired' || retirement === 'stale') {
-        if (scopedFailures.get(id) !== failure) return retirement;
-        settleRootPublication({
-          directory: input.directory,
-          root: input.root,
-          nativeRuntimeId: input.nativeRuntimeId,
-          target: input.target,
-          result: retirement,
-        });
-      }
-      return retirement;
-    });
-    return { cleanup, physical: failure.physical };
+    if (!failure) {
+      return {
+        cleanup,
+        physical: Promise.resolve(staleDisposition()),
+        disposition: staleDisposition,
+      };
+    }
+    const readDisposition = (): RootPublicationDisposition => {
+      const physical = failure.physical;
+      if (physical?.disposition) return physical.disposition;
+      if (physical?.attempt)
+        return makeRootPublicationDisposition(
+          'runtime',
+          failure.result ?? 'unconfirmed',
+          'pending',
+          true
+        );
+      return makeRootPublicationDisposition(scopeFor(), failure.result ?? 'unconfirmed', 'pending');
+    };
+    if (failure.physical?.disposition?.scope === 'root' && scopeFor() !== 'root') {
+      failure.physical = undefined;
+    }
+    if (failure.physical) {
+      return {
+        cleanup,
+        physical: failure.physical.promise,
+        disposition: readDisposition,
+      };
+    }
+    const physical = installPhysical(
+      failure,
+      failure.cleanup.then(async cleanupResult => {
+        if (scopedFailures.get(id) !== failure)
+          return makeRootPublicationDisposition('runtime', cleanupResult, 'stale');
+        const scope = scopeFor();
+        if (cleanupResult === 'confirmed' && scope === 'root') {
+          const disposition = makeRootPublicationDisposition(
+            'root',
+            cleanupResult,
+            'not_attempted'
+          );
+          if (failure.physical === physical) physical.disposition = disposition;
+          return disposition;
+        }
+        const retirement =
+          (await deps.native.retireRuntimeIfUnshared?.(
+            input.directory,
+            input.target ?? { runtimeId: input.nativeRuntimeId },
+            input.root,
+            input.deadlineAt,
+            input.reason
+          )) ?? 'unconfirmed';
+        if (retirement === 'retired' || retirement === 'stale') {
+          if (scopedFailures.get(id) !== failure)
+            return makeRootPublicationDisposition('runtime', cleanupResult, retirement);
+          settleRootPublication({
+            directory: input.directory,
+            root: input.root,
+            nativeRuntimeId: input.nativeRuntimeId,
+            target: input.target,
+            result: retirement,
+          });
+        }
+        const disposition =
+          retirement === 'shared'
+            ? makeRootPublicationDisposition('root', cleanupResult, retirement)
+            : makeRootPublicationDisposition('runtime', cleanupResult, retirement);
+        if (failure.physical === physical) physical.disposition = disposition;
+        return disposition;
+      })
+    );
+    return {
+      cleanup,
+      physical: physical.promise,
+      disposition: readDisposition,
+    };
   }
 
   function settleRootPublication(input: RootPublicationSettlement): void {
@@ -257,8 +521,43 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
     const failure = scopedFailures.get(id);
     if (!failure || failure.directory !== input.directory) return;
     if (!compatibleTarget(failure.target, input.target)) return;
-    if (input.result === 'retired' || input.result === 'stale') scopedFailures.delete(id);
-    else failure.result = 'unconfirmed';
+    const physical = failure.physical;
+    if (physical?.attempt) {
+      if (input.retirementId !== undefined && input.retirementId !== physical.attemptId) return;
+      const disposition = makeRootPublicationDisposition(
+        'runtime',
+        failure.result ?? 'unconfirmed',
+        input.result,
+        true
+      );
+      physical.attempt.resolve(disposition);
+      installPhysical(failure, Promise.resolve(disposition), disposition);
+      if (input.result === 'retired' || input.result === 'stale') {
+        scopedFailures.delete(id);
+        removeOrphanedArchivedClaims();
+      } else failure.result = 'unconfirmed';
+      return;
+    }
+    if (input.result === 'retired' || input.result === 'stale') {
+      scopedFailures.delete(id);
+      removeOrphanedArchivedClaims();
+    } else failure.result = 'unconfirmed';
+  }
+
+  function markRootRetirementStarted(input: RootPhysicalAttempt): void {
+    const id = scopedFailureKey(input.root, input.nativeRuntimeId);
+    const failure = scopedFailures.get(id);
+    if (
+      !failure ||
+      failure.directory !== input.directory ||
+      !compatibleTarget(failure.target, input.target)
+    )
+      return;
+    if (failure.physical?.attempt) {
+      if (failure.physical.attemptId === undefined) failure.physical.attemptId = input.retirementId;
+      return;
+    }
+    installPhysicalAttempt(failure, input.retirementId);
   }
 
   function settleScopedFailuresForIncarnation(
@@ -275,6 +574,7 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
       )
         scopedFailures.delete(id);
     }
+    removeOrphanedArchivedClaims();
   }
 
   function notifyRootDisappeared(input: RootPublicationDisappearance): void {
@@ -282,6 +582,27 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
     const failure = scopedFailures.get(id);
     if (failure?.directory === input.directory && compatibleTarget(failure.target, input.target))
       scopedFailures.delete(id);
+    removeOrphanedArchivedClaims();
+  }
+
+  function markSupersededRootClaims(
+    session: SessionRequestIdentity,
+    work: SessionOperationWork
+  ): void {
+    if (!ROOT_SCOPED_WORK.has(work.operation)) return;
+    clearStaleScopedFailures();
+    const root = rootForSession(session.kiloSessionId, session.directory);
+    if (!root) return;
+    const runtimeId = work.operation === 'session.prompt' ? work.runtime.runtimeId : undefined;
+    for (const failure of scopedFailures.values()) {
+      if (
+        failure.result === 'confirmed' &&
+        failure.directory === session.directory &&
+        failure.root === root &&
+        (runtimeId === undefined || failure.nativeRuntimeId === runtimeId)
+      )
+        failure.superseded = true;
+    }
   }
 
   function publicationFailureBlocks(operation: string, session: SessionRequestIdentity): boolean {
@@ -305,8 +626,10 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
   function prune(now = Date.now()): void {
     for (const [id, operation] of retained) {
       if (!operation.canPrune(now)) continue;
-      if (operation.releaseProcessOwnership()) retained.delete(id);
-      else {
+      if (operation.releaseProcessOwnership()) {
+        retained.delete(id);
+        removeOrphanedArchivedClaims();
+      } else {
         const deadlineAt = operation.captureCleanupDeadline();
         void operation
           .cleanupOwnedWork(deadlineAt)
@@ -316,6 +639,7 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
             const released = operation.releaseProcessOwnership();
             if (!confirmed || !released) operation.reportUnreapedProcessCleanup(!released);
             retained.delete(id);
+            removeOrphanedArchivedClaims();
           });
       }
     }
@@ -473,7 +797,20 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
           deps.retireRuntime(reason);
           return;
         }
-        void retireDirectory(identity.directory, reason, deadlineAt, target).then(retirement => {
+        const retiringRoot =
+          rootForSession(identity.kiloSessionId, identity.directory) ?? identity.kiloSessionId;
+        const retirement = deps.native.retireRuntimeIfUnshared
+          ? deps.native.retireRuntimeIfUnshared(
+              identity.directory,
+              target,
+              retiringRoot,
+              deadlineAt,
+              reason
+            )
+          : deps.native.rootRetirementScope?.(identity.directory, target, retiringRoot) === 'shared'
+            ? Promise.resolve<'shared'>('shared')
+            : retireDirectory(identity.directory, reason, deadlineAt, target);
+        void retirement.then(retirement => {
           if (retirement === 'unconfirmed') deps.retireRuntime(reason);
         });
       },
@@ -484,9 +821,11 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
         }
         if (authorization && !retain && retained.get(key(authorization)) === operation)
           retained.delete(key(authorization));
+        removeOrphanedArchivedClaims();
       },
       onCleanupConfirmed: () => undefined,
     });
+    markSupersededRootClaims(identity, work);
     if (authorization) retained.set(key(authorization), operation);
     active.set(identity.kiloSessionId, operation);
     deps.onStarted(identity, work.operation === 'session.attach');
@@ -499,6 +838,7 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
     retireRootPublication,
     escalateRootPublication,
     settleRootPublication,
+    markRootRetirementStarted,
     notifyRootDisappeared,
     start,
     prune,
@@ -523,7 +863,7 @@ export function createOperationRegistry(deps: OperationRegistryDependencies) {
     activeOperations: () => [...active.values()],
     retireDirectory,
     retained: () => [...retained.values()],
-    counts: () => ({ active: active.size, retained: retained.size }),
+    counts: () => ({ active: active.size, retained: retained.size, archived: archivedClaims.size }),
     async drainDelivery(deadlineAt: number): Promise<void> {
       const timeout = Math.max(0, deadlineAt - Date.now());
       let timer: ReturnType<typeof setTimeout> | undefined;

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.test.ts
@@ -254,6 +254,10 @@ describe('heartbeat version rollout compatibility', () => {
       protocolVersion: 1,
       handshakeComplete: true,
     });
+    expect(previousHelloResultSchema.parse(helloResult({ scopedCleanupResult: true }))).toEqual({
+      protocolVersion: 1,
+      handshakeComplete: true,
+    });
     const heartbeat = previousHeartbeatSchema.parse({
       state: 'idle',
       kilo: { ready: true },
@@ -286,6 +290,19 @@ describe('heartbeat version rollout compatibility', () => {
       }
     }
   );
+
+  it('exposes scoped cleanup results only after the Worker grants the capability', async () => {
+    const fake = new FakeWebSocket();
+    const { client } = createClientFixture({ openWebSocket: () => fake as unknown as WebSocket });
+    try {
+      const connecting = client.connect();
+      await handshake(fake, helloResult({ scopedCleanupResult: true }));
+      await connecting;
+      expect(client.supportsScopedCleanupResult?.()).toBe(true);
+    } finally {
+      client.close();
+    }
+  });
 });
 
 describe('createSandboxControlClient', () => {
@@ -369,6 +386,7 @@ describe('createSandboxControlClient', () => {
           nativeRuntimeRetirement?: boolean;
           connectionRecovery?: boolean;
           eventReceipts?: boolean;
+          scopedCleanupResult?: boolean;
           workingBranches?: boolean;
         };
       };
@@ -384,6 +402,7 @@ describe('createSandboxControlClient', () => {
         nativeRuntimeRetirement: true,
         connectionRecovery: true,
         eventReceipts: true,
+        scopedCleanupResult: true,
         workingBranches: true,
       },
     });

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.ts
@@ -110,6 +110,7 @@ export type SandboxControlClient = {
     reason: string;
     cleanupDeadlineAt: number;
   }): Promise<boolean>;
+  supportsScopedCleanupResult?(): boolean;
 };
 
 type ClientState =
@@ -122,6 +123,7 @@ type ClientState =
       kiloVersionHeartbeat: boolean;
       connectionRecovery: boolean;
       eventReceipts: boolean;
+      scopedCleanupResult: boolean;
     }
   | { kind: 'closed' };
 
@@ -461,6 +463,7 @@ export function createSandboxControlClient(
       let kiloVersionHeartbeat = false;
       let connectionRecovery = false;
       let negotiatedEventReceipts = false;
+      let negotiatedScopedCleanupResult = false;
       let timeout = setTimeout(fail, Math.min(CONNECT_TIMEOUT_MS, deadlineAt - Date.now()));
 
       function dispose(): void {
@@ -521,6 +524,7 @@ export function createSandboxControlClient(
               nativeRuntimeRetirement: true,
               connectionRecovery: true,
               eventReceipts: true,
+              scopedCleanupResult: true,
               workingBranches: true,
             },
             ...(wrapperInstanceId ? { wrapperInstanceId } : {}),
@@ -572,6 +576,7 @@ export function createSandboxControlClient(
           kiloVersionHeartbeat = hello.data.capabilities?.kiloVersionHeartbeat === true;
           connectionRecovery = hello.data.capabilities?.connectionRecovery === true;
           negotiatedEventReceipts = hello.data.capabilities?.eventReceipts === true;
+          negotiatedScopedCleanupResult = hello.data.capabilities?.scopedCleanupResult === true;
           phase = 'status';
           diagnostic('hello_accepted', ws);
           return;
@@ -616,6 +621,7 @@ export function createSandboxControlClient(
           kiloVersionHeartbeat,
           connectionRecovery,
           eventReceipts: negotiatedEventReceipts,
+          scopedCleanupResult: negotiatedScopedCleanupResult,
           dispose: () => {
             clearInterval(keepalive);
             dispose();
@@ -1041,6 +1047,10 @@ export function createSandboxControlClient(
       const report = sendNativeRuntimeRetirement(payload, payload.cleanupDeadlineAt);
       nativeRetirementReports.set(key, report);
       return report;
+    },
+
+    supportsScopedCleanupResult(): boolean {
+      return state.kind === 'ready' && state.scopedCleanupResult;
     },
 
     async publishSessionEvent(payload, session): Promise<boolean> {

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
@@ -176,7 +176,7 @@ function deps(
   });
 }
 
-function runtimeDeps(kiloClient: WrapperKiloClient) {
+function runtimeDeps(kiloClient: WrapperKiloClient, rootScope?: 'shared' | 'sole') {
   const abort = new AbortController();
   const events: SessionEventPayload[] = [];
   const retired: string[] = [];
@@ -184,6 +184,8 @@ function runtimeDeps(kiloClient: WrapperKiloClient) {
   const handlerDeps: HandlerDeps = createControlHandlerDeps({
     ...(() => {
       const base = deps({ kiloClient });
+      if (rootScope !== undefined && base.kiloRuntimes)
+        base.kiloRuntimes.rootRetirementScope = () => rootScope;
       return {
         kiloRuntimes: base.kiloRuntimes,
         worktreeCleanupClient: base.worktreeCleanupClient,
@@ -444,6 +446,22 @@ describe('handleControlRequest', () => {
       ok: false,
       error: { code: 'protocol_error', message: 'session identity is required', retryable: false },
     });
+  });
+
+  it('returns an unconfirmed result without starting late cleanup', async () => {
+    const handlerDeps = deps();
+    const result = await handleControlRequest(
+      'session.abort',
+      session,
+      {
+        messageId: 'late',
+        operationId: '11111111-1111-4111-8111-111111111111',
+        cleanupDeadlineAt: Date.now() - 1,
+      },
+      handlerDeps
+    );
+
+    expect(result).toEqual({ ok: true, result: { status: 'unconfirmed', quiescent: false } });
   });
 
   it('attaches by verifying the kilo session', async () => {
@@ -736,6 +754,137 @@ describe('handleControlRequest', () => {
     const result = await handleControlRequest('session.abort', session, {}, deps({ kiloClient }));
     expect(result).toEqual({ ok: true, result: { status: 'already_idle' } });
     expect(aborted).toEqual([]);
+  });
+
+  it('detaches the terminal only when abort cancels the current task', async () => {
+    const started = Promise.withResolvers<void>();
+    const running = Promise.withResolvers<Completion>();
+    const detached: unknown[] = [];
+    const handlerDeps = deps({
+      kiloClient: fakeKilo({
+        sendPrompt: async () => {
+          started.resolve();
+          return running.promise;
+        },
+        abortSession: async () => {
+          running.resolve(
+            completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } })
+          );
+          return true;
+        },
+      }),
+      terminalRuntime: fakeTerminalRuntime({
+        detachSession: async identity => {
+          detached.push(identity);
+        },
+      }),
+    });
+
+    try {
+      expect(
+        await handleControlRequest('session.prompt', session, promptPayload, handlerDeps)
+      ).toEqual({ ok: true, result: { messageId: 'msg_1', status: 'accepted' } });
+      await started.promise;
+
+      expect(
+        await handleControlRequest(
+          'session.abort',
+          session,
+          { messageId: promptPayload.messageId, cleanupDeadlineAt: Date.now() - 1 },
+          handlerDeps
+        )
+      ).toEqual({ ok: true, result: { status: 'already_idle' } });
+      expect(detached).toEqual([]);
+
+      expect(
+        await handleControlRequest(
+          'session.abort',
+          session,
+          { messageId: promptPayload.messageId },
+          handlerDeps
+        )
+      ).toEqual({ ok: true, result: { status: 'aborted' } });
+      expect(detached).toEqual([session]);
+
+      expect(await handleControlRequest('session.abort', session, {}, handlerDeps)).toEqual({
+        ok: true,
+        result: { status: 'already_idle' },
+      });
+      expect(detached).toEqual([session]);
+    } finally {
+      running.resolve(completion());
+      await waitForTasks(handlerDeps);
+    }
+  });
+
+  it('surfaces terminal cleanup failure from an active abort', async () => {
+    const started = Promise.withResolvers<void>();
+    const running = Promise.withResolvers<Completion>();
+    const handlerDeps = deps({
+      kiloClient: fakeKilo({
+        sendPrompt: async () => {
+          started.resolve();
+          return running.promise;
+        },
+        abortSession: async () => {
+          running.resolve(
+            completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } })
+          );
+          return true;
+        },
+      }),
+      terminalRuntime: fakeTerminalRuntime({
+        detachSession: async () => {
+          throw new ControlTerminalRuntimeError('not_ready', 'Terminal cleanup failed', true);
+        },
+      }),
+    });
+
+    try {
+      await handleControlRequest('session.prompt', session, promptPayload, handlerDeps);
+      await started.promise;
+      expect(
+        await handleControlRequest(
+          'session.abort',
+          session,
+          { messageId: promptPayload.messageId },
+          handlerDeps
+        )
+      ).toEqual({
+        ok: false,
+        error: { code: 'not_ready', message: 'Terminal cleanup failed', retryable: true },
+      });
+    } finally {
+      running.resolve(completion());
+      await waitForTasks(handlerDeps);
+    }
+  });
+
+  it('does not detach an attachment for a stale native runtime abort', async () => {
+    const detached: unknown[] = [];
+    const result = await handleControlRequest(
+      'session.abort',
+      session,
+      { nativeRuntimeId: '11111111-1111-4111-8111-111111111111' },
+      deps({
+        terminalRuntime: fakeTerminalRuntime({
+          detachSession: async identity => {
+            detached.push(identity);
+          },
+        }),
+      })
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: {
+        status: 'aborted',
+        quiescent: true,
+        runtimeRetired: true,
+        nativeRuntimeId: '11111111-1111-4111-8111-111111111111',
+      },
+    });
+    expect(detached).toEqual([]);
   });
 
   it('routes independent roots and their children through the matching worktree client', async () => {
@@ -2456,6 +2605,59 @@ describe('owned control execution', () => {
     }
   });
 
+  it('keeps a shared user Stop root-scoped without a publication claim', async () => {
+    const running = Promise.withResolvers<Completion>();
+    const started = Promise.withResolvers<void>();
+    const { handlerDeps, retired } = runtimeDeps(
+      fakeKilo({
+        sendPrompt: () => {
+          started.resolve();
+          return running.promise;
+        },
+        abortSession: async () => {
+          running.resolve(
+            completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } })
+          );
+          return true;
+        },
+      }),
+      'shared'
+    );
+    handlerDeps.scopedCleanupResult = true;
+    const directoryRetirement = spyOn(handlerDeps.operations, 'retireDirectory');
+    const promptRequest = handleControlRequest(
+      'session.prompt',
+      session,
+      promptPayload,
+      handlerDeps
+    );
+    try {
+      await started.promise;
+      expect(
+        await handleControlRequest(
+          'session.abort',
+          session,
+          {
+            messageId: promptPayload.messageId,
+            operationId: '55555555-5555-4555-8555-555555555555',
+            cleanupDeadlineAt: Date.now() + 1_000,
+          },
+          handlerDeps
+        )
+      ).toEqual({
+        ok: true,
+        result: { status: 'aborted', quiescent: false, cleanupScope: 'root' },
+      });
+      expect(directoryRetirement).not.toHaveBeenCalled();
+      expect(retired).toEqual([]);
+    } finally {
+      running.resolve(completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } }));
+      await Promise.allSettled([promptRequest]);
+      await waitForTasks(handlerDeps);
+      directoryRetirement.mockRestore();
+    }
+  });
+
   it('routes an early publication-scoped failed Stop through shared-root retirement without cancelling B', async () => {
     const runningA = Promise.withResolvers<Completion>();
     const runningB = Promise.withResolvers<Completion>();
@@ -2525,6 +2727,87 @@ describe('owned control execution', () => {
       await Promise.allSettled([requestA, requestB]);
       await waitForTasks(handlerDeps);
       directoryRetirement.mockRestore();
+    }
+  });
+
+  it('detaches A before returning an early shared-root Stop result', async () => {
+    const runningA = Promise.withResolvers<Completion>();
+    const runningB = Promise.withResolvers<Completion>();
+    const startedA = Promise.withResolvers<void>();
+    const startedB = Promise.withResolvers<void>();
+    const detachStarted = Promise.withResolvers<void>();
+    const releaseDetach = Promise.withResolvers<void>();
+    const sibling = { ...session, sessionId: 'ses_b', kiloSessionId: 'kilo_b' };
+    rememberAttachedRoot(sibling.kiloSessionId, sibling.directory);
+    const detached: unknown[] = [];
+    const { handlerDeps } = runtimeDeps(
+      fakeKilo({
+        sendPrompt: options => {
+          if (options.messageId === 'message_a') {
+            startedA.resolve();
+            return runningA.promise;
+          }
+          startedB.resolve();
+          return runningB.promise;
+        },
+      }),
+      'shared'
+    );
+    handlerDeps.scopedCleanupResult = true;
+    handlerDeps.terminalRuntime = fakeTerminalRuntime({
+      detachSession: async identity => {
+        detached.push(identity);
+        detachStarted.resolve();
+        await releaseDetach.promise;
+      },
+    });
+    const requestA = handleControlRequest(
+      'session.prompt',
+      session,
+      { ...promptPayload, messageId: 'message_a' },
+      handlerDeps
+    );
+    const requestB = handleControlRequest(
+      'session.prompt',
+      sibling,
+      { ...promptPayload, messageId: 'message_b' },
+      handlerDeps
+    );
+    try {
+      await startedA.promise;
+      await startedB.promise;
+      const taskA = handlerDeps.operations.active(session.kiloSessionId);
+      if (!taskA) throw new Error('Missing A operation');
+      taskA.markPublicationScoped('publication failure', Date.now() + 1_000);
+
+      const stopping = handleControlRequest(
+        'session.abort',
+        session,
+        {
+          messageId: 'message_a',
+          operationId: '11111111-1111-4111-8111-111111111111',
+          cleanupDeadlineAt: Date.now() + 1_000,
+        },
+        handlerDeps
+      );
+      await detachStarted.promise;
+      expect(detached).toEqual([session]);
+      expect(await Promise.race([stopping, Bun.sleep(20).then(() => 'pending' as const)])).toBe(
+        'pending'
+      );
+      expect(handlerDeps.operations.active(sibling.kiloSessionId)?.signal.aborted).toBe(false);
+
+      releaseDetach.resolve();
+      expect(await stopping).toMatchObject({
+        ok: true,
+        result: { status: 'unconfirmed', quiescent: false, cleanupScope: 'root' },
+      });
+    } finally {
+      releaseDetach.resolve();
+      runningA.resolve(completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } }));
+      runningB.resolve(completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } }));
+      await Promise.allSettled([requestA, requestB]);
+      await waitForTasks(handlerDeps);
     }
   });
 
@@ -2673,6 +2956,74 @@ describe('owned control execution', () => {
       await Promise.allSettled([promptRequest]);
       await waitForTasks(handlerDeps);
       directoryRetirement.mockRestore();
+    }
+  });
+
+  it('acknowledges a shared root cleanup before a blocked root can settle', async () => {
+    const running = Promise.withResolvers<Completion>();
+    const started = Promise.withResolvers<void>();
+    const abortStarted = Promise.withResolvers<void>();
+    const abortPending = Promise.withResolvers<boolean>();
+    const { handlerDeps } = runtimeDeps(
+      fakeKilo({
+        sendPrompt: async () => {
+          started.resolve();
+          return running.promise;
+        },
+        getSessionStatuses: async () => ({ [session.kiloSessionId]: { type: 'active' } }),
+        abortSession: async () => {
+          abortStarted.resolve();
+          return abortPending.promise;
+        },
+      }),
+      'shared'
+    );
+    const runtimes = handlerDeps.kiloRuntimes;
+    if (!runtimes) throw new Error('Missing runtimes');
+    handlerDeps.scopedCleanupResult = true;
+    const prompt = handleControlRequest('session.prompt', session, promptPayload, handlerDeps);
+    try {
+      await started.promise;
+      const stopping = handleControlRequest(
+        'session.abort',
+        session,
+        {
+          messageId: promptPayload.messageId,
+          operationId: '11111111-1111-4111-8111-111111111111',
+          cleanupDeadlineAt: Date.now() + 1_000,
+        },
+        handlerDeps
+      );
+      await abortStarted.promise;
+      const task = handlerDeps.operations.active(session.kiloSessionId);
+      if (!task) throw new Error('Missing A operation');
+      const target = task.nativeTarget();
+      if (!target) throw new Error('Missing A native target');
+      handlerDeps.operations.escalateRootPublication({
+        directory: session.directory,
+        root: session.kiloSessionId,
+        nativeRuntimeId: target.runtimeId,
+        target,
+        reason: 'publication failure',
+        deadlineAt: Date.now() + 1_000,
+      });
+      const response = await Promise.race([
+        stopping,
+        Bun.sleep(100).then(() => 'timed_out' as const),
+      ]);
+      expect(response).not.toBe('timed_out');
+      expect(response).toMatchObject({
+        ok: true,
+        result: {
+          status: 'unconfirmed',
+          quiescent: false,
+          cleanupScope: 'root',
+        },
+      });
+    } finally {
+      abortPending.resolve(false);
+      running.resolve(completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } }));
+      await Promise.allSettled([prompt, waitForTasks(handlerDeps)]);
     }
   });
 

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
@@ -44,7 +44,11 @@ import { isKiloServerUnreachableError, type WrapperKiloClient } from '../kilo-ap
 import type { materializeMessageAttachments } from '../session-bootstrap.js';
 import type { runAutoCommit } from '../auto-commit.js';
 import { rejectBeforeAdmission, type ControlHandlerResult } from './control-handler-result.js';
-import { createOperationRegistry, type OperationRegistry } from './operation-registry.js';
+import {
+  createOperationRegistry,
+  type OperationRegistry,
+  type RootPublicationDisposition,
+} from './operation-registry.js';
 import { applySessionAttach, type AttachPreparingEmitter } from './apply-attach';
 import {
   directoriesForRoot,
@@ -76,6 +80,7 @@ import {
 } from './delete-worktree';
 import { collectWorktreeChanges, collectWorktreeSnapshot } from './worktree-changes';
 import { createNativeObservations, type NativeObservations } from './native-observations.js';
+import type { NativeOperationTarget } from './session-operation-cleanup.js';
 
 export type { ControlHandlerResult } from './control-handler-result.js';
 export type { SessionOperation as OwnedSessionTask } from './session-operation.js';
@@ -213,6 +218,7 @@ export function createSessionActivityRegistry(
 
 export type HandlerDeps = {
   kiloRuntimes?: WorktreeKiloRuntimes;
+  scopedCleanupResult?: boolean | (() => boolean);
   worktreeCleanupClient?: WorktreeKiloCleanupClient;
   operations: OperationRegistry;
   version: string;
@@ -252,6 +258,44 @@ function ok(result: unknown): ControlHandlerResult {
 
 function fail(code: string, message: string, retryable: boolean): ControlHandlerResult {
   return { ok: false, error: { code, message, retryable } };
+}
+
+function supportsScopedCleanupResult(deps: HandlerDeps): boolean {
+  return typeof deps.scopedCleanupResult === 'function'
+    ? deps.scopedCleanupResult()
+    : deps.scopedCleanupResult === true;
+}
+
+function resultForPublicationDisposition(
+  disposition: RootPublicationDisposition,
+  nativeRuntimeId: string,
+  scopedCleanupResultGranted: boolean,
+  delivery?: SessionOperationDelivery
+): ControlHandlerResult {
+  if (disposition.scope === 'root') {
+    return ok({
+      status: scopedCleanupResultGranted ? disposition.status : 'unconfirmed',
+      quiescent: false,
+      ...(scopedCleanupResultGranted ? { cleanupScope: 'root' as const } : {}),
+      ...(delivery ? { delivery } : {}),
+    });
+  }
+  const hasRuntimeDisposition =
+    disposition.physical !== 'stale' && disposition.physical !== 'not_attempted';
+  return ok({
+    status: disposition.runtimeRetired ? 'aborted' : disposition.status,
+    quiescent: disposition.runtimeRetired,
+    ...(scopedCleanupResultGranted && hasRuntimeDisposition
+      ? {
+          cleanupScope: 'runtime' as const,
+          runtimeRetired: disposition.runtimeRetired,
+          ...(disposition.runtimeRetired ? { nativeRuntimeId } : {}),
+        }
+      : disposition.runtimeRetired
+        ? { runtimeRetired: true, nativeRuntimeId }
+        : {}),
+    ...(delivery ? { delivery } : {}),
+  });
 }
 
 function kiloFailure(error: unknown): ControlHandlerResult {
@@ -331,6 +375,10 @@ export async function refreshHeartbeatPayload(
 }
 
 export function createControlHandlerDeps(input: Omit<HandlerDeps, 'operations'>): HandlerDeps {
+  const rootRetirementScope = input.kiloRuntimes?.rootRetirementScope
+    ? (directory: string, target: NativeOperationTarget, retiringRoot: string) =>
+        input.kiloRuntimes?.rootRetirementScope?.(directory, target, retiringRoot) ?? 'stale'
+    : undefined;
   const deps: HandlerDeps = Object.assign(input, {
     operations: createOperationRegistry({
       native: {
@@ -340,14 +388,20 @@ export function createControlHandlerDeps(input: Omit<HandlerDeps, 'operations'>)
         retireRuntime: (directory, deadlineAt, target) =>
           input.kiloRuntimes?.retireRuntime?.(directory, deadlineAt, target) ??
           Promise.resolve('unconfirmed'),
-        retireRuntimeIfUnshared: (directory, target, retiringRoot, deadlineAt, reason) =>
-          input.kiloRuntimes?.retireRuntimeIfUnshared?.(
-            directory,
-            target,
-            retiringRoot,
-            deadlineAt,
-            reason
-          ) ?? Promise.resolve('unconfirmed'),
+        retireRuntimeIfUnshared: (directory, target, retiringRoot, deadlineAt, reason) => {
+          if (input.kiloRuntimes?.retireRuntimeIfUnshared)
+            return input.kiloRuntimes.retireRuntimeIfUnshared(
+              directory,
+              target,
+              retiringRoot,
+              deadlineAt,
+              reason
+            );
+          if (rootRetirementScope?.(directory, target, retiringRoot) === 'shared')
+            return Promise.resolve<'shared'>('shared');
+          return Promise.resolve<'unconfirmed'>('unconfirmed');
+        },
+        ...(rootRetirementScope ? { rootRetirementScope } : {}),
         verifyQuiescence: (directory, target, deadlineAt) =>
           input.kiloRuntimes?.verifyQuiescence?.(directory, target, deadlineAt) ??
           Promise.resolve(false),
@@ -653,11 +707,39 @@ function sessionKiloRuntime(
   return deps.kiloRuntimes?.get(session.directory);
 }
 
+function currentRuntimeMatchesTarget(
+  session: SessionRequestIdentity,
+  target: NativeOperationTarget | undefined,
+  deps: HandlerDeps
+): boolean {
+  if (!target) return false;
+  const runtime =
+    deps.kiloRuntimes?.getRetained?.(session.directory) ??
+    deps.kiloRuntimes?.get(session.directory);
+  return (
+    runtime !== undefined &&
+    runtime.runtimeId === target.runtimeId &&
+    (target.client === undefined || runtime.kiloClient === target.client)
+  );
+}
+
 function terminalFailure(error: unknown): ControlHandlerResult {
   if (error instanceof ControlTerminalRuntimeError || error instanceof WorktreeKiloRuntimeError) {
     return fail(error.code, error.message, error.retryable);
   }
   return fail('not_ready', 'Terminal request failed', isKiloServerUnreachableError(error));
+}
+
+async function detachAbortedTerminal(
+  session: SessionRequestIdentity,
+  deps: HandlerDeps
+): Promise<ControlHandlerResult | undefined> {
+  try {
+    await deps.terminalRuntime?.detachSession(session);
+    return undefined;
+  } catch (error) {
+    return terminalFailure(error);
+  }
 }
 
 async function handleAttach(
@@ -947,6 +1029,7 @@ async function handleAbort(
 ): Promise<ControlHandlerResult> {
   const parsed = sessionAbortPayloadSchema.safeParse(payload ?? {});
   if (!parsed.success) return fail('protocol_error', 'Invalid payload', false);
+  const scopedCleanupResultGranted = supportsScopedCleanupResult(deps);
   if (parsed.data.nativeRuntimeId) {
     const runtime = deps.kiloRuntimes?.getRetained?.(session.directory);
     if (!runtime || runtime.runtimeId !== parsed.data.nativeRuntimeId) {
@@ -965,16 +1048,25 @@ async function handleAbort(
       deadlineAt,
       { runtimeId: parsed.data.nativeRuntimeId, client: runtime.kiloClient }
     );
+    if (retirement === 'retired') {
+      const terminalError = await detachAbortedTerminal(session, deps);
+      if (terminalError) return terminalError;
+    }
     return ok({
       status: retirement === 'unconfirmed' ? 'unconfirmed' : 'aborted',
       quiescent: retirement !== 'unconfirmed',
       ...(retirement === 'retired'
-        ? { runtimeRetired: true, nativeRuntimeId: parsed.data.nativeRuntimeId }
+        ? {
+            runtimeRetired: true,
+            nativeRuntimeId: parsed.data.nativeRuntimeId,
+            ...(scopedCleanupResultGranted ? { cleanupScope: 'runtime' as const } : {}),
+          }
         : {}),
     });
   }
   const task = deps.operations.abortTarget(session, parsed.data.messageId);
   if (task) {
+    const ownsCurrentTask = deps.operations.active(session.kiloSessionId) === task;
     if (
       parsed.data.cleanupDeadlineAt !== undefined &&
       parsed.data.cleanupDeadlineAt <= Date.now()
@@ -990,23 +1082,33 @@ async function handleAbort(
       const result = await task.done;
       if (task.cleanup === 'unconfirmed')
         return fail('not_ready', 'Kilo cancellation was not confirmed', false);
+      if (ownsCurrentTask) {
+        const terminalError = await detachAbortedTerminal(session, deps);
+        if (terminalError) return terminalError;
+      }
       if (!result.ok && task.kind !== 'preparation') return result;
       return ok({ status: 'aborted' });
     }
     const deadlineAt = task.captureCleanupDeadline(
       parsed.data.cleanupDeadlineAt ?? Date.now() + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS
     );
-    let quiescent = await task.cleanupOwnedWork(deadlineAt);
-    const publicationScope = task.publicationScope();
-    const scopedCleanup = publicationScope ? await task.runRootScopedCleanup() : undefined;
-    if (publicationScope) quiescent = false;
-    let runtimeRetired = false;
-    let nativeRuntimeId: string | undefined;
+    let publicationScope = task.publicationScope();
     const target = task.nativeTarget();
-    if (!quiescent && target && publicationScope && scopedCleanup === 'unconfirmed') {
-      const retiringRoot =
-        rootForSession(session.kiloSessionId, session.directory) ?? session.kiloSessionId;
-      const escalation = deps.operations.escalateRootPublication({
+    const ownsCurrentRuntime = currentRuntimeMatchesTarget(session, target, deps);
+    const retiringRoot =
+      rootForSession(session.kiloSessionId, session.directory) ?? session.kiloSessionId;
+    const readRootRetirementScope = () =>
+      target
+        ? deps.kiloRuntimes?.rootRetirementScope?.(session.directory, target, retiringRoot)
+        : undefined;
+    const rootScopeBeforeCleanup = readRootRetirementScope();
+    let escalation: ReturnType<HandlerDeps['operations']['escalateRootPublication']> | undefined;
+    const ensureEscalation = ():
+      | ReturnType<HandlerDeps['operations']['escalateRootPublication']>
+      | undefined => {
+      publicationScope = task.publicationScope();
+      if (!publicationScope || !target || escalation) return escalation;
+      escalation = deps.operations.escalateRootPublication({
         directory: session.directory,
         root: retiringRoot,
         nativeRuntimeId: target.runtimeId,
@@ -1015,11 +1117,107 @@ async function handleAbort(
         deadlineAt: publicationScope.deadlineAt,
         ...(publicationScope.claim === undefined ? {} : { expectedClaim: publicationScope.claim }),
       });
-      const retirement = await escalation.physical;
-      runtimeRetired = retirement === 'retired';
-      if (runtimeRetired) nativeRuntimeId = target.runtimeId;
-      quiescent = retirement === 'retired';
-    } else if (!quiescent && !publicationScope && target && Date.now() < deadlineAt) {
+      publicationScope = task.publicationScope();
+      return escalation;
+    };
+    const sharedRootResult = async (): Promise<ControlHandlerResult | undefined> => {
+      const disposition = escalation?.disposition();
+      if (!publicationScope || disposition?.scope !== 'root' || !scopedCleanupResultGranted)
+        return undefined;
+      task.cancel(publicationScope.reason, 'failed', publicationScope.deadlineAt);
+      if (ownsCurrentTask) {
+        const terminalError = await detachAbortedTerminal(session, deps);
+        if (terminalError) return terminalError;
+      }
+      return resultForPublicationDisposition(
+        disposition,
+        target?.runtimeId ?? '',
+        scopedCleanupResultGranted,
+        task.deliveryResult()
+      );
+    };
+
+    let quiescent = false;
+    let runtimeRetired = false;
+    let nativeRuntimeId: string | undefined;
+    if (publicationScope) {
+      quiescent = await task.cleanupOwnedWork(deadlineAt);
+    } else {
+      const cleanup = task.cleanupOwnedWork(deadlineAt).catch(() => false);
+      const first = await Promise.race([
+        cleanup.then(result => ({ kind: 'cleanup' as const, result })),
+        task.waitForPublicationScope().then(() => ({ kind: 'claim' as const })),
+      ]);
+      if (first.kind === 'claim') {
+        ensureEscalation();
+        const claimedSharedRootResult = await sharedRootResult();
+        if (claimedSharedRootResult) return claimedSharedRootResult;
+        quiescent = await cleanup;
+      } else {
+        quiescent = first.result;
+      }
+    }
+
+    publicationScope = task.publicationScope();
+    ensureEscalation();
+    const settledSharedRootResult = await sharedRootResult();
+    if (settledSharedRootResult) return settledSharedRootResult;
+
+    if (publicationScope && escalation) {
+      const currentDisposition = escalation.disposition();
+      if (currentDisposition.physicalAttemptStarted) {
+        if ((ownsCurrentTask || ownsCurrentRuntime) && currentDisposition.scope === 'runtime') {
+          const terminalError = await detachAbortedTerminal(session, deps);
+          if (terminalError) return terminalError;
+        }
+        return resultForPublicationDisposition(
+          currentDisposition,
+          target?.runtimeId ?? '',
+          scopedCleanupResultGranted,
+          task.deliveryResult()
+        );
+      }
+      const disposition = await escalation.physical;
+      const result = await task.done;
+      if (parsed.data.operationId) {
+        if (
+          (ownsCurrentTask && disposition.scope === 'root') ||
+          ((ownsCurrentTask || ownsCurrentRuntime) && disposition.runtimeRetired)
+        ) {
+          const terminalError = await detachAbortedTerminal(session, deps);
+          if (terminalError) return terminalError;
+        }
+        return resultForPublicationDisposition(
+          disposition,
+          target?.runtimeId ?? '',
+          scopedCleanupResultGranted,
+          task.deliveryResult()
+        );
+      }
+      if (!result.ok && task.kind !== 'preparation') return result;
+      return ok({ status: disposition.status });
+    }
+
+    if (
+      !publicationScope &&
+      (rootScopeBeforeCleanup === 'shared' || readRootRetirementScope() === 'shared') &&
+      scopedCleanupResultGranted
+    ) {
+      await task.done;
+      if (ownsCurrentTask) {
+        const terminalError = await detachAbortedTerminal(session, deps);
+        if (terminalError) return terminalError;
+      }
+      const delivery = task.deliveryResult();
+      return ok({
+        status: quiescent ? 'aborted' : 'unconfirmed',
+        quiescent: false,
+        cleanupScope: 'root' as const,
+        ...(delivery ? { delivery } : {}),
+      });
+    }
+
+    if (!quiescent && !publicationScope && target && Date.now() < deadlineAt) {
       const retirementReason = 'Native cancellation did not settle';
       const retirement = await deps.operations.retireDirectory(
         session.directory,
@@ -1031,11 +1229,18 @@ async function handleAbort(
       if (runtimeRetired) nativeRuntimeId = target.runtimeId;
       quiescent = task.confirmCleanup(retirement !== 'unconfirmed', deadlineAt);
       if (retirement === 'unconfirmed') deps.retireRuntime(retirementReason);
-    } else if (!quiescent && !publicationScope) {
+    } else if (!quiescent) {
       task.requestRetirement('Kilo cancellation failed', deadlineAt);
     }
     const result = await task.done;
     if (parsed.data.operationId) {
+      if (
+        (ownsCurrentTask && quiescent) ||
+        ((ownsCurrentTask || ownsCurrentRuntime) && runtimeRetired)
+      ) {
+        const terminalError = await detachAbortedTerminal(session, deps);
+        if (terminalError) return terminalError;
+      }
       const delivery = task.deliveryResult();
       return ok({
         status: quiescent ? 'aborted' : 'unconfirmed',

--- a/services/cloud-agent-next/wrapper/src/control/session-directories.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-directories.test.ts
@@ -7,6 +7,7 @@ import {
   rememberChildSession,
   resetSessionDirectoryState,
   rootForSession,
+  ownerDirectoryForSession,
 } from './session-directories';
 
 describe('session directory root mappings', () => {
@@ -179,6 +180,32 @@ describe('session directory root mappings', () => {
     expect(directoryForSession('child')).toBeUndefined();
     expect(directoryForSession('nested')).toBeUndefined();
     expect(rootForSession('sibling', '/other')).toBe('sibling');
+  });
+
+  it('resolves a child and grandchild to the root owner directory without changing wire identity', () => {
+    rememberAttachedRoot('root', '/root');
+    rememberChildSession({ childId: 'child', parentId: 'root', directory: '/child' });
+    rememberChildSession({ childId: 'grandchild', parentId: 'child', directory: '/grandchild' });
+
+    expect(
+      ownerDirectoryForSession({
+        kiloSessionId: 'grandchild',
+        rootKiloSessionId: 'root',
+        directory: '/grandchild',
+      })
+    ).toBe('/root');
+  });
+
+  it('fails closed when a child lineage is unresolved', () => {
+    rememberAttachedRoot('root', '/root');
+
+    expect(
+      ownerDirectoryForSession({
+        kiloSessionId: 'unknown-child',
+        rootKiloSessionId: 'root',
+        directory: '/child',
+      })
+    ).toBeUndefined();
   });
 
   it('excludes existing descendants when their external directory gains an independent root', () => {

--- a/services/cloud-agent-next/wrapper/src/control/session-directories.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-directories.ts
@@ -1,3 +1,5 @@
+import type { SessionEventIdentity } from '../../../src/shared/sandbox-control-protocol.js';
+
 const directories = new Map<string, string>();
 const rootBySessionId = new Map<string, string>();
 const rootsByDirectory = new Map<string, Set<string>>();
@@ -118,4 +120,14 @@ export function resetSessionDirectoryState(): void {
 
 export function directoryForSession(kiloSessionId: string | undefined): string | undefined {
   return kiloSessionId ? directories.get(kiloSessionId) : undefined;
+}
+
+export function ownerDirectoryForSession(
+  identity: Pick<SessionEventIdentity, 'kiloSessionId' | 'rootKiloSessionId' | 'directory'>
+): string | undefined {
+  const mappedRoot = rootForSession(identity.kiloSessionId, identity.directory);
+  const root = identity.rootKiloSessionId ?? mappedRoot;
+  if (!root || (mappedRoot !== undefined && mappedRoot !== root)) return undefined;
+  if (identity.kiloSessionId !== root && mappedRoot !== root) return undefined;
+  return directoryForSession(root);
 }

--- a/services/cloud-agent-next/wrapper/src/control/session-operation-cleanup.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-operation-cleanup.test.ts
@@ -169,6 +169,80 @@ describe('SessionOperation cleanup', () => {
     await operation.done;
   });
 
+  it('polls root idleness until a busy root becomes idle within the deadline', async () => {
+    const pending = Promise.withResolvers<ReturnType<typeof completion>>();
+    let statusCalls = 0;
+    const client = fakeKilo({
+      sendPrompt: () => pending.promise,
+      abortSession: async () => true,
+      getSessionStatuses: async () => {
+        statusCalls += 1;
+        return { [session.kiloSessionId]: { type: statusCalls === 1 ? 'busy' : 'idle' } };
+      },
+    });
+    const runtime: WorktreeKiloRuntime = {
+      scopeId: 'worktree_1',
+      runtimeId: 'native_1',
+      directory: session.directory,
+      env: {},
+      kiloClient: client,
+      signal: new AbortController().signal,
+    };
+    const operation = new SessionOperation(
+      session,
+      undefined,
+      { operation: 'session.prompt', payload: promptPayload, runtime },
+      {
+        isCurrent: () => true,
+        getRuntime: () => runtime,
+        verifyQuiescence: async () => {
+          throw new Error('Root-scoped cleanup must not use runtime verification');
+        },
+        retireRuntime: () => {},
+        emitSessionEvent: () => {},
+        onLocalCompletion: () => {},
+        onCleanupConfirmed: () => {},
+      }
+    );
+    for (let index = 0; index < 5 && operation.snapshot().native.state !== 'pending'; index += 1)
+      await Promise.resolve();
+
+    operation.markPublicationScoped('event rejected', Date.now() + 200);
+    expect(await operation.runRootScopedCleanup()).toBe('confirmed');
+    expect(statusCalls).toBeGreaterThanOrEqual(2);
+    pending.resolve(completion({ name: 'MessageAbortedError', data: { message: 'cancelled' } }));
+    await operation.done;
+  });
+
+  it('does not infer root idleness from positive completion evidence without a target', async () => {
+    const operation = new SessionOperation(
+      session,
+      undefined,
+      {
+        operation: 'session.attach',
+        payload: {} as never,
+        apply: async () => ({
+          ok: true as const,
+          result: {},
+        }),
+        onAttached: () => {},
+      },
+      {
+        isCurrent: () => true,
+        getRuntime: () => undefined,
+        verifyQuiescence: async () => true,
+        retireRuntime: () => {},
+        emitSessionEvent: () => {},
+        onLocalCompletion: () => {},
+        onCleanupConfirmed: () => {},
+      }
+    );
+
+    await operation.done;
+    operation.markPublicationScoped('targetless completion', Date.now() + 1_000);
+    expect(await operation.runRootScopedCleanup()).toBe('unconfirmed');
+  });
+
   it('does not accept an idle root while a scoped native child is active', async () => {
     const pending = Promise.withResolvers<ReturnType<typeof completion>>();
     let verified = 0;

--- a/services/cloud-agent-next/wrapper/src/control/session-operation-cleanup.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-operation-cleanup.ts
@@ -25,7 +25,7 @@ export class SessionOperationCleanup {
   private state: CleanupState = 'not_requested';
   private pending?: Promise<boolean>;
   private rootScopedPending?: Promise<RootScopedCleanupResult>;
-  private rootScopedResult?: RootScopedCleanupResult;
+  private rootScopedFull?: Promise<RootScopedCleanupResult>;
   private processStop?: Promise<boolean>;
   private nativeAbort?: Promise<boolean>;
 
@@ -104,32 +104,17 @@ export class SessionOperationCleanup {
     completionEvidence: NativeCleanupEvidence;
     cancel: () => void;
   }): Promise<RootScopedCleanupResult> {
-    if (this.rootScopedResult) return Promise.resolve(this.rootScopedResult);
     if (this.rootScopedPending) return this.rootScopedPending;
 
     const deadlineAt = this.captureDeadline(input.deadlineAt);
-    const processes = this.stopProcesses(deadlineAt);
-    if (input.completionEvidence === 'unconfirmed') input.cancel();
-    this.rootScopedPending = (async () => {
-      if (!(await processes)) return 'unconfirmed';
-      const target = input.target;
-      const client = target?.client;
-      if (!target || !client)
-        return input.completionEvidence === 'unconfirmed' ? 'unconfirmed' : 'confirmed';
-      if (!this.rootCurrent(target, deadlineAt)) return 'unconfirmed';
-      if (
-        input.completionEvidence === 'unconfirmed' &&
-        !(await this.abortNative(target, deadlineAt))
-      )
-        return 'unconfirmed';
-      return (await this.observeRootIdle(target, client, deadlineAt)) ? 'confirmed' : 'unconfirmed';
-    })()
-      .catch(() => 'unconfirmed' as const)
-      .then(result => {
-        this.rootScopedResult = result;
-        return result;
-      });
+    const fullCleanup = this.performRootScopedCleanup(input, deadlineAt);
+    this.rootScopedFull = fullCleanup;
+    this.rootScopedPending = fullCleanup;
     return this.rootScopedPending;
+  }
+
+  waitForRootScopedCleanup(): Promise<RootScopedCleanupResult> {
+    return this.rootScopedFull ?? this.rootScopedPending ?? Promise.resolve('unconfirmed');
   }
 
   confirm(confirmed: boolean, deadlineAt: number): boolean {
@@ -234,11 +219,15 @@ export class SessionOperationCleanup {
             for (const [id, status] of Object.entries(statuses)) {
               if (status.type === 'idle') continue;
               const statusRoot = rootForSession(id, directory);
-              if (!statusRoot) return false;
-              if (statusRoot === root) idle = false;
+              if (!statusRoot || statusRoot === root) {
+                idle = false;
+                break;
+              }
             }
             if (idle) return current();
-            await delay(Math.min(25, Math.max(1, deadlineAt - Date.now())), undefined, { signal });
+            await delay(Math.min(25, Math.max(1, deadlineAt - Date.now())), undefined, {
+              signal,
+            });
           }
           return false;
         }, controller.signal),
@@ -250,6 +239,33 @@ export class SessionOperationCleanup {
       );
     } finally {
       controller.abort();
+    }
+  }
+
+  private async performRootScopedCleanup(
+    input: {
+      deadlineAt: number;
+      target?: NativeOperationTarget;
+      completionEvidence: NativeCleanupEvidence;
+      cancel: () => void;
+    },
+    deadlineAt: number
+  ): Promise<RootScopedCleanupResult> {
+    const processes = this.stopProcesses(deadlineAt);
+    if (input.completionEvidence === 'unconfirmed') input.cancel();
+    const target = input.target;
+    const client = target?.client;
+    const native =
+      target && client && input.completionEvidence === 'unconfirmed'
+        ? this.abortNative(target, deadlineAt)
+        : Promise.resolve(target && client ? true : false);
+    try {
+      const [processesStopped, nativeAccepted] = await Promise.all([processes, native]);
+      if (!processesStopped || !nativeAccepted || !target || !client) return 'unconfirmed';
+      if (!this.rootCurrent(target, deadlineAt)) return 'unconfirmed';
+      return (await this.observeRootIdle(target, client, deadlineAt)) ? 'confirmed' : 'unconfirmed';
+    } catch {
+      return 'unconfirmed';
     }
   }
 

--- a/services/cloud-agent-next/wrapper/src/control/session-operation.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-operation.ts
@@ -128,6 +128,12 @@ class ControlTaskCancellation extends Error {
   }
 }
 
+type PublicationScope = Readonly<{
+  reason: string;
+  deadlineAt: number;
+  claim?: symbol;
+}>;
+
 function fail(message: string, retryable: boolean): ControlHandlerResult {
   return { ok: false, error: { code: 'not_ready', message, retryable } };
 }
@@ -146,6 +152,7 @@ export class SessionOperation {
   readonly processes: OwnedProcessScope;
   private readonly controller = new AbortController();
   private readonly completion = Promise.withResolvers<ControlHandlerResult>();
+  private readonly publicationScopeChanged = Promise.withResolvers<PublicationScope>();
   private readonly intent: ReturnType<typeof operationIntent>;
   private readonly startedAt = Date.now();
   private readonly timeout: ReturnType<typeof setTimeout>;
@@ -161,11 +168,8 @@ export class SessionOperation {
   private delivery?: OperationResultDelivery;
   private readonly cleanupOwner: SessionOperationCleanup;
   private deadlineCleanup?: Promise<boolean>;
-  private publicationScoped?: Readonly<{
-    reason: string;
-    deadlineAt: number;
-    claim?: symbol;
-  }>;
+  private publicationScoped?: PublicationScope;
+  private publicationScopeNotified = false;
 
   constructor(
     session: SessionRequestIdentity,
@@ -293,10 +297,20 @@ export class SessionOperation {
             : { claim: claim ?? this.publicationScoped.claim }),
         }
       : { reason, deadlineAt: captured, ...(claim === undefined ? {} : { claim }) };
+    if (!this.publicationScopeNotified && this.publicationScoped) {
+      this.publicationScopeNotified = true;
+      this.publicationScopeChanged.resolve(this.publicationScoped);
+    }
   }
 
   publicationScope(): Readonly<{ reason: string; deadlineAt: number; claim?: symbol }> | undefined {
     return this.publicationScoped;
+  }
+
+  waitForPublicationScope(): Promise<PublicationScope> {
+    return this.publicationScoped
+      ? Promise.resolve(this.publicationScoped)
+      : this.publicationScopeChanged.promise;
   }
 
   runRootScopedCleanup(
@@ -312,6 +326,10 @@ export class SessionOperation {
       completionEvidence: this.cleanupEvidence(),
       cancel: () => this.cancel(scoped.reason, 'failed', scoped.deadlineAt),
     });
+  }
+
+  waitForRootScopedCleanup(): Promise<RootScopedCleanupResult> {
+    return this.cleanupOwner.waitForRootScopedCleanup();
   }
 
   snapshot() {

--- a/services/cloud-agent-next/wrapper/src/control/terminal-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/terminal-runtime.test.ts
@@ -251,7 +251,49 @@ describe('control terminal PTY ownership', () => {
 
     rememberAttachedRoot(firstSession.kiloSessionId, '/workspace/different');
     expect(() => runtime.rememberAttachedSession(firstSession)).toThrow(
-      'Terminal session ownership mismatch'
+      'Terminal session belongs to another session'
+    );
+  });
+
+  it('names unavailable, replaced, and conflicting terminal attachment runtimes', () => {
+    const unavailable = createControlTerminalRuntime({
+      controlUrl: 'ws://127.0.0.1:1/sandbox-control/unavailable',
+      wrapperInstanceId,
+      getKiloRuntime: () => undefined,
+    });
+    activeRuntimes.add(unavailable);
+    rememberAttachedRoot(firstSession.kiloSessionId, firstSession.directory);
+    expect(() => unavailable.rememberAttachedSession(firstSession)).toThrow(
+      'Terminal session runtime unavailable'
+    );
+
+    const initial: WorktreeKiloRuntime = {
+      runtimeId: 'native_initial',
+      scopeId: firstSession.directory,
+      directory: firstSession.directory,
+      env: {},
+      kiloClient: fakeKilo(),
+      signal: new AbortController().signal,
+    };
+    let current = initial;
+    const replaced = createControlTerminalRuntime({
+      controlUrl: 'ws://127.0.0.1:1/sandbox-control/replaced',
+      wrapperInstanceId,
+      getKiloRuntime: () => current,
+    });
+    activeRuntimes.add(replaced);
+    rememberAttachedRoot(firstSession.kiloSessionId, firstSession.directory);
+    replaced.rememberAttachedSession(firstSession);
+    current = { ...initial, runtimeId: 'native_replacement' };
+    expect(() => replaced.rememberAttachedSession(firstSession)).toThrow(
+      'Terminal session runtime was replaced'
+    );
+
+    const otherSession = { ...firstSession, sessionId: 'workspace_other' };
+    const conflicting = createRuntime(fakeKilo());
+    attach(conflicting, firstSession);
+    expect(() => attach(conflicting, otherSession)).toThrow(
+      'Terminal session belongs to another session'
     );
   });
 

--- a/services/cloud-agent-next/wrapper/src/control/terminal-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/terminal-runtime.ts
@@ -405,25 +405,37 @@ export function createControlTerminalRuntime(options: {
   return {
     rememberAttachedSession(identity) {
       const kiloRuntime = options.getKiloRuntime(identity.directory);
+      if (shutDown || !kiloRuntime) {
+        throw new ControlTerminalRuntimeError(
+          'unauthorized',
+          'Terminal session runtime unavailable',
+          false
+        );
+      }
       if (
-        shutDown ||
-        !kiloRuntime ||
         directoryForSession(identity.kiloSessionId) !== identity.directory ||
         rootForSession(identity.kiloSessionId) !== identity.kiloSessionId
       ) {
         throw new ControlTerminalRuntimeError(
           'unauthorized',
-          'Terminal session ownership mismatch',
+          'Terminal session belongs to another session',
           false
         );
       }
 
       const existing = attachedSessions.get(identity.sessionId);
       if (existing) {
-        if (!sameSession(existing, identity) || existing.kiloRuntime !== kiloRuntime) {
+        if (!sameSession(existing, identity)) {
           throw new ControlTerminalRuntimeError(
             'unauthorized',
-            'Terminal session ownership mismatch',
+            'Terminal session belongs to another session',
+            false
+          );
+        }
+        if (existing.kiloRuntime !== kiloRuntime) {
+          throw new ControlTerminalRuntimeError(
+            'unauthorized',
+            'Terminal session runtime was replaced',
             false
           );
         }
@@ -434,7 +446,7 @@ export function createControlTerminalRuntime(options: {
         if (attached.kiloSessionId === identity.kiloSessionId) {
           throw new ControlTerminalRuntimeError(
             'unauthorized',
-            'Terminal session ownership mismatch',
+            'Terminal session belongs to another session',
             false
           );
         }

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import {
   buildWorktreeKiloEnvironment,
   createWorktreeKiloRuntimes,
+  isRetirementReportCurrent,
   startWorktreeKiloServer,
   type RootRuntimeRetirement,
   type WorktreeKiloAuth,
@@ -34,6 +35,7 @@ import {
 } from './terminal-runtime';
 import { applySessionAttach, type ApplyAttachDeps } from './apply-attach';
 import { childFromSessionCreated, eventKiloSessionId, sessionEventIdentity } from './feed';
+import { operationAuthorization } from './control-test-fixtures';
 import {
   directoryForSession,
   rememberChildSession,
@@ -113,7 +115,7 @@ function createKiloStub(health: unknown = { healthy: true, version: '7.4.20' }) 
   const feeds = new Set<ReadableStreamDefaultController<Uint8Array>>();
   const encoder = new TextEncoder();
   let feedConnections = 0;
-  let heldPrompts: PromiseWithResolvers<void> | undefined;
+  const heldPrompts = new Map<string, PromiseWithResolvers<void>>();
   const server = Bun.serve({
     port: 0,
     hostname: '127.0.0.1',
@@ -163,10 +165,12 @@ function createKiloStub(health: unknown = { healthy: true, version: '7.4.20' }) 
         return Response.json(true);
       }
       if (request.method === 'POST' && url.pathname.endsWith('/abort')) {
-        heldPrompts?.resolve();
+        const sessionId = decodeURIComponent(url.pathname.split('/')[2] ?? '');
+        heldPrompts.get(sessionId)?.resolve();
         return Response.json(true);
       }
       if (request.method === 'POST' && /\/session\/[^/]+\/(message|command)$/.test(url.pathname)) {
+        const sessionId = decodeURIComponent(url.pathname.split('/')[2] ?? '');
         const directory = requests.at(-1)?.directory ?? '';
         const completion: Awaited<ReturnType<WrapperKiloClient['sendPrompt']>> = {
           info: {
@@ -185,7 +189,7 @@ function createKiloStub(health: unknown = { healthy: true, version: '7.4.20' }) 
           },
           parts: [],
         };
-        await heldPrompts?.promise;
+        await heldPrompts.get(sessionId)?.promise;
         return Response.json(completion);
       }
       if (request.method === 'GET' && url.pathname.startsWith('/session/')) {
@@ -219,11 +223,11 @@ function createKiloStub(health: unknown = { healthy: true, version: '7.4.20' }) 
     emit(event: unknown) {
       for (const feed of feeds) feed.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
     },
-    holdPrompts() {
-      heldPrompts ??= Promise.withResolvers<void>();
+    holdPrompts(sessionId: string) {
+      heldPrompts.set(sessionId, Promise.withResolvers<void>());
     },
-    releasePrompts() {
-      heldPrompts?.resolve();
+    releasePrompts(sessionId: string) {
+      heldPrompts.get(sessionId)?.resolve();
     },
     endFeeds() {
       for (const feed of feeds) feed.close();
@@ -325,6 +329,9 @@ function createIntegratedRegistry(
   const context: { handlerDeps?: HandlerDeps } = {};
   const settlements: RootRuntimeRetirement[] = [];
   const harness = createRegistry({
+    onRootRetirementStarted: attempt => {
+      context.handlerDeps?.operations.markRootRetirementStarted(attempt);
+    },
     onRootRetirement: settlement => {
       settlements.push(settlement);
       context.handlerDeps?.operations.settleRootPublication(settlement);
@@ -430,6 +437,87 @@ describe('observed Kilo runtime version', () => {
       expect(registry.isHealthy()).toBe(true);
     }
   );
+});
+
+describe('retirement report ownership', () => {
+  it('only permits shutdown when the retired entry is still current', () => {
+    const retiredRuntimeId = 'retired-runtime';
+
+    expect(isRetirementReportCurrent(undefined, retiredRuntimeId)).toBe(true);
+    expect(isRetirementReportCurrent(retiredRuntimeId, retiredRuntimeId)).toBe(true);
+    expect(isRetirementReportCurrent('replacement-runtime', retiredRuntimeId)).toBe(false);
+  });
+
+  it('exposes a replacement entry while startup is pending', async () => {
+    const replacementStarted = Promise.withResolvers<void>();
+    const releaseReplacement = Promise.withResolvers<void>();
+    const retirements: RootRuntimeRetirement[] = [];
+    let launches = 0;
+    const harness = createRegistry({
+      startServer: async options => {
+        launches += 1;
+        const server = createKiloStub();
+        servers.push(server);
+        options.onProcessScope?.({ stop: async () => true } as unknown as OwnedProcessScope);
+        if (launches === 2) {
+          replacementStarted.resolve();
+          await releaseReplacement.promise;
+        }
+        return { url: server.url, close: () => {} };
+      },
+      onRootRetirement: retirement => retirements.push(retirement),
+    });
+    const directory = path.join(tmpDir, 'retirement-report-replacement');
+    const firstIdentity = rootIdentity(directory, 'first');
+    const siblingIdentity = rootIdentity(directory, 'sibling');
+    const first = harness.registry.attach(firstIdentity, auth);
+    const runtime = await first.ready;
+    first.commit();
+    const sibling = harness.registry.attach(siblingIdentity, auth);
+    await sibling.ready;
+    sibling.commit();
+    const retiredRuntimeId = runtime.runtimeId;
+    try {
+      expect(
+        await harness.registry.retireRuntimeIfUnshared?.(
+          directory,
+          { runtimeId: retiredRuntimeId, client: runtime.kiloClient },
+          firstIdentity.kiloSessionId,
+          Date.now() + 1_000,
+          'event rejected'
+        )
+      ).toBe('shared');
+      expect(harness.registry.detach(siblingIdentity)).toBe(true);
+      await waitUntil(() => retirements.some(retirement => retirement.result === 'retired'));
+      expect(harness.registry.getEntryRuntimeId?.(directory)).toBeUndefined();
+
+      const replacement = harness.registry.attach(rootIdentity(directory, 'replacement'), auth);
+      await replacementStarted.promise;
+      const replacementRuntimeId = harness.registry.getEntryRuntimeId?.(directory);
+      expect(replacementRuntimeId).toBeDefined();
+      expect(replacementRuntimeId).not.toBe(retiredRuntimeId);
+      expect(harness.registry.get(directory)).toBeUndefined();
+      expect(isRetirementReportCurrent(replacementRuntimeId, retiredRuntimeId)).toBe(false);
+      expect(replacement.signal.aborted).toBe(false);
+
+      releaseReplacement.resolve();
+      const replacementRuntime = await replacement.ready;
+      replacement.commit();
+      replacement.release();
+      expect(harness.registry.getEntryRuntimeId?.(directory)).toBe(replacementRuntime.runtimeId);
+      expect(harness.registry.get(directory)).toBe(replacementRuntime);
+      expect(replacement.signal.aborted).toBe(false);
+      const completion = await replacementRuntime.kiloClient.sendPrompt({
+        sessionId: 'root_replacement',
+        messageId: 'replacement_message',
+        prompt: 'complete replacement work',
+      });
+      expect(completion.info.parentID).toBe('replacement_message');
+    } finally {
+      releaseReplacement.resolve();
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+  });
 });
 
 describe('worktree Kilo environments', () => {
@@ -1524,7 +1612,7 @@ describe('worktree Kilo runtime registry', () => {
       agent: { mode: 'code', model: 'test' },
     };
     server.sessionStatuses[identity.kiloSessionId] = { type: 'idle' };
-    server.holdPrompts();
+    server.holdPrompts(identity.kiloSessionId);
     server.permissions.push({
       id: 'permission_recovery',
       sessionID: identity.kiloSessionId,
@@ -1605,7 +1693,7 @@ describe('worktree Kilo runtime registry', () => {
       expect(runtime.kiloClient).toBe(client);
       expect(harness.unexpectedCloses).toBe(0);
     } finally {
-      server.releasePrompts();
+      server.releasePrompts(identity.kiloSessionId);
       timers.mockRestore();
     }
   });
@@ -2502,9 +2590,13 @@ setInterval(() => {}, 1000);
 
   it('reports immediate root retirement with its captured incarnation even without a deferred intent', async () => {
     const reports: string[] = [];
+    const attempts: string[] = [];
     const harness = createRegistry({
-      onRootRetirement: retirement =>
-        reports.push(`${retirement.root}:${retirement.nativeRuntimeId}:${retirement.result}`),
+      onRootRetirementStarted: retirement => attempts.push(retirement.retirementId),
+      onRootRetirement: retirement => {
+        reports.push(`${retirement.root}:${retirement.nativeRuntimeId}:${retirement.result}`);
+        expect(retirement.retirementId).toBe(attempts[0]);
+      },
     });
     const directory = path.join(tmpDir, 'immediate-root-retirement');
     const attachment = harness.registry.attach(rootIdentity(directory), auth);
@@ -2523,6 +2615,7 @@ setInterval(() => {}, 1000);
       )
     ).toBe('retired');
     expect(reports).toEqual([`root_immediate-root-retirement:${runtime.runtimeId}:retired`]);
+    expect(attempts).toHaveLength(1);
     expect(harness.closes).toBe(1);
   });
 
@@ -2684,6 +2777,542 @@ setInterval(() => {}, 1000);
 });
 
 describe('runtime-to-registry root settlement', () => {
+  it('allows A to reattach after a retained completed operation retires its runtime', async () => {
+    const harness = createRegistry();
+    const handlerDeps = createHandlerDeps(harness.registry);
+    const identity = rootIdentity(path.join(tmpDir, 'retained-abort-reattach'), 'a');
+    const prompt = {
+      messageId: 'retained_abort_a1',
+      turn: { type: 'prompt' as const, prompt: 'completed A work' },
+      agent: { mode: 'code', model: 'test' },
+    };
+    const authorization = operationAuthorization('session.prompt', prompt.messageId, identity);
+
+    expect(
+      await handleControlRequest('session.attach', identity, { kilo: auth }, handlerDeps)
+    ).toEqual({ ok: true, result: { attached: true } });
+    const runtime = harness.registry.get(identity.directory);
+    if (!runtime) throw new Error('Missing attached runtime');
+
+    try {
+      expect(
+        await handleControlRequest('session.prompt', identity, prompt, handlerDeps, authorization)
+      ).toMatchObject({
+        ok: true,
+        result: { messageId: prompt.messageId, status: 'accepted' },
+      });
+      await waitUntil(() =>
+        handlerDeps.operations
+          .retained()
+          .some(operation => operation.messageId === prompt.messageId)
+      );
+      const task = handlerDeps.operations
+        .retained()
+        .find(operation => operation.messageId === prompt.messageId);
+      if (!task) throw new Error('Missing retained operation');
+      await task.done;
+      expect(task.locallyComplete).toBe(true);
+      expect(handlerDeps.operations.active(identity.kiloSessionId)).toBeUndefined();
+      task.markPublicationScoped('retained publication failure', Date.now() + 1_000);
+
+      expect(
+        await handleControlRequest(
+          'session.abort',
+          identity,
+          {
+            messageId: prompt.messageId,
+            operationId: '33333333-3333-4333-8333-333333333333',
+            cleanupDeadlineAt: Date.now() + 1_000,
+          },
+          handlerDeps
+        )
+      ).toMatchObject({
+        ok: true,
+        result: {
+          status: 'aborted',
+          quiescent: true,
+          runtimeRetired: true,
+          nativeRuntimeId: runtime.runtimeId,
+        },
+      });
+      expect(harness.registry.get(identity.directory)).toBeUndefined();
+
+      expect(
+        await handleControlRequest('session.attach', identity, { kilo: auth }, handlerDeps)
+      ).toEqual({ ok: true, result: { attached: true } });
+      const replacement = harness.registry.get(identity.directory);
+      expect(replacement).toBeDefined();
+      expect(replacement).not.toBe(runtime);
+      expect(
+        (
+          await handleControlRequest(
+            'session.terminal.create',
+            identity,
+            { operationId: crypto.randomUUID() },
+            handlerDeps
+          )
+        ).ok
+      ).toBe(true);
+    } finally {
+      await Promise.allSettled(
+        handlerDeps.operations.activeOperations().map(operation => operation.done)
+      );
+    }
+  });
+
+  it('allows A to reattach after a sole active abort replaces its runtime', async () => {
+    const harness = createRegistry();
+    const handlerDeps = createHandlerDeps(harness.registry);
+    const identity = rootIdentity(path.join(tmpDir, 'abort-reattach'), 'a');
+    expect(
+      await handleControlRequest('session.attach', identity, { kilo: auth }, handlerDeps)
+    ).toEqual({ ok: true, result: { attached: true } });
+    const runtime = harness.registry.get(identity.directory);
+    const server = servers.at(-1);
+    if (!runtime || !server) throw new Error('Missing attached runtime');
+    server.holdPrompts(identity.kiloSessionId);
+    const prompt = {
+      messageId: 'abort_reattach_a1',
+      turn: { type: 'prompt' as const, prompt: 'active A work' },
+      agent: { mode: 'code', model: 'test' },
+    };
+    const promptRequest = handleControlRequest('session.prompt', identity, prompt, handlerDeps);
+
+    try {
+      expect(await promptRequest).toEqual({
+        ok: true,
+        result: { messageId: prompt.messageId, status: 'accepted' },
+      });
+      await waitUntil(() =>
+        server.requests.some(
+          request => request.pathname === `/session/${identity.kiloSessionId}/message`
+        )
+      );
+      const task = handlerDeps.operations.active(identity.kiloSessionId);
+      if (!task) throw new Error('Missing active operation');
+      task.markPublicationScoped('sole publication failure', Date.now() + 1_000);
+
+      expect(
+        await handleControlRequest(
+          'session.abort',
+          identity,
+          {
+            messageId: prompt.messageId,
+            operationId: '11111111-1111-4111-8111-111111111111',
+          },
+          handlerDeps
+        )
+      ).toMatchObject({
+        ok: true,
+        result: {
+          status: 'aborted',
+          quiescent: true,
+          runtimeRetired: true,
+          nativeRuntimeId: runtime.runtimeId,
+        },
+      });
+      expect(harness.registry.get(identity.directory)).toBeUndefined();
+
+      expect(
+        await handleControlRequest('session.attach', identity, { kilo: auth }, handlerDeps)
+      ).toEqual({ ok: true, result: { attached: true } });
+      const replacement = harness.registry.get(identity.directory);
+      expect(replacement).toBeDefined();
+      expect(replacement).not.toBe(runtime);
+      expect(
+        (
+          await handleControlRequest(
+            'session.terminal.create',
+            identity,
+            { operationId: crypto.randomUUID() },
+            handlerDeps
+          )
+        ).ok
+      ).toBe(true);
+    } finally {
+      server.releasePrompts(identity.kiloSessionId);
+      await Promise.allSettled([promptRequest]);
+    }
+  });
+
+  it('detaches A before returning a failed non-scoped abort so A can reattach', async () => {
+    const harness = createRegistry({
+      startServer: async options => {
+        const server = createKiloStub();
+        servers.push(server);
+        options.onProcessScope?.({
+          stop: async () => true,
+          verify: async () => true,
+        } as unknown as OwnedProcessScope);
+        return { url: server.url, close: () => {} };
+      },
+    });
+    const handlerDeps = createHandlerDeps(harness.registry);
+    handlerDeps.emitSessionEvent = () => false;
+    const identity = rootIdentity(path.join(tmpDir, 'failed-abort-reattach'), 'a');
+    expect(
+      await handleControlRequest('session.attach', identity, { kilo: auth }, handlerDeps)
+    ).toEqual({ ok: true, result: { attached: true } });
+    const runtime = harness.registry.get(identity.directory);
+    const server = servers.at(-1);
+    if (!runtime || !server) throw new Error('Missing attached runtime');
+    server.holdPrompts(identity.kiloSessionId);
+    const prompt = {
+      messageId: 'failed_abort_a1',
+      turn: { type: 'prompt' as const, prompt: 'active A work' },
+      agent: { mode: 'code', model: 'test' },
+    };
+    const promptRequest = handleControlRequest('session.prompt', identity, prompt, handlerDeps);
+
+    try {
+      expect(await promptRequest).toEqual({
+        ok: true,
+        result: { messageId: prompt.messageId, status: 'accepted' },
+      });
+      await waitUntil(() =>
+        server.requests.some(
+          request => request.pathname === `/session/${identity.kiloSessionId}/message`
+        )
+      );
+
+      expect(
+        await handleControlRequest(
+          'session.abort',
+          identity,
+          { messageId: prompt.messageId },
+          handlerDeps
+        )
+      ).toEqual({
+        ok: false,
+        error: { code: 'not_ready', message: 'Session outcome delivery failed', retryable: false },
+      });
+      expect(
+        server.requests.some(
+          request => request.pathname === `/session/${identity.kiloSessionId}/abort`
+        )
+      ).toBe(true);
+      expect(
+        await harness.registry.retireRuntime?.(identity.directory, Date.now() + 1_000, {
+          runtimeId: runtime.runtimeId,
+          client: runtime.kiloClient,
+        })
+      ).toBe('retired');
+      expect(harness.registry.get(identity.directory)).toBeUndefined();
+
+      expect(
+        await handleControlRequest('session.attach', identity, { kilo: auth }, handlerDeps)
+      ).toEqual({ ok: true, result: { attached: true } });
+      const replacement = harness.registry.get(identity.directory);
+      expect(replacement).toBeDefined();
+      expect(replacement).not.toBe(runtime);
+      expect(
+        (
+          await handleControlRequest(
+            'session.terminal.create',
+            identity,
+            { operationId: crypto.randomUUID() },
+            handlerDeps
+          )
+        ).ok
+      ).toBe(true);
+    } finally {
+      server.releasePrompts(identity.kiloSessionId);
+      await Promise.allSettled([promptRequest]);
+    }
+  });
+
+  it('keeps B attached while A aborts and reattaches on a shared runtime', async () => {
+    const harness = createRegistry();
+    const handlerDeps = createHandlerDeps(harness.registry);
+    handlerDeps.scopedCleanupResult = true;
+    const directory = path.join(tmpDir, 'shared-abort-reattach');
+    const identityA = rootIdentity(directory, 'a');
+    const identityB = rootIdentity(directory, 'b');
+    for (const identity of [identityA, identityB]) {
+      expect(
+        await handleControlRequest('session.attach', identity, { kilo: auth }, handlerDeps)
+      ).toEqual({ ok: true, result: { attached: true } });
+    }
+    const runtime = harness.registry.get(directory);
+    const server = servers.at(-1);
+    if (!runtime || !server) throw new Error('Missing shared runtime');
+    server.holdPrompts(identityA.kiloSessionId);
+    const prompt = {
+      messageId: 'shared_abort_a1',
+      turn: { type: 'prompt' as const, prompt: 'active A work' },
+      agent: { mode: 'code', model: 'test' },
+    };
+    const promptRequest = handleControlRequest('session.prompt', identityA, prompt, handlerDeps);
+
+    try {
+      expect(await promptRequest).toEqual({
+        ok: true,
+        result: { messageId: prompt.messageId, status: 'accepted' },
+      });
+      await waitUntil(() =>
+        server.requests.some(
+          request => request.pathname === `/session/${identityA.kiloSessionId}/message`
+        )
+      );
+      const taskA = handlerDeps.operations.active(identityA.kiloSessionId);
+      if (!taskA) throw new Error('Missing A operation');
+      taskA.markPublicationScoped('shared publication failure', Date.now() + 1_000);
+
+      expect(
+        await handleControlRequest(
+          'session.abort',
+          identityA,
+          {
+            messageId: prompt.messageId,
+            operationId: '22222222-2222-4222-8222-222222222222',
+            cleanupDeadlineAt: Date.now() + 1_000,
+          },
+          handlerDeps
+        )
+      ).toMatchObject({
+        ok: true,
+        result: { status: 'unconfirmed', quiescent: false, cleanupScope: 'root' },
+      });
+      expect(rootForSession(identityB.kiloSessionId, directory)).toBe(identityB.kiloSessionId);
+      expect(harness.registry.get(directory)).toBe(runtime);
+
+      await Promise.all(handlerDeps.operations.activeOperations().map(operation => operation.done));
+      expect(
+        (
+          await handleControlRequest(
+            'session.terminal.create',
+            identityB,
+            { operationId: crypto.randomUUID() },
+            handlerDeps
+          )
+        ).ok
+      ).toBe(true);
+      expect(
+        await handleControlRequest('session.attach', identityA, { kilo: auth }, handlerDeps)
+      ).toEqual({ ok: true, result: { attached: true } });
+      expect(harness.registry.get(directory)).toBe(runtime);
+      expect(
+        (
+          await handleControlRequest(
+            'session.terminal.create',
+            identityA,
+            { operationId: crypto.randomUUID() },
+            handlerDeps
+          )
+        ).ok
+      ).toBe(true);
+    } finally {
+      server.releasePrompts(identityA.kiloSessionId);
+      await Promise.allSettled([promptRequest]);
+      await Promise.allSettled(
+        handlerDeps.operations.activeOperations().map(operation => operation.done)
+      );
+    }
+  });
+
+  it('isolates a user Stop from B when both shared roots have active prompts', async () => {
+    const integrated = createIntegratedRegistry();
+    const directory = path.join(tmpDir, 'shared-user-stop');
+    const identityA = rootIdentity(directory, 'a');
+    const identityB = rootIdentity(directory, 'b');
+    for (const identity of [identityA, identityB]) {
+      expect(
+        await handleControlRequest(
+          'session.attach',
+          identity,
+          { kilo: auth },
+          integrated.handlerDeps
+        )
+      ).toEqual({ ok: true, result: { attached: true } });
+    }
+    const runtime = integrated.registry.get(directory);
+    const server = servers.at(-1);
+    if (!runtime || !server) throw new Error('Missing shared runtime');
+    for (const identity of [identityA, identityB]) {
+      expect(
+        (
+          await handleControlRequest(
+            'session.terminal.create',
+            identity,
+            { operationId: crypto.randomUUID() },
+            integrated.handlerDeps
+          )
+        ).ok
+      ).toBe(true);
+    }
+
+    integrated.handlerDeps.scopedCleanupResult = true;
+    server.holdPrompts(identityA.kiloSessionId);
+    server.holdPrompts(identityB.kiloSessionId);
+    server.sessionStatuses[identityA.kiloSessionId] = { type: 'busy' };
+    server.sessionStatuses[identityB.kiloSessionId] = { type: 'busy' };
+    const promptA = {
+      messageId: 'user_stop_a1',
+      turn: { type: 'prompt' as const, prompt: 'active A work' },
+      agent: { mode: 'code', model: 'test' },
+    };
+    const promptB = {
+      ...promptA,
+      messageId: 'user_stop_b1',
+      turn: { type: 'prompt' as const, prompt: 'active B work' },
+    };
+    const promptARequest = handleControlRequest(
+      'session.prompt',
+      identityA,
+      promptA,
+      integrated.handlerDeps
+    );
+    const promptBRequest = handleControlRequest(
+      'session.prompt',
+      identityB,
+      promptB,
+      integrated.handlerDeps
+    );
+    let taskA: ReturnType<typeof integrated.handlerDeps.operations.active>;
+    let taskB: ReturnType<typeof integrated.handlerDeps.operations.active>;
+    try {
+      expect(await promptARequest).toMatchObject({
+        ok: true,
+        result: { messageId: promptA.messageId, status: 'accepted' },
+      });
+      expect(await promptBRequest).toMatchObject({
+        ok: true,
+        result: { messageId: promptB.messageId, status: 'accepted' },
+      });
+      await waitUntil(
+        () =>
+          server.requests.some(
+            request => request.pathname === `/session/${identityA.kiloSessionId}/message`
+          ) &&
+          server.requests.some(
+            request => request.pathname === `/session/${identityB.kiloSessionId}/message`
+          )
+      );
+      taskA = integrated.handlerDeps.operations.active(identityA.kiloSessionId);
+      taskB = integrated.handlerDeps.operations.active(identityB.kiloSessionId);
+      if (!taskA || !taskB) throw new Error('Missing active shared-root operations');
+      expect(taskA.signal.aborted).toBe(false);
+      expect(taskB.signal.aborted).toBe(false);
+
+      const stopped = await handleControlRequest(
+        'session.abort',
+        identityA,
+        {
+          messageId: promptA.messageId,
+          operationId: '44444444-4444-4444-8444-444444444444',
+          cleanupDeadlineAt: Date.now() + 1_000,
+        },
+        integrated.handlerDeps
+      );
+      await taskA.done;
+      expect(stopped).toMatchObject({
+        ok: true,
+        result: { status: 'unconfirmed', quiescent: false, cleanupScope: 'root' },
+      });
+      expect(stopped).not.toHaveProperty('result.runtimeRetired');
+      expect(taskA.cleanup).toBe('unconfirmed');
+      expect(taskB.signal.aborted).toBe(false);
+      expect(integrated.handlerDeps.operations.active(identityB.kiloSessionId)).toBe(taskB);
+      expect(taskB.snapshot().native.state).toBe('pending');
+      server.releasePrompts(identityB.kiloSessionId);
+      expect(await taskB.done).toMatchObject({ ok: true });
+      expect(rootForSession(identityB.kiloSessionId, directory)).toBe(identityB.kiloSessionId);
+      expect(integrated.registry.get(directory)).toBe(runtime);
+      expect(runtime.signal.aborted).toBe(false);
+      expect(integrated.settlements).toEqual([]);
+
+      expect(
+        await handleControlRequest(
+          'session.attach',
+          identityA,
+          { kilo: auth },
+          integrated.handlerDeps
+        )
+      ).toEqual({ ok: true, result: { attached: true } });
+      for (const identity of [identityB, identityA]) {
+        expect(
+          (
+            await handleControlRequest(
+              'session.terminal.create',
+              identity,
+              { operationId: crypto.randomUUID() },
+              integrated.handlerDeps
+            )
+          ).ok
+        ).toBe(true);
+      }
+      await Promise.resolve();
+      expect(integrated.settlements).toEqual([]);
+    } finally {
+      server.releasePrompts(identityA.kiloSessionId);
+      server.releasePrompts(identityB.kiloSessionId);
+      await Promise.allSettled([promptARequest, promptBRequest]);
+      if (taskA) await Promise.allSettled([taskA.done]);
+      if (taskB) await Promise.allSettled([taskB.done]);
+    }
+  });
+
+  it('does not detach a replacement attachment for a stale native runtime abort', async () => {
+    const harness = createRegistry();
+    const handlerDeps = createHandlerDeps(harness.registry);
+    const identity = rootIdentity(path.join(tmpDir, 'stale-abort-attachment'), 'a');
+    expect(
+      await handleControlRequest('session.attach', identity, { kilo: auth }, handlerDeps)
+    ).toEqual({ ok: true, result: { attached: true } });
+    const initial = harness.registry.get(identity.directory);
+    if (!initial) throw new Error('Missing initial runtime');
+
+    expect(
+      await handleControlRequest(
+        'session.abort',
+        identity,
+        { nativeRuntimeId: initial.runtimeId },
+        handlerDeps
+      )
+    ).toMatchObject({
+      ok: true,
+      result: {
+        status: 'aborted',
+        quiescent: true,
+        runtimeRetired: true,
+        nativeRuntimeId: initial.runtimeId,
+      },
+    });
+    expect(
+      await handleControlRequest('session.attach', identity, { kilo: auth }, handlerDeps)
+    ).toEqual({ ok: true, result: { attached: true } });
+    const replacement = harness.registry.get(identity.directory);
+    if (!replacement) throw new Error('Missing replacement runtime');
+    expect(replacement).not.toBe(initial);
+
+    expect(
+      await handleControlRequest(
+        'session.abort',
+        identity,
+        { nativeRuntimeId: initial.runtimeId },
+        handlerDeps
+      )
+    ).toEqual({
+      ok: true,
+      result: {
+        status: 'aborted',
+        quiescent: true,
+        runtimeRetired: true,
+        nativeRuntimeId: initial.runtimeId,
+      },
+    });
+    expect(
+      (
+        await handleControlRequest(
+          'session.terminal.create',
+          identity,
+          { operationId: crypto.randomUUID() },
+          handlerDeps
+        )
+      ).ok
+    ).toBe(true);
+  });
+
   it('keeps a shared runtime alive after confirmed A cleanup, fresh A work, and B detach', async () => {
     const integrated = createIntegratedRegistry();
     const directory = path.join(tmpDir, 'confirmed-shared-runtime');
@@ -2712,7 +3341,7 @@ describe('runtime-to-registry root settlement', () => {
     const runtime = integrated.registry.get(directory);
     const server = servers.at(-1);
     if (!runtime || !server) throw new Error('Missing shared runtime');
-    server.holdPrompts();
+    server.holdPrompts(identityA.kiloSessionId);
     const prompt = {
       messageId: 'confirmed_a1',
       turn: { type: 'prompt' as const, prompt: 'confirm root cleanup' },
@@ -2740,7 +3369,14 @@ describe('runtime-to-registry root settlement', () => {
         reason: 'confirmed publication cleanup',
         deadlineAt: Date.now() + 1_000,
       });
-      expect(await escalation.physical).toBe('confirmed');
+      expect(await escalation.physical).toMatchObject({
+        scope: 'root',
+        status: 'aborted',
+        cleanup: 'confirmed',
+        physical: 'not_attempted',
+        quiescent: false,
+        runtimeRetired: false,
+      });
       expect(integrated.registry.get(directory)).toBe(runtime);
       await promptRequest;
       await waitForTasks();
@@ -2761,9 +3397,72 @@ describe('runtime-to-registry root settlement', () => {
       expect(runtime.signal.aborted).toBe(false);
       expect(integrated.closes).toBe(0);
     } finally {
-      server.releasePrompts();
+      server.releasePrompts(identityA.kiloSessionId);
       await Promise.allSettled([promptRequest]);
       await waitForTasks();
+    }
+  });
+
+  it('uses current membership when B attaches while sole-root cleanup is polling', async () => {
+    const integrated = createIntegratedRegistry();
+    const directory = path.join(tmpDir, 'membership-interleaving');
+    const identityA = rootIdentity(directory, 'a');
+    const identityB = rootIdentity(directory, 'b');
+    expect(
+      await handleControlRequest(
+        'session.attach',
+        identityA,
+        { kilo: auth },
+        integrated.handlerDeps
+      )
+    ).toMatchObject({ ok: true });
+    const runtime = integrated.registry.get(directory);
+    const server = servers.at(-1);
+    if (!runtime || !server) throw new Error('Missing sole runtime');
+    server.holdPrompts(identityA.kiloSessionId);
+    server.sessionStatuses[identityA.kiloSessionId] = { type: 'busy' };
+    const promptRequest = handleControlRequest(
+      'session.prompt',
+      identityA,
+      {
+        messageId: 'interleave_a',
+        turn: { type: 'prompt' as const, prompt: 'A cleanup' },
+        agent: { mode: 'code', model: 'test' },
+      },
+      integrated.handlerDeps
+    );
+    try {
+      await waitUntil(
+        () =>
+          integrated.handlerDeps.operations.active(identityA.kiloSessionId)?.snapshot().native
+            .state === 'pending'
+      );
+      const escalation = integrated.handlerDeps.operations.escalateRootPublication({
+        directory,
+        root: identityA.kiloSessionId,
+        nativeRuntimeId: runtime.runtimeId,
+        target: { runtimeId: runtime.runtimeId, client: runtime.kiloClient },
+        reason: 'interleaved publication failure',
+        deadlineAt: Date.now() + 1_000,
+      });
+      const attachmentB = integrated.registry.attach(identityB, auth);
+      await attachmentB.ready;
+      attachmentB.commit();
+      attachmentB.release();
+      server.sessionStatuses[identityA.kiloSessionId] = { type: 'idle' };
+
+      const disposition = await escalation.physical;
+      expect(disposition).toMatchObject({
+        scope: 'root',
+        physical: 'not_attempted',
+        runtimeRetired: false,
+        quiescent: false,
+      });
+      expect(integrated.registry.get(directory)).toBe(runtime);
+      expect(runtime.signal.aborted).toBe(false);
+    } finally {
+      server.releasePrompts(identityA.kiloSessionId);
+      await Promise.allSettled([promptRequest]);
     }
   });
 

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
@@ -62,9 +62,30 @@ export type RootRuntimeRetirement = {
   nativeRuntimeId: string;
   target: NativeOperationTarget;
   result: NativeRetirement;
+  retirementId?: string;
+  reason?: string;
+  cleanupDeadlineAt?: number;
+  reportToService?: boolean;
 };
 
-export type RootRuntimeDisappearance = Omit<RootRuntimeRetirement, 'result'>;
+export type RootRuntimeRetirementStarted = {
+  directory: string;
+  root: string;
+  nativeRuntimeId: string;
+  target: NativeOperationTarget;
+  retirementId: string;
+  reason: string;
+  cleanupDeadlineAt: number;
+  reportToService?: boolean;
+};
+
+export type RootRuntimeDisappearance = {
+  directory: string;
+  root: string;
+  nativeRuntimeId: string;
+  target: NativeOperationTarget;
+};
+export type RootRetirementScope = 'shared' | 'sole' | 'stale';
 
 export type WorktreeKiloRuntimes = {
   readonly kiloCliVersion?: string | null;
@@ -90,12 +111,18 @@ export type WorktreeKiloRuntimes = {
     deadlineAt: number,
     reason?: string
   ): Promise<NativeRetirement | 'shared'>;
+  rootRetirementScope?(
+    directory: string,
+    target: NativeOperationTarget,
+    retiringRoot: string
+  ): RootRetirementScope;
   verifyQuiescence?(
     directory: string,
     target: NativeOperationTarget,
     deadlineAt: number
   ): Promise<boolean>;
   getRetained?(directory: string): WorktreeKiloRuntime | undefined;
+  getEntryRuntimeId?(directory: string): string | undefined;
   get(directory: string): WorktreeKiloRuntime | undefined;
   prepareForNewWork?(directory: string): boolean;
   isHealthy(): boolean;
@@ -174,6 +201,13 @@ export class WorktreeKiloRuntimeError extends Error {
     super(message);
     this.name = 'WorktreeKiloRuntimeError';
   }
+}
+
+export function isRetirementReportCurrent(
+  currentRuntimeId: string | undefined,
+  retiredRuntimeId: string
+): boolean {
+  return currentRuntimeId === undefined || currentRuntimeId === retiredRuntimeId;
 }
 
 export function buildWorktreeKiloEnvironment(
@@ -348,6 +382,7 @@ export function createWorktreeKiloRuntimes(options: {
   inheritedEnv?: NodeJS.ProcessEnv;
   startServer?: (options: ServerOptions) => Promise<WorktreeKiloServerHandle>;
   onEvent?: (runtime: WorktreeKiloRuntime, event: WorktreeKiloEvent) => unknown;
+  onRootRetirementStarted?: (retirement: RootRuntimeRetirementStarted) => void;
   onRootRetirement?: (retirement: RootRuntimeRetirement) => void;
   onRootDisappeared?: (disappearance: RootRuntimeDisappearance) => void;
   onDiagnostic?: ControlDiagnosticReporter;
@@ -421,12 +456,7 @@ export function createWorktreeKiloRuntimes(options: {
   }
 
   function reportRootRetirement(
-    intent: {
-      directory: string;
-      root: string;
-      nativeRuntimeId: string;
-      target: NativeOperationTarget;
-    },
+    intent: Omit<RootRuntimeRetirement, 'result'>,
     result: NativeRetirement
   ): void {
     options.onRootRetirement?.({ ...intent, result });
@@ -512,7 +542,11 @@ export function createWorktreeKiloRuntimes(options: {
           now >= intent.deadlineAt
             ? now + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS
             : Math.min(intent.deadlineAt, now + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS);
-        void retire(entry, physicalDeadlineAt, intent.target);
+        void retire(entry, physicalDeadlineAt, intent.target, {
+          reason: intent.reason,
+          cleanupDeadlineAt: physicalDeadlineAt,
+          reportToService: true,
+        });
       }
     } finally {
       evaluatingDeferredRetirements.delete(entry);
@@ -540,10 +574,30 @@ export function createWorktreeKiloRuntimes(options: {
   function retire(
     entry: RuntimeEntry,
     requested?: number,
-    target?: NativeOperationTarget
+    target?: NativeOperationTarget,
+    metadata: {
+      reason?: string;
+      cleanupDeadlineAt?: number;
+      reportToService?: boolean;
+    } = {}
   ): Promise<NativeRetirement> {
     const settlementTarget = target ?? { runtimeId: entry.runtimeId, client: entry.kiloClient };
     const affectedRoots = [...entry.roots].map(root => root.identity.kiloSessionId);
+    const retirementId = crypto.randomUUID();
+    const cleanupDeadlineAt =
+      metadata.cleanupDeadlineAt ?? requested ?? Date.now() + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS;
+    const reason = metadata.reason ?? 'Native runtime retirement requested';
+    for (const root of affectedRoots)
+      options.onRootRetirementStarted?.({
+        directory: entry.directory,
+        root,
+        nativeRuntimeId: settlementTarget.runtimeId,
+        target: settlementTarget,
+        retirementId,
+        reason,
+        cleanupDeadlineAt,
+        ...(metadata.reportToService ? { reportToService: true } : {}),
+      });
     const retirement = retireWorktreeRuntime(entry, requested, target, {
       cleanupDeadline,
       unregisterRoot,
@@ -566,6 +620,10 @@ export function createWorktreeKiloRuntimes(options: {
               root,
               nativeRuntimeId: settlementTarget.runtimeId,
               target: settlementTarget,
+              retirementId,
+              reason,
+              cleanupDeadlineAt,
+              ...(metadata.reportToService ? { reportToService: true } : {}),
             },
             result
           );
@@ -619,7 +677,24 @@ export function createWorktreeKiloRuntimes(options: {
       return Promise.resolve('shared');
     }
     deferredRetirements.delete(deferredRetirementKey(retiringRoot, target.runtimeId));
-    return retire(entry, Date.now() + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS, target);
+    const physicalDeadlineAt = Date.now() + SANDBOX_CONTROL_CLEANUP_TIMEOUT_MS;
+    return retire(entry, physicalDeadlineAt, target, {
+      reason,
+      cleanupDeadlineAt: physicalDeadlineAt,
+      reportToService: true,
+    });
+  }
+
+  function rootRetirementScope(
+    directory: string,
+    target: NativeOperationTarget,
+    retiringRoot: string
+  ): RootRetirementScope {
+    const entry = entries.get(directory);
+    if (!entry || entry.retiring || !runtimeTargetMatches(entry, target)) return 'stale';
+    const failedRoot = [...entry.roots].find(root => root.identity.kiloSessionId === retiringRoot);
+    if (!failedRoot || !(failedRoot.attached || failedRoot.pending.size > 0)) return 'stale';
+    return liveRoots(entry).some(root => root !== failedRoot) ? 'shared' : 'sole';
   }
 
   function removeRoot(root: RootAttachment): void {
@@ -633,7 +708,10 @@ export function createWorktreeKiloRuntimes(options: {
     if (entry.abort.signal.aborted) return;
     const deadlineAt = cleanupDeadline(entry);
     const runtimeId = entry.runtimeId;
-    void retire(entry, deadlineAt).then(result => {
+    void retire(entry, deadlineAt, undefined, {
+      reason,
+      cleanupDeadlineAt: deadlineAt,
+    }).then(result => {
       if (result === 'unconfirmed') failedDirectories.add(entry.directory);
       options.onUnexpectedClose({
         retirementId: crypto.randomUUID(),
@@ -1075,6 +1153,7 @@ export function createWorktreeKiloRuntimes(options: {
     async retireRuntimeIfUnshared(directory, target, retiringRoot, deadlineAt, reason) {
       return retireRuntimeIfUnshared(directory, target, retiringRoot, deadlineAt, reason);
     },
+    rootRetirementScope,
     async verifyQuiescence(directory, target, deadlineAt) {
       const entry = entries.get(directory);
       if (
@@ -1096,6 +1175,9 @@ export function createWorktreeKiloRuntimes(options: {
     },
     getRetained(directory) {
       return entries.get(directory)?.runtime;
+    },
+    getEntryRuntimeId(directory) {
+      return entries.get(directory)?.runtimeId;
     },
     get(directory) {
       const entry = entries.get(directory);


### PR DESCRIPTION
## Summary
- Isolate scoped Stop across the service boundary.
- Release operation-only root cleanup without fencing sibling chats.
- Keep per-root claims from retiring a successor; reject root+quiescence on the strict abort-result reader.
- Preserve shared-root retirement without a kilo runtime; detach terminals only after successful abort retirement.

## Test plan
- [ ] cloud-agent-next wrapper unit tests for abort, worktree, terminal, operation-registry