### PR TITLE
feat(mobile): add tap-to-copy action to session code blocks

### DIFF
--- a/apps/mobile/src/components/agents/chat-markdown-text.tsx
+++ b/apps/mobile/src/components/agents/chat-markdown-text.tsx
@@ -17,8 +17,12 @@ import {
 } from './chat-link-actions';
 import { formatLinkHost } from './markdown-link-confirm';
 import { MarkdownText, type MarkdownTextProps } from './markdown-text';
+import { performCopy } from './use-message-copy';
 
-type ChatMarkdownTextProps = Omit<MarkdownTextProps, 'onLongPressLink' | 'onPressLink'>;
+type ChatMarkdownTextProps = Omit<
+  MarkdownTextProps,
+  'onLongPressLink' | 'onPressLink' | 'onCopyCode'
+>;
 
 /** Sheet message: host then full href, so the host is visible above the URL. */
 function sheetMessage(href: string): string {
@@ -120,7 +124,18 @@ export function ChatMarkdownText(props: Readonly<ChatMarkdownTextProps>) {
     [bottom, prReviewEnabled, router, showActionSheetWithOptions, t]
   );
 
+  // Code fences in the transcript copy through the shared clipboard helper, so
+  // success/failure feedback (haptic + toast) matches every other copy action.
+  const handleCopyCode = useCallback((code: string) => {
+    void performCopy(code);
+  }, []);
+
   return (
-    <MarkdownText {...props} onLongPressLink={handleLongPressLink} onPressLink={handlePressLink} />
+    <MarkdownText
+      {...props}
+      onLongPressLink={handleLongPressLink}
+      onPressLink={handlePressLink}
+      onCopyCode={handleCopyCode}
+    />
   );
 }

--- a/apps/mobile/src/components/agents/code-block.test.ts
+++ b/apps/mobile/src/components/agents/code-block.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- token-color, truncation, and copy/long-press suites share the direct-invocation CodeBlock harness. */
 /* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (node env, no jsdom); same pattern as tool-diff-preview.test.ts */
 import * as React from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
@@ -19,6 +20,7 @@ const { useMonoScrollSheetMock } = vi.hoisted(() => ({
 // RNGH ships Flow source that the node project cannot parse, so the horizontal
 // ScrollView becomes a string element.
 vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
   View: 'View',
   Text: 'RNText',
 }));
@@ -86,6 +88,58 @@ function truncatedMarkers(root: TestRenderer.ReactTestInstance): TestRenderer.Re
       (node.type as string) === 'Text' &&
       propOf(node, 'accessibilityLabel') === 'Content truncated'
   );
+}
+
+function byTestId(
+  root: TestRenderer.ReactTestInstance,
+  testID: string
+): TestRenderer.ReactTestInstance[] {
+  return root.findAll(node => propOf(node, 'testID') === testID);
+}
+
+function firstByTestId(
+  root: TestRenderer.ReactTestInstance,
+  testID: string
+): TestRenderer.ReactTestInstance {
+  const first = byTestId(root, testID)[0];
+  if (!first) {
+    throw new TypeError(`expected a node with testID ${testID}`);
+  }
+  return first;
+}
+
+function press(instance: TestRenderer.ReactTestInstance): void {
+  const onPress = propOf(instance, 'onPress');
+  if (typeof onPress !== 'function') {
+    throw new TypeError('expected an onPress handler');
+  }
+  (onPress as () => void)();
+}
+
+function longPress(instance: TestRenderer.ReactTestInstance): void {
+  const onLongPress = propOf(instance, 'onLongPress');
+  if (typeof onLongPress !== 'function') {
+    throw new TypeError('expected an onLongPress handler');
+  }
+  (onLongPress as () => void)();
+}
+
+function layout(instance: TestRenderer.ReactTestInstance, width: number, height: number): void {
+  const onLayout = propOf(instance, 'onLayout');
+  if (typeof onLayout !== 'function') {
+    throw new TypeError('expected an onLayout handler');
+  }
+  (
+    onLayout as (event: {
+      nativeEvent: { layout: { x: number; y: number; width: number; height: number } };
+    }) => void
+  )({
+    nativeEvent: { layout: { x: 0, y: 0, width, height } },
+  });
+}
+
+function pressables(root: TestRenderer.ReactTestInstance): TestRenderer.ReactTestInstance[] {
+  return root.findAll(node => isMockedStringElement(node, 'Pressable'));
 }
 
 async function mount(element: React.ReactElement): Promise<TestRenderer.ReactTestRenderer> {
@@ -217,6 +271,249 @@ describe('CodeBlock', () => {
     const parent = codeParent(renderer.root);
     expect(parent).toBeDefined();
     expect(propOf(parent, 'selectable')).toBe(false);
+    await unmount(renderer);
+  });
+});
+
+describe('CodeBlock copy action', () => {
+  it('renders no copy affordance without an onCopyCode handler', async () => {
+    const renderer = await mount(blockElement());
+    expect(byTestId(renderer.root, 'code-block-copy-trigger')).toHaveLength(0);
+    expect(byTestId(renderer.root, 'code-block-copy-action')).toHaveLength(0);
+    await unmount(renderer);
+  });
+
+  it('reveals the copy action on a single tap and hands back the full source', async () => {
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const renderer = await mount(blockElement({ code: 'const x = 1;', onCopyCode }));
+
+    expect(byTestId(renderer.root, 'code-block-copy-trigger')).toHaveLength(1);
+    expect(byTestId(renderer.root, 'code-block-copy-action')).toHaveLength(0);
+
+    act(() => {
+      press(firstByTestId(renderer.root, 'code-block-copy-trigger'));
+    });
+    expect(byTestId(renderer.root, 'code-block-copy-action')).toHaveLength(1);
+
+    act(() => {
+      press(firstByTestId(renderer.root, 'code-block-copy-action'));
+    });
+    expect(onCopyCode).toHaveBeenCalledWith('const x = 1;');
+    expect(byTestId(renderer.root, 'code-block-copy-action')).toHaveLength(0);
+    await unmount(renderer);
+  });
+
+  it('anchors the revealed action to the tap, so a tall fence shows it in view', async () => {
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const renderer = await mount(blockElement({ code: 'x'.repeat(5000), onCopyCode }));
+    const trigger = firstByTestId(renderer.root, 'code-block-copy-trigger');
+    const onPress = propOf(trigger, 'onPress') as (event: {
+      nativeEvent: { locationY: number };
+    }) => void;
+
+    act(() => {
+      onPress({ nativeEvent: { locationY: 1234 } });
+    });
+
+    const action = firstByTestId(renderer.root, 'code-block-copy-action');
+    expect(propOf(action, 'style')).toEqual({ top: 1234 });
+    await unmount(renderer);
+  });
+
+  it('falls back to the block top for a synthetic press with no coordinates', async () => {
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const renderer = await mount(blockElement({ onCopyCode }));
+
+    act(() => {
+      press(firstByTestId(renderer.root, 'code-block-copy-trigger'));
+    });
+
+    const action = firstByTestId(renderer.root, 'code-block-copy-action');
+    expect(propOf(action, 'style')).toEqual({ top: 0 });
+    await unmount(renderer);
+  });
+
+  it('reserves the measured action width as a right gutter on the copy trigger', async () => {
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const renderer = await mount(blockElement({ onCopyCode }));
+    const trigger = firstByTestId(renderer.root, 'code-block-copy-trigger');
+    expect(propOf(trigger, 'style')).toBeUndefined();
+
+    act(() => {
+      layout(firstByTestId(renderer.root, 'code-block-copy-measure'), 96, 28);
+    });
+
+    expect(propOf(firstByTestId(renderer.root, 'code-block-copy-trigger'), 'style')).toEqual({
+      paddingRight: 104,
+    });
+    await unmount(renderer);
+  });
+
+  it('measures the label without leaking a hidden copy button to assistive tech', async () => {
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const renderer = await mount(blockElement({ onCopyCode }));
+    const measure = firstByTestId(renderer.root, 'code-block-copy-measure');
+    expect(propOf(measure, 'accessibilityElementsHidden')).toBe(true);
+    expect(propOf(measure, 'importantForAccessibility')).toBe('no-hide-descendants');
+    expect(propOf(measure, 'pointerEvents')).toBe('none');
+    await unmount(renderer);
+  });
+
+  it('leaves the code at full width without a copy handler', async () => {
+    const renderer = await mount(blockElement());
+    expect(byTestId(renderer.root, 'code-block-copy-measure')).toHaveLength(0);
+    expect(byTestId(renderer.root, 'code-block-copy-trigger')).toHaveLength(0);
+    await unmount(renderer);
+  });
+
+  it('reserves the measured gutter on the scroll-mode trigger so the action clears the glyphs', async () => {
+    const track = vi.fn(() => () => undefined);
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const renderer = await mount(withSheet('scroll', track, blockElement({ onCopyCode })));
+
+    act(() => {
+      layout(firstByTestId(renderer.root, 'code-block-copy-measure'), 72, 28);
+    });
+
+    expect(propOf(firstByTestId(renderer.root, 'code-block-copy-trigger'), 'style')).toEqual({
+      paddingRight: 80,
+    });
+    await unmount(renderer);
+  });
+
+  it('right-aligns the revealed action inside the reserved gutter', async () => {
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const renderer = await mount(blockElement({ onCopyCode }));
+
+    act(() => {
+      press(firstByTestId(renderer.root, 'code-block-copy-trigger'));
+    });
+
+    const action = firstByTestId(renderer.root, 'code-block-copy-action');
+    expect(propOf(action, 'className')).toContain('right-0');
+    await unmount(renderer);
+  });
+
+  it('copies the source before the display cap, not the truncated slice', async () => {
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const full = 'x'.repeat(300);
+    const renderer = await mount(blockElement({ code: full, maxLength: 50, onCopyCode }));
+
+    act(() => {
+      press(firstByTestId(renderer.root, 'code-block-copy-trigger'));
+    });
+    act(() => {
+      press(firstByTestId(renderer.root, 'code-block-copy-action'));
+    });
+    expect(onCopyCode).toHaveBeenCalledWith(full);
+    await unmount(renderer);
+  });
+
+  it('exposes a copy accessibility action on the code text', async () => {
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const renderer = await mount(blockElement({ onCopyCode }));
+    const parent = codeParent(renderer.root);
+    expect(parent).toBeDefined();
+    const onAccessibilityAction = propOf(parent, 'onAccessibilityAction');
+    expect(typeof onAccessibilityAction).toBe('function');
+
+    act(() => {
+      (onAccessibilityAction as (event: { nativeEvent: { actionName: string } }) => void)({
+        nativeEvent: { actionName: 'copyCode' },
+      });
+    });
+    expect(onCopyCode).toHaveBeenCalledWith('const x = 1;');
+    await unmount(renderer);
+  });
+
+  it('offers no copy action for an empty fence', async () => {
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const renderer = await mount(blockElement({ code: '', onCopyCode }));
+    expect(byTestId(renderer.root, 'code-block-copy-trigger')).toHaveLength(0);
+    expect(byTestId(renderer.root, 'code-block-copy-action')).toHaveLength(0);
+    await unmount(renderer);
+  });
+
+  it('hides a revealed action when the code changes', async () => {
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const renderer = await mount(blockElement({ code: 'first', onCopyCode }));
+    act(() => {
+      press(firstByTestId(renderer.root, 'code-block-copy-trigger'));
+    });
+    expect(byTestId(renderer.root, 'code-block-copy-action')).toHaveLength(1);
+
+    act(() => {
+      renderer.update(blockElement({ code: 'second', onCopyCode }));
+    });
+    expect(byTestId(renderer.root, 'code-block-copy-action')).toHaveLength(0);
+    await unmount(renderer);
+  });
+});
+
+describe('CodeBlock copy trigger long-press forwarding', () => {
+  it('forwards a long press on the trigger instead of revealing the action', async () => {
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const onLongPressCode = vi.fn<() => void>();
+    const renderer = await mount(blockElement({ onCopyCode, onLongPressCode }));
+    const trigger = firstByTestId(renderer.root, 'code-block-copy-trigger');
+
+    act(() => {
+      longPress(trigger);
+    });
+
+    expect(onLongPressCode).toHaveBeenCalledTimes(1);
+    expect(onCopyCode).not.toHaveBeenCalled();
+    expect(byTestId(renderer.root, 'code-block-copy-action')).toHaveLength(0);
+    await unmount(renderer);
+  });
+
+  it('hides a revealed action when a long press opens message details', async () => {
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const onLongPressCode = vi.fn<() => void>();
+    const renderer = await mount(blockElement({ onCopyCode, onLongPressCode }));
+    const trigger = firstByTestId(renderer.root, 'code-block-copy-trigger');
+
+    act(() => {
+      press(trigger);
+    });
+    expect(byTestId(renderer.root, 'code-block-copy-action')).toHaveLength(1);
+
+    act(() => {
+      longPress(trigger);
+    });
+
+    expect(onLongPressCode).toHaveBeenCalledTimes(1);
+    expect(byTestId(renderer.root, 'code-block-copy-action')).toHaveLength(0);
+    await unmount(renderer);
+  });
+
+  it('mounts no responder wrapper without a copy handler', async () => {
+    const renderer = await mount(blockElement());
+    expect(pressables(renderer.root)).toHaveLength(0);
+    await unmount(renderer);
+  });
+
+  it('mounts no responder wrapper without a copy handler in sheet scroll mode', async () => {
+    const track = vi.fn(() => () => undefined);
+    const renderer = await mount(withSheet('scroll', track, blockElement()));
+    expect(pressables(renderer.root)).toHaveLength(0);
+    await unmount(renderer);
+  });
+
+  it('forwards a long press on the scroll-mode trigger', async () => {
+    const track = vi.fn(() => () => undefined);
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const onLongPressCode = vi.fn<() => void>();
+    const renderer = await mount(
+      withSheet('scroll', track, blockElement({ onCopyCode, onLongPressCode }))
+    );
+    const trigger = firstByTestId(renderer.root, 'code-block-copy-trigger');
+
+    act(() => {
+      longPress(trigger);
+    });
+
+    expect(onLongPressCode).toHaveBeenCalledTimes(1);
     await unmount(renderer);
   });
 });

