### PR TITLE
feat(models): expose all Kilo Auto routing choices

### DIFF
--- a/apps/web/src/lib/ai-gateway/auto-model/index.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/index.ts
@@ -10,6 +10,10 @@ import {
   type Verbosity,
 } from '@kilocode/db/schema-types';
 import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
+import {
+  gemma_4_26b_a4b_it_free_model,
+  GEMMA_4_26B_A4B_IT_ID,
+} from '@/lib/ai-gateway/providers/google';
 
 export type AutoModelPricing = {
   prompt: string;
@@ -158,6 +162,11 @@ export const KILO_AUTO_SMALL_MODEL: AutoModel = {
   supports_pdf: false,
   opencode_settings: undefined,
 };
+
+export const AUTO_SMALL_TARGET_MODELS = {
+  paid: GEMMA_4_26B_A4B_IT_ID,
+  free: gemma_4_26b_a4b_it_free_model.public_id,
+} as const;
 
 export const KILO_AUTO_EFFICIENT_MODEL: AutoModel = {
   ...KILO_AUTO_BALANCED_MODEL,

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -1,8 +1,4 @@
 import type { FeatureValue } from '@/lib/feature-detection';
-import {
-  gemma_4_26b_a4b_it_free_model,
-  GEMMA_4_26B_A4B_IT_ID,
-} from '@/lib/ai-gateway/providers/google';
 import type {
   GatewayRequest,
   OpenRouterChatCompletionRequest,
@@ -15,6 +11,7 @@ import type {
 } from '@/lib/organizations/organization-types';
 import { isVirtualAutoModelId, type AutoRoutingDecision } from '@kilocode/auto-routing-contracts';
 import {
+  AUTO_SMALL_TARGET_MODELS,
   KILO_AUTO_FREE_MODEL,
   KILO_AUTO_SMALL_MODEL,
   KILO_AUTO_BALANCED_MODEL,
@@ -314,8 +311,8 @@ export async function resolveAutoModel(
       resolved: {
         model:
           (await balancePromise) > 0
-            ? GEMMA_4_26B_A4B_IT_ID
-            : gemma_4_26b_a4b_it_free_model.public_id,
+            ? AUTO_SMALL_TARGET_MODELS.paid
+            : AUTO_SMALL_TARGET_MODELS.free,
       },
     };
   }

--- a/apps/web/src/lib/ai-gateway/auto-routing-models.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-routing-models.test.ts
@@ -65,6 +65,23 @@ describe('addAutoRoutingModels', () => {
     ]);
   });
 
+  test('annotates the frontier auto model with its visible targets', async () => {
+    const frontierModel = makeModel('kilo-auto/frontier');
+    const opusModel = makeModel('anthropic/claude-opus-5');
+    const sonnetModel = makeModel('anthropic/claude-sonnet-5');
+
+    const result = await addAutoRoutingModels([frontierModel, sonnetModel, opusModel]);
+
+    expect(result).toEqual([
+      {
+        ...frontierModel,
+        autoRouting: { models: ['anthropic/claude-opus-5', 'anthropic/claude-sonnet-5'] },
+      },
+      sonnetModel,
+      opusModel,
+    ]);
+  });
+
   test('excludes virtual auto ids and dedupes and sorts candidates', async () => {
     const efficientModel = makeModel('kilo-auto/efficient');
     const balancedModel = makeModel('kilo-auto/balanced');

--- a/apps/web/src/lib/ai-gateway/auto-routing-models.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-routing-models.test.ts
@@ -82,6 +82,25 @@ describe('addAutoRoutingModels', () => {
     ]);
   });
 
+  test('annotates the small auto model with its visible targets', async () => {
+    const smallModel = makeModel('kilo-auto/small');
+    const paidModel = makeModel('google/gemma-4-26b-a4b-it');
+    const freeModel = makeModel('google/gemma-4-26b-a4b-it:free');
+
+    const result = await addAutoRoutingModels([smallModel, paidModel, freeModel]);
+
+    expect(result).toEqual([
+      {
+        ...smallModel,
+        autoRouting: {
+          models: ['google/gemma-4-26b-a4b-it', 'google/gemma-4-26b-a4b-it:free'],
+        },
+      },
+      paidModel,
+      freeModel,
+    ]);
+  });
+
   test('excludes virtual auto ids and dedupes and sorts candidates', async () => {
     const efficientModel = makeModel('kilo-auto/efficient');
     const balancedModel = makeModel('kilo-auto/balanced');

--- a/apps/web/src/lib/ai-gateway/auto-routing-models.ts
+++ b/apps/web/src/lib/ai-gateway/auto-routing-models.ts
@@ -1,8 +1,10 @@
 import type { OpenRouterModelsResponse } from '@/lib/organizations/organization-types';
 import {
+  FRONTIER_MODE_TO_MODEL,
   KILO_AUTO_BALANCED_MODEL,
   KILO_AUTO_EFFICIENT_MODEL,
   KILO_AUTO_FREE_MODEL,
+  KILO_AUTO_FRONTIER_MODEL,
 } from '@/lib/ai-gateway/auto-model';
 import { getAutoFreeCandidates } from '@/lib/ai-gateway/auto-model/resolution';
 import { isVirtualAutoModelId } from '@kilocode/auto-routing-contracts';
@@ -19,6 +21,7 @@ export async function addAutoRoutingModels(
 ): Promise<OpenRouterModelsResponse['data']> {
   const availableModelIds = new Set(models.map(model => model.id));
   if (
+    !availableModelIds.has(KILO_AUTO_FRONTIER_MODEL.id) &&
     !availableModelIds.has(KILO_AUTO_BALANCED_MODEL.id) &&
     !availableModelIds.has(KILO_AUTO_EFFICIENT_MODEL.id) &&
     !availableModelIds.has(KILO_AUTO_FREE_MODEL.id)
@@ -37,9 +40,14 @@ export async function addAutoRoutingModels(
       .map(candidate => candidate.model),
     availableModelIds
   );
+  const frontierModelIds = visibleConcreteModelIds(
+    Object.values(FRONTIER_MODE_TO_MODEL).map(({ model }) => model),
+    availableModelIds
+  );
   const freeModelIds = visibleConcreteModelIds(autoFreeCandidates ?? [], availableModelIds);
   const hideAutoFreeModel = autoFreeCandidates !== null && freeModelIds.length === 0;
   const autoRoutingChoices = new Map([
+    [KILO_AUTO_FRONTIER_MODEL.id, frontierModelIds],
     [KILO_AUTO_BALANCED_MODEL.id, efficientModelIds],
     [KILO_AUTO_EFFICIENT_MODEL.id, efficientModelIds],
     [KILO_AUTO_FREE_MODEL.id, freeModelIds],

--- a/apps/web/src/lib/ai-gateway/auto-routing-models.ts
+++ b/apps/web/src/lib/ai-gateway/auto-routing-models.ts
@@ -1,10 +1,12 @@
 import type { OpenRouterModelsResponse } from '@/lib/organizations/organization-types';
 import {
+  AUTO_SMALL_TARGET_MODELS,
   FRONTIER_MODE_TO_MODEL,
   KILO_AUTO_BALANCED_MODEL,
   KILO_AUTO_EFFICIENT_MODEL,
   KILO_AUTO_FREE_MODEL,
   KILO_AUTO_FRONTIER_MODEL,
+  KILO_AUTO_SMALL_MODEL,
 } from '@/lib/ai-gateway/auto-model';
 import { getAutoFreeCandidates } from '@/lib/ai-gateway/auto-model/resolution';
 import { isVirtualAutoModelId } from '@kilocode/auto-routing-contracts';
@@ -24,7 +26,8 @@ export async function addAutoRoutingModels(
     !availableModelIds.has(KILO_AUTO_FRONTIER_MODEL.id) &&
     !availableModelIds.has(KILO_AUTO_BALANCED_MODEL.id) &&
     !availableModelIds.has(KILO_AUTO_EFFICIENT_MODEL.id) &&
-    !availableModelIds.has(KILO_AUTO_FREE_MODEL.id)
+    !availableModelIds.has(KILO_AUTO_FREE_MODEL.id) &&
+    !availableModelIds.has(KILO_AUTO_SMALL_MODEL.id)
   ) {
     return models;
   }
@@ -45,12 +48,17 @@ export async function addAutoRoutingModels(
     availableModelIds
   );
   const freeModelIds = visibleConcreteModelIds(autoFreeCandidates ?? [], availableModelIds);
+  const smallModelIds = visibleConcreteModelIds(
+    Object.values(AUTO_SMALL_TARGET_MODELS),
+    availableModelIds
+  );
   const hideAutoFreeModel = autoFreeCandidates !== null && freeModelIds.length === 0;
   const autoRoutingChoices = new Map([
     [KILO_AUTO_FRONTIER_MODEL.id, frontierModelIds],
     [KILO_AUTO_BALANCED_MODEL.id, efficientModelIds],
     [KILO_AUTO_EFFICIENT_MODEL.id, efficientModelIds],
     [KILO_AUTO_FREE_MODEL.id, freeModelIds],
+    [KILO_AUTO_SMALL_MODEL.id, smallModelIds],
   ]);
 
   return models.flatMap(model => {


### PR DESCRIPTION
## Summary

Complete `autoRouting.models` metadata for the public Kilo Auto catalog by adding the two missing entries: Auto Frontier and Auto Small. Auto Efficient, Auto Balanced, and Auto Free were already represented.

- derive Auto Frontier choices from its mode-to-model routing map
- define Auto Small paid and free Gemma targets once and reuse them for runtime resolution and metadata
- deduplicate and sort target IDs, while only exposing models visible in the caller's catalog
- add focused regression coverage for both newly annotated auto models

## Verification

- `./node_modules/.bin/oxfmt apps/web/src/lib/ai-gateway/auto-model/index.ts apps/web/src/lib/ai-gateway/auto-model/resolution.ts apps/web/src/lib/ai-gateway/auto-routing-models.ts apps/web/src/lib/ai-gateway/auto-routing-models.test.ts`
- `git diff --check`
- Tests not run locally; CI will handle them as requested.