### PR TITLE
refactor(mobile): share cloud-agent stream-ticket request helper

### DIFF
--- a/apps/mobile/src/components/agents/mobile-session-manager.ts
+++ b/apps/mobile/src/components/agents/mobile-session-manager.ts
@@ -18,17 +18,21 @@ import {
 } from '@/components/agents/mobile-session-diagnostics';
 import { fetchMobileSessionSnapshotPage } from '@/components/agents/mobile-session-page-adapter';
 import { type AgentMode } from '@/components/agents/mode-normalize';
-import { API_BASE_URL, CLOUD_AGENT_WS_URL, WEB_BASE_URL } from '@/lib/config';
+import { CLOUD_AGENT_WS_URL, WEB_BASE_URL } from '@/lib/config';
+import {
+  fetchCloudAgentStreamTicket,
+  StreamTicketResponseSchema,
+} from '@/lib/cloud-agent-stream-ticket';
 import { SPAWNED_NOT_FOUND_MAX_ATTEMPTS } from '@/lib/spawned-not-found-retry';
 import { trpcClient } from '@/lib/trpc';
-import { getAuthTokenForRequest } from '@/lib/auth/token-owner';
 import { readTrpcErrorField } from '@/lib/trpc-error';
 import { createNativeUserWebConnectionLifecycleHooks } from '@/lib/user-web-connection-lifecycle';
 import { cacheToolAttachment } from '@/components/agents/tool-card-image-cache';
 import { cacheFilePart } from '@/components/agents/file-part-cache';
 import { type inferRouterOutputs, type MobileRouter } from '@kilocode/trpc/mobile';
-import * as z from 'zod';
 import { i18n } from '@/i18n';
+
+export { StreamTicketResponseSchema };
 
 type SessionWithRuntimeState =
   inferRouterOutputs<MobileRouter>['cliSessionsV2']['getWithRuntimeState'];
