### PR TITLE
feat(cloud-agent-next): allow workspace backups without setup commands

### DIFF
--- a/services/cloud-agent-next/src/workspace-backup-cache.test.ts
+++ b/services/cloud-agent-next/src/workspace-backup-cache.test.ts
@@ -44,17 +44,8 @@ function bucketWith(value: unknown) {
 }
 
 describe('workspace backup cache policy', () => {
-  it.each([[undefined], [[]]])(
-    'rejects requests without setup commands: %j',
-    async setupCommands => {
-      await expect(
-        buildWorkspaceBackupCandidate({ ...eligibleRequest, setupCommands })
-      ).resolves.toBeNull();
-    }
-  );
-
-  it.each([[['npm ci']], [['echo first', 'custom-tool --prepare', 'npm test']]])(
-    'accepts fresh repository requests with setup commands: %j',
+  it.each([[undefined], [[]], [['npm ci']], [['echo first', 'custom-tool --prepare', 'npm test']]])(
+    'accepts fresh repository requests regardless of setup commands: %j',
     async setupCommands => {
       await expect(
         buildWorkspaceBackupCandidate({ ...eligibleRequest, setupCommands })
@@ -111,6 +102,7 @@ describe('workspace backup cache policy', () => {
         repository: { type: 'github', repo: 'acme/other' },
       }),
       buildWorkspaceBackupCandidate({ ...eligibleRequest, shallow: false }),
+      buildWorkspaceBackupCandidate({ ...eligibleRequest, setupCommands: [] }),
       buildWorkspaceBackupCandidate({ ...eligibleRequest, setupCommands: ['npm ci'] }),
       buildWorkspaceBackupCandidate({
         ...eligibleRequest,
@@ -121,7 +113,7 @@ describe('workspace backup cache policy', () => {
       }),
     ]);
 
-    expect(new Set([base?.digest, ...variants.map(value => value?.digest)]).size).toBe(6);
+    expect(new Set([base?.digest, ...variants.map(value => value?.digest)]).size).toBe(7);
   });
 
   it('canonicalizes setup environment key order', async () => {

--- a/services/cloud-agent-next/src/workspace-backup-cache.ts
+++ b/services/cloud-agent-next/src/workspace-backup-cache.ts
@@ -174,13 +174,7 @@ function ownersEqual(left: WorkspaceBackupOwner, right: WorkspaceBackupOwner): b
 export async function buildWorkspaceBackupCandidate(
   request: WorkspaceBackupCandidateRequest
 ): Promise<WorkspaceBackupCandidate | null> {
-  if (
-    !request.fresh ||
-    request.devcontainer ||
-    request.userId.length === 0 ||
-    request.orgId === '' ||
-    !request.setupCommands?.length
-  )
+  if (!request.fresh || request.devcontainer || request.userId.length === 0 || request.orgId === '')
     return null;
 
   const canonicalRepository = canonicalizeRepository(request.repository);


### PR DESCRIPTION
## What

Workspace repo snapshots (`buildWorkspaceBackupCandidate`) required a non-empty `setupCommands` list. Sessions that only clone a repository — for example code reviews resolved from an explicit profile — therefore never populated or reused the prepared-workspace cache.

This removes that gate. Setup commands remain part of the cache fingerprint, so sessions with different setup recipes keep distinct entries and cannot share a snapshot.

## Verification

- `pnpm exec vitest run src/workspace-backup-cache.test.ts` — 24 passed
- `pnpm exec vitest run src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.test.ts` — 51 passed
- `oxlint` on the changed files — clean
- `oxfmt --check` on the changed files — clean
- `tsgo --noEmit` — clean

Note: unit tests only. No end-to-end run of a session/code review with snapshots enabled.