### PR TITLE
Remove StepFun 3.7 Flash from Auto Free

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -870,12 +870,8 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
 
     expect(response.status).toBe(200);
     expect(mockedGetProvider).toHaveBeenCalledTimes(2);
-    expect(mockedGetProvider.mock.calls[1]?.[0].requestedModel).toBe(
-      'poolside/laguna-s-2.1:free'
-    );
-    expect(mockedUpstreamRequest.mock.calls[0]?.[0].body.model).toBe(
-      'poolside/laguna-s-2.1:free'
-    );
+    expect(mockedGetProvider.mock.calls[1]?.[0].requestedModel).toBe('poolside/laguna-s-2.1:free');
+    expect(mockedUpstreamRequest.mock.calls[0]?.[0].body.model).toBe('poolside/laguna-s-2.1:free');
     expect(mockedAccountForMicrodollarUsage.mock.calls[0]?.[1]).toMatchObject({
       abuse_delay: 6000,
       abuse_downgraded_from: 'openai/gpt-4o',

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -498,7 +498,7 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     mockedClassifyAbuse.mockResolvedValue(classifyResult(null));
     mockedRedisGet.mockResolvedValue(null);
     mockedRedisSet.mockResolvedValue('OK');
-    mockedGetOpenRouterModels.mockResolvedValue(new Set(['stepfun/step-3.7-flash:free']));
+    mockedGetOpenRouterModels.mockResolvedValue(new Set(['poolside/laguna-s-2.1:free']));
     mockedIsValidOpenRouterModelId.mockResolvedValue(true);
     mockedUpstreamRequest.mockResolvedValue({
       type: 'success',
@@ -871,10 +871,10 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     expect(response.status).toBe(200);
     expect(mockedGetProvider).toHaveBeenCalledTimes(2);
     expect(mockedGetProvider.mock.calls[1]?.[0].requestedModel).toBe(
-      stepfun_37_flash_free_model.public_id
+      'poolside/laguna-s-2.1:free'
     );
     expect(mockedUpstreamRequest.mock.calls[0]?.[0].body.model).toBe(
-      stepfun_37_flash_free_model.internal_id
+      'poolside/laguna-s-2.1:free'
     );
     expect(mockedAccountForMicrodollarUsage.mock.calls[0]?.[1]).toMatchObject({
       abuse_delay: 6000,

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -5,7 +5,6 @@ jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
 }));
 
 import { resolveAutoModel } from './resolution';
-import { getOpenRouterModelsFromDatabase } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import {
   FRONTIER_MODE_TO_MODEL,
   KILO_AUTO_BALANCED_MODEL,
@@ -28,7 +27,9 @@ const baseParams = {
 const nullUserPromise = Promise.resolve(null);
 const zeroBalancePromise = Promise.resolve(0);
 const primaryDefaultFallback = { model: PRIMARY_DEFAULT_MODEL };
-const mockedGetOpenRouterModels = jest.mocked(getOpenRouterModelsFromDatabase);
+const { getOpenRouterModelsFromDatabase: mockedGetOpenRouterModels } = jest.requireMock<
+  jest.Mocked<typeof import('@/lib/ai-gateway/providers/gateway-models-cache')>
+>('@/lib/ai-gateway/providers/gateway-models-cache');
 
 const sampleDecision: AutoRoutingDecision = {
   model: 'anthropic/claude-haiku-4',

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -4,7 +4,7 @@ jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
   getOpenRouterModelsFromDatabase: jest.fn(),
 }));
 
-import { resolveAutoModel } from './resolution';
+import type * as AutoModelResolution from './resolution';
 import {
   FRONTIER_MODE_TO_MODEL,
   KILO_AUTO_BALANCED_MODEL,
@@ -15,6 +15,8 @@ import {
 import type { AutoRoutingDecision } from '@kilocode/auto-routing-contracts';
 import { PRIMARY_DEFAULT_MODEL } from '@/lib/ai-gateway/models';
 import type * as GatewayModelsCache from '@/lib/ai-gateway/providers/gateway-models-cache';
+
+const { resolveAutoModel } = jest.requireActual<typeof AutoModelResolution>('./resolution');
 
 const baseParams = {
   model: KILO_AUTO_EFFICIENT_MODEL.id,

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@/lib/ai-gateway/auto-model';
 import type { AutoRoutingDecision } from '@kilocode/auto-routing-contracts';
 import { PRIMARY_DEFAULT_MODEL } from '@/lib/ai-gateway/models';
+import type * as GatewayModelsCache from '@/lib/ai-gateway/providers/gateway-models-cache';
 
 const baseParams = {
   model: KILO_AUTO_EFFICIENT_MODEL.id,
@@ -28,7 +29,7 @@ const nullUserPromise = Promise.resolve(null);
 const zeroBalancePromise = Promise.resolve(0);
 const primaryDefaultFallback = { model: PRIMARY_DEFAULT_MODEL };
 const { getOpenRouterModelsFromDatabase: mockedGetOpenRouterModels } = jest.requireMock<
-  jest.Mocked<typeof import('@/lib/ai-gateway/providers/gateway-models-cache')>
+  jest.Mocked<typeof GatewayModelsCache>
 >('@/lib/ai-gateway/providers/gateway-models-cache');
 
 const sampleDecision: AutoRoutingDecision = {

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -1,12 +1,11 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
-  getOpenRouterModelsFromDatabase: jest.fn(
-    async () => new Set<string>(['poolside/laguna-s-2.1:free'])
-  ),
+  getOpenRouterModelsFromDatabase: jest.fn(),
 }));
 
 import { resolveAutoModel } from './resolution';
+import { getOpenRouterModelsFromDatabase } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import {
   FRONTIER_MODE_TO_MODEL,
   KILO_AUTO_BALANCED_MODEL,
@@ -29,6 +28,7 @@ const baseParams = {
 const nullUserPromise = Promise.resolve(null);
 const zeroBalancePromise = Promise.resolve(0);
 const primaryDefaultFallback = { model: PRIMARY_DEFAULT_MODEL };
+const mockedGetOpenRouterModels = jest.mocked(getOpenRouterModelsFromDatabase);
 
 const sampleDecision: AutoRoutingDecision = {
   model: 'anthropic/claude-haiku-4',
@@ -408,6 +408,10 @@ describe('resolveAutoModel — kilo-auto/efficient branch', () => {
 });
 
 describe('resolveAutoModel — kilo-auto/free branch', () => {
+  beforeEach(() => {
+    mockedGetOpenRouterModels.mockResolvedValue(new Set(['poolside/laguna-s-2.1:free']));
+  });
+
   it('excludes candidates denied by the effective organization policy', async () => {
     const isAutoFreeCandidateAllowed = jest.fn(
       async (modelId: string) => modelId === 'poolside/laguna-s-2.1:free'

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type * as GatewayModelsCache from '@/lib/ai-gateway/providers/gateway-models-cache';
 
 jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
+  ...jest.requireActual<typeof GatewayModelsCache>(
+    '@/lib/ai-gateway/providers/gateway-models-cache'
+  ),
   getOpenRouterModelsFromDatabase: jest.fn(),
 }));
 
@@ -14,7 +18,6 @@ import {
 } from '@/lib/ai-gateway/auto-model';
 import type { AutoRoutingDecision } from '@kilocode/auto-routing-contracts';
 import { PRIMARY_DEFAULT_MODEL } from '@/lib/ai-gateway/models';
-import type * as GatewayModelsCache from '@/lib/ai-gateway/providers/gateway-models-cache';
 
 const { resolveAutoModel } = jest.requireActual<typeof AutoModelResolution>('./resolution');
 

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
-  getOpenRouterModelsFromDatabase: jest.fn(async () => new Set<string>()),
+  getOpenRouterModelsFromDatabase: jest.fn(
+    async () => new Set<string>(['poolside/laguna-s-2.1:free'])
+  ),
 }));
 
 import { resolveAutoModel } from './resolution';
@@ -408,7 +410,7 @@ describe('resolveAutoModel — kilo-auto/efficient branch', () => {
 describe('resolveAutoModel — kilo-auto/free branch', () => {
   it('excludes candidates denied by the effective organization policy', async () => {
     const isAutoFreeCandidateAllowed = jest.fn(
-      async (modelId: string) => modelId === 'stepfun/step-3.7-flash:free'
+      async (modelId: string) => modelId === 'poolside/laguna-s-2.1:free'
     );
 
     const result = await resolveAutoModel(
@@ -425,11 +427,11 @@ describe('resolveAutoModel — kilo-auto/free branch', () => {
     expect(result).toEqual({
       kind: 'ok',
       resolved: {
-        model: 'stepfun/step-3.7-flash:free',
+        model: 'poolside/laguna-s-2.1:free',
         reasoning: { enabled: true, effort: 'high' },
       },
     });
-    expect(isAutoFreeCandidateAllowed).toHaveBeenCalledWith('stepfun/step-3.7-flash:free');
+    expect(isAutoFreeCandidateAllowed).toHaveBeenCalledWith('poolside/laguna-s-2.1:free');
   });
 
   it('reports no free models when organization policy denies every candidate', async () => {

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -231,7 +231,6 @@ describe('isFreeModel', () => {
       expect(
         Object.fromEntries(autoFreeModels.map(({ model, reasoning }) => [model, reasoning]))
       ).toEqual({
-        'stepfun/step-3.7-flash:free': { enabled: true, effort: 'high' },
         'poolside/laguna-s-2.1:free': { enabled: true, effort: 'high' },
         'nvidia/nemotron-3-ultra-550b-a55b:free': { enabled: true, effort: 'high' },
         'dots-studio/dots-3-note-preview:free': { enabled: true, effort: 'high' },
@@ -244,7 +243,6 @@ describe('isFreeModel', () => {
         autoFreeModels.map(({ model, weight }) => [model, weight])
       );
       expect(weights).toEqual({
-        'stepfun/step-3.7-flash:free': 1,
         'poolside/laguna-s-2.1:free': 1,
         'nvidia/nemotron-3-ultra-550b-a55b:free': 1,
         'dots-studio/dots-3-note-preview:free': 1,

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -39,15 +39,6 @@ export type AutoFreeModel = {
 };
 
 export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
-  ...(stepfun_37_flash_free_model.status === 'public'
-    ? [
-        {
-          model: stepfun_37_flash_free_model.public_id,
-          weight: 1,
-          reasoning: { enabled: true, effort: 'high' },
-        } satisfies AutoFreeModel,
-      ]
-    : []),
   {
     model: 'poolside/laguna-s-2.1:free',
     weight: 1,


### PR DESCRIPTION
## Summary
- remove `stepfun/step-3.7-flash:free` from the Auto Free routing pool
- keep the model public in the catalog
- update Auto Free membership expectations

## Testing
- not run locally; CI will validate the change