### PR TITLE
fix(auth): handle missing device auth codes

### DIFF
--- a/apps/web/src/app/device-auth/page.test.ts
+++ b/apps/web/src/app/device-auth/page.test.ts
@@ -1,0 +1,34 @@
+import { redirect } from 'next/navigation';
+import { getUserFromAuthOrRedirect } from '@/lib/user/server';
+import DeviceAuthPage from './page';
+
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn(),
+}));
+
+jest.mock('@/lib/user/server', () => ({
+  getUserFromAuthOrRedirect: jest.fn(),
+}));
+
+jest.mock('@/lib/device-auth/device-auth-viewer-token', () => ({
+  createDeviceAuthViewerToken: jest.fn(),
+}));
+
+const mockedRedirect = jest.mocked(redirect);
+const mockedGetUserFromAuthOrRedirect = jest.mocked(getUserFromAuthOrRedirect);
+
+describe('DeviceAuthPage missing code handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test.each([{}, { code: '' }, { code: '   ' }])(
+    'redirects malformed device-auth links without authenticating: %j',
+    async searchParams => {
+      await DeviceAuthPage({ searchParams: Promise.resolve(searchParams) });
+
+      expect(mockedRedirect).toHaveBeenCalledWith('/');
+      expect(mockedGetUserFromAuthOrRedirect).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/apps/web/src/app/device-auth/page.tsx
+++ b/apps/web/src/app/device-auth/page.tsx
@@ -10,27 +10,28 @@ type PageProps = {
 };
 
 const deviceAuthSearchParamsSchema = z.object({
-  code: z.preprocess(
-    value => (Array.isArray(value) ? value[0] : value),
-    z.string().min(1).optional()
-  ),
+  code: z.preprocess(value => {
+    const code = Array.isArray(value) ? value[0] : value;
+    return typeof code === 'string' ? code.trim() || undefined : code;
+  }, z.string().min(1).optional()),
   app: z.union([z.string(), z.array(z.string())]).optional(),
 });
 
 export default async function DeviceAuthPage({ searchParams }: PageProps) {
   const params = deviceAuthSearchParamsSchema.parse(await searchParams);
   const code = params.code;
+
+  if (!code) {
+    return redirect('/');
+  }
+
   const isAppMode = isDeviceAuthAppMode(params.app);
 
   // Redirect to login if not authenticated, with callback to return here
-  const callbackPath = code ? buildDeviceAuthPath(code, { app: isAppMode }) : '/device-auth';
+  const callbackPath = buildDeviceAuthPath(code, { app: isAppMode });
   const user = await getUserFromAuthOrRedirect(
     `/users/sign_in?callbackPath=${encodeURIComponent(callbackPath)}`
   );
-
-  if (!code) {
-    redirect('/');
-  }
 
   const viewerToken = createDeviceAuthViewerToken(code, user.id);
 


### PR DESCRIPTION
## Summary
- Treat missing, empty, and whitespace-only device auth codes as invalid input.
- Redirect malformed device-auth links before performing authentication lookup.
- Add regression coverage for the malformed-link cases.

## Testing
- Isolated Jest regression test: 3 passed.
- Focused Oxlint: 0 warnings, 0 errors.
- Formatting and whitespace checks passed.
- Full web typecheck was attempted but exceeded the local two-minute execution limit.

## Related
- Sentry: KILOCODE-WEB-27P8