### PR TITLE
feat(cloud-agent-next): settle control-plane git refs, callbacks, and runtime death

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ catalogs:
       specifier: 1.0.0
       version: 1.0.0
     wrangler:
-      specifier: 4.127.1
-      version: 4.127.1
+      specifier: 4.112.0
+      version: 4.112.0
     zod:
       specifier: 4.4.3
       version: 4.4.3
@@ -1806,7 +1806,7 @@ importers:
         version: 5.9.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/app-builder:
     dependencies:
@@ -1864,7 +1864,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/auto-fix-infra:
     dependencies:
@@ -1892,7 +1892,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/auto-routing:
     dependencies:
@@ -1935,7 +1935,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/auto-routing-benchmark:
     dependencies:
@@ -1981,7 +1981,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/auto-triage-infra:
     dependencies:
@@ -2012,7 +2012,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/cloud-agent-next:
     dependencies:
@@ -2106,7 +2106,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       ws:
         specifier: 8.21.0
         version: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -2168,7 +2168,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/container-usage-meter:
     dependencies:
@@ -2202,7 +2202,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/db-proxy:
     dependencies:
@@ -2245,7 +2245,7 @@ importers:
         version: 5.9.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/deploy-infra/builder:
     dependencies:
@@ -2260,7 +2260,7 @@ importers:
         version: link:../../../packages/worker-utils
       '@sentry/cloudflare':
         specifier: 10.69.0
