### PR TITLE
fix(auth): reject malformed JWT payloads without throwing

### DIFF
--- a/apps/web/src/lib/user/server.test.ts
+++ b/apps/web/src/lib/user/server.test.ts
@@ -555,6 +555,40 @@ describe('uuidSchema (organization ID validation)', () => {
 });
 
 describe('getUserFromAuth', () => {
+  test.each(['Bearer', 'bEaReR'])(
+    'returns 401 for a %s token with malformed JSON payload',
+    async scheme => {
+      const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString(
+        'base64url'
+      );
+      const payload = Buffer.from('{').toString('base64url');
+      const token = `${header}.${payload}.signature`;
+      expect(() => jwt.decode(token)).toThrow(SyntaxError);
+      mockHeaders.mockResolvedValue(new Headers({ authorization: `${scheme} ${token}` }));
+
+      const result = await getUserFromAuth({ adminOnly: false });
+
+      expect(result.user).toBeNull();
+      expect(result.authFailedResponse?.status).toBe(401);
+      expect(mockGetServerSession).not.toHaveBeenCalled();
+    }
+  );
+
+  test('returns 401 for a token with malformed JSON header', async () => {
+    const header = Buffer.from('{').toString('base64url');
+    const payload = Buffer.from(JSON.stringify({ kiloUserId: 'malformed-token-user' })).toString(
+      'base64url'
+    );
+    const token = `${header}.${payload}.signature`;
+    mockHeaders.mockResolvedValue(new Headers({ authorization: `Bearer ${token}` }));
+
+    const result = await getUserFromAuth({ adminOnly: false });
+
+    expect(result.user).toBeNull();
+    expect(result.authFailedResponse?.status).toBe(401);
+    expect(mockGetServerSession).not.toHaveBeenCalled();
+  });
+
   test('enforces the requested audience without falling through to a valid session', async () => {
     const user = await insertTestUser({
       api_token_pepper: 'audience-transition-pepper',

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -1226,7 +1226,12 @@ async function resolveUserFromAuth(
   if (headersList.get('Authorization')) {
     const rawAuthorization = headersList.get('Authorization');
     const bearer = rawAuthorization?.match(/^Bearer (.+)$/i)?.[1];
-    const decoded = bearer ? jwt.decode(bearer) : null;
+    let decoded: ReturnType<typeof jwt.decode>;
+    try {
+      decoded = bearer ? jwt.decode(bearer) : null;
+    } catch {
+      return authError(401, 'Invalid API token', '?');
+    }
     const decodedPayload = decoded !== null && typeof decoded !== 'string' ? decoded : null;
     const decodedRuntimeAuthorization = decodedPayload?.runtimeAuthorization;
     const runtimeAuthorization = CloudAgentNextRuntimeAuthorizationClaimSchema.safeParse(


### PR DESCRIPTION
## Summary

Malformed bearer tokens with invalid JSON payloads can throw during runtime-proof inspection, causing gateway requests to fail with an unhandled exception. Catch decoding failures and return the existing 401 authentication response without logging the token.

Fixes [KILOCODE-WEB-27VB](https://kilo-code.sentry.io/issues/KILOCODE-WEB-27VB). Valid-token verification and runtime-proof requirements are unchanged. This hotfix targets `main` independently of the remaining token rollout PRs.

## Verification

Reproduced the decoder exception locally with a synthetic malformed JWT. No live-environment manual test was performed.

## Automated checks

- Both new malformed-payload regression cases failed against the original code, then passed with the fix. Tests also cover mixed-case Bearer headers, malformed JSON headers, and no session fallback.
- 228 tests passed across authentication, token validation, gateway audience integration, and gateway request handling.
- Web typecheck, changed-file lint, formatting, and `git diff --check` passed.

## Visual Changes

N/A
