### PR TITLE
fix(mobile): drop the broken-install DSO crash from native Sentry

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -205,6 +205,11 @@ const config: ExpoConfig = {
       },
     ],
     'expo-web-browser',
+    // Registered before @sentry/react-native/expo on purpose: config-plugin
+    // mods run in reverse registration order, so this one runs after Sentry has
+    // inserted RNSentrySDK.init(this) into MainApplication. It then adds the
+    // ignored-error filter for the broken-install DSO crash (KILO-APP-53).
+    './plugins/withAndroidSentryIgnoredInstallErrors',
     [
       '@sentry/react-native/expo',
       {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -20,7 +20,7 @@
     "check:unused": "node --env-file=.env node_modules/knip/bin/knip.js --no-config-hints",
     "check:i18n": "pnpm -w exec oxlint --config apps/mobile/.oxlintrc.i18n.json apps/mobile/src packages/app-shared/src && node ../../tools/i18n/check-catalogs.mjs",
     "check:classes": "node ../../tools/nativewind/check-classes.mjs",
-    "test": "node scripts/assert-theme-colors.mjs && vitest run",
+    "test": "node scripts/assert-theme-colors.mjs && node --test plugins/*.test.mjs && vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/apps/mobile/plugins/withAndroidSentryIgnoredInstallErrors.js
+++ b/apps/mobile/plugins/withAndroidSentryIgnoredInstallErrors.js
@@ -1,0 +1,77 @@
+const { withMainApplication } = require('expo/config-plugins');
+
+/**
+ * Stops the native Sentry SDK reporting an unrecoverable broken-install crash.
+ *
+ * KILO-APP-53: `com.facebook.soloader.SoLoaderDSONotFoundError: couldn't find
+ * DSO to load: libreactnative.so` thrown from `MainApplication.onCreate` before
+ * JS starts. The released AAB ships `libreactnative.so` for every ABI, so this
+ * only happens when the app is side-loaded from split APKs whose ABI split is
+ * missing or does not match the device (base.apk alone, or the arm64 split on
+ * an x86_64 device). No code can load a library that is not installed; the
+ * crash is an install-integrity failure, not an app defect, so it is dropped
+ * instead of paged.
+ *
+ * The native SDK captures this crash before JS loads, so the JS `beforeSend`
+ * never sees it and `options.ignoreErrors` is not read from
+ * `sentry.options.json` on the native-init path. The only hook is the
+ * `OptionsConfiguration` passed to `RNSentrySDK.init`.
+ *
+ * The Sentry config plugin inserts `RNSentrySDK.init(this)` after
+ * `super.onCreate()`. Config-plugin mods run in reverse registration order, so
+ * this plugin is registered BEFORE `@sentry/react-native/expo` and patches the
+ * line the Sentry plugin has already written.
+ */
+// Java `Pattern.matches` is a full-string match and the SoLoader message spans
+// several lines, so `[\s\S]` (not `.`) spans newlines. It is also valid in the
+// JS `RegExp` the test uses.
+const DSO_MESSAGE_PATTERN = "[\\s\\S]*couldn't find DSO to load: libreactnative\\.so[\\s\\S]*";
+
+const KOTLIN_TARGET = 'RNSentrySDK.init(this)';
+const JAVA_TARGET = 'RNSentrySDK.init(this);';
+
+function kotlinReplacement() {
+  return [
+    'RNSentrySDK.init(this) { options ->',
+    `      options.addIgnoredError(${JSON.stringify(DSO_MESSAGE_PATTERN)})`,
+    '    }',
+  ].join('\n');
+}
+
+function javaReplacement() {
+  return `RNSentrySDK.init(this, options -> options.addIgnoredError(${JSON.stringify(
+    DSO_MESSAGE_PATTERN
+  )}));`;
+}
+
+/**
+ * Replaces the Sentry native-init call with one that installs the ignored-error
+ * filter. Returns `null` when the target is absent, so the caller decides how
+ * loud to be.
+ */
+function patchMainApplication(contents, language) {
+  if (language === 'java') {
+    return contents.includes(JAVA_TARGET) ? contents.replace(JAVA_TARGET, javaReplacement()) : null;
+  }
+  return contents.includes(KOTLIN_TARGET) ? contents.replace(KOTLIN_TARGET, kotlinReplacement()) : null;
+}
+
+function withAndroidSentryIgnoredInstallErrors(config) {
+  return withMainApplication(config, config => {
+    const { language, contents } = config.modResults;
+    const patched = patchMainApplication(contents, language);
+    if (patched === null) {
+      throw new Error(
+        `withAndroidSentryIgnoredInstallErrors: could not find '${KOTLIN_TARGET}' in ` +
+          'MainApplication. The @sentry/react-native/expo plugin must run first (register this ' +
+          'plugin before it) and insert RNSentrySDK.init. Re-check the plugin order in app.config.ts.'
+      );
+    }
+    config.modResults.contents = patched;
+    return config;
+  });
+}
+
+module.exports = withAndroidSentryIgnoredInstallErrors;
+module.exports.patchMainApplication = patchMainApplication;
+module.exports.DSO_MESSAGE_PATTERN = DSO_MESSAGE_PATTERN;

--- a/apps/mobile/plugins/withAndroidSentryIgnoredInstallErrors.test.mjs
+++ b/apps/mobile/plugins/withAndroidSentryIgnoredInstallErrors.test.mjs
@@ -1,0 +1,62 @@
+import { createRequire } from 'node:module';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const require = createRequire(import.meta.url);
+const { patchMainApplication, DSO_MESSAGE_PATTERN } = require(
+  './withAndroidSentryIgnoredInstallErrors.js'
+);
+
+const KOTLIN_TARGET = 'RNSentrySDK.init(this)';
+const JAVA_TARGET = 'RNSentrySDK.init(this);';
+
+test('patches the Kotlin native-init call with the ignored-error filter', () => {
+  const contents = [
+    '  override fun onCreate() {',
+    '    super.onCreate()',
+    `    ${KOTLIN_TARGET}`,
+    '    loadReactNative(this)',
+    '  }',
+  ].join('\n');
+
+  const patched = patchMainApplication(contents, 'kt');
+
+  assert.ok(patched, 'expected the Kotlin target to be replaced');
+  assert.match(patched, /RNSentrySDK\.init\(this\) \{ options ->/);
+  assert.ok(
+    patched.includes(`options.addIgnoredError(${JSON.stringify(DSO_MESSAGE_PATTERN)})`),
+    'expected the ignored-error filter to be installed'
+  );
+  assert.ok(patched.includes('loadReactNative(this)'), 'expected the rest of onCreate untouched');
+});
+
+test('patches the Java native-init call with the ignored-error filter', () => {
+  const contents = [
+    '  public void onCreate() {',
+    '    super.onCreate();',
+    `    ${JAVA_TARGET}`,
+    '    loadReactNative(this);',
+    '  }',
+  ].join('\n');
+
+  const patched = patchMainApplication(contents, 'java');
+
+  assert.ok(patched, 'expected the Java target to be replaced');
+  assert.match(patched, /RNSentrySDK\.init\(this, options -> options\.addIgnoredError\(/);
+  assert.ok(patched.includes(`addIgnoredError(${JSON.stringify(DSO_MESSAGE_PATTERN)})`));
+});
+
+test('returns null when the Sentry native-init call is absent', () => {
+  assert.equal(patchMainApplication('class MainApplication {}', 'kt'), null);
+});
+
+test('the ignored pattern matches the side-load SoLoader DSO message', () => {
+  const regex = new RegExp(DSO_MESSAGE_PATTERN);
+  const message = [
+    "B: couldn't find DSO to load: libreactnative.so",
+    '\texisting SO sources:',
+    '\tSoSource 0: ApplicationSoSource',
+  ].join('\n');
+
+  assert.ok(regex.test(message), 'expected the multi-line DSO message to match');
+});


### PR DESCRIPTION
## What

Stop the native Sentry SDK reporting the broken-install crash KILO-APP-53.

## Why

KILO-APP-53 reports 145 events from 25 users:

```text
com.facebook.soloader.SoLoaderDSONotFoundError: couldn't find DSO to load: libreactnative.so
```

The crash comes from `MainApplication.onCreate` before JS starts.

The released AAB ships `libreactnative.so` for all four ABIs. I verified this against kilo-app build 34481127753. The crash only happens when the app is side-loaded from split APKs whose ABI split is missing or does not match the device:

- The user installed `base.apk` alone. An AAB keeps native libraries in the ABI split, not in the base.
- The user installed the arm64 split on an x86_64 device.

No code can load a library that is not installed. The crash is an install-integrity failure, not an app defect.

## How

The native SDK captures the crash before JS loads. The JS `beforeSend` never sees it, and the native-init path does not read `ignoreErrors` from `sentry.options.json`. The only hook is the `OptionsConfiguration` passed to `RNSentrySDK.init`.

The new config plugin replaces `RNSentrySDK.init(this)` with a call that adds a narrow ignored-error filter for the `libreactnative.so` DSO message. It registers before `@sentry/react-native/expo`, because config-plugin mods run in reverse registration order, so its mod runs after Sentry has inserted `RNSentrySDK.init`.

The plugin throws if it cannot find the Sentry call, so a Sentry upgrade cannot silently drop the filter.

## Verification

- `expo prebuild --platform android` produced the intended `MainApplication.kt` (filter present, import intact).
- `pnpm --filter kilo-app run test`: 700 files, 9513 tests pass, plus 4 new plugin tests.
- `pnpm --filter kilo-app run typecheck`, `lint`, `check:unused`, `format:check`: pass.

Fixes KILO-APP-53