--- a/apps/mobile/src/components/agents/code-block.tsx
+++ b/apps/mobile/src/components/agents/code-block.tsx
@@ -1,6 +1,13 @@
 import { Fragment, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { type LayoutChangeEvent, Text as RNText, View } from 'react-native';
+import {
+  type AccessibilityActionEvent,
+  type GestureResponderEvent,
+  type LayoutChangeEvent,
+  Pressable,
+  Text as RNText,
+  View,
+} from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
 import { Text } from '@/components/ui/text';
@@ -29,7 +36,37 @@ type CodeBlockProps = {
       The markdown renderer passes palette.textColor so code inside user
       variant bubbles keeps its designed ink color (lime/primary surfaces). */
   baseColor?: string;
+  /**
+   * When provided, a single tap on the block reveals an inline "Copy" action
+   * that hands the full source (before the display cap) back to the caller.
+   * The caller owns the clipboard write and its success/failure feedback, so
+   * this presentational block stays free of platform side effects. Omitted by
+   * non-transcript callers (tool cards), which keep the static block.
+   */
+  onCopyCode?: (code: string) => void;
+  /**
+   * Long-press handler for the copy trigger. A transcript host forwards its
+   * message-details long-press here so press-and-hold on a fence still opens
+   * details instead of being swallowed by the trigger. Ignored when
+   * `onCopyCode` is omitted, because no trigger renders without it.
+   */
+  onLongPressCode?: () => void;
 };
+
+/**
+ * Space between the code's right edge and the revealed action's left edge.
+ *
+ * The revealed action is right-aligned to the block edge (the tap can be many
+ * screens into a long fence, so the action must land in view), so the code area
+ * gives up its right edge instead of the action covering source glyphs. The
+ * gutter lives on the trigger, whose parent is unpadded, so the absolutely
+ * positioned pill anchors to the parent edge and lands inside this padding.
+ *
+ * The gutter is the measured width of the pill itself, not a fixed value: the
+ * label is `t('common.copy')`, and a length tied to the English "Copy" is too
+ * narrow in a longer catalog, where the pill would draw over the code again.
+ */
+const COPY_ACTION_GAP = 8;
 
 /**
  * Shared highlighted code block for tool detail sheets and markdown fences.
@@ -48,6 +85,21 @@ type CodeBlockProps = {
  * height-pin model from `mono-scroll-block-model.ts`. Outside the sheet
  * (chat bubbles) the mode is always `wrap` — the no-nested-horizontal-
  * ScrollView rule that protects RN 0.83 Fabric from spurious heights.
+ *
+ * Copy: when the markdown host supplies `onCopyCode`, a single tap anywhere
+ * on the code reveals an absolutely-positioned "Copy" action (no layout
+ * shift) and a `copyCode` accessibility action on the code text. The action is
+ * anchored to the tap's content-space Y, so a fence taller than the viewport
+ * still reveals it in view instead of off the top. The copy trigger reserves a
+ * right gutter measured from that action, so the pill never covers source
+ * glyphs in any locale. The pill hands the full source to the caller and
+ * dismisses itself. The copy trigger is the only pressable wrapper the block
+ * mounts: without `onCopyCode` the code text renders bare, so the transcript
+ * bubble's own long-press still reaches a fence in tool cards and static
+ * callers. When the host supplies `onLongPressCode`, the trigger forwards
+ * press-and-hold to it (message details) instead of revealing the action, and
+ * hides any action a prior tap already revealed so the pill cannot outlive the
+ * details sheet.
  */
 function CodeBlockImpl({
   code,
@@ -55,6 +107,8 @@ function CodeBlockImpl({
   maxLength,
   selectable,
   baseColor,
+  onCopyCode,
+  onLongPressCode,
 }: Readonly<CodeBlockProps>) {
   const sheet = useMonoScrollSheet();
   const textMode = sheet?.mode ?? 'wrap';
@@ -70,13 +124,36 @@ function CodeBlockImpl({
     [displayText, language]
   );
   const [heightPin, setHeightPin] = useState<MonoScrollHeightPin | undefined>(undefined);
+  // Content-space Y of the revealed copy action; null means hidden. The action
+  // is anchored to the tap, not the block top: a long fence is many screens
+  // tall, so a top-anchored action on a fence scrolled near its end renders
+  // above the viewport and is unreachable.
+  const [copyActionTop, setCopyActionTop] = useState<number | null>(null);
+  // The revealed action's width for the current label, measured off the hidden
+  // pill. Keyed by label so a catalog change re-measures instead of reusing the
+  // previous language's width.
+  const [copyActionMetrics, setCopyActionMetrics] = useState<{
+    label: string;
+    width: number;
+  } | null>(null);
   const contentHeight = resolveMonoScrollPinnedHeight(heightPin, displayText);
   const textBase = baseColor ?? colors.foreground;
+  // An empty fence has nothing to hand over, so it never offers the action.
+  const canCopyCode = onCopyCode !== undefined && code.length > 0;
+  // The label is translated, so the gutter has to come from what the pill
+  // actually renders, not a width tied to English.
+  const copyLabel = t('common.copy');
+  const copyActionWidth = copyActionMetrics?.label === copyLabel ? copyActionMetrics.width : null;
 
   // Registers this block's presence exactly once per mount; the cleanup is the
   // unregister. The effect only re-runs when `track` identity changes, which
   // the sheet keeps stable, so mode flips never re-register.
   useEffect(() => track?.(), [track]);
+
+  // A session or display-text change must not leave a stale action revealed.
+  useEffect(() => {
+    setCopyActionTop(null);
+  }, [code]);
 
   const handleContentLayout = useCallback(
     (event: LayoutChangeEvent) => {
@@ -85,6 +162,75 @@ function CodeBlockImpl({
     },
     [displayText]
   );
+
+  // Records the hidden pill's width so the trigger can reserve exactly that
+  // much of the code's right edge.
+  const handleCopyActionLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const width = event.nativeEvent.layout.width;
+      setCopyActionMetrics(previous =>
+        previous?.label === copyLabel && previous.width === width
+          ? previous
+          : { label: copyLabel, width }
+      );
+    },
+    [copyLabel]
+  );
+
+  // Reserve exactly the revealed pill's width plus a gap, so the action never
+  // covers a glyph whatever the catalog renders for `common.copy`.
+  const copyTriggerStyle = useMemo(
+    () =>
+      copyActionWidth === null ? undefined : { paddingRight: copyActionWidth + COPY_ACTION_GAP },
+    [copyActionWidth]
+  );
+
+  // The reveal's top follows the tap's content-space Y; a memoized object keeps
+  // the style off the inline-style lint rule.
+  const copyActionTopStyle = useMemo(
+    () => (copyActionTop === null ? undefined : { top: copyActionTop }),
+    [copyActionTop]
+  );
+
+  const handleCopyCode = useCallback(() => {
+    setCopyActionTop(null);
+    // The full source, not the display-capped slice: the user asked for the
+    // code, and the Truncated marker already says the view is a prefix.
+    onCopyCode?.(code);
+  }, [code, onCopyCode]);
+
+  const handleToggleCopyAction = useCallback((event?: GestureResponderEvent) => {
+    setCopyActionTop(previous => {
+      if (previous !== null) {
+        return null;
+      }
+      const tappedY = event?.nativeEvent.locationY;
+      // A synthetic press (no touch event) has no coordinates; fall back to the
+      // block top, which a short fence still shows.
+      return tappedY === undefined || !Number.isFinite(tappedY) ? 0 : Math.max(0, tappedY);
+    });
+  }, []);
+
+  // Opening message details must not strand a revealed copy action: without
+  // this, a tap-then-hold leaves the pill mounted under the sheet and it is
+  // still visible over the transcript once the sheet closes.
+  const handleLongPressCode = useCallback(() => {
+    setCopyActionTop(null);
+    onLongPressCode?.();
+  }, [onLongPressCode]);
+
+  const handleCopyAccessibilityAction = useCallback(
+    (event: AccessibilityActionEvent) => {
+      if (event.nativeEvent.actionName === 'copyCode') {
+        handleCopyCode();
+      }
+    },
+    [handleCopyCode]
+  );
+
+  const copyAccessibilityActions = canCopyCode
+    ? [{ name: 'copyCode', label: copyLabel }]
+    : undefined;
 
   const content = tokenLines.map((tokens, lineIndex) => (
     <Fragment key={`line-${lineIndex}`}>
@@ -110,34 +256,115 @@ function CodeBlockImpl({
     </Text>
   ) : null;
 
+  // Inline (not in-flow) so revealing it never shifts the transcript layout.
+  // The reveal is anchored to the tap's content-space Y so it lands in view on
+  // fences taller than the viewport. Right-aligned into the code text's reserved
+  // gutter (measured from this pill) so it sits clear of the source glyphs.
+  const copyActionRevealed = canCopyCode && copyActionTop !== null;
+  // Until the label is measured the same pill renders hidden, purely to report
+  // its width; it unmounts as soon as the gutter is reserved, so a hidden "Copy"
+  // never lingers in the accessibility tree.
+  const copyActionMeasuring = canCopyCode && copyActionWidth === null;
+  const copyAction =
+    copyActionRevealed || copyActionMeasuring ? (
+      <Pressable
+        onPress={copyActionRevealed ? handleCopyCode : undefined}
+        onLayout={handleCopyActionLayout}
+        accessibilityRole="button"
+        accessibilityLabel={copyLabel}
+        testID={copyActionRevealed ? 'code-block-copy-action' : 'code-block-copy-measure'}
+        hitSlop={8}
+        pointerEvents={copyActionRevealed ? 'auto' : 'none'}
+        accessibilityElementsHidden={!copyActionRevealed}
+        importantForAccessibility={copyActionRevealed ? 'auto' : 'no-hide-descendants'}
+        style={copyActionRevealed ? copyActionTopStyle : undefined}
+        className={`absolute right-0 rounded-md border border-border bg-card px-2 py-1 ${
+          copyActionRevealed ? 'active:opacity-70' : 'opacity-0'
+        }`}
+      >
+        <Text className="text-xs font-medium text-foreground">{copyLabel}</Text>
+      </Pressable>
+    ) : null;
+
+  // The copy trigger is the only responder wrapper the block ever mounts. It
+  // must not wrap the code when there is nothing to copy: an unconditional
+  // Pressable claims the touch responder and swallows the transcript bubble's
+  // own long-press (message details) even in tool cards that render a plain
+  // static block. When a copy handler exists, a long press is forwarded back to
+  // the host so press-and-hold still opens details.
+  const copyTriggerProps = canCopyCode
+    ? {
+        onPress: handleToggleCopyAction,
+        onLongPress: onLongPressCode ? handleLongPressCode : undefined,
+        accessible: false,
+      }
+    : null;
+
   if (textMode === 'wrap') {
+    const codeText = (
+      <RNText
+        selectable={effectiveSelectable}
+        className="font-mono text-xs leading-4"
+        accessibilityActions={copyAccessibilityActions}
+        onAccessibilityAction={canCopyCode ? handleCopyAccessibilityAction : undefined}
+      >
+        {content}
+      </RNText>
+    );
     return (
       <View>
-        <RNText selectable={effectiveSelectable} className="font-mono text-xs leading-4">
-          {content}
-        </RNText>
+        {copyTriggerProps ? (
+          // Leave the selectable code text its own accessible element: it reads
+          // the code and carries the copyCode action, instead of collapsing the
+          // whole block into one synthesized button label. The right gutter is
+          // reserved on the trigger, not the text, so the pill anchored to this
+          // view's (unpadded) right edge lands in the padding, clear of glyphs.
+          <Pressable
+            {...copyTriggerProps}
+            testID="code-block-copy-trigger"
+            style={copyTriggerStyle}
+          >
+            {codeText}
+          </Pressable>
+        ) : (
+          codeText
+        )}
         {truncatedMarker}
+        {copyAction}
       </View>
     );
   }
 
+  const scrollView = (
+    <ScrollView
+      {...MONO_SCROLL_VIEW_PROPS}
+      // Explicit height from measured content — see MonoScrollBlock's doc.
+      // eslint-disable-next-line react-native/no-inline-styles -- measured height cannot be a Tailwind class
+      style={contentHeight === undefined ? undefined : { height: contentHeight }}
+    >
+      <RNText
+        selectable={effectiveSelectable}
+        onLayout={handleContentLayout}
+        className="shrink-0 self-start font-mono text-xs leading-4"
+        accessibilityActions={copyAccessibilityActions}
+        onAccessibilityAction={canCopyCode ? handleCopyAccessibilityAction : undefined}
+      >
+        {content}
+      </RNText>
+    </ScrollView>
+  );
+
   return (
     <View>
-      <ScrollView
-        {...MONO_SCROLL_VIEW_PROPS}
-        // Explicit height from measured content — see MonoScrollBlock's doc.
-        // eslint-disable-next-line react-native/no-inline-styles -- measured height cannot be a Tailwind class
-        style={contentHeight === undefined ? undefined : { height: contentHeight }}
-      >
-        <RNText
-          selectable={effectiveSelectable}
-          onLayout={handleContentLayout}
-          className="shrink-0 self-start font-mono text-xs leading-4"
-        >
-          {content}
-        </RNText>
-      </ScrollView>
+      {copyTriggerProps ? (
+        <Pressable {...copyTriggerProps} testID="code-block-copy-trigger" style={copyTriggerStyle}>
+          {scrollView}
+        </Pressable>
+      ) : (
+        scrollView
+      )}
       {truncatedMarker}
+      {copyAction}
     </View>
   );
 }

--- a/apps/mobile/src/components/agents/markdown-renderer.test.ts
+++ b/apps/mobile/src/components/agents/markdown-renderer.test.ts
@@ -566,6 +566,48 @@ describe('MarkdownRenderer code override', () => {
     >;
     expect((inner(element).props as { maxLength?: unknown }).maxLength).toBe(cap);
   });
+
+  it('passes an onCopyCode handler through to CodeBlock and omits it otherwise', async () => {
+    const { MarkdownRenderer: RendererClass } = await import('./markdown-renderer');
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const copyable = new RendererClass(palette, true, { onCopyCode });
+    const element = copyable.code('const x = 1;', 'ts', containerStyle, undefined) as ReactElement<
+      Record<string, unknown>
+    >;
+    expect((inner(element).props as { onCopyCode?: unknown }).onCopyCode).toBe(onCopyCode);
+
+    const plain = new RendererClass(palette, true, {});
+    const plainElement = plain.code(
+      'const x = 1;',
+      'ts',
+      containerStyle,
+      undefined
+    ) as ReactElement<Record<string, unknown>>;
+    expect((inner(plainElement).props as { onCopyCode?: unknown }).onCopyCode).toBeUndefined();
+  });
+
+  it('passes an onLongPressCode handler through to CodeBlock and omits it otherwise', async () => {
+    const { MarkdownRenderer: RendererClass } = await import('./markdown-renderer');
+    const onLongPressCode = vi.fn<() => void>();
+    const copyable = new RendererClass(palette, true, { onLongPressCode });
+    const element = copyable.code('const x = 1;', 'ts', containerStyle, undefined) as ReactElement<
+      Record<string, unknown>
+    >;
+    expect((inner(element).props as { onLongPressCode?: unknown }).onLongPressCode).toBe(
+      onLongPressCode
+    );
+
+    const plain = new RendererClass(palette, true, {});
+    const plainElement = plain.code(
+      'const x = 1;',
+      'ts',
+      containerStyle,
+      undefined
+    ) as ReactElement<Record<string, unknown>>;
+    expect(
+      (inner(plainElement).props as { onLongPressCode?: unknown }).onLongPressCode
+    ).toBeUndefined();
+  });
 });
 
 describe('MarkdownRenderer empty fence mounting', () => {

--- a/apps/mobile/src/components/agents/markdown-renderer.ts
+++ b/apps/mobile/src/components/agents/markdown-renderer.ts
@@ -39,6 +39,21 @@ export type MarkdownLinkLongPressHandler = (href: string, event?: GestureRespond
 
 export type MarkdownLinkPressHandler = (href: string) => boolean;
 
+/**
+ * Invoked when the reader taps a rendered code fence's inline "Copy" action.
+ * The renderer only reveals the action when this handler is supplied, so
+ * markdown hosts that do not offer code copying keep the static block.
+ */
+export type MarkdownCopyCodeHandler = (code: string) => void;
+
+/**
+ * Invoked when the reader press-and-holds a rendered code fence's copy
+ * trigger. Transcript hosts forward their message-details long-press here so a
+ * long press on a fence still opens details instead of being swallowed by the
+ * copy trigger. Optional: hosts without a long-press destination omit it.
+ */
+export type MarkdownCodeLongPressHandler = () => void;
+
 // Fenced code blocks are highlighted by the shared CodeBlock; a huge pasted
 // fence must not threaten the transcript's scroll performance, so the code
 // payload is capped and the hit shows the shared Truncated marker.
@@ -120,6 +135,8 @@ function containsMeaningfulNonImageText(nodes: ReactNode[]): boolean {
 type MarkdownRendererHandlers = {
   onLongPressLink?: MarkdownLinkLongPressHandler;
   onPressLink?: MarkdownLinkPressHandler;
+  onCopyCode?: MarkdownCopyCodeHandler;
+  onLongPressCode?: MarkdownCodeLongPressHandler;
 };
 
 export class MarkdownRenderer extends Renderer {
@@ -127,6 +144,8 @@ export class MarkdownRenderer extends Renderer {
   private readonly selectable: boolean;
   private readonly onLongPressLink?: MarkdownLinkLongPressHandler;
   private readonly onPressLink?: MarkdownLinkPressHandler;
+  private readonly onCopyCode?: MarkdownCopyCodeHandler;
+  private readonly onLongPressCode?: MarkdownCodeLongPressHandler;
   // Ordinal host key: the parser builds every header/body cell (each consuming
   // getKey()) before table() returns, so a slugger-based host key would shift
   // as rows/cells grow. A fresh renderer per parse restarts this counter, so
@@ -140,6 +159,8 @@ export class MarkdownRenderer extends Renderer {
     this.selectable = selectable;
     this.onLongPressLink = handlers.onLongPressLink;
     this.onPressLink = handlers.onPressLink;
+    this.onCopyCode = handlers.onCopyCode;
+    this.onLongPressCode = handlers.onLongPressCode;
   }
 
   private textNode(
@@ -196,6 +217,8 @@ export class MarkdownRenderer extends Renderer {
         selectable: this.selectable,
         baseColor: this.palette.textColor,
         maxLength: MARKDOWN_CODE_CHARACTER_CAP,
+        onCopyCode: this.onCopyCode,
+        onLongPressCode: this.onLongPressCode,
       })
     );
   }

--- a/apps/mobile/src/components/agents/markdown-table.test.ts
+++ b/apps/mobile/src/components/agents/markdown-table.test.ts
@@ -889,4 +889,89 @@ describe('MarkdownTable streaming and press paths (real parser)', () => {
       renderer.unmount();
     });
   });
+
+  it('threads the MarkdownText onCopyCode handler down to the code fence', async () => {
+    const { MarkdownText } = await import('./markdown-text');
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+      current: undefined,
+    };
+    await act(async () => {
+      await Promise.resolve();
+      rendererRef.current = TestRenderer.create(
+        createElement(MarkdownText, { value: '```ts\nconst x = 1;\n```', onCopyCode })
+      );
+    });
+    const renderer = rendererRef.current;
+    if (!renderer) {
+      throw new Error('renderer was not created');
+    }
+
+    const blocks = renderer.root.findAll(node => (node.type as unknown) === 'CodeBlock');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.props.onCopyCode).toBe(onCopyCode);
+
+    await act(async () => {
+      await Promise.resolve();
+      renderer.unmount();
+    });
+  });
+
+  it('leaves the code fence static without an onCopyCode handler', async () => {
+    const { MarkdownText } = await import('./markdown-text');
+    const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+      current: undefined,
+    };
+    await act(async () => {
+      await Promise.resolve();
+      rendererRef.current = TestRenderer.create(
+        createElement(MarkdownText, { value: '```ts\nconst x = 1;\n```' })
+      );
+    });
+    const renderer = rendererRef.current;
+    if (!renderer) {
+      throw new Error('renderer was not created');
+    }
+
+    const blocks = renderer.root.findAll(node => (node.type as unknown) === 'CodeBlock');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.props.onCopyCode).toBeUndefined();
+
+    await act(async () => {
+      await Promise.resolve();
+      renderer.unmount();
+    });
+  });
+
+  it('threads the MarkdownText onLongPressCode handler down to the code fence', async () => {
+    const { MarkdownText } = await import('./markdown-text');
+    const onCopyCode = vi.fn<(code: string) => void>();
+    const onLongPressCode = vi.fn<() => void>();
+    const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+      current: undefined,
+    };
+    await act(async () => {
+      await Promise.resolve();
+      rendererRef.current = TestRenderer.create(
+        createElement(MarkdownText, {
+          value: '```ts\nconst x = 1;\n```',
+          onCopyCode,
+          onLongPressCode,
+        })
+      );
+    });
+    const renderer = rendererRef.current;
+    if (!renderer) {
+      throw new Error('renderer was not created');
+    }
+
+    const blocks = renderer.root.findAll(node => (node.type as unknown) === 'CodeBlock');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.props.onLongPressCode).toBe(onLongPressCode);
+
+    await act(async () => {
+      await Promise.resolve();
+      renderer.unmount();
+    });
+  });
 });

