### PR TITLE
fix(mobile): enlarge Kilo Chat attachment chip touch targets

### DIFF
--- a/apps/mobile/src/components/kilo-chat/message-attachment-preview-chip.mounted.test.tsx
+++ b/apps/mobile/src/components/kilo-chat/message-attachment-preview-chip.mounted.test.tsx
@@ -1,0 +1,138 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/components/agents/attachment-preview-strip.mounted.test.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type QueuedAttachment } from '@kilocode/kilo-chat-hooks';
+
+import { MessageAttachmentPreviewChip } from './message-attachment-preview-chip';
+
+const reactNativeMock = vi.hoisted(() => ({
+  Platform: { OS: 'ios' as string },
+}));
+
+vi.mock('react-native', () => ({
+  Platform: reactNativeMock.Platform,
+  Pressable: 'Pressable',
+  View: 'View',
+}));
+vi.mock('@/components/ui/activity-indicator', () => ({ ActivityIndicator: 'ActivityIndicator' }));
+vi.mock('@/components/ui/icons', () => ({
+  AlertCircle: 'AlertCircle',
+  File: 'File',
+  RotateCcw: 'RotateCcw',
+  X: 'X',
+}));
+vi.mock('@/components/ui/image', () => ({ Image: 'Image' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({
+    destructive: '#b91c1c',
+    foreground: '#111827',
+    mutedForeground: '#6b7280',
+  }),
+}));
+
+type HitSlop = { top: number; bottom: number; left: number; right: number };
+
+const RETRY_LABEL = 'Retry upload for photo.jpg';
+const REMOVE_LABEL = 'Remove photo.jpg';
+
+// The visible `h-7 w-7` badge. Tailwind's `h-7` is 1.75rem and NativeWind
+// renders 1rem as 14 on native, so the badge measures 24.5pt — not the 28pt the
+// 4px spacing scale implies (measured 65px at density 420 = 2.625 from the
+// Android emulator). A slop computed from 28 left the Android target at 44.5dp.
+const CONTROL_BADGE_SIZE = 24.5;
+
+function makeFailedImageRow(): QueuedAttachment {
+  return {
+    tempId: 'a1',
+    filename: 'photo.jpg',
+    mimeType: 'image/jpeg',
+    size: 2048,
+    status: 'failed',
+    progress: 1,
+  };
+}
+
+async function mount(): Promise<TestRenderer.ReactTestRenderer> {
+  const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+  await act(async () => {
+    await Promise.resolve();
+    ref.current = TestRenderer.create(
+      createElement(MessageAttachmentPreviewChip, {
+        row: makeFailedImageRow(),
+        localUri: 'file:///cache/photo.jpg',
+        onRemove: () => undefined,
+        onRetry: () => undefined,
+      })
+    );
+  });
+  const renderer = ref.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return renderer;
+}
+
+function hitSlopFor(root: TestRenderer.ReactTestInstance, label: string): HitSlop {
+  const control = root.find(
+    node =>
+      typeof node.type === 'string' &&
+      (node.type as string) === 'Pressable' &&
+      node.props.accessibilityLabel === label
+  );
+  return control.props.hitSlop as HitSlop;
+}
+
+beforeEach(() => {
+  reactNativeMock.Platform.OS = 'ios';
+});
+
+describe('MessageAttachmentPreviewChip — control hit targets', () => {
+  // Each control renders an `h-7 w-7` badge. NativeWind renders 1rem as 14 on
+  // native, so the badge is 24.5pt, not the 28pt the 4px spacing scale implies;
+  // asserting against the real size catches a slop computed from 28, which left
+  // the Android target at 44.5dp instead of 48dp.
+  it('keeps the Retry target at the 44pt minimum on iOS', async () => {
+    const renderer = await mount();
+
+    const hitSlop = hitSlopFor(renderer.root, RETRY_LABEL);
+    expect(CONTROL_BADGE_SIZE + hitSlop.top + hitSlop.bottom).toBeGreaterThanOrEqual(44);
+    expect(CONTROL_BADGE_SIZE + hitSlop.left + hitSlop.right).toBeGreaterThanOrEqual(44);
+
+    renderer.unmount();
+  });
+
+  it('keeps the Remove target at the 44pt minimum on iOS', async () => {
+    const renderer = await mount();
+
+    const hitSlop = hitSlopFor(renderer.root, REMOVE_LABEL);
+    expect(CONTROL_BADGE_SIZE + hitSlop.top + hitSlop.bottom).toBeGreaterThanOrEqual(44);
+    expect(CONTROL_BADGE_SIZE + hitSlop.left + hitSlop.right).toBeGreaterThanOrEqual(44);
+
+    renderer.unmount();
+  });
+
+  it('keeps the Retry target at the 48dp minimum on Android', async () => {
+    reactNativeMock.Platform.OS = 'android';
+    const renderer = await mount();
+
+    const hitSlop = hitSlopFor(renderer.root, RETRY_LABEL);
+    expect(CONTROL_BADGE_SIZE + hitSlop.top + hitSlop.bottom).toBeGreaterThanOrEqual(48);
+    expect(CONTROL_BADGE_SIZE + hitSlop.left + hitSlop.right).toBeGreaterThanOrEqual(48);
+
+    renderer.unmount();
+  });
+
+  it('keeps the Remove target at the 48dp minimum on Android', async () => {
+    reactNativeMock.Platform.OS = 'android';
+    const renderer = await mount();
+
+    const hitSlop = hitSlopFor(renderer.root, REMOVE_LABEL);
+    expect(CONTROL_BADGE_SIZE + hitSlop.top + hitSlop.bottom).toBeGreaterThanOrEqual(48);
+    expect(CONTROL_BADGE_SIZE + hitSlop.left + hitSlop.right).toBeGreaterThanOrEqual(48);
+
+    renderer.unmount();
+  });
+});