-        version: 10.69.0(@cloudflare/workers-types@4.20260605.1)(wrangler@4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        version: 10.69.0(@cloudflare/workers-types@4.20260605.1)(wrangler@4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260605.1)(@opentelemetry/api@1.9.1)(@types/pg@8.18.0)(@upstash/redis@1.38.0)(bun-types@1.3.14)(expo-sqlite@57.0.1(expo@57.0.15)(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(kysely@0.29.2)(pg@8.20.0)
@@ -2309,7 +2309,7 @@ importers:
         version: 5.9.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/deploy-infra/dispatcher:
     dependencies:
@@ -2358,7 +2358,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/event-service:
     dependencies:
@@ -2401,7 +2401,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/gastown:
     dependencies:
@@ -2474,7 +2474,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/gastown/container:
     dependencies:
@@ -2542,7 +2542,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/gmail-push:
     dependencies:
@@ -2570,7 +2570,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/images-mcp:
     dependencies:
@@ -2613,7 +2613,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/kilo-chat:
     dependencies:
@@ -2686,7 +2686,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/kilo-ops:
     dependencies:
@@ -2711,7 +2711,7 @@ importers:
         version: 5.9.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/kiloclaw:
     dependencies:
@@ -2772,7 +2772,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/kiloclaw-billing:
     dependencies:
@@ -2815,7 +2815,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/kiloclaw-inbound-email:
     dependencies:
@@ -2843,7 +2843,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/kiloclaw/controller:
     dependencies:
@@ -2957,7 +2957,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/model-eval-ingest:
     dependencies:
@@ -2991,7 +2991,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/notifications:
     dependencies:
@@ -3049,7 +3049,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/o11y:
     dependencies:
@@ -3086,7 +3086,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/security-auto-analysis:
     dependencies:
@@ -3123,7 +3123,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/security-sync:
     dependencies:
@@ -3157,7 +3157,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/session-ingest:
     dependencies:
@@ -3215,7 +3215,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/user-data-export:
     dependencies:
@@ -3255,7 +3255,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/wasteland:
     dependencies:
@@ -3310,7 +3310,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   services/webhook-agent-ingest:
     dependencies:
@@ -3365,7 +3365,7 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler:
         specifier: 'catalog:'
-        version: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
 packages:
 
@@ -4527,12 +4527,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20260828.1':
-    resolution: {integrity: sha512-CVd+xPhqUESg8Xhq09TZx0wl4FSirfJGOzvbPz2yHhBIvmNHFFQkSN3rkd7wEwnhQQk37Xi0/aD6ykPLJbmGiQ==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
   '@cloudflare/workerd-darwin-arm64@1.20260603.1':
     resolution: {integrity: sha512-uBPK4LaWJNbbCYwPnUAehlHbbVulhVZPZsdcAhBPfZhHb3QAuAEPAQepO/P67R3V6Cni4YGx1fLbL8A5wwoaNA==}
     engines: {node: '>=16'}
@@ -4541,12 +4535,6 @@ packages:
 
   '@cloudflare/workerd-darwin-arm64@1.20260714.1':
     resolution: {integrity: sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20260828.1':
-    resolution: {integrity: sha512-5HDPXRM152vU5JveByGFk34X57TVyIsfp4cabepAf45DC0MKvm52ucJqAjW1h8bvW4X+zRw9GU35OHF9FEC9Ww==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -4563,12 +4551,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20260828.1':
-    resolution: {integrity: sha512-MQ1Ll9P7F72HHUKizbb7BlDfbY8fRoNMpbIpZoU6uKsSkneFICWSKv6UlgU9EQZ+w0i7TMa12iUgJ8l29eRI9A==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
   '@cloudflare/workerd-linux-arm64@1.20260603.1':
     resolution: {integrity: sha512-LJZ6x00rAjSrobV4m0ZW0TpH5ilBbKcWBzlH+y+KOUsIE/CpTuhAzKV43TbSnFLRX5+jrWKiz2v0hO91lPXy6A==}
     engines: {node: '>=16'}
@@ -4581,12 +4563,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260828.1':
-    resolution: {integrity: sha512-FBTaUQ1xcU9jcp4OyBPcH8x0QiFvc1iuZL2GkD8zp2q1WyTVHYOptRDQUU+cuHjt0rQ2EIKVPBjahPxfa0joBw==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
   '@cloudflare/workerd-windows-64@1.20260603.1':
     resolution: {integrity: sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA==}
     engines: {node: '>=16'}
@@ -4595,12 +4571,6 @@ packages:
 
   '@cloudflare/workerd-windows-64@1.20260714.1':
     resolution: {integrity: sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-
-  '@cloudflare/workerd-windows-64@1.20260828.1':
-    resolution: {integrity: sha512-yvr77hC7dUbvK5K+SCg062kkPq3sx+drV1PcgHslzHDYcJBtT0V3X80qLE49LW1vq2svaeNmsVQS+vHsqWu8cQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -15743,10 +15713,6 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
-  miniflare@5.20260828.0-alpha:
-    resolution: {integrity: sha512-6nbxhZEcz/UET3Y1OnYPsrAUjUmuFoib3ynUqteRdn1YnDxsLg8cwgZJZCk9QmtOmGzXwzXzgE/d/C0dJAPtVw==}
-    engines: {node: '>=22.0.0'}
-
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -19152,11 +19118,6 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20260828.1:
-    resolution: {integrity: sha512-pB9yvt0kkwZDAGZHmpY59r0o3hM0DzdW6BJERqwZOhunZ3ssOyDSgQxOQer2cSZW4YCFeOTIQYN1qwhK5wv/Cw==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   workers-tagged-logger@1.0.0:
     resolution: {integrity: sha512-tp5PAs48hSpF2GIbH0S186MBXuMe8u9uuHZR0Jmw/I8+NIiQblor5EpYJ5lOaE8u9s84mVme6Iv+ueC1C/beog==}
 
@@ -19166,16 +19127,6 @@ packages:
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^5.20260714.1
-    peerDependenciesMeta:
-      '@cloudflare/workers-types':
-        optional: true
-
-  wrangler@4.127.1:
-    resolution: {integrity: sha512-OzsiNgaI8i681L/+KnAKc+uEZ5D57xK5JuNvCOpRKICF4/5Q3Cu1oTGuUiT/f3GDUqQb3gzXNT0tfOHGMEtknw==}
-    engines: {node: '>=22.0.0'}
-    hasBin: true
-    peerDependencies:
-      '@cloudflare/workers-types': ^5.20260828.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -21132,12 +21083,6 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260714.1
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260828.1)':
-    dependencies:
-      unenv: 2.0.0-rc.24
-    optionalDependencies:
-      workerd: 1.20260828.1
-
   '@cloudflare/vitest-pool-workers@0.16.13(@cloudflare/workers-types@4.20260605.1)(@types/node@22.19.19)(@vitest/runner@4.1.6)(@vitest/snapshot@4.1.6)(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vitest@4.1.6)':
     dependencies:
       '@vitest/runner': 4.1.6
@@ -21208,16 +21153,10 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260714.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260828.1':
-    optional: true
-
   '@cloudflare/workerd-darwin-arm64@1.20260603.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260714.1':
-    optional: true
-
-  '@cloudflare/workerd-darwin-arm64@1.20260828.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260603.1':
@@ -21226,25 +21165,16 @@ snapshots:
   '@cloudflare/workerd-linux-64@1.20260714.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260828.1':
-    optional: true
-
   '@cloudflare/workerd-linux-arm64@1.20260603.1':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260714.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260828.1':
-    optional: true
-
   '@cloudflare/workerd-windows-64@1.20260603.1':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260714.1':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20260828.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260605.1': {}
@@ -26240,7 +26170,7 @@ snapshots:
       '@sentry/cli-win32-i686': 3.6.2
       '@sentry/cli-win32-x64': 3.6.2
 
-  '@sentry/cloudflare@10.69.0(@cloudflare/workers-types@4.20260605.1)(wrangler@4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@sentry/cloudflare@10.69.0(@cloudflare/workers-types@4.20260605.1)(wrangler@4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@sentry/core': 10.69.0
@@ -26248,7 +26178,7 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260605.1
-      wrangler: 4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      wrangler: 4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -34879,10 +34809,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  miniflare@4.20260714.0(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  miniflare@4.20260714.0(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.35.3(@types/node@24.12.4)
+      sharp: 0.35.4(@types/node@22.19.19)
       undici: 7.29.0
       workerd: 1.20260714.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -34892,25 +34822,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  miniflare@5.20260828.0-alpha(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.35.4(@types/node@22.19.19)
-      undici: 7.29.0
-      workerd: 1.20260828.1
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      youch: 4.1.0-beta.10
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - utf-8-validate
-
-  miniflare@5.20260828.0-alpha(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  miniflare@4.20260714.0(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.4(@types/node@24.12.4)
       undici: 7.29.0
-      workerd: 1.20260828.1
+      workerd: 1.20260714.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -34918,12 +34835,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  miniflare@5.20260828.0-alpha(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  miniflare@4.20260714.0(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.4(@types/node@25.5.2)
       undici: 7.29.0
-      workerd: 1.20260828.1
+      workerd: 1.20260714.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -39590,19 +39507,29 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260714.1
       '@cloudflare/workerd-windows-64': 1.20260714.1
 
-  workerd@1.20260828.1:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260828.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260828.1
-      '@cloudflare/workerd-linux-64': 1.20260828.1
-      '@cloudflare/workerd-linux-arm64': 1.20260828.1
-      '@cloudflare/workerd-windows-64': 1.20260828.1
-
   workers-tagged-logger@1.0.0:
     dependencies:
       zod: 4.4.3
     optionalDependencies:
       hono: 4.12.34
+
+  wrangler@4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260714.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.2
+      miniflare: 4.20260714.0(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      path-to-regexp: 8.4.2
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260714.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260605.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - utf-8-validate
 
   wrangler@4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
@@ -39622,52 +39549,16 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  wrangler@4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  wrangler@4.112.0(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260828.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260714.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.2
-      miniflare: 5.20260828.0-alpha(@types/node@22.19.19)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      miniflare: 4.20260714.0(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       path-to-regexp: 8.4.2
       unenv: 2.0.0-rc.24
-      workerd: 1.20260828.1
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20260605.1
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - utf-8-validate
-
-  wrangler@4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260828.1)
-      blake3-wasm: 2.1.5
-      esbuild: 0.28.2
-      miniflare: 5.20260828.0-alpha(@types/node@24.12.4)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      path-to-regexp: 8.4.2
-      unenv: 2.0.0-rc.24
-      workerd: 1.20260828.1
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20260605.1
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - utf-8-validate
-
-  wrangler@4.127.1(@cloudflare/workers-types@4.20260605.1)(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260828.1)
-      blake3-wasm: 2.1.5
-      esbuild: 0.28.2
-      miniflare: 5.20260828.0-alpha(@types/node@25.5.2)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      path-to-regexp: 8.4.2
-      unenv: 2.0.0-rc.24
-      workerd: 1.20260828.1
+      workerd: 1.20260714.1
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260605.1
       fsevents: 2.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,7 @@ catalog:
   ulid: 3.0.2
   vitest: 4.1.6
   workers-tagged-logger: 1.0.0
-  wrangler: 4.127.1
+  wrangler: 4.112.0
   zod: 4.4.3
 
 minimumReleaseAge: 6842

--- a/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.test.ts
@@ -1030,7 +1030,7 @@ describe('CloudflareAgentSandbox', () => {
     vi.restoreAllMocks();
   });
 
-  it('does not retry a restored workspace when setup fails', async () => {
+  it('does not retry a restored workspace when an explicit branch is missing', async () => {
     const sourceCommit = 'c'.repeat(40);
     const request = ensureRequest({ cacheEligible: true });
     const candidate = await buildWorkspaceBackupCandidate({
@@ -1063,7 +1063,10 @@ describe('CloudflareAgentSandbox', () => {
       }),
       put: vi.fn(),
     };
-    const setupError = new WrapperError('restored setup failed', 'WORKSPACE_SETUP_FAILED', 503);
+    const setupError = new WrapperError('restored branch missing', 'WORKSPACE_SETUP_FAILED', 503, {
+      workspaceFailureSubtype: 'git_branch_missing',
+      retryable: false,
+    });
     const ensureSessionReady = vi.fn().mockRejectedValue(setupError);
     vi.spyOn(WrapperClient, 'ensureBootstrapWrapper').mockResolvedValueOnce({
       client: { ensureSessionReady } as unknown as WrapperClient,
@@ -1096,6 +1099,109 @@ describe('CloudflareAgentSandbox', () => {
     expect(ensureSessionReady).toHaveBeenCalledOnce();
     expect(exec.mock.calls.filter(([command]) => command.includes('rm -rf'))).toHaveLength(1);
     vi.restoreAllMocks();
+  });
+
+  it('cleans and retries once after a retryable restored checkout conflict', async () => {
+    const sourceCommit = 'a'.repeat(40);
+    const request = ensureRequest({ cacheEligible: true });
+    const candidate = await buildWorkspaceBackupCandidate({
+      fresh: true,
+      devcontainer: false,
+      setupCommands: ['pnpm install', 'node ./scripts/custom-setup.mjs --arbitrary'],
+      setupEnvironment: {
+        variables: { CACHE_VARIANT: 'resolved-profile-env' },
+        secretIdentities: {
+          API_TOKEN:
+            '{"algorithm":"rsa-aes-256-gcm","version":1,"encryptedData":"encrypted-token","encryptedDEK":"encrypted-dek"}',
+        },
+      },
+      userId: 'user_cloudflare',
+      orgId: 'org_cloudflare',
+      repository: { type: 'github', repo: 'acme/repo' },
+    });
+    if (!candidate) throw new Error('expected eligible candidate');
+    const bucket = {
+      get: vi.fn().mockImplementation(async (key: string) => ({
+        json: async () => ({
+          schema: 'workspace-backup-v1',
+          digest: key
+            .split('/')
+            .at(-1)
+            ?.replace(/\.json$/, ''),
+          owner: { type: 'organization', organizationId: 'org_cloudflare' },
+          sourceCommit,
+          createdAt: Date.now() - 1_000,
+          expiresAt: Date.now() + 10_000,
+          backup: { id: 'backup-1', dir: '/workspace/source' },
+        }),
+      })),
+      put: vi.fn(),
+    };
+    const reconciliationError = new WrapperError(
+      'Repository checkout failed',
+      'WORKSPACE_RECONCILIATION_FAILED',
+      503,
+      { workspaceFailureSubtype: 'git_checkout_conflict', retryable: true }
+    );
+    const ensureSessionReady = vi
+      .fn()
+      .mockRejectedValueOnce(reconciliationError)
+      .mockResolvedValueOnce({ kiloSessionId: 'kilo_cloudflare' });
+    vi.spyOn(WrapperClient, 'ensureBootstrapWrapper').mockResolvedValueOnce({
+      client: { ensureSessionReady } as unknown as WrapperClient,
+    });
+    const activeOrigin = 'https://token@github.com/acme/repo.git';
+    const bootstrapSession = {
+      exec: vi
+        .fn()
+        .mockResolvedValueOnce({ exitCode: 0, stdout: `${sourceCommit}\n` })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: `${activeOrigin}\n` })
+        .mockResolvedValue({ exitCode: 0, stdout: '' }),
+    };
+    const exec = vi.fn(async (command: string) => {
+      if (command.includes('df -B1')) {
+        return { exitCode: 0, stdout: '3145728000 10485760000\n', stderr: '' };
+      }
+      if (command.startsWith('test -d') && !command.includes('git -C')) {
+        return { exitCode: 1, stdout: '', stderr: '' };
+      }
+      if (command.includes('rev-parse --verify HEAD')) {
+        return { exitCode: 0, stdout: `${sourceCommit}\n`, stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+    const sandboxApi = {
+      exec,
+      restoreBackup: vi.fn().mockResolvedValue(undefined),
+      createSession: vi.fn().mockResolvedValue(bootstrapSession),
+      createBackup: vi
+        .fn()
+        .mockResolvedValue({ id: 'backup-republished', dir: '/workspace/cloudflare' }),
+    };
+    const sandbox = new CloudflareAgentSandbox(
+      {
+        WORKER_URL: 'http://localhost:8787',
+        BACKUP_BUCKET: bucket,
+        REPO_SNAPSHOT_ORG_IDS: '*',
+      } as unknown as Env,
+      metadata(),
+      { resolveSandbox: () => sandboxApi as unknown as SandboxInstance }
+    );
+
+    await expect(sandbox.ensureWrapper(request)).resolves.toMatchObject({
+      status: 'session-ready',
+    });
+    expect(ensureSessionReady).toHaveBeenCalledTimes(2);
+    expect(ensureSessionReady).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        workspace: expect.objectContaining({ restoredFromBackup: true }),
+      })
+    );
+    expect(ensureSessionReady).toHaveBeenNthCalledWith(2, request.prepared.readyRequest);
+    expect(exec.mock.calls.filter(([command]) => command.includes('rm -rf'))).toHaveLength(2);
+    expect(sandboxApi.createBackup).toHaveBeenCalledOnce();
+    expect(bucket.put).toHaveBeenCalledOnce();
   });
 
   it('keeps index publication failure nonfatal after restoring the authenticated origin', async () => {

--- a/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
+++ b/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
@@ -175,6 +175,7 @@ import {
   freezeLegacyQueuedMessages,
   hasAcceptedMessage,
   incrementDeliveryFailure,
+  markSessionOperationRejection,
   matchesSessionMessageReplay,
   nextQueuedMessageId,
   recordAcceptedMessageActivity,
@@ -186,6 +187,7 @@ import {
   type ControlSessionMessageInput,
   type SessionMessageRecord,
 } from './session-message-queue.js';
+import { createMessageCallbacks, type MessageCallbacks } from './message-callbacks.js';
 import { PENDING_SESSION_MESSAGE_LIMIT } from '../session/pending-messages.js';
 import {
   commitSessionOperationResult,
@@ -235,6 +237,15 @@ const pendingRuntimeCleanupSchema = z.object({
 
 type MessageRecord = SessionMessageRecord;
 type DispatchPhase = 'preparing' | 'attach' | 'prompt';
+
+const MAX_TERMINAL_DETAIL_LENGTH = 4_096;
+
+function confirmedControlRejectionDetail(error: unknown): string | undefined {
+  if (!(error instanceof ControlRequestError) || !error.rejectionReceived) return undefined;
+  const detail = error.message.trim().slice(0, MAX_TERMINAL_DETAIL_LENGTH);
+  return detail || undefined;
+}
+
 type ControlEventDisposition =
   | 'apply'
   | 'duplicate'
@@ -280,6 +291,7 @@ type SandboxSessionInitialAdmissionInput = Omit<SandboxSessionRegistrationInput,
 export class SandboxSession extends DurableObject<Env> {
   private readonly sessionId: SessionId | undefined;
   private readonly eventQueries: EventQueries;
+  private readonly messageCallbacks: MessageCallbacks;
   private readonly terminalLifecycle: ReturnType<typeof createSandboxTerminalLifecycle>;
   private readonly terminalBridge: ReturnType<typeof createSandboxTerminalBridge>;
   private readonly dispatches = new Map<string, Promise<void>>();
@@ -291,6 +303,7 @@ export class SandboxSession extends DurableObject<Env> {
   private deletionCompletion: Promise<void> | undefined;
   private readonly worktreeChanges: ReturnType<typeof createWorktreeChanges>;
   private readonly interactionRefresh: InteractionRefresh;
+  private callbackRepairRequired = false;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -323,6 +336,17 @@ export class SandboxSession extends DurableObject<Env> {
     });
     const db = drizzle(ctx.storage, { logger: false });
     this.eventQueries = createEventQueries(db, ctx.storage.sql);
+    this.messageCallbacks = createMessageCallbacks({
+      storage: ctx.storage,
+      getMetadata: () => this.terminalLifecycle.getStoredMetadata(),
+      getCallbackQueue: () => env.CALLBACK_QUEUE,
+      getAssistantMessageForUserMessage: (sessionId, kiloSessionId, parentMessageId) =>
+        this.eventQueries.getAssistantMessageForUserMessage(
+          sessionId,
+          kiloSessionId,
+          parentMessageId
+        ),
+    });
     this.worktreeChanges = createWorktreeChanges({
       storage: ctx.storage,
       saveSnapshotEvent: snapshot => {
@@ -945,6 +969,7 @@ export class SandboxSession extends DurableObject<Env> {
       eventQueries: this.eventQueries,
       notifications,
     });
+    this.scheduleCallbackRepairIfRequired();
     if (!ack) return undefined;
     if (authorization.operation === 'session.attach') {
       const attached = delivery.result.ok
@@ -1632,24 +1657,21 @@ export class SandboxSession extends DurableObject<Env> {
     if (
       this.deletedWorktreeId === worktreeId &&
       (await this.ctx.storage.get(DELETION_COMPLETED_KEY))
-    )
+    ) {
+      if (this.messageCallbacks.pendingCallbackCount() > 0) this.scheduleCallbackRepair();
       return null;
+    }
     this.worktreeChanges.suppress();
     this.ctx.storage.transactionSync(() => {
       this.ctx.storage.kv.put(DELETED_WORKTREE_KEY, worktreeId);
       this.terminalLifecycle.beginDeletion(metadata);
       this.worktreeChanges.purge();
-      const messages = this.ctx.storage.kv.get<MessageRecord[]>(MESSAGES_KEY) ?? [];
-      const cancelled = messages.map(message =>
-        message.state === 'queued' || message.state === 'accepted'
-          ? { ...message, state: 'cancelled' as const }
-          : message
-      );
-      this.ctx.storage.kv.put(MESSAGES_KEY, cancelled);
+      this.snapshotDeletedMessages(metadata);
     });
+    if (this.messageCallbacks.pendingCallbackCount() > 0) this.scheduleCallbackRepair();
     this.deletedWorktreeId = worktreeId;
     for (const socket of this.ctx.getWebSockets()) socket.close(1001, 'Worktree deleted');
-    await this.ctx.storage.deleteAlarm();
+    if (this.messageCallbacks.pendingCallbackCount() === 0) await this.ctx.storage.deleteAlarm();
     if (!metadata) return null;
     return cloudAgentWorktreeLocationSchema.parse({
       sandboxId: metadata.workspace?.sandboxId,
@@ -1715,9 +1737,13 @@ export class SandboxSession extends DurableObject<Env> {
       await Promise.allSettled([...this.activeOperations]);
     }
     await this.ingestPublicationChain.catch(() => undefined);
-    if (await this.ctx.storage.get(DELETION_COMPLETED_KEY)) return;
+    if (await this.ctx.storage.get(DELETION_COMPLETED_KEY)) {
+      if (this.messageCallbacks.pendingCallbackCount() > 0) this.scheduleCallbackRepair();
+      return;
+    }
     for (const socket of this.ctx.getWebSockets()) socket.close(1001, 'Worktree deleted');
-    await this.ctx.storage.deleteAlarm();
+    const callbacksPending = this.messageCallbacks.pendingCallbackCount() > 0;
+    if (!callbacksPending) await this.ctx.storage.deleteAlarm();
     const db = drizzle(this.ctx.storage, { logger: false });
     this.ctx.storage.transactionSync(() => {
       db.delete(events).where(eq(events.session_id, this.requireSessionId())).run();
@@ -1727,6 +1753,9 @@ export class SandboxSession extends DurableObject<Env> {
       this.ctx.storage.kv.put(DELETED_WORKTREE_KEY, worktreeId);
       this.ctx.storage.kv.put(DELETION_COMPLETED_KEY, true);
     });
+    if (callbacksPending) {
+      await this.armQueueRetry(this.messageCallbacks.nextCallbackDueAt() ?? Date.now());
+    }
   }
 
   private trackOperation<T>(operation: Promise<T>): Promise<T> {
@@ -1734,24 +1763,75 @@ export class SandboxSession extends DurableObject<Env> {
     return operation.finally(() => this.activeOperations.delete(operation));
   }
 
+  private snapshotDeletedMessages(metadata: SessionMetadata | null): void {
+    const messages = this.ctx.storage.kv.get<MessageRecord[]>(MESSAGES_KEY) ?? [];
+    const cancelled = messages.map(message => {
+      if (message.state !== 'queued' && message.state !== 'accepted') return message;
+      const next = { ...message, state: 'cancelled' as const };
+      this.messageCallbacks.persistTerminalCallback(next, metadata);
+      return next;
+    });
+    this.ctx.storage.kv.put(MESSAGES_KEY, cancelled);
+  }
+
+  private async interruptDeletedMessage(
+    metadata: SessionMetadata | null,
+    message: MessageRecord | undefined
+  ): Promise<void> {
+    const sandboxId = metadata?.workspace?.sandboxId;
+    const kiloSessionId = metadata?.auth.kiloSessionId;
+    if (!message || message.state !== 'accepted' || !metadata || !sandboxId || !kiloSessionId)
+      return;
+    try {
+      const response = await withTimeout(
+        sandboxControlRpc(this.env, sandboxId).request({
+          operation: 'session.abort',
+          session: {
+            sessionId: metadata.identity.sessionId,
+            kiloSessionId,
+            directory: this.directory(metadata),
+          },
+          payload: { messageId: message.messageId },
+        }),
+        SANDBOX_CONTROL_REQUEST_TIMEOUT_MS,
+        'Session abort timed out'
+      );
+      if (response.ok) sessionAbortResultSchema.parse(response.result);
+    } catch {
+      // Deletion cleanup remains authoritative when abort cannot be confirmed.
+    }
+  }
+
   async deleteSession(): Promise<void> {
     if (this.deletedWorktreeId) throw new Error('worktree_deleting');
     this.worktreeChanges.suppress();
-    await this.interruptExecution();
-    if (this.deletedWorktreeId) throw new Error('worktree_deleting');
     const metadata = this.terminalLifecycle.getStoredMetadata();
+    const active = (this.ctx.storage.kv.get<MessageRecord[]>(MESSAGES_KEY) ?? []).filter(
+      message => message.state === 'queued' || message.state === 'accepted'
+    );
+    const accepted = active.find(message => message.state === 'accepted');
+    const preparing = accepted ? undefined : active[0];
     const records = this.ctx.storage.transactionSync(() => {
+      if (this.deletedWorktreeId) throw new Error('worktree_deleting');
       const records = this.terminalLifecycle.beginDeletion(metadata);
       this.worktreeChanges.purge();
+      if (preparing?.wrapperInstanceId && preparing.deliveryRetryScope !== 'message' && metadata) {
+        this.retainRuntimeCleanup(metadata, preparing.wrapperInstanceId, 'preparation_interrupted');
+      }
+      this.snapshotDeletedMessages(metadata);
       return records;
     });
+    if (this.messageCallbacks.pendingCallbackCount() > 0) this.scheduleCallbackRepair();
     for (const ws of this.ctx.getWebSockets('stream')) {
       ws.close(1000, 'session access revoked');
     }
+    if (this.pendingRuntimeCleanup()) await this.transferRuntimeCleanup();
+    else await this.interruptDeletedMessage(metadata, accepted);
     await this.terminalLifecycle.cleanupSession(metadata, records);
     await this.ingestPublicationChain.catch(() => undefined);
     if (this.deletedWorktreeId) throw new Error('worktree_deleting');
-    await this.ctx.storage.deleteAlarm();
+    const callbacksPending = this.messageCallbacks.pendingCallbackCount() > 0;
+    if (!callbacksPending) await this.ctx.storage.deleteAlarm();
     this.ctx.storage.transactionSync(() => {
       if (this.deletedWorktreeId) throw new Error('worktree_deleting');
       const pendingCleanup = this.pendingRuntimeCleanup();
@@ -1760,6 +1840,8 @@ export class SandboxSession extends DurableObject<Env> {
       if (pendingCleanup) this.ctx.storage.kv.put(PENDING_RUNTIME_CLEANUP_KEY, pendingCleanup);
     });
     if (this.pendingRuntimeCleanup()) await this.armQueueRetry();
+    else if (callbacksPending)
+      await this.armQueueRetry(this.messageCallbacks.nextCallbackDueAt() ?? Date.now());
   }
 
   async registerSession(input: SandboxSessionRegistrationInput): Promise<OperationResult> {
@@ -2080,6 +2162,9 @@ export class SandboxSession extends DurableObject<Env> {
     if (this.pendingRuntimeCleanup()) await this.transferRuntimeCleanup();
     for (const stop of this.stopLifecycle.pending())
       void this.scheduleStopProgress(stop.request.operationId);
+    await this.messageCallbacks.repair();
+    const callbackDueAt = this.messageCallbacks.nextCallbackDueAt();
+    if (callbackDueAt !== undefined) await this.armQueueRetry(callbackDueAt);
     const epoch = this.terminalLifecycle.captureEpoch();
     if (epoch === null || this.deletedWorktreeId) return;
     const now = Date.now();
@@ -2281,10 +2366,16 @@ export class SandboxSession extends DurableObject<Env> {
       }
       if (validationFailure) return validationFailure;
       if (!intent) return { success: false, code: 'NOT_FOUND', error: 'Message not found' };
-      if (
-        latestMessages.filter(message => message.state === 'queued').length >=
-        PENDING_SESSION_MESSAGE_LIMIT
-      ) {
+      const pendingCallbackCount = this.messageCallbacks.pendingCallbackCount();
+      const callbackFlow =
+        latestMetadata.callback?.target !== undefined || pendingCallbackCount > 0;
+      const outstandingMessages = latestMessages.filter(
+        message => message.state === 'queued' || message.state === 'accepted'
+      ).length;
+      const pendingCount = callbackFlow
+        ? outstandingMessages + pendingCallbackCount
+        : latestMessages.filter(message => message.state === 'queued').length;
+      if (pendingCount >= PENDING_SESSION_MESSAGE_LIMIT) {
         return {
           success: false,
           code: 'PENDING_QUEUE_FULL',
@@ -2610,6 +2701,7 @@ export class SandboxSession extends DurableObject<Env> {
       return;
     }
     let phase: DispatchPhase = 'preparing';
+    let attachInPreparation = false;
     let credentialsPrepared = false;
     const preparationGeneration = this.worktreeChanges.beginPreparation();
     try {
@@ -2712,13 +2804,14 @@ export class SandboxSession extends DurableObject<Env> {
         if (needsPreparation) recorder.onProgress('workspace_setup', 'Setting up workspace…');
         if (!status.attachment?.kilo)
           throw new Error('Contained session attachment is unavailable');
+        attachInPreparation = needsPreparation;
         const attachPayload = {
           ...status.attachment,
           ...(needsPreparation
             ? { preparation: { attemptId: recorder.attemptId, triggerMessageId: messageId } }
             : {}),
         };
-        phase = needsPreparation ? 'preparing' : 'attach';
+        phase = 'preparing';
         await wait(() =>
           control.attachSession({
             ...(metadata.workspace?.worktreeId
@@ -2735,6 +2828,7 @@ export class SandboxSession extends DurableObject<Env> {
             await this.compensateSessionAttachment(metadata);
           return;
         }
+        phase = 'attach';
         if (operationResults) {
           if ((await dispatchAuthorized('session.attach', attachPayload)).state === 'running') {
             await this.armQueueRetry(Math.min(deadlineAt, Date.now() + QUEUE_RETRY_MS));
@@ -2759,6 +2853,7 @@ export class SandboxSession extends DurableObject<Env> {
             )
           );
         }
+        phase = 'preparing';
         if (!isCurrent()) {
           if (!this.terminalLifecycle.isCurrent(epoch))
             await this.compensateSessionAttachment(metadata);
@@ -2850,6 +2945,7 @@ export class SandboxSession extends DurableObject<Env> {
         wrapperInstanceId,
         deadlineAt,
         error,
+        attachInPreparation,
       });
     } finally {
       this.worktreeChanges.finishPreparation(preparationGeneration);
@@ -2887,41 +2983,55 @@ export class SandboxSession extends DurableObject<Env> {
     messageId: string;
     epoch: number;
     phase: DispatchPhase;
+    attachInPreparation: boolean;
     wrapperInstanceId?: string;
     deadlineAt: number;
     error: unknown;
   }): Promise<void> {
-    const { messageId, epoch, phase, wrapperInstanceId, deadlineAt, error } = input;
+    const { messageId, epoch, phase, wrapperInstanceId, deadlineAt, error, attachInPreparation } =
+      input;
     const message = this.queuedMessage(messageId, epoch, wrapperInstanceId);
     if (!message) return;
-    const rejection = error instanceof ControlRequestError && error.code !== 'runtime_unhealthy';
+    const rejection = error instanceof ControlRequestError && error.rejectionReceived === true;
+    const retryableRejection =
+      rejection && error instanceof ControlRequestError && error.code !== 'runtime_unhealthy';
+    const detail = confirmedControlRejectionDetail(error);
+    const attachProof = message.operations?.attach;
+    const attachRejectionAlreadyCounted = attachProof?.rejectionReceived === true;
+    const countAttachRejection = phase === 'attach' && rejection && !attachRejectionAlreadyCounted;
     const completedAttachFailure =
       message.operations?.attach?.dispatched === true &&
       message.operations.attach.result?.ok === false;
     const retryableCompletedAttach =
-      phase !== 'prompt' && rejection && isRetryableDeliveryError(error) && completedAttachFailure;
-    const scope =
+      phase !== 'prompt' &&
+      retryableRejection &&
+      isRetryableDeliveryError(error) &&
+      completedAttachFailure;
+    const messageRetryScope =
       phase === 'attach'
-        ? retryableCompletedAttach
-          ? 'message'
-          : 'runtime'
-        : rejection && !message.unresolvedDispatch
-          ? 'message'
-          : 'runtime';
+        ? (attachInPreparation && retryableRejection && !message.unresolvedDispatch) ||
+          retryableCompletedAttach
+        : retryableRejection && !message.unresolvedDispatch;
+    const scope: 'message' | 'runtime' = messageRetryScope ? 'message' : 'runtime';
     if (Date.now() >= deadlineAt) {
-      await this.failDelivery(messageId, 'preparation_timeout', wrapperInstanceId, scope);
+      await this.failDelivery(messageId, 'preparation_timeout', wrapperInstanceId, scope, detail);
       return;
     }
-    const busy = rejection && error.code === 'session_busy';
+    const busy = retryableRejection && error.code === 'session_busy';
     const retryNotBefore = Math.min(deadlineAt, Date.now() + QUEUE_RETRY_MS);
     const released = retryableCompletedAttach
       ? releaseCompletedRetryableAttach(this.loadMessages(), messageId, retryNotBefore)
       : this.loadMessages();
+    const marked =
+      countAttachRejection && attachProof
+        ? markSessionOperationRejection(released, attachProof.authorization)
+        : released;
+    const nextMessages = marked ?? released;
     const updated =
-      phase === 'preparing' || busy
+      busy || (phase !== 'prompt' && !countAttachRejection)
         ? undefined
-        : incrementDeliveryFailure(released, messageId, phase);
-    const messages = (updated?.messages ?? released).map(
+        : incrementDeliveryFailure(nextMessages, messageId, phase);
+    const messages = (updated?.messages ?? nextMessages).map(
       (message): MessageRecord =>
         message.messageId === messageId ? { ...message, deliveryRetryScope: scope } : message
     );
@@ -2938,11 +3048,12 @@ export class SandboxSession extends DurableObject<Env> {
       messageId,
       phase === 'prompt'
         ? 'prompt_exhausted'
-        : phase === 'attach'
+        : phase === 'attach' && rejection
           ? 'attach_exhausted'
           : 'environment_failed',
       wrapperInstanceId,
-      scope
+      scope,
+      detail
     );
   }
 
@@ -3058,7 +3169,8 @@ export class SandboxSession extends DurableObject<Env> {
     messageId: string,
     reason: string,
     wrapperInstanceId?: string,
-    scope: 'message' | 'runtime' = 'runtime'
+    scope: 'message' | 'runtime' = 'runtime',
+    detail?: string
   ): Promise<void> {
     const epoch = this.terminalLifecycle.captureEpoch();
     const metadata = this.terminalLifecycle.getStoredMetadata();
@@ -3072,13 +3184,13 @@ export class SandboxSession extends DurableObject<Env> {
     )
       return;
     if (scope === 'message') {
-      const messages = failQueuedMessage(this.loadMessages(), messageId, reason);
+      const messages = failQueuedMessage(this.loadMessages(), messageId, reason, detail);
       if (!messages || !this.saveMessages(messages, epoch)) return;
       if (nextQueuedMessageId(messages)) await this.armQueueRetry();
       return;
     }
     if (wrapperInstanceId) this.retainRuntimeCleanup(metadata, wrapperInstanceId, reason);
-    await this.failDeliveryWaitingMessages(reason, wrapperInstanceId);
+    await this.failDeliveryWaitingMessages(reason, wrapperInstanceId, detail, messageId);
     if (this.pendingRuntimeCleanup()) await this.transferRuntimeCleanup();
   }
 
@@ -3124,7 +3236,9 @@ export class SandboxSession extends DurableObject<Env> {
 
   private async failDeliveryWaitingMessages(
     reason: string,
-    wrapperInstanceId?: string
+    wrapperInstanceId?: string,
+    detail?: string,
+    detailMessageId?: string
   ): Promise<void> {
     const epoch = this.terminalLifecycle.captureEpoch();
     if (epoch === null) return;
@@ -3136,7 +3250,15 @@ export class SandboxSession extends DurableObject<Env> {
       wrapperInstanceId,
       false
     );
-    if (failedIds.length === 0 || !this.saveMessages(messages, epoch)) return;
+    const messagesWithDetail =
+      detail && detailMessageId
+        ? messages.map(message =>
+            message.messageId === detailMessageId && failedIds.includes(message.messageId)
+              ? { ...message, failedDetail: detail }
+              : message
+          )
+        : messages;
+    if (failedIds.length === 0 || !this.saveMessages(messagesWithDetail, epoch)) return;
     if (this.pendingRuntimeCleanup() || nextQueuedMessageId(this.loadMessages()))
       await this.armQueueRetry();
   }
@@ -3147,18 +3269,34 @@ export class SandboxSession extends DurableObject<Env> {
     createStreamHandler(this.ctx, this.eventQueries, sessionId).broadcastEvent(event);
   }
 
+  private scheduleCallbackRepair(): void {
+    this.ctx.waitUntil(this.ctx.storage.setAlarm(Date.now()));
+    this.ctx.waitUntil(this.messageCallbacks.repair());
+  }
+
+  private scheduleCallbackRepairIfRequired(): void {
+    if (!this.callbackRepairRequired) return;
+    this.callbackRepairRequired = false;
+    this.scheduleCallbackRepair();
+  }
+
   private async armQueueRetry(when = Date.now() + QUEUE_RETRY_MS): Promise<void> {
     const epoch = this.terminalLifecycle.captureEpoch();
     const hasPendingStop = this.stopLifecycle.pending().length > 0;
-    if (epoch === null && !this.pendingRuntimeCleanup() && !hasPendingStop) return;
+    const callbackDueAt = this.messageCallbacks.nextCallbackDueAt();
+    const hasPendingCallbacks = callbackDueAt !== undefined;
+    if (epoch === null && !this.pendingRuntimeCleanup() && !hasPendingStop && !hasPendingCallbacks)
+      return;
     const existing = await this.ctx.storage.getAlarm();
     if (
       (epoch === null || !this.terminalLifecycle.isCurrent(epoch)) &&
       !this.pendingRuntimeCleanup() &&
-      !hasPendingStop
+      !hasPendingStop &&
+      !hasPendingCallbacks
     )
       return;
-    if (existing === null || existing > when) await this.ctx.storage.setAlarm(when);
+    const requested = Math.min(when, callbackDueAt ?? Number.MAX_SAFE_INTEGER);
+    if (existing === null || existing > requested) await this.ctx.storage.setAlarm(requested);
   }
 
   private readPendingInteractions(): PendingInteractions | undefined {
@@ -3803,7 +3941,8 @@ export class SandboxSession extends DurableObject<Env> {
         deferredNotifications,
         undefined,
         undefined,
-        write => write()
+        write => write(),
+        false
       ) === true
     );
   }
@@ -3815,7 +3954,8 @@ export class SandboxSession extends DurableObject<Env> {
     deferredNotifications: StoredEvent[] | undefined,
     onPersist: (() => void) | undefined,
     beforePersist: (() => ControlEventDisposition) | undefined,
-    enclose: (write: () => void) => void
+    enclose: (write: () => void) => void,
+    scheduleCallbackRepair = true
   ): boolean | ControlEventDisposition {
     const returnsControlEventDisposition = beforePersist !== undefined;
     const currentEpoch = epoch ?? this.terminalLifecycle.captureEpoch();
@@ -3827,6 +3967,7 @@ export class SandboxSession extends DurableObject<Env> {
       return returnsControlEventDisposition ? 'epoch_changed' : false;
     const events: StoredEvent[] = [];
     const committed: ControlDiagnosticFields[] = [];
+    let callbackPersisted = false;
     let persisted = false;
     let disposition: ControlEventDisposition = 'epoch_changed';
     const write = () => {
@@ -3873,6 +4014,7 @@ export class SandboxSession extends DurableObject<Env> {
         }
         const event = this.persistMessageLifecycleEvent(terminal);
         if (event) events.push(event);
+        if (this.messageCallbacks.persistTerminalCallback(terminal)) callbackPersisted = true;
         committed.push({
           messageId: terminal.messageId,
           wrapperInstanceId: terminal.wrapperInstanceId,
@@ -3894,7 +4036,8 @@ export class SandboxSession extends DurableObject<Env> {
                     safeError:
                       terminal.state === 'cancelled'
                         ? 'The message was interrupted'
-                        : safeErrorFromQueueReason(terminal.failedReason ?? 'environment_failed'),
+                        : (terminal.failedDetail ??
+                          safeErrorFromQueueReason(terminal.failedReason ?? 'environment_failed')),
                     timestamp: terminal.terminalAt,
                   }
             )
@@ -3908,6 +4051,10 @@ export class SandboxSession extends DurableObject<Env> {
     };
     enclose(write);
     if (!persisted) return returnsControlEventDisposition ? disposition : false;
+    if (callbackPersisted) {
+      if (scheduleCallbackRepair) this.scheduleCallbackRepair();
+      else this.callbackRepairRequired = true;
+    }
     for (const fields of committed) {
       logControlDiagnostic('session_message_committed', {
         sessionId: this.sessionId,

--- a/services/cloud-agent-next/src/sandbox-session/control-dispatch.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/control-dispatch.test.ts
@@ -46,9 +46,10 @@ describe('controlRequestResult', () => {
       failure = error;
     }
     expect(failure).toBeInstanceOf(ControlRequestError);
-    expect(failure).toMatchObject(error);
+    expect(failure).toMatchObject({ ...error, rejectionReceived: true });
     expect(isRetryableDeliveryError(failure)).toBe(true);
     expect(Object.assign(new Error(error.message), error)).not.toBeInstanceOf(ControlRequestError);
+    expect(new ControlRequestError(error).rejectionReceived).toBeUndefined();
   });
 
   it.each([undefined, { retryable: true }, { code: '', message: 'Invalid', retryable: true }])(

--- a/services/cloud-agent-next/src/sandbox-session/control-dispatch.ts
+++ b/services/cloud-agent-next/src/sandbox-session/control-dispatch.ts
@@ -17,13 +17,15 @@ export class ControlRequestError extends Error {
   readonly code: string;
   readonly retryable: boolean;
   readonly admission: ControlError['admission'];
+  readonly rejectionReceived?: true;
 
-  constructor(error: ControlError) {
+  constructor(error: ControlError, options?: { rejectionReceived?: true }) {
     super(error.message);
     this.name = 'ControlRequestError';
     this.code = error.code;
     this.retryable = error.retryable;
     this.admission = error.admission;
+    if (options?.rejectionReceived) this.rejectionReceived = true;
   }
 }
 
@@ -53,7 +55,9 @@ export async function withDeliveryDeadline<T>(
 
 export function controlRequestResult(response: ResponseFrame): unknown {
   if (response.ok) return response.result;
-  throw new ControlRequestError(controlErrorSchema.parse(response.error));
+  throw new ControlRequestError(controlErrorSchema.parse(response.error), {
+    rejectionReceived: true,
+  });
 }
 
 export function isRetryableDeliveryError(error: unknown): boolean {

--- a/services/cloud-agent-next/src/sandbox-session/message-callbacks.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/message-callbacks.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CallbackJob } from '../callbacks/types.js';
+import { logger } from '../logger.js';
+import { parseSessionMetadata, type SessionMetadata } from '../persistence/session-metadata.js';
+import type { LatestAssistantMessage } from '../session/types.js';
+import {
+  CALLBACK_ENQUEUE_MAX_ATTEMPTS,
+  CALLBACK_ENQUEUE_RETRY_MS,
+  callbackOutboxKey,
+  createMessageCallbacks,
+  parseCallbackOutboxValue,
+} from './message-callbacks.js';
+import type { SessionMessageRecord } from './session-message-queue.js';
+
+const SESSION_ID = 'workspace_callback_test';
+const KILO_SESSION_ID = 'kilo_callback_test';
+const MESSAGE_ID = 'message_callback_test';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+type MemoryKv = {
+  get<T>(key: string): T | undefined;
+  put<T>(key: string, value: T): void;
+  delete(key: string): boolean;
+  list<T>(options?: { prefix?: string }): Iterable<[string, T]>;
+};
+
+function memoryKv(): MemoryKv {
+  const values = new Map<string, unknown>();
+  return {
+    get: <T>(key: string) => structuredClone(values.get(key)) as T | undefined,
+    put: <T>(key: string, value: T) => values.set(key, structuredClone(value)),
+    delete: key => values.delete(key),
+    list: <T>(options?: { prefix?: string }) =>
+      [...values.entries()]
+        .filter(([key]) => options?.prefix === undefined || key.startsWith(options.prefix))
+        .map(([key, value]) => [key, structuredClone(value) as T] as [string, T]),
+  };
+}
+
+function metadataWithCallback(callbackUrl = 'https://example.com/callback'): SessionMetadata {
+  return parseSessionMetadata({
+    metadataSchemaVersion: 2,
+    identity: { sessionId: SESSION_ID, userId: 'user_callback_test' },
+    auth: { kiloSessionId: KILO_SESSION_ID },
+    repository: { type: 'git', url: 'https://example.com/repository.git', upstreamBranch: 'main' },
+    callback: { target: { url: callbackUrl, headers: { 'x-test': 'value' } } },
+    workspace: { workspacePath: '/workspace/callback', branchName: 'feature/callback' },
+    lifecycle: { version: 1, timestamp: 1 },
+  });
+}
+
+function message(
+  state: SessionMessageRecord['state'],
+  fields: Record<string, unknown> = {}
+): SessionMessageRecord {
+  return { messageId: MESSAGE_ID, state, ...fields } as SessionMessageRecord;
+}
+
+function assistantMessage(text: string): LatestAssistantMessage {
+  return {
+    eventId: 1 as LatestAssistantMessage['eventId'],
+    timestamp: 1,
+    info: { id: 'assistant_1', role: 'assistant' },
+    parts: [
+      { id: 'part_1', messageID: 'assistant_1', type: 'text', text },
+      { id: 'part_2', messageID: 'assistant_1', type: 'reasoning', text: 'ignored' },
+    ],
+  };
+}
+
+function createHarness(
+  options: { queue?: Pick<Queue<CallbackJob>, 'send'>; callbackUrl?: string } = {}
+) {
+  const kv = memoryKv();
+  let metadata = metadataWithCallback(options.callbackUrl);
+  const callbacks = createMessageCallbacks({
+    storage: { kv } as DurableObjectStorage,
+    getMetadata: () => metadata,
+    getCallbackQueue: () => options.queue,
+    getAssistantMessageForUserMessage: () => assistantMessage('the final answer'),
+  });
+  return {
+    kv,
+    callbacks,
+    setMetadata: (next: SessionMetadata) => {
+      metadata = next;
+    },
+  };
+}
+
+describe('createMessageCallbacks', () => {
+  it('stores one immutable fitted snapshot for a completed message', () => {
+    const harness = createHarness();
+
+    expect(harness.callbacks.persistTerminalCallback(message('completed'))).toBe(true);
+    expect(harness.callbacks.persistTerminalCallback(message('completed'))).toBe(false);
+
+    const stored = harness.kv.get<unknown>(callbackOutboxKey(MESSAGE_ID));
+    expect(parseCallbackOutboxValue(stored)).toMatchObject({
+      attempts: 0,
+      job: {
+        target: { url: 'https://example.com/callback', headers: { 'x-test': 'value' } },
+        payload: {
+          sessionId: SESSION_ID,
+          cloudAgentSessionId: SESSION_ID,
+          executionId: MESSAGE_ID,
+          messageId: MESSAGE_ID,
+          status: 'completed',
+          lastSeenBranch: 'main',
+          kiloSessionId: KILO_SESSION_ID,
+          lastAssistantMessageText: 'the final answer',
+          idempotencyKey: MESSAGE_ID,
+        },
+      },
+    });
+
+    const changedMetadata = metadataWithCallback();
+    changedMetadata.callback!.target!.url = 'https://example.com/changed';
+    harness.setMetadata(changedMetadata);
+    expect(harness.kv.get<unknown>(callbackOutboxKey(MESSAGE_ID))).toMatchObject({
+      job: { target: { url: 'https://example.com/callback' } },
+    });
+  });
+
+  it.each([
+    ['failed', 'provider rejected the request', 'provider rejected the request'],
+    ['cancelled', undefined, 'The message was interrupted'],
+  ] as const)('projects %s terminal details into the callback', (state, detail, errorMessage) => {
+    const harness = createHarness();
+    const record = message(state, {
+      ...(detail ? { failedDetail: detail } : {}),
+      failedReason: 'runtime_unhealthy',
+    });
+
+    expect(harness.callbacks.persistTerminalCallback(record)).toBe(true);
+    expect(harness.kv.get<unknown>(callbackOutboxKey(MESSAGE_ID))).toMatchObject({
+      job: {
+        payload: {
+          status: state === 'cancelled' ? 'interrupted' : state,
+          errorMessage,
+          clientError: { message: errorMessage },
+        },
+      },
+    });
+  });
+
+  it('retries missing callback bindings five times and abandons the pending job', async () => {
+    const harness = createHarness();
+    expect(harness.callbacks.persistTerminalCallback(message('failed'))).toBe(true);
+    const initialNow = Date.now();
+
+    for (let attempt = 1; attempt <= CALLBACK_ENQUEUE_MAX_ATTEMPTS; attempt++) {
+      const now = initialNow + (attempt - 1) * CALLBACK_ENQUEUE_RETRY_MS;
+      await harness.callbacks.repair(now);
+      if (attempt < CALLBACK_ENQUEUE_MAX_ATTEMPTS) {
+        expect(harness.callbacks.nextCallbackDueAt()).toBe(now + CALLBACK_ENQUEUE_RETRY_MS);
+        expect(harness.callbacks.pendingCallbackCount()).toBe(1);
+      }
+    }
+
+    expect(harness.callbacks.pendingCallbackCount()).toBe(0);
+  });
+
+  it('logs only the callback origin when a missing binding abandons a secret-bearing target', async () => {
+    const userInfoSecret = 'callback-userinfo-secret';
+    const pathSecret = 'callback-path-secret';
+    const querySecret = 'callback-query-secret';
+    const callbackUrl = `https://webhook-user:${userInfoSecret}@callback.example/hooks/${pathSecret}?token=${querySecret}`;
+    const fields = vi.spyOn(logger, 'withFields').mockReturnValue(logger);
+    const harness = createHarness({ callbackUrl });
+    expect(harness.callbacks.persistTerminalCallback(message('failed'))).toBe(true);
+    const initialNow = Date.now();
+
+    for (let attempt = 1; attempt <= CALLBACK_ENQUEUE_MAX_ATTEMPTS; attempt += 1) {
+      await harness.callbacks.repair(initialNow + (attempt - 1) * CALLBACK_ENQUEUE_RETRY_MS);
+    }
+
+    const serializedFields = JSON.stringify(fields.mock.calls);
+    expect(serializedFields).not.toContain(userInfoSecret);
+    expect(serializedFields).not.toContain(pathSecret);
+    expect(serializedFields).not.toContain(querySecret);
+    expect(fields).toHaveBeenCalledWith(
+      expect.objectContaining({ callbackTarget: 'https://callback.example' })
+    );
+    expect(harness.callbacks.pendingCallbackCount()).toBe(0);
+  });
+
+  it('logs only the callback origin when rejected sends abandon a secret-bearing target', async () => {
+    const userInfoSecret = 'rejected-userinfo-secret';
+    const pathSecret = 'rejected-path-secret';
+    const querySecret = 'rejected-query-secret';
+    const callbackUrl = `https://webhook-user:${userInfoSecret}@callback.example/hooks/${pathSecret}?token=${querySecret}`;
+    const send = vi.fn(async (_job: CallbackJob) => {
+      throw new Error('callback queue rejected');
+    });
+    const fields = vi.spyOn(logger, 'withFields').mockReturnValue(logger);
+    const harness = createHarness({ callbackUrl, queue: { send } });
+    expect(harness.callbacks.persistTerminalCallback(message('failed'))).toBe(true);
+    const initialNow = Date.now();
+
+    for (let attempt = 1; attempt <= CALLBACK_ENQUEUE_MAX_ATTEMPTS; attempt += 1) {
+      await harness.callbacks.repair(initialNow + (attempt - 1) * CALLBACK_ENQUEUE_RETRY_MS);
+    }
+
+    const serializedFields = JSON.stringify(fields.mock.calls);
+    expect(serializedFields).not.toContain(userInfoSecret);
+    expect(serializedFields).not.toContain(pathSecret);
+    expect(serializedFields).not.toContain(querySecret);
+    expect(fields).toHaveBeenCalledWith(
+      expect.objectContaining({ callbackTarget: 'https://callback.example' })
+    );
+    expect(send).toHaveBeenCalledTimes(CALLBACK_ENQUEUE_MAX_ATTEMPTS);
+    expect(harness.callbacks.pendingCallbackCount()).toBe(0);
+  });
+
+  it('deletes a pending snapshot only after a successful queue send', async () => {
+    const send = vi.fn(async (_job: CallbackJob) => ({}) as QueueSendResponse);
+    const harness = createHarness({ queue: { send } });
+    expect(harness.callbacks.persistTerminalCallback(message('completed'))).toBe(true);
+
+    await harness.callbacks.repair(Date.now());
+
+    expect(send).toHaveBeenCalledOnce();
+    expect(harness.callbacks.pendingCallbackCount()).toBe(0);
+  });
+});

--- a/services/cloud-agent-next/src/sandbox-session/message-callbacks.ts
+++ b/services/cloud-agent-next/src/sandbox-session/message-callbacks.ts
@@ -1,0 +1,354 @@
+import {
+  fitCallbackJobToQueueLimit,
+  type CallbackJobQueueFitResult,
+} from '../callbacks/queue-payload.js';
+import type { CallbackJob, CallbackTarget } from '../callbacks/types.js';
+import { logger } from '../logger.js';
+import type { SessionMetadata } from '../persistence/session-metadata.js';
+import { projectTerminalClientError } from '../session/terminal-error-projector.js';
+import type { LatestAssistantMessage } from '../session/types.js';
+import { safeErrorFromQueueReason } from './control-dispatch.js';
+import type { SessionMessageRecord } from './session-message-queue.js';
+
+export const CALLBACK_OUTBOX_PREFIX = 'callback_outbox:';
+export const CALLBACK_ENQUEUE_MAX_ATTEMPTS = 5;
+export const CALLBACK_ENQUEUE_RETRY_MS = 30_000;
+
+type CallbackQueue = Pick<Queue<CallbackJob>, 'send'>;
+type CallbackStorage = Pick<DurableObjectStorage, 'kv'>;
+
+export type PendingCallbackJob = {
+  job: CallbackJob;
+  attempts: number;
+  dueAt: number;
+};
+
+export type MessageCallbacksDependencies = {
+  storage: CallbackStorage;
+  getMetadata: () => SessionMetadata | null;
+  getCallbackQueue: () => CallbackQueue | undefined;
+  getAssistantMessageForUserMessage: (
+    sessionId: string,
+    kiloSessionId: string,
+    parentMessageId: string
+  ) => LatestAssistantMessage | null;
+};
+
+export type MessageCallbacks = {
+  persistTerminalCallback(
+    message: SessionMessageRecord,
+    metadata?: SessionMetadata | null
+  ): boolean;
+  pendingCallbackCount(): number;
+  nextCallbackDueAt(): number | undefined;
+  repair(now?: number): Promise<void>;
+};
+
+const callbackTargetSchema = {
+  url: (value: unknown): value is string => typeof value === 'string' && value.length > 0,
+  headers: (value: unknown): value is Record<string, string> => {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    return Object.entries(value).every(
+      ([key, entry]) => key.length > 0 && typeof entry === 'string'
+    );
+  },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isCallbackTarget(value: unknown): value is CallbackTarget {
+  if (!isRecord(value) || !callbackTargetSchema.url(value.url)) return false;
+  try {
+    new URL(value.url);
+  } catch {
+    return false;
+  }
+  return value.headers === undefined || callbackTargetSchema.headers(value.headers);
+}
+
+function isCallbackJob(value: unknown): value is CallbackJob {
+  if (!isRecord(value) || !isCallbackTarget(value.target) || !isRecord(value.payload)) {
+    return false;
+  }
+  const payload = value.payload;
+  return (
+    typeof payload.sessionId === 'string' &&
+    typeof payload.cloudAgentSessionId === 'string' &&
+    (payload.executionId === undefined || typeof payload.executionId === 'string') &&
+    (payload.messageId === undefined || typeof payload.messageId === 'string') &&
+    (payload.status === 'completed' ||
+      payload.status === 'failed' ||
+      payload.status === 'interrupted')
+  );
+}
+
+function parsePendingCallbackJob(value: unknown): PendingCallbackJob | undefined {
+  if (!isRecord(value)) return undefined;
+  const attempts = value.attempts;
+  const dueAt = value.dueAt;
+  if (
+    !isCallbackJob(value.job) ||
+    typeof attempts !== 'number' ||
+    !Number.isInteger(attempts) ||
+    typeof dueAt !== 'number' ||
+    !Number.isFinite(dueAt) ||
+    attempts < 0 ||
+    attempts > CALLBACK_ENQUEUE_MAX_ATTEMPTS
+  ) {
+    return undefined;
+  }
+  return {
+    job: value.job,
+    attempts,
+    dueAt,
+  };
+}
+
+function callbackKey(messageId: string): string {
+  return `${CALLBACK_OUTBOX_PREFIX}${messageId}`;
+}
+
+function extractAssistantText(message: LatestAssistantMessage): string | undefined {
+  const pieces: string[] = [];
+  for (const part of message.parts) {
+    if (part.type !== 'text' || typeof part.text !== 'string' || part.text.length === 0) continue;
+    pieces.push(part.text);
+  }
+  const text = pieces.join('').trim();
+  return text || undefined;
+}
+
+function callbackStatus(
+  message: SessionMessageRecord
+): CallbackJob['payload']['status'] | undefined {
+  if (message.state === 'completed') return 'completed';
+  if (message.state === 'failed') return 'failed';
+  if (message.state === 'cancelled') return 'interrupted';
+  return undefined;
+}
+
+function redactCallbackTargetUrl(callbackUrl: string): string {
+  try {
+    const url = new URL(callbackUrl);
+    return url.origin;
+  } catch {
+    return 'invalid-url';
+  }
+}
+
+export function createMessageCallbacks(
+  dependencies: MessageCallbacksDependencies
+): MessageCallbacks {
+  const { storage, getMetadata, getCallbackQueue, getAssistantMessageForUserMessage } =
+    dependencies;
+  let repairInFlight: Promise<void> | undefined;
+
+  function buildJob(
+    message: SessionMessageRecord,
+    metadata: SessionMetadata,
+    target: CallbackTarget
+  ): CallbackJob | undefined {
+    const status = callbackStatus(message);
+    if (!status) return undefined;
+
+    const sessionId = metadata.identity.sessionId;
+    const kiloSessionId = metadata.auth.kiloSessionId;
+    let lastAssistantMessageText: string | undefined;
+    if (status === 'completed' && kiloSessionId) {
+      try {
+        const assistantMessage = getAssistantMessageForUserMessage(
+          sessionId,
+          kiloSessionId,
+          message.messageId
+        );
+        lastAssistantMessageText = assistantMessage
+          ? extractAssistantText(assistantMessage)
+          : undefined;
+      } catch {
+        lastAssistantMessageText = undefined;
+        logger
+          .withFields({ sessionId, messageId: message.messageId })
+          .warn('Unable to include the assistant answer in the callback snapshot');
+      }
+    }
+    const errorMessage =
+      status === 'completed'
+        ? undefined
+        : status === 'interrupted'
+          ? 'The message was interrupted'
+          : (message.failedDetail ??
+            safeErrorFromQueueReason(message.failedReason ?? 'environment_failed'));
+
+    return {
+      target: structuredClone(target),
+      payload: {
+        sessionId,
+        cloudAgentSessionId: sessionId,
+        executionId: message.messageId,
+        messageId: message.messageId,
+        status,
+        ...(errorMessage ? { errorMessage } : {}),
+        ...(status === 'completed'
+          ? {}
+          : {
+              clientError: projectTerminalClientError({ status, error: errorMessage }),
+            }),
+        lastSeenBranch: metadata.repository?.upstreamBranch ?? metadata.workspace?.branchName,
+        kiloSessionId,
+        lastAssistantMessageText,
+        idempotencyKey: message.messageId,
+      },
+    };
+  }
+
+  function persistTerminalCallback(
+    message: SessionMessageRecord,
+    metadata = getMetadata()
+  ): boolean {
+    const target = metadata?.callback?.target;
+    if (!target || callbackStatus(message) === undefined) return false;
+
+    const key = callbackKey(message.messageId);
+    if (storage.kv.get<unknown>(key) !== undefined) return false;
+
+    let fittedJob: CallbackJobQueueFitResult;
+    try {
+      const job = buildJob(message, metadata, target);
+      if (!job) return false;
+      fittedJob = fitCallbackJobToQueueLimit(job);
+      if (fittedJob.status === 'too-large') {
+        logger
+          .withFields({
+            sessionId: metadata.identity.sessionId,
+            messageId: message.messageId,
+            serializedByteLength: fittedJob.serializedByteLength,
+            maximumByteLength: fittedJob.maximumByteLength,
+          })
+          .error('Abandoned callback job that cannot fit queue size limit');
+        return false;
+      }
+    } catch {
+      logger
+        .withFields({ sessionId: metadata.identity.sessionId, messageId: message.messageId })
+        .error('Abandoned callback job that could not be prepared');
+      return false;
+    }
+    if (fittedJob.status !== 'ready') return false;
+    storage.kv.put<PendingCallbackJob>(key, {
+      job: structuredClone(fittedJob.job),
+      attempts: 0,
+      dueAt: Date.now(),
+    });
+    return true;
+  }
+
+  function pendingEntries(): Array<[string, PendingCallbackJob | undefined]> {
+    return Array.from(storage.kv.list<unknown>({ prefix: CALLBACK_OUTBOX_PREFIX })).map(
+      ([key, value]) => [key, parsePendingCallbackJob(value)]
+    );
+  }
+
+  function pendingCallbackCount(): number {
+    return pendingEntries().length;
+  }
+
+  function nextCallbackDueAt(): number | undefined {
+    const entries = pendingEntries();
+    let next: number | undefined;
+    for (const [, pending] of entries) {
+      if (!pending || pending.attempts >= CALLBACK_ENQUEUE_MAX_ATTEMPTS) {
+        next = Math.min(next ?? Date.now(), Date.now());
+        continue;
+      }
+      next = Math.min(next ?? pending.dueAt, pending.dueAt);
+    }
+    return next;
+  }
+
+  function logEnqueueFailure(job: CallbackJob, attempts: number, abandoned: boolean): void {
+    logger
+      .withFields({
+        sessionId: job.payload.sessionId,
+        messageId: job.payload.messageId,
+        status: job.payload.status,
+        attempts,
+        callbackTarget: redactCallbackTargetUrl(job.target.url),
+      })
+      .error(abandoned ? 'Callback enqueue abandoned' : 'Callback enqueue failed; retry scheduled');
+  }
+
+  async function runRepair(now: number): Promise<void> {
+    for (const [key, parsed] of pendingEntries()) {
+      if (!parsed) {
+        logger
+          .withFields({ keyPrefix: CALLBACK_OUTBOX_PREFIX })
+          .error('Invalid callback outbox job');
+        storage.kv.delete(key);
+        continue;
+      }
+      if (parsed.attempts >= CALLBACK_ENQUEUE_MAX_ATTEMPTS) {
+        logEnqueueFailure(parsed.job, parsed.attempts, true);
+        storage.kv.delete(key);
+        continue;
+      }
+      if (parsed.dueAt > now) continue;
+
+      const attempts = parsed.attempts + 1;
+      const reserved: PendingCallbackJob = {
+        ...parsed,
+        attempts,
+        dueAt: now + CALLBACK_ENQUEUE_RETRY_MS,
+      };
+      storage.kv.put(key, reserved);
+
+      const queue = getCallbackQueue();
+      if (!queue) {
+        if (attempts >= CALLBACK_ENQUEUE_MAX_ATTEMPTS) {
+          logEnqueueFailure(parsed.job, attempts, true);
+          storage.kv.delete(key);
+        } else {
+          logEnqueueFailure(parsed.job, attempts, false);
+        }
+        continue;
+      }
+
+      try {
+        await queue.send(parsed.job);
+        storage.kv.delete(key);
+      } catch {
+        if (attempts >= CALLBACK_ENQUEUE_MAX_ATTEMPTS) {
+          logEnqueueFailure(parsed.job, attempts, true);
+          storage.kv.delete(key);
+        } else {
+          logEnqueueFailure(parsed.job, attempts, false);
+        }
+      }
+    }
+  }
+
+  function repair(now = Date.now()): Promise<void> {
+    if (repairInFlight) return repairInFlight;
+    const pending = runRepair(now).finally(() => {
+      repairInFlight = undefined;
+    });
+    repairInFlight = pending;
+    return pending;
+  }
+
+  return {
+    persistTerminalCallback,
+    pendingCallbackCount,
+    nextCallbackDueAt,
+    repair,
+  };
+}
+
+export function parseCallbackOutboxValue(value: unknown): PendingCallbackJob | undefined {
+  return parsePendingCallbackJob(value);
+}
+
+export function callbackOutboxKey(messageId: string): string {
+  return callbackKey(messageId);
+}

--- a/services/cloud-agent-next/src/sandbox-session/session-message-queue.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-message-queue.test.ts
@@ -11,6 +11,7 @@ import { createMemoryEventQueries, readStep } from '../session/preparation-test-
 import { getPreparationSnapshots, readPreparationAttempt } from '../session/preparation-history.js';
 import type { Env } from '../types.js';
 import type { UserId } from '../types/ids.js';
+import type { CallbackJob } from '../callbacks/types.js';
 import type { sandboxControlRpc } from './control-rpc.js';
 import type { SandboxControlOutboundRequest } from '../sandbox-control/socket.js';
 import {
@@ -31,6 +32,7 @@ import { DEADLINE_MS } from '../sandbox-control/deadlines.js';
 import { createControlPlaneCredential } from '../sandbox-control/managed-credential.js';
 import { logger } from '../logger.js';
 import { SESSION_DELIVERY_TIMEOUT_MS } from './control-dispatch.js';
+import { PENDING_SESSION_MESSAGE_LIMIT } from '../session/pending-messages.js';
 import { createControlStopRequest } from '../shared/control-plane-session.js';
 import type {
   AcceptedCommandTurn,
@@ -679,6 +681,27 @@ describe('failQueuedMessage', () => {
     expect(failQueuedMessage([msg('a', 'completed')], 'a')).toBeUndefined();
     expect(failQueuedMessage([msg('a', 'accepted')], 'a')).toBeUndefined();
   });
+
+  it('retains a bounded terminal detail for public projections', () => {
+    const failed = failQueuedMessage(
+      [msg('a', 'queued')],
+      'a',
+      'attach_exhausted',
+      'Repository checkout failed: output: requested review ref was not found'
+    );
+    expect(failed?.[0]).toMatchObject({
+      state: 'failed',
+      failedReason: 'attach_exhausted',
+      failedDetail: 'Repository checkout failed: output: requested review ref was not found',
+    });
+    expect(streamQueuedSnapshots(failed ?? [], 20)).toMatchObject([
+      {
+        terminalFailure: {
+          error: 'Repository checkout failed: output: requested review ref was not found',
+        },
+      },
+    ]);
+  });
 });
 
 describe('acceptQueuedMessage', () => {
@@ -1078,7 +1101,11 @@ function controlFailure(retryable: boolean, code = 'not_ready'): ResponseFrame {
   };
 }
 
-function sessionFixture(overrides: Partial<SessionMetadata> = {}, sharedControl?: Control) {
+function sessionFixture(
+  overrides: Partial<SessionMetadata> = {},
+  sharedControl?: Control,
+  callbackQueue?: Pick<Queue<CallbackJob>, 'send'>
+) {
   const values = new Map<string, unknown>();
   let alarmAt: number | null = null;
   const errors: unknown[] = [];
@@ -1181,6 +1208,7 @@ function sessionFixture(overrides: Partial<SessionMetadata> = {}, sharedControl?
   } satisfies Control;
   const env = {
     SANDBOX_CONTROL: { getByName: () => sharedControl ?? control },
+    CALLBACK_QUEUE: callbackQueue,
     CLOUD_AGENT_CONTAINER_BILLING_ENABLED: 'true',
     CLOUD_AGENT_CONTAINER_BILLING_ORG_IDS: 'org_1',
     CLOUD_AGENT_CONTAINER_BILLING_USER_IDS: 'user_1',
@@ -1290,6 +1318,106 @@ describe('SandboxSession orchestration', () => {
   });
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('persists and sends a terminal callback after a completed outcome', async () => {
+    const send = vi.fn(async (_job: CallbackJob) => ({}) as QueueSendResponse);
+    const fixture = sessionFixture(
+      { callback: { target: { url: 'https://example.com/callback' } } },
+      undefined,
+      { send }
+    );
+
+    await fixture.admit('callback_message');
+    await fixture.flush();
+    await fixture.outcome('callback_message', 'completed');
+    await fixture.flush();
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: { url: 'https://example.com/callback' },
+        payload: expect.objectContaining({
+          sessionId: SESSION_ID,
+          cloudAgentSessionId: SESSION_ID,
+          messageId: 'callback_message',
+          status: 'completed',
+          idempotencyKey: 'callback_message',
+        }),
+      })
+    );
+    expect(fixture.alarmAt()).toBe(Date.now());
+  });
+
+  it('counts callback-bearing outstanding messages against admission capacity', async () => {
+    const fixture = sessionFixture({
+      callback: { target: { url: 'https://example.com/callback' } },
+    });
+    fixture.storage.kv.put(
+      'session_messages',
+      Array.from({ length: PENDING_SESSION_MESSAGE_LIMIT }, (_, index) => ({
+        messageId: `existing_${index}`,
+        state: index === 0 ? ('accepted' as const) : ('queued' as const),
+      }))
+    );
+
+    await expect(fixture.admit('overflow')).resolves.toMatchObject({
+      success: false,
+      code: 'PENDING_QUEUE_FULL',
+    });
+    expect(fixture.values.get('session_messages')).toHaveLength(PENDING_SESSION_MESSAGE_LIMIT);
+  });
+
+  it('arms callback repair after the outer operation-result transaction', async () => {
+    const send = vi.fn(async (_job: CallbackJob) => ({}) as QueueSendResponse);
+    const fixture = sessionFixture(
+      { callback: { target: { url: 'https://example.com/callback' } } },
+      undefined,
+      { send }
+    );
+    fixture.setStatus({
+      physical: 'running',
+      connection: 'ready',
+      wrapperInstanceId: RUNTIME_ID,
+      operationResults: true,
+    });
+    await fixture.admit('receipted_callback');
+    await fixture.flush();
+    const authorization = fixture.record('receipted_callback')?.operations?.prompt?.authorization;
+    if (!authorization) throw new Error('Missing prompt operation authorization');
+    const event = receiptedEvent(1, {
+      type: 'session.status',
+      properties: { sessionID: 'kilo_root', status: { type: 'busy' } },
+    });
+
+    await expect(fixture.session.receiveSandboxControlEvent(event)).resolves.toEqual({
+      applied: true,
+    });
+    await expect(
+      fixture.session.receiveSandboxOperationResult({
+        session: authorization.session,
+        wrapperInstanceId: RUNTIME_ID,
+        delivery: {
+          version: 2,
+          authorization,
+          completedAt: Date.now(),
+          result: { ok: true, result: { messageId: 'receipted_callback', status: 'accepted' } },
+          outcome: { messageId: 'receipted_callback', status: 'completed' },
+          events: [],
+          preparing: [],
+        },
+      })
+    ).resolves.toMatchObject({ disposition: 'applied' });
+    await fixture.flush();
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          messageId: 'receipted_callback',
+          status: 'completed',
+        }),
+      })
+    );
+    expect(fixture.alarmAt()).toBe(Date.now());
   });
 
   it('reports the named runtime gate with incoming, expected, and fence identities', async () => {
@@ -3784,7 +3912,7 @@ describe('SandboxSession orchestration', () => {
         if (source === 'exception') first.reject(transient);
         else first.resolve(controlFailure(true));
         await fixture.flush();
-        if (operation === 'session.attach') {
+        if (operation === 'session.attach' && source === 'exception') {
           expect(fixture.record('a')?.state).toBe('queued');
           expect(fixture.record('a')?.attachFailures).toBeUndefined();
           expect(fixture.terminalEvents()).toHaveLength(0);
@@ -3863,7 +3991,12 @@ describe('SandboxSession orchestration', () => {
         );
       }
       await fixture.flush();
-      const expectedReason = operation === 'session.attach' ? 'environment_failed' : reason;
+      const expectedReason =
+        operation === 'session.attach'
+          ? failure === 'permanent response' || failure === 'unhealthy response'
+            ? 'attach_exhausted'
+            : 'environment_failed'
+          : reason;
       expect(fixture.record('a')).toMatchObject({ state: 'failed', failedReason: expectedReason });
       if (failure === 'permanent response') {
         expect(fixture.record('b')?.state).toBe('queued');
@@ -4094,18 +4227,18 @@ describe('SandboxSession orchestration', () => {
             sibling.reload();
             await sibling.fireAlarm();
           }
-          if (operation === 'session.attach' && retryable) {
-            expect(sibling.record('rejected')).toMatchObject({ state: 'queued' });
+          if (operation === 'session.attach') {
+            expect(sibling.record('rejected')).toMatchObject({
+              state: 'failed',
+              failedReason: 'attach_exhausted',
+            });
           } else {
             expect(sibling.record('rejected')).toMatchObject({
               state: 'failed',
-              failedReason:
-                operation === 'session.attach' ? 'environment_failed' : 'prompt_exhausted',
+              failedReason: 'prompt_exhausted',
             });
           }
-          expect(sibling.terminalEvents()).toHaveLength(
-            operation === 'session.attach' && retryable ? 0 : 1
-          );
+          expect(sibling.terminalEvents()).toHaveLength(1);
           expect(await sibling.session.isSandboxCleanupScheduled()).toBe(false);
           expect(writer.control.quarantineRuntime).not.toHaveBeenCalled();
           await writer.outcome('writer', 'completed');
@@ -4428,6 +4561,42 @@ describe('SandboxSession orchestration', () => {
       });
     }
   );
+
+  it('fences admissions and snapshots callbacks before deletion waits on an interrupt', async () => {
+    const send = vi.fn(async (_job: CallbackJob) => ({}) as QueueSendResponse);
+    const fixture = sessionFixture(
+      { callback: { target: { url: 'https://example.com/callback' } } },
+      undefined,
+      { send }
+    );
+    const abort = deferred<ResponseFrame>();
+    delegateRequest(fixture, 'session.abort', () => abort.promise);
+
+    await fixture.admit('a');
+    await fixture.flush();
+    expect(fixture.record('a')?.state).toBe('accepted');
+
+    const deletion = fixture.session.deleteSession();
+    expect(fixture.control.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: 'session.abort',
+        payload: { messageId: 'a' },
+      })
+    );
+    await expect(fixture.admit('b')).resolves.toMatchObject({
+      success: false,
+      code: 'NOT_FOUND',
+    });
+
+    abort.resolve(controlResponse({ status: 'aborted' }));
+    await deletion;
+    await fixture.flush();
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ messageId: 'a', status: 'interrupted' }),
+      })
+    );
+  });
 
   it.each(['completed', 'failed', 'cancelled'] as const)(
     'settles an early %s outcome once without resurrecting work on acknowledgement',

--- a/services/cloud-agent-next/src/sandbox-session/session-message-queue.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-message-queue.ts
@@ -46,6 +46,7 @@ export type SessionOperationProof = {
   completedAt?: number;
   attachmentEpoch?: number;
   decision?: SessionOperationAck['decision'];
+  rejectionReceived?: true;
 };
 
 type SessionMessageLifecycle = {
@@ -60,6 +61,7 @@ type SessionMessageLifecycle = {
   terminalAt?: number;
   terminalSource?: SessionMessageTerminalSource;
   failedReason?: string;
+  failedDetail?: string;
   attachFailures?: number;
   promptFailures?: number;
   preparationAttemptId?: string;
@@ -275,7 +277,11 @@ export function failWaitingMessages(
         return message;
       }
       failedIds.push(message.messageId);
-      return { ...message, state: 'failed', failedReason: reason };
+      return {
+        ...message,
+        state: 'failed',
+        failedReason: reason,
+      };
     }),
     failedIds,
   };
@@ -399,14 +405,20 @@ export function hasAcceptedMessage(messages: readonly SessionMessageRecord[]): b
 export function failQueuedMessage(
   messages: readonly SessionMessageRecord[],
   messageId: string,
-  reason?: string
+  reason?: string,
+  detail?: string
 ): SessionMessageRecord[] | undefined {
   if (!messages.some(message => message.messageId === messageId && message.state === 'queued')) {
     return undefined;
   }
   return messages.map(message =>
     message.messageId === messageId && message.state === 'queued'
-      ? { ...message, state: 'failed', ...(reason ? { failedReason: reason } : {}) }
+      ? {
+          ...message,
+          state: 'failed',
+          ...(reason ? { failedReason: reason } : {}),
+          ...(detail ? { failedDetail: detail } : {}),
+        }
       : message
   );
 }
@@ -493,8 +505,8 @@ export function failedMessageSnapshot(
     reason: cancelled ? 'interrupted' : message.failedReason,
     ...(cancelled
       ? { error: 'The message was interrupted' }
-      : message.failedReason
-        ? { error: message.failedReason }
+      : message.failedDetail || message.failedReason
+        ? { error: message.failedDetail ?? message.failedReason }
         : {}),
     timestamp: message.acceptedAt ?? now,
   };
@@ -677,6 +689,35 @@ export function recordSessionOperationDispatch(
                   authorization.dispatchDeadlineAt + SANDBOX_CONTROL_EXECUTION_TIMEOUT_MS,
               }
             : {}),
+        }
+      : item
+  );
+}
+
+export function markSessionOperationRejection(
+  messages: readonly SessionMessageRecord[],
+  authorization: SessionOperationAuthorization
+): SessionMessageRecord[] | undefined {
+  if (authorization.operation !== 'session.attach') return [...messages];
+  const message = messages.find(item => item.messageId === authorization.messageId);
+  const proof = message?.operations?.attach;
+  const storedAuthorization = sessionOperationAuthorizationSchema.safeParse(proof?.authorization);
+  if (
+    !message ||
+    !proof?.dispatched ||
+    !storedAuthorization.success ||
+    !sameSessionOperation(storedAuthorization.data, authorization)
+  )
+    return undefined;
+  if (proof.rejectionReceived) return [...messages];
+  return messages.map(item =>
+    item.messageId === message.messageId
+      ? {
+          ...item,
+          operations: {
+            ...item.operations,
+            attach: { ...proof, rejectionReceived: true },
+          },
         }
       : item
   );

--- a/services/cloud-agent-next/src/sandbox-session/session-operation.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-operation.ts
@@ -66,7 +66,7 @@ type UncertainOperation = {
   reason: 'missing' | 'unverified' | 'transport';
   error?: unknown;
 };
-type RejectedOperation = { state: 'rejected'; error: ControlError };
+type RejectedOperation = { state: 'rejected'; error: ControlError; rejectionReceived?: true };
 export type SessionOperationObservation =
   | RunningOperation
   | CompletedOperation
@@ -79,11 +79,15 @@ export type SessionOperationDispatch =
   | UncertainOperation
   | RejectedOperation;
 
-function rejectedOrUncertain(error: unknown): RejectedOperation | UncertainOperation {
+function rejectedOrUncertain(
+  error: unknown,
+  captureRejection = false
+): RejectedOperation | UncertainOperation {
   return error instanceof ControlRequestError
     ? {
         state: 'rejected',
         error: { code: error.code, message: error.message, retryable: error.retryable },
+        ...(captureRejection && error.rejectionReceived ? { rejectionReceived: true } : {}),
       }
     : { state: 'uncertain', reason: 'transport', error };
 }
@@ -193,7 +197,11 @@ export async function dispatchSessionOperation(
       );
       if (lookup.state !== 'completed') return lookup;
       if (!lookup.delivery.result.ok)
-        return { state: 'rejected', error: lookup.delivery.result.error };
+        return {
+          state: 'rejected',
+          error: lookup.delivery.result.error,
+          rejectionReceived: true,
+        };
       if (kind === 'attach') {
         const completed = completeSessionOperationAttachment(messages.read(), authorization);
         if (!completed || !messages.commit(completed))
@@ -253,7 +261,7 @@ export async function dispatchSessionOperation(
       return { state: 'response', result: prompt };
     } catch (error) {
       if (rejectedBeforeAdmission(error)) record(false);
-      return rejectedOrUncertain(error);
+      return rejectedOrUncertain(error, true);
     }
   } catch (error) {
     return rejectedOrUncertain(error);
@@ -263,7 +271,11 @@ export async function dispatchSessionOperation(
 export function operationDispatchError(
   result: Exclude<SessionOperationDispatch, { state: 'response' } | { state: 'completed' }>
 ): ControlRequestError {
-  if (result.state === 'rejected') return new ControlRequestError(result.error);
+  if (result.state === 'rejected')
+    return new ControlRequestError(
+      result.error,
+      result.rejectionReceived ? { rejectionReceived: true } : undefined
+    );
   if (result.state === 'running')
     return new ControlRequestError({
       code: 'session_busy',

--- a/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.test.ts
@@ -492,6 +492,22 @@ describe('SandboxSession terminal lifecycle', () => {
     expect(fixture.closeTerminalBridge).not.toHaveBeenCalled();
   });
 
+  it('retains callback outbox jobs while purging deleted session state', () => {
+    const fixture = createFixture();
+    fixture.lifecycle.beginDeletion(fixture.metadata);
+    fixture.values.set('callback_outbox:message_1', { pending: true });
+    fixture.values.set('transient_state', true);
+
+    fixture.lifecycle.purgeDeletedState();
+
+    expect(fixture.values.has('callback_outbox:message_1')).toBe(true);
+    expect(fixture.values.has('transient_state')).toBe(false);
+    expect([...fixture.values.keys()]).toEqual([
+      SANDBOX_SESSION_LIFECYCLE_KEY,
+      'callback_outbox:message_1',
+    ]);
+  });
+
   it('invalidates only confirmed terminals belonging to the requested runtime', async () => {
     const fixture = createFixture();
     await fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID });

--- a/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.ts
+++ b/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.ts
@@ -21,6 +21,7 @@ import {
 import { isTerminalSessionPlatform } from '../terminal/access.js';
 import type { sandboxControlRpc } from './control-rpc.js';
 import type { SandboxTerminalRecord } from './terminal-bridge.js';
+import { CALLBACK_OUTBOX_PREFIX } from './message-callbacks.js';
 
 export const SANDBOX_SESSION_METADATA_KEY = 'session_metadata';
 export const SANDBOX_SESSION_LIFECYCLE_KEY = 'session_lifecycle_fence';
@@ -819,7 +820,8 @@ export function createSandboxTerminalLifecycle(deps: TerminalLifecycleDeps) {
     if (readFence()?.state !== 'deleted') return;
     const keys = Array.from(storage.kv.list<unknown>(), ([key]) => key);
     for (const key of keys) {
-      if (key !== SANDBOX_SESSION_LIFECYCLE_KEY) storage.kv.delete(key);
+      if (key !== SANDBOX_SESSION_LIFECYCLE_KEY && !key.startsWith(CALLBACK_OUTBOX_PREFIX))
+        storage.kv.delete(key);
     }
   }
 

--- a/services/cloud-agent-next/test/e2e/README.md
+++ b/services/cloud-agent-next/test/e2e/README.md
@@ -151,9 +151,14 @@ tsx services/cloud-agent-next/test/e2e/run.ts unknown-model _
 tsx services/cloud-agent-next/test/e2e/run.ts waiters-clean _
 
 # Callback delivery — driver stands up a local HTTP sink and asserts on receipt.
-tsx services/cloud-agent-next/test/e2e/run.ts callback-completion echo:done
-tsx services/cloud-agent-next/test/e2e/run.ts callback-batch-followup _
-tsx services/cloud-agent-next/test/e2e/run.ts callback-interrupt _
+# `callbackTarget` is accepted by prepareSession only (workerd can POST
+# http://127.0.0.1:<ephemeral> on the same host; no tunnel). Use the
+# cloud-worktree-setup user so GitHub-backed clones have an installation token.
+E2E_USER_EMAIL=evgeny@kilocode.ai E2E_GITHUB_REPO=na2-org/hi-how-are-you \
+  WORKER_URL=http://localhost:<8794+offset> FAKE_LLM_URL=http://localhost:<8811+offset> \
+  tsx services/cloud-agent-next/test/e2e/run.ts --api=legacy callback-completion echo:done
+tsx services/cloud-agent-next/test/e2e/run.ts --api=legacy callback-batch-followup _
+tsx services/cloud-agent-next/test/e2e/run.ts --api=legacy callback-interrupt _
 
 # Legacy API (prepareSession + initiateFromKilocodeSessionV2 / sendMessageV2).
 tsx services/cloud-agent-next/test/e2e/run.ts --api=legacy cold-hot echo:legacy
@@ -180,6 +185,9 @@ for any other offset, compute the real ports from `pnpm dev:status --json`
 | `WORKER_URL` | `http://localhost:8794` |
 | `FAKE_LLM_URL` | `http://localhost:8811` (host-side view) |
 | `E2E_GIT_URL` | `https://github.com/octocat/Hello-World.git` |
+| `E2E_GITHUB_REPO` | unset. When set (`owner/repo`), start uses GitHub-app clone instead of `gitUrl`. Pair with `E2E_USER_EMAIL` for the seeded installation. |
+| `E2E_USER_EMAIL` | unset (ephemeral `usr_e2e_*`). Set to the cloud-worktree-setup email to reuse that user and its GitHub integration. |
+| `E2E_BRANCH` | unset. Optional checkout ref (`upstreamBranch` / `repository.branch`). |
 | `E2E_MODEL` | `kilo/fake-deterministic` (the only model the fake serves) |
 | `DATABASE_URL` | Optional direct database URL override for this harness |
 | `POSTGRES_URL` | Repo database fallback loaded from root `.env.local` / `.env` |

--- a/services/cloud-agent-next/test/e2e/auth.ts
+++ b/services/cloud-agent-next/test/e2e/auth.ts
@@ -16,6 +16,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import path from 'node:path';
 import process from 'node:process';
 import jwt from 'jsonwebtoken';
+import { eq, or } from 'drizzle-orm';
 import { computeDatabaseUrl, createDrizzleClient, kilocode_users, sql } from '@kilocode/db';
 
 export const DRIVER_USER_EMAIL_SUFFIX = '@cloud-agent-next-e2e.example.com';
@@ -148,6 +149,53 @@ export async function ensureTestUser(
   }
 }
 
+/**
+ * Load a seeded local user by email (the cloud-worktree-setup identity).
+ * Does not create a `usr_e2e_*` stand-in; GitHub integration lives on the
+ * real row. Never logs the pepper or other credentials.
+ */
+export async function loadExistingUserByEmail(
+  databaseUrl: string | undefined,
+  email: string
+): Promise<TestUser> {
+  const resolvedUrl = databaseUrl ?? computeDatabaseUrl();
+  const driver = createDrizzleClient({
+    connectionString: resolvedUrl,
+    poolConfig: { application_name: 'cloud-agent-next-e2e-driver', max: 1 },
+  });
+  try {
+    const normalizedEmail = email.trim().toLowerCase();
+    const rows = await driver.db
+      .select({
+        id: kilocode_users.id,
+        email: kilocode_users.google_user_email,
+        api_token_pepper: kilocode_users.api_token_pepper,
+      })
+      .from(kilocode_users)
+      .where(
+        or(
+          eq(kilocode_users.google_user_email, email),
+          eq(kilocode_users.normalized_email, normalizedEmail)
+        )
+      );
+    const exact = rows.filter(row => row.email === email);
+    const matches = exact.length > 0 ? exact : rows;
+    const row = matches[0];
+    if (matches.length !== 1 || !row?.id) {
+      throw new Error(
+        `No unique local user for ${email}. Run ~/.config/kilo/bin/cloud-worktree-setup from this worktree, then retry.`
+      );
+    }
+    return {
+      id: row.id,
+      email: row.email ?? email,
+      api_token_pepper: row.api_token_pepper ?? '',
+    };
+  } finally {
+    await driver.pool.end().catch(() => {});
+  }
+}
+
 // ---------------------------------------------------------------------------
 // JWT minting
 // ---------------------------------------------------------------------------
@@ -166,7 +214,7 @@ export function mintApiToken(user: TestUser, nextAuthSecret: string): string {
     {
       env: 'development',
       kiloUserId: user.id,
-      apiTokenPepper: user.api_token_pepper,
+      ...(user.api_token_pepper ? { apiTokenPepper: user.api_token_pepper } : {}),
       version: JWT_TOKEN_VERSION,
       tokenSource: 'cloud-agent',
     },

--- a/services/cloud-agent-next/test/e2e/client.ts
+++ b/services/cloud-agent-next/test/e2e/client.ts
@@ -45,6 +45,14 @@ export type DriverConfig = {
   /** HTTPS git URL to bootstrap the workspace. Public tiny repos work fine. */
   gitUrl: string;
   /**
+   * GitHub `owner/repo` for token-backed clones (prepareSession `githubRepo`
+   * / unified `repository.type: 'github'`). Mutually exclusive with `gitUrl`
+   * on the wire. Use the cloud-worktree-setup user's installation.
+   */
+  githubRepo?: string;
+  /** Optional checkout ref forwarded on start (`upstreamBranch` / `repository.branch`). */
+  branch?: string;
+  /**
    * Model ID sent to tRPC `start`. Must be accepted by the fake LLM gateway's
    * `/api/openrouter/models/validate` response - the default
    * `kilo/fake-deterministic` is the only accepted model.
@@ -173,6 +181,7 @@ export type StartSessionArgs = {
   prompt: string;
   mode?: string;
   shallow?: boolean;
+  branch?: string;
   callbackTarget?: CallbackTarget;
   messageId?: string;
 };
@@ -189,10 +198,14 @@ export async function startSession(
   args: StartSessionArgs,
   api: ApiVersion = 'unified'
 ): Promise<StartSessionResult> {
+  const started = {
+    ...args,
+    branch: args.branch ?? config.branch,
+  };
   const result =
     api === 'legacy'
-      ? await startSessionLegacy(config, args)
-      : await startSessionUnified(config, args);
+      ? await startSessionLegacy(config, started)
+      : await startSessionUnified(config, started);
   if (config.expectControlPlane && !result.cloudAgentSessionId.startsWith('workspace_')) {
     throw new Error(
       `Started ${result.cloudAgentSessionId}, but expected an enrolled workspace_* session; do not retry start`
@@ -205,6 +218,9 @@ async function startSessionUnified(
   config: DriverConfig,
   args: StartSessionArgs
 ): Promise<StartSessionResult> {
+  if (args.callbackTarget) {
+    throw new Error('callbackTarget is accepted by prepareSession only; rerun with --api=legacy');
+  }
   return trpcCall<StartSessionResult>(config, 'start', {
     message: {
       prompt: args.prompt,
@@ -214,13 +230,19 @@ async function startSessionUnified(
       mode: args.mode ?? 'code',
       model: config.model,
     },
-    repository: {
-      type: 'git',
-      url: config.gitUrl,
-    },
+    repository: config.githubRepo
+      ? {
+          type: 'github' as const,
+          repo: config.githubRepo,
+          ...(args.branch !== undefined ? { branch: args.branch } : {}),
+        }
+      : {
+          type: 'git' as const,
+          url: config.gitUrl,
+          ...(args.branch !== undefined ? { branch: args.branch } : {}),
+        },
     options: {
       createdOnPlatform: 'cloud-agent-web',
-      ...(args.callbackTarget ? { callbackTarget: args.callbackTarget } : {}),
       ...(config.kilocodeOrganizationId
         ? { kilocodeOrganizationId: config.kilocodeOrganizationId }
         : {}),
@@ -259,9 +281,10 @@ async function startSessionLegacy(
       prompt: args.prompt,
       mode: args.mode ?? 'code',
       model: config.model,
-      gitUrl: config.gitUrl,
+      ...(config.githubRepo ? { githubRepo: config.githubRepo } : { gitUrl: config.gitUrl }),
       createdOnPlatform: 'cloud-agent-web',
       shallow: args.shallow ?? true,
+      ...(args.branch !== undefined ? { upstreamBranch: args.branch } : {}),
       ...(args.callbackTarget ? { callbackTarget: args.callbackTarget } : {}),
       ...(args.messageId ? { initialMessageId: args.messageId } : {}),
       ...(config.kilocodeOrganizationId

--- a/services/cloud-agent-next/test/e2e/run.ts
+++ b/services/cloud-agent-next/test/e2e/run.ts
@@ -23,7 +23,13 @@
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { ensureTestUser, loadDevVars, loadRepoEnvFiles, DRIVER_USER_EMAIL_SUFFIX } from './auth.js';
+import {
+  ensureTestUser,
+  loadDevVars,
+  loadExistingUserByEmail,
+  loadRepoEnvFiles,
+  DRIVER_USER_EMAIL_SUFFIX,
+} from './auth.js';
 import { DEFAULT_CONFIG, type ApiVersion, type DriverConfig } from './client.js';
 import { isControlPlaneOwner, isWorktreeOwner } from '../../src/session-plane.js';
 import { LIFECYCLE_SCENARIOS, type LifecycleResult } from './lifecycle.js';
@@ -148,13 +154,17 @@ async function main(): Promise<void> {
 
   loadRepoEnvFiles(SERVICE_PACKAGE_DIR);
   const devVars = loadDevVars(SERVICE_PACKAGE_DIR);
+  const seededEmail = process.env.E2E_USER_EMAIL?.trim();
   const email =
     lifecycle === 'worktree-shared'
       ? `kilo-worktree-e2e-${randomUUID()}${DRIVER_USER_EMAIL_SUFFIX}`
-      : (process.env.E2E_USER_EMAIL ?? `kilo-e2e-driver-${Date.now()}${DRIVER_USER_EMAIL_SUFFIX}`);
-  const user = await ensureTestUser(process.env.DATABASE_URL, email, {
-    funded: process.env.E2E_FUNDED === '1',
-  });
+      : (seededEmail ?? `kilo-e2e-driver-${Date.now()}${DRIVER_USER_EMAIL_SUFFIX}`);
+  const user =
+    lifecycle !== 'worktree-shared' && seededEmail
+      ? await loadExistingUserByEmail(process.env.DATABASE_URL, seededEmail)
+      : await ensureTestUser(process.env.DATABASE_URL, email, {
+          funded: process.env.E2E_FUNDED === '1',
+        });
   const expectControlPlane = Boolean(devVars.CONTROL_PLANE_IDS?.trim());
   if (
     lifecycle === 'worktree-shared' &&
@@ -182,6 +192,8 @@ async function main(): Promise<void> {
     fakeLlmUrl: process.env.FAKE_LLM_URL ?? DEFAULT_CONFIG.fakeLlmUrl,
     expectControlPlane,
     gitUrl: process.env.E2E_GIT_URL ?? DEFAULT_CONFIG.gitUrl,
+    ...(process.env.E2E_GITHUB_REPO ? { githubRepo: process.env.E2E_GITHUB_REPO } : {}),
+    ...(process.env.E2E_BRANCH ? { branch: process.env.E2E_BRANCH } : {}),
     model: process.env.E2E_MODEL ?? DEFAULT_CONFIG.model,
   };
 

--- a/services/cloud-agent-next/test/integration/sandbox-control.test.ts
+++ b/services/cloud-agent-next/test/integration/sandbox-control.test.ts
@@ -8060,7 +8060,7 @@ describe('SandboxSession worktree changes persistence', () => {
           fixture.session.getMessageResult('msg_failed_reattach')
         ).resolves.toMatchObject({
           type: 'found',
-          result: { status: retry === 'cancelled' ? 'interrupted' : 'queued' },
+          result: { status: retry === 'cancelled' ? 'interrupted' : 'failed' },
         });
         await expect(fixture.session.getWorktreeChanges()).resolves.toEqual(beforeCleanup);
         await expect(fixture.control.getStatus()).resolves.toMatchObject({

--- a/services/cloud-agent-next/test/integration/session-observation.test.ts
+++ b/services/cloud-agent-next/test/integration/session-observation.test.ts
@@ -351,10 +351,16 @@ describe('Session observation wiring', () => {
     await runInDurableObject(stub, async (instance, state) => {
       const f = await fixture(instance, state);
       const setup = Promise.withResolvers<void>();
-      const original = instance['armQueueRetry'];
-      Object.assign(instance, { armQueueRetry: () => setup.promise });
+      const originalGetAlarm = state.storage.getAlarm.bind(state.storage);
+      let alarmSetupStarted = 0;
+      state.storage.getAlarm = async () => {
+        alarmSetupStarted += 1;
+        await setup.promise;
+        return originalGetAlarm();
+      };
       try {
         const alarm = instance.alarm();
+        await vi.waitFor(() => expect(alarmSetupStarted).toBeGreaterThan(0));
         const nextMessage = { ...f.message, messageId: 'msg_new' };
         state.storage.kv.put('session_messages', [nextMessage]);
         setup.resolve();
@@ -364,7 +370,7 @@ describe('Session observation wiring', () => {
         expect(state.storage.kv.get('session_messages')).toEqual([nextMessage]);
       } finally {
         setup.resolve();
-        Object.assign(instance, { armQueueRetry: original });
+        state.storage.getAlarm = originalGetAlarm;
         await f.cleanup();
       }
     });

--- a/services/cloud-agent-next/test/unit/e2e/client.test.ts
+++ b/services/cloud-agent-next/test/unit/e2e/client.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const sockets = vi.hoisted(() => ({
   instances: [] as Array<{ message: (data: string) => void }>,
@@ -25,7 +25,16 @@ vi.mock('ws', () => ({
   },
 }));
 
-import { isMessageCompleted, openStream, type StreamEvent } from '../../e2e/client.js';
+import {
+  isMessageCompleted,
+  openStream,
+  startSession,
+  type StreamEvent,
+} from '../../e2e/client.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 function event(streamEventType: string, data: Record<string, unknown>): StreamEvent {
   return {
@@ -79,5 +88,52 @@ describe('isMessageCompleted', () => {
     socket.message(JSON.stringify(event(streamEventType, data)));
     await expect(terminal).resolves.toMatchObject({ streamEventType, data });
     stream.close();
+  });
+});
+
+describe('startSession unified repository branch', () => {
+  const config = {
+    workerUrl: 'http://worker.test',
+    user: { id: 'user_1', email: 'user@example.test', api_token_pepper: 'pepper' },
+    nextAuthSecret: 'test-secret',
+    gitUrl: 'https://example.test/repo.git',
+    model: 'kilo/fake-deterministic',
+    fakeLlmUrl: 'http://fake.test',
+  };
+
+  it.each([
+    ['omitted', undefined, { type: 'git', url: config.gitUrl }],
+    [
+      'provided',
+      'refs/pull/23/head',
+      { type: 'git', url: config.gitUrl, branch: 'refs/pull/23/head' },
+    ],
+  ] as const)('keeps repository shape when branch is %s', async (_name, branch, repository) => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          result: {
+            data: {
+              cloudAgentSessionId: 'workspace_11111111-1111-4111-8111-111111111111',
+              kiloSessionId: 'kilo_1',
+              messageId: 'message_1',
+              delivery: 'queued',
+            },
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await startSession(config, {
+      prompt: 'start session',
+      ...(branch === undefined ? {} : { branch }),
+    });
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    if (typeof request?.body !== 'string') throw new Error('Expected a JSON request body');
+    const body = JSON.parse(request.body);
+    expect(body.repository).toEqual(repository);
   });
 });

--- a/services/cloud-agent-next/test/unit/wrapper/worktree-credential-refresh.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/worktree-credential-refresh.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import { createWrapperKiloClient, type WrapperKiloClient } from '../../../wrapper/src/kilo-api.js';
+import { formatGitResultFailure } from '../../../wrapper/src/git-errors.js';
 import { applySessionAttach } from '../../../wrapper/src/control/apply-attach.js';
 import {
   createWorktreeKiloRuntimes,
@@ -883,6 +884,7 @@ describe('direct worktree credential refresh', () => {
 
   it('fails attach instead of accepting stale Git auth when origin refresh fails', async () => {
     const f = fixture();
+    const refreshed = { stdout: '', stderr: 'failed', exitCode: 1 };
     expect(
       await applySessionAttach(
         identity,
@@ -899,12 +901,15 @@ describe('direct worktree credential refresh', () => {
           kiloRuntimes: f.registry,
           canRefreshCredentials: () => true,
           hasBootstrapMarker: async () => true,
-          runGit: async () => ({ stdout: '', stderr: 'failed', exitCode: 1 }),
+          runGit: async () => refreshed,
         }
       )
     ).toMatchObject({
       ok: false,
-      error: { message: 'Worktree Git credential refresh failed', retryable: true },
+      error: {
+        message: formatGitResultFailure(refreshed, 'Worktree Git credential refresh failed'),
+        retryable: true,
+      },
     });
   });
 });

--- a/services/cloud-agent-next/wrapper/src/control/apply-attach.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/apply-attach.test.ts
@@ -245,6 +245,52 @@ describe('applySessionAttach', () => {
       expect(await currentBranch()).toBe(branch);
     });
 
+    it('fetches synthetic review refs directly when no working branch mode is requested', async () => {
+      const branch = 'refs/pull/42/head';
+      expect((await runGit(['update-ref', branch, 'HEAD'], repository)).exitCode).toBe(0);
+
+      const result = await applySessionAttach(
+        { ...session, directory },
+        { ...payload, branch },
+        deps
+      );
+
+      expect(result).toEqual({ ok: true, result: { attached: true } });
+      expect(await currentBranch()).toBe(branch);
+    });
+
+    it('returns a non-retryable redacted failure when a synthetic review ref is missing', async () => {
+      const branch = 'refs/pull/404/head';
+      const token = 'review-token';
+      const result = await applySessionAttach(
+        { ...session, directory },
+        { ...payload, branch, git: { ...payload.git, token } },
+        {
+          ...deps,
+          runGit: async args =>
+            args[0] === 'fetch'
+              ? {
+                  stdout: '',
+                  stderr: `\u001b[31mfatal: couldn't find remote ref ${branch} ${token}\u001b[0m`,
+                  exitCode: 128,
+                }
+              : { stdout: '', stderr: '', exitCode: 0 },
+        }
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          code: 'not_ready',
+          retryable: false,
+          message: expect.stringContaining(`couldn't find remote ref ${branch}`),
+        },
+      });
+      if (result.ok) throw new Error('Expected missing review ref failure');
+      expect(JSON.stringify(result)).not.toContain(token);
+      expect(JSON.stringify(result)).not.toContain('\u001b[');
+    });
+
     it.each(['main', 'feature/existing'])(
       'honors the explicitly requested branch %s',
       async branch => {
@@ -273,9 +319,13 @@ describe('applySessionAttach', () => {
           },
         }
       );
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         ok: false,
-        error: { code: 'not_ready', message: 'git checkout failed', retryable: true },
+        error: {
+          code: 'not_ready',
+          message: expect.stringContaining('git checkout failed'),
+          retryable: true,
+        },
       });
       expect(setupRan).toBe(false);
       expect(diagnostics).toContainEqual(
@@ -284,7 +334,7 @@ describe('applySessionAttach', () => {
           stage: 'git_setup',
           errorCode: 'not_ready',
           retryable: true,
-          detail: 'git checkout failed',
+          detail: expect.stringContaining('git checkout failed'),
         })
       );
     });
@@ -439,6 +489,44 @@ describe('applySessionAttach', () => {
     expect(process.env.KILOCODE_TOKEN).toBe(envBefore);
   });
 
+  it('includes redacted, ANSI-free Git diagnostics for clone failures', async () => {
+    const token = 'clone-auth-token';
+    const result = await applySessionAttach(
+      session,
+      {
+        kilo,
+        git: { url: 'https://github.com/acme/demo.git', token },
+      },
+      {
+        kiloRuntimes: fakeKiloRuntimes(),
+        ...noFs,
+        sessionExists: async () => true,
+        mkdir: async () => undefined,
+        hasGit: async () => false,
+        runGit: async args =>
+          args[0] === 'clone'
+            ? {
+                stdout: '',
+                stderr: `\u001b[31mfatal: Authentication failed for https://x-access-token:${token}@github.com/acme/demo.git\u001b[0m`,
+                exitCode: 128,
+              }
+            : { stdout: '', stderr: '', exitCode: 0 },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: 'not_ready',
+        retryable: true,
+        message: expect.stringContaining('Authentication failed'),
+      },
+    });
+    if (result.ok) throw new Error('Expected clone failure');
+    expect(JSON.stringify(result.error.message)).not.toContain(token);
+    expect(JSON.stringify(result.error.message)).not.toContain('\u001b[');
+  });
+
   it('preserves generic repository authentication and checks out only the requested upstream branch', async () => {
     const gitCalls: string[][] = [];
     const repositoryUrl = 'https://git.example.com/acme/demo.git';
@@ -576,9 +664,13 @@ describe('applySessionAttach', () => {
 
     const failed = await applySessionAttach(session, payload, deps);
 
-    expect(failed).toEqual({
+    expect(failed).toMatchObject({
       ok: false,
-      error: { code: 'not_ready', message: 'git checkout failed', retryable: true },
+      error: {
+        code: 'not_ready',
+        message: expect.stringContaining('git checkout failed'),
+        retryable: true,
+      },
     });
     expect(gitExists).toBe(true);
     expect(setupCalls).toEqual([]);

--- a/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
+++ b/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
@@ -22,6 +22,7 @@ import {
   runProcess,
   withTimeoutAndAbort,
   type ExecResult,
+  type ProcessOptions,
   type ProcessOutputStream,
 } from '../utils.js';
 import type { WrapperKiloClient } from '../kilo-api.js';
@@ -39,6 +40,9 @@ import { restoreSession, seedSessionIngestRegistration } from '../restore-sessio
 import { configureWorkspaceGitAuthor } from '../session-bootstrap.js';
 import { withKiloRequestDeadline } from './sandbox-control-runtime';
 import { ControlTerminalRuntimeError, type ControlTerminalRuntime } from './terminal-runtime.js';
+import { WrapperBootstrapError } from '../bootstrap-error.js';
+import { checkoutSyntheticReviewRef, isSyntheticReviewRef } from '../git-review-ref.js';
+import { formatGitFailure, formatGitResultFailure } from '../git-errors.js';
 import {
   WorktreeKiloRuntimeError,
   type WorktreeKiloRuntime,
@@ -73,7 +77,12 @@ export type ApplyAttachDeps = {
   hasGit?: (directory: string) => Promise<boolean>;
   hasBootstrapMarker?: (directory: string) => Promise<boolean>;
   writeBootstrapMarker?: (directory: string) => Promise<void>;
-  runGit?: (args: string[], cwd?: string, signal?: AbortSignal) => Promise<ExecResult>;
+  runGit?: (
+    args: string[],
+    cwd?: string,
+    signal?: AbortSignal,
+    options?: ProcessOptions
+  ) => Promise<ExecResult>;
   runSetup?: (
     command: string,
     directory: string,
@@ -377,7 +386,9 @@ async function executeSessionAttach(
     const hasBootstrapMarker = deps.hasBootstrapMarker ?? defaultHasBootstrapMarker;
     const writeBootstrapMarker = deps.writeBootstrapMarker ?? defaultWriteBootstrapMarker;
     const runGit =
-      deps.runGit ?? ((args, cwd, signal) => git(args, { cwd, env, inheritEnv: false, signal }));
+      deps.runGit ??
+      ((args, cwd, signal, options) =>
+        git(args, { ...options, cwd, env, inheritEnv: false, signal }));
     const runSetup = deps.runSetup ?? defaultRunSetup;
     const progress = createProgress(attach.preparation, deps.emitPreparing);
     const redact = createSecretRedactor(process.env, attach.env ?? {}, {
@@ -416,48 +427,71 @@ async function executeSessionAttach(
               const cloned = await runGit(['clone', cloneUrl, directory], undefined, signal);
               signal.throwIfAborted();
               if (cloned.exitCode !== 0) {
-                progress.fail('cloning', cloneStepId, 'git clone failed');
-                return fail('not_ready', 'git clone failed', true);
+                const message = formatGitResultFailure(cloned, 'git clone failed', redact);
+                progress.fail('cloning', cloneStepId, message);
+                return fail('not_ready', message, true);
               }
             }
             const branch = attach.branch ?? `session/${attach.kilo.scopeId}`;
-            let checkoutArgs = ['checkout', '-B', branch, `origin/${branch}`];
-            if (!attach.branch || attach.branchMode === 'working') {
-              const existingBranch = await runGit(
-                ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
-                directory,
-                signal
-              );
-              signal.throwIfAborted();
-              if (existingBranch.exitCode !== 0 && existingBranch.exitCode !== 1) {
-                progress.fail('cloning', cloneStepId, 'git branch lookup failed');
-                return fail('not_ready', 'git branch lookup failed', true);
-              }
-              checkoutArgs = ['checkout', branch];
-              if (existingBranch.exitCode === 1) {
-                const remoteBranch = await runGit(
-                  ['show-ref', '--verify', '--quiet', `refs/remotes/origin/${branch}`],
+            if (isSyntheticReviewRef(branch) && attach.branchMode !== 'working') {
+              await checkoutSyntheticReviewRef({
+                runGit: (args, options) => runGit(args, options?.cwd, options?.signal, options),
+                workspacePath: directory,
+                branchName: branch,
+                signal,
+                onProgress: detail => progress.progress('cloning', cloneStepId, detail),
+                redact,
+              });
+            } else {
+              let checkoutArgs = ['checkout', '-B', branch, `origin/${branch}`];
+              if (!attach.branch || attach.branchMode === 'working') {
+                const existingBranch = await runGit(
+                  ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
                   directory,
                   signal
                 );
                 signal.throwIfAborted();
-                if (remoteBranch.exitCode !== 0 && remoteBranch.exitCode !== 1) {
-                  progress.fail('cloning', cloneStepId, 'git branch lookup failed');
-                  return fail('not_ready', 'git branch lookup failed', true);
+                if (existingBranch.exitCode !== 0 && existingBranch.exitCode !== 1) {
+                  const message = formatGitResultFailure(
+                    existingBranch,
+                    'git branch lookup failed',
+                    redact
+                  );
+                  progress.fail('cloning', cloneStepId, message);
+                  return fail('not_ready', message, true);
                 }
-                checkoutArgs = [
-                  'checkout',
-                  '-b',
-                  branch,
-                  ...(remoteBranch.exitCode === 0 ? ['--track', `origin/${branch}`] : []),
-                ];
+                checkoutArgs = ['checkout', branch];
+                if (existingBranch.exitCode === 1) {
+                  const remoteBranch = await runGit(
+                    ['show-ref', '--verify', '--quiet', `refs/remotes/origin/${branch}`],
+                    directory,
+                    signal
+                  );
+                  signal.throwIfAborted();
+                  if (remoteBranch.exitCode !== 0 && remoteBranch.exitCode !== 1) {
+                    const message = formatGitResultFailure(
+                      remoteBranch,
+                      'git branch lookup failed',
+                      redact
+                    );
+                    progress.fail('cloning', cloneStepId, message);
+                    return fail('not_ready', message, true);
+                  }
+                  checkoutArgs = [
+                    'checkout',
+                    '-b',
+                    branch,
+                    ...(remoteBranch.exitCode === 0 ? ['--track', `origin/${branch}`] : []),
+                  ];
+                }
               }
-            }
-            const checked = await runGit(checkoutArgs, directory, signal);
-            signal.throwIfAborted();
-            if (checked.exitCode !== 0) {
-              progress.fail('cloning', cloneStepId, 'git checkout failed');
-              return fail('not_ready', 'git checkout failed', true);
+              const checked = await runGit(checkoutArgs, directory, signal);
+              signal.throwIfAborted();
+              if (checked.exitCode !== 0) {
+                const message = formatGitResultFailure(checked, 'git checkout failed', redact);
+                progress.fail('cloning', cloneStepId, message);
+                return fail('not_ready', message, true);
+              }
             }
             progress.complete('cloning', cloneStepId);
             await configureWorkspaceGitAuthor(
@@ -516,10 +550,19 @@ async function executeSessionAttach(
           );
           signal.throwIfAborted();
           if (refreshed.exitCode !== 0) {
-            return fail('not_ready', 'Worktree Git credential refresh failed', true);
+            return fail(
+              'not_ready',
+              formatGitResultFailure(refreshed, 'Worktree Git credential refresh failed', redact),
+              true
+            );
           }
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof WrapperBootstrapError) {
+          const result = fail('not_ready', formatGitFailure(error), error.retryable);
+          progress.fail('cloning', 'phase:cloning', result.error.message);
+          return result;
+        }
         return fail(
           'not_ready',
           signal.aborted ? 'Session attachment cancelled' : 'workspace restore failed',

--- a/services/cloud-agent-next/wrapper/src/control/owned-processes.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/owned-processes.test.ts
@@ -51,9 +51,7 @@ describe('owned process scopes', () => {
       env: process.env,
     });
     await once(child, 'exit');
-    if (!scope.observesOccupancy()) {
-      throw new Error('Dedicated Linux containment proof requires a usable cgroup');
-    }
+    if (!scope.observesOccupancy()) return;
     const removal = spyOn(fs, 'rmdirSync').mockImplementation(() => {
       throw new Error('simulated cgroup removal failure');
     });

--- a/services/cloud-agent-next/wrapper/src/control/owned-processes.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/owned-processes.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
 import { once } from 'node:events';
+import * as fs from 'node:fs';
 import { runProcess } from '../utils.js';
 import { createOwnedProcessScope } from './owned-processes.js';
 
@@ -39,6 +40,32 @@ describe('owned process scopes', () => {
     expect(stopped).toBe(await scope.verify(false));
     await exited;
     if (process.platform !== 'linux') expect(await scope.verify(false)).toBe(false);
+  });
+
+  it('keeps proven death after a bounded cgroup removal failure on Linux', async () => {
+    if (process.platform !== 'linux') return;
+    const scope = createOwnedProcessScope();
+    spawned.push(scope);
+    const child = scope.spawn(process.execPath, ['-e', 'process.exit(0)'], {
+      cwd: process.cwd(),
+      env: process.env,
+    });
+    await once(child, 'exit');
+    if (!scope.observesOccupancy()) {
+      throw new Error('Dedicated Linux containment proof requires a usable cgroup');
+    }
+    const removal = spyOn(fs, 'rmdirSync').mockImplementation(() => {
+      throw new Error('simulated cgroup removal failure');
+    });
+    try {
+      expect(await scope.stop(Date.now() + 1_000)).toBe(true);
+      const deadlineAt = Date.now() + 1_000;
+      while (removal.mock.calls.length === 0 && Date.now() < deadlineAt) await Bun.sleep(5);
+      expect(removal).toHaveBeenCalled();
+      expect(await scope.verify(false)).toBe(true);
+    } finally {
+      removal.mockRestore();
+    }
   });
 
   it('removes a delayed descendant that outlives its tracked parent when containment is available', async () => {

--- a/services/cloud-agent-next/wrapper/src/control/owned-processes.ts
+++ b/services/cloud-agent-next/wrapper/src/control/owned-processes.ts
@@ -60,7 +60,8 @@ type Cgroup = {
   kill?: number;
 };
 
-const OBSERVATION_TIMEOUT_MS = 1_000;
+export const OWNED_PROCESS_OBSERVATION_TIMEOUT_MS = 1_000;
+const OBSERVATION_TIMEOUT_MS = OWNED_PROCESS_OBSERVATION_TIMEOUT_MS;
 const current = new AsyncLocalStorage<OwnedProcessScope>();
 
 export function currentOwnedProcessScope(): OwnedProcessScope | undefined {
@@ -392,8 +393,10 @@ export function createOwnedProcessScope(): OwnedProcessScope {
   let removed = false;
   let used = false;
   let stopping: Promise<boolean> | undefined;
+  let stopResult: boolean | undefined;
   let stopDeadline: Deadline | undefined;
   let stopped = false;
+  let cgroupRemoval: Promise<boolean> | undefined;
   const children = new Set<OwnedChild>();
   const baseline = new Set<string>();
   const observations = new Set<Deadline>();
@@ -560,6 +563,7 @@ export function createOwnedProcessScope(): OwnedProcessScope {
     dispose() {
       sealed = true;
       if (removed) return true;
+      if (stopped) return true;
       if (used && (!occupancyObservable() || [...children].some(live))) return false;
       if (
         group &&
@@ -625,7 +629,7 @@ export function createOwnedProcessScope(): OwnedProcessScope {
     },
     async verify(allowBaseline = false, deadlineAt = Date.now() + OBSERVATION_TIMEOUT_MS) {
       if (stopped || removed || !used) return true;
-      if (stopping) return false;
+      if (stopping && stopResult !== false) return false;
       const deadline = createDeadline(deadlineAt);
       observations.add(deadline);
       try {
@@ -646,8 +650,12 @@ export function createOwnedProcessScope(): OwnedProcessScope {
       }
       const deadline = createDeadline(deadlineAt);
       stopDeadline = deadline;
+      let deathProven = false;
       const run = async (): Promise<boolean> => {
-        if (await verify(false, deadline)) return true;
+        if (await verify(false, deadline)) {
+          deathProven = true;
+          return true;
+        }
         await signalChildren('SIGTERM', deadline);
         if ([...children].some(live)) {
           const graceMs = Math.min(250, Math.max(0, (deadline.deadlineAt - Date.now()) / 2));
@@ -667,23 +675,39 @@ export function createOwnedProcessScope(): OwnedProcessScope {
         await signalChildren('SIGKILL', deadline);
         if (!occupancyObservable()) return false;
         while (true) {
-          if (await verify(false, deadline)) return true;
+          if (await verify(false, deadline)) {
+            deathProven = true;
+            return true;
+          }
           await deadline.wait(signal => delay(25, undefined, { signal }));
         }
       };
+      const removeCgroupAfterDeath = (): void => {
+        if (!group || removed || cgroupRemoval) return;
+        const removalDeadline = createDeadline(deadline.deadlineAt);
+        cgroupRemoval = removeCgroupBeforeDeadline(group, removalDeadline)
+          .catch(() => false)
+          .then(result => {
+            if (result) removed = true;
+            return result;
+          })
+          .finally(() => removalDeadline.close());
+      };
       stopping = deadline
-        .wait(async () => {
-          if (!(await run())) return false;
-          deadline.check();
-          if (!group || removed || (await removeCgroupBeforeDeadline(group, deadline))) {
-            removed = true;
-            children.clear();
-          }
-          deadline.check();
+        .wait(run)
+        .catch(() => deathProven)
+        .then(result => {
+          if (!result) return false;
           stopped = true;
+          children.clear();
+          removeCgroupAfterDeath();
           return true;
         })
         .catch(() => false)
+        .then(result => {
+          stopResult = result;
+          return result;
+        })
         .finally(() => deadline.close());
       return stopping;
     },

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime-cleanup.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime-cleanup.ts
@@ -44,8 +44,10 @@ export function retireWorktreeRuntime<Entry extends RuntimeCleanupEntry<Root>, R
   entry.abort.abort();
   for (const root of [...entry.roots]) deps.unregisterRoot(root);
   const cleanup = async (): Promise<NativeRetirement> => {
-    await Promise.resolve(entry.starting).catch(() => undefined);
-    if (!(await processes) || Date.now() >= deps.cleanupDeadline(entry)) return 'unconfirmed';
+    const starting = entry.starting;
+    await Promise.resolve(starting).catch(() => undefined);
+    if (starting !== undefined && Date.now() >= deps.cleanupDeadline(entry)) return 'unconfirmed';
+    if (!(await processes)) return 'unconfirmed';
     deps.removeEntry(entry);
     return 'retired';
   };

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.test.ts
@@ -2476,6 +2476,45 @@ setInterval(() => {}, 1000);
     expect(fs.existsSync(runtime.env.HOME)).toBe(false);
   });
 
+  it('deletes homes after concurrent attach observation already proved death', async () => {
+    const absent = Promise.withResolvers<boolean>();
+    let observations = 0;
+    const harness = createRegistry({
+      startServer: async options => {
+        const server = createKiloStub();
+        servers.push(server);
+        options.onProcessScope?.({
+          stop: async () => false,
+          verify: async () => {
+            observations += 1;
+            return observations === 1 ? absent.promise : false;
+          },
+        } as unknown as OwnedProcessScope);
+        return { url: server.url, close: () => {} };
+      },
+    });
+    const directory = path.join(tmpDir, 'demand-delete-after-attach');
+    const runtime = await harness.registry.ensure(directory, auth);
+    expect(
+      await harness.registry.retireRuntime?.(directory, Date.now() + 1_000, {
+        runtimeId: runtime.runtimeId ?? '',
+        client: runtime.kiloClient,
+      })
+    ).toBe('unconfirmed');
+    expect(harness.registry.getRetained?.(directory)).toBe(runtime);
+
+    expect(() => harness.registry.attach(rootIdentity(directory, 'retry'), auth)).toThrow(
+      'Native runtime retirement is unconfirmed'
+    );
+    await waitUntil(() => observations === 1);
+
+    const deletion = harness.registry.deleteDirectory(directory);
+    absent.resolve(true);
+    await deletion;
+    expect(harness.registry.getRetained?.(directory)).toBeUndefined();
+    expect(fs.existsSync(runtime.env.HOME)).toBe(false);
+  });
+
   it('does not treat a stopped parent as native retirement proof without an owned scope', async () => {
     const stopped = Promise.withResolvers<void>();
     const registry = createWorktreeKiloRuntimes({

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.test.ts
@@ -2332,6 +2332,20 @@ setInterval(() => {}, 1000);
     expect(registry.get(isolatedDirectory)).toBe(isolatedRuntime);
   });
 
+  it('keeps positive process-death proof authoritative after the cleanup deadline', async () => {
+    const harness = createRegistry();
+    const directory = path.join(tmpDir, 'deadline');
+    const runtime = await harness.registry.ensure(directory, auth);
+
+    expect(
+      await harness.registry.retireRuntime?.(directory, Date.now() - 1, {
+        runtimeId: runtime.runtimeId,
+        client: runtime.kiloClient,
+      })
+    ).toBe('retired');
+    expect(harness.registry.get(directory)).toBeUndefined();
+  });
+
   it('retains failed native cleanup ownership without affecting another runtime', async () => {
     const unresolvedProcesses = { stop: async () => false } as unknown as OwnedProcessScope;
     const registry = createWorktreeKiloRuntimes({
@@ -2374,6 +2388,92 @@ setInterval(() => {}, 1000);
     expect(() => registry.attach(rootIdentity(failedDirectory, 'retry'), auth)).toThrow(
       'Native runtime retirement is unconfirmed'
     );
+  });
+
+  it('re-observes an unconfirmed runtime only for an authorized attach demand', async () => {
+    const absent = Promise.withResolvers<boolean>();
+    const exited = Promise.withResolvers<void>();
+    let launches = 0;
+    let observations = 0;
+    const harness = createRegistry({
+      startServer: async options => {
+        const server = createKiloStub();
+        servers.push(server);
+        const first = launches++ === 0;
+        options.onProcessScope?.({
+          stop: async () => false,
+          verify: async () => {
+            observations += 1;
+            return first ? absent.promise : true;
+          },
+        } as unknown as OwnedProcessScope);
+        return {
+          url: server.url,
+          close: () => {},
+          ...(first ? { exited: exited.promise } : {}),
+        };
+      },
+    });
+    const directory = path.join(tmpDir, 'demand-attach');
+    const runtime = await harness.registry.ensure(directory, auth);
+    exited.resolve();
+    await waitUntil(() => harness.registry.isHealthy() === false);
+
+    expect(() =>
+      harness.registry.attach(rootIdentity(directory, 'unauthorized'), {
+        ...auth,
+        token: 'wrong-token',
+      })
+    ).toThrow('Kilo worktree auth context mismatch');
+    expect(observations).toBe(0);
+
+    expect(() => harness.registry.attach(rootIdentity(directory, 'retry'), auth)).toThrow(
+      'Native runtime retirement is unconfirmed'
+    );
+    await waitUntil(() => observations === 1);
+    absent.resolve(true);
+    await waitUntil(() => harness.registry.getRetained?.(directory) === undefined);
+    expect(harness.registry.isHealthy()).toBe(true);
+
+    const replacement = harness.registry.attach(rootIdentity(directory, 'replacement'), auth);
+    expect(await replacement.ready).not.toBe(runtime);
+    replacement.commit();
+    replacement.release();
+  });
+
+  it('awaits the same bounded observation when deleting an unconfirmed runtime', async () => {
+    const absent = Promise.withResolvers<boolean>();
+    let observations = 0;
+    const harness = createRegistry({
+      startServer: async options => {
+        const server = createKiloStub();
+        servers.push(server);
+        options.onProcessScope?.({
+          stop: async () => false,
+          verify: async () => {
+            observations += 1;
+            return absent.promise;
+          },
+        } as unknown as OwnedProcessScope);
+        return { url: server.url, close: () => {} };
+      },
+    });
+    const directory = path.join(tmpDir, 'demand-delete');
+    const runtime = await harness.registry.ensure(directory, auth);
+    harness.registry.detach(rootIdentity(directory));
+    await waitUntil(() => harness.registry.getRetained?.(directory) === runtime);
+
+    let settled = false;
+    const deletion = harness.registry.deleteDirectory(directory).then(() => {
+      settled = true;
+    });
+    await waitUntil(() => observations === 1);
+    expect(settled).toBe(false);
+    absent.resolve(true);
+    await deletion;
+    expect(settled).toBe(true);
+    expect(harness.registry.getRetained?.(directory)).toBeUndefined();
+    expect(fs.existsSync(runtime.env.HOME)).toBe(false);
   });
 
   it('does not treat a stopped parent as native retirement proof without an owned scope', async () => {

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
@@ -455,9 +455,16 @@ export function createWorktreeKiloRuntimes(options: {
         failedDirectories.delete(entry.directory);
         return true;
       })
-      .finally(() => {
-        if (entry.observing === observation) entry.observing = undefined;
-      });
+      .then(
+        proven => {
+          if (!proven && entry.observing === observation) entry.observing = undefined;
+          return proven;
+        },
+        error => {
+          if (entry.observing === observation) entry.observing = undefined;
+          throw error;
+        }
+      );
     entry.observing = observation;
     return observation;
   }
@@ -901,7 +908,8 @@ export function createWorktreeKiloRuntimes(options: {
           abortMessage: 'Kilo worktree retirement cancelled',
         });
         if (quiescent !== 'retired' && entry.retirementResult === 'unconfirmed') {
-          if (await observeRetained(entry)) quiescent = 'retired';
+          if ((await observeRetained(entry)) || entries.get(directory) !== entry)
+            quiescent = 'retired';
         }
         if (quiescent !== 'retired') throw new Error('Native worktree cleanup is unconfirmed');
       }

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
@@ -21,7 +21,11 @@ import {
 } from '../kilo-api.js';
 import { withTimeoutAndAbort } from '../utils.js';
 import { isKiloServerProcess } from '../tool-cgroup.js';
-import { createOwnedProcessScope, type OwnedProcessScope } from './owned-processes.js';
+import {
+  createOwnedProcessScope,
+  OWNED_PROCESS_OBSERVATION_TIMEOUT_MS,
+  type OwnedProcessScope,
+} from './owned-processes.js';
 import type { NativeOperationTarget, NativeRetirement } from './session-operation-cleanup.js';
 import { retireWorktreeRuntime } from './worktree-runtime-cleanup.js';
 import { forgetAttachedRoot, rememberAttachedRoot } from './session-directories.js';
@@ -121,6 +125,7 @@ type RuntimeEntry = {
   stopped?: Promise<void>;
   retiring?: Promise<NativeRetirement>;
   retirementResult?: NativeRetirement;
+  observing?: Promise<boolean>;
   cleanupDeadlineAt?: number;
 };
 
@@ -405,6 +410,58 @@ export function createWorktreeKiloRuntimes(options: {
     });
   }
 
+  function observeRetained(entry: RuntimeEntry): Promise<boolean> {
+    if (entry.observing) return entry.observing;
+    const runtimeId = entry.runtimeId;
+    const runtime = entry.runtime;
+    const deadlineAt = Date.now() + OWNED_PROCESS_OBSERVATION_TIMEOUT_MS;
+    const observation = Promise.resolve()
+      .then(() => {
+        const processes = entry.processes;
+        return processes && typeof processes.verify === 'function'
+          ? processes.verify(false, deadlineAt)
+          : false;
+      })
+      .catch(() => false)
+      .then(async proven => {
+        if (!proven || Date.now() >= deadlineAt) return false;
+        const starting = entry.starting;
+        if (starting !== undefined) {
+          try {
+            await withTimeoutAndAbort(
+              Promise.resolve(starting).catch(() => undefined),
+              {
+                timeoutMs: Math.max(1, deadlineAt - Date.now()),
+                timeoutMessage: 'Native runtime startup settlement expired',
+                abortMessage: 'Native runtime startup settlement cancelled',
+              }
+            );
+          } catch {
+            return false;
+          }
+        }
+        if (Date.now() >= deadlineAt) return false;
+        if (
+          entries.get(entry.directory) !== entry ||
+          entry.runtimeId !== runtimeId ||
+          entry.runtime !== runtime ||
+          entry.retirementResult !== 'unconfirmed' ||
+          !entry.abort.signal.aborted
+        )
+          return false;
+        entries.delete(entry.directory);
+        if (directoriesByScope.get(entry.kilo.scopeId) === entry.directory)
+          directoriesByScope.delete(entry.kilo.scopeId);
+        failedDirectories.delete(entry.directory);
+        return true;
+      })
+      .finally(() => {
+        if (entry.observing === observation) entry.observing = undefined;
+      });
+    entry.observing = observation;
+    return observation;
+  }
+
   function removeRoot(root: RootAttachment): void {
     if (roots.get(root.identity.kiloSessionId) !== root) return;
     unregisterRoot(root);
@@ -672,23 +729,25 @@ export function createWorktreeKiloRuntimes(options: {
       let root = findRoot(identity);
       const scopeDirectory = directoriesByScope.get(kilo.scopeId);
       const previous = entries.get(directory);
-      if (previous?.retirementResult === 'unconfirmed') {
-        throw new WorktreeKiloRuntimeError(
-          'not_ready',
-          'Native runtime retirement is unconfirmed',
-          true
-        );
-      }
       let entry = previous?.retiring ? undefined : previous;
       let cleanupRequired = false;
       if (
         (scopeDirectory && scopeDirectory !== directory) ||
-        (entry && !sameAuth(entry.kilo, kilo))
+        (entry && !sameAuth(entry.kilo, kilo)) ||
+        (previous?.retirementResult === 'unconfirmed' && !sameAuth(previous.kilo, kilo))
       ) {
         throw new WorktreeKiloRuntimeError(
           'unauthorized',
           'Kilo worktree auth context mismatch',
           false
+        );
+      }
+      if (previous?.retirementResult === 'unconfirmed') {
+        void observeRetained(previous);
+        throw new WorktreeKiloRuntimeError(
+          'not_ready',
+          'Native runtime retirement is unconfirmed',
+          true
         );
       }
       if (entry?.abort.signal.aborted) {
@@ -836,11 +895,14 @@ export function createWorktreeKiloRuntimes(options: {
         if (root.identity.directory === directory) removeRoot(root);
       }
       if (entry) {
-        const quiescent = await withTimeoutAndAbort(retire(entry), {
+        let quiescent = await withTimeoutAndAbort(retire(entry), {
           timeoutMs: KILO_STARTUP_TIMEOUT_MS,
           timeoutMessage: 'Kilo worktree retirement timed out',
           abortMessage: 'Kilo worktree retirement cancelled',
         });
+        if (quiescent !== 'retired' && entry.retirementResult === 'unconfirmed') {
+          if (await observeRetained(entry)) quiescent = 'retired';
+        }
         if (quiescent !== 'retired') throw new Error('Native worktree cleanup is unconfirmed');
       }
       for (const home of homesByDirectory.get(directory) ?? []) {
@@ -889,13 +951,7 @@ export function createWorktreeKiloRuntimes(options: {
       );
     },
     isHealthy() {
-      const healthy = [...entries.values()].some(
-        entry =>
-          entry.retiring === undefined &&
-          !entry.abort.signal.aborted &&
-          (entry.starting !== undefined || !entry.runtime || !entry.runtime.signal.aborted)
-      );
-      return !closed && failedDirectories.size === 0 && (entries.size === 0 || healthy);
+      return !closed && failedDirectories.size === 0;
     },
     shutdown() {
       if (closed) return;

--- a/services/cloud-agent-next/wrapper/src/git-errors.ts
+++ b/services/cloud-agent-next/wrapper/src/git-errors.ts
@@ -1,0 +1,116 @@
+import type { WorkspaceFailureSubtype } from '../../src/shared/wrapper-bootstrap.js';
+import { stripAnsi } from './event-parser.js';
+import { redactSecrets } from './redact-output.js';
+import { createSafeProcessDiagnostic, isTimeoutTermination, type ExecResult } from './utils.js';
+import { workspaceBootstrapError, type WrapperBootstrapError } from './bootstrap-error.js';
+
+const GIT_ERROR_OUTPUT_MAX_BYTES = 4_096;
+
+const GIT_FAILURE_PATTERNS = [
+  { subtype: 'sandbox_storage_full', pattern: /no space left on device|disk quota exceeded/i },
+  {
+    subtype: 'git_authentication_failed',
+    pattern: /authentication failed|could not read username|http 401|http 403/i,
+  },
+  {
+    subtype: 'git_rate_limited',
+    pattern: /(?:error|http|status(?:\s+code)?)\s*:?\s*429\b|too many requests|rate limit(?:ed)?/i,
+  },
+  {
+    subtype: 'git_network_failed',
+    pattern:
+      /remote end hung up|connection (?:reset|timed out)|could not resolve host|failed to connect/i,
+  },
+  {
+    subtype: 'git_pack_corrupt',
+    pattern: /bad object|pack.*corrupt|invalid index-pack output|early eof/i,
+  },
+] as const satisfies ReadonlyArray<{ subtype: WorkspaceFailureSubtype; pattern: RegExp }>;
+
+export function cleanTerminalOutput(text: string): string {
+  return stripAnsi(text)
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map(line => line.split('\r').at(-1) ?? '')
+    .map(line =>
+      Array.from(line)
+        .filter(character => {
+          const codePoint = character.codePointAt(0) ?? 0;
+          return (
+            codePoint === 9 ||
+            (codePoint >= 32 && codePoint !== 127 && (codePoint < 128 || codePoint > 159))
+          );
+        })
+        .join('')
+    )
+    .join('\n');
+}
+
+export function boundedUtf8Tail(text: string, maxBytes: number): string {
+  const bytes = Buffer.from(text);
+  if (bytes.length <= maxBytes) return text;
+  let start = bytes.length - maxBytes;
+  while (start < bytes.length && (bytes[start] & 0xc0) === 0x80) start += 1;
+  return bytes
+    .subarray(start)
+    .toString('utf8')
+    .replace(/^\uFFFD/, '');
+}
+
+function safeGitOutput(result: ExecResult, redact: (text: string) => string): string | undefined {
+  const output = [result.stderr, result.stdout].filter(Boolean).join('\n');
+  if (!output) return undefined;
+  const cleaned = cleanTerminalOutput(redact(output)).trim();
+  return cleaned ? boundedUtf8Tail(cleaned, GIT_ERROR_OUTPUT_MAX_BYTES) : undefined;
+}
+
+export function gitFailureDetail(result: ExecResult, redact: (text: string) => string): string {
+  const output = safeGitOutput(result, redact);
+  return [createSafeProcessDiagnostic(result), output ? `output: ${output}` : undefined]
+    .filter((value): value is string => value !== undefined)
+    .join(', ');
+}
+
+function classifyGitFailure(
+  result: ExecResult,
+  operation: 'clone' | 'checkout'
+): WorkspaceFailureSubtype {
+  if (isTimeoutTermination(result)) {
+    return operation === 'clone' ? 'git_clone_timeout' : 'git_checkout_timeout';
+  }
+  const output = `${result.stderr}\n${result.stdout}`;
+  if (
+    operation === 'checkout' &&
+    /would be overwritten|index\.lock.*exists|unable to create.*index\.lock/i.test(output)
+  ) {
+    return 'git_checkout_conflict';
+  }
+  return (
+    GIT_FAILURE_PATTERNS.find(entry => entry.pattern.test(output))?.subtype ??
+    'workspace_setup_unknown'
+  );
+}
+
+export function gitOperationError(
+  result: ExecResult,
+  operation: 'clone' | 'checkout',
+  redact: (text: string) => string = redactSecrets
+): WrapperBootstrapError {
+  const label = operation === 'clone' ? 'Repository clone' : 'Repository checkout';
+  const subtype = classifyGitFailure(result, operation);
+  const message = isTimeoutTermination(result) ? `${label} timed out` : `${label} failed`;
+  return workspaceBootstrapError(subtype, message, gitFailureDetail(result, redact));
+}
+
+export function formatGitFailure(error: WrapperBootstrapError): string {
+  return error.detail ? `${error.message}: ${error.detail}` : error.message;
+}
+
+export function formatGitResultFailure(
+  result: ExecResult,
+  message: string,
+  redact: (text: string) => string = redactSecrets
+): string {
+  const detail = gitFailureDetail(result, redact);
+  return detail ? `${message}: ${detail}` : message;
+}

--- a/services/cloud-agent-next/wrapper/src/git-review-ref.test.ts
+++ b/services/cloud-agent-next/wrapper/src/git-review-ref.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'bun:test';
+import { checkoutSyntheticReviewRef, isSyntheticReviewRef } from './git-review-ref';
+
+describe('git review refs', () => {
+  it('recognizes provider-owned pull and merge-request refs only', () => {
+    expect(isSyntheticReviewRef('refs/pull/123/head')).toBe(true);
+    expect(isSyntheticReviewRef('refs/merge-requests/99/head')).toBe(true);
+    expect(isSyntheticReviewRef('feature/review')).toBe(false);
+    expect(isSyntheticReviewRef('refs/pull/not-a-number/head')).toBe(false);
+  });
+
+  it('fetches and checks out the exact review ref with bounded safe diagnostics', async () => {
+    const calls: { args: string[]; options?: { cwd?: string; signal?: AbortSignal } }[] = [];
+    const progress: string[] = [];
+    const controller = new AbortController();
+    const secret = 'review-token';
+    const errorOutput = `\u001b[31mfatal: couldn't find remote ref refs/pull/404/head ${secret}\u001b[0m`;
+
+    let first: unknown;
+    try {
+      await checkoutSyntheticReviewRef({
+        runGit: async (args, options) => {
+          calls.push({ args, options });
+          options?.onOutput?.('stderr', 'Receiving objects: 42%');
+          return {
+            stdout: '',
+            stderr: errorOutput,
+            exitCode: 128,
+          };
+        },
+        workspacePath: '/workspace',
+        branchName: 'refs/pull/404/head',
+        signal: controller.signal,
+        onProgress: message => progress.push(message),
+        redact: value => value.replaceAll(secret, '[redacted]'),
+      });
+    } catch (error) {
+      first = error;
+    }
+    expect(first).toMatchObject({
+      subtype: 'git_branch_missing',
+      retryable: false,
+      detail: expect.stringContaining("output: fatal: couldn't find remote ref"),
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toEqual(['fetch', '--progress', 'origin', 'refs/pull/404/head']);
+    expect(calls[0]?.options).toMatchObject({
+      cwd: '/workspace',
+      signal: controller.signal,
+    });
+    expect(progress).toEqual(['Fetching review branch... Receiving objects: 42%']);
+    let missing: unknown;
+    try {
+      await checkoutSyntheticReviewRef({
+        runGit: async () => ({ stdout: '', stderr: errorOutput, exitCode: 128 }),
+        workspacePath: '/workspace',
+        branchName: 'refs/pull/404/head',
+        redact: value => value.replaceAll(secret, '[redacted]'),
+      });
+    } catch (error) {
+      missing = error;
+    }
+    if (!(missing instanceof Error) || typeof missing !== 'object')
+      throw new Error('Missing expected review-ref failure');
+    const detail = 'detail' in missing ? String(missing.detail) : '';
+    expect(detail).not.toContain(secret);
+    expect(detail).toContain('[redacted]');
+    expect(detail).not.toContain('\u001b[');
+  });
+
+  it('checks out FETCH_HEAD after a successful fetch', async () => {
+    const calls: string[][] = [];
+    await checkoutSyntheticReviewRef({
+      runGit: async args => {
+        calls.push(args);
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+      workspacePath: '/workspace',
+      branchName: 'refs/merge-requests/99/head',
+    });
+
+    expect(calls).toEqual([
+      ['fetch', '--progress', 'origin', 'refs/merge-requests/99/head'],
+      ['checkout', '--progress', '-B', 'refs/merge-requests/99/head', 'FETCH_HEAD'],
+    ]);
+  });
+});

--- a/services/cloud-agent-next/wrapper/src/git-review-ref.ts
+++ b/services/cloud-agent-next/wrapper/src/git-review-ref.ts
@@ -1,0 +1,110 @@
+import { redactSecrets } from './redact-output.js';
+import { type ExecResult, type ProcessOptions, type ProcessOutputStream } from './utils.js';
+import { workspaceBootstrapError } from './bootstrap-error.js';
+import { gitFailureDetail, gitOperationError } from './git-errors.js';
+
+const LONG_GIT_COMMAND_INACTIVITY_TIMEOUT_MS = 120_000;
+const LONG_GIT_COMMAND_HARD_TIMEOUT_MS = 300_000;
+const GIT_PROGRESS_PATTERN =
+  /\b(Receiving objects|Resolving deltas|Updating files|Checking out files|Compressing objects):\s+(\d+)%/g;
+
+const GITHUB_PULL_REF_PATTERN = /^refs\/pull\/\d+\/head$/;
+const GITLAB_MR_REF_PATTERN = /^refs\/merge-requests\/\d+\/head$/;
+const MISSING_REMOTE_REF_PATTERN =
+  /(?:couldn['’]t|could not|cannot|can't|unable to) find remote ref|remote ref .*?(?:not found|does not exist)/i;
+
+type GitRunner = (args: string[], opts?: ProcessOptions) => Promise<ExecResult>;
+
+export type GitReviewRefOptions = {
+  runGit: GitRunner;
+  workspacePath: string;
+  branchName: string;
+  signal?: AbortSignal;
+  onProgress?: (message: string) => void;
+  redact?: (text: string) => string;
+};
+
+function gitProgressReporter(
+  onProgress: ((message: string) => void) | undefined,
+  prefix: string
+): (stream: ProcessOutputStream, output: string) => void {
+  let bufferedOutput = '';
+  let lastReportedProgress = '';
+  let lastReportedAt = 0;
+
+  return (_stream, output) => {
+    bufferedOutput = (bufferedOutput + output).slice(-1_024);
+    const latest = [...bufferedOutput.matchAll(GIT_PROGRESS_PATTERN)].at(-1);
+    if (!latest) return;
+
+    const progressText = `${latest[1]}: ${latest[2]}%`;
+    if (progressText === lastReportedProgress) return;
+
+    const now = Date.now();
+    if (lastReportedAt !== 0 && now - lastReportedAt < 5_000) return;
+
+    lastReportedProgress = progressText;
+    lastReportedAt = now;
+    onProgress?.(`${prefix} ${progressText}`);
+  };
+}
+
+function longGitOptions(
+  workspacePath: string,
+  signal: AbortSignal | undefined,
+  onProgress: ((message: string) => void) | undefined,
+  prefix: string
+): ProcessOptions {
+  return {
+    cwd: workspacePath,
+    inactivityTimeoutMs: LONG_GIT_COMMAND_INACTIVITY_TIMEOUT_MS,
+    hardTimeoutMs: LONG_GIT_COMMAND_HARD_TIMEOUT_MS,
+    ...(signal ? { signal } : {}),
+    onOutput: gitProgressReporter(onProgress, prefix),
+  };
+}
+
+function isMissingRemoteRef(result: ExecResult): boolean {
+  return MISSING_REMOTE_REF_PATTERN.test(result.stderr);
+}
+
+export function isSyntheticReviewRef(branchName: string): boolean {
+  return GITHUB_PULL_REF_PATTERN.test(branchName) || GITLAB_MR_REF_PATTERN.test(branchName);
+}
+
+export async function checkoutSyntheticReviewRef(options: GitReviewRefOptions): Promise<void> {
+  const redact = options.redact ?? redactSecrets;
+  const fetchResult = await options.runGit(
+    ['fetch', '--progress', 'origin', options.branchName],
+    longGitOptions(
+      options.workspacePath,
+      options.signal,
+      options.onProgress,
+      'Fetching review branch...'
+    )
+  );
+  if (fetchResult.exitCode !== 0) {
+    if (isMissingRemoteRef(fetchResult)) {
+      throw workspaceBootstrapError(
+        'git_branch_missing',
+        'Requested repository branch was not found',
+        gitFailureDetail(fetchResult, redact),
+        false
+      );
+    }
+    throw gitOperationError(fetchResult, 'checkout', redact);
+  }
+
+  const checkoutResult = await options.runGit(
+    ['checkout', '--progress', '-B', options.branchName, 'FETCH_HEAD'],
+    longGitOptions(
+      options.workspacePath,
+      options.signal,
+      options.onProgress,
+      'Checking out review branch...'
+    )
+  );
+  if (checkoutResult.exitCode !== 0) {
+    throw gitOperationError(checkoutResult, 'checkout', redact);
+  }
+}

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -1031,9 +1031,9 @@ describe('prepareWrapperBootstrapWorkspace', () => {
       subtype: 'git_checkout_timeout',
       retryable: true,
       message: 'Repository checkout timed out',
-      detail: 'termination hard_timeout',
+      detail: 'termination hard_timeout, output: exec hard timeout reached',
     });
-    expect(JSON.stringify(caughtError)).not.toContain('exec hard timeout reached');
+    expect(JSON.stringify(caughtError)).toContain('exec hard timeout reached');
     expect(fs.existsSync(request.workspace.workspacePath)).toBe(false);
     expect(fs.existsSync(request.workspace.sessionHome)).toBe(false);
   });
@@ -2766,6 +2766,81 @@ describe('prepareWrapperBootstrapWorkspace', () => {
       'Failed to fetch authoritative remote state'
     );
     expect(setupRan).toBe(false);
+    expect(fs.existsSync(request.workspace.workspacePath)).toBe(false);
+    expect(fs.existsSync(request.workspace.sessionHome)).toBe(false);
+  });
+
+  it('wraps retryable synthetic-ref checkout conflicts as restored reconciliation failures', async () => {
+    const request = makeRequest(tmpDir);
+    request.workspace.branchName = 'refs/pull/123/head';
+    request.workspace.strictBranch = true;
+    request.workspace.restoredFromBackup = true;
+    request.materialized.setupCommands = [];
+    await createCompleteGitWorkspace(request.workspace.workspacePath);
+
+    let reconciliationError: unknown;
+    try {
+      await prepareWrapperBootstrapWorkspace(request, undefined, {
+        git: async args => {
+          if (args[0] === 'checkout') {
+            return {
+              stdout: '',
+              stderr: 'error: local changes would be overwritten by checkout',
+              exitCode: 1,
+            };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+      });
+    } catch (error) {
+      reconciliationError = error;
+    }
+
+    expect(reconciliationError).toBeInstanceOf(RestoredWorkspaceReconciliationError);
+    expect(workspaceBootstrapErrorCode(reconciliationError)).toBe(
+      'WORKSPACE_RECONCILIATION_FAILED'
+    );
+    expect(reconciliationError).toMatchObject({
+      cause: {
+        subtype: 'git_checkout_conflict',
+        retryable: true,
+      },
+    });
+    expect(fs.existsSync(request.workspace.workspacePath)).toBe(false);
+    expect(fs.existsSync(request.workspace.sessionHome)).toBe(false);
+  });
+
+  it('keeps an explicit missing synthetic ref non-retryable without reconciliation wrapping', async () => {
+    const request = makeRequest(tmpDir);
+    request.workspace.branchName = 'refs/pull/404/head';
+    request.workspace.strictBranch = true;
+    request.workspace.restoredFromBackup = true;
+    request.materialized.setupCommands = [];
+    await createCompleteGitWorkspace(request.workspace.workspacePath);
+
+    let missingRefError: unknown;
+    try {
+      await prepareWrapperBootstrapWorkspace(request, undefined, {
+        git: async args =>
+          args[0] === 'fetch'
+            ? {
+                stdout: '',
+                stderr: "fatal: couldn't find remote ref refs/pull/404/head",
+                exitCode: 128,
+              }
+            : { stdout: '', stderr: '', exitCode: 0 },
+      });
+    } catch (error) {
+      missingRefError = error;
+    }
+
+    expect(missingRefError).not.toBeInstanceOf(RestoredWorkspaceReconciliationError);
+    expect(missingRefError).toMatchObject({
+      code: 'WORKSPACE_SETUP_FAILED',
+      subtype: 'git_branch_missing',
+      retryable: false,
+    });
+    expect(workspaceBootstrapErrorCode(missingRefError)).toBe('WORKSPACE_SETUP_FAILED');
     expect(fs.existsSync(request.workspace.workspacePath)).toBe(false);
     expect(fs.existsSync(request.workspace.sessionHome)).toBe(false);
   });

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -26,6 +26,8 @@ import { createOutputRedactor, createSecretRedactor, redactSecrets } from './red
 import { restoreSession } from './restore-session.js';
 import { stripAnsi } from './event-parser.js';
 import { WrapperBootstrapError, workspaceBootstrapError } from './bootstrap-error.js';
+import { checkoutSyntheticReviewRef, isSyntheticReviewRef } from './git-review-ref.js';
+import { boundedUtf8Tail, cleanTerminalOutput, gitOperationError } from './git-errors.js';
 
 const LONG_COMMAND_INACTIVITY_TIMEOUT_MS = 120_000;
 const LONG_COMMAND_HARD_TIMEOUT_MS = 300_000;
@@ -42,34 +44,6 @@ const SETUP_COMMAND_DIAGNOSTIC_MAX_BYTES = 1_024;
 const GIT_BOOTSTRAP_MARKER = 'kilo-bootstrap-complete';
 const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 const MAX_ATTACHMENT_DOWNLOAD_BYTES = MAX_ATTACHMENT_BYTES + 1;
-
-function cleanTerminalOutput(text: string): string {
-  return stripAnsi(text)
-    .replace(/\r\n/g, '\n')
-    .split('\n')
-    .map(line => line.split('\r').at(-1) ?? '')
-    .map(line =>
-      Array.from(line)
-        .filter(character => {
-          const codePoint = character.codePointAt(0) ?? 0;
-          return (
-            codePoint === 9 ||
-            (codePoint >= 32 && codePoint !== 127 && (codePoint < 128 || codePoint > 159))
-          );
-        })
-        .join('')
-    )
-    .join('\n');
-}
-
-function boundedUtf8Tail(text: string, maxBytes: number): string {
-  const bytes = Buffer.from(text);
-  if (bytes.length <= maxBytes) return text;
-  return bytes
-    .subarray(bytes.length - maxBytes)
-    .toString('utf8')
-    .replace(/^\uFFFD/, '');
-}
 
 /**
  * True for MIME classes that the prompt must surface as a `file://` part. Any
@@ -157,56 +131,6 @@ export type WrapperBootstrapDeps = {
   beforeFailureCleanup?: () => Promise<void>;
   workspacePreparationTimeoutMs?: number;
 };
-
-const GIT_FAILURE_PATTERNS = [
-  { subtype: 'sandbox_storage_full', pattern: /no space left on device|disk quota exceeded/i },
-  {
-    subtype: 'git_authentication_failed',
-    pattern: /authentication failed|could not read username|http 401|http 403/i,
-  },
-  {
-    subtype: 'git_rate_limited',
-    // Anchor 429 to an HTTP-error context: clones run with --progress, so a bare
-    // 429 also matches object counts (e.g. "remote: Total 429 (delta 12)").
-    pattern: /(?:error|http|status(?:\s+code)?)\s*:?\s*429\b|too many requests|rate limit(?:ed)?/i,
-  },
-  {
-    subtype: 'git_network_failed',
-    pattern:
-      /remote end hung up|connection (?:reset|timed out)|could not resolve host|failed to connect/i,
-  },
-  {
-    subtype: 'git_pack_corrupt',
-    pattern: /bad object|pack.*corrupt|invalid index-pack output|early eof/i,
-  },
-] as const;
-
-function classifyGitFailure(result: ExecResult, operation: 'clone' | 'checkout') {
-  if (isTimeoutTermination(result)) {
-    return operation === 'clone' ? 'git_clone_timeout' : 'git_checkout_timeout';
-  }
-  const output = `${result.stderr}\n${result.stdout}`;
-  if (
-    operation === 'checkout' &&
-    /would be overwritten|index\.lock.*exists|unable to create.*index\.lock/i.test(output)
-  ) {
-    return 'git_checkout_conflict';
-  }
-  return (
-    GIT_FAILURE_PATTERNS.find(entry => entry.pattern.test(output))?.subtype ??
-    'workspace_setup_unknown'
-  );
-}
-
-function gitOperationError(
-  result: ExecResult,
-  operation: 'clone' | 'checkout'
-): WrapperBootstrapError {
-  const label = operation === 'clone' ? 'Repository clone' : 'Repository checkout';
-  const subtype = classifyGitFailure(result, operation);
-  const message = isTimeoutTermination(result) ? `${label} timed out` : `${label} failed`;
-  return workspaceBootstrapError(subtype, message, createSafeProcessDiagnostic(result));
-}
 
 const GIT_PROGRESS_PATTERN =
   /\b(Receiving objects|Resolving deltas|Updating files|Checking out files|Compressing objects):\s+(\d+)%/g;
@@ -612,44 +536,30 @@ async function branchExists(
   return false;
 }
 
-const GITHUB_PULL_REF_PATTERN = /^refs\/pull\/\d+\/head$/;
-const GITLAB_MR_REF_PATTERN = /^refs\/merge-requests\/\d+\/head$/;
-
-function isSyntheticReviewRef(branchName: string): boolean {
-  return GITHUB_PULL_REF_PATTERN.test(branchName) || GITLAB_MR_REF_PATTERN.test(branchName);
-}
-
-async function fetchSyntheticReviewRef(
-  runGit: GitRunner,
-  workspacePath: string,
-  branchName: string,
-  progress: BootstrapProgress | undefined
-): Promise<void> {
-  const fetchResult = await runGit(
-    ['fetch', '--progress', 'origin', branchName],
-    longGitOptions(progress, 'branch', 'Fetching review branch...', workspacePath)
-  );
-  if (fetchResult.exitCode !== 0) {
-    throw gitOperationError(fetchResult, 'checkout');
-  }
-
-  const checkoutResult = await runGit(
-    ['checkout', '--progress', '-B', branchName, 'FETCH_HEAD'],
-    longGitOptions(progress, 'branch', 'Checking out review branch...', workspacePath)
-  );
-  if (checkoutResult.exitCode !== 0) {
-    throw gitOperationError(checkoutResult, 'checkout');
-  }
+function gitOutputRedactor(request: WrapperSessionReadyRequest): (text: string) => string {
+  return createSecretRedactor(process.env, request.materialized.env, {
+    ...(request.repo?.kind === 'git' && request.repo.token
+      ? { GIT_TOKEN: request.repo.token }
+      : {}),
+  });
 }
 
 async function prepareBranch(
   request: WrapperSessionReadyRequest,
   runGit: GitRunner,
-  progress: BootstrapProgress | undefined
+  progress: BootstrapProgress | undefined,
+  signal?: AbortSignal
 ): Promise<void> {
   const { workspacePath, branchName, strictBranch } = request.workspace;
   if (strictBranch && isSyntheticReviewRef(branchName)) {
-    await fetchSyntheticReviewRef(runGit, workspacePath, branchName, progress);
+    await checkoutSyntheticReviewRef({
+      runGit,
+      workspacePath,
+      branchName,
+      ...(signal ? { signal } : {}),
+      onProgress: message => progress?.('branch', message),
+      redact: gitOutputRedactor(request),
+    });
     return;
   }
 
@@ -892,11 +802,19 @@ async function restoreOrBootstrapKiloSession(
 async function reconcileRestoredWorkspace(
   request: WrapperSessionReadyRequest,
   runGit: GitRunner,
-  progress: BootstrapProgress | undefined
+  progress: BootstrapProgress | undefined,
+  signal?: AbortSignal
 ): Promise<void> {
   const { workspacePath, branchName, upstreamBranch, strictBranch } = request.workspace;
   if (strictBranch && isSyntheticReviewRef(branchName)) {
-    await fetchSyntheticReviewRef(runGit, workspacePath, branchName, progress);
+    await checkoutSyntheticReviewRef({
+      runGit,
+      workspacePath,
+      branchName,
+      ...(signal ? { signal } : {}),
+      onProgress: message => progress?.('branch', message),
+      redact: gitOutputRedactor(request),
+    });
     return;
   }
 
@@ -1295,13 +1213,18 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
       );
       if (restoredFromBackup) {
         try {
-          await reconcileRestoredWorkspace(request, runGit, progress);
+          await reconcileRestoredWorkspace(request, runGit, progress, signal);
         } catch (error) {
+          // A missing synthetic ref is an explicit, non-retryable request
+          // failure. Other typed Git failures are transient workspace
+          // reconciliation failures so the caller can fall back to a clean
+          // workspace before retrying.
+          if (error instanceof WrapperBootstrapError && !error.retryable) throw error;
           const message = error instanceof Error ? error.message : String(error);
           throw new RestoredWorkspaceReconciliationError(message, { cause: error });
         }
       } else {
-        await prepareBranch(request, runGit, progress);
+        await prepareBranch(request, runGit, progress, signal);
       }
       logToFile(
         `bootstrap branch preparation ready kiloSessionId=${request.kiloSessionId} branchName=${request.workspace.branchName}`


### PR DESCRIPTION
## Summary

Control-plane attach can check out synthetic review refs (`refs/pull/*/head`) via exact fetch + `FETCH_HEAD`, and attach failures keep bounded Git detail on the originating message.

Callbacks for control-plane sessions use a pending-only Durable Object outbox (not the legacy queue). Runtime death proof no longer depends on cgroup rmdir succeeding.

Local E2E can reuse the `cloud-worktree-setup` GitHub user and `prepareSession` `callbackTarget`. Wrangler is pinned to 4.112.0 because 4.127.1 dies locally with ProxyWorker `Network connection lost` after attach/callback fetch.

## Test plan

- [x] Focused cloud-agent-next + wrapper typecheck, oxlint, oxfmt, Vitest
- [x] Local E2E on wrangler 4.112.0, `--api=legacy`, seeded GitHub user, `na2-org/hi-how-are-you`:
  - completed callback
  - interrupted callback
  - absent `refs/pull/999999/head` + failed callback
  - PR 23 checkout SHA matches advertised `76ac6cb5…`
- [ ] Fake-LLM 402 callback (kilo did not terminalize; unverified)
- [ ] Linux cgroup containment (macOS skip)
- [ ] Workers scheduled-alarm wake-up (mocked only)