### PR TITLE
fix(mobile): patch null headless loader crash in expo-task-manager

### DIFF
--- a/patches/expo-task-manager@57.0.16.patch
+++ b/patches/expo-task-manager@57.0.16.patch
@@ -1,0 +1,40 @@
+diff --git a/android/src/main/java/expo/modules/taskManager/TaskService.java b/android/src/main/java/expo/modules/taskManager/TaskService.java
+index de829ca..a99a58d 100644
+--- a/android/src/main/java/expo/modules/taskManager/TaskService.java
++++ b/android/src/main/java/expo/modules/taskManager/TaskService.java
+@@ -423,7 +423,19 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
+     }
+     mTasksAndEventsRepository.putEventForAppScopeKey(appScopeKey, body);
+ 
+-    getAppLoader().loadApp(mContextRef.get(),
++    HeadlessAppLoader appLoader = getAppLoader();
++    if (appLoader == null) {
++      // The headless app loader is unavailable because the context has been released
++      // (e.g. the process was killed and the JobService is restoring jobs in the
++      // background before the app context is set up again). Calling loadApp() on a
++      // null loader crashes the OS-level JobService callback with a NullPointerException,
++      // so drop the queued event and let the job finish cleanly instead.
++      Log.e(TAG, "Cannot execute background task '" + task.getName() + "': headless app loader is unavailable (context released). Dropping queued event.");
++      mTasksAndEventsRepository.removeEvents(appScopeKey);
++      return;
++    }
++
++    appLoader.loadApp(mContextRef.get(),
+       new HeadlessAppLoader.Params(appScopeKey, task.getAppUrl()),
+       () -> {
+       },
+@@ -443,8 +455,12 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
+   //region helpers
+ 
+   private HeadlessAppLoader getAppLoader() {
+-    if (mContextRef.get() != null) {
+-      return AppLoaderProvider.getLoader("react-native-headless", mContextRef.get());
++    // Guard against `mContextRef` itself being null (not just its referent): `executeTask`
++    // runs on the JobScheduler worker thread, which can observe a not-yet-initialized
++    // field, and the WeakReference may also have been cleared once the process is killed.
++    Context context = mContextRef != null ? mContextRef.get() : null;
++    if (context != null) {
++      return AppLoaderProvider.getLoader("react-native-headless", context);
+     } else {
+       return null;
+     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,7 @@ patchedDependencies:
   decode-uri-component@0.5.0: 44dc7ee3ec754d20fab8b07d7efd2442940d872ab7e8c3b61386a3d344fa3ac8
   expo-router@57.0.20: 6df17fcb26aa3cc5cba2a46b9dcc776be8c0cb2547c74725804b44484ab22a51
   expo-server-sdk: 7850520582b5b394397b35d1ea195192fe78589d8a6a748fe15177b818c4ed0b
+  expo-task-manager@57.0.16: 7b144f9d84c386dfc1bc93db75d62887c20db3f652bad1f5c01b01ebb531315c
   expo-widgets@57.0.18: 908ffc840dbd462cf5f402683fa6bb4632ff1d01de6ae53c485f3173258a5613
   react-native-appsflyer@6.18.0: 82df99378c830e774b0f01796d8be595da114d1d13393d85ddd47d565c5c2aab
 
@@ -555,7 +556,7 @@ importers:
         version: 57.0.2(expo@57.0.21)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-task-manager:
         specifier: 57.0.16
-        version: 57.0.16(expo@57.0.21)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
+        version: 57.0.16(patch_hash=7b144f9d84c386dfc1bc93db75d62887c20db3f652bad1f5c01b01ebb531315c)(expo@57.0.21)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo-tracking-transparency:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.21)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
@@ -1411,7 +1412,7 @@ importers:
         version: 7.0.0-dev.20260514.1
       jest:
         specifier: 30.3.0
-        version: 30.3.0(@types/node@25.5.2)(node-notifier@10.0.1)
+        version: 30.3.0(@types/node@24.12.4)(node-notifier@10.0.1)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -28363,7 +28364,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -28449,7 +28450,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -29154,8 +29155,8 @@ snapshots:
       react-refresh: 0.14.2
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      expo: 57.0.21(@babel/core@7.29.7)(@expo/metro-runtime@57.0.15)(bufferutil@4.1.0)(expo-router@57.0.20)(expo-widgets@57.0.18)(react-dom@19.2.6(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      expo-widgets: 57.0.18(patch_hash=908ffc840dbd462cf5f402683fa6bb4632ff1d01de6ae53c485f3173258a5613)(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(expo@57.0.21)(react-dom@19.2.6(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo: 57.0.21(@babel/core@7.29.7)(@expo/metro-runtime@57.0.15)(bufferutil@4.1.0)(expo-router@57.0.20)(expo-widgets@57.0.18)(react-dom@19.2.6(react@19.2.6))(react-native-worklets@0.10.1(@babel/core@7.29.7)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      expo-widgets: 57.0.18(patch_hash=908ffc840dbd462cf5f402683fa6bb4632ff1d01de6ae53c485f3173258a5613)(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(expo@57.0.21)(react-dom@19.2.6(react@19.2.6))(react-native-worklets@0.10.1(@babel/core@7.29.7)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -31570,7 +31571,7 @@ snapshots:
       sf-symbols-typescript: 2.2.0
     optional: true
 
-  expo-task-manager@57.0.16(expo@57.0.21)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
+  expo-task-manager@57.0.16(patch_hash=7b144f9d84c386dfc1bc93db75d62887c20db3f652bad1f5c01b01ebb531315c)(expo@57.0.21)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
       expo: 57.0.21(@babel/core@7.29.7)(@expo/metro-runtime@57.0.15)(bufferutil@4.1.0)(expo-router@57.0.20)(expo-widgets@57.0.18)(react-dom@19.2.6(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
       react-native: 0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
@@ -31603,6 +31604,21 @@ snapshots:
       - '@types/react-dom'
       - react-dom
       - react-native-worklets
+
+  expo-widgets@57.0.18(patch_hash=908ffc840dbd462cf5f402683fa6bb4632ff1d01de6ae53c485f3173258a5613)(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(expo@57.0.21)(react-dom@19.2.6(react@19.2.6))(react-native-worklets@0.10.1(@babel/core@7.29.7)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
+    dependencies:
+      '@expo/plist': 0.8.1
+      '@expo/ui': 57.0.17(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(expo@57.0.21)(react-dom@19.2.6(react@19.2.6))(react-native-worklets@0.10.1(@babel/core@7.29.7)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
+      expo: 57.0.21(@babel/core@7.29.7)(@expo/metro-runtime@57.0.15)(bufferutil@4.1.0)(expo-router@57.0.20)(expo-widgets@57.0.18)(react-dom@19.2.6(react@19.2.6))(react-native-worklets@0.10.1(@babel/core@7.29.7)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      react: 19.2.6
+      react-native: 0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+      - react-native-worklets
+    optional: true
 
   expo@57.0.21(@babel/core@7.29.7)(@expo/metro-runtime@57.0.15)(bufferutil@4.1.0)(expo-router@57.0.20)(expo-widgets@57.0.18)(react-dom@19.2.6(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.3(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -189,6 +189,10 @@ patchedDependencies:
   # includeEnded instance reads, factory-registered push-to-start URL.
   expo-router@57.0.20: patches/expo-router@57.0.20.patch
   expo-server-sdk: patches/expo-server-sdk.patch
+  # Null-guard the headless app loader in TaskService.executeTask. Without it a
+  # data-only FCM wake during cold start dereferences a null loader and fatally
+  # crashes the app (KILO-APP-9V; expo/expo#41663, expo/expo#46449).
+  expo-task-manager@57.0.16: patches/expo-task-manager@57.0.16.patch
   expo-widgets@57.0.18: patches/expo-widgets@57.0.18.patch
   react-native-appsflyer@6.18.0: patches/react-native-appsflyer@6.18.0.patch
 publicHoistPattern:


### PR DESCRIPTION
## Summary

Fix KILO-APP-9V: a fatal `NullPointerException` in `expo.modules.taskManager.TaskService.executeTask` on Android.

**The Android app needs a new build.** This is a native patch and cannot ship via OTA.

## Root cause

A data-only `active_agents_glanceable` FCM wake can reach `TaskService.executeTask` before the React task manager is registered and while the app context is unavailable. `getAppLoader()` then returns `null`, and the unguarded `loadApp(...)` call throws on the Firebase messaging thread.

- Matches expo/expo#41663; upstream fix is expo/expo#46449 (unmerged).
- `expo-task-manager@57.0.16` still contains the unguarded call, so the SDK upgrade does not fix it.
- Sentry shows 14 events, 11 users, Android only, all on the same `executeTask` frame.

## Change

- Add `patches/expo-task-manager@57.0.16.patch`: null-guard the loader in `executeTask`; drop the queued event and return instead of crashing.
- Register the patch in `pnpm-workspace.yaml` and `pnpm-lock.yaml`.

## Verification

- `git apply -p1 --check` against the exact 57.0.16 package passes.
- `pnpm install --lockfile-only` regenerated the lock with the patch hash.

## Caveat

The same method has an unsynchronized `sEvents` check-then-act race (expo/expo#41663) that can throw in the same frame. Left unpatched to keep this change minimal.

Fixes KILO-APP-9V