### PR TITLE
feat(mobile): bring GitLab and Bitbucket pull request review to GitHub parity (stack 10/30)

### DIFF
--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -338,9 +338,7 @@
       "banner": {
         "title": "Not available on this provider",
         "accessibility": "Not available on this provider: {{reason}}"
-      },
-      "autoMergeUnavailable": "Auto-merge is not available",
-      "autoMergeUnavailableReason": "Bitbucket Cloud does not expose auto-merge in its API"
+      }
     },
     "merge": {
       "merge": "Merge",


### PR DESCRIPTION
> **Not verified.** kwf reopened this section on 2026-09-09: publication failed: level 2: pr-api: HTTP/2.0 422 Unprocessable Entity
pr-api: date: Wed, 09 Sep 2026 17:39:45 GMT
pr-api: x-ratelimit-limit: 5000
pr-api: x-ratelimit-remaining: 4901
pr-api: x-ratelimit-used: 99
pr-api: x-ratelimit-reset: 1788978098
pr-api: x-ratelimit-resource: core
pr-api: x-githu
> The proof below came from an earlier round and can be stale. Do not review until this note is gone.

Level 10 of the `bring-mobile-gitlab-and-bitb-3792` stack.

- chore: translate the new catalog keys into every locale (kwf bring-mobile-gitlab-and-bitb-3792/s-final)

## PR stack (merge bottom to top)
- level 1: #6006 (`kwf/bring-mobile-gitlab-and-bitb-3792-l1`)
- level 2: `kwf/bring-mobile-gitlab-and-bitb-3792-l2`
- level 3: `kwf/bring-mobile-gitlab-and-bitb-3792-l3`
- level 4: `kwf/bring-mobile-gitlab-and-bitb-3792-l4`
- level 5: #6007 (`kwf/bring-mobile-gitlab-and-bitb-3792-l5`)
- level 6: #6008 (`kwf/bring-mobile-gitlab-and-bitb-3792-l6`)
- level 7: `kwf/bring-mobile-gitlab-and-bitb-3792-l7`
- level 8: `kwf/bring-mobile-gitlab-and-bitb-3792-l8`
- level 9: `kwf/bring-mobile-gitlab-and-bitb-3792-l9`
- level 10: #6009 (`kwf/bring-mobile-gitlab-and-bitb-3792-l10`) ← this PR
- level 11: #6010 (`kwf/bring-mobile-gitlab-and-bitb-3792-l11`)
- level 12: `kwf/bring-mobile-gitlab-and-bitb-3792-l12`
- level 13: #6011 (`kwf/bring-mobile-gitlab-and-bitb-3792-l13`)
- level 14: `kwf/bring-mobile-gitlab-and-bitb-3792-l14`
- level 15: #6012 (`kwf/bring-mobile-gitlab-and-bitb-3792-l15`)
- level 16: #6013 (`kwf/bring-mobile-gitlab-and-bitb-3792-l16`)
- level 17: `kwf/bring-mobile-gitlab-and-bitb-3792-l17`
- level 18: `kwf/bring-mobile-gitlab-and-bitb-3792-l18`
- level 19: #6014 (`kwf/bring-mobile-gitlab-and-bitb-3792-l19`)
- level 20: `kwf/bring-mobile-gitlab-and-bitb-3792-l20`
- level 21: `kwf/bring-mobile-gitlab-and-bitb-3792-l21`
- level 23: #6015 (`kwf/bring-mobile-gitlab-and-bitb-3792-l23`)
- level 24: #6016 (`kwf/bring-mobile-gitlab-and-bitb-3792-l24`)
- level 25: #6017 (`kwf/bring-mobile-gitlab-and-bitb-3792-l25`)
- level 26: #6018 (`kwf/bring-mobile-gitlab-and-bitb-3792-l26`)
- level 27: #6019 (`kwf/bring-mobile-gitlab-and-bitb-3792-l27`)
- level 28: #6020 (`kwf/bring-mobile-gitlab-and-bitb-3792-l28`)
- level 29: `kwf/bring-mobile-gitlab-and-bitb-3792-l29`
- level 30: #6021 (`kwf/bring-mobile-gitlab-and-bitb-3792-l30`)