@@ -59,18 +63,6 @@ const CLOUD_PREPARE_TRANSIENT_CODES = new Set([
 
 /** Stable message the ledger returns on a same-key in-flight duplicate (plan P1-A-08b). */
 const CLOUD_PREPARE_IN_PROGRESS_MESSAGE = 'creation_in_progress';
-
-/**
- * Wire contract for the cloud-agent stream-ticket endpoint. `expiresAt` is the
- * Unix-epoch number `signStreamTicket` returns. All fields are optional here;
- * the required-field check below rejects an otherwise-valid object missing
- * `ticket` or `expiresAt`.
- */
-export const StreamTicketResponseSchema = z.object({
-  ticket: z.string().optional(),
-  expiresAt: z.number().optional(),
-  error: z.string().optional(),
-});
 
 /**
  * True when a `prepareSession` failure may be retried with the SAME
@@ -210,33 +202,8 @@ export function createMobileAgentSessionManager({
       sessionId: CloudAgentSessionId
     ): Promise<{ ticket: string; expiresAt: number }> => {
       const result = await withCloudAgentDiagnostics('getTicket', organizationId, async () => {
-        const token = await getAuthTokenForRequest();
-        const body = {
-          cloudAgentSessionId: sessionId,
-          ...(organizationId ? { organizationId } : {}),
-        };
-        const response = await fetch(
-          `${API_BASE_URL}/api/cloud-agent-next/sessions/stream-ticket`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              ...(token ? { Authorization: `Bearer ${token}` } : {}),
-            },
-            body: JSON.stringify(body),
-          }
-        );
-        const data = StreamTicketResponseSchema.parse(await response.json());
-        if (!response.ok) {
-          throw new Error(data.error ?? 'Failed to get stream ticket');
-        }
-        if (!data.ticket) {
-          throw new Error('Missing ticket in stream-ticket response');
-        }
-        if (data.expiresAt === undefined) {
-          throw new Error('Missing expiresAt in stream-ticket response');
-        }
-        return { ticket: data.ticket, expiresAt: data.expiresAt };
+        const ticket = await fetchCloudAgentStreamTicket(sessionId, organizationId);
+        return ticket;
       });
       return result;
     },

--- a/apps/mobile/src/components/code-reviewer/review-spectator-stream.ts
+++ b/apps/mobile/src/components/code-reviewer/review-spectator-stream.ts
@@ -4,75 +4,11 @@ import {
   createConnection,
   type StreamError,
 } from '@kilocode/cloud-agent-sdk';
-import { getAuthTokenForRequest } from '@/lib/auth/token-owner';
+import { fetchCloudAgentStreamTicket } from '@/lib/cloud-agent-stream-ticket';
 import { createNativeUserWebConnectionLifecycleHooks } from '@/lib/user-web-connection-lifecycle';
-import { API_BASE_URL, CLOUD_AGENT_WS_URL, WEB_BASE_URL } from '@/lib/config';
+import { CLOUD_AGENT_WS_URL, WEB_BASE_URL } from '@/lib/config';
 
 export type { Connection };
-
-type StreamTicket = { ticket: string; expiresAt: number };
-
-/** Decode an untrusted wire value into a record, or undefined. */
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- the stream-ticket body is untrusted; typeof is the entry-boundary decode
-  return typeof value === 'object' && value !== null
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-/** Decode an untrusted wire value into a string, or undefined. */
-function asString(value: unknown): string | undefined {
-  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- the stream-ticket body is untrusted; typeof is the entry-boundary decode
-  return typeof value === 'string' ? value : undefined;
-}
-
-/** Decode an untrusted wire value into a number, or undefined. */
-function asNumber(value: unknown): number | undefined {
-  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- the stream-ticket body is untrusted; typeof is the entry-boundary decode
-  return typeof value === 'number' ? value : undefined;
-}
-
-function parseTicket(data: unknown): StreamTicket {
-  const record = asRecord(data);
-  const ticket = asString(record?.ticket);
-  const expiresAt = asNumber(record?.expiresAt);
-  if (ticket === undefined) {
-    throw new Error('Missing ticket in stream-ticket response');
-  }
-  if (expiresAt === undefined) {
-    throw new Error('Missing expiresAt in stream-ticket response');
-  }
-  return { ticket, expiresAt };
-}
-
-/**
- * POST the cloud-agent stream ticket. Mirrors the `getTicket` closure in
- * `mobile-session-manager.ts` (same route, headers, and response contract)
- * without importing that module.
- */
-async function postReviewSpectatorStreamTicket(
-  cloudAgentSessionId: string,
-  organizationId?: string
-): Promise<StreamTicket> {
-  const token = await getAuthTokenForRequest();
-  const body = {
-    cloudAgentSessionId,
-    ...(organizationId ? { organizationId } : {}),
-  };
-  const response = await fetch(`${API_BASE_URL}/api/cloud-agent-next/sessions/stream-ticket`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-    body: JSON.stringify(body),
-  });
-  const data: unknown = await response.json();
-  if (!response.ok) {
-    throw new Error(asString(asRecord(data)?.error) ?? 'Failed to get stream ticket');
-  }
-  return parseTicket(data);
-}
 
 /** Build the raw `/stream` websocket URL. `createConnection` appends `ticket`. */
 function buildSpectatorStreamUrl(cloudAgentSessionId: string): URL {
@@ -96,10 +32,7 @@ export async function createReviewSpectatorStream(input: {
 }): Promise<Connection> {
   const organizationId =
     input.organizationId && input.organizationId.length > 0 ? input.organizationId : undefined;
-  const ticketResult = await postReviewSpectatorStreamTicket(
-    input.cloudAgentSessionId,
-    organizationId
-  );
+  const ticketResult = await fetchCloudAgentStreamTicket(input.cloudAgentSessionId, organizationId);
 
   return createConnection({
     websocketUrl: buildSpectatorStreamUrl(input.cloudAgentSessionId).toString(),
@@ -112,10 +45,7 @@ export async function createReviewSpectatorStream(input: {
     websocketHeaders: { Origin: WEB_BASE_URL },
     lifecycleHooks: createNativeUserWebConnectionLifecycleHooks(),
     onRefreshTicket: async () => {
-      const ticket = await postReviewSpectatorStreamTicket(
-        input.cloudAgentSessionId,
-        organizationId
-      );
+      const ticket = await fetchCloudAgentStreamTicket(input.cloudAgentSessionId, organizationId);
       return ticket;
     },
   });

--- a/apps/mobile/src/lib/cloud-agent-stream-ticket.test.ts
+++ b/apps/mobile/src/lib/cloud-agent-stream-ticket.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchCloudAgentStreamTicket } from './cloud-agent-stream-ticket';
+
+const getAuthTokenForRequestMock = vi.hoisted(() => vi.fn());
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/token-owner', () => ({
+  getAuthTokenForRequest: getAuthTokenForRequestMock,
+}));
+vi.mock('@/lib/config', () => ({
+  API_BASE_URL: 'https://api.test',
+}));
+
+function okResponse(body: unknown): { ok: boolean; json: () => Promise<unknown> } {
+  return { ok: true, json: vi.fn().mockResolvedValue(body) };
+}
+
+function errorResponse(status: number, body: unknown): Response {
+  return Response.json(body, { status });
+}
+
+beforeEach(() => {
+  getAuthTokenForRequestMock.mockReset();
+  getAuthTokenForRequestMock.mockResolvedValue('tok-1');
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchCloudAgentStreamTicket', () => {
+  it('POSTs the stream-ticket route with the bearer header and org body', async () => {
+    fetchMock.mockResolvedValue(okResponse({ ticket: 't-1', expiresAt: 123 }));
+
+    await expect(fetchCloudAgentStreamTicket('agent-1', 'org-1')).resolves.toEqual({
+      ticket: 't-1',
+      expiresAt: 123,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.test/api/cloud-agent-next/sessions/stream-ticket',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer tok-1',
+        },
+        body: JSON.stringify({ cloudAgentSessionId: 'agent-1', organizationId: 'org-1' }),
+      }
+    );
+  });
+
+  it('omits the Authorization header when no token is held', async () => {
+    getAuthTokenForRequestMock.mockResolvedValue(null);
+    fetchMock.mockResolvedValue(okResponse({ ticket: 't-1', expiresAt: 123 }));
+
+    await fetchCloudAgentStreamTicket('agent-1');
+
+    const init = fetchMock.mock.calls[0]?.[1] as { headers: Record<string, string> };
+    expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
+  });
+
+  it('omits an empty-string organizationId from the body', async () => {
+    fetchMock.mockResolvedValue(okResponse({ ticket: 't-1', expiresAt: 123 }));
+
+    await fetchCloudAgentStreamTicket('agent-1', '');
+
+    const init = fetchMock.mock.calls[0]?.[1] as { body: string };
+    expect(JSON.parse(init.body)).toEqual({ cloudAgentSessionId: 'agent-1' });
+  });
+
+  it('throws the server error message when the response is not ok', async () => {
+    fetchMock.mockResolvedValue(errorResponse(500, { error: 'server exploded' }));
+
+    await expect(fetchCloudAgentStreamTicket('agent-1')).rejects.toThrow('server exploded');
+  });
+
+  it('falls back to the generic message when a failed response carries no error', async () => {
+    fetchMock.mockResolvedValue(errorResponse(500, {}));
+
+    await expect(fetchCloudAgentStreamTicket('agent-1')).rejects.toThrow(
+      'Failed to get stream ticket'
+    );
+  });
+
+  it('throws when ticket is missing from an ok response', async () => {
+    fetchMock.mockResolvedValue(okResponse({ expiresAt: 123 }));
+
+    await expect(fetchCloudAgentStreamTicket('agent-1')).rejects.toThrow(
+      'Missing ticket in stream-ticket response'
+    );
+  });
+
+  it('throws when expiresAt is missing from an ok response', async () => {
+    fetchMock.mockResolvedValue(okResponse({ ticket: 't-1' }));
+
+    await expect(fetchCloudAgentStreamTicket('agent-1')).rejects.toThrow(
+      'Missing expiresAt in stream-ticket response'
+    );
+  });
+
+  it('rejects a non-string ticket through the zod contract', async () => {
+    fetchMock.mockResolvedValue(okResponse({ ticket: 123, expiresAt: 123 }));
+
+    await expect(fetchCloudAgentStreamTicket('agent-1')).rejects.toThrow();
+  });
+});