--- a/apps/mobile/src/components/agents/markdown-text.tsx
+++ b/apps/mobile/src/components/agents/markdown-text.tsx
@@ -12,6 +12,8 @@ import {
   type MarkdownVariant,
 } from './markdown-palette';
 import {
+  type MarkdownCodeLongPressHandler,
+  type MarkdownCopyCodeHandler,
   type MarkdownLinkLongPressHandler,
   type MarkdownLinkPressHandler,
   MarkdownRenderer,
@@ -31,6 +33,17 @@ export type MarkdownTextProps = {
    * caller has fully handled the press and the default open should be skipped.
    */
   onPressLink?: MarkdownLinkPressHandler;
+  /**
+   * Optional handler that hands a rendered code fence's source to the caller.
+   * When omitted, fences render statically with no copy affordance.
+   */
+  onCopyCode?: MarkdownCopyCodeHandler;
+  /**
+   * Optional long-press handler for a code fence's copy trigger. Transcript
+   * hosts forward their message-details long-press here so press-and-hold on a
+   * fence still opens details. Ignored when `onCopyCode` is omitted.
+   */
+  onLongPressCode?: MarkdownCodeLongPressHandler;
 };
 
 export function MarkdownText({
@@ -39,6 +52,8 @@ export function MarkdownText({
   selectable = true,
   onLongPressLink,
   onPressLink,
+  onCopyCode,
+  onLongPressCode,
 }: Readonly<MarkdownTextProps>) {
   const colors = useThemeColors();
 
@@ -69,6 +84,8 @@ export function MarkdownText({
             selectable={selectable}
             onLongPressLink={onLongPressLink}
             onPressLink={onPressLink}
+            onCopyCode={onCopyCode}
+            onLongPressCode={onLongPressCode}
           />
         )
       )}
@@ -86,6 +103,8 @@ function MarkdownContent({
   selectable = true,
   onLongPressLink,
   onPressLink,
+  onCopyCode,
+  onLongPressCode,
 }: Readonly<MarkdownContentProps>) {
   // Tables are extracted before any renderer runs: each table becomes a chip
   // (parsed on open), and the remaining markdown runs render through useMarkdown.
@@ -119,6 +138,8 @@ function MarkdownContent({
             selectable={selectable}
             onLongPressLink={onLongPressLink}
             onPressLink={onPressLink}
+            onCopyCode={onCopyCode}
+            onLongPressCode={onLongPressCode}
           />
         )
       )}
@@ -132,6 +153,8 @@ type MarkdownSegmentProps = {
   selectable: boolean;
   onLongPressLink?: MarkdownLinkLongPressHandler;
   onPressLink?: MarkdownLinkPressHandler;
+  onCopyCode?: MarkdownCopyCodeHandler;
+  onLongPressCode?: MarkdownCodeLongPressHandler;
 };
 
 function MarkdownSegment({
@@ -140,6 +163,8 @@ function MarkdownSegment({
   selectable,
   onLongPressLink,
   onPressLink,
+  onCopyCode,
+  onLongPressCode,
 }: Readonly<MarkdownSegmentProps>) {
   const colorScheme = useColorScheme();
 
@@ -164,9 +189,15 @@ function MarkdownSegment({
   // identical parse prefixes, so element state survives while streaming
   // updates flow in as props.
   const renderer = useMemo(
-    () => new MarkdownRenderer(palette, selectable, { onLongPressLink, onPressLink }),
+    () =>
+      new MarkdownRenderer(palette, selectable, {
+        onLongPressLink,
+        onPressLink,
+        onCopyCode,
+        onLongPressCode,
+      }),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `value` intentionally recreates the renderer per markdown-source change so element keys stay stable across streaming re-parses
-    [palette, selectable, onLongPressLink, onPressLink, value]
+    [palette, selectable, onLongPressLink, onPressLink, onCopyCode, onLongPressCode, value]
   );
 
   const elements = useMarkdown(value, {

--- a/apps/mobile/src/components/agents/message-bubble-longpress-stability.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/message-bubble-longpress-stability.mounted.test.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/components/kilo-chat/message-bubble.mounted.test.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import '@/i18n';
+import { type StoredMessage } from '@kilocode/cloud-agent-sdk';
+
+import { MessageBubble } from './message-bubble';
+import { userMessage } from './message-bubble-test-utils';
+
+// Captures the props MessageBubble hands to the markdown host, so the test can
+// compare the forwarded `onLongPressCode` identity across two renders.
+const captured = vi.hoisted(() => [] as Record<string, unknown>[]);
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  View: 'View',
+  Platform: { OS: 'android' },
+}));
+vi.mock('expo-clipboard', () => ({ setStringAsync: vi.fn() }));
+vi.mock('expo-haptics', () => ({
+  notificationAsync: vi.fn(),
+  NotificationFeedbackType: { Success: 'success' },
+}));
+vi.mock('sonner-native', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@/components/ui/icons', () => ({ Clock: 'Clock' }));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({ useThemeColors: () => ({}) }));
+vi.mock('@/components/ui/bubble', () => ({ Bubble: 'Bubble' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/components/ui/button', () => ({ Button: 'Button' }));
+vi.mock('./compaction-separator', () => ({ CompactionSeparator: 'CompactionSeparator' }));
+vi.mock('./file-part-renderer', () => ({ FilePartRenderer: 'FilePartRenderer' }));
+vi.mock('./part-renderer', () => ({ PartRenderer: 'PartRenderer' }));
+vi.mock('./use-message-copy', () => ({ useMessageCopy: () => ({ copyMessage: vi.fn() }) }));
+vi.mock('./chat-markdown-text', () => ({
+  ChatMarkdownText: (props: Record<string, unknown>) => {
+    captured.push(props);
+    return null;
+  },
+}));
+
+function mount(props: {
+  message: StoredMessage;
+  onLongPressDetails: (value: StoredMessage) => void;
+}): TestRenderer.ReactTestRenderer {
+  const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+  act(() => {
+    ref.current = TestRenderer.create(createElement(MessageBubble, props));
+  });
+  if (!ref.current) {
+    throw new Error('renderer was not created');
+  }
+  return ref.current;
+}
+
+describe('MessageBubble code-fence long-press stability', () => {
+  it('keeps onLongPressCode identity across an unrelated re-render', () => {
+    const message = userMessage('m-longpress-stability');
+    const onLongPressDetails = vi.fn<(value: StoredMessage) => void>();
+    const renderer = mount({ message, onLongPressDetails });
+
+    // A second render must happen for the identity to be comparable: flip a
+    // prop the user branch ignores so React.memo lets the update through while
+    // `message` and `onLongPressDetails` stay referentially equal.
+    act(() => {
+      renderer.update(
+        createElement(MessageBubble, { message, onLongPressDetails, isLastAssistantMessage: true })
+      );
+    });
+
+    const withHandler = captured.filter(props => typeof props.onLongPressCode === 'function');
+    expect(withHandler.length).toBeGreaterThanOrEqual(2);
+    expect(withHandler.at(-1)?.onLongPressCode).toBe(withHandler.at(-2)?.onLongPressCode);
+  });
+});

--- a/apps/mobile/src/components/agents/message-bubble.test.ts
+++ b/apps/mobile/src/components/agents/message-bubble.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { type MessageDeliveryState, type StoredMessage } from '@kilocode/cloud-agent-sdk';
+import type * as React from 'react';
 
 import type * as PartTypes from './part-types';
 import {
@@ -15,6 +16,13 @@ import {
 
 import '@/i18n';
 import type * as ReactI18next from 'react-i18next';
+
+// The harness invokes the memoized component directly (no React renderer), so
+// the identity `useCallback` mock keeps the stabilized handler callable there.
+vi.mock('react', async importOriginal => ({
+  ...(await importOriginal<typeof React>()),
+  useCallback: <T>(fn: T) => fn,
+}));
 
 vi.mock('react-i18next', async importOriginal => {
   const actual = await importOriginal<typeof ReactI18next>();
@@ -603,6 +611,70 @@ describe('MessageBubble in-bubble text selection context', () => {
     const provider = findProvider(tree, InMessageBubbleContext.Provider);
     expect(provider).not.toBeNull();
     expect(provider?.props.value).toBe(true);
+  });
+});
+
+describe('MessageBubble code-copy long-press forwarding', () => {
+  it('forwards the details long-press into user markdown code fences', async () => {
+    const { isTextPart } = await import('./part-types');
+    vi.mocked(isTextPart).mockReturnValue(true);
+    try {
+      const { ChatMarkdownText: MockChatMarkdownText } = await import('./chat-markdown-text');
+      const message = userMessage('m-code-copy');
+      const onLongPressDetails = vi.fn<(value: StoredMessage) => void>();
+      const tree = await renderBubbleWithHandlers(message, { onLongPressDetails });
+
+      const element = findElementByTypeFn(tree, MockChatMarkdownText);
+      expect(element).not.toBeNull();
+      const handler = element?.props.onLongPressCode as (() => void) | undefined;
+      expect(typeof handler).toBe('function');
+      handler?.();
+      expect(onLongPressDetails).toHaveBeenCalledWith(message);
+    } finally {
+      vi.mocked(isTextPart).mockReturnValue(false);
+    }
+  });
+
+  it('forwards the details long-press into assistant part renderers', async () => {
+    const { PartRenderer: MockPartRenderer } = await import('./part-renderer');
+    const message = assistantMessage('m-code-copy-assistant');
+    message.parts = [
+      {
+        id: 'm-code-copy-assistant-text',
+        sessionID: 'ses_1',
+        messageID: 'm-code-copy-assistant',
+        type: 'text',
+        text: 'hi',
+      },
+    ] as typeof message.parts;
+    const onLongPressDetails = vi.fn<(value: StoredMessage) => void>();
+    const tree = await renderBubbleWithHandlers(message, { onLongPressDetails });
+
+    const element = findElementByTypeFn(tree, MockPartRenderer);
+    expect(element).not.toBeNull();
+    const handler = element?.props.onLongPressCode as (() => void) | undefined;
+    expect(typeof handler).toBe('function');
+    handler?.();
+    expect(onLongPressDetails).toHaveBeenCalledWith(message);
+  });
+
+  it('omits the long-press handler when the bubble has no details action', async () => {
+    const { PartRenderer: MockPartRenderer } = await import('./part-renderer');
+    const message = assistantMessage('m-code-copy-none');
+    message.parts = [
+      {
+        id: 'm-code-copy-none-text',
+        sessionID: 'ses_1',
+        messageID: 'm-code-copy-none',
+        type: 'text',
+        text: 'hi',
+      },
+    ] as typeof message.parts;
+    const tree = await renderBubbleWithHandlers(message, {});
+
+    const element = findElementByTypeFn(tree, MockPartRenderer);
+    expect(element).not.toBeNull();
+    expect(element?.props.onLongPressCode).toBeUndefined();
   });
 });
 

--- a/apps/mobile/src/components/agents/message-bubble.tsx
+++ b/apps/mobile/src/components/agents/message-bubble.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { type MessageDeliveryState, type StoredMessage } from '@kilocode/cloud-agent-sdk';
 import { Clock } from '@/components/ui/icons';
 import { type AccessibilityActionEvent, Platform, Pressable, View } from 'react-native';
@@ -78,9 +78,13 @@ function MessageBubbleImpl({
     canOpenDetails: onLongPressDetails !== undefined,
   });
 
-  const handleLongPress = () => {
+  // Stable identity matters: this handler becomes `onLongPressCode` in the
+  // markdown renderer's useMemo deps, so an inline function would rebuild the
+  // renderer (and re-parse the fence markdown) on every bubble render rather
+  // than only when the markdown source changes.
+  const handleLongPress = useCallback(() => {
     onLongPressDetails?.(message);
-  };
+  }, [message, onLongPressDetails]);
 
   // Keep actions on the separate host so interactive descendants remain reachable.
   // Accessible Copy retains the existing ActionSheet path; details matches long-press.
@@ -181,7 +185,15 @@ function MessageBubbleImpl({
               <Bubble side="user">
                 <InMessageBubbleContext.Provider value>
                   {userTextContent ? (
-                    <ChatMarkdownText value={userTextContent} variant="user" selectable={false} />
+                    <ChatMarkdownText
+                      value={userTextContent}
+                      variant="user"
+                      selectable={false}
+                      // Forward the bubble's long-press so a press-and-hold on a
+                      // code fence still opens message details instead of being
+                      // swallowed by the fence's copy trigger.
+                      onLongPressCode={onLongPressDetails ? handleLongPress : undefined}
+                    />
                   ) : null}
                   {fileParts.map(part => (
                     <FilePartRenderer
@@ -270,6 +282,9 @@ function MessageBubbleImpl({
                 defaultReasoningExpanded={defaultReasoningExpanded}
                 onOpenChildSession={onOpenChildSession}
                 modelOptions={modelOptions}
+                // Markdown text parts forward this into the code-fence copy
+                // trigger so a long press still opens message details.
+                onLongPressCode={onLongPressDetails ? handleLongPress : undefined}
               />
             ))}
           </View>

--- a/apps/mobile/src/components/agents/part-renderer.tsx
+++ b/apps/mobile/src/components/agents/part-renderer.tsx
@@ -33,6 +33,12 @@ type PartRendererProps = {
   defaultReasoningExpanded?: boolean;
   onOpenChildSession?: OpenChildSession;
   modelOptions?: SessionModelOption[];
+  /**
+   * Long-press handler forwarded into rendered code fences' copy trigger. The
+   * message bubble supplies its details long-press so a press-and-hold on a
+   * fence still opens message details. Omitted outside a bubble.
+   */
+  onLongPressCode?: () => void;
 };
 
 export function PartRenderer({
@@ -42,6 +48,7 @@ export function PartRenderer({
   defaultReasoningExpanded,
   onOpenChildSession,
   modelOptions,
+  onLongPressCode,
 }: Readonly<PartRendererProps>) {
   const { t } = useTranslation();
   if (!partRendersContent(part)) {
@@ -50,7 +57,7 @@ export function PartRenderer({
   if (isTextPart(part)) {
     return (
       <MessageErrorBoundary>
-        <TextPartRenderer text={part.text} />
+        <TextPartRenderer text={part.text} onLongPressCode={onLongPressCode} />
       </MessageErrorBoundary>
     );
   }
@@ -60,7 +67,7 @@ export function PartRenderer({
         <ToolPartRenderer
           part={part}
           getChildMessages={getChildMessages}
-          renderPart={props => <PartRenderer {...props} />}
+          renderPart={props => <PartRenderer {...props} onLongPressCode={onLongPressCode} />}
           onOpenChildSession={onOpenChildSession}
           modelOptions={modelOptions}
         />

--- a/apps/mobile/src/components/agents/text-part-renderer.tsx
+++ b/apps/mobile/src/components/agents/text-part-renderer.tsx
@@ -2,14 +2,27 @@ import { ChatMarkdownText } from './chat-markdown-text';
 
 type TextPartRendererProps = {
   text: string;
+  /**
+   * Long-press handler forwarded into rendered code fences' copy trigger so a
+   * press-and-hold on a fence still opens message details. Omitted outside a
+   * message bubble.
+   */
+  onLongPressCode?: () => void;
 };
 
-export function TextPartRenderer({ text }: Readonly<TextPartRendererProps>) {
+export function TextPartRenderer({ text, onLongPressCode }: Readonly<TextPartRendererProps>) {
   if (!text.trim()) {
     return null;
   }
 
   // selectable={false}: the message Pressable's long-press copy sheet and iOS
   // native text selection would both trigger on the same gesture otherwise.
-  return <ChatMarkdownText value={text} variant="assistant" selectable={false} />;
+  return (
+    <ChatMarkdownText
+      value={text}
+      variant="assistant"
+      selectable={false}
+      onLongPressCode={onLongPressCode}
+    />
+  );
 }

--- a/apps/mobile/src/components/agents/use-message-copy.test.ts
+++ b/apps/mobile/src/components/agents/use-message-copy.test.ts
@@ -41,7 +41,11 @@ describe('performCopy', () => {
     await performCopy('hello');
     expect(setStringAsync).toHaveBeenCalledWith('hello');
     expect(notificationAsync).toHaveBeenCalledWith('success');
-    expect(toastSuccess).toHaveBeenCalledWith('Copied to clipboard');
+    // Longer than the default: on Android the system clipboard preview covers
+    // the toast for its full default life (see COPY_TOAST_DURATION_MS).
+    expect(toastSuccess).toHaveBeenCalledWith('Copied to clipboard', {
+      duration: expect.any(Number),
+    });
     expect(toastError).not.toHaveBeenCalled();
   });
 

--- a/apps/mobile/src/components/agents/use-message-copy.ts
+++ b/apps/mobile/src/components/agents/use-message-copy.ts
@@ -38,6 +38,14 @@ export function useMessageCopy() {
 }
 
 /**
+ * Android's system clipboard preview (Android 13+) covers the bottom-center
+ * toast region for roughly six seconds after a copy, so a default-length
+ * success toast is hidden for its entire life on those devices. Keep the
+ * confirmation up long enough to be seen once the preview clears.
+ */
+const COPY_TOAST_DURATION_MS = 8000;
+
+/**
  * Immediate clipboard write used by the message-details sheet and by the
  * a11y/ActionSheet copy path after the user confirms. Success haptic + toast;
  * failure → error toast (caller keeps its UI open).
@@ -46,7 +54,7 @@ export async function performCopy(text: string): Promise<void> {
   try {
     await Clipboard.setStringAsync(text);
     void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-    toast.success(i18n.t('common.copiedToClipboard'));
+    toast.success(i18n.t('common.copiedToClipboard'), { duration: COPY_TOAST_DURATION_MS });
   } catch {
     toast.error(i18n.t('common.couldNotCopyToClipboard'));
   }

--- a/apps/mobile/src/components/kilo-chat/message-bubble-content.tsx
+++ b/apps/mobile/src/components/kilo-chat/message-bubble-content.tsx
@@ -23,6 +23,12 @@ type Props = {
   pendingActionGroupId: string | null;
   replyToMessage?: ReplyPreviewSource | null;
   onExecuteAction: (message: Message, groupId: string, value: ExecApprovalDecision) => void;
+  /**
+   * Long-press handler forwarded into rendered code fences' copy trigger, so
+   * press-and-hold on a fence still opens the bubble's message actions instead
+   * of being swallowed by the trigger. Omitted when the bubble has no actions.
+   */
+  onLongPressCode?: () => void;
 };
 
 function actionStyleToVariant(
@@ -45,6 +51,7 @@ export function MessageBubbleContent({
   pendingActionGroupId,
   replyToMessage,
   onExecuteAction,
+  onLongPressCode,
 }: Props) {
   const { t } = useTranslation();
   const colors = useThemeColors();
@@ -79,7 +86,14 @@ export function MessageBubbleContent({
       )}
       {message.content.map((block, index) => {
         if (block.type === 'text') {
-          return <MessageMarkdown key={index} text={block.text} isFromMe={isFromMe} />;
+          return (
+            <MessageMarkdown
+              key={index}
+              text={block.text}
+              isFromMe={isFromMe}
+              onLongPressCode={onLongPressCode}
+            />
+          );
         }
 
         if (block.type === 'attachment') {

--- a/apps/mobile/src/components/kilo-chat/message-bubble.tsx
+++ b/apps/mobile/src/components/kilo-chat/message-bubble.tsx
@@ -1,6 +1,6 @@
 import { type ExecApprovalDecision, type KiloChatClient, type Message } from '@kilocode/kilo-chat';
 import { Reply } from '@/components/ui/icons';
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { type AccessibilityActionEvent, Pressable, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { scheduleOnRN } from 'react-native-worklets';
@@ -102,7 +102,9 @@ function MessageBubbleComponent({
     longPressHighlight.value = withTiming(feedback.highlightOpacity, { duration: 180 });
   }
 
-  function handleLongPress() {
+  // Stable identity so forwarding it into the markdown code fences' copy
+  // trigger does not rebuild the markdown renderer on every bubble render.
+  const handleLongPress = useCallback(() => {
     const feedback = resolveLongPressFeedback({ pressed: true, longPressed: true });
     pressScale.value = withSequence(
       withTiming(feedback.scale, { duration: 90, easing: Easing.out(Easing.cubic) }),
@@ -113,7 +115,7 @@ function MessageBubbleComponent({
       withTiming(0, { duration: 260 })
     );
     onLongPress?.(message);
-  }
+  }, [longPressHighlight, message, onLongPress, pressScale]);
 
   // Mirror the long-press (action menu) and swipe-reply gestures as
   // accessibility custom actions so VoiceOver / TalkBack rotor users
@@ -248,6 +250,9 @@ function MessageBubbleComponent({
               pendingActionGroupId={pendingActionGroupId}
               replyToMessage={replyToMessage}
               onExecuteAction={onExecuteAction}
+              // The copy trigger is a nested Pressable that would otherwise
+              // swallow the bubble's long-press, so forward it into code fences.
+              onLongPressCode={onLongPress ? handleLongPress : undefined}
             />
 
             {!showAuthor && timestamp !== null && (

--- a/apps/mobile/src/components/kilo-chat/message-markdown-longpress.mounted.test.tsx
+++ b/apps/mobile/src/components/kilo-chat/message-markdown-longpress.mounted.test.tsx
@@ -1,0 +1,128 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as ./message-bubble.mounted.test.tsx) */
+import { type KiloChatClient, type Message } from '@kilocode/kilo-chat';
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MessageBubble } from './message-bubble';
+
+const captured = vi.hoisted(() => [] as Record<string, unknown>[]);
+
+vi.mock('expo-crypto', () => ({
+  getRandomValues: (typedArray: Uint8Array) => {
+    typedArray[0] = 128;
+    return typedArray;
+  },
+}));
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  View: 'View',
+  Platform: { OS: 'ios' },
+}));
+vi.mock('react-native-gesture-handler', () => {
+  const chainable: Record<string, unknown> = {};
+  for (const method of ['activeOffsetX', 'onUpdate', 'onEnd', 'onFinalize']) {
+    chainable[method] = () => chainable;
+  }
+  return { Gesture: { Pan: () => chainable }, GestureDetector: 'GestureDetector' };
+});
+vi.mock('react-native-reanimated', () => ({
+  default: { View: 'Animated.View' },
+  Easing: { out: (f: unknown) => f, cubic: 'cubic' },
+  useAnimatedStyle: () => ({}),
+  useSharedValue: () => ({ value: 0 }),
+  withSequence: (...values: unknown[]) => values[0],
+  withTiming: (value: unknown) => value,
+}));
+vi.mock('react-native-worklets', () => ({ scheduleOnRN: vi.fn() }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@/i18n', () => ({ i18n: { language: 'en', t: (key: string) => key } }));
+vi.mock('@/lib/intl-cache', () => ({
+  dateTimeFormat: (locale: string, options: Intl.DateTimeFormatOptions) =>
+    new Intl.DateTimeFormat(locale, options),
+}));
+vi.mock('@/lib/utils', () => ({
+  cn: (...inputs: unknown[]) => inputs.filter(Boolean).join(' '),
+}));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({
+    foreground: '#111111',
+    primaryForeground: '#111111',
+    mutedForeground: '#666666',
+    destructive: '#ff0000',
+  }),
+}));
+vi.mock('@/components/ui/icons', () => ({
+  Reply: 'Reply',
+  AlertCircle: 'AlertCircle',
+  CheckCircle2: 'CheckCircle2',
+  XCircle: 'XCircle',
+}));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/components/ui/button', () => ({ Button: 'Button' }));
+vi.mock('./message-attachment', () => ({ MessageAttachment: 'MessageAttachment' }));
+vi.mock('./message-reaction-pills', () => ({ MessageReactionPills: 'MessageReactionPills' }));
+vi.mock('../agents/chat-markdown-text', () => ({
+  ChatMarkdownText: (props: Record<string, unknown>) => {
+    captured.push(props);
+    return null;
+  },
+}));
+
+function message(): Message {
+  return {
+    id: 'message-1',
+    senderId: 'user-1',
+    content: [{ type: 'text', text: 'const x = 1;' }],
+    inReplyToMessageId: null,
+    replyTo: null,
+    updatedAt: 1_800_000_000_000,
+    clientUpdatedAt: null,
+    deleted: false,
+    deliveryFailed: false,
+    reactions: [],
+  };
+}
+
+function mountBubble(onLongPress?: (m: Message) => void): TestRenderer.ReactTestRenderer {
+  const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+  act(() => {
+    ref.current = TestRenderer.create(
+      createElement(MessageBubble, {
+        client: undefined as unknown as KiloChatClient,
+        conversationId: 'c1',
+        message: message(),
+        currentUserId: 'user-1',
+        isFromMe: false,
+        showAuthor: false,
+        authorLabel: 'Igor',
+        pendingActionGroupId: null,
+        onExecuteAction: () => undefined,
+        onReactionPress: () => undefined,
+        onLongPress,
+      })
+    );
+  });
+  if (!ref.current) {
+    throw new Error('renderer was not created');
+  }
+  return ref.current;
+}
+
+describe('Kilo Chat code-fence long-press forwarding', () => {
+  it('forwards the bubble long-press into the rendered markdown code fences', () => {
+    const onLongPress = vi.fn<(m: Message) => void>();
+    mountBubble(onLongPress);
+
+    const handler = captured.at(-1)?.onLongPressCode as (() => void) | undefined;
+    expect(typeof handler).toBe('function');
+    handler?.();
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    expect(onLongPress.mock.calls[0]?.[0]).toMatchObject({ id: 'message-1' });
+  });
+
+  it('omits the fence long-press handler when the bubble has no actions', () => {
+    mountBubble(undefined);
+    expect(captured.at(-1)?.onLongPressCode).toBeUndefined();
+  });
+});

--- a/apps/mobile/src/components/kilo-chat/message-markdown.tsx
+++ b/apps/mobile/src/components/kilo-chat/message-markdown.tsx
@@ -6,9 +6,18 @@ import { isMessageTextSelectionEnabled, textBlockHasVisibleContent } from './mes
 type MessageMarkdownProps = {
   text: string;
   isFromMe: boolean;
+  /**
+   * Long-press handler forwarded into rendered code fences' copy trigger so a
+   * press-and-hold on a fence still opens the bubble's message actions.
+   */
+  onLongPressCode?: () => void;
 };
 
-export function MessageMarkdown({ text, isFromMe }: Readonly<MessageMarkdownProps>) {
+export function MessageMarkdown({
+  text,
+  isFromMe,
+  onLongPressCode,
+}: Readonly<MessageMarkdownProps>) {
   if (!textBlockHasVisibleContent(text)) {
     return null;
   }
@@ -19,6 +28,7 @@ export function MessageMarkdown({ text, isFromMe }: Readonly<MessageMarkdownProp
         value={text}
         variant={isFromMe ? 'kilo-chat-user' : 'assistant'}
         selectable={isMessageTextSelectionEnabled()}
+        onLongPressCode={onLongPressCode}
       />
     );
   } catch {


### PR DESCRIPTION
## Changelog for users
- Tapping a rendered code block on the session page reveals an inline "Copy" action.
- The action is placed at the tapped position, so it stays visible on code blocks taller than the screen.
- Tapping "Copy" copies the whole code block, including text hidden behind the display cap.
- A "Copied to clipboard" confirmation appears after a successful copy.
- Empty code blocks never offer the copy action.
- Long-pressing a code block opens message details and dismisses any revealed copy action.
- Screen readers get a "copy code" action on the code text.

## Changelog for maintainers
- `MarkdownText` and `MarkdownRenderer` take optional `onCopyCode` and `onLongPressCode` handlers; omitting them keeps fences static, as tool cards do.
- `CodeBlock` reserves a right gutter from the rendered copy label width, so the pill never covers source glyphs in any locale.
- The copy trigger is the block's only pressable wrapper; a long press forwards to the host instead of revealing the action.
- The value handed to the caller is the full source before the display cap, not the truncated slice.
- `chat-markdown-text` routes copies through `performCopy`, so haptic and toast feedback matches every other copy action.
- `message-bubble`, `part-renderer`, and `text-part-renderer` forward the details long-press into code fences.
- The success toast now lasts 8000 ms because Android's system clipboard preview covers the default-length toast.
- Review first: the tap-anchored positioning and gutter measurement in `code-block.tsx`; companion test files cover reveal, dismissal, empty fences, and long-press forwarding.

## E2E proof

**[p3] Session page: long-press a code block inside a tool card (e.g.** — Android emulator-5606, live re-run on head 0d86de5f (clean tree): on the 'Mobile sheet fixtures' session page that renders the read/task tool cards, long-press on the console.log("Hello World"); fenced code block opened the message-details sheet — p3-live2.log line 1 'SCENE p3 OK' and line 4 'android.view.View Message details tappable [37,183][858,248]'; same-commit reviewed artifacts p3-verify.log and p3-lp-inline.log carry the identical digest (collection 2026-09-12), captures for the visual reviewer are p3.png and p3.mp4. Gap: the New-session model picker lists no 'Fake Deterministic'…

https://github.com/user-attachments/assets/088ff4a6-376e-40fd-beda-76f23329577f

**[p1] Session page: tap a code block in an assistant message -> an inline 'Copy' pill appears; tapping it copies the full source (including text past the display cap) and shows 'Copied to clipboard'.** — Re-ran live on android emulator-5554 (HEAD 0d86de5; identical to prior pass): session.sh enter ses_000000000001RootFixture001 (Mobile sheet fixtures, 50000 display cap), tap at (541,1045) on the assistant-message fence [69,360][1013,1730] -> p1-reveal-run.log 'SCENE p1-reveal OK' + 'android.widget.Button Copy tappable [907,1045][1013,1106]' (no reflow: fence bounds unchanged); tap Copy -> p1-copyrun.log 'SCENE p1 OK' (absent Copy) and p1-clipboard-proof-run.log '{"clipboardLength":61253,"displayCap":50000,"beyondDisplayCap":true,"endsWithFullSourceMarker":true,...}', written onto an empty…

https://github.com/user-attachments/assets/3385b60d-bc8a-480d-b560-ee7544a3d9c3

**[p1] Session page: tap a code block in an assistant message -> an inline 'Copy' pill appears; tapping it copies the full source (including text past the display cap) and shows 'Copied to clipboard'.** — android emulator-5554, session ses_000000000001RootFixture001: one scripted run 'SCENE p1 OK' (p1-run.log:1) asserted 'Content truncated', tapped the fence and tapped 'Copy'; independently p1-tap.log:10 shows 'android.widget.Button Copy tappable [907,1045][1013,1106]' (pill anchored to the real tap at (541,1045)); copy proof p1-clipboard-fullsource.log quotes '{"clipboardLength":61253,"displayCap":50000,"beyondDisplayCap":true,"endsWithFullSourceMarker":true}', i.e. the full source past the 50k display cap; p1-lp.log confirms the fence is in an assistant message (long-press -> 'Message…

https://github.com/user-attachments/assets/ad7dd0b5-d2f0-4588-831a-f61d4c35a721

**[p1] Session page: tap a code block in an assistant message -> an inline 'Copy' pill appears; tapping it copies the full source (including text past the display cap) and shows 'Copied to clipboard'.** — android emulator-5604, worktree head d86532b0e9e499ffda025fb232074460141ddc14; setup was the read-only fixture session via `session.sh enter emulator-5604 ses_000000000001RootFixture001` (the CLI fixture session is not listed on Home/Agents, so the deep link is the only path), then one scripted call. p1-behavior.log:1 'SCENE p1-reveal OK' with :11 'android.widget.Button Copy tappable [907,1215][1013,1276]' (single tap reveals the inline pill; fence bounds :10 'code-block-copy-trigger tappable [69,360][1013,1730]' unchanged, and :13 'Content truncated' marks the 50000 display cap) and :45…

https://github.com/user-attachments/assets/48f19010-5354-4ef9-beab-544bd03fa2d3

![[p1] Session page: tap a code block in an assistant message -> an inline 'Copy' pill appears; tapping it copies the full source (including text past the display cap) and shows 'Copied to clipboard'. — prior/p1-toast-6s.png](https://github.com/user-attachments/assets/9678d045-654a-4326-bf8b-5884af8a72d3)

![[p1] Session page: tap a code block in an assistant message -> an inline 'Copy' pill appears; tapping it copies the full source (including text past the display cap) and shows 'Copied to clipboard'. — prior/p1-copy-toast.png](https://github.com/user-attachments/assets/17031194-70e2-445d-a192-19afe410c139)

## E2E proof — log excerpts

```
[e1] Session page: tap a code block in an assistant message -> an inline 'Copy'  -> pass :: android emulator-5554; single tap revealed the pill ('SCENE e1 OK', 'android.widget.Button Copy tappable [907,1215][1013,1276]' in e1-scene.log); after wiping the clipboard to a 20-char sentinel, tapping the pill wrote the full 61253-char source past the 50000 display cap (on-screen text lacks END_OF_FULL_SOURCE_MARKER) per e1-clipboard-fresh.log; the app committed 'Copied to clipboard' to its React tree (e1-toast.log) and the assistant role is proved in e1-role.log; no UX-DEFECT (trigger bounds unchanged after reveal).
[e2] Session page: long-press a code block in an assistant or user message -> th -> pass :: android/emulator-5604: scripted-e2.log line 1 'SCENE e2 OK' proves scene e2 (scripts-shard2.json: longPress the fence, assert 'Message details', tap Done, absent 'Copy') opened the message-details sheet with no copy pill; digest line 14 'code-block-copy-trigger tappable' is present and no Copy element remains. Owner-request single-tap check: e2-tap2.log line 1 'SCENE e2-tap-reveal OK' with digest line 15 'android.widget.Button Copy tappable [874,1530][980,1590]' proves a single tap reveals the inline Copy action, and 'Preparation complete tappable [40,1643][1042,1744]' keeps identical bounds before/after reveal (no layout shift). Replay banked at e2.replay.json.
[e3] Session page: long-press a code block inside a tool card (e.g. Read tool ou -> pass :: android emulator-5606; independent replay logged 'SCENE e3 OK' and the message-details sheet digest 'android.view.View Message details tappable [37,183][858,248]' (e3-longpress.log), matching the pre-run scripted-e3.log; the long-press was not swallowed by the new code-block copy trigger.
```

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/surface-the-mobile-app-apps-mobile-65e8/e2e-mobile-app/e1-scene.log</code></summary>

```
android.widget.TextView direct-fixture.txt tappable [128,1857][366,1903]
android.view.ViewGroup User message tappable [0,2071][1080,2090]
android.widget.TextView This is a read-only session tappable [36,2141][1044,2187]
android.widget.Button Continue tappable [37,2215][1043,2309]
android.widget.TextView Continue tappable [473,2239][606,2285]
SCENE e1-pill OK
android.widget.LinearLayout com.kilocode.kiloapp:id/action_bar_root tappable [0,0][1080,2400]
android.widget.FrameLayout android:id/content tappable [0,0][1080,2400]
android.widget.Button Go back tappable [0,163][101,264]
android.widget.Button Rename session: Mobile sheet fixtures tappable [111,149][746,278]
android.view.View Mobile sheet fixtures tappable [111,180][746,245]
android.widget.Button Context 1,375 of 1,000,000 tokens, 0% used, cost 1 cent. Tap to view context details. tappable [773,156][1043,271]
android.widget.TextView 0% tappable [895,195][932,232]
android.widget.TextView $0.01 tappable [941,195][1013,232]
android.view.ViewGroup code-block-copy-trigger tappable [69,360][1013,1730]
android.widget.Button Copy tappable [907,1215][1013,1276]
android.widget.TextView Copy tappable [928,1226][992,1263]
android.widget.TextView Content truncated tappable [69,1739][1013,1776]
android.widget.Button direct-fixture.txt tool, completed tappable [40,1839][1042,1922]
android.widget.TextView direct-fixture.txt tappable [128,1857][366,1903]
android.view.ViewGroup User message tappable [0,2071][1080,2090]
android.widget.TextView This is a read-only session tappable [36,2141][1044,2187]
android.widget.Button Continue tappable [37,2215][1043,2309]
android.widget.TextView Continue tappable [473,2239][606,2285]
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/surface-the-mobile-app-apps-mobile-65e8/e2e-mobile-app/e1-clipboard-fresh.log</code></summary>

```
e1 clipboard proof — 2026-09-12 — android emulator-5554 (RN inspector target 3d56ddb19be6ce5dca1bff1113b7151b9d545159)
setup: session.sh enter emulator-5554 ses_000000000001RootFixture001  (session "Mobile sheet fixtures"; the code fence is in an assistant message, proved by long-press -> Message details ROLE=Assistan
session.sh: link delivered on emulator-5554
freshness: before the UI copy the device clipboard is overwritten with a 20-char sentinel:
  proving command: cdp-eval.sh <ws> Runtime.evaluate 'expo.modules.ExpoClipboard.setStringAsync("SENTINEL_KWF_E1_2026",{})'
  read back: {"id":1,"result":{"result":{"type":"string","value":"ok | len=20;val=SENTINEL_KWF_E1_2026"}}}
copy: appium.sh emulator-5554 script scenes-e1-final.json --out <OUT>
  steps: tap code block; assert Copy; tap Copy pill
  SCENE e1 OK
  android.widget.Button Copy tappable [907,1215][1013,1276]
after the UI copy, read the device clipboard again:
  proving command: cdp-eval.sh <ws> Runtime.evaluate 'expo.modules.ExpoClipboard.getStringAsync({})'
  {"len":61253,"beyondCap":true,"sourceRole":"assistant","hasMarker":true,"head":"console.log(\"Hello World\");\n001xxxxxxxxxxx","tail":"xxxxxxxxxxxxxxxxxxx\nEND_OF_FULL_SOURCE_MARKER"}
the on-screen code text is truncated and does NOT contain the source tail marker:
  grep -c END_OF_FULL_SOURCE_MARKER e1-state.xml  ->  0
so the 61253-char clipboard value (ending END_OF_FULL_SOURCE_MARKER) is the full source,
not the truncated slice the transcript displays.
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/surface-the-mobile-app-apps-mobile-65e8/e2e-mobile-app/e1-toast.log</code></summary>

```
e1 copy-feedback proof — 2026-09-12 — android emulator-5554 (RN inspector target 3d56ddb19be6ce5dca1bff1113b7151b9d545159)
proving command: cdp-eval.sh <ws> Runtime.evaluate  (installs a 150 ms poll over the React fiber tree
  that records any committed node whose text contains 'Copied')
  {"id":1,"result":{"result":{"type":"string","value":"installed"}}}
copy: appium.sh emulator-5554 script scenes-e1-toastfiber.json --out <OUT>
  steps: tap code block; assert Copy; tap Copy pill
  SCENE e1-toastfiber OK
fiber poll result read right after the copy:
  {"id":1,"result":{"result":{"type":"string","value":"[\"Copied to clipboard\"]"}}}
so the copy action commits the feedback text "Copied to clipboard" to the running app's
React tree; the toast's on-screen appearance is left to the visual reviewer
(capture: e1.png, recording: e1-copy-recording.mp4).
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/surface-the-mobile-app-apps-mobile-65e8/e2e-mobile-app/e1-role.log</code></summary>

```
android.widget.TextView Select text tappable [94,479][985,535]
android.widget.Button Report AI response tappable [55,621][1025,737]
android.widget.TextView Report AI response tappable [94,651][985,707]
android.widget.TextView ROLE tappable [55,792][1025,829]
android.widget.TextView Assistant tappable [55,838][1025,894]
android.widget.TextView SENT tappable [55,931][1025,968]
android.widget.TextView Nov 14, 2023, 10:13 PM tappable [55,977][1025,1033]
android.widget.TextView MODEL tappable [55,1070][1025,1107]
android.widget.TextView Claude Sonnet 4 tappable [55,1116][1025,1172]
android.widget.TextView Cost &amp; tokens tappable [55,1246][1025,1292]
android.widget.TextView COST tappable [55,1329][1025,1366]
android.widget.TextView $0.0100 tappable [55,1375][1025,1431]
android.widget.TextView Input tappable [55,1468][131,1514]
android.widget.TextView 1,000 tappable [941,1468][1024,1514]
android.widget.TextView Output tappable [55,1542][155,1588]
android.widget.TextView 200 tappable [967,1542][1024,1588]
android.widget.TextView Reasoning tappable [55,1615][211,1661]
android.widget.TextView 100 tappable [967,1615][1024,1661]
android.widget.TextView Cache read tappable [55,1689][222,1735]
android.widget.TextView 50 tappable [986,1689][1024,1735]
android.widget.TextView Cache write tappable [55,1762][229,1808]
android.widget.TextView 25 tappable [986,1762][1024,1808]
android.widget.TextView Total tappable [55,1836][129,1882]
android.widget.TextView 1,375 tappable [941,1836][1024,1882]
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/surface-the-mobile-app-apps-mobile-65e8/e2e-mobile-app/scripted-e2.log</code></summary>

```
SCENE e2 OK
android.widget.LinearLayout com.kilocode.kiloapp:id/action_bar_root tappable [0,0][1080,2400]
android.widget.FrameLayout android:id/content tappable [0,0][1080,2400]
android.widget.Button Go back tappable [0,163][101,265]
android.widget.Button Rename session: TypeScript code fence comparison tappable [111,149][714,279]
android.view.View TypeScript code fence comparison tappable [111,149][714,279]
android.widget.Button Context 11,079 of 1,000,000 tokens, 1% used, cost 0.09 cents. Tap to view context details. tappable [741,156][1043,272]
android.widget.TextView 1% tappable [863,195][900,232]
android.widget.TextView $0.0009 tappable [909,195][1013,232]
android.widget.TextView 8:13 AM tappable [476,1110][604,1149]
android.view.ViewGroup fake:echo:Empty fence below:, Non-empty fence below:, User message tappable [0,1167][1080,1623]
android.widget.TextView fake:echo:Empty fence below: tappable [250,1204][1012,1267]
android.widget.TextView Non-empty fence below: tappable [250,1400][1012,1463]
android.view.ViewGroup code-block-copy-trigger tappable [282,1511][980,1549]
android.widget.Button Preparation complete tappable [40,1643][1042,1744]
android.widget.TextView Preparation complete tappable [188,1670][506,1716]
android.widget.Button Thought tappable [40,1777][1042,1850]
android.widget.TextView THOUGHT tappable [68,1795][206,1832]
android.widget.Button Add attachment tappable [28,2214][101,2288]
android.widget.EditText Message tappable [126,2191][800,2311]
android.widget.Button Start voice input tappable [835,2205][926,2297]
android.widget.Button Send message [926,2188][1052,2314]
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/surface-the-mobile-app-apps-mobile-65e8/e2e-mobile-app/e2-tap2.log</code></summary>

```
android.widget.Button Start voice input tappable [835,2205][926,2297]
android.widget.Button Send message [926,2188][1052,2314]
SCENE e2-tap-hide OK
android.widget.LinearLayout com.kilocode.kiloapp:id/action_bar_root tappable [0,0][1080,2400]
android.widget.FrameLayout android:id/content tappable [0,0][1080,2400]
android.widget.Button Go back tappable [0,163][101,265]
android.widget.Button Rename session: TypeScript code fence comparison tappable [111,149][714,279]
android.view.View TypeScript code fence comparison tappable [111,149][714,279]
android.widget.Button Context 11,079 of 1,000,000 tokens, 1% used, cost 0.09 cents. Tap to view context details. tappable [741,156][1043,272]
android.widget.TextView 1% tappable [863,195][900,232]
android.widget.TextView $0.0009 tappable [909,195][1013,232]
android.widget.TextView 8:13 AM tappable [476,1110][604,1149]
android.view.ViewGroup fake:echo:Empty fence below:, Non-empty fence below:, User message tappable [0,1167][1080,1622]
android.widget.TextView fake:echo:Empty fence below: tappable [250,1204][1012,1267]
android.widget.TextView Non-empty fence below: tappable [250,1400][1012,1463]
android.view.ViewGroup code-block-copy-trigger tappable [282,1511][980,1549]
android.widget.Button Preparation complete tappable [40,1643][1042,1744]
android.widget.TextView Preparation complete tappable [188,1670][506,1716]
android.widget.Button Thought tappable [40,1777][1042,1850]
android.widget.TextView THOUGHT tappable [68,1795][206,1832]
android.widget.Button Add attachment tappable [28,2214][101,2288]
android.widget.EditText Message tappable [126,2191][800,2311]
android.widget.Button Start voice input tappable [835,2205][926,2297]
android.widget.Button Send message [926,2188][1052,2314]
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/surface-the-mobile-app-apps-mobile-65e8/e2e-mobile-app/e3-longpress.log</code></summary>

```
android.widget.TextView Select text tappable [94,479][985,535]
android.widget.Button Report AI response tappable [55,621][1025,737]
android.widget.TextView Report AI response tappable [94,651][985,707]
android.widget.TextView ROLE tappable [55,792][1025,829]
android.widget.TextView Assistant tappable [55,838][1025,894]
android.widget.TextView SENT tappable [55,931][1025,968]
android.widget.TextView Nov 14, 2023, 10:13 PM tappable [55,977][1025,1033]
android.widget.TextView MODEL tappable [55,1070][1025,1107]
android.widget.TextView Claude Sonnet 4 tappable [55,1116][1025,1172]
android.widget.TextView Cost &amp; tokens tappable [55,1246][1025,1292]
android.widget.TextView COST tappable [55,1329][1025,1366]
android.widget.TextView $0.0100 tappable [55,1375][1025,1431]
android.widget.TextView Input tappable [55,1468][131,1514]
android.widget.TextView 1,000 tappable [941,1468][1024,1514]
android.widget.TextView Output tappable [55,1542][155,1588]
android.widget.TextView 200 tappable [967,1542][1024,1588]
android.widget.TextView Reasoning tappable [55,1615][211,1661]
android.widget.TextView 100 tappable [967,1615][1024,1661]
android.widget.TextView Cache read tappable [55,1689][222,1735]
android.widget.TextView 50 tappable [986,1689][1024,1735]
android.widget.TextView Cache write tappable [55,1762][229,1808]
android.widget.TextView 25 tappable [986,1762][1024,1808]
android.widget.TextView Total tappable [55,1836][129,1882]
android.widget.TextView 1,375 tappable [941,1836][1024,1882]
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/surface-the-mobile-app-apps-mobile-65e8/e2e-mobile-app/scripted-e3.log</code></summary>

```
android.widget.TextView Select text tappable [94,479][985,535]
android.widget.Button Report AI response tappable [55,621][1025,737]
android.widget.TextView Report AI response tappable [94,651][985,707]
android.widget.TextView ROLE tappable [55,792][1025,829]
android.widget.TextView Assistant tappable [55,838][1025,894]
android.widget.TextView SENT tappable [55,931][1025,968]
android.widget.TextView Nov 14, 2023, 10:13 PM tappable [55,977][1025,1033]
android.widget.TextView MODEL tappable [55,1070][1025,1107]
android.widget.TextView Claude Sonnet 4 tappable [55,1116][1025,1172]
android.widget.TextView Cost &amp; tokens tappable [55,1246][1025,1292]
android.widget.TextView COST tappable [55,1329][1025,1366]
android.widget.TextView $0.0100 tappable [55,1375][1025,1431]
android.widget.TextView Input tappable [55,1468][131,1514]
android.widget.TextView 1,000 tappable [941,1468][1024,1514]
android.widget.TextView Output tappable [55,1542][155,1588]
android.widget.TextView 200 tappable [967,1542][1024,1588]
android.widget.TextView Reasoning tappable [55,1615][211,1661]
android.widget.TextView 100 tappable [967,1615][1024,1661]
android.widget.TextView Cache read tappable [55,1689][222,1735]
android.widget.TextView 50 tappable [986,1689][1024,1735]
android.widget.TextView Cache write tappable [55,1762][229,1808]
android.widget.TextView 25 tappable [986,1762][1024,1808]
android.widget.TextView Total tappable [55,1836][129,1882]
android.widget.TextView 1,375 tappable [941,1836][1024,1882]
```
</details>

<details>
<summary>Owner request</summary>

> Surface: the mobile app (apps/mobile).
> 
> When markdown renders a code block on the session page, a single tap on the code block should spawn an inline (or popover, or tooltip, or similar) "copy code" action.

</details>

## Owner manual verification
The workflow skipped these checks. Owner verification is pending; these checks did not pass automatically.
- owner-manual: none.