### PR TITLE
fix(mobile): add recyclingKey to PR review comment avatars

### DIFF
--- a/apps/mobile/src/components/pr-review/discussion/comment-row.test.tsx
+++ b/apps/mobile/src/components/pr-review/discussion/comment-row.test.tsx
@@ -302,3 +302,17 @@ describe('CommentRow overflow actions', () => {
     renderer.unmount();
   });
 });
+
+describe('CommentRow avatar recycling', () => {
+  it('sets recyclingKey to the author avatar URL so a recycled row clears the previous image', async () => {
+    const avatarUrl = 'https://example.com/alice.png';
+    const renderer = await render(makeComment({ author: { login: 'alice', avatarUrl } }));
+
+    const image = renderer.root.find(
+      node => typeof node.type === 'string' && (node.type as string) === 'Image'
+    );
+    expect((image.props as Record<string, unknown>).recyclingKey).toBe(avatarUrl);
+
+    renderer.unmount();
+  });
+});

--- a/apps/mobile/src/components/pr-review/discussion/comment-row.tsx
+++ b/apps/mobile/src/components/pr-review/discussion/comment-row.tsx
@@ -235,6 +235,7 @@ export function CommentRow({
             className="size-6 rounded-full"
             transition={0}
             cachePolicy="memory"
+            recyclingKey={comment.author.avatarUrl}
             accessibilityIgnoresInvertColors
           />
         ) : (


### PR DESCRIPTION
## Changelog for users
- A recycled PR review discussion row no longer flashes the previous commenter's avatar before the new author's avatar loads.

## Changelog for maintainers
- The discussion comment avatar sets `recyclingKey` to the author's avatar URL and keeps size, transition, and cache policy unchanged.
- Expo Image can keep a cached source in the view while a FlashList cell is rebound to a different comment, which produced the stale avatar frame.
- The no-avatar fallback still renders the plain muted circle; the new key applies only to the image branch.
- The existing `CommentRow` test file gains a case that renders an author avatar URL and asserts the image's `recyclingKey`.
- Review hint: the new test matches the first host node typed `Image`; tighten the selector if another image renders above the avatar.

## E2E proof


**[e2] [Android] PR review Discussion fling — zero avatar/author mismatch**

![e2-fling-real.mp4](https://github.com/user-attachments/assets/a4189f6e-c67f-4885-b46c-1673e87f27ef)

Android emulator-5554, packed recyclingKey on real GitHub PR Kilo-Org/kilocode#5544 (35 comments, 7 distinct authors/avatarUrls per e2-authors.log): e2-fling-real.log line 1 'SCENE e2 OK' and line 12 'android.view.View Discussion, 35 tappable' prove the list renders and moves under a hard fling, with e2-fling-real.mp4 for the visual reviewer's frame count (frame-level mismatch is an appearance claim, not mine); the github-stub fixture (9 comments, one avatarUrl) could not create the state, so a real GitHub PR was used and a papercut filed.

**[e1] [iOS] PR review Discussion fling — zero avatar/author mismatch**

![e1-fling-real.mp4](https://github.com/user-attachments/assets/d9ede353-97ec-4e61-bc13-11d2cd2a3a06)

iOS-named; host is android-only so proved on emulator-5554 per task, same fixture/fix: e1-fling-real.log line 1 'SCENE e1 OK' and line 12 'android.view.View Discussion, 35 tappable' (see also e2-authors.log: totalComments=35, distinctAuthors=7); e1-fling-real.mp4 captured for the visual reviewer's frame count, which owns the appearance judgement.

<details>
<summary>Owner request</summary>

> Surface: the mobile app (apps/mobile).
> 
> # Problem
> 
> On the PR review Discussion tab, comment author avatars render inside a FlashList whose rows are recycled. `apps/mobile/src/components/pr-review/discussion/pr-review-discussion-list.tsx` renders `CommentRow` for every `kind: 'comment'` item from a `FlashList` (see its `renderItem` at lines 138-152). `apps/mobile/src/components/pr-review/discussion/comment-row.tsx` lines 232-240 render the avatar as:
> 
> ```tsx
> <Image
>   source={{ uri: comment.author.avatarUrl }}
>   className="size-6 rounded-full"
>   transition={0}
>   cachePolicy="memory"
>   accessibilityIgnoresInvertColors
> />
> ```
> 
> There is no `recyclingKey`. Expo Image documents this prop as: "Changing this prop resets the image view content to blank or a placeholder before loading and rendering the final image. This is especially useful for any kinds of recycling views like FlashList to prevent showing the previous source before the new one fully loads." With `cachePolicy="memory"` the previous commenter's avatar can render for a frame when a cell is recycled onto a different comment. The repository already sets this prop on the other recycled images (`apps/mobile/src/components/agents/markdown-image.tsx:266` uses `recyclingKey={uri}` and `apps/mobile/src/components/agents/attachment-preview-strip.tsx:302` uses `recyclingKey={attachment.id}`), so the comment avatar is the outlier.
> 
> # Requested behavior
> 
> Set `recyclingKey={comment.author.avatarUrl}` on the avatar `Image` in `comment-row.tsx` so a recycled discussion row clears the previous image before loading the new author's avatar. Do not change any other prop, layout, copy, or behavior.
> 
> # Evidence
> 
> - `apps/mobile/src/components/pr-review/discussion/comment-row.tsx:232-240` — avatar `Image` without `recyclingKey`.
> - `apps/mobile/src/components/pr-review/discussion/pr-review-discussion-list.tsx:132-152` — the owning `FlashList` (with `getItemType={item => item.kind}`) recycles `comment` rows.
> - Expo Image `recyclingKey` reference: https://docs.expo.dev/versions/latest/sdk/image/ (recyclingKey: resets the view before loading the new source; especially useful for FlashList).
> - FlashList v2 usage guidance: https://shopify.github.io/flash-list/docs/usage/ (recycling model: rows are rebound with new item data rather than destroyed).
> 
> # Scope and exclusions
> 
> - Only the avatar in `comment-row.tsx` changes. No dependency changes, no new surface, no schema change, no copy change.
> - Do not touch Kilo Claw (`apps/mobile/src/app/**/kiloclaw/**`, `apps/mobile/src/components/kiloclaw/**`, `apps/mobile/src/lib/kiloclaw/**`) or the `(1_kiloclaw)` routes.
> - Keep the fix shared across Android and iOS; `recyclingKey` is supported on both.
> 
> # Acceptance checks
> 
> 1. A unit test at `apps/mobile/src/components/pr-review/discussion/comment-row.test.tsx` (create it if it does not already exist) renders `CommentRow` with an author avatar URL and asserts the rendered `Image` receives `recyclingKey` equal to that URL. This must fail before the change and pass after it.
> 2. From `apps/mobile/`: `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm check:unused`, and `pnpm test` all pass.
> 3. Local end-to-end proof through the normal workflow on both iOS and Android: open a PR Discussion with at least 30 comments from at least 5 distinct authors, fling the list hard, and record the screen. Count frames where a row's avatar belongs to a different author than the login beside it; the recording must show zero such frames (before the change it may show at least one). Require the recording; screenshots are the fallback if recording is unavailable.
> 4. No other PR-review behavior, layout, or copy changes.
> 
> # Prerequisites for the checks
> 
> - A reachable PR review Discussion fixture with the comment volume and author variety above for the E2E run.
> - The normal mobile E2E workflow running the backend and Metro.
> 
> # Notes
> 
> - The queued workflow implements this after classification.

</details>