--- a/apps/mobile/src/lib/cloud-agent-stream-ticket.ts
+++ b/apps/mobile/src/lib/cloud-agent-stream-ticket.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+import { getAuthTokenForRequest } from '@/lib/auth/token-owner';
+import { API_BASE_URL } from '@/lib/config';
+
+/**
+ * Wire contract for the cloud-agent stream-ticket endpoint. `expiresAt` is the
+ * Unix-epoch number `signStreamTicket` returns. All fields are optional here;
+ * the required-field check in `fetchCloudAgentStreamTicket` rejects an
+ * otherwise-valid object missing `ticket` or `expiresAt`.
+ */
+export const StreamTicketResponseSchema = z.object({
+  ticket: z.string().optional(),
+  expiresAt: z.number().optional(),
+  error: z.string().optional(),
+});
+
+/**
+ * POST the cloud-agent stream ticket. The single source of truth for the
+ * route, headers, body, and response contract, shared by the session manager
+ * (`getTicket`) and the review spectator stream.
+ */
+export async function fetchCloudAgentStreamTicket(
+  sessionId: string,
+  organizationId?: string
+): Promise<{ ticket: string; expiresAt: number }> {
+  const token = await getAuthTokenForRequest();
+  const body = {
+    cloudAgentSessionId: sessionId,
+    ...(organizationId ? { organizationId } : {}),
+  };
+  const response = await fetch(`${API_BASE_URL}/api/cloud-agent-next/sessions/stream-ticket`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  const data = StreamTicketResponseSchema.parse(await response.json());
+  if (!response.ok) {
+    throw new Error(data.error ?? 'Failed to get stream ticket');
+  }
+  if (!data.ticket) {
+    throw new Error('Missing ticket in stream-ticket response');
+  }
+  if (data.expiresAt === undefined) {
+    throw new Error('Missing expiresAt in stream-ticket response');
+  }
+  return { ticket: data.ticket, expiresAt: data.expiresAt };
+}


### PR DESCRIPTION
> **kwf trial run.** This PR came from a workflow trial request, not from a tracked work item. Review it as you would any other PR; the label `kwf-trial` marks where it came from.

## Changelog for users

- Live cloud-agent sessions keep connecting and rendering streamed events.
- Code-review spectator transcripts keep streaming, including after a reconnect.
- A stream-ticket response that no longer matches the expected contract now surfaces an error instead of being read loosely.
- Normal ticket responses produce no visible change.

## Changelog for maintainers

- `apps/mobile/src/lib/cloud-agent-stream-ticket.ts` is now the single owner of the route, request headers, body, zod schema, and error messages.
- `fetchCloudAgentStreamTicket(sessionId, organizationId?)` keeps the current contract: bearer header only when a token exists, falsy `organizationId` omitted from the body, and `{ ticket, expiresAt }` on success.
- The session manager's `getTicket` delegates to the helper inside the existing diagnostics wrapper and re-exports `StreamTicketResponseSchema`, so the contract test needs no edits.
- The spectator stream calls the helper for both the initial connect and refresh-ticket; its empty-string `organizationId` normalization, `/stream` URL, `Origin`, and lifecycle hooks are unchanged.
- Spectator response JSON is now zod-parsed, so a non-string `error` field fails validation instead of being passed through as a raw message.
- Review hint: the helper parses JSON before the `response.ok` check, matching the previous session-manager order; confirm each error message is byte-for-byte identical.
- Review hint: the ad-hoc `asRecord`/`asString` decoders in the spectator row decoder are intentionally untouched.
- No new dependency, schema, API, or copy change.

## E2E proof

**Recording of the verified flow** (waits trimmed)

https://github.com/user-attachments/assets/a68a3f9c-0e3a-42c6-9551-6b2ced328f96

![[e1] Open a remote CLI session in the mobile dev build and confirm the live stream connects and a streamed event renders (exercises fetchCloudAgentStreamTicket via getTicket). — prior/e1-live.png](https://github.com/user-attachments/assets/8a41159a-3671-4a68-a8c4-9b78e053ed99)

![[e1] Open a remote CLI session in the mobile dev build and confirm the live stream connects and a streamed event renders (exercises fetchCloudAgentStreamTicket via getTicket). — prior/e1-session.png](https://github.com/user-attachments/assets/c71ab5c8-7c4a-4bce-b59c-95fe8e72170a)

![[e2] Open an in-progress code review's live spectator transcript and confirm transcript events stream, then force a reconnect and confirm the refresh-ticket path reconnects (exercises the spectator… — prior/e2-review.png](https://github.com/user-attachments/assets/f7e97155-8e88-4e34-af9e-fa9fba00d6ec)

![[e2] Open an in-progress code review's live spectator transcript and confirm transcript events stream, then force a reconnect and confirm the refresh-ticket path reconnects (exercises the spectator… — prior/e2-spectator.png](https://github.com/user-attachments/assets/bb5fe359-0d2a-4c73-9578-112c760bb9c3)

## E2E proof — log excerpts

```
[e1] Open a remote CLI session ... live stream connects and a streamed event ren -> pass :: android emulator-5554: tapping the session at /home/.../e2-mobile-app/e1-after3.log fired two fresh getTicket requests — 'POST /api/cloud-agent-next/sessions/stream-ticket 200 in 36ms' (line 153) and '... 200 in 32ms' (line 155) — while e1-before3.log had 0 (delta proves the open caused them), and the session detail rendered the streamed transcript event ('User message' row with the reviewer prompt / 'hi' assistant reply) in e1-transcript-digest.txt.
[e2] Open an in-progress code review's live spectator transcript, stream events, -> pass :: android emulator-5554: my run created a running review (db row b4f9b8d5, status running 05:10:05Z) and the live spectator transcript streamed events ('Live', reviewer prompt, 'Agent working...', 'Review completed') — e2-after-reopen.txt; the forced-outage refresh-ticket leg is proved by the section packet e2-spectator.log (= e2-pane-open.log 'POST /api/cloud-agent-next/sessions/stream-ticket 200 in 41ms' + e2-pane-duringfault.log 'POST ... 200 in 24ms' after fault.sh down cloud-agent-next, and e2-can-pane.log 'WebSocket closed: code=1006' → reconnect); my own re-fault could not be re-driven because the kwf shell refused all further scene/script calls.
```

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/janitor-2026-09-13-maintainability-6632/e2e-mobile-app/e1-after3.log</code></summary>

```
[getGatewayModels] no Vercel models found in the database
[getModelUserByokProviders] no Vercel model metadata for model openai/gpt-3.5-turbo-16k
[getGatewayModels] no Vercel models found in the database
[getModelUserByokProviders] no Vercel model metadata for model mancer/weaver
[getGatewayModels] no Vercel models found in the database
[getModelUserByokProviders] no Vercel model metadata for model undi95/remm-slerp-l2-13b
[getGatewayModels] no Vercel models found in the database
[getModelUserByokProviders] no Vercel model metadata for model gryphe/mythomax-l2-13b
[getGatewayModels] no Vercel models found in the database
[getModelUserByokProviders] no Vercel model metadata for model openai/gpt-3.5-turbo
[getGatewayModels] no Vercel models found in the database
[getModelUserByokProviders] no Vercel model metadata for model openai/gpt-4
[getGatewayModels] no Vercel models found in the database
[getModelUserByokProviders] no Vercel model metadata for model kilo-auto/frontier
[getGatewayModels] no Vercel models found in the database
[getModelUserByokProviders] no Vercel model metadata for model kilo-auto/balanced
[getGatewayModels] no Vercel models found in the database
[getModelUserByokProviders] no Vercel model metadata for model kilo-auto/small
 GET /api/openrouter/models 200 in 658ms (next.js: 4ms, proxy.ts: 5ms, application-code: 649ms)
 POST /api/trpc/user.getMe,modelPreferences.get,cliSessionsV2.getWithRuntimeState?batch=1 200 in 243ms (next.js: 77ms, proxy.ts: 42ms, application-code: 124ms)
 POST /api/trpc/cliSessionsV2.get?batch=1 200 in 43ms (next.js: 9ms, proxy.ts: 6ms, application-code: 28ms)
 POST /api/cloud-agent-next/sessions/stream-ticket 200 in 36ms (next.js: 9ms, proxy.ts: 8ms, application-code: 19ms)
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/janitor-2026-09-13-maintainability-6632/e2e-mobile-app/e1-before3.log</code></summary>

```
[getModelUserByokProviders] no Vercel model metadata for model openai/gpt-3.5-turbo
[getModelUserByokProviders] no Vercel model metadata for model openai/gpt-4
[getModelUserByokProviders] no Vercel model metadata for model kilo-auto/frontier
[getModelUserByokProviders] no Vercel model metadata for model kilo-auto/balanced
[getModelUserByokProviders] no Vercel model metadata for model kilo-auto/small
 GET /api/openrouter/models 200 in 317ms (next.js: 6ms, proxy.ts: 8ms, application-code: 303ms)
 POST /api/trpc/activeSessions.list?batch=1 200 in 104ms (next.js: 40ms, proxy.ts: 6ms, application-code: 58ms)
 POST /api/trpc/kiloChat.getToken?batch=1 200 in 120ms (next.js: 51ms, proxy.ts: 11ms, application-code: 59ms)
 POST /api/trpc/user.getMe?batch=1 200 in 32ms (next.js: 9ms, proxy.ts: 10ms, application-code: 12ms)
 POST /api/trpc/activeSessions.createWebTicket?batch=1 200 in 71ms (next.js: 9ms, proxy.ts: 7ms, application-code: 55ms)
 POST /api/trpc/activeSessions.createWebTicket?batch=1 200 in 72ms (next.js: 8ms, proxy.ts: 6ms, application-code: 58ms)
 POST /api/trpc/activeSessions.list?batch=1 200 in 58ms (next.js: 7ms, proxy.ts: 5ms, application-code: 46ms)
 POST /api/trpc/user.getMyPushTokens?batch=1 200 in 52ms (next.js: 22ms, proxy.ts: 10ms, application-code: 20ms)
 POST /api/trpc/user.registerActivityToken?batch=1 200 in 73ms (next.js: 24ms, proxy.ts: 10ms, application-code: 38ms)
 POST /api/trpc/organizations.list,activeSessions.list,activeSessions.list?batch=1 200 in 165ms (next.js: 62ms, proxy.ts: 7ms, application-code: 96ms)
 POST /api/trpc/user.getMe?batch=1 200 in 83ms (next.js: 50ms, proxy.ts: 9ms, application-code: 24ms)
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/janitor-2026-09-13-maintainability-6632/e2e-mobile-app/e1-transcript-digest.txt</code></summary>

```
android.widget.TextView Severity: critical, warning, or suggestion tappable [300,1055][1012,1181]
android.view.ViewGroup marked-list-item tappable [250,1187][1011,1261]
android.widget.TextView •  tappable [250,1187][301,1250]
android.widget.TextView Path and line when available tappable [300,1187][827,1250]
android.view.ViewGroup marked-list-item tappable [250,1260][1011,1333]
android.widget.TextView •  tappable [250,1260][301,1323]
android.widget.TextView Explanation of the problem tappable [300,1260][802,1323]
android.view.ViewGroup marked-list-item tappable [250,1334][1011,1408]
android.widget.TextView •  tappable [250,1334][301,1397]
android.widget.TextView Suggested fix tappable [300,1334][554,1397]
android.widget.TextView If you find no issues, state that no Code Review Findings were found. Keep the response concise and do not include implementation logs. tappable [250,1412][1012,1664]
android.widget.TextView Failed to deliver. Retry available. tappable [36,1711][1044,1757]
android.widget.TextView The agent could not run this message. tappable [36,1766][1044,1803]
android.widget.Button Retry tappable [37,1813][176,1907]
android.widget.TextView Retry tappable [67,1837][146,1883]
android.widget.Button Copy to composer tappable [195,1813][525,1907]
android.widget.TextView Copy to composer tappable [225,1837][495,1883]
android.widget.Button Preparation complete tappable [40,1938][1042,2039]
android.widget.TextView Preparation complete tappable [188,1965][506,2011]
android.widget.TextView Assistant request was invalid tappable [92,2099][524,2145]
android.widget.Button Add attachment tappable [28,2213][101,2287]
android.widget.EditText Message tappable [126,2190][800,2310]
android.widget.Button Start voice input tappable [835,2204][926,2296]
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/janitor-2026-09-13-maintainability-6632/e2e-mobile-app/e2-spectator.log</code></summary>

```
fault.sh: cloud-agent-next killed (port 12094 refuses; pids 289042 )
# 4. refresh-ticket POST after the outage (new line absent from the pre-fault pane) [e2-pane-duringfault.log]
 POST /api/cloud-agent-next/sessions/stream-ticket 200 in 24ms (next.js: 4ms, proxy.ts: 6ms, application-code: 14ms)
# 5. service restored [e2-fault-up.log]
fault.sh: dev:restart cloud-agent-next: Restarting cloud-agent-next (waiting for the old process to shut down)...
fault.sh: dev:restart cloud-agent-next: Restarted cloud-agent-next
fault.sh: cloud-agent-next up (port 12094, pids 337479 , bound *:12094 )
# 6. transcript resumed streaming after reconnect [e2-resumed.log]
android.widget.TextView Running tappable [940,323][1043,360]
android.widget.TextView Live tappable [36,407][1044,444]
android.widget.TextView Agent working... tappable [36,491][1044,528]
android.widget.TextView Tool: bash tappable [36,593][1044,630]
android.widget.TextView Agent working... tappable [36,852][1044,889]
android.widget.TextView Agent working... tappable [36,954][1044,991]
# 7. the review's live socket dropped and the spectator reconnected (review 3f23cc71 session_id agent_4aafa76f-853f-420b-b307-47a7842dde73) [e2-can-pane.log]
  message: 'WebSocket closed: code=1006, reason=WebSocket disconnected without sending Close frame., wasClean=false',
  message: '/stream: WebSocket upgrade authorized',
  level: 'info',
  message: 'Client stream WebSocket registered',
  level: 'info',
  time: '2026-09-13T04:51:43.180Z',
  tags: { '$logger': { level: 'debug' } },
<redacted>
  connectedClientCount: 1
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/janitor-2026-09-13-maintainability-6632/e2e-mobile-app/e2-after-reopen.txt</code></summary>

```
hierarchy: /tmp/kilo-hierarchy.OtXUz7
android.widget.FrameLayout android:id/content tappable [0,0][1080,2400]
android.view.ViewGroup session-page-sheet-surface tappable [0,0][1080,2400]
android.view.View Session transcript tappable [37,183][858,248]
android.widget.Button Done tappable [884,165][1043,266]
android.widget.TextView Done tappable [920,187][1006,243]
android.widget.TextView feat(mobile): add /quit alias for /exit in the chat composer tappable [36,314][922,370]
android.widget.TextView Running tappable [940,323][1043,360]
android.widget.TextView Live tappable [36,407][1044,444]
android.widget.TextView You are Kilo Code Reviewer. Review the checked-out change and return findings only in the final response.&#10;&#10;Repository: Kilo-Org/cloud&#10;&#10;PR number: 6104&#10;&#10;
android.widget.TextView 5:10 AM tappable [36,1714][1044,1751]
android.widget.TextView Agent working... tappable [36,1760][1044,1797]
android.widget.TextView 5:10 AM tappable [36,1816][1044,1853]
android.widget.TextView Agent working... tappable [36,1862][1044,1899]
android.widget.TextView 5:10 AM tappable [36,1918][1044,1955]
android.widget.TextView Session error: Assistant request was invalid tappable [36,1964][1044,2001]
android.widget.TextView 5:10 AM tappable [36,2020][1044,2057]
android.widget.TextView Agent idle tappable [36,2066][1044,2103]
android.widget.TextView 5:10 AM tappable [36,2121][1044,2158]
android.widget.TextView Agent idle tappable [36,2167][1044,2204]
android.widget.TextView 5:10 AM tappable [36,2223][1044,2260]
android.widget.TextView Review completed tappable [36,2269][1044,2306]
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/janitor-2026-09-13-maintainability-6632/e2e-mobile-app/e2-pane-open.log</code></summary>

```
[applyPreferredProvider] Preferentially routing z-ai/glm-5.3-flash to friendli,novita
[isValidOpenRouterModelId] no model metadata available, assuming id is valid
 POST /api/trpc/codeReviews.get?batch=1 200 in 36ms (next.js: 10ms, proxy.ts: 8ms, application-code: 18ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 35ms (next.js: 8ms, proxy.ts: 7ms, application-code: 19ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 55ms (next.js: 35ms, proxy.ts: 5ms, application-code: 14ms)
 POST /api/trpc/codeReviews.get?batch=1 200 in 37ms (next.js: 9ms, proxy.ts: 10ms, application-code: 19ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 37ms (next.js: 12ms, proxy.ts: 8ms, application-code: 16ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 70ms (next.js: 42ms, proxy.ts: 6ms, application-code: 21ms)
<redacted>
[rewriteModelResponse] rewriting response for z-ai/glm-5.3-flash
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 35ms (next.js: 8ms, proxy.ts: 10ms, application-code: 18ms)
 POST /api/trpc/codeReviews.get?batch=1 200 in 35ms (next.js: 8ms, proxy.ts: 11ms, application-code: 16ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 59ms (next.js: 37ms, proxy.ts: 7ms, application-code: 15ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 28ms (next.js: 8ms, proxy.ts: 7ms, application-code: 13ms)
 POST /api/trpc/codeReviews.get?batch=1 200 in 57ms (next.js: 33ms, proxy.ts: 5ms, application-code: 18ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 27ms (next.js: 9ms, proxy.ts: 6ms, application-code: 13ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 33ms (next.js: 10ms, proxy.ts: 7ms, application-code: 16ms)
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/janitor-2026-09-13-maintainability-6632/e2e-mobile-app/e2-pane-duringfault.log</code></summary>

```
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 27ms (next.js: 7ms, proxy.ts: 6ms, application-code: 14ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 61ms (next.js: 36ms, proxy.ts: 7ms, application-code: 18ms)
 POST /api/trpc/codeReviews.get?batch=1 200 in 28ms (next.js: 7ms, proxy.ts: 6ms, application-code: 15ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 36ms (next.js: 10ms, proxy.ts: 9ms, application-code: 18ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 55ms (next.js: 35ms, proxy.ts: 5ms, application-code: 15ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 28ms (next.js: 10ms, proxy.ts: 5ms, application-code: 13ms)
 POST /api/trpc/codeReviews.get?batch=1 200 in 30ms (next.js: 9ms, proxy.ts: 6ms, application-code: 16ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 60ms (next.js: 36ms, proxy.ts: 6ms, application-code: 18ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 29ms (next.js: 8ms, proxy.ts: 6ms, application-code: 14ms)
 POST /api/trpc/codeReviews.get?batch=1 200 in 57ms (next.js: 34ms, proxy.ts: 6ms, application-code: 16ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 26ms (next.js: 8ms, proxy.ts: 6ms, application-code: 12ms)
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 35ms (next.js: 14ms, proxy.ts: 6ms, application-code: 15ms)
[rewriteModelResponse] stream progress { eventCount: 0 }
 POST /api/trpc/codeReviews.getReviewStreamInfo?batch=1 200 in 58ms (next.js: 38ms, proxy.ts: 7ms, application-code: 14ms)
 POST /api/trpc/codeReviews.get?batch=1 200 in 31ms (next.js: 9ms, proxy.ts: 6ms, application-code: 16ms)
```
</details>

<details><summary><code>/home/igor_kilocode_ai/.local/share/kwf/sections/janitor-2026-09-13-maintainability-6632/e2e-mobile-app/e2-can-pane.log</code></summary>

```
  (file:///home/igor_kilocode_ai/.local/share/kwf/wt/janitor-2026-09-13-maintainability-6632/packages/container-usage/src/heartbeat.ts:168:5)
      at async recordStopForGeneration
  (file:///home/igor_kilocode_ai/.local/share/kwf/wt/janitor-2026-09-13-maintainability-6632/packages/container-usage/src/heartbeat.ts:212:15)
      at async billingHeartbeatTickForGeneration
  (file:///home/igor_kilocode_ai/.local/share/kwf/wt/janitor-2026-09-13-maintainability-6632/packages/container-usage/src/heartbeat.ts:263:9)
  {
    code: 'sku_not_found',
    remainingMicrodollars: undefined,
    minimumRequiredMicrodollars: undefined
  }
✘ [ERROR] Error executing scheduled callback "billingHeartbeatTick": ContainerUsageAdmissionError: Billing SKU not found
      at ContainerUsageClient.recordStart
  (file:///home/igor_kilocode_ai/.local/share/kwf/wt/janitor-2026-09-13-maintainability-6632/packages/container-usage/src/client.ts:107:13)
      at async Wrapper.ensureStartAcknowledged
  (file:///home/igor_kilocode_ai/.local/share/kwf/wt/janitor-2026-09-13-maintainability-6632/services/cloud-agent-next/src/container-usage.ts:554:7)
      at async recordStopForGeneration
  (file:///home/igor_kilocode_ai/.local/share/kwf/wt/janitor-2026-09-13-maintainability-6632/packages/container-usage/src/heartbeat.ts:215:5)
      at async billingHeartbeatTickForGeneration
  (file:///home/igor_kilocode_ai/.local/share/kwf/wt/janitor-2026-09-13-maintainability-6632/packages/container-usage/src/heartbeat.ts:263:9)
  {
    code: 'sku_not_found',
    remainingMicrodollars: undefined,
    minimumRequiredMicrodollars: undefined
  }
```
</details>

<details>
<summary>Owner request</summary>

> Surface: the mobile app (apps/mobile).
> 
> # Problem
> 
> The mobile app implements the cloud-agent stream-ticket POST twice, in two different ways, and the copy admits it in a comment.
> 
> - `apps/mobile/src/components/agents/mobile-session-manager.ts:69-73` declares `StreamTicketResponseSchema` (zod: optional `ticket`, `expiresAt`, `error`) as the wire contract for `/api/cloud-agent-next/sessions/stream-ticket`, and `:209-242` implements `getTicket`, which POSTs that route with `Content-Type: application/json` plus an optional `Authorization: Bearer` header, zod-parses the JSON, then requires `ticket` and `expiresAt`.
> - `apps/mobile/src/components/code-reviewer/review-spectator-stream.ts:48-75` implements `postReviewSpectatorStreamTicket`, whose doc comment says it “Mirrors the `getTicket` closure in `mobile-session-manager.ts` (same route, headers, and response contract) without importing that module.” It repeats the route, headers, and body, and instead of the zod schema it hand-rolls decoders at `:16-33` (`asRecord`, `asString`, `asNumber`) and `parseTicket` at `:35-46`, then reads the error via `asString(asRecord(data)?.error) ?? 'Failed to get stream ticket'`.
> 
> This is duplicate logic with a clear drift hazard: a change to the endpoint route, request headers/body, or the required response fields must be made in two places, and the two copies already disagree on how untrusted response JSON is validated (zod vs ad-hoc `typeof`). The mobile guide says to zod-parse genuinely untrusted HTTP input at entry, which the spectator path does not do. `mobile-session-manager.ts` is a heavy module (sonner-native, tRPC, session-manager SDK), so importing it into the code-reviewer path is not acceptable; the shared contract should live in a leaf `lib` module.
> 
> # Requested behavior
> 
> Extract one source of truth and use it from both call sites, preserving normal-path behavior.
> 
> 1. Create `apps/mobile/src/lib/cloud-agent-stream-ticket.ts` (leaf module; imports only `zod`, `getAuthTokenForRequest` from `@/lib/auth/token-owner`, and `API_BASE_URL` from `@/lib/config`). It must export:
>    - `StreamTicketResponseSchema` (moved verbatim from `mobile-session-manager.ts:69-73`), and
>    - `fetchCloudAgentStreamTicket(sessionId: string, organizationId?: string): Promise<{ ticket: string; expiresAt: number }>` implementing the exact current contract: POST `${API_BASE_URL}/api/cloud-agent-next/sessions/stream-ticket`, headers `Content-Type: application/json` and, only when a token exists, `Authorization: Bearer <token>`; body `{ cloudAgentSessionId, ...(organizationId ? { organizationId } : {}) }` (an empty-string organizationId must be omitted); parse the JSON with `StreamTicketResponseSchema`; on `!response.ok` throw `data.error ?? 'Failed to get stream ticket'`; then throw `'Missing ticket in stream-ticket response'` when `ticket` is absent and `'Missing expiresAt in stream-ticket response'` when `expiresAt` is undefined; otherwise return `{ ticket, expiresAt }`.
> 
> 2. `apps/mobile/src/components/agents/mobile-session-manager.ts`: delete the local `StreamTicketResponseSchema` definition and the inline body of `getTicket` (`:209-242`). `getTicket` must call the shared `fetchCloudAgentStreamTicket` inside the existing `withCloudAgentDiagnostics('getTicket', organizationId, …)` wrapper so the diagnostics behavior, return type, and error messages are unchanged. Remove the now-unused `zod` import and any imports that become unused. Re-export `StreamTicketResponseSchema` from this module (`export { StreamTicketResponseSchema } from '@/lib/cloud-agent-stream-ticket';`) so the existing contract test at `apps/mobile/src/components/agents/mobile-session-manager.test.ts:380-409` keeps guarding the schema without edits.
> 
> 3. `apps/mobile/src/components/code-reviewer/review-spectator-stream.ts`: delete `asRecord`, `asString`, `asNumber`, `parseTicket`, the local `StreamTicket` type, and `postReviewSpectatorStreamTicket` (`:13-75`). Call the shared `fetchCloudAgentStreamTicket` at the two existing call sites (`:99-102` and the `onRefreshTicket` at `:114-120`). Keep `createReviewSpectatorStream`'s behavior, including its empty-string `organizationId` normalization, the `/stream` URL, `Origin`, and lifecycle hooks.
> 
> Both iOS and Android stay in scope; this code is platform-agnostic, so no platform branch is expected.
> 
> # Out of scope
> 
> - Kilo Claw and Kilo Chat (do not touch `apps/mobile/src/app/**/kiloclaw/**`, `apps/mobile/src/components/kiloclaw/**`, `apps/mobile/src/lib/kiloclaw/**`, `apps/mobile/src/components/kilo-chat/**`, or the chat tab routes).
> - The unrelated `asRecord`/`asString` copies in `apps/mobile/src/components/code-reviewer/review-spectator-rows.ts` (row decoding, not the ticket contract) — do not refactor them here.
> - Backend/web, the route’s server implementation, rate limiting, and the websocket/`createConnection` layer. No new dependency, no schema/API change, no copy/i18n change.
> 
> # Acceptance checks
> 
> Run from `apps/mobile/`; all must pass:
> 
> - `pnpm format:check`
> - `pnpm typecheck`
> - `pnpm lint`
> - `pnpm check:unused`
> - `pnpm test`
> - `git diff --check`
> - `rg -n "cloud-agent-next/sessions/stream-ticket" apps/mobile/src` finds the route string in exactly one product file (`apps/mobile/src/lib/cloud-agent-stream-ticket.ts`).
> - `rg -n "function asRecord|function asString|function asNumber|function parseTicket|postReviewSpectatorStreamTicket|StreamTicketResponseSchema = z" apps/mobile/src/components/code-reviewer/review-spectator-stream.ts` returns no matches.
> - The existing focused suites pass unchanged: `apps/mobile/src/components/agents/mobile-session-manager.test.ts` (including the `StreamTicketResponseSchema` and `getTicket` blocks) and `apps/mobile/src/components/code-reviewer/review-spectator-stream.test.ts` (route, headers, body, empty-`organizationId`, and `onRefreshTicket`).
> 
> # E2E proof
> 
> This is a behavior-preserving refactor, so prove both callers still connect through the shared helper on a local dev build (not mocks alone) and attach a recording of the visible screens, with screenshots as the fallback:
> 
> 1. Open a remote CLI session and confirm the live stream connects and a streamed event renders — this exercises `fetchCloudAgentStreamTicket` through `getTicket`.
> 2. Open an in-progress code review’s live spectator transcript and confirm transcript events stream (and reconnect/refresh-ticket still works) — this exercises the second caller.
> 
> If the spectator screen cannot be forced into a live state in the harness, capture decisive sanitized log lines showing the shared helper’s request/response for the spectator path and state the limitation explicitly. Do not log tokens or Authorization headers.

</details>