### PR TITLE
fix(mobile): restore last picked model and effort on new session

### DIFF
--- a/apps/mobile/src/lib/hooks/auto-select-model.test.ts
+++ b/apps/mobile/src/lib/hooks/auto-select-model.test.ts
@@ -14,6 +14,12 @@ const claude = {
   variants: ['thinking'],
   isPreferred: true,
 };
+const opus = {
+  id: 'anthropic/opus',
+  name: 'Opus',
+  variants: ['low', 'high'],
+  isPreferred: false,
+};
 const gpt = { id: 'openai/gpt', name: 'GPT', variants: [], isPreferred: false };
 
 const base: AutoSelectInput = {
@@ -60,22 +66,42 @@ describe('pickAutoSelectedModel', () => {
     ).toEqual({ model: 'kilo-auto/efficient', variant: '' });
   });
 
-  it('dev, efficient wins over server lastSelected', () => {
+  it('dev, persisted server combo wins over the efficient default', () => {
     expect(
       pickAutoSelectedModel({
         ...base,
         models: [claude, efficient],
         lastSelected: { model: 'anthropic/claude', variant: 'thinking' },
       })
-    ).toEqual({ model: 'kilo-auto/efficient', variant: '' });
+    ).toEqual({ model: 'anthropic/claude', variant: 'thinking' });
   });
 
-  it('dev, efficient wins over a local persisted preference', () => {
+  it('dev, server combo restores the selected effort', () => {
+    expect(
+      pickAutoSelectedModel({
+        ...base,
+        models: [opus, efficient],
+        lastSelected: { model: 'anthropic/opus', variant: 'high' },
+      })
+    ).toEqual({ model: 'anthropic/opus', variant: 'high' });
+  });
+
+  it('dev, local persisted combo wins over the efficient default', () => {
     expect(
       pickAutoSelectedModel({
         ...base,
         models: [gpt, efficient],
         stored: { personal: { model: 'openai/gpt', variant: '' } },
+      })
+    ).toEqual({ model: 'openai/gpt', variant: '' });
+  });
+
+  it('dev, persisted model gone from the catalog → falls back to efficient', () => {
+    expect(
+      pickAutoSelectedModel({
+        ...base,
+        models: [claude, efficient],
+        stored: { personal: { model: 'gone/model', variant: 'high' } },
       })
     ).toEqual({ model: 'kilo-auto/efficient', variant: '' });
   });

--- a/apps/mobile/src/lib/hooks/auto-select-model.ts
+++ b/apps/mobile/src/lib/hooks/auto-select-model.ts
@@ -24,28 +24,30 @@ export type AutoSelectInput = {
 };
 
 /**
- * Pick the new-session model. In dev builds, `kilo-auto/efficient` wins over every
- * override when the catalog holds it. Otherwise the priority is server lastSelected,
- * then local persisted preference, then org default, then the first catalog entry.
+ * Pick the new-session model. A persisted choice is always restored first so
+ * the user's last picked model/effort combo comes back: the server
+ * `lastSelected`, then the local persisted preference. When neither is
+ * available in the catalog, dev builds fall back to `kilo-auto/efficient`,
+ * then the org default, then the first catalog entry.
  */
 export function pickAutoSelectedModel(
   input: AutoSelectInput
 ): { model: string; variant: string } | null {
   const { models, lastSelected, stored, organizationId, orgDefaultModel, isDev } = input;
+  const serverMatch = lastSelected ? models.find(m => m.id === lastSelected.model) : undefined;
+  if (serverMatch) {
+    return { model: serverMatch.id, variant: pickVariant(serverMatch, lastSelected?.variant) };
+  }
+  const localEntry = resolveModelForContext(stored, contextKey(organizationId), models);
+  if (localEntry) {
+    return localEntry;
+  }
   const devDefaultMatch = isDev ? models.find(m => m.id === DEV_DEFAULT_MODEL_ID) : undefined;
   if (devDefaultMatch) {
     return { model: devDefaultMatch.id, variant: pickVariant(devDefaultMatch, undefined) };
   }
-  const serverMatch = lastSelected ? models.find(m => m.id === lastSelected.model) : undefined;
-  const localEntry = resolveModelForContext(stored, contextKey(organizationId), models);
   const orgDefaultMatch = orgDefaultModel ? models.find(m => m.id === orgDefaultModel) : undefined;
   const fallback = orgDefaultMatch ?? models[0];
-  if (serverMatch) {
-    return { model: serverMatch.id, variant: pickVariant(serverMatch, lastSelected?.variant) };
-  }
-  if (localEntry) {
-    return localEntry;
-  }
   if (fallback) {
     return { model: fallback.id, variant: pickVariant(fallback, undefined) };
   }


### PR DESCRIPTION
## Changelog for users

- The New session screen restores the model and thinking effort the user picked last, instead of resetting to an automatic default.
- The restored selection includes the chosen effort, not just the model.
- If the saved model is no longer offered, the screen falls back to the usual default: the dev efficient model, then the organization default, then the first catalog model.
- If the saved model still exists but its saved effort is gone, the model's first offered effort is used.

## Changelog for maintainers

- `pickAutoSelectedModel` now resolves in this order: server `lastSelected`, local stored preference, dev `kilo-auto/efficient`, org default, first catalog entry.
- The dev efficient default previously short-circuited before both persisted sources, so dev builds ignored a saved combo; the persisted sources now win.
- Release builds already resolved server and local before the fallback, so the reorder changes dev-build selection only.
- A stored model missing from the catalog is dropped by `resolveModelForContext` and falls through to the next source.
- An unavailable stored variant falls back to the model's first variant; an invalid server variant does too via `pickVariant`.
- The picker already writes each pick to device storage and the server in `handleModelSelect`; this change fixes the restore priority, not the save path.
- Remote CLI-catalog picks still return early and are not persisted; unchanged.
- Tests now cover dev restore of the server combo, dev restore of the local combo, and catalog-missing fallback to the efficient default.

## E2E proof

**Recording of the verified flow** (waits trimmed)

https://github.com/user-attachments/assets/ba034127-470e-4bc7-8d1c-8aad0b874dac

![[e1] On the mobile New session page, pick a non-default model and a thinking effort, leave the page (back), reopen New session: the same model and effort are preselected. — scripted-shard1/e1.png](https://github.com/user-attachments/assets/135f8b8a-6790-4874-a384-6854f6c34e10)

![[e2] On the mobile New session page, pick a model/effort, force-quit and relaunch the app, open New session: the same combo is restored from device-local storage. — scripted-shard1/e2.png](https://github.com/user-attachments/assets/612fd364-803f-4c37-b80c-ee228e0369d0)

## E2E proof — log excerpts

```
[p1] New session keeps the picked model and thinking effort across back/reopen -> pass :: Scripted scene proof: 'SCENE p1 OK' with digest line 'android.widget.Button Claude Opus 4 ($$$$), Extra High thinking effort tappable [319,707][957,781]'; not replayed per the runbook's scripted-OK rule.
[p2] New session restores the picked model/effort after force-quit and relaunch -> pass :: Picked Claude Opus 5 + High, nulled the server last_selected fixture (p2-server-cleared.log), then adb force-stop + monkey relaunch (p2-forcequit.log); after reopening New session the digest shows 'android.widget.Button Claude Opus 5, High thinking effort tappable [319,707][780,781]' under 'SCENE p2 OK', proving the device-local restore.
```

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/persist-last-model-effort-choice-30cb/e2e-mobile-app/scripted-p1.log</code></summary>

```
android.widget.TextView Extra High tappable [736,725][866,762]
android.widget.TextView Run on tappable [37,857][1045,903]
android.widget.Button Run on: Cloud Agent tappable [37,921][909,1037]
android.widget.TextView Cloud Agent tappable [67,951][844,1007]
android.widget.Button Refresh tappable [928,921][1043,1037]
android.widget.TextView Run `kilo remote` on your computer, or `/remote` in a running CLI session, to control a local kilo process. tappable [36,1056][1044,1130]
android.widget.TextView Repository tappable [37,1176][1045,1222]
android.widget.Button Repository: Select repository tappable [37,1240][1043,1356]
android.widget.TextView Select repository tappable [67,1270][978,1326]
android.widget.TextView Connect GitLab tappable [76,1423][1004,1469]
android.widget.TextView Connect GitLab in your browser, then return here to pick a repository. tappable [76,1478][1004,1570]
android.widget.Button Open GitLab tappable [76,1598][870,1714]
android.widget.TextView Open GitLab tappable [412,1632][594,1678]
android.widget.Button Refresh repositories tappable [888,1598][1004,1714]
android.widget.TextView Changes tappable [37,1799][1045,1845]
android.view.View Changes tappable [37,1863][1043,1982]
android.widget.RadioButton Leave changes tappable [46,1872][540,1973]
android.widget.TextView Leave changes tappable [182,1899][403,1945]
android.widget.RadioButton Commit and push tappable [540,1872][1034,1973]
android.widget.TextView Commit and push tappable [656,1899][917,1945]
android.widget.TextView Environment tappable [37,2029][1045,2075]
android.widget.TextView Default environment tappable [37,2093][1045,2139]
android.widget.Button Start session [37,2195][1043,2311]
android.widget.TextView Start session tappable [442,2229][638,2275]
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/persist-last-model-effort-choice-30cb/e2e-mobile-app/p2-verify.log</code></summary>

```
android.widget.TextView High tappable [630,725][689,762]
android.widget.TextView Run on tappable [37,857][1045,903]
android.widget.Button Run on: Cloud Agent tappable [37,921][909,1037]
android.widget.TextView Cloud Agent tappable [67,951][844,1007]
android.widget.Button Refresh tappable [928,921][1043,1036]
android.widget.TextView Run `kilo remote` on your computer, or `/remote` in a running CLI session, to control a local kilo process. tappable [36,1056][1044,1130]
android.widget.TextView Repository tappable [37,1176][1045,1222]
android.widget.Button Repository: Select repository tappable [37,1240][1043,1357]
android.widget.TextView Select repository tappable [67,1270][978,1326]
android.widget.TextView Connect GitLab tappable [76,1423][1004,1469]
android.widget.TextView Connect GitLab in your browser, then return here to pick a repository. tappable [76,1478][1004,1570]
android.widget.Button Open GitLab tappable [76,1598][870,1714]
android.widget.TextView Open GitLab tappable [412,1632][594,1678]
android.widget.Button Refresh repositories tappable [888,1598][1004,1714]
android.widget.TextView Changes tappable [37,1799][1045,1845]
android.view.View Changes tappable [37,1863][1043,1982]
android.widget.RadioButton Leave changes tappable [46,1872][540,1973]
android.widget.TextView Leave changes tappable [182,1899][403,1945]
android.widget.RadioButton Commit and push tappable [540,1872][1034,1973]
android.widget.TextView Commit and push tappable [656,1899][917,1945]
android.widget.TextView Environment tappable [37,2029][1045,2075]
android.widget.TextView Default environment tappable [37,2093][1045,2139]
android.widget.Button Start session [37,2195][1043,2311]
android.widget.TextView Start session tappable [442,2229][638,2275]
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/persist-last-model-effort-choice-30cb/e2e-mobile-app/p2-server-cleared.log</code></summary>

```
=== clear server last_selected (isolate device-local storage) ===
UPDATE 1
=== select after clear ===
af622f55-12ab-49e0-b865-4e88a983eec3|
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/persist-last-model-effort-choice-30cb/e2e-mobile-app/p2-forcequit.log</code></summary>

```
=== adb force-stop ===
exit=0
=== adb monkey launch ===
data="android.intent.category.LAUNCHER"
Events injected: 1
## Network stats: elapsed time=15ms (0ms mobile, 0ms wifi, 15ms not connected)
```
</details>

<details>
<summary>Owner request</summary>

> Surface: the mobile app (apps/mobile).
> 
> On the new session page, the last selected model/effort combo is not persisted, so the user is forced to pick for every new session. Persist the last picked model/effort combo and restore it on the new session page, with a reasonable fallback in case the persisted choice is not available.

</details>