### PR TITLE
feat(mobile): bring GitLab and Bitbucket pull request review to GitHub parity (stack 15/30)

### DIFF
--- a/apps/mobile/src/components/organization/credit-activity-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/organization/credit-activity-screen.mounted.test.tsx
@@ -344,7 +344,7 @@ describe('OrganizationCreditActivityScreen pagination', () => {
     const texts = await renderScreen();
 
     expect(texts).toContain('Top-up');
-    expect(texts).toContain("Couldn't load more.");
+    expect(texts).toContain("Couldn't load more");
     expect(texts).not.toContain('Older credit activity is available.');
 
     const retry = buttons.rendered.find(button => button.accessibilityLabel === 'Retry');
@@ -383,7 +383,7 @@ describe('OrganizationCreditActivityScreen pagination', () => {
 
     expect(texts).toContain('Top-up');
     expect(texts).toContain('Older credit activity is available.');
-    expect(texts).not.toContain("Couldn't load more.");
+    expect(texts).not.toContain("Couldn't load more");
     expect(buttons.rendered.some(button => button.accessibilityLabel === 'Load more')).toBe(true);
   });
 });

--- a/apps/mobile/src/components/organization/invoices-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/organization/invoices-screen.mounted.test.tsx
@@ -331,7 +331,7 @@ describe('OrganizationInvoicesScreen pagination', () => {
     const texts = await renderScreen();
 
     expect(texts).toContain('INV-0001');
-    expect(texts).toContain("Couldn't load more.");
+    expect(texts).toContain("Couldn't load more");
     expect(texts).not.toContain('Older invoices are available.');
 
     const retry = buttons.rendered.find(button => button.accessibilityLabel === 'Retry');
@@ -370,7 +370,7 @@ describe('OrganizationInvoicesScreen pagination', () => {
 
     expect(texts).toContain('INV-0001');
     expect(texts).toContain('Older invoices are available.');
-    expect(texts).not.toContain("Couldn't load more.");
+    expect(texts).not.toContain("Couldn't load more");
     expect(buttons.rendered.some(button => button.accessibilityLabel === 'Load more')).toBe(true);
   });
 });

