### PR TITLE
fix(mobile): keep the stored transcription model on a cold start

### DIFF
--- a/apps/mobile/src/lib/voice-input/gateway/gateway-transcription-preference.ts
+++ b/apps/mobile/src/lib/voice-input/gateway/gateway-transcription-preference.ts
@@ -69,6 +69,11 @@ export function readGatewayTranscriptionModel(): GatewayTranscriptionModel | nul
   return modelStore.get();
 }
 
+/** Await the persisted model read. For callers with no React tree. */
+export async function whenGatewayTranscriptionModelLoaded(): Promise<void> {
+  await modelStore.whenLoaded();
+}
+
 export function writeGatewayTranscriptionModel(model: GatewayTranscriptionModel | null): void {
   modelStore.set(model);
 }

--- a/apps/mobile/src/lib/voice-input/gateway/native-gateway-voice-input.test.ts
+++ b/apps/mobile/src/lib/voice-input/gateway/native-gateway-voice-input.test.ts
@@ -33,9 +33,13 @@ const storedModel = vi.hoisted(() => ({
 const writeTranscriptionModel = vi.hoisted(() =>
   vi.fn<(model: { id: string; name: string } | null) => void>()
 );
+const modelLoad = vi.hoisted(() => ({
+  whenLoaded: vi.fn(async (): Promise<void> => undefined),
+}));
 vi.mock('./gateway-transcription-preference', () => ({
   readGatewayTranscriptionModel: vi.fn(() => storedModel.current),
   writeGatewayTranscriptionModel: writeTranscriptionModel,
+  whenGatewayTranscriptionModelLoaded: modelLoad.whenLoaded,
 }));
 const transcriptionModels = vi.hoisted(() => ({
   fetchTranscriptionModels: vi.fn(async (): Promise<{ id: string; name: string }[]> => []),
@@ -131,6 +135,19 @@ async function flush(): Promise<void> {
   }
 }
 
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let storedResolve: (() => void) | undefined = undefined;
+  const promise = new Promise<void>(resolve => {
+    storedResolve = resolve;
+  });
+  return {
+    promise,
+    resolve: () => {
+      storedResolve?.();
+    },
+  };
+}
+
 describe('gatewayVoiceInputNative recorder construction', () => {
   beforeEach(() => {
     recorderBox.calls.length = 0;
@@ -204,6 +221,8 @@ describe('resolveGatewayTranscriptionModelId', () => {
     storedModel.current = null;
     transcriptionModels.fetchTranscriptionModels.mockReset();
     writeTranscriptionModel.mockReset();
+    modelLoad.whenLoaded.mockReset();
+    modelLoad.whenLoaded.mockImplementation(async () => undefined);
     vi.mocked(SecureStore.getItemAsync).mockResolvedValue(null);
   });
 
@@ -254,6 +273,26 @@ describe('resolveGatewayTranscriptionModelId', () => {
 
     await resolveGatewayTranscriptionModelId();
 
+    expect(writeTranscriptionModel).not.toHaveBeenCalled();
+  });
+
+  it('awaits the stored-model read before falling back, so a cold start cannot overwrite an existing choice', async () => {
+    const load = deferred();
+    modelLoad.whenLoaded.mockReturnValueOnce(load.promise);
+    transcriptionModels.fetchTranscriptionModels.mockResolvedValue([
+      { id: 'first-model', name: 'First Model' },
+    ]);
+    storedModel.current = null;
+
+    const pending = resolveGatewayTranscriptionModelId();
+
+    // The disk read lands with the user's existing choice, then the store load
+    // settles. The resolver must keep that choice, not persist the fallback.
+    storedModel.current = { id: 'stored-model', name: 'Stored Model' };
+    load.resolve();
+
+    await expect(pending).resolves.toEqual({ id: 'stored-model', name: 'Stored Model' });
+    expect(transcriptionModels.fetchTranscriptionModels).not.toHaveBeenCalled();
     expect(writeTranscriptionModel).not.toHaveBeenCalled();
   });
 

--- a/apps/mobile/src/lib/voice-input/gateway/native-gateway-voice-input.ts
+++ b/apps/mobile/src/lib/voice-input/gateway/native-gateway-voice-input.ts
@@ -11,6 +11,7 @@ import { persistFirstTranscriptionModel } from './gateway-transcription-model-se
 import {
   type GatewayTranscriptionModel,
   readGatewayTranscriptionModel,
+  whenGatewayTranscriptionModelLoaded,
 } from './gateway-transcription-preference';
 
 const HIGH_QUALITY = RecordingPresets.HIGH_QUALITY;
@@ -29,6 +30,10 @@ async function readStoredOrganizationId(): Promise<string | null> {
  * picker message on the first dictation instead of an upload that must fail.
  */
 export async function resolveGatewayTranscriptionModelId(): Promise<GatewayTranscriptionModel | null> {
+  // Wait for the persisted-model read before treating null as "never chose
+  // one": a cold start reports null until SecureStore settles, and persisting
+  // the fallback first would mark the store dirty and discard the choice.
+  await whenGatewayTranscriptionModelLoaded();
   const stored = readGatewayTranscriptionModel();
   if (stored !== null) {
     return stored;


### PR DESCRIPTION
The review remark is valid. `resolveGatewayTranscriptionModelId` read the model store before its SecureStore load settled.

## Cause

`readGatewayTranscriptionModel()` returned the default `null` while the module-scope preload was still pending. The resolver then fetched the catalogue and called `persistFirstTranscriptionModel(models)`. That write set the store's `dirty` flag, so the pending read discarded the persisted choice and the fallback was written to disk.

The settings hook already gated on `modelStoreLoaded`. The native dictation path did not.

## Fix

- Add `whenGatewayTranscriptionModelLoaded()` to the preference module, mirroring `whenLanguagePreferenceLoaded`.
- Await it in `resolveGatewayTranscriptionModelId` before the stored-model read.

## Test

Add a regression test that resolves the store with an existing model after the resolver starts. It asserts no catalogue fetch and no fallback write. The test fails on the pre-fix code (catalogue fetch called) and passes with the fix.

## Verification

- `pnpm exec vitest run src/lib/voice-input/gateway/` -> 71 passed
- `pnpm typecheck` -> pass
- `pnpm lint` -> 0 errors, 0 warnings
- `pnpm check:unused` -> clean
- `git diff --check` -> clean

Addresses the review remark on Kilo-Org/cloud#6078 at `apps/mobile/src/lib/voice-input/gateway/native-gateway-voice-input.ts`.
