### PR TITLE
feat(mobile): bring GitLab and Bitbucket pull request review to GitHub parity (stack 19/30)

### DIFF
--- a/apps/mobile/src/components/agents/repository-branch-selector.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/repository-branch-selector.mounted.test.tsx
@@ -19,24 +19,10 @@ vi.mock('react-native', async () => {
     View: 'View',
     Modal: 'Modal',
     Pressable: 'Pressable',
-    // The real FlatList virtualizes; the fake renders every row so the picker's
-    // rows are assertable.
-    FlatList: ({
-      data,
-      renderItem,
-      keyExtractor,
-    }: {
-      data: string[];
-      renderItem: (info: { item: string }) => React.ReactNode;
-      keyExtractor: (item: string) => string;
-    }) =>
-      React.createElement(
-        'FlatList',
-        {},
-        ...data.map(item =>
-          React.createElement('FlatListRow', { key: keyExtractor(item) }, renderItem({ item }))
-        )
-      ),
+    // The real ScrollView scrolls; the fake renders every row so the
+    // picker's rows are assertable.
+    ScrollView: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('ScrollView', {}, children),
   };
 });
 vi.mock('@/components/ui/text', async () => {

--- a/apps/mobile/src/components/pr-review/diff/pr-diff-floating-actions.test.tsx
+++ b/apps/mobile/src/components/pr-review/diff/pr-diff-floating-actions.test.tsx
@@ -286,20 +286,19 @@ describe('PrDiffFloatingActions provider routes (s6)', () => {
     pressButtonWith(GITLAB_REF, 'Comment on selected lines');
 
     expect(routerPush).toHaveBeenCalledTimes(1);
-    expect(routerPush).toHaveBeenCalledWith({
-      pathname: '/(app)/pr-review/gitlab/group/sub/repo/12/comment-composer',
-      params: { path: 'src/lib.ts', side: 'RIGHT', line: 5, startLine: 3 },
-    });
+    expect(routerPush).toHaveBeenCalledWith(
+      '/(app)/pr-review/gitlab/group/sub/repo/12/comment-composer?path=src%2Flib.ts&side=RIGHT&line=5&startLine=3'
+    );
   });
 
   it.each<[ProviderPrRef, string]>([
     [GITLAB_REF, '/(app)/pr-review/gitlab/group/sub/repo/12/review-submit'],
     [BITBUCKET_REF, '/(app)/pr-review/bitbucket/acme/api/42/review-submit'],
-  ])('pushes the review-submit sheet inside the %s ref route', (prRef, expectedPathname) => {
+  ])('pushes the review-submit sheet inside the %s ref route', (prRef, expectedHref) => {
     pressButtonWith(prRef, 'Finish review');
 
     expect(routerPush).toHaveBeenCalledTimes(1);
-    expect(routerPush).toHaveBeenCalledWith({ pathname: expectedPathname, params: {} });
+    expect(routerPush).toHaveBeenCalledWith(expectedHref);
   });
 });
 

--- a/apps/mobile/src/components/pr-review/merge/pr-merge-section-provider.test.tsx
+++ b/apps/mobile/src/components/pr-review/merge/pr-merge-section-provider.test.tsx
@@ -129,10 +129,9 @@ describe('PrMergeSectionProvider (s6)', () => {
     act(() => {
       findButton(renderer, 'Merge merge request')?.();
     });
-    expect(routerPush).toHaveBeenCalledWith({
-      pathname: '/(app)/pr-review/gitlab/group/sub/repo/12/merge',
-      params: { mode: 'merge' },
-    });
+    expect(routerPush).toHaveBeenCalledWith(
+      '/(app)/pr-review/gitlab/group/sub/repo/12/merge?mode=merge'
+    );
     renderer.unmount();
   });
 