--- a/apps/mobile/src/components/pr-review/merge/pr-merge-sheet.tsx
+++ b/apps/mobile/src/components/pr-review/merge/pr-merge-sheet.tsx
@@ -144,7 +144,7 @@ export function staleHeadRejectionMessage(error: unknown): string | null {
  * through the existing term-parameterized key; GitHub keeps the exact
  * pre-s6 copy.
  */
-export function mergeForbiddenCopy(
+function mergeForbiddenCopy(
   platform: ProviderPrPlatform | undefined,
   t: ReturnType<typeof useTranslation>['t']
 ): string {

--- a/apps/mobile/src/lib/hooks/use-settings-back-guard.mounted.test.tsx
+++ b/apps/mobile/src/lib/hooks/use-settings-back-guard.mounted.test.tsx
@@ -132,7 +132,7 @@ describe('useSettingsBackGuard', () => {
     });
   });
 
-  it('shows Save / Discard / Keep Editing for a dirty-valid screen', () => {
+  it('shows Save / Discard / Keep editing for a dirty-valid screen', () => {
     const { renderer } = mountGuard(true, true, noOpSave);
 
     triggerPreventRemove();
@@ -141,7 +141,7 @@ describe('useSettingsBackGuard', () => {
     expect(lastAlertButtons()?.map(button => button.text)).toEqual([
       'Save changes',
       'Discard',
-      'Keep Editing',
+      'Keep editing',
     ]);
 
     act(() => {
@@ -149,12 +149,12 @@ describe('useSettingsBackGuard', () => {
     });
   });
 
-  it('shows Discard / Keep Editing for a dirty-invalid screen', () => {
+  it('shows Discard / Keep editing for a dirty-invalid screen', () => {
     const { renderer } = mountGuard(true, false, noOpSave);
 
     triggerPreventRemove();
     expect(alertMock).toHaveBeenCalledTimes(1);
-    expect(lastAlertButtons()?.map(button => button.text)).toEqual(['Discard', 'Keep Editing']);
+    expect(lastAlertButtons()?.map(button => button.text)).toEqual(['Discard', 'Keep editing']);
 
     act(() => {
       renderer.unmount();
@@ -233,14 +233,14 @@ describe('useSettingsBackGuard', () => {
     });
   });
 
-  it('Keep Editing leaves the screen untouched', () => {
+  it('Keep editing leaves the screen untouched', () => {
     const onSave = vi.fn(async () => {
       await Promise.resolve();
     });
     const { renderer } = mountGuard(true, true, onSave);
     triggerPreventRemove();
 
-    const keep = lastAlertButtons()?.find(button => button.text === 'Keep Editing');
+    const keep = lastAlertButtons()?.find(button => button.text === 'Keep editing');
     // The cancel button carries no handler: dismissing it must not save or leave.
     expect(keep?.onPress).toBeUndefined();
     expect(onSave).not.toHaveBeenCalled();

--- a/apps/mobile/src/lib/pr-review/use-check-provider-connection.ts
+++ b/apps/mobile/src/lib/pr-review/use-check-provider-connection.ts
@@ -13,7 +13,7 @@ import { toast } from 'sonner-native';
 
 import { useTRPC } from '@/lib/trpc';
 
-export type ProviderConnectionPlatform = 'gitlab' | 'bitbucket';
+type ProviderConnectionPlatform = 'gitlab' | 'bitbucket';
 
 export type CheckProviderConnectionInput = {
   platform: ProviderConnectionPlatform;

--- a/apps/mobile/src/lib/pr-review/use-pr-review-mutations.ts
+++ b/apps/mobile/src/lib/pr-review/use-pr-review-mutations.ts
@@ -186,7 +186,7 @@ export type SubmitReviewComment = NonNullable<SubmitReviewInput['comments']>[num
  * user tapped, with `startLine` marking the first line of a multi-line
  * range ending at `line`. Absent, the comment is a top-level note.
  */
-export type ProviderCommentAnchor = {
+type ProviderCommentAnchor = {
   path: string;
   side: 'LEFT' | 'RIGHT';
   line: number;
@@ -216,7 +216,7 @@ export function formatPendingCommentBody(item: {
 }
 
 /** One anchored item in a provider `submitReview` batch (c3). */
-export type ProviderSubmitReviewComment = ProviderCommentAnchor & { body: string };
+type ProviderSubmitReviewComment = ProviderCommentAnchor & { body: string };
 
 /**
  * The provider `submitReview` intent the submit sheet builds: every pending


### PR DESCRIPTION
> **Not verified.** kwf reopened this section on 2026-09-09: publication failed: level 2: pr-api: HTTP/2.0 422 Unprocessable Entity
pr-api: date: Wed, 09 Sep 2026 17:39:45 GMT
pr-api: x-ratelimit-limit: 5000
pr-api: x-ratelimit-remaining: 4901
pr-api: x-ratelimit-used: 99
pr-api: x-ratelimit-reset: 1788978098
pr-api: x-ratelimit-resource: core
pr-api: x-githu
> The proof below came from an earlier round and can be stale. Do not review until this note is gone.

Level 15 of the `bring-mobile-gitlab-and-bitb-3792` stack.

- fix: fix the failed mobile-app verification gate (kwf bring-mobile-gitlab-and-bitb-3792/gr1)

## PR stack (merge bottom to top)
- level 1: #6006 (`kwf/bring-mobile-gitlab-and-bitb-3792-l1`)
- level 2: `kwf/bring-mobile-gitlab-and-bitb-3792-l2`
- level 3: `kwf/bring-mobile-gitlab-and-bitb-3792-l3`
- level 4: `kwf/bring-mobile-gitlab-and-bitb-3792-l4`
- level 5: #6007 (`kwf/bring-mobile-gitlab-and-bitb-3792-l5`)
- level 6: #6008 (`kwf/bring-mobile-gitlab-and-bitb-3792-l6`)
- level 7: `kwf/bring-mobile-gitlab-and-bitb-3792-l7`
- level 8: `kwf/bring-mobile-gitlab-and-bitb-3792-l8`
- level 9: `kwf/bring-mobile-gitlab-and-bitb-3792-l9`
- level 10: #6009 (`kwf/bring-mobile-gitlab-and-bitb-3792-l10`)
- level 11: #6010 (`kwf/bring-mobile-gitlab-and-bitb-3792-l11`)
- level 12: `kwf/bring-mobile-gitlab-and-bitb-3792-l12`
- level 13: #6011 (`kwf/bring-mobile-gitlab-and-bitb-3792-l13`)
- level 14: `kwf/bring-mobile-gitlab-and-bitb-3792-l14`
- level 15: #6012 (`kwf/bring-mobile-gitlab-and-bitb-3792-l15`) ← this PR
- level 16: #6013 (`kwf/bring-mobile-gitlab-and-bitb-3792-l16`)
- level 17: `kwf/bring-mobile-gitlab-and-bitb-3792-l17`
- level 18: `kwf/bring-mobile-gitlab-and-bitb-3792-l18`
- level 19: #6014 (`kwf/bring-mobile-gitlab-and-bitb-3792-l19`)
- level 20: `kwf/bring-mobile-gitlab-and-bitb-3792-l20`
- level 21: `kwf/bring-mobile-gitlab-and-bitb-3792-l21`
- level 23: #6015 (`kwf/bring-mobile-gitlab-and-bitb-3792-l23`)
- level 24: #6016 (`kwf/bring-mobile-gitlab-and-bitb-3792-l24`)
- level 25: #6017 (`kwf/bring-mobile-gitlab-and-bitb-3792-l25`)
- level 26: #6018 (`kwf/bring-mobile-gitlab-and-bitb-3792-l26`)
- level 27: #6019 (`kwf/bring-mobile-gitlab-and-bitb-3792-l27`)
- level 28: #6020 (`kwf/bring-mobile-gitlab-and-bitb-3792-l28`)
- level 29: `kwf/bring-mobile-gitlab-and-bitb-3792-l29`
- level 30: #6021 (`kwf/bring-mobile-gitlab-and-bitb-3792-l30`)
