### PR TITLE
feat(mobile): show answer-choice subtitles in the agent question card

### DIFF
--- a/apps/mobile/src/components/agents/question-card.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/question-card.mounted.test.tsx
@@ -112,12 +112,18 @@ function optionButton(
   root: TestRenderer.ReactTestInstance,
   label: string
 ): TestRenderer.ReactTestInstance | undefined {
-  return root.findAll(
-    node =>
-      typeof node.type === 'string' &&
-      (node.type as string) === 'Button' &&
-      node.props.accessibilityLabel === label
-  )[0];
+  // A described option joins its subtitle into the accessible name
+  // (`<label>, <description>`), so match the leading label too.
+  return root.findAll(node => {
+    if (typeof node.type !== 'string' || (node.type as string) !== 'Button') {
+      return false;
+    }
+    const accessibleLabel = node.props.accessibilityLabel;
+    return (
+      accessibleLabel === label ||
+      (typeof accessibleLabel === 'string' && accessibleLabel.startsWith(`${label},`))
+    );
+  })[0];
 }
 
 function press(node: TestRenderer.ReactTestInstance | undefined): void {
@@ -146,6 +152,19 @@ function typeCustomText(root: TestRenderer.ReactTestInstance, text: string): voi
   act(() => {
     (input.props.onChangeText as (text: string) => void)(text);
   });
+}
+
+/** The row of text lines rendered inside one preset option button. */
+function optionTextLines(root: TestRenderer.ReactTestInstance, label: string): string[] {
+  const button = optionButton(root, label);
+  if (!button) {
+    throw new Error(`option button "${label}" not found`);
+  }
+  return button
+    .findAll(node => typeof node.type === 'string' && (node.type as string) === 'Text')
+    .map(node =>
+      node.children.filter((child): child is string => typeof child === 'string').join('')
+    );
 }
 
 describe('QuestionCard custom answer selection', () => {
@@ -197,6 +216,51 @@ describe('QuestionCard custom answer selection', () => {
 
     press(optionButton(renderer.root, 'Continue'));
     expect(customChoiceChecked(renderer.root)).toBe(false);
+  });
+
+  it('renders an option description as a subtitle under its label', async () => {
+    const renderer = await renderCard([
+      {
+        question: 'How should the agent proceed?',
+        header: 'Agent needs input',
+        options: [
+          { label: 'Continue', description: 'Deploy to production' },
+          { label: 'Stop', description: '' },
+        ],
+        custom: true,
+      },
+    ]);
+
+    expect(optionTextLines(renderer.root, 'Continue')).toEqual([
+      'Continue',
+      'Deploy to production',
+    ]);
+    // No description means no empty subtitle line under the label.
+    expect(optionTextLines(renderer.root, 'Stop')).toEqual(['Stop']);
+  });
+
+  it('announces an option description in its accessible name, never only as a hint', async () => {
+    const renderer = await renderCard([
+      {
+        question: 'How should the agent proceed?',
+        header: 'Agent needs input',
+        options: [
+          { label: 'Continue', description: 'Deploy to production' },
+          { label: 'Stop', description: '' },
+        ],
+        custom: true,
+      },
+    ]);
+
+    // TalkBack reads a node's hint text, not the tooltip React Native fills
+    // from `accessibilityHint`, so the subtitle has to be part of the name.
+    const described = optionButton(renderer.root, 'Continue');
+    expect(described?.props.accessibilityLabel).toBe('Continue, Deploy to production');
+    expect(described?.props.accessibilityHint).toBeUndefined();
+
+    // An option without a description keeps its bare label and no hint.
+    expect(optionButton(renderer.root, 'Stop')?.props.accessibilityLabel).toBe('Stop');
+    expect(optionButton(renderer.root, 'Stop')?.props.accessibilityHint).toBeUndefined();
   });
 
   it('cancels the delayed focus retry when a new request replaces the card', async () => {

--- a/apps/mobile/src/components/agents/question-card.tsx
+++ b/apps/mobile/src/components/agents/question-card.tsx
@@ -227,6 +227,14 @@ export function QuestionCard({
                 <View className="gap-1">
                   {question.options.map((option, oIndex) => {
                     const isSelected = selectedOptions[qIndex]?.has(oIndex) ?? false;
+                    // The description is content, not an action hint: TalkBack
+                    // (Android) reads the node's hint text, never the tooltip
+                    // React Native fills from `accessibilityHint`, so a hint
+                    // would leave the subtitle unannounced. Join it into the
+                    // accessible name, the way the Kilo Pass card does.
+                    const optionLabel = option.description
+                      ? `${option.label}, ${option.description}`
+                      : option.label;
                     return (
                       <Button
                         key={oIndex}
@@ -239,22 +247,43 @@ export function QuestionCard({
                         accessibilityRole="button"
                         accessibilityLabel={
                           isSelected
-                            ? t('agentChat.questionCard.optionSelected', { label: option.label })
-                            : t('agentChat.questionCard.option', { label: option.label })
+                            ? t('agentChat.questionCard.optionSelected', { label: optionLabel })
+                            : t('agentChat.questionCard.option', { label: optionLabel })
                         }
                         className={cn(
                           'h-auto justify-start py-2.5',
                           isSelected ? 'bg-primary' : 'bg-background'
                         )}
                       >
-                        <Text
-                          className={cn(
-                            'text-sm',
-                            isSelected ? 'text-primary-foreground' : 'text-foreground'
-                          )}
-                        >
-                          {option.label}
-                        </Text>
+                        {/*
+                          The agent may attach an explanation to a choice; the
+                          CLI, web, and extension all show it as a muted
+                          subtitle under the label. Stack the two lines so the
+                          label stays the prominent line and the description
+                          reads as supporting text.
+                        */}
+                        <View className="flex-1 flex-col items-start gap-0.5">
+                          <Text
+                            className={cn(
+                              'text-sm',
+                              isSelected ? 'text-primary-foreground' : 'text-foreground'
+                            )}
+                          >
+                            {option.label}
+                          </Text>
+                          {option.description ? (
+                            <Text
+                              className={cn(
+                                'text-xs',
+                                isSelected
+                                  ? 'text-primary-foreground opacity-70'
+                                  : 'text-muted-foreground'
+                              )}
+                            >
+                              {option.description}
+                            </Text>
+                          ) : null}
+                        </View>
                       </Button>
                     );
                   })}


### PR DESCRIPTION
## Changelog for users
- Agent answer choices now show each choice description as muted supporting text beneath its label.
- Selected choices keep both the label and description readable on filled buttons.
- Choices without descriptions show only their labels, without an empty second line.
- Screen readers announce a described choice's label followed by its description.
- The approved repair changes no user-visible behavior.

## Changelog for maintainers
- The subtitle joins the accessible name (`<label>, <description>`) instead of `accessibilityHint`, because TalkBack reads hint text and ignores the tooltip React Native fills from `accessibilityHint`.
- A choice without a description keeps its bare label as the accessible name and sets no hint.
- Label and subtitle use a full-width column inside the option button, preserving its existing height, padding, and selected background.
- The subtitle uses a smaller muted style and a translucent foreground color on the selected filled button.
- The feature reuses existing option and option-selected translations with the composed label; it adds no copy or catalog keys.
- Unit tests cover subtitle rendering, the no-description branch, and the accessible-name/no-hint contract.
- Review the option button first because accessible naming and selected contrast are risky; feature evidence collected on 2026-09-12 does not establish visual legibility.
- .kwf-keep-device: accepted — the unreferenced zero-byte artifact was removed. Replacement evidence from 2026-09-12 replaces repair-specific runtime proof: it shows no runtime change, so no live proof applies to the repair. Feature captures remain unaffected.

## E2E proof

https://github.com/user-attachments/assets/2e98f6ad-3c1b-46f6-a6a7-6cb7ce87413d

![[p3] With VoiceOver/TalkBack enabled, focusing a described option announces the option label followed by its description as the hint. — e2e-mobile-app/p3.png](https://github.com/user-attachments/assets/de55d6fc-a034-45bc-8275-ba9d73dd626d)

![[p3] With VoiceOver/TalkBack enabled, focusing a described option announces the option label followed by its description as the hint. — prior/p3-talkback.png](https://github.com/user-attachments/assets/4d7cf19d-6134-42b8-93c5-9a3a1880badb)

![[p1] Open a cloud-agent session that asks a question whose options carry descriptions; each choice button shows the label on top with the muted description underneath, and the card scrolls/CTAs stay… — prior/p1sel.png](https://github.com/user-attachments/assets/c5170729-22b6-4026-848e-bbfd922cb0a3)

![[p2] In the same card, an option with an empty description shows only its label (no blank second line), and selecting a described option keeps both lines legible on the filled-primary button. — prior/p2-select.png](https://github.com/user-attachments/assets/84975ab5-26a1-4bf3-8c4b-55703077393a)

![[p2] In the same card, an option with an empty description shows only its label (no blank second line), and selecting a described option keeps both lines legible on the filled-primary button. — e2e-mobile-app/p2.png](https://github.com/user-attachments/assets/85385cd7-6f87-4bf2-8c09-5d25c23d3701)

<details>
<summary>Owner request</summary>

> Surface: the mobile app (apps/mobile).
> 
> The question tool should support a subtitle for the answer choices, same as the CLI.

</details>