### PR TITLE
fix(ci): avoid recursive Next.js cache hashing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,9 +345,10 @@ jobs:
           path: |
             ~/.npm
             ${{ github.workspace }}/apps/web/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          # Avoid recursive source hashing after install; it can time out scanning node_modules.
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
 
       - name: Setup dummy build env
         working-directory: apps/web


### PR DESCRIPTION
The Next.js build job can fail before compilation because its cache key recursively hashes JavaScript and TypeScript files after dependencies are installed. The main run at `6ccb257c9` hit the 120-second `hashFiles` limit.

Use the root lockfile hash and commit SHA for the cache key. Keep the lockfile-based restore prefix so builds can reuse the previous incremental cache without scanning the dependency tree.

Validation: workflow YAML parsing, changed-file formatting, and `git diff --check` passed. The application build was not rerun locally; the existing paths filter skips it for workflow-only changes.