@@ -141,10 +140,9 @@ describe('PrMergeSectionProvider (s6)', () => {
     act(() => {
       findButton(renderer, 'Enable auto-merge')?.();
     });
-    expect(routerPush).toHaveBeenCalledWith({
-      pathname: '/(app)/pr-review/gitlab/group/sub/repo/12/merge',
-      params: { mode: 'enable-auto-merge' },
-    });
+    expect(routerPush).toHaveBeenCalledWith(
+      '/(app)/pr-review/gitlab/group/sub/repo/12/merge?mode=enable-auto-merge'
+    );
     renderer.unmount();
   });
 


### PR DESCRIPTION
> **Not verified.** kwf reopened this section on 2026-09-09: publication failed: level 2: pr-api: HTTP/2.0 422 Unprocessable Entity
pr-api: date: Wed, 09 Sep 2026 17:39:45 GMT
pr-api: x-ratelimit-limit: 5000
pr-api: x-ratelimit-remaining: 4901
pr-api: x-ratelimit-used: 99
pr-api: x-ratelimit-reset: 1788978098
pr-api: x-ratelimit-resource: core
pr-api: x-githu
> The proof below came from an earlier round and can be stale. Do not review until this note is gone.

Level 19 of the `bring-mobile-gitlab-and-bitb-3792` stack.

- fix: fix the failed device scenarios (escalation: kilo/x-ai/grok-4.6) (kwf bring-mobile-gitlab-and-bitb-3792/vr4)

## PR stack (merge bottom to top)
- level 1: #6006 (`kwf/bring-mobile-gitlab-and-bitb-3792-l1`)
- level 2: `kwf/bring-mobile-gitlab-and-bitb-3792-l2`
- level 3: `kwf/bring-mobile-gitlab-and-bitb-3792-l3`
- level 4: `kwf/bring-mobile-gitlab-and-bitb-3792-l4`
- level 5: #6007 (`kwf/bring-mobile-gitlab-and-bitb-3792-l5`)
- level 6: #6008 (`kwf/bring-mobile-gitlab-and-bitb-3792-l6`)
- level 7: `kwf/bring-mobile-gitlab-and-bitb-3792-l7`
- level 8: `kwf/bring-mobile-gitlab-and-bitb-3792-l8`
- level 9: `kwf/bring-mobile-gitlab-and-bitb-3792-l9`
- level 10: #6009 (`kwf/bring-mobile-gitlab-and-bitb-3792-l10`)
- level 11: #6010 (`kwf/bring-mobile-gitlab-and-bitb-3792-l11`)
- level 12: `kwf/bring-mobile-gitlab-and-bitb-3792-l12`
- level 13: #6011 (`kwf/bring-mobile-gitlab-and-bitb-3792-l13`)
- level 14: `kwf/bring-mobile-gitlab-and-bitb-3792-l14`
- level 15: #6012 (`kwf/bring-mobile-gitlab-and-bitb-3792-l15`)
- level 16: #6013 (`kwf/bring-mobile-gitlab-and-bitb-3792-l16`)
- level 17: `kwf/bring-mobile-gitlab-and-bitb-3792-l17`
- level 18: `kwf/bring-mobile-gitlab-and-bitb-3792-l18`
- level 19: #6014 (`kwf/bring-mobile-gitlab-and-bitb-3792-l19`) ← this PR
- level 20: `kwf/bring-mobile-gitlab-and-bitb-3792-l20`
- level 21: `kwf/bring-mobile-gitlab-and-bitb-3792-l21`
- level 23: #6015 (`kwf/bring-mobile-gitlab-and-bitb-3792-l23`)
- level 24: #6016 (`kwf/bring-mobile-gitlab-and-bitb-3792-l24`)
- level 25: #6017 (`kwf/bring-mobile-gitlab-and-bitb-3792-l25`)
- level 26: #6018 (`kwf/bring-mobile-gitlab-and-bitb-3792-l26`)
- level 27: #6019 (`kwf/bring-mobile-gitlab-and-bitb-3792-l27`)
- level 28: #6020 (`kwf/bring-mobile-gitlab-and-bitb-3792-l28`)
- level 29: `kwf/bring-mobile-gitlab-and-bitb-3792-l29`
- level 30: #6021 (`kwf/bring-mobile-gitlab-and-bitb-3792-l30`)
