### PR TITLE
Add Ling 3.0 Flash VL to Auto Free

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -236,6 +236,7 @@ describe('isFreeModel', () => {
         'nvidia/nemotron-3-ultra-550b-a55b:free': { enabled: true, effort: 'high' },
         'dots-studio/dots-3-note-preview:free': { enabled: true, effort: 'high' },
         'nex-agi/nex-n2.5-pro:free': { enabled: true, effort: 'high' },
+        'inclusionai/ling-3.0-flash-vl:free': { enabled: true, effort: 'high' },
       });
     });
 
@@ -249,6 +250,7 @@ describe('isFreeModel', () => {
         'nvidia/nemotron-3-ultra-550b-a55b:free': 1,
         'dots-studio/dots-3-note-preview:free': 1,
         'nex-agi/nex-n2.5-pro:free': 1,
+        'inclusionai/ling-3.0-flash-vl:free': 1,
       });
     });
 

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -68,6 +68,11 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
     weight: 1,
     reasoning: { enabled: true, effort: 'high' },
   } satisfies AutoFreeModel,
+  {
+    model: 'inclusionai/ling-3.0-flash-vl:free',
+    weight: 1,
+    reasoning: { enabled: true, effort: 'high' },
+  } satisfies AutoFreeModel,
 ];
 
 export function selectAutoFreeCandidate(


### PR DESCRIPTION
## Summary
- add inclusionai/ling-3.0-flash-vl:free to the Auto Free pool
- assign the same weight and reasoning configuration as existing candidates
- update Auto Free configuration assertions

## Testing
- not run locally; CI will validate