--- a/apps/mobile/src/components/kilo-chat/message-attachment-preview-chip.tsx
+++ b/apps/mobile/src/components/kilo-chat/message-attachment-preview-chip.tsx
@@ -1,4 +1,4 @@
-import { Pressable, View } from 'react-native';
+import { Platform, Pressable, View } from 'react-native';
 import { ActivityIndicator } from '@/components/ui/activity-indicator';
 import { useTranslation } from 'react-i18next';
 import { AlertCircle, File as FileIcon, RotateCcw, X } from '@/components/ui/icons';
@@ -19,6 +19,26 @@ type Props = {
   onRetry: () => void;
 };
 
+/**
+ * Retry and Remove render a visible `h-7 w-7` badge. Tailwind's `h-7` is
+ * 1.75rem, and NativeWind renders 1rem as 14 on native (react-native-css
+ * `rem: 14`), so the badge measures 24.5pt — not the 28pt the 4px spacing scale
+ * implies. The hitSlop is derived from that real size, otherwise the effective
+ * target falls short of the platform minimum (measured 24.5 + 2x10 = 44.5dp on
+ * Android, below 48dp).
+ */
+const ATTACHMENT_CONTROL_BADGE_SIZE = 7 * 0.25 * 14;
+
+/**
+ * Reach the platform minimum touch target through hitSlop. Read at render time
+ * so it follows the platform, never captured once at module load.
+ */
+function controlHitSlop() {
+  const minimum = Platform.OS === 'android' ? 48 : 44;
+  const slop = Math.ceil((minimum - ATTACHMENT_CONTROL_BADGE_SIZE) / 2);
+  return { top: slop, bottom: slop, left: slop, right: slop };
+}
+
 export function MessageAttachmentPreviewChip({ row, localUri, onRemove, onRetry }: Props) {
   const { t } = useTranslation();
   const colors = useThemeColors();
@@ -37,51 +57,60 @@ export function MessageAttachmentPreviewChip({ row, localUri, onRemove, onRetry 
   }
 
   return (
+    // The outer wrapper anchors the absolute Retry/Remove controls and keeps
+    // the strip's spacing (mr-2). It has NO overflow-hidden, so the controls'
+    // hitSlop is never clipped; the rounded, clipping chip surface below is a
+    // sibling of the controls, not their ancestor.
     <View
-      className={cn(
-        'relative mr-2 overflow-hidden rounded-md border border-border bg-card',
-        isImage ? 'h-16 w-20' : 'h-12 w-48 flex-row items-center gap-2 px-2'
-      )}
+      className="relative mr-2"
       accessibilityLabel={t('chat.attachmentPreview.accessibility', {
         filename: row.filename,
         status: row.status,
       })}
     >
-      {isImage && localUri ? (
-        <Image
-          source={{ uri: localUri }}
-          className="h-full w-full"
-          contentFit="cover"
-          transition={0}
-        />
-      ) : (
-        <View className="min-w-0 flex-1 flex-row items-center gap-2">
-          {renderLeadingIcon()}
-          <View className="min-w-0 flex-1">
-            <Text numberOfLines={1} className="text-xs text-foreground">
-              {row.filename}
-            </Text>
-            <Text numberOfLines={1} className="text-[10px] text-muted-foreground">
-              {uploading
-                ? formatPercent(row.progress * 100, i18n.language)
-                : formatFileSize(row.size, i18n.language)}
+      <View
+        className={cn(
+          'overflow-hidden rounded-md border border-border bg-card',
+          isImage ? 'h-16 w-20' : 'h-12 w-48 flex-row items-center gap-2 px-2'
+        )}
+      >
+        {isImage && localUri ? (
+          <Image
+            source={{ uri: localUri }}
+            className="h-full w-full"
+            contentFit="cover"
+            transition={0}
+          />
+        ) : (
+          <View className="min-w-0 flex-1 flex-row items-center gap-2">
+            {renderLeadingIcon()}
+            <View className="min-w-0 flex-1">
+              <Text numberOfLines={1} className="text-xs text-foreground">
+                {row.filename}
+              </Text>
+              <Text numberOfLines={1} className="text-[10px] text-muted-foreground">
+                {uploading
+                  ? formatPercent(row.progress * 100, i18n.language)
+                  : formatFileSize(row.size, i18n.language)}
+              </Text>
+            </View>
+          </View>
+        )}
+
+        {isImage && uploading ? (
+          <View className="absolute inset-0 items-center justify-center bg-[#00000033]">
+            <ActivityIndicator size="small" color={colors.foreground} />
+            <Text className="mt-1 text-[10px] text-foreground">
+              {formatPercent(row.progress * 100, i18n.language)}
             </Text>
           </View>
-        </View>
-      )}
-
-      {isImage && uploading ? (
-        <View className="absolute inset-0 items-center justify-center bg-[#00000033]">
-          <ActivityIndicator size="small" color={colors.foreground} />
-          <Text className="mt-1 text-[10px] text-foreground">
-            {formatPercent(row.progress * 100, i18n.language)}
-          </Text>
-        </View>
-      ) : null}
+        ) : null}
+      </View>
 
       {failed ? (
         <Pressable
           onPress={onRetry}
+          hitSlop={controlHitSlop()}
           className="absolute bottom-1 left-1 h-7 w-7 items-center justify-center rounded-full bg-background active:opacity-70"
           accessibilityRole="button"
           accessibilityLabel={t('chat.attachmentPreview.retryUploading', {
@@ -94,6 +123,7 @@ export function MessageAttachmentPreviewChip({ row, localUri, onRemove, onRetry 
 
       <Pressable
         onPress={onRemove}
+        hitSlop={controlHitSlop()}
         className="absolute right-1 top-1 h-7 w-7 items-center justify-center rounded-full bg-background active:opacity-70"
         accessibilityRole="button"
         accessibilityLabel={t('chat.attachmentPreview.remove', { filename: row.filename })}


### PR DESCRIPTION
> **Not verified.** kwf reopened this section on 2026-09-14: dropped by the owner: PR 6092 was closed
> The proof below came from an earlier round and can be stale. Do not review until this note is gone.

## Changelog for users

- Retry and Remove on the Kilo Chat attachment chip now register taps across the full platform touch target, not only the small visible badge.

## Changelog for maintainers

- The Kilo Chat attachment chip is split into a non-clipping outer wrapper that anchors the absolute Retry/Remove controls and a sibling rounded `overflow-hidden` surface, so `hitSlop` is no longer clipped.
- Both controls receive a `hitSlop` of 10pt per side on iOS and 12pt per side on Android.
- The slop derives from the badge's real rendered size, 24.5pt, because NativeWind maps `h-7`/1rem to 14; the effective targets measure 44.5pt on iOS and 48.5pt on Android.
- This corrects the requested `((android ? 48 : 44) - 28) / 2` formula and its 28pt assertion: with 28 the Android target would land at 44.5dp, below the 48dp minimum.
- The slop is recomputed on every render so it follows `Platform.OS`.
- A new mounted test asserts, for both Retry and Remove, that the 24.5pt badge plus slop reaches 44 on iOS and 48 on Android.
- Review first the 24.5pt badge assumption and the 44.5/48.5 arithmetic, then confirm the outer wrapper no longer clips the rounded surface.
- Visible sizes (`h-16 w-20` image, `h-12 w-48` file), `transition={0}`, the progress overlay, labels/roles, and `active:opacity-70` are unchanged.

## E2E proof

No recording is attached: the diff does not change the visible badge, icon, or layout, so the change adds no new visual state to capture.

On an Android emulator, a tap about 6pt beyond the Remove badge edge removed the attachment.

On an Android emulator, a tap about 6pt beyond the Retry badge edge retried the upload.

iOS device verification did not pass: the iOS run timed out after 3600s, so the iOS tap-through is skipped and pending owner verification.

<details>
<summary>Owner request</summary>

> Surface: the mobile app (apps/mobile).
> 
> Fix the undersized touch targets on the Kilo Chat attachment preview chip in the mobile app.
> 
> Problem
> `apps/mobile/src/components/kilo-chat/message-attachment-preview-chip.tsx` renders two icon-only controls inside the chip:
> - Retry: lines 82-93 (Pressable at 83, `h-7 w-7` class at 85), no `hitSlop`.
> - Remove: lines 95-102 (Pressable at 96, `h-7 w-7` class at 97), no `hitSlop`.
> Their effective touch target is 28x28pt, below the app's iOS 44pt / Android 48dp minimum, stated at `apps/mobile/src/components/agents/chat-composer-input-row.tsx:26-27` (WCAG 2.5.8 AA). The equivalent Cloud Agent composer chip already fixed this: `apps/mobile/src/components/agents/attachment-preview-strip.tsx` computes a platform-sized slop in `removeHitSlop()` (lines 59-67), applies it to Remove at line 447, and keeps its outer wrapper free of `overflow-hidden` (lines 362-376) so the slop is not clipped. The Kilo Chat chip instead puts `overflow-hidden` on the same View that contains the buttons (line 42), so any slop would be partially clipped and the controls would still miss the minimum.
> 
> Requested behavior
> In `apps/mobile/src/components/kilo-chat/message-attachment-preview-chip.tsx`:
> 1. Restructure as the agent chip does: a non-clipping outer wrapper that anchors the absolute Retry/Remove controls, with the rounded, `overflow-hidden` chip surface (image/file body) as a sibling of those controls, so the controls' hitSlop is not clipped.
> 2. Give both the Retry and Remove Pressables a hitSlop of `((Platform.OS === 'android' ? 48 : 44) - 28) / 2` on each side, so each reaches the platform minimum.
> 3. Keep the existing accessibility labels/roles, `active:opacity-70` feedback, the file/image visual sizes (h-16 w-20 / h-12 w-48), the `transition={0}` image, and the progress overlay unchanged.
> 
> Add `apps/mobile/src/components/kilo-chat/message-attachment-preview-chip.mounted.test.tsx` mirroring `apps/mobile/src/components/agents/attachment-preview-strip.mounted.test.tsx:1038-1079`: mount a failed image chip and assert, for both Retry and Remove, that `28 + hitSlop.top + hitSlop.bottom >= 44` and `28 + hitSlop.left + hitSlop.right >= 44` on iOS, and `>= 48` on Android.
> 
> Exclusions
> - Do not change any other screen, copy, or the Kilo Claw surface.
> - Do not change the chip's visible size, badges, icons, colors, or labels.
> 
> Acceptance checks
> - `cd apps/mobile && pnpm format:check && pnpm typecheck && pnpm lint && pnpm check:unused`
> - `cd apps/mobile && pnpm vitest run --project mobile-mounted src/components/kilo-chat/message-attachment-preview-chip.mounted.test.tsx` passes (new iOS >=44 and Android >=48 assertions for Retry and Remove).
> - `cd apps/mobile && pnpm test` passes.
> - Dev-build E2E on both an iOS simulator and an Android emulator through the normal workflow: queue an attachment in a Kilo Chat composer, then tap inside the new slop but outside the 28pt badge (about 6pt beyond the badge edge) and confirm Remove removes the attachment and Retry re-uploads. Attach the sanitized accessibility-node bounds and the tap-coordinate log lines as decisive evidence. A recording is not required because the visible badge, icon, and layout are unchanged; state that in the PR.
> - `git diff --check` is clean.
> 
> Prerequisites for the checks
> - A mobile dev build and the local dev stack are running per `apps/mobile/AGENTS.md`; Metro is owned by the repo dev runner and must not be started manually.

</details>
