### PR TITLE
fix(cloud-agent-next): stabilize abort timeout test

### DIFF
--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
@@ -3241,6 +3241,7 @@ describe('owned control execution', () => {
 
   it('bounds a hanging abort and cannot revive the runtime when its acknowledgement arrives late', async () => {
     const timers = spyOn(globalThis, 'setTimeout');
+    setSystemTime(0);
     const running = Promise.withResolvers<Completion>();
     const abortStarted = Promise.withResolvers<AbortSignal>();
     const remoteStopped = Promise.withResolvers<boolean>();


### PR DESCRIPTION
## Summary
- Freeze the system clock in the hanging-abort test before scheduling deadlines.
- Keep the exact timeout assertion deterministic when elapsed wall time would otherwise produce 9,999ms timers.

## Verification
- Focused test passed 20 consecutive runs.
- Full wrapper suite passed: 1,425 tests, 0 failures.