### PR TITLE
Remove hardcoded request logging domain opt-ins

### DIFF
--- a/apps/web/src/app/admin/request-logging-opt-ins/RequestLoggingOptInsContent.tsx
+++ b/apps/web/src/app/admin/request-logging-opt-ins/RequestLoggingOptInsContent.tsx
@@ -139,7 +139,6 @@ export default function RequestLoggingOptInsContent() {
       <Card>
         <CardHeader>
           <CardTitle>Active opt-ins</CardTitle>
-          <CardDescription>Hardcoded email-domain opt-ins are not listed here.</CardDescription>
         </CardHeader>
         <CardContent>
           <Table>
@@ -164,7 +163,7 @@ export default function RequestLoggingOptInsContent() {
               {!isLoading && optIns?.length === 0 && (
                 <TableRow>
                   <TableCell colSpan={6} className="text-muted-foreground">
-                    No dynamic request logging opt-ins.
+                    No request logging opt-ins.
                   </TableCell>
                 </TableRow>
               )}

--- a/apps/web/src/lib/ai-gateway/rewriteModelResponse.ts
+++ b/apps/web/src/lib/ai-gateway/rewriteModelResponse.ts
@@ -77,9 +77,6 @@ async function isLoggingEnabledForUser(
   user: User | null,
   organizationId: string | null
 ): Promise<boolean> {
-  // Hardcoded opt-ins mainly for local testing
-  if (user?.google_user_email.endsWith('@anaconda.com')) return true;
-  if (user?.google_user_email.endsWith('@kilocode.ai')) return true;
   return isDynamicallyOptedIntoRequestLogging({
     accountId: user?.id ?? null,
     organizationId,


### PR DESCRIPTION
## Summary
- remove automatic API request logging opt-ins for `anaconda.com` and `kilocode.ai` email domains
- rely on account and organization opt-ins for non-custom provider traffic
- update admin copy to reflect the single opt-in source

## Testing
- not run locally; CI will validate the change